### PR TITLE
docs: README rewrite for session layer + add TODO.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # The Librarian
 
-The Librarian is a portable memory system for AI agents. It gives agents one disciplined funnel for recalling, proposing, saving, updating, and reviewing durable context.
+The Librarian is a portable memory system for AI agents with a cross-harness session layer for handing work between them. It gives agents one disciplined funnel for recalling, proposing, saving, updating, and reviewing durable context, plus a neutral session-continuity layer so work started in one harness (Hermes, Claude Code, Codex, OpenCode, Pi) can be resumed cleanly in another.
 
 This MVP is intentionally local-first and dependency-light:
 
-- canonical append-only JSONL event log
-- generated human-readable memory snapshot
-- generated SQLite + FTS5 query index
-- MCP-compatible stdio server
-- editable local dashboard
+- canonical append-only JSONL event logs (`events.jsonl` for memories, `sessions.jsonl` for sessions)
+- generated human-readable memory snapshot (`memories.md`)
+- generated SQLite + FTS5 query index covering both memories and sessions
+- MCP-compatible stdio server and JSON-RPC-over-HTTP endpoint
+- editable local dashboard with Memories and Sessions tabs
+- `the-librarian` CLI exposing the full session lifecycle from any shell
+- harness setup packages under [`integrations/`](./integrations/) for Hermes, Claude Code, Codex, OpenCode, and Pi
 
 ## Quick Start
 
@@ -23,22 +25,30 @@ Open the dashboard at:
 http://0.0.0.0:3838
 ```
 
-Run the MCP server:
+Run the MCP stdio server:
 
 ```sh
 npm start
 ```
 
-Run the production-style HTTP service:
+Run the production-style HTTP service with auth tokens:
 
 ```sh
-LIBRARIAN_ADMIN_TOKEN=dev-admin-token LIBRARIAN_AGENT_TOKEN=dev-agent-token npm run serve
+LIBRARIAN_ADMIN_TOKEN=dev-admin-token \
+LIBRARIAN_AGENT_TOKEN=dev-agent-token \
+npm run serve
 ```
 
 The MCP-compatible JSON-RPC-over-HTTP endpoint is available at:
 
 ```text
 http://0.0.0.0:3838/mcp
+```
+
+Verify a deployment end-to-end:
+
+```sh
+npm run healthcheck
 ```
 
 ## Data Layout
@@ -53,30 +63,102 @@ LIBRARIAN_DATA_DIR=/path/to/librarian-data npm start
 
 Files:
 
-- `events.jsonl`: canonical append-only event log
-- `librarian.sqlite`: generated SQLite index
-- `memories.md`: generated human-readable snapshot
+- `events.jsonl` — canonical append-only event log for memories
+- `sessions.jsonl` — canonical append-only event log for sessions
+- `librarian.sqlite` — generated SQLite index (memories + sessions + FTS)
+- `memories.md` — generated human-readable snapshot of memories
 
-The JSONL event log is the source of truth. SQLite and Markdown can be rebuilt at any time.
+The JSONL logs are the source of truth. SQLite and Markdown can be rebuilt at any time via `npm run rebuild`. Memory writes never touch the session projection and vice versa — each ledger has its own incremental projection path so traffic on one side does not regress the other.
 
 ## MCP Tools
 
-- `start_context`: required context package for an agent
-- `recall`: search memories
-- `remember`: create active memory, or proposal for protected categories
-- `propose_memory`: create a proposed memory
-- `update_memory`: edit an active memory
-- `verify_memory`: record usefulness/wrong/outdated feedback
-- `list_proposals`: list pending proposed memories
-- `delete_memory`: admin-only tombstone a memory
-- `approve_proposal`: admin-only activate, edit, or reject a proposal
-- `resolve_conflict`: admin-only resolve conflicts between memories
+### Memory tools
 
-Remote HTTP deployments keep token authentication on the `/mcp` endpoint. The dashboard and its browser API are unauthenticated, so run them only on localhost, behind your own access control, or inside a private network such as a Tailnet. Agents should use the agent token for `/mcp`; approval, deletion, and conflict-resolution MCP tools require admin authorization. For stronger `agent_private` isolation, set `LIBRARIAN_AGENT_TOKENS` to comma-separated `agent_id:token` pairs so each agent is pinned to its authenticated identity.
+- `start_context` — required context package for an agent
+- `recall` — search memories
+- `remember` — create active memory, or proposal for protected categories
+- `propose_memory` — create a proposed memory
+- `update_memory` — edit an active memory
+- `verify_memory` — record usefulness/wrong/outdated feedback
+- `list_proposals` — list pending proposed memories
+- `delete_memory` — admin-only tombstone a memory
+- `approve_proposal` — admin-only activate, edit, or reject a proposal
+- `resolve_conflict` — admin-only resolve conflicts between memories
+
+### Session tools
+
+- `start_session` — start a new Librarian session attributed to the calling agent
+- `get_session` / `list_sessions` / `list_session_events` / `search_sessions` — read operations
+- `record_session_event` — append a typed evidence event (decision, command, file, error, question, etc.); implicitly resumes a paused session
+- `checkpoint_session` / `pause_session` / `end_session` — explicit lifecycle
+- `attach_session` / `continue_session` — cross-harness attachment + handover (continue defaults to attach in the same call)
+- `archive_session` / `restore_session` / `delete_session` — hide / restore / soft-delete (delete and restore are owner-or-admin)
+- `promote_session_fact` — promote a session fact into a durable memory; protected categories route through the proposal flow
+
+Visibility filtering is enforced at the MCP dispatch layer: each agent sees only `common` sessions plus their own `agent_private` sessions. Admin role bypasses.
+
+### Authentication
+
+Remote HTTP deployments keep token authentication on the `/mcp` endpoint. The dashboard and its browser REST API are currently unauthenticated (see [`issues/001-dashboard-rest-no-auth.md`](./issues/001-dashboard-rest-no-auth.md)), so run them only on localhost, behind your own access control, or inside a private network such as a Tailnet. Agents should use the agent token for `/mcp`; approval, deletion, and conflict-resolution MCP tools require admin authorization. For stronger `agent_private` isolation and per-agent session attribution, set `LIBRARIAN_AGENT_TOKENS` to comma-separated `agent_id:token` pairs so each agent is pinned to its authenticated identity.
+
+## Sessions
+
+The session layer is the neutral handover surface across harnesses. Full spec: [`specs/session-layer-and-harness-packages.md`](./specs/session-layer-and-harness-packages.md). Highlights:
+
+- **List-and-select resume.** `list_sessions` returns ranked candidates (by status, project match, source match, has-next-steps, recency) and never auto-selects. Numbered entries in the slash UX are agent-side scratch; every tool call uses the canonical `session_id`.
+- **Explicit lifecycle.** `active` → `paused` / `ended`, with `archived` and `deleted` as hidden states. Restore returns a session to its `prior_status` (paused as a fallback). Recording activity on a paused session implicitly resumes it.
+- **Common by default.** Visibility defaults to `common` because cross-agent handover is the point. Agents scan for sensitivity signals (identity, secrets, personal context, sensitive debugging) and confirm before starting a `common` session whose content looks private. `agent_private` is opt-in.
+- **Evidence, not memory.** Session history is evidence; durable facts are promoted explicitly via `promote_session_fact` (or via `end_session`'s `candidate_memories`). Nothing auto-promotes.
+- **Both ledgers rebuild.** `npm run rebuild` replays `events.jsonl` and `sessions.jsonl` into the SQLite projection. Deleting `librarian.sqlite` is recoverable.
+
+## CLI
+
+The `the-librarian` binary exposes the full session lifecycle from any shell, alongside the existing `rebuild` and `seed`:
+
+```sh
+the-librarian sessions start --title "Refactor auth" --harness codex --cwd "$PWD"
+the-librarian sessions list --project the-librarian
+the-librarian sessions continue ses_… --format markdown
+the-librarian sessions checkpoint ses_… --summary-file checkpoint.md
+the-librarian sessions pause ses_…
+the-librarian sessions end ses_… --summary-file end.md
+the-librarian sessions archive ses_… --reason "throwaway spike"
+the-librarian sessions restore ses_…
+the-librarian sessions delete ses_… --reason "test session"
+the-librarian sessions search "BM25 recall" --project the-librarian
+the-librarian sessions show ses_…
+the-librarian sessions events ses_… --type decision --limit 50
+```
+
+Every verb supports `--json` for machine-readable output, `--agent <id>` to set the calling agent, and `--admin` to elevate to admin role (required for cross-agent delete/restore). `continue` supports `--format prose|markdown|claude|codex|opencode|hermes|pi` and `--no-attach` for preview-only handover.
+
+## Slash commands
+
+The canonical cross-harness slash surface is `/lib:session <verb>`. The contract lives in [`docs/slash-commands.md`](./docs/slash-commands.md). Each harness implements it with whatever native pattern fits best:
+
+- **Claude Code** and **OpenCode** ship per-verb commands (`/lib-session-start`, `/lib-session-list`, `/lib-session-resume`, etc.) — see `integrations/<harness>/commands/`. Eleven thin markdown files, one per verb; the agent calls the corresponding MCP tool with the right scoping.
+- **Hermes** registers a single `/lib:session` command and parses the remainder.
+- **Codex** and **Pi** are documented but their per-verb story is deferred (the Codex CLI has no user-invokable slash primitive today; Pi's runtime interface is an open question per the spec).
+
+## Harness integrations
+
+Copyable setup packages live under [`integrations/`](./integrations/):
+
+```text
+integrations/
+  README.md                # file conventions across packages
+  hermes/                  # AGENTS.append.md snippet for Hermes's existing AGENTS.md
+  claude-code/             # standalone CLAUDE.md + commands/ + wrapper.sh
+  codex/                   # AGENTS.md + wrapper.sh
+  opencode/                # AGENTS.md + commands/ + wrapper.sh
+  pi/                      # conservative MVP — capture defaults to summary, never log
+```
+
+Each package ships an MCP config example, install steps, the `/lib:session` contract for that harness, the slash-command mapping, a wrapper script (where useful) that brackets the harness binary with `sessions start` on launch and `sessions pause` on exit and exposes `LIBRARIAN_SESSION_ID` to child processes, plus an end-to-end healthcheck.
 
 ## Protected Memory
 
-The `identity` and `relationship` categories are proposal-only. Agents can propose these memories, but they cannot activate them directly.
+The `identity` and `relationship` categories are proposal-only. Agents can propose these memories, but they cannot activate them directly. Promotion of session facts into these categories via `promote_session_fact` routes through the proposal flow regardless of caller role.
 
 ## Agent Policy
 
@@ -87,6 +169,8 @@ Agents should:
 3. Save durable lessons through `remember`.
 4. Use proposals for identity, relationship, and major preference changes.
 5. Verify memories that helped, misled, or became stale.
+6. Use `/lib:session start` to bound non-trivial work, and `/lib:session checkpoint` / `pause` / `end` to make handover possible across harnesses.
+7. Never auto-promote session content to durable memory — let the user direct.
 
 ## Agent Skill
 
@@ -100,6 +184,23 @@ Install or copy that skill into any agent environment that supports skills. It e
 
 For agents that do not reliably auto-discover skills, this repo also includes a minimal [SOUL.md](./SOUL.md) that points them to the skill and states the required memory behavior.
 
+## Commands
+
+```sh
+npm start             # MCP stdio server
+npm run serve         # HTTP service (dashboard + /mcp)
+npm run seed          # seed sample memories
+npm run rebuild       # replay both JSONL ledgers into the SQLite projection
+npm run healthcheck   # five-check end-to-end smoke (JSONL append, rebuild, lifecycle, stdio MCP, HTTP MCP+auth)
+npm test              # full test suite
+npm run test:sessions # session-focused test files only (store, MCP, HTTP, integrations)
+npm run smoke         # legacy smoke test (pre-session-layer)
+```
+
 ## Remote Server
 
 This repository provides the storage engine, MCP stdio server, HTTP MCP endpoint, and browser dashboard. For Docker/Tailnet deployment, see [DEPLOYMENT.md](./DEPLOYMENT.md).
+
+## Outstanding work
+
+See [TODO.md](./TODO.md) for the current outstanding list — verbs still to exercise end-to-end, the per-agent token wiring follow-up, the dashboard REST auth issue, and the deferred cross-harness items (Codex slash surface, Pi runtime).

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,44 @@
+# The Librarian — Outstanding work
+
+Snapshot taken 2026-05-18 after shipping Phases 1–6 of `specs/session-layer-and-harness-packages.md` (commits `0d7a329..42935b7`, all on `main`). Items reflect what was open at that point; check the active session's `next_steps` for fresher movement before relying on this list.
+
+## Open from the active session
+
+Active session at time of writing: `ses_e4e7fc21-0096-42b4-b091-5701c84539e5` ("Verifying /lib-session-* native commands").
+
+1. **Exercise the remaining `/lib-session-*` verbs end-to-end** (resume, checkpoint, pause, archive, restore, delete, search) to confirm Claude Code dispatches each natively. Start was verified. Status was verified.
+2. **Run `npm run healthcheck` against the deployed canonical instance.** It passes locally — needs a run against the production Librarian to validate the actual deployment.
+3. **Click through the Sessions dashboard tab in a real browser.** Server-side wiring is covered by HTTP + curl smoke; visual layout and button handlers have never been exercised interactively.
+4. **Configure `LIBRARIAN_AGENT_TOKENS` on the canonical server** so Claude Code session calls attribute to a real `agent_id`. Today they record as `unknown-agent` because no per-agent token is mapped for the Claude Code client.
+5. **Decide whether to promote any of yesterday's decisions into durable memory.** My read so far is that none meet the bar (the substantive work is in git, the operational facts are observable from the dashboard), but worth a deliberate pass.
+
+## Cross-harness follow-ups
+
+6. **Hermes per-verb commands.** Pending Jim's answer on whether Hermes supports per-command registration with autocomplete. If it does, port the per-verb pattern; if not, stay with single-command-plus-parse and update the package docs accordingly.
+7. **Codex slash surface (shelved).** Codex CLI has no user-invokable slash command primitive. Future call: ship a single `lib-session` skill that primes the agent on the verb surface, build a `UserPromptSubmit` hook that intercepts `/lib-session-*` and shells out, or wait for Codex to add native commands.
+8. **Pi runtime (shelved).** Spec defers Pi's runtime as an open question. Revisit once Pi's interface is defined.
+
+## Open repo issue
+
+9. **`issues/001-dashboard-rest-no-auth.md` — REST endpoints lack authentication.** Discovered 2026-05-12 by Joseph. The `/api/*` routes on the dashboard have no auth gate while `/mcp` requires a Bearer token. The Phase 4.1 work I shipped (`/api/sessions/*`) extends this surface without fixing the underlying auth gap. Worth prioritising — this is the only outstanding item that's a real security risk rather than polish.
+
+## Documentation cleanup
+
+10. **Residual `/lib:session` references.** A few places still use the old `/lib:session <verb>` form where they should now use the per-verb name (`/lib-session-<verb>`). Confirmed offenders (run `rg "/lib:session"` to refresh):
+    - `integrations/claude-code/CLAUDE.md` line 45 (`/lib:session resume <id>` → `/lib-session-resume <id>`) and line 57 (`/lib:session end`'s candidates → `/lib-session-end`'s candidate memories).
+    - `integrations/claude-code/slash-commands.md` line 38 ("Hermes and OpenCode register a single `/lib:session` command…") — OpenCode is now per-verb too; that line needs to drop OpenCode and reference the canonical doc instead.
+    - References that mention `/lib:session <verb>` as the **abstract cross-harness contract surface** are correct (e.g. `docs/slash-commands.md`, the "canonical contract" lines in each commands `.md`) and should stay.
+
+## Spec open questions (deferred)
+
+11. **`harness_private` visibility.** Add later if sandbox/test traffic patterns demand it.
+12. **Physical purge of soft-deleted sessions.** Retention policy + admin UI.
+13. **`session.split` / `session.merged` event types.** Revisit once usage patterns emerge.
+
+## Priority read
+
+- **#9 is the only real risk.** Everything else is polish or exercise.
+- **#4** is the easiest win — once tokens are mapped, dashboard logs and session ownership checks become useful.
+- **#2 and #3** are the spec checkpoints that were never formally closed.
+- **#10** is small but worth knocking out next time anyone touches the integration packages.
+- The rest can wait until the layer is next touched.


### PR DESCRIPTION
## Summary

- Rewrite `README.md` to reflect everything that landed in commits `0d7a329..42935b7` (Phases 1–6 of the cross-harness session layer + the OpenCode per-verb commands)
- Add `TODO.md` capturing the current outstanding list

## What the README now covers

- Cross-harness session layer in the intro and feature list
- `sessions.jsonl` in the data layout, with a note that memory and session projection paths are isolated
- All 15 new session MCP tools, split from the memory tools and explicitly noting visibility filtering at the dispatch layer
- New **Sessions** section explaining list-and-select resume, lifecycle, common-by-default + sensitivity check, evidence-not-memory, and rebuild semantics
- New **CLI** section listing all 13 `sessions <verb>` commands with `--json`, `--format`, `--no-attach`, `--admin`, `--agent`
- New **Slash commands** section pointing at `docs/slash-commands.md` and naming each harness's pattern (Claude Code + OpenCode per-verb, Hermes single-command, Codex/Pi deferred)
- New **Harness integrations** section with the `integrations/` directory tree
- Agent Policy expanded with the two session rules (use `/lib:session start` to bound work; never auto-promote)
- New **Commands** section listing every npm script including `healthcheck` and `test:sessions`
- Authentication section cross-references `issues/001-dashboard-rest-no-auth.md` so the open auth gap is visible from the front door
- Footer links to `TODO.md`

## TODO.md contents

Five session next_steps, three cross-harness follow-ups (Hermes pending input, Codex + Pi shelved), the dashboard REST auth issue (flagged as the only real risk), residual `/lib:session` cleanup in integration package files, and the deferred spec open questions.

## Test plan

- [ ] Skim the rendered README on GitHub
- [ ] Confirm every link resolves
- [ ] Confirm the listed npm scripts match `package.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)