### PR TITLE
chore(tooling): ESLint flat + Prettier + Lefthook (T1.2)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,14 @@
+node_modules
+dist
+.next
+data
+public
+pnpm-lock.yaml
+package-lock.json
+
+# Generated fixtures and data files
+**/*.jsonl
+**/*.sqlite
+
+# Markdown is hand-authored; Prettier's table padding mangles spec tables.
+**/*.md

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,101 @@
+// @ts-check
+import js from "@eslint/js";
+import vitest from "@vitest/eslint-plugin";
+import importPlugin from "eslint-plugin-import";
+import unicorn from "eslint-plugin-unicorn";
+import globals from "globals";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  {
+    ignores: [
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/.next/**",
+      "**/coverage/**",
+      "**/data/**",
+      "**/public/**",
+      "pnpm-lock.yaml",
+    ],
+  },
+
+  // Base JS recommended ruleset (applies to every file the flat config sees).
+  js.configs.recommended,
+
+  // Shared language options + plugin registration for JS/TS source.
+  {
+    files: ["**/*.{js,mjs,cjs,ts,tsx}"],
+    languageOptions: {
+      ecmaVersion: 2023,
+      sourceType: "module",
+      globals: {
+        ...globals.node,
+      },
+    },
+    plugins: {
+      import: importPlugin,
+      unicorn,
+    },
+    settings: {
+      "import/resolver": {
+        node: { extensions: [".js", ".mjs", ".cjs", ".ts", ".tsx"] },
+      },
+    },
+    rules: {
+      "no-empty": ["error", { allowEmptyCatch: true }],
+      "no-unused-vars": ["error", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
+
+      "import/no-duplicates": "error",
+      "import/newline-after-import": "error",
+      "import/order": [
+        "warn",
+        {
+          groups: ["builtin", "external", "internal", "parent", "sibling", "index"],
+          "newlines-between": "never",
+          alphabetize: { order: "asc", caseInsensitive: true },
+        },
+      ],
+
+      // Unicorn: opt-in to a small, useful subset. The rest of the plugin
+      // is too opinionated for the existing JS; revisit when TS lands.
+      "unicorn/prefer-node-protocol": "error",
+      "unicorn/no-instanceof-builtins": "error",
+    },
+  },
+
+  // TypeScript-specific rules. Applied via typescript-eslint flat presets so
+  // both the parser and the plugin's recommended ruleset are wired up.
+  ...tseslint.configs.recommended.map((config) => ({
+    ...config,
+    files: ["**/*.{ts,tsx}"],
+  })),
+  {
+    files: ["**/*.{ts,tsx}"],
+    rules: {
+      "@typescript-eslint/no-explicit-any": "error",
+      "@typescript-eslint/ban-ts-comment": [
+        "error",
+        {
+          "ts-ignore": true,
+          "ts-expect-error": "allow-with-description",
+          "ts-nocheck": true,
+          "ts-check": false,
+          minimumDescriptionLength: 10,
+        },
+      ],
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+      // Use the TS-aware version; disable the base rule it supersedes.
+      "no-unused-vars": "off",
+    },
+  },
+
+  // Vitest plugin for test files (currently inert — tests are still
+  // `node:test`; this lights up as suites migrate from Phase 3 onward).
+  {
+    files: ["**/*.{test,spec}.{js,ts,tsx}", "**/tests/**/*.{js,ts,tsx}"],
+    plugins: { vitest },
+  },
+);

--- a/integrations/pi/config.example.yaml
+++ b/integrations/pi/config.example.yaml
@@ -4,7 +4,7 @@
 librarian:
   # Transport: prefer http_mcp if the device can reach the canonical instance.
   # Fall back to cli (which delegates to the-librarian binary, itself reaching MCP).
-  transport: http_mcp  # or: cli
+  transport: http_mcp # or: cli
 
   # Canonical Librarian HTTP MCP endpoint. Only used when transport=http_mcp.
   mcp_url: "https://librarian.internal.example/mcp"
@@ -17,7 +17,7 @@ librarian:
   # Conservative capture default. Never set to "log" without explicit operator
   # consent — raw transcript capture goes through the safe-fallback-capture
   # mechanism, not this knob.
-  default_capture_mode: summary  # or: off (on constrained devices)
+  default_capture_mode: summary # or: off (on constrained devices)
 
   # Default project key for sessions started on this device.
   default_project_key: ""

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,9 @@
+pre-commit:
+  parallel: true
+  commands:
+    prettier:
+      glob: "*.{js,mjs,cjs,ts,tsx,jsx,json,md,yml,yaml,css}"
+      run: pnpm exec prettier --check {staged_files}
+    eslint:
+      glob: "*.{js,mjs,cjs,ts,tsx,jsx}"
+      run: pnpm exec eslint --max-warnings 0 {staged_files}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "the-librarian": "./src/server.js"
   },
   "scripts": {
+    "prepare": "lefthook install",
     "start": "node --no-warnings src/server.js",
     "serve": "node --no-warnings src/dashboard.js",
     "dashboard": "node --no-warnings src/dashboard.js",
@@ -18,14 +19,27 @@
     "test:sessions": "node --no-warnings --test test/sessions.test.js test/sessions.mcp.test.js test/sessions.http.test.js test/integrations.test.js",
     "test:vitest": "vitest run",
     "smoke": "node --no-warnings scripts/smoke-test.js",
-    "healthcheck": "node --no-warnings scripts/healthcheck.js"
+    "healthcheck": "node --no-warnings scripts/healthcheck.js",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "engines": {
     "node": ">=22.5.0",
     "pnpm": ">=9.15.0"
   },
   "devDependencies": {
+    "@eslint/js": "^9.17.0",
+    "@vitest/eslint-plugin": "^1.1.40",
+    "eslint": "^9.17.0",
+    "eslint-plugin-import": "^2.31.0",
+    "eslint-plugin-unicorn": "^57.0.0",
+    "globals": "^15.14.0",
+    "lefthook": "^1.10.10",
+    "prettier": "^3.4.2",
     "typescript": "catalog:",
+    "typescript-eslint": "^8.19.0",
     "vitest": "catalog:"
   },
   "license": "Apache-2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,36 @@ importers:
 
   .:
     devDependencies:
+      '@eslint/js':
+        specifier: ^9.17.0
+        version: 9.39.4
+      '@vitest/eslint-plugin':
+        specifier: ^1.1.40
+        version: 1.6.17(@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)(vitest@2.1.9)
+      eslint:
+        specifier: ^9.17.0
+        version: 9.39.4
+      eslint-plugin-import:
+        specifier: ^2.31.0
+        version: 2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)
+      eslint-plugin-unicorn:
+        specifier: ^57.0.0
+        version: 57.0.0(eslint@9.39.4)
+      globals:
+        specifier: ^15.14.0
+        version: 15.15.0
+      lefthook:
+        specifier: ^1.10.10
+        version: 1.13.6
+      prettier:
+        specifier: ^3.4.2
+        version: 3.8.3
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.19.0
+        version: 8.59.4(eslint@9.39.4)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
         version: 2.1.9
@@ -61,6 +88,14 @@ importers:
         version: 2.1.9
 
 packages:
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -200,6 +235,64 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.21.2':
+    resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.4.2':
+    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.17.0':
+    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/eslintrc@3.3.5':
+    resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.39.4':
+    resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.7':
+    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.4.1':
+    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
@@ -328,11 +421,98 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rtsao/scc@1.1.0':
+    resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/json5@0.0.29':
+    resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/normalize-package-data@2.4.4':
+    resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+
+  '@typescript-eslint/eslint-plugin@8.59.4':
+    resolution: {integrity: sha512-PegsU+XfyJJNjd4+u/k6f9yTyp0lEXXiPopUNobZcIAUJFGICFLN+sP0Rb3JehVmiij1Ph0dFGYqODoRo/2+6A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.59.4
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.59.4':
+    resolution: {integrity: sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.59.4':
+    resolution: {integrity: sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.59.4':
+    resolution: {integrity: sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.59.4':
+    resolution: {integrity: sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.59.4':
+    resolution: {integrity: sha512-uonTuPAAKr9XaBGqJ3LjYTh72zy5DyGesljO9gtmk/eFW0W1fRHjnwVYKB35Lm8d5Q5CluEW3gPHjTvZTmgrfA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.59.4':
+    resolution: {integrity: sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.59.4':
+    resolution: {integrity: sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.59.4':
+    resolution: {integrity: sha512-cYXeNAUsG4lJo5dbc1FcKm+JwIWrj1/UpTORsC6tGMjEZ81DYcvIr9/ueikhMa/Y/gDQYGp+YX9/xQrXje5BJw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.59.4':
+    resolution: {integrity: sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@vitest/eslint-plugin@1.6.17':
+    resolution: {integrity: sha512-sIVY9ZeVcXyPxFCNRkIt8Yw4keKIcUyp9/8qnmuomPwE+ST1htw5sZsbqdUMTiah9SmCg1JYoK9RqdDtPeNYYg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': '*'
+      eslint: '>=8.57.0'
+      typescript: '>=5.0.0'
+      vitest: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
+      typescript:
+        optional: true
+      vitest:
+        optional: true
 
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
@@ -363,21 +543,169 @@ packages:
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  array-buffer-byte-length@1.0.2:
+    resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
+    engines: {node: '>= 0.4'}
+
+  array-includes@3.1.9:
+    resolution: {integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.findlastindex@1.2.6:
+    resolution: {integrity: sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.flat@1.3.3:
+    resolution: {integrity: sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.flatmap@1.3.3:
+    resolution: {integrity: sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==}
+    engines: {node: '>= 0.4'}
+
+  arraybuffer.prototype.slice@1.0.4:
+    resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
+    engines: {node: '>= 0.4'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  async-function@1.0.0:
+    resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
+    engines: {node: '>= 0.4'}
+
+  available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  baseline-browser-mapping@2.10.31:
+    resolution: {integrity: sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  builtin-modules@4.0.0:
+    resolution: {integrity: sha512-p1n8zyCkt1BVrKNFymOHjcDSAl7oq/gUvfgULv2EblgpPVQlQr9yHnWjg9IJ2MhfwPqiYqMMrr01OY7yQoK2yA==}
+    engines: {node: '>=18.20'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bind@1.0.9:
+    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  caniuse-lite@1.0.30001793:
+    resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
+
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
 
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
+
+  ci-info@4.4.0:
+    resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
+    engines: {node: '>=8'}
+
+  clean-regexp@1.0.0:
+    resolution: {integrity: sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==}
+    engines: {node: '>=4'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  core-js-compat@3.49.0:
+    resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  data-view-buffer@1.0.2:
+    resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
+    engines: {node: '>= 0.4'}
+
+  data-view-byte-length@1.0.2:
+    resolution: {integrity: sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==}
+    engines: {node: '>= 0.4'}
+
+  data-view-byte-offset@1.0.1:
+    resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
+    engines: {node: '>= 0.4'}
+
+  debug@3.2.7:
+    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -392,31 +720,546 @@ packages:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
+  define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
+
+  doctrine@2.1.0:
+    resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
+    engines: {node: '>=0.10.0'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  electron-to-chromium@1.5.359:
+    resolution: {integrity: sha512-8lPELWuYZIWk7NDvCNthtmMw/7Q5Wu25NpM4djFMHBmk8DubPAtL4YTOp7ou0e7HyJtwkVlWv8XMLURnrtgJQw==}
+
+  es-abstract@1.24.2:
+    resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
+    engines: {node: '>= 0.4'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  es-shim-unscopables@1.1.0:
+    resolution: {integrity: sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==}
+    engines: {node: '>= 0.4'}
+
+  es-to-primitive@1.3.0:
+    resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
     hasBin: true
 
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  escape-string-regexp@1.0.5:
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
+    engines: {node: '>=0.8.0'}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-import-resolver-node@0.3.10:
+    resolution: {integrity: sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==}
+
+  eslint-module-utils@2.12.1:
+    resolution: {integrity: sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+
+  eslint-plugin-import@2.32.0:
+    resolution: {integrity: sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+
+  eslint-plugin-unicorn@57.0.0:
+    resolution: {integrity: sha512-zUYYa6zfNdTeG9BISWDlcLmz16c+2Ck2o5ZDHh0UzXJz3DEP7xjmlVDTzbyV0W+XksgZ0q37WEWzN2D2Ze+g9Q==}
+    engines: {node: '>=18.18'}
+    peerDependencies:
+      eslint: '>=9.20.0'
+
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@9.39.4:
+    resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
+  find-up-simple@1.0.1:
+    resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
+    engines: {node: '>=18'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
+  for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  function.prototype.name@1.1.8:
+    resolution: {integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==}
+    engines: {node: '>= 0.4'}
+
+  functions-have-names@1.2.3:
+    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  generator-function@2.0.1:
+    resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
+    engines: {node: '>= 0.4'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  get-symbol-description@1.1.0:
+    resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
+    engines: {node: '>= 0.4'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  globals@15.15.0:
+    resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
+    engines: {node: '>=18'}
+
+  globalthis@1.0.4:
+    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-bigints@1.1.0:
+    resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
+    engines: {node: '>= 0.4'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
+  has-proto@1.2.0:
+    resolution: {integrity: sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  hosted-git-info@7.0.2:
+    resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
+    engines: {node: ^16.14.0 || >=18.0.0}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  indent-string@5.0.0:
+    resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
+    engines: {node: '>=12'}
+
+  index-to-position@1.2.0:
+    resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
+    engines: {node: '>=18'}
+
+  internal-slot@1.1.0:
+    resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
+    engines: {node: '>= 0.4'}
+
+  is-array-buffer@3.0.5:
+    resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
+    engines: {node: '>= 0.4'}
+
+  is-async-function@2.1.1:
+    resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
+    engines: {node: '>= 0.4'}
+
+  is-bigint@1.1.0:
+    resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
+    engines: {node: '>= 0.4'}
+
+  is-boolean-object@1.2.2:
+    resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
+    engines: {node: '>= 0.4'}
+
+  is-builtin-module@4.0.0:
+    resolution: {integrity: sha512-rWP3AMAalQSesXO8gleROyL2iKU73SX5Er66losQn9rWOWL4Gef0a/xOEOVqjWGMuR2vHG3FJ8UUmT700O8oFg==}
+    engines: {node: '>=18.20'}
+
+  is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
+
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
+    engines: {node: '>= 0.4'}
+
+  is-data-view@1.0.2:
+    resolution: {integrity: sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==}
+    engines: {node: '>= 0.4'}
+
+  is-date-object@1.1.0:
+    resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
+    engines: {node: '>= 0.4'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-finalizationregistry@1.1.1:
+    resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
+    engines: {node: '>= 0.4'}
+
+  is-generator-function@1.1.2:
+    resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
+    engines: {node: '>= 0.4'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-map@2.0.3:
+    resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
+    engines: {node: '>= 0.4'}
+
+  is-negative-zero@2.0.3:
+    resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
+    engines: {node: '>= 0.4'}
+
+  is-number-object@1.1.1:
+    resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
+    engines: {node: '>= 0.4'}
+
+  is-regex@1.2.1:
+    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
+    engines: {node: '>= 0.4'}
+
+  is-set@2.0.3:
+    resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
+    engines: {node: '>= 0.4'}
+
+  is-shared-array-buffer@1.0.4:
+    resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
+    engines: {node: '>= 0.4'}
+
+  is-string@1.1.1:
+    resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
+    engines: {node: '>= 0.4'}
+
+  is-symbol@1.1.1:
+    resolution: {integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==}
+    engines: {node: '>= 0.4'}
+
+  is-typed-array@1.1.15:
+    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
+    engines: {node: '>= 0.4'}
+
+  is-weakmap@2.0.2:
+    resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
+    engines: {node: '>= 0.4'}
+
+  is-weakref@1.1.1:
+    resolution: {integrity: sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==}
+    engines: {node: '>= 0.4'}
+
+  is-weakset@2.0.4:
+    resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
+    engines: {node: '>= 0.4'}
+
+  isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  jsesc@3.0.2:
+    resolution: {integrity: sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json5@1.0.2:
+    resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
+    hasBin: true
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  lefthook-darwin-arm64@1.13.6:
+    resolution: {integrity: sha512-m6Lb77VGc84/Qo21Lhq576pEvcgFCnvloEiP02HbAHcIXD0RTLy9u2yAInrixqZeaz13HYtdDaI7OBYAAdVt8A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@1.13.6:
+    resolution: {integrity: sha512-CoRpdzanu9RK3oXR1vbEJA5LN7iB+c7hP+sONeQJzoOXuq4PNKVtEaN84Gl1BrVtCNLHWFAvCQaZPPiiXSy8qg==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@1.13.6:
+    resolution: {integrity: sha512-X4A7yfvAJ68CoHTqP+XvQzdKbyd935sYy0bQT6Ajz7FL1g7hFiro8dqHSdPdkwei9hs8hXeV7feyTXbYmfjKQQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@1.13.6:
+    resolution: {integrity: sha512-ai2m+Sj2kGdY46USfBrCqLKe9GYhzeq01nuyDYCrdGISePeZ6udOlD1k3lQKJGQCHb0bRz4St0r5nKDSh1x/2A==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@1.13.6:
+    resolution: {integrity: sha512-cbo4Wtdq81GTABvikLORJsAWPKAJXE8Q5RXsICFUVznh5PHigS9dFW/4NXywo0+jfFPCT6SYds2zz4tCx6DA0Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@1.13.6:
+    resolution: {integrity: sha512-uJl9vjCIIBTBvMZkemxCE+3zrZHlRO7Oc+nZJ+o9Oea3fu+W82jwX7a7clw8jqNfaeBS+8+ZEQgiMHWCloTsGw==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@1.13.6:
+    resolution: {integrity: sha512-7r153dxrNRQ9ytRs2PmGKKkYdvZYFPre7My7XToSTiRu5jNCq++++eAKVkoyWPduk97dGIA+YWiEr5Noe0TK2A==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@1.13.6:
+    resolution: {integrity: sha512-Z+UhLlcg1xrXOidK3aLLpgH7KrwNyWYE3yb7ITYnzJSEV8qXnePtVu8lvMBHs/myzemjBzeIr/U/+ipjclR06g==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@1.13.6:
+    resolution: {integrity: sha512-Uxef6qoDxCmUNQwk8eBvddYJKSBFglfwAY9Y9+NnnmiHpWTjjYiObE9gT2mvGVpEgZRJVAatBXc+Ha5oDD/OgQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@1.13.6:
+    resolution: {integrity: sha512-mOZoM3FQh3o08M8PQ/b3IYuL5oo36D9ehczIw1dAgp1Ly+Tr4fJ96A+4SEJrQuYeRD4mex9bR7Ps56I73sBSZA==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@1.13.6:
+    resolution: {integrity: sha512-ojj4/4IJ29Xn4drd5emqVgilegAPN3Kf0FQM2p/9+lwSTpU+SZ1v4Ig++NF+9MOa99UKY8bElmVrLhnUUNFh5g==}
+    hasBin: true
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -425,6 +1268,83 @@ packages:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  node-exports-info@1.6.0:
+    resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
+    engines: {node: '>= 0.4'}
+
+  node-releases@2.0.44:
+    resolution: {integrity: sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==}
+
+  normalize-package-data@6.0.2:
+    resolution: {integrity: sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==}
+    engines: {node: ^16.14.0 || >=18.0.0}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
+
+  object.assign@4.1.7:
+    resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
+    engines: {node: '>= 0.4'}
+
+  object.entries@1.1.9:
+    resolution: {integrity: sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==}
+    engines: {node: '>= 0.4'}
+
+  object.fromentries@2.0.8:
+    resolution: {integrity: sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==}
+    engines: {node: '>= 0.4'}
+
+  object.groupby@1.0.3:
+    resolution: {integrity: sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==}
+    engines: {node: '>= 0.4'}
+
+  object.values@1.2.1:
+    resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
+    engines: {node: '>= 0.4'}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  own-keys@1.0.1:
+    resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
+    engines: {node: '>= 0.4'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  parse-json@8.3.0:
+    resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
+    engines: {node: '>=18'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
@@ -436,14 +1356,129 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  pluralize@8.0.0:
+    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
+    engines: {node: '>=4'}
+
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
+
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  read-package-up@11.0.0:
+    resolution: {integrity: sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==}
+    engines: {node: '>=18'}
+
+  read-pkg@9.0.1:
+    resolution: {integrity: sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==}
+    engines: {node: '>=18'}
+
+  reflect.getprototypeof@1.0.10:
+    resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
+    engines: {node: '>= 0.4'}
+
+  regexp-tree@0.1.27:
+    resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
+    hasBin: true
+
+  regexp.prototype.flags@1.5.4:
+    resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
+    engines: {node: '>= 0.4'}
+
+  regjsparser@0.12.0:
+    resolution: {integrity: sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==}
+    hasBin: true
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  resolve@2.0.0-next.7:
+    resolution: {integrity: sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
 
   rollup@4.60.4:
     resolution: {integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  safe-array-concat@1.1.4:
+    resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
+    engines: {node: '>=0.4'}
+
+  safe-push-apply@1.0.0:
+    resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
+    engines: {node: '>= 0.4'}
+
+  safe-regex-test@1.1.0:
+    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
+    engines: {node: '>= 0.4'}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  semver@7.8.0:
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+
+  set-function-name@2.0.2:
+    resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
+    engines: {node: '>= 0.4'}
+
+  set-proto@1.0.0:
+    resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
+    engines: {node: '>= 0.4'}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -452,17 +1487,69 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  spdx-correct@3.2.0:
+    resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
+
+  spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+
+  spdx-expression-parse@3.0.1:
+    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
+
+  spdx-license-ids@3.0.23:
+    resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  stop-iteration-iterator@1.1.0:
+    resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trim@1.2.10:
+    resolution: {integrity: sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trimend@1.0.9:
+    resolution: {integrity: sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trimstart@1.0.8:
+    resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
+    engines: {node: '>= 0.4'}
+
+  strip-bom@3.0.0:
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
+    engines: {node: '>=4'}
+
+  strip-indent@4.1.1:
+    resolution: {integrity: sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==}
+    engines: {node: '>=12'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
 
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
@@ -476,10 +1563,70 @@ packages:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
+  tsconfig-paths@3.15.0:
+    resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
+
+  typed-array-buffer@1.0.3:
+    resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-byte-length@1.0.3:
+    resolution: {integrity: sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-byte-offset@1.0.4:
+    resolution: {integrity: sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-length@1.0.7:
+    resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
+    engines: {node: '>= 0.4'}
+
+  typescript-eslint@8.59.4:
+    resolution: {integrity: sha512-Rw6+44QNFaXtgHSjPy+Kw8hrJniMYzR85E9yLmOLcfZ91/rz+JXQbDTCmc6ccxMPY6K6PgAq26f0JCBfR7LIPQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  unbox-primitive@1.1.0:
+    resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
+    engines: {node: '>= 0.4'}
+
+  unicorn-magic@0.1.0:
+    resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
+    engines: {node: '>=18'}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  validate-npm-package-license@3.0.4:
+    resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
@@ -542,12 +1689,49 @@ packages:
       jsdom:
         optional: true
 
+  which-boxed-primitive@1.1.1:
+    resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
+    engines: {node: '>= 0.4'}
+
+  which-builtin-type@1.2.1:
+    resolution: {integrity: sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==}
+    engines: {node: '>= 0.4'}
+
+  which-collection@1.0.2:
+    resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
+    engines: {node: '>= 0.4'}
+
+  which-typed-array@1.1.20:
+    resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
+    engines: {node: '>= 0.4'}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
 
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
 snapshots:
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.28.5': {}
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -617,6 +1801,68 @@ snapshots:
 
   '@esbuild/win32-x64@0.21.5':
     optional: true
+
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)':
+    dependencies:
+      eslint: 9.39.4
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.21.2':
+    dependencies:
+      '@eslint/object-schema': 2.1.7
+      debug: 4.4.3
+      minimatch: 3.1.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.4.2':
+    dependencies:
+      '@eslint/core': 0.17.0
+
+  '@eslint/core@0.17.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/eslintrc@3.3.5':
+    dependencies:
+      ajv: 6.15.0
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      minimatch: 3.1.5
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.39.4': {}
+
+  '@eslint/object-schema@2.1.7': {}
+
+  '@eslint/plugin-kit@0.4.1':
+    dependencies:
+      '@eslint/core': 0.17.0
+      levn: 0.4.1
+
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
@@ -695,9 +1941,120 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.4':
     optional: true
 
+  '@rtsao/scc@1.1.0': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/estree@1.0.9': {}
+
+  '@types/json-schema@7.0.15': {}
+
+  '@types/json5@0.0.29': {}
+
+  '@types/normalize-package-data@2.4.4': {}
+
+  '@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.59.4(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.59.4
+      '@typescript-eslint/type-utils': 8.59.4(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.4(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.4
+      eslint: 9.39.4
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.59.4(eslint@9.39.4)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.59.4
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/typescript-estree': 8.59.4(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.4
+      debug: 4.4.3
+      eslint: 9.39.4
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.59.4(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.59.4(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.4
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.59.4':
+    dependencies:
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/visitor-keys': 8.59.4
+
+  '@typescript-eslint/tsconfig-utils@8.59.4(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@typescript-eslint/type-utils@8.59.4(eslint@9.39.4)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/typescript-estree': 8.59.4(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.4(eslint@9.39.4)(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 9.39.4
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.59.4': {}
+
+  '@typescript-eslint/typescript-estree@8.59.4(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.59.4(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.4(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/visitor-keys': 8.59.4
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.8.0
+      tinyglobby: 0.2.16
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.59.4(eslint@9.39.4)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@typescript-eslint/scope-manager': 8.59.4
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/typescript-estree': 8.59.4(typescript@5.9.3)
+      eslint: 9.39.4
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.59.4':
+    dependencies:
+      '@typescript-eslint/types': 8.59.4
+      eslint-visitor-keys: 5.0.1
+
+  '@vitest/eslint-plugin@1.6.17(@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)(vitest@2.1.9)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.59.4
+      '@typescript-eslint/utils': 8.59.4(eslint@9.39.4)(typescript@5.9.3)
+      eslint: 9.39.4
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
+      typescript: 5.9.3
+      vitest: 2.1.9
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitest/expect@2.1.9':
     dependencies:
@@ -739,9 +2096,130 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn@8.16.0: {}
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  argparse@2.0.1: {}
+
+  array-buffer-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      is-array-buffer: 3.0.5
+
+  array-includes@3.1.9:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-object-atoms: 1.1.1
+      get-intrinsic: 1.3.0
+      is-string: 1.1.1
+      math-intrinsics: 1.1.0
+
+  array.prototype.findlastindex@1.2.6:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      es-shim-unscopables: 1.1.0
+
+  array.prototype.flat@1.3.3:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-shim-unscopables: 1.1.0
+
+  array.prototype.flatmap@1.3.3:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-shim-unscopables: 1.1.0
+
+  arraybuffer.prototype.slice@1.0.4:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      is-array-buffer: 3.0.5
+
   assertion-error@2.0.1: {}
 
+  async-function@1.0.0: {}
+
+  available-typed-arrays@1.0.7:
+    dependencies:
+      possible-typed-array-names: 1.1.0
+
+  balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
+
+  baseline-browser-mapping@2.10.31: {}
+
+  brace-expansion@1.1.14:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.31
+      caniuse-lite: 1.0.30001793
+      electron-to-chromium: 1.5.359
+      node-releases: 2.0.44
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  builtin-modules@4.0.0: {}
+
   cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bind@1.0.9:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
+  callsites@3.1.0: {}
+
+  caniuse-lite@1.0.30001793: {}
 
   chai@5.3.3:
     dependencies:
@@ -751,7 +2229,58 @@ snapshots:
       loupe: 3.2.1
       pathval: 2.0.1
 
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
   check-error@2.1.3: {}
+
+  ci-info@4.4.0: {}
+
+  clean-regexp@1.0.0:
+    dependencies:
+      escape-string-regexp: 1.0.5
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  concat-map@0.0.1: {}
+
+  core-js-compat@3.49.0:
+    dependencies:
+      browserslist: 4.28.2
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  data-view-buffer@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  data-view-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  data-view-byte-offset@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  debug@3.2.7:
+    dependencies:
+      ms: 2.1.3
 
   debug@4.4.3:
     dependencies:
@@ -759,7 +2288,115 @@ snapshots:
 
   deep-eql@5.0.2: {}
 
+  deep-is@0.1.4: {}
+
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  define-properties@1.2.1:
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
+
+  doctrine@2.1.0:
+    dependencies:
+      esutils: 2.0.3
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  electron-to-chromium@1.5.359: {}
+
+  es-abstract@1.24.2:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      arraybuffer.prototype.slice: 1.0.4
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      data-view-buffer: 1.0.2
+      data-view-byte-length: 1.0.2
+      data-view-byte-offset: 1.0.1
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      es-set-tostringtag: 2.1.0
+      es-to-primitive: 1.3.0
+      function.prototype.name: 1.1.8
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      get-symbol-description: 1.1.0
+      globalthis: 1.0.4
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+      has-proto: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      internal-slot: 1.1.0
+      is-array-buffer: 3.0.5
+      is-callable: 1.2.7
+      is-data-view: 1.0.2
+      is-negative-zero: 2.0.3
+      is-regex: 1.2.1
+      is-set: 2.0.3
+      is-shared-array-buffer: 1.0.4
+      is-string: 1.1.1
+      is-typed-array: 1.1.15
+      is-weakref: 1.1.1
+      math-intrinsics: 1.1.0
+      object-inspect: 1.13.4
+      object-keys: 1.1.1
+      object.assign: 4.1.7
+      own-keys: 1.0.1
+      regexp.prototype.flags: 1.5.4
+      safe-array-concat: 1.1.4
+      safe-push-apply: 1.0.0
+      safe-regex-test: 1.1.0
+      set-proto: 1.0.0
+      stop-iteration-iterator: 1.1.0
+      string.prototype.trim: 1.2.10
+      string.prototype.trimend: 1.0.9
+      string.prototype.trimstart: 1.0.8
+      typed-array-buffer: 1.0.3
+      typed-array-byte-length: 1.0.3
+      typed-array-byte-offset: 1.0.4
+      typed-array-length: 1.0.7
+      unbox-primitive: 1.1.0
+      which-typed-array: 1.1.20
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
+
+  es-shim-unscopables@1.1.0:
+    dependencies:
+      hasown: 2.0.3
+
+  es-to-primitive@1.3.0:
+    dependencies:
+      is-callable: 1.2.7
+      is-date-object: 1.1.0
+      is-symbol: 1.1.1
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -787,24 +2424,600 @@ snapshots:
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
 
+  escalade@3.2.0: {}
+
+  escape-string-regexp@1.0.5: {}
+
+  escape-string-regexp@4.0.0: {}
+
+  eslint-import-resolver-node@0.3.10:
+    dependencies:
+      debug: 3.2.7
+      is-core-module: 2.16.2
+      resolve: 2.0.0-next.7
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.4(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.59.4(eslint@9.39.4)(typescript@5.9.3)
+      eslint: 9.39.4
+      eslint-import-resolver-node: 0.3.10
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.39.4
+      eslint-import-resolver-node: 0.3.10
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.4(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4)
+      hasown: 2.0.3
+      is-core-module: 2.16.2
+      is-glob: 4.0.3
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.59.4(eslint@9.39.4)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-unicorn@57.0.0(eslint@9.39.4):
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      ci-info: 4.4.0
+      clean-regexp: 1.0.0
+      core-js-compat: 3.49.0
+      eslint: 9.39.4
+      esquery: 1.7.0
+      globals: 15.15.0
+      indent-string: 5.0.0
+      is-builtin-module: 4.0.0
+      jsesc: 3.1.0
+      pluralize: 8.0.0
+      read-package-up: 11.0.0
+      regexp-tree: 0.1.27
+      regjsparser: 0.12.0
+      semver: 7.8.0
+      strip-indent: 4.1.1
+
+  eslint-scope@8.4.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@9.39.4:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.2
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.5
+      '@eslint/js': 9.39.4
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 4.2.1
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
 
+  esutils@2.0.3: {}
+
   expect-type@1.3.0: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  find-up-simple@1.0.1: {}
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.2
+      keyv: 4.5.4
+
+  flatted@3.4.2: {}
+
+  for-each@0.3.5:
+    dependencies:
+      is-callable: 1.2.7
 
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
+  function.prototype.name@1.1.8:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      functions-have-names: 1.2.3
+      hasown: 2.0.3
+      is-callable: 1.2.7
+
+  functions-have-names@1.2.3: {}
+
+  generator-function@2.0.1: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  get-symbol-description@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  globals@14.0.0: {}
+
+  globals@15.15.0: {}
+
+  globalthis@1.0.4:
+    dependencies:
+      define-properties: 1.2.1
+      gopd: 1.2.0
+
+  gopd@1.2.0: {}
+
+  has-bigints@1.1.0: {}
+
+  has-flag@4.0.0: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+
+  has-proto@1.2.0:
+    dependencies:
+      dunder-proto: 1.0.1
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  hosted-git-info@7.0.2:
+    dependencies:
+      lru-cache: 10.4.3
+
+  ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  imurmurhash@0.1.4: {}
+
+  indent-string@5.0.0: {}
+
+  index-to-position@1.2.0: {}
+
+  internal-slot@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      hasown: 2.0.3
+      side-channel: 1.1.0
+
+  is-array-buffer@3.0.5:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
+  is-async-function@2.1.1:
+    dependencies:
+      async-function: 1.0.0
+      call-bound: 1.0.4
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
+
+  is-bigint@1.1.0:
+    dependencies:
+      has-bigints: 1.1.0
+
+  is-boolean-object@1.2.2:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-builtin-module@4.0.0:
+    dependencies:
+      builtin-modules: 4.0.0
+
+  is-callable@1.2.7: {}
+
+  is-core-module@2.16.2:
+    dependencies:
+      hasown: 2.0.3
+
+  is-data-view@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+      is-typed-array: 1.1.15
+
+  is-date-object@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-extglob@2.1.1: {}
+
+  is-finalizationregistry@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-generator-function@1.1.2:
+    dependencies:
+      call-bound: 1.0.4
+      generator-function: 2.0.1
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-map@2.0.3: {}
+
+  is-negative-zero@2.0.3: {}
+
+  is-number-object@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-regex@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
+
+  is-set@2.0.3: {}
+
+  is-shared-array-buffer@1.0.4:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-string@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-symbol@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-symbols: 1.1.0
+      safe-regex-test: 1.1.0
+
+  is-typed-array@1.1.15:
+    dependencies:
+      which-typed-array: 1.1.20
+
+  is-weakmap@2.0.2: {}
+
+  is-weakref@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-weakset@2.0.4:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
+  isarray@2.0.5: {}
+
+  isexe@2.0.0: {}
+
+  js-tokens@4.0.0: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
+  jsesc@3.0.2: {}
+
+  jsesc@3.1.0: {}
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json5@1.0.2:
+    dependencies:
+      minimist: 1.2.8
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  lefthook-darwin-arm64@1.13.6:
+    optional: true
+
+  lefthook-darwin-x64@1.13.6:
+    optional: true
+
+  lefthook-freebsd-arm64@1.13.6:
+    optional: true
+
+  lefthook-freebsd-x64@1.13.6:
+    optional: true
+
+  lefthook-linux-arm64@1.13.6:
+    optional: true
+
+  lefthook-linux-x64@1.13.6:
+    optional: true
+
+  lefthook-openbsd-arm64@1.13.6:
+    optional: true
+
+  lefthook-openbsd-x64@1.13.6:
+    optional: true
+
+  lefthook-windows-arm64@1.13.6:
+    optional: true
+
+  lefthook-windows-x64@1.13.6:
+    optional: true
+
+  lefthook@1.13.6:
+    optionalDependencies:
+      lefthook-darwin-arm64: 1.13.6
+      lefthook-darwin-x64: 1.13.6
+      lefthook-freebsd-arm64: 1.13.6
+      lefthook-freebsd-x64: 1.13.6
+      lefthook-linux-arm64: 1.13.6
+      lefthook-linux-x64: 1.13.6
+      lefthook-openbsd-arm64: 1.13.6
+      lefthook-openbsd-x64: 1.13.6
+      lefthook-windows-arm64: 1.13.6
+      lefthook-windows-x64: 1.13.6
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  lodash.merge@4.6.2: {}
+
   loupe@3.2.1: {}
+
+  lru-cache@10.4.3: {}
 
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  math-intrinsics@1.1.0: {}
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.14
+
+  minimist@1.2.8: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.12: {}
+
+  natural-compare@1.4.0: {}
+
+  node-exports-info@1.6.0:
+    dependencies:
+      array.prototype.flatmap: 1.3.3
+      es-errors: 1.3.0
+      object.entries: 1.1.9
+      semver: 6.3.1
+
+  node-releases@2.0.44: {}
+
+  normalize-package-data@6.0.2:
+    dependencies:
+      hosted-git-info: 7.0.2
+      semver: 7.8.0
+      validate-npm-package-license: 3.0.4
+
+  object-inspect@1.13.4: {}
+
+  object-keys@1.1.1: {}
+
+  object.assign@4.1.7:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+      has-symbols: 1.1.0
+      object-keys: 1.1.1
+
+  object.entries@1.1.9:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+
+  object.fromentries@2.0.8:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-object-atoms: 1.1.1
+
+  object.groupby@1.0.3:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+
+  object.values@1.2.1:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  own-keys@1.0.1:
+    dependencies:
+      get-intrinsic: 1.3.0
+      object-keys: 1.1.1
+      safe-push-apply: 1.0.0
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  parse-json@8.3.0:
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      index-to-position: 1.2.0
+      type-fest: 4.41.0
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
+
+  path-parse@1.0.7: {}
 
   pathe@1.1.2: {}
 
@@ -812,11 +3025,74 @@ snapshots:
 
   picocolors@1.1.1: {}
 
+  picomatch@4.0.4: {}
+
+  pluralize@8.0.0: {}
+
+  possible-typed-array-names@1.1.0: {}
+
   postcss@8.5.14:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  prelude-ls@1.2.1: {}
+
+  prettier@3.8.3: {}
+
+  punycode@2.3.1: {}
+
+  read-package-up@11.0.0:
+    dependencies:
+      find-up-simple: 1.0.1
+      read-pkg: 9.0.1
+      type-fest: 4.41.0
+
+  read-pkg@9.0.1:
+    dependencies:
+      '@types/normalize-package-data': 2.4.4
+      normalize-package-data: 6.0.2
+      parse-json: 8.3.0
+      type-fest: 4.41.0
+      unicorn-magic: 0.1.0
+
+  reflect.getprototypeof@1.0.10:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      which-builtin-type: 1.2.1
+
+  regexp-tree@0.1.27: {}
+
+  regexp.prototype.flags@1.5.4:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-errors: 1.3.0
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      set-function-name: 2.0.2
+
+  regjsparser@0.12.0:
+    dependencies:
+      jsesc: 3.0.2
+
+  resolve-from@4.0.0: {}
+
+  resolve@2.0.0-next.7:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      node-exports-info: 1.6.0
+      object-keys: 1.1.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
 
   rollup@4.60.4:
     dependencies:
@@ -849,17 +3125,155 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.4
       fsevents: 2.3.3
 
+  safe-array-concat@1.1.4:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+      has-symbols: 1.1.0
+      isarray: 2.0.5
+
+  safe-push-apply@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      isarray: 2.0.5
+
+  safe-regex-test@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-regex: 1.2.1
+
+  semver@6.3.1: {}
+
+  semver@7.8.0: {}
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+
+  set-function-name@2.0.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      functions-have-names: 1.2.3
+      has-property-descriptors: 1.0.2
+
+  set-proto@1.0.0:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   siginfo@2.0.0: {}
 
   source-map-js@1.2.1: {}
+
+  spdx-correct@3.2.0:
+    dependencies:
+      spdx-expression-parse: 3.0.1
+      spdx-license-ids: 3.0.23
+
+  spdx-exceptions@2.5.0: {}
+
+  spdx-expression-parse@3.0.1:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.23
+
+  spdx-license-ids@3.0.23: {}
 
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
 
+  stop-iteration-iterator@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      internal-slot: 1.1.0
+
+  string.prototype.trim@1.2.10:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-data-property: 1.1.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-object-atoms: 1.1.1
+      has-property-descriptors: 1.0.2
+
+  string.prototype.trimend@1.0.9:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+
+  string.prototype.trimstart@1.0.8:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+
+  strip-bom@3.0.0: {}
+
+  strip-indent@4.1.1: {}
+
+  strip-json-comments@3.1.1: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-preserve-symlinks-flag@1.0.0: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinypool@1.1.1: {}
 
@@ -867,7 +3281,92 @@ snapshots:
 
   tinyspy@3.0.2: {}
 
+  ts-api-utils@2.5.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
+  tsconfig-paths@3.15.0:
+    dependencies:
+      '@types/json5': 0.0.29
+      json5: 1.0.2
+      minimist: 1.2.8
+      strip-bom: 3.0.0
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  type-fest@4.41.0: {}
+
+  typed-array-buffer@1.0.3:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-typed-array: 1.1.15
+
+  typed-array-byte-length@1.0.3:
+    dependencies:
+      call-bind: 1.0.9
+      for-each: 0.3.5
+      gopd: 1.2.0
+      has-proto: 1.2.0
+      is-typed-array: 1.1.15
+
+  typed-array-byte-offset@1.0.4:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      for-each: 0.3.5
+      gopd: 1.2.0
+      has-proto: 1.2.0
+      is-typed-array: 1.1.15
+      reflect.getprototypeof: 1.0.10
+
+  typed-array-length@1.0.7:
+    dependencies:
+      call-bind: 1.0.9
+      for-each: 0.3.5
+      gopd: 1.2.0
+      is-typed-array: 1.1.15
+      possible-typed-array-names: 1.1.0
+      reflect.getprototypeof: 1.0.10
+
+  typescript-eslint@8.59.4(eslint@9.39.4)(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.4(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.59.4(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.4(eslint@9.39.4)(typescript@5.9.3)
+      eslint: 9.39.4
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   typescript@5.9.3: {}
+
+  unbox-primitive@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-bigints: 1.1.0
+      has-symbols: 1.1.0
+      which-boxed-primitive: 1.1.1
+
+  unicorn-magic@0.1.0: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  validate-npm-package-license@3.0.4:
+    dependencies:
+      spdx-correct: 3.2.0
+      spdx-expression-parse: 3.0.1
 
   vite-node@2.1.9:
     dependencies:
@@ -928,7 +3427,56 @@ snapshots:
       - supports-color
       - terser
 
+  which-boxed-primitive@1.1.1:
+    dependencies:
+      is-bigint: 1.1.0
+      is-boolean-object: 1.2.2
+      is-number-object: 1.1.1
+      is-string: 1.1.1
+      is-symbol: 1.1.1
+
+  which-builtin-type@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      function.prototype.name: 1.1.8
+      has-tostringtag: 1.0.2
+      is-async-function: 2.1.1
+      is-date-object: 1.1.0
+      is-finalizationregistry: 1.1.1
+      is-generator-function: 1.1.2
+      is-regex: 1.2.1
+      is-weakref: 1.1.1
+      isarray: 2.0.5
+      which-boxed-primitive: 1.1.1
+      which-collection: 1.0.2
+      which-typed-array: 1.1.20
+
+  which-collection@1.0.2:
+    dependencies:
+      is-map: 2.0.3
+      is-set: 2.0.3
+      is-weakmap: 2.0.2
+      is-weakset: 2.0.4
+
+  which-typed-array@1.1.20:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  word-wrap@1.2.5: {}
+
+  yocto-queue@0.1.0: {}

--- a/scripts/healthcheck.js
+++ b/scripts/healthcheck.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
-import { spawn } from "node:child_process";
 import { LibrarianStore } from "../src/store.js";
 
 const CHECKS = [
@@ -11,7 +11,7 @@ const CHECKS = [
   { name: "SQLite rebuild", fn: checkSqliteRebuild },
   { name: "Session lifecycle", fn: checkSessionLifecycle },
   { name: "MCP stdio reachability", fn: checkMcpStdio },
-  { name: "HTTP MCP reachability + auth", fn: checkHttpMcp }
+  { name: "HTTP MCP reachability + auth", fn: checkHttpMcp },
 ];
 
 async function main() {
@@ -58,12 +58,12 @@ async function checkJsonlAppend() {
         body: "Append a memory event to events.jsonl.",
         category: "tools",
         visibility: "common",
-        scope: "tool"
+        scope: "tool",
       });
       store.startSession({
         agent_id: "healthcheck",
         title: "healthcheck session",
-        harness: "test"
+        harness: "test",
       });
     } finally {
       store.close();
@@ -88,12 +88,12 @@ async function checkSqliteRebuild() {
         body: "Survives a SQLite wipe.",
         category: "tools",
         visibility: "common",
-        scope: "tool"
+        scope: "tool",
       }).memory.id;
       sessionId = store.startSession({
         agent_id: "healthcheck",
         title: "rebuildable session",
-        harness: "test"
+        harness: "test",
       }).session.id;
     } finally {
       store.close();
@@ -108,13 +108,13 @@ async function checkSqliteRebuild() {
       if (!session) {
         throw hint(
           new Error("Session did not survive a SQLite wipe."),
-          "sessions.jsonl is not being replayed on startup."
+          "sessions.jsonl is not being replayed on startup.",
         );
       }
       if (!memory) {
         throw hint(
           new Error("Memory did not survive a SQLite wipe."),
-          "events.jsonl is not being replayed on startup."
+          "events.jsonl is not being replayed on startup.",
         );
       }
     } finally {
@@ -134,51 +134,60 @@ async function checkSessionLifecycle() {
         agent_id: "healthcheck",
         title: "lifecycle",
         harness: "test",
-        start_summary: "starting"
+        start_summary: "starting",
       });
 
       store.checkpointSession({
         agent_id: "healthcheck",
         session_id: session.id,
-        summary: "midway"
+        summary: "midway",
       });
       let reloaded = store.getSession(session.id);
       if (reloaded.rolling_summary !== "midway") {
-        throw hint(new Error("Checkpoint did not update rolling_summary."), "Lifecycle apply path is broken.");
+        throw hint(
+          new Error("Checkpoint did not update rolling_summary."),
+          "Lifecycle apply path is broken.",
+        );
       }
 
       store.pauseSession({
         agent_id: "healthcheck",
         session_id: session.id,
-        summary: "pausing"
+        summary: "pausing",
       });
       reloaded = store.getSession(session.id);
       if (reloaded.status !== "paused") {
-        throw hint(new Error("pauseSession did not transition status to paused."), "Pause event handler is broken.");
+        throw hint(
+          new Error("pauseSession did not transition status to paused."),
+          "Pause event handler is broken.",
+        );
       }
 
       store.recordSessionEvent({
         agent_id: "healthcheck",
         session_id: session.id,
         type: "note",
-        summary: "back"
+        summary: "back",
       });
       reloaded = store.getSession(session.id);
       if (reloaded.status !== "active") {
         throw hint(
           new Error("Implicit resume on activity did not fire."),
-          "recordSessionEvent should transition paused → active."
+          "recordSessionEvent should transition paused → active.",
         );
       }
 
       store.endSession({
         agent_id: "healthcheck",
         session_id: session.id,
-        summary: "done"
+        summary: "done",
       });
       reloaded = store.getSession(session.id);
       if (reloaded.status !== "ended") {
-        throw hint(new Error("endSession did not mark the session ended."), "End event handler is broken.");
+        throw hint(
+          new Error("endSession did not mark the session ended."),
+          "End event handler is broken.",
+        );
       }
       if (reloaded.end_summary !== "done") {
         throw hint(new Error("endSession did not write end_summary."), "End payload is dropped.");
@@ -196,7 +205,7 @@ async function checkMcpStdio() {
   const child = spawn(process.execPath, ["--no-warnings", "src/server.js"], {
     cwd: path.resolve("."),
     env: { ...process.env, LIBRARIAN_DATA_DIR: dir },
-    stdio: ["pipe", "pipe", "pipe"]
+    stdio: ["pipe", "pipe", "pipe"],
   });
   const messages = [];
   let stderr = "";
@@ -204,18 +213,30 @@ async function checkMcpStdio() {
   child.stderr.setEncoding("utf8");
   child.stdout.on("data", (chunk) => {
     for (const line of chunk.split("\n").filter(Boolean)) {
-      try { messages.push(JSON.parse(line)); } catch { /* ignore non-JSON */ }
+      try {
+        messages.push(JSON.parse(line));
+      } catch {
+        /* ignore non-JSON */
+      }
     }
   });
-  child.stderr.on("data", (chunk) => { stderr += chunk; });
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
 
   try {
-    child.stdin.write(JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} }) + "\n");
-    child.stdin.write(JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} }) + "\n");
+    child.stdin.write(
+      JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} }) + "\n",
+    );
+    child.stdin.write(
+      JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} }) + "\n",
+    );
 
     const deadline = Date.now() + 3000;
     while (Date.now() < deadline) {
-      const initOk = messages.some((m) => m.id === 1 && m.result?.serverInfo?.name === "the-librarian");
+      const initOk = messages.some(
+        (m) => m.id === 1 && m.result?.serverInfo?.name === "the-librarian",
+      );
       const listOk = messages.some((m) => m.id === 2 && Array.isArray(m.result?.tools));
       if (initOk && listOk) return;
       await wait(50);
@@ -223,7 +244,7 @@ async function checkMcpStdio() {
 
     throw hint(
       new Error("MCP stdio did not respond to initialize + tools/list."),
-      `src/server.js may be failing on startup. stderr:\n${stderr || "(empty)"}`
+      `src/server.js may be failing on startup. stderr:\n${stderr || "(empty)"}`,
     );
   } finally {
     child.kill("SIGTERM");
@@ -243,13 +264,15 @@ async function checkHttpMcp() {
       LIBRARIAN_HOST: "127.0.0.1",
       LIBRARIAN_PORT: String(port),
       LIBRARIAN_AUTH_TOKEN: "hc-admin-token",
-      LIBRARIAN_AGENT_TOKEN: "hc-agent-token"
+      LIBRARIAN_AGENT_TOKEN: "hc-agent-token",
     },
-    stdio: ["ignore", "ignore", "pipe"]
+    stdio: ["ignore", "ignore", "pipe"],
   });
   let stderr = "";
   child.stderr.setEncoding("utf8");
-  child.stderr.on("data", (chunk) => { stderr += chunk; });
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
 
   try {
     const url = `http://127.0.0.1:${port}`;
@@ -258,31 +281,31 @@ async function checkHttpMcp() {
     const unauthorized = await fetch(`${url}/mcp`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} })
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} }),
     });
     if (unauthorized.status !== 401) {
       throw hint(
         new Error(`Unauthorized request returned ${unauthorized.status}, expected 401.`),
-        "MCP auth is not being enforced."
+        "MCP auth is not being enforced.",
       );
     }
 
     const authorized = await fetch(`${url}/mcp`, {
       method: "POST",
       headers: { "content-type": "application/json", authorization: "Bearer hc-agent-token" },
-      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} })
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} }),
     });
     if (!authorized.ok) {
       throw hint(
         new Error(`Authorized request failed with status ${authorized.status}.`),
-        "Agent token bearer auth is broken."
+        "Agent token bearer auth is broken.",
       );
     }
     const json = await authorized.json();
     if (json.result?.serverInfo?.name !== "the-librarian") {
       throw hint(
         new Error("HTTP MCP initialize returned an unexpected payload."),
-        "Dispatch chain may not be wired correctly."
+        "Dispatch chain may not be wired correctly.",
       );
     }
   } finally {
@@ -327,12 +350,14 @@ async function waitForHttp(url, stderr) {
     try {
       const r = await fetch(url);
       if (r.ok) return;
-    } catch { /* server may not be ready yet */ }
+    } catch {
+      /* server may not be ready yet */
+    }
     await wait(100);
   }
   throw hint(
     new Error(`Timed out waiting for ${url}.`),
-    `Dashboard stderr:\n${stderr || "(empty)"}`
+    `Dashboard stderr:\n${stderr || "(empty)"}`,
   );
 }
 
@@ -359,7 +384,7 @@ function usage() {
     "  - HTTP MCP reachability + auth (src/dashboard.js)",
     "",
     "Each named check prints PASS or FAIL with a reason and a hint when it fails.",
-    "Exit 0 when every check passes, 1 otherwise."
+    "Exit 0 when every check passes, 1 otherwise.",
   ].join("\n");
 }
 

--- a/scripts/smoke-test.js
+++ b/scripts/smoke-test.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
-import { spawn } from "node:child_process";
 import { LibrarianStore } from "../src/store.js";
 
 const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-smoke-"));
@@ -19,10 +19,7 @@ try {
     scope: "global",
     priority: "core",
   });
-  assert(
-    protectedResult.status === "proposed",
-    "identity memory should be proposed",
-  );
+  assert(protectedResult.status === "proposed", "identity memory should be proposed");
 
   const lessonResult = store.createMemory({
     agent_id: "codex",
@@ -49,10 +46,7 @@ try {
     agent_id: "codex",
     task_summary: "memory policy",
   });
-  assert(
-    context.text.includes("Memory Context"),
-    "start_context should return prose",
-  );
+  assert(context.text.includes("Memory Context"), "start_context should return prose");
 
   store.close();
   await smokeMcp(tmp);
@@ -74,8 +68,7 @@ async function smokeMcp(dataDir) {
   const messages = [];
   child.stdout.setEncoding("utf8");
   child.stdout.on("data", (chunk) => {
-    for (const line of chunk.split("\n").filter(Boolean))
-      messages.push(JSON.parse(line));
+    for (const line of chunk.split("\n").filter(Boolean)) messages.push(JSON.parse(line));
   });
 
   child.stdin.write(
@@ -99,16 +92,12 @@ async function smokeMcp(dataDir) {
   child.kill("SIGTERM");
   assert(
     messages.some(
-      (message) =>
-        message.id === 1 &&
-        message.result?.serverInfo?.name === "the-librarian",
+      (message) => message.id === 1 && message.result?.serverInfo?.name === "the-librarian",
     ),
     "MCP initialize should work",
   );
   assert(
-    messages.some(
-      (message) => message.id === 2 && Array.isArray(message.result?.tools),
-    ),
+    messages.some((message) => message.id === 2 && Array.isArray(message.result?.tools)),
     "MCP tools/list should work",
   );
 }
@@ -160,10 +149,7 @@ async function smokeHttp(dataDir) {
     });
     const json = await authorized.json();
     assert(authorized.ok, "authorized HTTP MCP should succeed");
-    assert(
-      json.result?.serverInfo?.name === "the-librarian",
-      "HTTP MCP initialize should work",
-    );
+    assert(json.result?.serverInfo?.name === "the-librarian", "HTTP MCP initialize should work");
   } finally {
     child.kill("SIGTERM");
   }

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
 import fs from "node:fs";
-import { LibrarianStore } from "./store.js";
 import {
   formatSessionDetail,
   formatSessionEvents,
   formatSessionLifecycle,
   formatSessionList,
   formatSessionSearch,
-  formatSessionStart
+  formatSessionStart,
 } from "./mcp.js";
+import { LibrarianStore } from "./store.js";
 
 export function runCli(argv, store) {
   const [command, ...rest] = argv;
@@ -25,7 +25,7 @@ export function runCli(argv, store) {
     store.rebuildIndex();
     return {
       stdout: `Rebuilt projection from ${store.eventsPath} and ${store.sessionsPath}`,
-      exitCode: 0
+      exitCode: 0,
     };
   }
 
@@ -33,7 +33,7 @@ export function runCli(argv, store) {
     seed(store);
     return {
       stdout: `Seeded sample proposal and operating memory in ${store.dataDir}`,
-      exitCode: 0
+      exitCode: 0,
     };
   }
 
@@ -54,7 +54,8 @@ function runSessionsCommand(args, store) {
     if (verb === "start") return cmdSessionsStart(store, flags);
     if (verb === "list") return cmdSessionsList(store, flags);
     if (verb === "show") return cmdSessionsShow(store, positionals[0], flags);
-    if (verb === "checkpoint") return cmdSessionsLifecycle(store, "checkpoint", positionals[0], flags);
+    if (verb === "checkpoint")
+      return cmdSessionsLifecycle(store, "checkpoint", positionals[0], flags);
     if (verb === "pause") return cmdSessionsLifecycle(store, "pause", positionals[0], flags);
     if (verb === "end") return cmdSessionsLifecycle(store, "end", positionals[0], flags);
     if (verb === "attach") return cmdSessionsAttach(store, positionals[0], flags);
@@ -73,9 +74,7 @@ function runSessionsCommand(args, store) {
 }
 
 function cmdSessionsStart(store, flags) {
-  const visibility = flags.private
-    ? "agent_private"
-    : flags.visibility || "common";
+  const visibility = flags.private ? "agent_private" : flags.visibility || "common";
   const result = store.startSession({
     agent_id: callerAgent(flags),
     title: flags.title,
@@ -87,7 +86,7 @@ function cmdSessionsStart(store, flags) {
     visibility,
     start_summary: flags["start-summary"],
     tags: collectArray(flags.tag),
-    next_steps: collectArray(flags["next-step"])
+    next_steps: collectArray(flags["next-step"]),
   });
 
   if (flags.json) {
@@ -107,7 +106,7 @@ function cmdSessionsList(store, flags) {
     status: collectArray(flags.status),
     include_archived: flags["include-archived"] === true,
     include_deleted: flags["include-deleted"] === true,
-    limit: parseNumber(flags.limit)
+    limit: parseNumber(flags.limit),
   });
 
   if (flags.json) {
@@ -138,7 +137,7 @@ function cmdSessionsLifecycle(store, verb, sessionId, flags) {
   if (summary == null) {
     return {
       stdout: `Provide --summary "<text>" or --summary-file <path> for ${verb}.`,
-      exitCode: 1
+      exitCode: 1,
     };
   }
   const input = {
@@ -150,18 +149,22 @@ function cmdSessionsLifecycle(store, verb, sessionId, flags) {
     files_touched: collectArray(flags.file),
     commands_run: collectArray(flags.command),
     open_questions: collectArray(flags.question),
-    next_steps: collectArray(flags["next-step"])
+    next_steps: collectArray(flags["next-step"]),
   };
-  const method = verb === "checkpoint"
-    ? store.checkpointSession.bind(store)
-    : verb === "pause"
-      ? store.pauseSession.bind(store)
-      : store.endSession.bind(store);
+  const method =
+    verb === "checkpoint"
+      ? store.checkpointSession.bind(store)
+      : verb === "pause"
+        ? store.pauseSession.bind(store)
+        : store.endSession.bind(store);
   const result = method(input);
   if (flags.json) return { stdout: JSON.stringify(result, null, 2), exitCode: 0 };
-  const headline = verb === "checkpoint"
-    ? "Checkpoint recorded."
-    : verb === "pause" ? "Session paused." : "Session ended.";
+  const headline =
+    verb === "checkpoint"
+      ? "Checkpoint recorded."
+      : verb === "pause"
+        ? "Session paused."
+        : "Session ended.";
   return { stdout: formatSessionLifecycle(result.session, headline), exitCode: 0 };
 }
 
@@ -175,15 +178,15 @@ function cmdSessionsAttach(store, sessionId, flags) {
     session_id: sessionId,
     harness: flags.harness,
     source_ref: flags["source-ref"],
-    cwd: flags.cwd
+    cwd: flags.cwd,
   });
   if (flags.json) return { stdout: JSON.stringify(result, null, 2), exitCode: 0 };
   return {
     stdout: formatSessionLifecycle(
       result.session,
-      `Attached to ${result.session.current_harness || "(unspecified harness)"}.`
+      `Attached to ${result.session.current_harness || "(unspecified harness)"}.`,
     ),
-    exitCode: 0
+    exitCode: 0,
   };
 }
 
@@ -200,7 +203,7 @@ function cmdSessionsContinue(store, sessionId, flags) {
     target_source_ref: flags["target-source-ref"],
     target_cwd: flags["target-cwd"],
     attach,
-    format: flags.format
+    format: flags.format,
   });
   if (flags.json) return { stdout: JSON.stringify(result, null, 2), exitCode: 0 };
   return { stdout: result.text, exitCode: 0 };
@@ -214,7 +217,7 @@ function cmdSessionsArchive(store, sessionId, flags) {
     agent_id: callerAgent(flags),
     admin: flags.admin === true,
     session_id: sessionId,
-    reason: flags.reason
+    reason: flags.reason,
   });
   if (flags.json) return { stdout: JSON.stringify(result, null, 2), exitCode: 0 };
   return { stdout: formatSessionLifecycle(result.session, "Session archived."), exitCode: 0 };
@@ -227,12 +230,12 @@ function cmdSessionsRestore(store, sessionId, flags) {
   const result = store.restoreSession({
     agent_id: callerAgent(flags),
     admin: flags.admin === true,
-    session_id: sessionId
+    session_id: sessionId,
   });
   if (flags.json) return { stdout: JSON.stringify(result, null, 2), exitCode: 0 };
   return {
     stdout: formatSessionLifecycle(result.session, `Session restored to ${result.session.status}.`),
-    exitCode: 0
+    exitCode: 0,
   };
 }
 
@@ -244,7 +247,7 @@ function cmdSessionsDelete(store, sessionId, flags) {
     agent_id: callerAgent(flags),
     admin: flags.admin === true,
     session_id: sessionId,
-    reason: flags.reason
+    reason: flags.reason,
   });
   if (flags.json) return { stdout: JSON.stringify(result, null, 2), exitCode: 0 };
   return { stdout: formatSessionLifecycle(result.session, "Session deleted."), exitCode: 0 };
@@ -261,7 +264,7 @@ function cmdSessionsSearch(store, query, flags) {
     project_key: flags.project,
     include_archived: flags["include-archived"] === true,
     include_deleted: flags["include-deleted"] === true,
-    limit: parseNumber(flags.limit)
+    limit: parseNumber(flags.limit),
   });
   if (flags.json) return { stdout: JSON.stringify(result, null, 2), exitCode: 0 };
   return { stdout: formatSessionSearch(result), exitCode: 0 };
@@ -279,7 +282,7 @@ function cmdSessionsEvents(store, sessionId, flags) {
     session_id: sessionId,
     type: flags.type,
     limit: parseNumber(flags.limit),
-    offset: parseNumber(flags.offset)
+    offset: parseNumber(flags.offset),
   });
   if (flags.json) return { stdout: JSON.stringify(result, null, 2), exitCode: 0 };
   return { stdout: formatSessionEvents(result, session), exitCode: 0 };
@@ -349,7 +352,7 @@ function usage() {
     "Commands:",
     "  rebuild                       Replay events.jsonl and sessions.jsonl into the SQLite projection",
     "  seed                          Seed sample memories (no-op if any exist)",
-    "  sessions <verb>               Manage Librarian sessions (see 'sessions help')"
+    "  sessions <verb>               Manage Librarian sessions (see 'sessions help')",
   ].join("\n");
 }
 
@@ -382,7 +385,7 @@ function sessionsUsage() {
     "  --json                        Emit JSON instead of prose",
     "  --format <name>               continue: prose|markdown|claude|codex|opencode|hermes|pi",
     "  --summary-file <path>         checkpoint/pause/end: read summary from a file",
-    "  --no-attach                   continue: skip attachment (preview only)"
+    "  --no-attach                   continue: skip attachment (preview only)",
   ].join("\n");
 }
 
@@ -399,7 +402,7 @@ function seed(target) {
     scope: "tool",
     priority: "high",
     confidence: "strong",
-    tags: ["librarian", "policy"]
+    tags: ["librarian", "policy"],
   });
 
   target.createMemory({
@@ -411,7 +414,7 @@ function seed(target) {
     scope: "global",
     priority: "core",
     confidence: "working",
-    tags: ["identity", "protected"]
+    tags: ["identity", "protected"],
   });
 }
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -7,7 +7,7 @@ export const CATEGORIES = [
   "tools",
   "lessons",
   "people",
-  "open_threads"
+  "open_threads",
 ];
 
 export const PROTECTED_CATEGORIES = new Set(["identity", "relationship"]);
@@ -30,7 +30,7 @@ export const SESSION_EVENT_TYPES = [
   "session.archived",
   "session.restored",
   "session.deleted",
-  "session.promoted_to_memory"
+  "session.promoted_to_memory",
 ];
 export const SESSION_PAYLOAD_TYPES = [
   "message",
@@ -41,7 +41,7 @@ export const SESSION_PAYLOAD_TYPES = [
   "question",
   "checkpoint",
   "handover",
-  "note"
+  "note",
 ];
 
 export const DEFAULT_AGENT_ID = "unknown-agent";
@@ -87,7 +87,7 @@ export function normalizeMemoryInput(input = {}) {
     priority: normalizeEnum(input.priority, PRIORITIES, "normal"),
     confidence: normalizeEnum(input.confidence, CONFIDENCES, "working"),
     tags: asArray(input.tags),
-    status: normalizeEnum(input.status, STATUSES, "active")
+    status: normalizeEnum(input.status, STATUSES, "active"),
   };
 }
 

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -1,39 +1,24 @@
 #!/usr/bin/env node
-import http from "node:http";
+import { timingSafeEqual as cryptoTimingSafeEqual } from "node:crypto";
 import fs from "node:fs";
+import http from "node:http";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { timingSafeEqual as cryptoTimingSafeEqual } from "node:crypto";
-import { LibrarianStore } from "./store.js";
 import { DEFAULT_AGENT_ID } from "./constants.js";
 import { handleMcpPayload } from "./mcp.js";
+import { LibrarianStore } from "./store.js";
 
 const store = new LibrarianStore();
-const host =
-  process.env.LIBRARIAN_HOST ||
-  process.env.LIBRARIAN_DASHBOARD_HOST ||
-  "127.0.0.1";
-const port = Number(
-  process.env.LIBRARIAN_PORT || process.env.LIBRARIAN_DASHBOARD_PORT || 3838,
-);
-const adminToken =
-  process.env.LIBRARIAN_ADMIN_TOKEN || process.env.LIBRARIAN_AUTH_TOKEN || "";
+const host = process.env.LIBRARIAN_HOST || process.env.LIBRARIAN_DASHBOARD_HOST || "127.0.0.1";
+const port = Number(process.env.LIBRARIAN_PORT || process.env.LIBRARIAN_DASHBOARD_PORT || 3838);
+const adminToken = process.env.LIBRARIAN_ADMIN_TOKEN || process.env.LIBRARIAN_AUTH_TOKEN || "";
 const agentToken = process.env.LIBRARIAN_AGENT_TOKEN || "";
-const agentTokenMap = parseAgentTokenMap(
-  process.env.LIBRARIAN_AGENT_TOKENS || "",
-);
+const agentTokenMap = parseAgentTokenMap(process.env.LIBRARIAN_AGENT_TOKENS || "");
 const allowedOrigins = parseCsv(process.env.LIBRARIAN_ALLOWED_ORIGINS || "");
 const allowNoAuth =
-  process.env.LIBRARIAN_ALLOW_NO_AUTH === "true" ||
-  host === "127.0.0.1" ||
-  host === "localhost";
-const maxBodyBytes = Number(
-  process.env.LIBRARIAN_MAX_BODY_BYTES || 1024 * 1024,
-);
-const publicDir = path.resolve(
-  path.dirname(fileURLToPath(import.meta.url)),
-  "../public",
-);
+  process.env.LIBRARIAN_ALLOW_NO_AUTH === "true" || host === "127.0.0.1" || host === "localhost";
+const maxBodyBytes = Number(process.env.LIBRARIAN_MAX_BODY_BYTES || 1024 * 1024);
+const publicDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../public");
 
 if (!adminToken && !allowNoAuth) {
   console.error(
@@ -49,10 +34,7 @@ if (adminToken && agentToken && adminToken === agentToken) {
   process.exit(1);
 }
 
-if (
-  adminToken &&
-  [...agentTokenMap.values()].some((token) => token === adminToken)
-) {
+if (adminToken && [...agentTokenMap.values()].some((token) => token === adminToken)) {
   console.error(
     "Refusing to start because LIBRARIAN_ADMIN_TOKEN must not match any LIBRARIAN_AGENT_TOKENS entry.",
   );
@@ -85,8 +67,7 @@ const server = http.createServer(async (req, res) => {
       });
     }
 
-    if (!isAllowedOrigin(req))
-      return sendJson(res, { error: "Origin not allowed" }, 403);
+    if (!isAllowedOrigin(req)) return sendJson(res, { error: "Origin not allowed" }, 403);
 
     if (url.pathname === "/mcp") {
       const auth = authenticateMcp(req);
@@ -98,8 +79,7 @@ const server = http.createServer(async (req, res) => {
           message: "POST JSON-RPC MCP messages to this endpoint.",
         });
       }
-      if (req.method !== "POST")
-        return sendJson(res, { error: "Method not allowed" }, 405);
+      if (req.method !== "POST") return sendJson(res, { error: "Method not allowed" }, 405);
       const payload = await readJson(req);
       const response = await handleMcpPayload(store, payload, {
         role: auth.role,
@@ -141,17 +121,17 @@ const server = http.createServer(async (req, res) => {
 
     if (req.method === "GET" && url.pathname === "/api/memories") {
       const result = store.listMemories({
-        status:      url.searchParams.get("status")      || "",
-        agent_id:    url.searchParams.get("agent_id")    || "",
+        status: url.searchParams.get("status") || "",
+        agent_id: url.searchParams.get("agent_id") || "",
         project_key: url.searchParams.get("project_key") || "",
-        category:    url.searchParams.get("category")    || "",
-        visibility:  url.searchParams.get("visibility")  || "",
-        scope:       url.searchParams.get("scope")       || "",
-        from:        url.searchParams.get("from")        || "",
-        to:          url.searchParams.get("to")          || "",
-        sort:        url.searchParams.get("sort")        || "updated_at",
-        order:       url.searchParams.get("order")       || "desc",
-        limit:  Number(url.searchParams.get("limit")  || 100),
+        category: url.searchParams.get("category") || "",
+        visibility: url.searchParams.get("visibility") || "",
+        scope: url.searchParams.get("scope") || "",
+        from: url.searchParams.get("from") || "",
+        to: url.searchParams.get("to") || "",
+        sort: url.searchParams.get("sort") || "updated_at",
+        order: url.searchParams.get("order") || "desc",
+        limit: Number(url.searchParams.get("limit") || 100),
         offset: Number(url.searchParams.get("offset") || 0),
       });
       return sendJson(res, result);
@@ -178,36 +158,24 @@ const server = http.createServer(async (req, res) => {
       return sendJson(res, result);
     }
 
-    const updateMatch = url.pathname.match(
-      /^\/api\/memories\/([^/]+)\/update$/,
-    );
+    const updateMatch = url.pathname.match(/^\/api\/memories\/([^/]+)\/update$/);
     if (req.method === "POST" && updateMatch) {
       const body = await readJson(req);
       return sendJson(
         res,
-        store.updateMemory(
-          updateMatch[1],
-          body.patch || body,
-          body.agent_id || "dashboard",
-          { allowProtected: true },
-        ),
+        store.updateMemory(updateMatch[1], body.patch || body, body.agent_id || "dashboard", {
+          allowProtected: true,
+        }),
       );
     }
 
-    const deleteMatch = url.pathname.match(
-      /^\/api\/memories\/([^/]+)\/delete$/,
-    );
+    const deleteMatch = url.pathname.match(/^\/api\/memories\/([^/]+)\/delete$/);
     if (req.method === "POST" && deleteMatch) {
       const body = await readJson(req);
-      return sendJson(
-        res,
-        store.deleteMemory(deleteMatch[1], body.agent_id || "dashboard"),
-      );
+      return sendJson(res, store.deleteMemory(deleteMatch[1], body.agent_id || "dashboard"));
     }
 
-    const approveMatch = url.pathname.match(
-      /^\/api\/proposals\/([^/]+)\/approve$/,
-    );
+    const approveMatch = url.pathname.match(/^\/api\/proposals\/([^/]+)\/approve$/);
     if (req.method === "POST" && approveMatch) {
       const body = await readJson(req);
       return sendJson(
@@ -221,19 +189,12 @@ const server = http.createServer(async (req, res) => {
       );
     }
 
-    const rejectMatch = url.pathname.match(
-      /^\/api\/proposals\/([^/]+)\/reject$/,
-    );
+    const rejectMatch = url.pathname.match(/^\/api\/proposals\/([^/]+)\/reject$/);
     if (req.method === "POST" && rejectMatch) {
       const body = await readJson(req);
       return sendJson(
         res,
-        store.approveProposal(
-          rejectMatch[1],
-          "reject",
-          {},
-          body.agent_id || "dashboard",
-        ),
+        store.approveProposal(rejectMatch[1], "reject", {}, body.agent_id || "dashboard"),
       );
     }
 
@@ -247,7 +208,7 @@ const server = http.createServer(async (req, res) => {
         status: url.searchParams.getAll("status"),
         include_archived: url.searchParams.get("include_archived") === "true",
         include_deleted: url.searchParams.get("include_deleted") === "true",
-        limit: url.searchParams.get("limit") ? Number(url.searchParams.get("limit")) : undefined
+        limit: url.searchParams.get("limit") ? Number(url.searchParams.get("limit")) : undefined,
       });
       return sendJson(res, result);
     }
@@ -267,7 +228,7 @@ const server = http.createServer(async (req, res) => {
         session_id: sessionEventsMatch[1],
         type: url.searchParams.get("type") || "",
         limit: url.searchParams.get("limit") ? Number(url.searchParams.get("limit")) : undefined,
-        offset: url.searchParams.get("offset") ? Number(url.searchParams.get("offset")) : undefined
+        offset: url.searchParams.get("offset") ? Number(url.searchParams.get("offset")) : undefined,
       });
       return sendJson(res, result);
     }
@@ -280,13 +241,13 @@ const server = http.createServer(async (req, res) => {
         project_key: body.project_key || "",
         include_archived: body.include_archived === true,
         include_deleted: body.include_deleted === true,
-        limit: body.limit ? Number(body.limit) : undefined
+        limit: body.limit ? Number(body.limit) : undefined,
       });
       return sendJson(res, result);
     }
 
     const sessionActionMatch = url.pathname.match(
-      /^\/api\/sessions\/([^/]+)\/(checkpoint|pause|end|archive|restore|delete|continue|promote)$/
+      /^\/api\/sessions\/([^/]+)\/(checkpoint|pause|end|archive|restore|delete|continue|promote)$/,
     );
     if (req.method === "POST" && sessionActionMatch) {
       const sessionId = sessionActionMatch[1];
@@ -298,7 +259,7 @@ const server = http.createServer(async (req, res) => {
         ...body,
         session_id: sessionId,
         agent_id: body.agent_id || "dashboard",
-        admin: true
+        admin: true,
       };
       if (action === "checkpoint") return sendJson(res, store.checkpointSession(base));
       if (action === "pause") return sendJson(res, store.pauseSession(base));
@@ -320,11 +281,7 @@ const server = http.createServer(async (req, res) => {
         include_private: body.include_private !== false,
         limit: Number(body.limit || 12),
       });
-      store.recordRecall(
-        memories,
-        body.agent_id || DEFAULT_AGENT_ID,
-        body.query || "",
-      );
+      store.recordRecall(memories, body.agent_id || DEFAULT_AGENT_ID, body.query || "");
       return sendJson(res, { memories });
     }
 
@@ -335,9 +292,7 @@ const server = http.createServer(async (req, res) => {
 });
 
 server.listen(port, host, () => {
-  console.error(
-    `The Librarian HTTP service is running at http://${host}:${port}`,
-  );
+  console.error(`The Librarian HTTP service is running at http://${host}:${port}`);
   console.error(`Dashboard: http://${host}:${port}/`);
   console.error(`MCP endpoint: http://${host}:${port}/mcp`);
 });
@@ -407,11 +362,9 @@ function authenticateMcp(req) {
   if (header.startsWith("Bearer ")) {
     const token = header.slice("Bearer ".length);
     for (const [agentId, mappedToken] of agentTokenMap) {
-      if (timingSafeEqual(token, mappedToken))
-        return { role: "agent", agentId };
+      if (timingSafeEqual(token, mappedToken)) return { role: "agent", agentId };
     }
-    if (agentToken && timingSafeEqual(token, agentToken))
-      return { role: "agent" };
+    if (agentToken && timingSafeEqual(token, agentToken)) return { role: "agent" };
     if (timingSafeEqual(token, adminToken)) return { role: "admin" };
     return null;
   }
@@ -466,9 +419,7 @@ function parseAgentTokenMap(value) {
     const agentId = entry.slice(0, separator).trim();
     const token = entry.slice(separator + 1).trim();
     if (map.has(agentId)) {
-      console.error(
-        `Duplicate LIBRARIAN_AGENT_TOKENS entry for agent ${agentId}.`,
-      );
+      console.error(`Duplicate LIBRARIAN_AGENT_TOKENS entry for agent ${agentId}.`);
       process.exit(1);
     }
     if (seenTokens.has(token)) {

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -1,5 +1,5 @@
-import { formatRecall } from "./store.js";
 import { DEFAULT_AGENT_ID, SESSION_PAYLOAD_TYPES } from "./constants.js";
+import { formatRecall } from "./store.js";
 
 export const tools = [
   {
@@ -10,9 +10,9 @@ export const tools = [
       properties: {
         agent_id: { type: "string" },
         project_key: { type: "string" },
-        task_summary: { type: "string" }
-      }
-    }
+        task_summary: { type: "string" },
+      },
+    },
   },
   {
     name: "recall",
@@ -25,19 +25,19 @@ export const tools = [
         categories: { type: "array", items: { type: "string" } },
         project_key: { type: "string" },
         include_private: { type: "boolean" },
-        limit: { type: "number" }
-      }
-    }
+        limit: { type: "number" },
+      },
+    },
   },
   {
     name: "remember",
     description: "Save a durable memory. Protected categories become proposals.",
-    inputSchema: memoryInputSchema()
+    inputSchema: memoryInputSchema(),
   },
   {
     name: "propose_memory",
     description: "Create a proposed memory for review.",
-    inputSchema: memoryInputSchema()
+    inputSchema: memoryInputSchema(),
   },
   {
     name: "update_memory",
@@ -48,9 +48,9 @@ export const tools = [
       properties: {
         agent_id: { type: "string" },
         memory_id: { type: "string" },
-        patch: { type: "object" }
-      }
-    }
+        patch: { type: "object" },
+      },
+    },
   },
   {
     name: "delete_memory",
@@ -60,9 +60,9 @@ export const tools = [
       required: ["memory_id"],
       properties: {
         agent_id: { type: "string" },
-        memory_id: { type: "string" }
-      }
-    }
+        memory_id: { type: "string" },
+      },
+    },
   },
   {
     name: "verify_memory",
@@ -74,9 +74,9 @@ export const tools = [
         agent_id: { type: "string" },
         memory_id: { type: "string" },
         result: { type: "string", enum: ["useful", "not_useful", "outdated", "wrong"] },
-        note: { type: "string" }
-      }
-    }
+        note: { type: "string" },
+      },
+    },
   },
   {
     name: "list_proposals",
@@ -84,9 +84,9 @@ export const tools = [
     inputSchema: {
       type: "object",
       properties: {
-        agent_id: { type: "string" }
-      }
-    }
+        agent_id: { type: "string" },
+      },
+    },
   },
   {
     name: "approve_proposal",
@@ -98,9 +98,9 @@ export const tools = [
         agent_id: { type: "string" },
         memory_id: { type: "string" },
         action: { type: "string", enum: ["approve", "reject"] },
-        patch: { type: "object" }
-      }
-    }
+        patch: { type: "object" },
+      },
+    },
   },
   {
     name: "resolve_conflict",
@@ -113,9 +113,9 @@ export const tools = [
         memory_ids: { type: "array", items: { type: "string" } },
         resolution: { type: "string", enum: ["supersede", "keep_both", "archive", "edit"] },
         explanation: { type: "string" },
-        patch: { type: "object" }
-      }
-    }
+        patch: { type: "object" },
+      },
+    },
   },
   {
     name: "start_session",
@@ -132,9 +132,9 @@ export const tools = [
         capture_mode: { type: "string", enum: ["off", "summary", "log"] },
         start_summary: { type: "string" },
         tags: { type: "array", items: { type: "string" } },
-        next_steps: { type: "array", items: { type: "string" } }
-      }
-    }
+        next_steps: { type: "array", items: { type: "string" } },
+      },
+    },
   },
   {
     name: "get_session",
@@ -143,9 +143,9 @@ export const tools = [
       type: "object",
       required: ["session_id"],
       properties: {
-        session_id: { type: "string" }
-      }
-    }
+        session_id: { type: "string" },
+      },
+    },
   },
   {
     name: "list_sessions",
@@ -160,9 +160,9 @@ export const tools = [
         status: { type: "array", items: { type: "string" } },
         include_archived: { type: "boolean" },
         include_deleted: { type: "boolean" },
-        limit: { type: "number" }
-      }
-    }
+        limit: { type: "number" },
+      },
+    },
   },
   {
     name: "list_session_events",
@@ -174,9 +174,9 @@ export const tools = [
         session_id: { type: "string" },
         type: { type: "string", enum: SESSION_PAYLOAD_TYPES },
         limit: { type: "number" },
-        offset: { type: "number" }
-      }
-    }
+        offset: { type: "number" },
+      },
+    },
   },
   {
     name: "search_sessions",
@@ -189,13 +189,14 @@ export const tools = [
         project_key: { type: "string" },
         include_archived: { type: "boolean" },
         include_deleted: { type: "boolean" },
-        limit: { type: "number" }
-      }
-    }
+        limit: { type: "number" },
+      },
+    },
   },
   {
     name: "record_session_event",
-    description: "Record a typed evidence event on a visible session. Implicitly resumes a paused session.",
+    description:
+      "Record a typed evidence event on a visible session. Implicitly resumes a paused session.",
     inputSchema: {
       type: "object",
       required: ["session_id", "type", "summary"],
@@ -205,34 +206,37 @@ export const tools = [
         summary: { type: "string" },
         payload: { type: "object" },
         harness: { type: "string" },
-        source_ref: { type: "string" }
-      }
-    }
+        source_ref: { type: "string" },
+      },
+    },
   },
   {
     name: "checkpoint_session",
     description: "Update the rolling summary, decisions, and next steps. Keeps the session active.",
-    inputSchema: sessionLifecycleSchema()
+    inputSchema: sessionLifecycleSchema(),
   },
   {
     name: "pause_session",
-    description: "Mark the session paused and store a pause summary. Activity resumes it implicitly.",
-    inputSchema: sessionLifecycleSchema()
+    description:
+      "Mark the session paused and store a pause summary. Activity resumes it implicitly.",
+    inputSchema: sessionLifecycleSchema(),
   },
   {
     name: "end_session",
-    description: "Mark the session ended. Writes end_summary; rolling_summary is frozen at the last checkpoint.",
+    description:
+      "Mark the session ended. Writes end_summary; rolling_summary is frozen at the last checkpoint.",
     inputSchema: {
       ...sessionLifecycleSchema(),
       properties: {
         ...sessionLifecycleSchema().properties,
-        candidate_memories: { type: "array", items: { type: "object" } }
-      }
-    }
+        candidate_memories: { type: "array", items: { type: "object" } },
+      },
+    },
   },
   {
     name: "attach_session",
-    description: "Record attachment of a session to the calling harness/source without generating a handover.",
+    description:
+      "Record attachment of a session to the calling harness/source without generating a handover.",
     inputSchema: {
       type: "object",
       required: ["session_id"],
@@ -240,13 +244,14 @@ export const tools = [
         session_id: { type: "string" },
         harness: { type: "string" },
         source_ref: { type: "string" },
-        cwd: { type: "string" }
-      }
-    }
+        cwd: { type: "string" },
+      },
+    },
   },
   {
     name: "continue_session",
-    description: "Generate a handover package for the session and (by default) attach to the target harness.",
+    description:
+      "Generate a handover package for the session and (by default) attach to the target harness.",
     inputSchema: {
       type: "object",
       required: ["session_id"],
@@ -256,58 +261,65 @@ export const tools = [
         target_source_ref: { type: "string" },
         target_cwd: { type: "string" },
         attach: { type: "boolean" },
-        format: { type: "string", enum: ["prose", "markdown", "claude", "codex", "opencode", "hermes", "pi"] }
-      }
-    }
+        format: {
+          type: "string",
+          enum: ["prose", "markdown", "claude", "codex", "opencode", "hermes", "pi"],
+        },
+      },
+    },
   },
   {
     name: "archive_session",
-    description: "Hide a session from default lists while keeping it searchable via include_archived.",
+    description:
+      "Hide a session from default lists while keeping it searchable via include_archived.",
     inputSchema: {
       type: "object",
       required: ["session_id"],
       properties: {
         session_id: { type: "string" },
-        reason: { type: "string" }
-      }
-    }
+        reason: { type: "string" },
+      },
+    },
   },
   {
     name: "restore_session",
-    description: "Restore an archived or soft-deleted session to its prior status. Owner-or-admin only.",
-    inputSchema: {
-      type: "object",
-      required: ["session_id"],
-      properties: {
-        session_id: { type: "string" }
-      }
-    }
-  },
-  {
-    name: "delete_session",
-    description: "Soft-delete a session. Owner may delete their own sessions; admin may delete any.",
+    description:
+      "Restore an archived or soft-deleted session to its prior status. Owner-or-admin only.",
     inputSchema: {
       type: "object",
       required: ["session_id"],
       properties: {
         session_id: { type: "string" },
-        reason: { type: "string" }
-      }
-    }
+      },
+    },
+  },
+  {
+    name: "delete_session",
+    description:
+      "Soft-delete a session. Owner may delete their own sessions; admin may delete any.",
+    inputSchema: {
+      type: "object",
+      required: ["session_id"],
+      properties: {
+        session_id: { type: "string" },
+        reason: { type: "string" },
+      },
+    },
   },
   {
     name: "promote_session_fact",
-    description: "Promote a fact from a visible session into a durable memory (or proposal for protected categories).",
+    description:
+      "Promote a fact from a visible session into a durable memory (or proposal for protected categories).",
     inputSchema: {
       type: "object",
       required: ["session_id", "memory"],
       properties: {
         session_id: { type: "string" },
         session_event_id: { type: "string" },
-        memory: { type: "object" }
-      }
-    }
-  }
+        memory: { type: "object" },
+      },
+    },
+  },
 ];
 
 const ADMIN_TOOL_NAMES = new Set(["approve_proposal", "delete_memory", "resolve_conflict"]);
@@ -319,30 +331,31 @@ export async function dispatchMcp(store, method, params = {}, context = {}) {
       protocolVersion: params.protocolVersion || "2025-06-18",
       capabilities: {
         tools: {},
-        resources: {}
+        resources: {},
       },
       serverInfo: {
         name: "the-librarian",
-        version: "0.1.0"
-      }
+        version: "0.1.0",
+      },
     };
   }
 
   if (method === "tools/list") return { tools: toolsForRole(role) };
   if (method === "tools/call") return callTool(store, params.name, params.arguments || {}, context);
   if (method === "resources/list") {
-    const description = role === "admin"
-      ? "Human-readable memory snapshot."
-      : "Human-readable common memory snapshot.";
+    const description =
+      role === "admin"
+        ? "Human-readable memory snapshot."
+        : "Human-readable common memory snapshot.";
     return {
       resources: [
         {
           uri: "librarian://memories",
           name: "The Librarian Memories",
           description,
-          mimeType: "text/markdown"
-        }
-      ]
+          mimeType: "text/markdown",
+        },
+      ],
     };
   }
   if (method === "resources/read" && params.uri === "librarian://memories") {
@@ -352,9 +365,9 @@ export async function dispatchMcp(store, method, params = {}, context = {}) {
         {
           uri: "librarian://memories",
           mimeType: "text/markdown",
-          text: formatRecall(memories, "The Librarian Memories")
-        }
-      ]
+          text: formatRecall(memories, "The Librarian Memories"),
+        },
+      ],
     };
   }
 
@@ -410,9 +423,10 @@ function callTool(store, name, args, context = {}) {
     if (result.status === "conflict") {
       return textResult(formatConflict(result));
     }
-    const suffix = result.status === "proposed"
-      ? "This memory is protected and has been saved as a proposal for review."
-      : "Memory saved.";
+    const suffix =
+      result.status === "proposed"
+        ? "This memory is protected and has been saved as a proposal for review."
+        : "Memory saved.";
     const duplicateText = result.duplicates?.length
       ? `\n\nPossible duplicates:\n${result.duplicates.map((memory) => `- ${memory.title}: ${memory.body}`).join("\n")}`
       : "";
@@ -420,22 +434,37 @@ function callTool(store, name, args, context = {}) {
   }
 
   if (name === "propose_memory") {
-    const result = store.createMemory({ ...scopedArgs, status: "proposed" }, { status: "proposed" });
+    const result = store.createMemory(
+      { ...scopedArgs, status: "proposed" },
+      { status: "proposed" },
+    );
     return textResult(`Memory proposal saved.\n\n${result.memory.title}: ${result.memory.body}`);
   }
 
   if (name === "update_memory") {
-    const memory = store.updateMemory(scopedArgs.memory_id, scopedArgs.patch || {}, scopedArgs.agent_id || DEFAULT_AGENT_ID);
+    const memory = store.updateMemory(
+      scopedArgs.memory_id,
+      scopedArgs.patch || {},
+      scopedArgs.agent_id || DEFAULT_AGENT_ID,
+    );
     return textResult(`Memory updated.\n\n${memory.title}: ${memory.body}`);
   }
 
   if (name === "delete_memory") {
-    const memory = store.deleteMemory(scopedArgs.memory_id, scopedArgs.agent_id || DEFAULT_AGENT_ID);
+    const memory = store.deleteMemory(
+      scopedArgs.memory_id,
+      scopedArgs.agent_id || DEFAULT_AGENT_ID,
+    );
     return textResult(`Memory deleted.\n\n${memory.title}`);
   }
 
   if (name === "verify_memory") {
-    const memory = store.verifyMemory(scopedArgs.memory_id, scopedArgs.result, scopedArgs.note || "", scopedArgs.agent_id || DEFAULT_AGENT_ID);
+    const memory = store.verifyMemory(
+      scopedArgs.memory_id,
+      scopedArgs.result,
+      scopedArgs.note || "",
+      scopedArgs.agent_id || DEFAULT_AGENT_ID,
+    );
     return textResult(`Memory verification recorded.\n\n${memory.title}`);
   }
 
@@ -449,9 +478,11 @@ function callTool(store, name, args, context = {}) {
       scopedArgs.memory_id,
       scopedArgs.action || "approve",
       scopedArgs.patch || {},
-      scopedArgs.agent_id || DEFAULT_AGENT_ID
+      scopedArgs.agent_id || DEFAULT_AGENT_ID,
     );
-    return textResult(`Proposal ${scopedArgs.action === "reject" ? "rejected" : "approved"}.\n\n${memory.title}: ${memory.body}`);
+    return textResult(
+      `Proposal ${scopedArgs.action === "reject" ? "rejected" : "approved"}.\n\n${memory.title}: ${memory.body}`,
+    );
   }
 
   if (name === "resolve_conflict") {
@@ -521,7 +552,12 @@ function callTool(store, name, args, context = {}) {
     }
     if (name === "attach_session") {
       const result = store.attachSession(scopedArgs);
-      return textResult(formatSessionLifecycle(result.session, `Attached to ${result.session.current_harness || "(unspecified harness)"}.`));
+      return textResult(
+        formatSessionLifecycle(
+          result.session,
+          `Attached to ${result.session.current_harness || "(unspecified harness)"}.`,
+        ),
+      );
     }
     if (name === "continue_session") {
       const result = store.continueSession(scopedArgs);
@@ -538,9 +574,10 @@ function callTool(store, name, args, context = {}) {
     if (result.status === "conflict") {
       return textResult(formatPromotionConflict(result));
     }
-    const headline = result.status === "proposed"
-      ? "Promoted to memory proposal (awaiting review)."
-      : "Promoted to active memory.";
+    const headline =
+      result.status === "proposed"
+        ? "Promoted to memory proposal (awaiting review)."
+        : "Promoted to active memory.";
     return textResult(`${headline}\n\n${result.memory.title}: ${result.memory.body}`);
   }
 
@@ -555,7 +592,9 @@ function callTool(store, name, args, context = {}) {
     }
     if (name === "restore_session") {
       const result = store.restoreSession(scopedArgs);
-      return textResult(formatSessionLifecycle(result.session, `Session restored to ${result.session.status}.`));
+      return textResult(
+        formatSessionLifecycle(result.session, `Session restored to ${result.session.status}.`),
+      );
     }
     if (name === "delete_session") {
       const result = store.deleteSession(scopedArgs);
@@ -586,7 +625,11 @@ function isSessionVisible(session, context = {}) {
   if (!session) return false;
   if (context.role === "admin") return true;
   if (session.visibility === "common") return true;
-  if (context.role === "agent" && context.agentId && session.created_by_agent_id === context.agentId) {
+  if (
+    context.role === "agent" &&
+    context.agentId &&
+    session.created_by_agent_id === context.agentId
+  ) {
     return true;
   }
   return false;
@@ -594,7 +637,8 @@ function isSessionVisible(session, context = {}) {
 
 function visibleResourceMemories(store, context = {}) {
   const role = context.role || "agent";
-  return store._listAll({})
+  return store
+    ._listAll({})
     .filter((memory) => memory.status !== "deleted")
     .filter((memory) => {
       if (role === "admin") return true;
@@ -605,7 +649,8 @@ function visibleResourceMemories(store, context = {}) {
 
 function listVisibleProposals(store, args = {}, role = "agent") {
   const agentId = args.agent_id || DEFAULT_AGENT_ID;
-  return store._listAll({ status: "proposed", agent_id: role === "admin" ? "" : agentId })
+  return store
+    ._listAll({ status: "proposed", agent_id: role === "admin" ? "" : agentId })
     .filter((memory) => {
       if (role === "admin") return true;
       if (memory.visibility === "common") return true;
@@ -618,9 +663,9 @@ function textResult(text) {
     content: [
       {
         type: "text",
-        text
-      }
-    ]
+        text,
+      },
+    ],
   };
 }
 
@@ -631,7 +676,7 @@ function formatConflict(result) {
     `Candidate: ${result.candidate.title}: ${result.candidate.body}`,
     "",
     "Conflicts:",
-    ...result.conflicts.map((memory) => `- ${memory.title}: ${memory.body}`)
+    ...result.conflicts.map((memory) => `- ${memory.title}: ${memory.body}`),
   ].join("\n");
 }
 
@@ -644,7 +689,7 @@ export function formatSessionStart(session) {
     `Status: ${session.status}`,
     `Visibility: ${session.visibility}`,
     `Project: ${session.project_key || "(none)"}`,
-    `Harness: ${session.current_harness || "(unattached)"}`
+    `Harness: ${session.current_harness || "(unattached)"}`,
   ];
   if (session.start_summary) {
     lines.push("", `Goal: ${session.start_summary}`);
@@ -665,7 +710,7 @@ export function formatSessionDetail(session) {
     session.source_ref ? `Source: ${session.source_ref}` : null,
     session.cwd ? `Cwd: ${session.cwd}` : null,
     `Started: ${session.started_at}`,
-    `Last activity: ${session.last_activity_at}`
+    `Last activity: ${session.last_activity_at}`,
   ].filter(Boolean);
   if (session.start_summary) lines.push("", `Goal: ${session.start_summary}`);
   if (session.rolling_summary) lines.push("", `Current summary: ${session.rolling_summary}`);
@@ -690,7 +735,7 @@ export function formatSessionList(result) {
     const harness = session.current_harness || "(unattached)";
     const last = session.last_activity_at || "(unknown)";
     lines.push(
-      `${idx}. [${session.status}] ${session.title} — ${project} — ${harness} — last: ${last}`
+      `${idx}. [${session.status}] ${session.title} — ${project} — ${harness} — last: ${last}`,
     );
     if (session.next_steps?.length) {
       lines.push(`   next: ${session.next_steps[0]}`);
@@ -726,7 +771,7 @@ export function formatSessionSearch(result) {
   result.sessions.forEach((session, index) => {
     const project = session.project_key || "no project";
     lines.push(
-      `${index + 1}. [${session.status}] ${session.title} — ${project} — id: ${session.id}`
+      `${index + 1}. [${session.status}] ${session.title} — ${project} — id: ${session.id}`,
     );
   });
   return lines.join("\n");
@@ -739,7 +784,7 @@ function formatPromotionConflict(result) {
     `Candidate: ${result.candidate.title}: ${result.candidate.body}`,
     "",
     "Conflicts:",
-    ...result.conflicts.map((memory) => `- ${memory.title}: ${memory.body}`)
+    ...result.conflicts.map((memory) => `- ${memory.title}: ${memory.body}`),
   ].join("\n");
 }
 
@@ -749,7 +794,7 @@ export function formatSessionLifecycle(session, headline) {
     "",
     `Session: ${session.title}`,
     `ID: ${session.id}`,
-    `Status: ${session.status}`
+    `Status: ${session.status}`,
   ];
   if (session.rolling_summary) lines.push(`Rolling summary: ${session.rolling_summary}`);
   if (session.end_summary) lines.push(`End summary: ${session.end_summary}`);
@@ -772,8 +817,8 @@ function sessionLifecycleSchema() {
       open_questions: { type: "array", items: { type: "string" } },
       next_steps: { type: "array", items: { type: "string" } },
       harness: { type: "string" },
-      source_ref: { type: "string" }
-    }
+      source_ref: { type: "string" },
+    },
   };
 }
 
@@ -792,8 +837,8 @@ function memoryInputSchema() {
       applies_to: { type: "array", items: { type: "string" } },
       priority: { type: "string" },
       confidence: { type: "string" },
-      tags: { type: "array", items: { type: "string" } }
-    }
+      tags: { type: "array", items: { type: "string" } },
+    },
   };
 }
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-import { LibrarianStore } from "./store.js";
 import { handleMcpMessage } from "./mcp.js";
+import { LibrarianStore } from "./store.js";
 
 const store = new LibrarianStore();
 
@@ -26,7 +26,11 @@ async function handleLine(line) {
   try {
     message = JSON.parse(line);
   } catch (error) {
-    send({ jsonrpc: "2.0", id: null, error: { code: -32700, message: `Parse error: ${error.message}` } });
+    send({
+      jsonrpc: "2.0",
+      id: null,
+      error: { code: -32700, message: `Parse error: ${error.message}` },
+    });
     return;
   }
 
@@ -34,7 +38,7 @@ async function handleLine(line) {
 
   const response = await handleMcpMessage(store, message, {
     role: process.env.LIBRARIAN_STDIO_ROLE || "agent",
-    agentId: process.env.LIBRARIAN_STDIO_AGENT_ID || ""
+    agentId: process.env.LIBRARIAN_STDIO_AGENT_ID || "",
   });
   if (response) send(response);
 }

--- a/src/store.js
+++ b/src/store.js
@@ -12,7 +12,7 @@ import {
   normalizeEnum,
   normalizeMemoryInput,
   normalizeString,
-  nowIso
+  nowIso,
 } from "./constants.js";
 
 const DEFAULT_DATA_DIR = path.join(process.cwd(), "data");
@@ -140,9 +140,10 @@ export class LibrarianStore {
       event_id: makeId("evt"),
       event_type: eventType,
       memory_id: options.memory_id || payload.memory_id || payload.memory?.id || null,
-      agent_id: options.agent_id || payload.agent_id || payload.memory?.agent_id || DEFAULT_AGENT_ID,
+      agent_id:
+        options.agent_id || payload.agent_id || payload.memory?.agent_id || DEFAULT_AGENT_ID,
       created_at: nowIso(),
-      payload
+      payload,
     };
     fs.appendFileSync(this.eventsPath, `${JSON.stringify(event)}\n`, "utf8");
     this._rebuildMemoryIndex();
@@ -172,47 +173,47 @@ export class LibrarianStore {
           ...existing,
           ...payload.patch,
           id,
-          updated_at: event.created_at
+          updated_at: event.created_at,
         });
       } else if (event.event_type === "memory.approved") {
         memories.set(id, {
           ...existing,
           ...payload.patch,
           status: "active",
-          updated_at: event.created_at
+          updated_at: event.created_at,
         });
       } else if (event.event_type === "memory.rejected") {
         memories.set(id, {
           ...existing,
           status: "rejected",
-          updated_at: event.created_at
+          updated_at: event.created_at,
         });
       } else if (event.event_type === "memory.deleted") {
         memories.set(id, {
           ...existing,
           status: "deleted",
           deleted_at: event.created_at,
-          updated_at: event.created_at
+          updated_at: event.created_at,
         });
       } else if (event.event_type === "memory.archived") {
         memories.set(id, {
           ...existing,
           status: "archived",
-          updated_at: event.created_at
+          updated_at: event.created_at,
         });
       } else if (event.event_type === "memory.recalled") {
         memories.set(id, {
           ...existing,
           last_recalled_at: event.created_at,
           recall_count: Number(existing.recall_count || 0) + 1,
-          updated_at: existing.updated_at
+          updated_at: existing.updated_at,
         });
       } else if (event.event_type === "memory.verified") {
         const delta = payload.result === "useful" ? 1 : payload.result === "not_useful" ? -1 : -2;
         memories.set(id, {
           ...existing,
           usefulness_score: Number(existing.usefulness_score || 0) + delta,
-          updated_at: event.created_at
+          updated_at: event.created_at,
         });
       } else if (event.event_type === "memory.conflict_detected") {
         const conflicts = new Set(asArray(existing.conflicts_with));
@@ -221,14 +222,14 @@ export class LibrarianStore {
           ...existing,
           status: existing.status === "proposed" ? "proposed" : "conflicted",
           conflicts_with: [...conflicts],
-          updated_at: event.created_at
+          updated_at: event.created_at,
         });
       } else if (event.event_type === "memory.conflict_resolved") {
         memories.set(id, {
           ...existing,
           ...payload.patch,
           status: payload.status || "active",
-          updated_at: event.created_at
+          updated_at: event.created_at,
         });
       }
     }
@@ -256,7 +257,9 @@ export class LibrarianStore {
           conflicts_with_json, created_at, updated_at, last_recalled_at, recall_count, usefulness_score
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `);
-      const insertFts = this.db.prepare("INSERT INTO memories_fts (id, title, body, category, tags) VALUES (?, ?, ?, ?, ?)");
+      const insertFts = this.db.prepare(
+        "INSERT INTO memories_fts (id, title, body, category, tags) VALUES (?, ?, ?, ?, ?)",
+      );
       const insertEvent = this.db.prepare(`
         INSERT INTO events (event_id, event_type, memory_id, agent_id, created_at, payload_json)
         VALUES (?, ?, ?, ?, ?, ?)
@@ -283,9 +286,15 @@ export class LibrarianStore {
           memory.updated_at,
           memory.last_recalled_at || null,
           Number(memory.recall_count || 0),
-          Number(memory.usefulness_score || 0)
+          Number(memory.usefulness_score || 0),
         );
-        insertFts.run(memory.id, memory.title, memory.body, memory.category, asArray(memory.tags).join(" "));
+        insertFts.run(
+          memory.id,
+          memory.title,
+          memory.body,
+          memory.category,
+          asArray(memory.tags).join(" "),
+        );
       }
 
       for (const event of events) {
@@ -295,7 +304,7 @@ export class LibrarianStore {
           event.memory_id || null,
           event.agent_id || null,
           event.created_at,
-          JSON.stringify(event.payload || {})
+          JSON.stringify(event.payload || {}),
         );
       }
 
@@ -315,7 +324,7 @@ export class LibrarianStore {
     tx.run();
     try {
       this.db.exec(
-        "DELETE FROM sessions; DELETE FROM session_events; DELETE FROM session_events_fts;"
+        "DELETE FROM sessions; DELETE FROM session_events; DELETE FROM session_events_fts;",
       );
       for (const event of events) this._applySessionEvent(event);
       commit.run();
@@ -343,7 +352,9 @@ export class LibrarianStore {
       lines.push(`- id: ${memory.id}`);
       lines.push(`- status: ${memory.status}`);
       lines.push(`- category: ${memory.category}`);
-      lines.push(`- visibility: ${memory.visibility}${memory.agent_id ? ` (${memory.agent_id})` : ""}`);
+      lines.push(
+        `- visibility: ${memory.visibility}${memory.agent_id ? ` (${memory.agent_id})` : ""}`,
+      );
       lines.push(`- scope: ${memory.scope}${memory.project_key ? ` (${memory.project_key})` : ""}`);
       lines.push(`- priority: ${memory.priority}`);
       lines.push(`- confidence: ${memory.confidence}`);
@@ -356,39 +367,89 @@ export class LibrarianStore {
   _listAll(filters = {}) {
     const clauses = [];
     const params = [];
-    if (filters.status) { clauses.push("status = ?"); params.push(filters.status); }
-    if (filters.category) { clauses.push("category = ?"); params.push(filters.category); }
-    if (filters.visibility) { clauses.push("visibility = ?"); params.push(filters.visibility); }
-    if (filters.agent_id) { clauses.push("(visibility = 'common' OR agent_id = ?)"); params.push(filters.agent_id); }
-    if (filters.project_key) { clauses.push("(project_key IS NULL OR project_key = ?)"); params.push(filters.project_key); }
+    if (filters.status) {
+      clauses.push("status = ?");
+      params.push(filters.status);
+    }
+    if (filters.category) {
+      clauses.push("category = ?");
+      params.push(filters.category);
+    }
+    if (filters.visibility) {
+      clauses.push("visibility = ?");
+      params.push(filters.visibility);
+    }
+    if (filters.agent_id) {
+      clauses.push("(visibility = 'common' OR agent_id = ?)");
+      params.push(filters.agent_id);
+    }
+    if (filters.project_key) {
+      clauses.push("(project_key IS NULL OR project_key = ?)");
+      params.push(filters.project_key);
+    }
     const sql = `SELECT * FROM memories ${clauses.length ? `WHERE ${clauses.join(" AND ")}` : ""} ORDER BY CASE priority WHEN 'core' THEN 0 WHEN 'high' THEN 1 WHEN 'normal' THEN 2 ELSE 3 END, updated_at DESC`;
-    return this.db.prepare(sql).all(...params).map(rowToMemory);
+    return this.db
+      .prepare(sql)
+      .all(...params)
+      .map(rowToMemory);
   }
 
   listMemories(filters = {}) {
     const clauses = [];
     const params = [];
-    if (filters.status) { clauses.push("status = ?"); params.push(filters.status); }
-    if (filters.category) { clauses.push("category = ?"); params.push(filters.category); }
-    if (filters.visibility) { clauses.push("visibility = ?"); params.push(filters.visibility); }
-    if (filters.agent_id) { clauses.push("(visibility = 'common' OR agent_id = ?)"); params.push(filters.agent_id); }
-    if (filters.project_key) { clauses.push("(project_key IS NULL OR project_key = ?)"); params.push(filters.project_key); }
-    if (filters.scope) { clauses.push("scope = ?"); params.push(filters.scope); }
-    if (filters.from) { clauses.push("created_at >= ?"); params.push(filters.from); }
-    if (filters.to) { clauses.push("created_at <= ?"); params.push(filters.to + "T23:59:59.999Z"); }
+    if (filters.status) {
+      clauses.push("status = ?");
+      params.push(filters.status);
+    }
+    if (filters.category) {
+      clauses.push("category = ?");
+      params.push(filters.category);
+    }
+    if (filters.visibility) {
+      clauses.push("visibility = ?");
+      params.push(filters.visibility);
+    }
+    if (filters.agent_id) {
+      clauses.push("(visibility = 'common' OR agent_id = ?)");
+      params.push(filters.agent_id);
+    }
+    if (filters.project_key) {
+      clauses.push("(project_key IS NULL OR project_key = ?)");
+      params.push(filters.project_key);
+    }
+    if (filters.scope) {
+      clauses.push("scope = ?");
+      params.push(filters.scope);
+    }
+    if (filters.from) {
+      clauses.push("created_at >= ?");
+      params.push(filters.from);
+    }
+    if (filters.to) {
+      clauses.push("created_at <= ?");
+      params.push(filters.to + "T23:59:59.999Z");
+    }
 
     const sortField = ["created_at", "updated_at", "title", "priority"].includes(filters.sort)
-      ? filters.sort : "updated_at";
+      ? filters.sort
+      : "updated_at";
     const sortDir = filters.order === "asc" ? "ASC" : "DESC";
     const safeLimit = Math.min(Math.max(Number(filters.limit ?? 100), 1), 200);
     const safeOffset = Math.max(Number(filters.offset ?? 0), 0);
 
-    const prioritySql = "CASE priority WHEN 'core' THEN 0 WHEN 'high' THEN 1 WHEN 'normal' THEN 2 ELSE 3 END";
-    const orderSql = sortField === "priority" ? `${prioritySql} ${sortDir}` : `${sortField} ${sortDir}`;
+    const prioritySql =
+      "CASE priority WHEN 'core' THEN 0 WHEN 'high' THEN 1 WHEN 'normal' THEN 2 ELSE 3 END";
+    const orderSql =
+      sortField === "priority" ? `${prioritySql} ${sortDir}` : `${sortField} ${sortDir}`;
     const whereClause = clauses.length ? `WHERE ${clauses.join(" AND ")}` : "";
 
-    const total = this.db.prepare(`SELECT COUNT(*) as n FROM memories ${whereClause}`).get(...params).n;
-    const memories = this.db.prepare(`SELECT * FROM memories ${whereClause} ORDER BY ${orderSql} LIMIT ? OFFSET ?`).all(...params, safeLimit, safeOffset).map(rowToMemory);
+    const total = this.db
+      .prepare(`SELECT COUNT(*) as n FROM memories ${whereClause}`)
+      .get(...params).n;
+    const memories = this.db
+      .prepare(`SELECT * FROM memories ${whereClause} ORDER BY ${orderSql} LIMIT ? OFFSET ?`)
+      .all(...params, safeLimit, safeOffset)
+      .map(rowToMemory);
     return { memories, total, limit: safeLimit, offset: safeOffset };
   }
 
@@ -403,17 +464,19 @@ export class LibrarianStore {
         if (!v) continue;
         map.set(v, (map.get(v) ?? 0) + 1);
       }
-      return [...map.entries()].sort((a, b) => b[1] - a[1]).map(([value, count]) => ({ value, count }));
+      return [...map.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .map(([value, count]) => ({ value, count }));
     };
 
     return {
-      agents:     tally("agent_id"),
-      projects:   tally("project_key"),
+      agents: tally("agent_id"),
+      projects: tally("project_key"),
       categories: tally("category"),
-      statuses:   tally("status"),
-      scopes:     tally("scope"),
+      statuses: tally("status"),
+      scopes: tally("scope"),
       priorities: tally("priority"),
-      total:      active.length,
+      total: active.length,
     };
   }
 
@@ -432,7 +495,9 @@ export class LibrarianStore {
 
     const related = pool
       .map((other) => {
-        const otherTerms = new Set(tokenize(`${other.title} ${other.body} ${other.tags.join(" ")}`));
+        const otherTerms = new Set(
+          tokenize(`${other.title} ${other.body} ${other.tags.join(" ")}`),
+        );
         const overlap = [...terms].filter((t) => otherTerms.has(t)).length;
         const ratio = overlap / Math.max(terms.size, otherTerms.size, 1);
         const isDuplicate = ratio >= 0.55;
@@ -450,7 +515,15 @@ export class LibrarianStore {
     return row ? rowToMemory(row) : null;
   }
 
-  listEvents({ type = "", agent_id = "", memory_id = "", result = "", query = "", limit = 25, offset = 0 } = {}) {
+  listEvents({
+    type = "",
+    agent_id = "",
+    memory_id = "",
+    result = "",
+    query = "",
+    limit = 25,
+    offset = 0,
+  } = {}) {
     const eventType = normalizeString(type);
     const agentId = normalizeString(agent_id);
     const memoryId = normalizeString(memory_id);
@@ -476,8 +549,11 @@ export class LibrarianStore {
             payload.memory?.title,
             payload.memory?.body,
             payload.patch?.title,
-            payload.patch?.body
-          ].filter(Boolean).join(" ").toLowerCase();
+            payload.patch?.body,
+          ]
+            .filter(Boolean)
+            .join(" ")
+            .toLowerCase();
           if (!haystack.includes(searchQuery)) return false;
         }
         return true;
@@ -488,55 +564,76 @@ export class LibrarianStore {
       events: filtered.slice(safeOffset, safeOffset + safeLimit),
       total: filtered.length,
       limit: safeLimit,
-      offset: safeOffset
+      offset: safeOffset,
     };
   }
 
-  searchMemories({ agent_id = DEFAULT_AGENT_ID, query = "", categories = [], project_key = "", include_private = true, limit = 8, status = "active" } = {}) {
+  searchMemories({
+    agent_id = DEFAULT_AGENT_ID,
+    query = "",
+    categories = [],
+    project_key = "",
+    include_private = true,
+    limit = 8,
+    status = "active",
+  } = {}) {
     const cleaned = normalizeString(query);
     const categorySet = new Set(asArray(categories));
     const all = this._listAll({ status, agent_id: include_private ? agent_id : "", project_key });
     const allowed = all.filter((memory) => {
       if (categorySet.size && !categorySet.has(memory.category)) return false;
-      if (memory.visibility === "agent_private" && (!include_private || memory.agent_id !== agent_id)) return false;
+      if (
+        memory.visibility === "agent_private" &&
+        (!include_private || memory.agent_id !== agent_id)
+      )
+        return false;
       return true;
     });
 
     if (!cleaned) return allowed.slice(0, limit);
 
     const terms = tokenize(cleaned);
-    const scored = allowed.map((memory) => {
-      const haystack = `${memory.title} ${memory.body} ${memory.category} ${memory.tags.join(" ")} ${memory.project_key || ""}`.toLowerCase();
-      let score = 0;
-      for (const term of terms) {
-        if (haystack.includes(term)) score += term.length > 4 ? 3 : 1;
-      }
-      if (memory.priority === "core") score += 3;
-      if (memory.priority === "high") score += 1;
-      if (memory.project_key && memory.project_key === project_key) score += 3;
-      return { memory, score };
-    }).filter((item) => item.score > 0);
+    const scored = allowed
+      .map((memory) => {
+        const haystack =
+          `${memory.title} ${memory.body} ${memory.category} ${memory.tags.join(" ")} ${memory.project_key || ""}`.toLowerCase();
+        let score = 0;
+        for (const term of terms) {
+          if (haystack.includes(term)) score += term.length > 4 ? 3 : 1;
+        }
+        if (memory.priority === "core") score += 3;
+        if (memory.priority === "high") score += 1;
+        if (memory.project_key && memory.project_key === project_key) score += 3;
+        return { memory, score };
+      })
+      .filter((item) => item.score > 0);
 
-    scored.sort((a, b) => b.score - a.score || b.memory.updated_at.localeCompare(a.memory.updated_at));
+    scored.sort(
+      (a, b) => b.score - a.score || b.memory.updated_at.localeCompare(a.memory.updated_at),
+    );
     return scored.slice(0, limit).map((item) => item.memory);
   }
 
   detectRelated(candidate, options = {}) {
-    const terms = new Set(tokenize(`${candidate.title} ${candidate.body} ${candidate.tags.join(" ")}`));
+    const terms = new Set(
+      tokenize(`${candidate.title} ${candidate.body} ${candidate.tags.join(" ")}`),
+    );
     if (!terms.size) return { duplicates: [], conflicts: [] };
 
     const pool = this._listAll({
       status: "active",
       agent_id: candidate.agent_id,
-      project_key: candidate.project_key
+      project_key: candidate.project_key,
     }).filter((memory) => memory.id !== candidate.id && memory.category === candidate.category);
 
-    const related = pool.map((memory) => {
-      const other = new Set(tokenize(`${memory.title} ${memory.body} ${memory.tags.join(" ")}`));
-      const overlap = [...terms].filter((term) => other.has(term)).length;
-      const ratio = overlap / Math.max(terms.size, other.size, 1);
-      return { memory, ratio };
-    }).filter((item) => item.ratio >= (options.threshold || 0.32));
+    const related = pool
+      .map((memory) => {
+        const other = new Set(tokenize(`${memory.title} ${memory.body} ${memory.tags.join(" ")}`));
+        const overlap = [...terms].filter((term) => other.has(term)).length;
+        const ratio = overlap / Math.max(terms.size, other.size, 1);
+        return { memory, ratio };
+      })
+      .filter((item) => item.ratio >= (options.threshold || 0.32));
 
     const duplicates = related.filter((item) => item.ratio >= 0.55).map((item) => item.memory);
     const conflicts = related
@@ -560,41 +657,56 @@ export class LibrarianStore {
       recall_count: 0,
       usefulness_score: 0,
       supersedes: [],
-      conflicts_with: []
+      conflicts_with: [],
     };
 
     const related = this.detectRelated(memory);
     if (related.conflicts.length && !options.allowConflict) {
-      this.appendEvent("memory.conflict_detected", {
-        agent_id: memory.agent_id,
-        candidate: memory,
-        conflicts_with: related.conflicts.map((item) => item.id)
-      }, { memory_id: memory.id, agent_id: memory.agent_id });
+      this.appendEvent(
+        "memory.conflict_detected",
+        {
+          agent_id: memory.agent_id,
+          candidate: memory,
+          conflicts_with: related.conflicts.map((item) => item.id),
+        },
+        { memory_id: memory.id, agent_id: memory.agent_id },
+      );
       return {
         status: "conflict",
-        message: "Potential conflicting memories found. Ask the agent or user to resolve before saving.",
+        message:
+          "Potential conflicting memories found. Ask the agent or user to resolve before saving.",
         candidate: memory,
-        conflicts: related.conflicts
+        conflicts: related.conflicts,
       };
     }
 
-    this.appendEvent(status === "proposed" ? "memory.proposed" : "memory.created", { memory }, { memory_id: memory.id, agent_id: memory.agent_id });
+    this.appendEvent(
+      status === "proposed" ? "memory.proposed" : "memory.created",
+      { memory },
+      { memory_id: memory.id, agent_id: memory.agent_id },
+    );
     return {
       status,
       memory,
-      duplicates: related.duplicates
+      duplicates: related.duplicates,
     };
   }
 
   updateMemory(id, patch = {}, agent_id = DEFAULT_AGENT_ID, options = {}) {
     const existing = this.getMemory(id);
     if (!existing) throw new Error(`No memory found for id ${id}`);
-    if (isProtectedCategory(existing.category) && existing.status === "active" && !options.allowProtected) {
+    if (
+      isProtectedCategory(existing.category) &&
+      existing.status === "active" &&
+      !options.allowProtected
+    ) {
       throw new Error("Protected memories must be changed through a proposal workflow.");
     }
     const normalizedPatch = cleanPatch(patch);
     if (normalizedPatch.status !== undefined && normalizedPatch.status !== existing.status) {
-      throw new Error("Memory status changes must use the dedicated approval, delete, archive, or conflict-resolution workflow.");
+      throw new Error(
+        "Memory status changes must use the dedicated approval, delete, archive, or conflict-resolution workflow.",
+      );
     }
     if (
       normalizedPatch.category !== undefined &&
@@ -602,9 +714,15 @@ export class LibrarianStore {
       (isProtectedCategory(existing.category) || isProtectedCategory(normalizedPatch.category)) &&
       !options.allowProtected
     ) {
-      throw new Error("Protected memory categories cannot be assigned or removed through update_memory.");
+      throw new Error(
+        "Protected memory categories cannot be assigned or removed through update_memory.",
+      );
     }
-    this.appendEvent("memory.updated", { memory_id: id, agent_id, patch: normalizedPatch }, { memory_id: id, agent_id });
+    this.appendEvent(
+      "memory.updated",
+      { memory_id: id, agent_id, patch: normalizedPatch },
+      { memory_id: id, agent_id },
+    );
     return this.getMemory(id);
   }
 
@@ -618,21 +736,33 @@ export class LibrarianStore {
   verifyMemory(id, result, note = "", agent_id = DEFAULT_AGENT_ID) {
     const existing = this.getMemory(id);
     if (!existing) throw new Error(`No memory found for id ${id}`);
-    this.appendEvent("memory.verified", { memory_id: id, agent_id, result, note }, { memory_id: id, agent_id });
+    this.appendEvent(
+      "memory.verified",
+      { memory_id: id, agent_id, result, note },
+      { memory_id: id, agent_id },
+    );
     return this.getMemory(id);
   }
 
   recordRecall(memories, agent_id = DEFAULT_AGENT_ID, query = "") {
     if (!memories.length) {
-      this.appendEvent("memory.recall_empty", {
-        agent_id,
-        query,
-        returned_count: 0
-      }, { agent_id });
+      this.appendEvent(
+        "memory.recall_empty",
+        {
+          agent_id,
+          query,
+          returned_count: 0,
+        },
+        { agent_id },
+      );
       return;
     }
     for (const memory of memories) {
-      this.appendEvent("memory.recalled", { memory_id: memory.id, agent_id, query }, { memory_id: memory.id, agent_id });
+      this.appendEvent(
+        "memory.recalled",
+        { memory_id: memory.id, agent_id, query },
+        { memory_id: memory.id, agent_id },
+      );
     }
   }
 
@@ -644,11 +774,21 @@ export class LibrarianStore {
       this.appendEvent("memory.rejected", { memory_id: id, agent_id }, { memory_id: id, agent_id });
       return this.getMemory(id);
     }
-    this.appendEvent("memory.approved", { memory_id: id, agent_id, patch: cleanPatch(patch) }, { memory_id: id, agent_id });
+    this.appendEvent(
+      "memory.approved",
+      { memory_id: id, agent_id, patch: cleanPatch(patch) },
+      { memory_id: id, agent_id },
+    );
     return this.getMemory(id);
   }
 
-  resolveConflict({ memory_ids = [], resolution = "keep_both", explanation = "", agent_id = DEFAULT_AGENT_ID, patch = {} } = {}) {
+  resolveConflict({
+    memory_ids = [],
+    resolution = "keep_both",
+    explanation = "",
+    agent_id = DEFAULT_AGENT_ID,
+    patch = {},
+  } = {}) {
     const ids = asArray(memory_ids);
     if (!ids.length) throw new Error("memory_ids is required");
     const results = [];
@@ -656,56 +796,72 @@ export class LibrarianStore {
       const existing = this.getMemory(id);
       if (!existing) continue;
       if (isProtectedCategory(existing.category)) {
-        throw new Error("Protected category conflicts require user approval through the dashboard.");
+        throw new Error(
+          "Protected category conflicts require user approval through the dashboard.",
+        );
       }
       let status = "active";
       let eventPatch = cleanPatch(patch);
       if (resolution === "archive") status = "archived";
       if (resolution === "keep_both") status = "active";
       if (resolution === "supersede" && id !== ids[0]) status = "archived";
-      this.appendEvent("memory.conflict_resolved", {
-        memory_id: id,
-        agent_id,
-        resolution,
-        explanation,
-        status,
-        patch: eventPatch
-      }, { memory_id: id, agent_id });
+      this.appendEvent(
+        "memory.conflict_resolved",
+        {
+          memory_id: id,
+          agent_id,
+          resolution,
+          explanation,
+          status,
+          patch: eventPatch,
+        },
+        { memory_id: id, agent_id },
+      );
       results.push(this.getMemory(id));
     }
     return results;
   }
 
   startContext({ agent_id = DEFAULT_AGENT_ID, project_key = "", task_summary = "" } = {}) {
-    const identity = this._listAll({ status: "active", category: "identity" })
-      .filter((memory) => memory.visibility === "common");
-    const relationship = this._listAll({ status: "active", category: "relationship" })
-      .filter((memory) => memory.visibility === "common");
+    const identity = this._listAll({ status: "active", category: "identity" }).filter(
+      (memory) => memory.visibility === "common",
+    );
+    const relationship = this._listAll({ status: "active", category: "relationship" }).filter(
+      (memory) => memory.visibility === "common",
+    );
     const privateMemories = this.searchMemories({
       agent_id,
       query: task_summary || project_key || agent_id,
       categories: [],
       project_key,
       include_private: true,
-      limit: 6
+      limit: 6,
     }).filter((memory) => memory.visibility === "agent_private" && memory.agent_id === agent_id);
 
-    const relevant = task_summary || project_key
-      ? this.searchMemories({
-        agent_id,
-        query: `${task_summary} ${project_key}`,
-        categories: ["projects", "environment", "tools", "lessons", "open_threads", "preferences"],
-        project_key,
-        include_private: true,
-        limit: 8
-      }).filter((memory) => !["identity", "relationship"].includes(memory.category))
-      : [];
+    const relevant =
+      task_summary || project_key
+        ? this.searchMemories({
+            agent_id,
+            query: `${task_summary} ${project_key}`,
+            categories: [
+              "projects",
+              "environment",
+              "tools",
+              "lessons",
+              "open_threads",
+              "preferences",
+            ],
+            project_key,
+            include_private: true,
+            limit: 8,
+          }).filter((memory) => !["identity", "relationship"].includes(memory.category))
+        : [];
 
     const memories = uniqueById([...identity, ...relationship, ...privateMemories, ...relevant]);
     this.recordRecall(memories, agent_id, task_summary || "start_context");
     return {
       memories,
-      text: formatContextPackage({ identity, relationship, privateMemories, relevant })
+      text: formatContextPackage({ identity, relationship, privateMemories, relevant }),
     };
   }
 
@@ -718,7 +874,7 @@ export class LibrarianStore {
       harness: options.harness ?? payload.harness ?? null,
       source_ref: options.source_ref ?? payload.source_ref ?? null,
       created_at: nowIso(),
-      payload
+      payload,
     };
     fs.appendFileSync(this.sessionsPath, `${JSON.stringify(event)}\n`, "utf8");
     this._applySessionEvent(event);
@@ -744,12 +900,12 @@ export class LibrarianStore {
         source_ref: payload.source_ref ?? session.source_ref,
         cwd: payload.cwd ?? session.cwd,
         last_activity_at: event.created_at,
-        updated_at: event.created_at
+        updated_at: event.created_at,
       });
       this._insertSessionEventRow(
         event,
         `Attached to ${payload.harness || "unknown harness"}.`,
-        shortType(type)
+        shortType(type),
       );
       return;
     }
@@ -761,7 +917,7 @@ export class LibrarianStore {
       const wasPaused = session.status === "paused";
       const updates = {
         last_activity_at: event.created_at,
-        updated_at: event.created_at
+        updated_at: event.created_at,
       };
       if (wasPaused) {
         updates.status = "active";
@@ -779,7 +935,7 @@ export class LibrarianStore {
       const updates = {
         rolling_summary: summary || session.rolling_summary,
         last_activity_at: event.created_at,
-        updated_at: event.created_at
+        updated_at: event.created_at,
       };
       if (session.status === "paused") {
         updates.status = "active";
@@ -802,7 +958,7 @@ export class LibrarianStore {
         rolling_summary: summary || session.rolling_summary,
         paused_at: event.created_at,
         last_activity_at: event.created_at,
-        updated_at: event.created_at
+        updated_at: event.created_at,
       };
       if (Array.isArray(nextSteps) && nextSteps.length) {
         updates.next_steps_json = JSON.stringify(asArray(nextSteps));
@@ -821,7 +977,7 @@ export class LibrarianStore {
         end_summary: summary,
         ended_at: event.created_at,
         last_activity_at: event.created_at,
-        updated_at: event.created_at
+        updated_at: event.created_at,
       };
       if (Array.isArray(nextSteps) && nextSteps.length) {
         updates.next_steps_json = JSON.stringify(asArray(nextSteps));
@@ -837,7 +993,7 @@ export class LibrarianStore {
         status: "archived",
         archived_at: event.created_at,
         last_activity_at: event.created_at,
-        updated_at: event.created_at
+        updated_at: event.created_at,
       };
       if (!["archived", "deleted"].includes(session.status)) {
         updates.prior_status = session.status;
@@ -846,7 +1002,7 @@ export class LibrarianStore {
       this._insertSessionEventRow(
         event,
         event.payload?.reason || "Session archived.",
-        shortType(type)
+        shortType(type),
       );
       return;
     }
@@ -857,7 +1013,7 @@ export class LibrarianStore {
         status: "deleted",
         deleted_at: event.created_at,
         last_activity_at: event.created_at,
-        updated_at: event.created_at
+        updated_at: event.created_at,
       };
       if (!["archived", "deleted"].includes(session.status)) {
         updates.prior_status = session.status;
@@ -866,7 +1022,7 @@ export class LibrarianStore {
       this._insertSessionEventRow(
         event,
         event.payload?.reason || "Session deleted.",
-        shortType(type)
+        shortType(type),
       );
       return;
     }
@@ -875,7 +1031,7 @@ export class LibrarianStore {
       if (!session) return;
       this._patchSessionRow(session.id, {
         last_activity_at: event.created_at,
-        updated_at: event.created_at
+        updated_at: event.created_at,
       });
       const title = event.payload?.title || "Promoted to memory.";
       this._insertSessionEventRow(event, title, shortType(type));
@@ -891,7 +1047,7 @@ export class LibrarianStore {
         archived_at: null,
         deleted_at: null,
         last_activity_at: event.created_at,
-        updated_at: event.created_at
+        updated_at: event.created_at,
       });
       this._insertSessionEventRow(event, `Restored to ${restoreTo}.`, shortType(type));
     }
@@ -899,12 +1055,31 @@ export class LibrarianStore {
 
   _patchSessionRow(id, patch) {
     const allowed = [
-      "title", "project_key", "status", "prior_status", "visibility",
-      "created_by_agent_id", "current_agent_id", "created_in_harness", "current_harness",
-      "source_ref", "cwd", "start_summary", "rolling_summary", "end_summary",
-      "next_steps_json", "tags_json", "capture_mode",
-      "started_at", "updated_at", "last_activity_at",
-      "paused_at", "ended_at", "archived_at", "deleted_at", "metadata_json"
+      "title",
+      "project_key",
+      "status",
+      "prior_status",
+      "visibility",
+      "created_by_agent_id",
+      "current_agent_id",
+      "created_in_harness",
+      "current_harness",
+      "source_ref",
+      "cwd",
+      "start_summary",
+      "rolling_summary",
+      "end_summary",
+      "next_steps_json",
+      "tags_json",
+      "capture_mode",
+      "started_at",
+      "updated_at",
+      "last_activity_at",
+      "paused_at",
+      "ended_at",
+      "archived_at",
+      "deleted_at",
+      "metadata_json",
     ];
     const keys = [];
     const params = [];
@@ -920,7 +1095,9 @@ export class LibrarianStore {
   }
 
   _insertSessionRow(session) {
-    this.db.prepare(`
+    this.db
+      .prepare(
+        `
       INSERT OR REPLACE INTO sessions (
         id, title, project_key, status, prior_status, visibility,
         created_by_agent_id, current_agent_id, created_in_harness, current_harness,
@@ -929,61 +1106,66 @@ export class LibrarianStore {
         started_at, updated_at, last_activity_at,
         paused_at, ended_at, archived_at, deleted_at, metadata_json
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(
-      session.id,
-      session.title,
-      session.project_key || null,
-      session.status,
-      session.prior_status || null,
-      session.visibility,
-      session.created_by_agent_id || null,
-      session.current_agent_id || null,
-      session.created_in_harness || null,
-      session.current_harness || null,
-      session.source_ref || null,
-      session.cwd || null,
-      session.start_summary || null,
-      session.rolling_summary || null,
-      session.end_summary || null,
-      JSON.stringify(asArray(session.next_steps)),
-      JSON.stringify(asArray(session.tags)),
-      session.capture_mode,
-      session.started_at,
-      session.updated_at,
-      session.last_activity_at,
-      session.paused_at || null,
-      session.ended_at || null,
-      session.archived_at || null,
-      session.deleted_at || null,
-      JSON.stringify(session.metadata || {})
-    );
+    `,
+      )
+      .run(
+        session.id,
+        session.title,
+        session.project_key || null,
+        session.status,
+        session.prior_status || null,
+        session.visibility,
+        session.created_by_agent_id || null,
+        session.current_agent_id || null,
+        session.created_in_harness || null,
+        session.current_harness || null,
+        session.source_ref || null,
+        session.cwd || null,
+        session.start_summary || null,
+        session.rolling_summary || null,
+        session.end_summary || null,
+        JSON.stringify(asArray(session.next_steps)),
+        JSON.stringify(asArray(session.tags)),
+        session.capture_mode,
+        session.started_at,
+        session.updated_at,
+        session.last_activity_at,
+        session.paused_at || null,
+        session.ended_at || null,
+        session.archived_at || null,
+        session.deleted_at || null,
+        JSON.stringify(session.metadata || {}),
+      );
   }
 
   _insertSessionEventRow(event, summary, type) {
-    this.db.prepare(`
+    this.db
+      .prepare(
+        `
       INSERT OR REPLACE INTO session_events (
         id, session_id, type, agent_id, harness, source_ref, summary, payload_json, created_at
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(
-      event.event_id,
-      event.session_id,
-      type,
-      event.agent_id || null,
-      event.harness || null,
-      event.source_ref || null,
-      summary,
-      JSON.stringify(event.payload || {}),
-      event.created_at
-    );
-    this.db.prepare(`
+    `,
+      )
+      .run(
+        event.event_id,
+        event.session_id,
+        type,
+        event.agent_id || null,
+        event.harness || null,
+        event.source_ref || null,
+        summary,
+        JSON.stringify(event.payload || {}),
+        event.created_at,
+      );
+    this.db
+      .prepare(
+        `
       INSERT INTO session_events_fts (event_id, session_id, summary, payload_text)
       VALUES (?, ?, ?, ?)
-    `).run(
-      event.event_id,
-      event.session_id,
-      summary,
-      JSON.stringify(event.payload || {})
-    );
+    `,
+      )
+      .run(event.event_id, event.session_id, summary, JSON.stringify(event.payload || {}));
   }
 
   startSession(input = {}) {
@@ -993,7 +1175,8 @@ export class LibrarianStore {
     const agentId = normalizeString(input.agent_id, DEFAULT_AGENT_ID);
     const visibility = normalizeEnum(input.visibility, VISIBILITIES, "common");
     const captureMode = normalizeEnum(input.capture_mode, SESSION_CAPTURE_MODES, "summary");
-    const title = normalizeString(input.title) || `${projectKey || harness || "agent"} session @ ${now}`;
+    const title =
+      normalizeString(input.title) || `${projectKey || harness || "agent"} session @ ${now}`;
 
     const session = {
       id: makeId("ses"),
@@ -1021,7 +1204,7 @@ export class LibrarianStore {
       ended_at: null,
       archived_at: null,
       deleted_at: null,
-      metadata: isPlainObject(input.metadata) ? input.metadata : {}
+      metadata: isPlainObject(input.metadata) ? input.metadata : {},
     };
 
     this.appendSessionEvent(
@@ -1031,8 +1214,8 @@ export class LibrarianStore {
         session_id: session.id,
         agent_id: agentId,
         harness: session.current_harness,
-        source_ref: session.source_ref
-      }
+        source_ref: session.source_ref,
+      },
     );
 
     return { session: this.getSession(session.id) };
@@ -1062,7 +1245,9 @@ export class LibrarianStore {
     if (!statuses.length) return { sessions: [], total: 0, limit };
 
     const placeholders = statuses.map(() => "?").join(", ");
-    const rows = this.db.prepare(`SELECT * FROM sessions WHERE status IN (${placeholders})`).all(...statuses);
+    const rows = this.db
+      .prepare(`SELECT * FROM sessions WHERE status IN (${placeholders})`)
+      .all(...statuses);
     const sessions = rows.map(rowToSession);
 
     const visible = sessions.filter((session) => {
@@ -1083,8 +1268,8 @@ export class LibrarianStore {
         projectKey && session.project_key === projectKey ? 0 : 1,
         sourceMatches(session, sourceRef, cwd) ? 0 : 1,
         (session.next_steps || []).length > 0 ? 0 : 1,
-        -Date.parse(session.last_activity_at || session.started_at || 0)
-      ]
+        -Date.parse(session.last_activity_at || session.started_at || 0),
+      ],
     }));
 
     scored.sort((a, b) => compareKeys(a.key, b.key));
@@ -1092,7 +1277,7 @@ export class LibrarianStore {
     return {
       sessions: scored.slice(0, limit).map(({ session }) => session),
       total: scored.length,
-      limit
+      limit,
     };
   }
 
@@ -1116,14 +1301,14 @@ export class LibrarianStore {
       type,
       summary,
       agent_id: agentId,
-      ...extra
+      ...extra,
     };
 
     return this.appendSessionEvent("session.event_recorded", payload, {
       session_id: sessionId,
       agent_id: agentId,
       harness,
-      source_ref: sourceRef
+      source_ref: sourceRef,
     });
   }
 
@@ -1160,9 +1345,9 @@ export class LibrarianStore {
         previous_agent_id: session.current_agent_id,
         previous_harness: session.current_harness,
         previous_source_ref: session.source_ref,
-        previous_cwd: session.cwd
+        previous_cwd: session.cwd,
       },
-      { session_id: sessionId, agent_id: agentId, harness, source_ref: sourceRef }
+      { session_id: sessionId, agent_id: agentId, harness, source_ref: sourceRef },
     );
 
     return { session: this.getSession(sessionId) };
@@ -1191,7 +1376,7 @@ export class LibrarianStore {
         agent_id: agentId,
         harness: targetHarness || session.current_harness,
         source_ref: targetSourceRef || session.source_ref,
-        cwd: targetCwd || session.cwd
+        cwd: targetCwd || session.cwd,
       }).session;
     }
 
@@ -1218,20 +1403,22 @@ export class LibrarianStore {
       open_questions: aggregates.questions,
       next_steps: working.next_steps || [],
       tags: working.tags || [],
-      last_activity_at: working.last_activity_at
+      last_activity_at: working.last_activity_at,
     };
 
     return {
       session: working,
       handover,
       text: renderHandover(handover, format),
-      format
+      format,
     };
   }
 
   _getOriginalSessionSnapshot(sessionId) {
     const row = this.db
-      .prepare(`SELECT payload_json FROM session_events WHERE session_id = ? AND type = 'started' ORDER BY created_at ASC LIMIT 1`)
+      .prepare(
+        `SELECT payload_json FROM session_events WHERE session_id = ? AND type = 'started' ORDER BY created_at ASC LIMIT 1`,
+      )
       .get(sessionId);
     if (!row) return null;
     const payload = JSON.parse(row.payload_json || "{}");
@@ -1240,7 +1427,9 @@ export class LibrarianStore {
 
   _aggregateHandoverInputs(sessionId) {
     const rows = this.db
-      .prepare(`SELECT type, payload_json FROM session_events WHERE session_id = ? ORDER BY created_at ASC, id ASC`)
+      .prepare(
+        `SELECT type, payload_json FROM session_events WHERE session_id = ? ORDER BY created_at ASC, id ASC`,
+      )
       .all(sessionId);
     const decisions = [];
     const files = [];
@@ -1275,14 +1464,14 @@ export class LibrarianStore {
       {
         agent_id: agentId,
         reason: normalizeString(input.reason),
-        prior_status: session.status
+        prior_status: session.status,
       },
       {
         session_id: sessionId,
         agent_id: agentId,
         harness: session.current_harness,
-        source_ref: session.source_ref
-      }
+        source_ref: session.source_ref,
+      },
     );
     return { session: this.getSession(sessionId) };
   }
@@ -1296,22 +1485,20 @@ export class LibrarianStore {
     }
     const agentId = normalizeString(input.agent_id, DEFAULT_AGENT_ID);
     if (input.admin !== true && session.created_by_agent_id !== agentId) {
-      throw new Error(
-        `Only the session owner or an admin may delete this session (${sessionId}).`
-      );
+      throw new Error(`Only the session owner or an admin may delete this session (${sessionId}).`);
     }
     this.appendSessionEvent(
       "session.deleted",
       {
         agent_id: agentId,
-        reason: normalizeString(input.reason)
+        reason: normalizeString(input.reason),
       },
       {
         session_id: sessionId,
         agent_id: agentId,
         harness: session.current_harness,
-        source_ref: session.source_ref
-      }
+        source_ref: session.source_ref,
+      },
     );
     return { session: this.getSession(sessionId) };
   }
@@ -1326,7 +1513,7 @@ export class LibrarianStore {
     const agentId = normalizeString(input.agent_id, DEFAULT_AGENT_ID);
     if (input.admin !== true && session.created_by_agent_id !== agentId) {
       throw new Error(
-        `Only the session owner or an admin may restore this session (${sessionId}).`
+        `Only the session owner or an admin may restore this session (${sessionId}).`,
       );
     }
     const restoreTo = session.prior_status || "paused";
@@ -1335,14 +1522,14 @@ export class LibrarianStore {
       {
         agent_id: agentId,
         restore_to: restoreTo,
-        from_status: session.status
+        from_status: session.status,
       },
       {
         session_id: sessionId,
         agent_id: agentId,
         harness: session.current_harness,
-        source_ref: session.source_ref
-      }
+        source_ref: session.source_ref,
+      },
     );
     return { session: this.getSession(sessionId) };
   }
@@ -1365,7 +1552,7 @@ export class LibrarianStore {
       files_touched: asArray(input.files_touched),
       commands_run: asArray(input.commands_run),
       open_questions: asArray(input.open_questions),
-      next_steps: asArray(input.next_steps)
+      next_steps: asArray(input.next_steps),
     };
     if (eventType === "session.ended" && Array.isArray(input.candidate_memories)) {
       payload.candidate_memories = input.candidate_memories;
@@ -1375,7 +1562,7 @@ export class LibrarianStore {
       session_id: sessionId,
       agent_id: agentId,
       harness,
-      source_ref: sourceRef
+      source_ref: sourceRef,
     });
 
     return { session: this.getSession(sessionId) };
@@ -1387,7 +1574,10 @@ export class LibrarianStore {
     if (!session) throw new Error(`No session found for id ${sessionId}`);
 
     const memoryInput = input.memory || {};
-    const hasContent = normalizeString(memoryInput.title) || normalizeString(memoryInput.body) || normalizeString(memoryInput.content);
+    const hasContent =
+      normalizeString(memoryInput.title) ||
+      normalizeString(memoryInput.body) ||
+      normalizeString(memoryInput.content);
     if (!hasContent) {
       throw new Error("promote_session_fact requires a memory with a title or body.");
     }
@@ -1397,7 +1587,7 @@ export class LibrarianStore {
 
     const memoryResult = this.createMemory({
       ...memoryInput,
-      agent_id: memoryInput.agent_id || agentId
+      agent_id: memoryInput.agent_id || agentId,
     });
 
     if (memoryResult.status === "conflict") {
@@ -1406,7 +1596,7 @@ export class LibrarianStore {
         conflicts: memoryResult.conflicts,
         candidate: memoryResult.candidate,
         session_id: sessionId,
-        session_event_id: sessionEventId
+        session_event_id: sessionEventId,
       };
     }
 
@@ -1418,14 +1608,14 @@ export class LibrarianStore {
         session_event_id: sessionEventId,
         memory_status: memoryResult.status,
         memory_category: memoryResult.memory.category,
-        title: memoryResult.memory.title
+        title: memoryResult.memory.title,
       },
       {
         session_id: sessionId,
         agent_id: agentId,
         harness: session.current_harness,
-        source_ref: session.source_ref
-      }
+        source_ref: session.source_ref,
+      },
     );
 
     return {
@@ -1433,7 +1623,7 @@ export class LibrarianStore {
       memory: memoryResult.memory,
       duplicates: memoryResult.duplicates || [],
       session_id: sessionId,
-      session_event_id: sessionEventId
+      session_event_id: sessionEventId,
     };
   }
 
@@ -1454,7 +1644,9 @@ export class LibrarianStore {
     let matchedIds;
     try {
       const rows = this.db
-        .prepare(`SELECT DISTINCT session_id FROM session_events_fts WHERE session_events_fts MATCH ?`)
+        .prepare(
+          `SELECT DISTINCT session_id FROM session_events_fts WHERE session_events_fts MATCH ?`,
+        )
         .all(ftsQuery);
       matchedIds = rows.map((row) => row.session_id).filter(Boolean);
     } catch {
@@ -1472,7 +1664,12 @@ export class LibrarianStore {
     const filtered = sessions.filter((session) => {
       if (!includeDeleted && session.status === "deleted") return false;
       if (!includeArchived && session.status === "archived") return false;
-      if (!isAdmin && session.visibility === "agent_private" && session.created_by_agent_id !== agentId) return false;
+      if (
+        !isAdmin &&
+        session.visibility === "agent_private" &&
+        session.created_by_agent_id !== agentId
+      )
+        return false;
       if (projectKey && session.project_key !== projectKey) return false;
       return true;
     });
@@ -1482,7 +1679,7 @@ export class LibrarianStore {
     return {
       sessions: filtered.slice(0, limit),
       total: filtered.length,
-      limit
+      limit,
     };
   }
 
@@ -1499,30 +1696,37 @@ export class LibrarianStore {
       params.push(type);
     }
     const whereSql = `WHERE ${clauses.join(" AND ")}`;
-    const total = this.db.prepare(`SELECT COUNT(*) AS n FROM session_events ${whereSql}`).get(...params).n;
+    const total = this.db
+      .prepare(`SELECT COUNT(*) AS n FROM session_events ${whereSql}`)
+      .get(...params).n;
     const rows = this.db
-      .prepare(`SELECT * FROM session_events ${whereSql} ORDER BY created_at ASC, id ASC LIMIT ? OFFSET ?`)
+      .prepare(
+        `SELECT * FROM session_events ${whereSql} ORDER BY created_at ASC, id ASC LIMIT ? OFFSET ?`,
+      )
       .all(...params, limit, offset);
 
     return {
       events: rows.map(rowToSessionEvent),
       total,
       limit,
-      offset
+      offset,
     };
   }
 }
 
 function canTransitionTo(target, currentStatus) {
   if (target === "archived") return ["active", "paused", "ended"].includes(currentStatus);
-  if (target === "deleted") return ["active", "paused", "ended", "archived"].includes(currentStatus);
+  if (target === "deleted")
+    return ["active", "paused", "ended", "archived"].includes(currentStatus);
   if (target === "restored") return ["archived", "deleted"].includes(currentStatus);
   return false;
 }
 
 function assertSessionMutable(session, action) {
   if (session.status === "ended") {
-    throw new Error(`Cannot ${action} an ended session (${session.id}); start a new one with continues_from instead.`);
+    throw new Error(
+      `Cannot ${action} an ended session (${session.id}); start a new one with continues_from instead.`,
+    );
   }
   if (session.status === "archived") {
     throw new Error(`Cannot ${action} an archived session (${session.id}); restore it first.`);
@@ -1558,7 +1762,9 @@ function compareKeys(a, b) {
 function eventSummary(event) {
   const type = event.event_type;
   if (type === "session.started") {
-    return event.payload?.session?.start_summary || event.payload?.session?.title || "Session started.";
+    return (
+      event.payload?.session?.start_summary || event.payload?.session?.title || "Session started."
+    );
   }
   return type;
 }
@@ -1588,7 +1794,9 @@ function renderHandover(handover, format) {
 function renderHandoverProse(handover) {
   const parts = [];
   const project = handover.project_key ? ` on project ${handover.project_key}` : "";
-  parts.push(`Session "${handover.title}" (${handover.id})${project} is currently ${handover.status}.`);
+  parts.push(
+    `Session "${handover.title}" (${handover.id})${project} is currently ${handover.status}.`,
+  );
   const origin = handover.created_in_harness || "unknown harness";
   const dest = handover.current_harness || "unknown harness";
   parts.push(`Started in ${origin}; continuing in ${dest}.`);
@@ -1596,11 +1804,16 @@ function renderHandoverProse(handover) {
   if (handover.rolling_summary) parts.push(`Current state: ${handover.rolling_summary}`);
   if (handover.end_summary) parts.push(`End summary: ${handover.end_summary}`);
   if (handover.decisions.length) parts.push(`Decisions so far: ${handover.decisions.join("; ")}.`);
-  if (handover.files_touched.length) parts.push(`Files touched: ${handover.files_touched.join(", ")}.`);
-  if (handover.commands_run.length) parts.push(`Commands run: ${handover.commands_run.join("; ")}.`);
-  if (handover.open_questions.length) parts.push(`Open questions: ${handover.open_questions.join("; ")}.`);
+  if (handover.files_touched.length)
+    parts.push(`Files touched: ${handover.files_touched.join(", ")}.`);
+  if (handover.commands_run.length)
+    parts.push(`Commands run: ${handover.commands_run.join("; ")}.`);
+  if (handover.open_questions.length)
+    parts.push(`Open questions: ${handover.open_questions.join("; ")}.`);
   if (handover.next_steps.length) parts.push(`Next steps: ${handover.next_steps.join("; ")}.`);
-  parts.push("Treat this as session evidence, not durable memory; use remember/propose_memory for durable facts.");
+  parts.push(
+    "Treat this as session evidence, not durable memory; use remember/propose_memory for durable facts.",
+  );
   return parts.join(" ");
 }
 
@@ -1620,7 +1833,7 @@ function renderHandoverMarkdown(handover) {
     handover.start_summary || "(no start summary recorded)",
     "",
     "## Current Summary",
-    handover.rolling_summary || "(no rolling summary recorded)"
+    handover.rolling_summary || "(no rolling summary recorded)",
   ];
   if (handover.end_summary) {
     lines.push("", "## End Summary", handover.end_summary);
@@ -1638,13 +1851,17 @@ function renderHandoverMarkdown(handover) {
     lines.push("", "## Open Questions", ...handover.open_questions.map((item) => `- ${item}`));
   }
   if (handover.next_steps.length) {
-    lines.push("", "## Next Steps", ...handover.next_steps.map((item, index) => `${index + 1}. ${item}`));
+    lines.push(
+      "",
+      "## Next Steps",
+      ...handover.next_steps.map((item, index) => `${index + 1}. ${item}`),
+    );
   }
   lines.push(
     "",
     "## Boundaries",
     "- Treat this as session evidence, not automatically true durable memory.",
-    "- Use The Librarian `remember`/`propose_memory` only for durable facts."
+    "- Use The Librarian `remember`/`propose_memory` only for durable facts.",
   );
   return lines.join("\n");
 }
@@ -1659,13 +1876,18 @@ function readJsonl(filePath) {
   if (!fs.existsSync(filePath)) return [];
   const raw = fs.readFileSync(filePath, "utf8").trim();
   if (!raw) return [];
-  return raw.split("\n").filter(Boolean).map((line, index) => {
-    try {
-      return JSON.parse(line);
-    } catch (error) {
-      throw new Error(`Invalid JSONL event in ${filePath} at line ${index + 1}: ${error.message}`);
-    }
-  });
+  return raw
+    .split("\n")
+    .filter(Boolean)
+    .map((line, index) => {
+      try {
+        return JSON.parse(line);
+      } catch (error) {
+        throw new Error(
+          `Invalid JSONL event in ${filePath} at line ${index + 1}: ${error.message}`,
+        );
+      }
+    });
 }
 
 function rowToSessionEvent(row) {
@@ -1679,7 +1901,7 @@ function rowToSessionEvent(row) {
     source_ref: row.source_ref,
     summary: row.summary,
     payload: JSON.parse(row.payload_json || "{}"),
-    created_at: row.created_at
+    created_at: row.created_at,
   };
 }
 
@@ -1711,7 +1933,7 @@ function rowToSession(row) {
     ended_at: row.ended_at,
     archived_at: row.archived_at,
     deleted_at: row.deleted_at,
-    metadata: JSON.parse(row.metadata_json || "{}")
+    metadata: JSON.parse(row.metadata_json || "{}"),
   };
 }
 
@@ -1723,7 +1945,7 @@ function rowToMemory(row) {
     supersedes: JSON.parse(row.supersedes_json || "[]"),
     conflicts_with: JSON.parse(row.conflicts_with_json || "[]"),
     recall_count: Number(row.recall_count || 0),
-    usefulness_score: Number(row.usefulness_score || 0)
+    usefulness_score: Number(row.usefulness_score || 0),
   };
 }
 
@@ -1733,7 +1955,12 @@ function tokenize(text) {
     .replace(/[^a-z0-9_./-]+/g, " ")
     .split(/\s+/)
     .filter((term) => term.length > 2)
-    .filter((term) => !["the", "and", "for", "with", "that", "this", "from", "into", "agent", "memory"].includes(term));
+    .filter(
+      (term) =>
+        !["the", "and", "for", "with", "that", "this", "from", "into", "agent", "memory"].includes(
+          term,
+        ),
+    );
 }
 
 function seemsConflict(a, b) {
@@ -1741,7 +1968,9 @@ function seemsConflict(a, b) {
   const right = normalizeString(b).toLowerCase();
   const negations = ["not", "never", "avoid", "prefer", "must", "should"];
   const sharedNegation = negations.some((word) => left.includes(word) && right.includes(word));
-  const oppositeSignals = (left.includes("prefer") && right.includes("avoid")) || (left.includes("avoid") && right.includes("prefer"));
+  const oppositeSignals =
+    (left.includes("prefer") && right.includes("avoid")) ||
+    (left.includes("avoid") && right.includes("prefer"));
   return oppositeSignals || sharedNegation;
 }
 
@@ -1760,11 +1989,12 @@ function cleanPatch(patch = {}) {
     "confidence",
     "supersedes",
     "conflicts_with",
-    "tags"
+    "tags",
   ];
   const output = {};
   for (const key of allowed) {
-    if (patch[key] !== undefined) output[key] = Array.isArray(patch[key]) ? asArray(patch[key]) : patch[key];
+    if (patch[key] !== undefined)
+      output[key] = Array.isArray(patch[key]) ? asArray(patch[key]) : patch[key];
   }
   return output;
 }
@@ -1786,9 +2016,13 @@ function formatContextPackage({ identity, relationship, privateMemories, relevan
   sections.push("");
   sections.push(formatSection("Identity", identity));
   sections.push(formatSection("Relationship", relationship));
-  if (privateMemories.length) sections.push(formatSection("Agent Operating Notes", privateMemories));
+  if (privateMemories.length)
+    sections.push(formatSection("Agent Operating Notes", privateMemories));
   if (relevant.length) sections.push(formatSection("Relevant Working Context", relevant));
-  return sections.filter(Boolean).join("\n\n").trim() || "Memory Context\n\nNo active memories found yet.";
+  return (
+    sections.filter(Boolean).join("\n\n").trim() ||
+    "Memory Context\n\nNo active memories found yet."
+  );
 }
 
 export function formatRecall(memories, heading = "Relevant Memories") {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,7 +1,7 @@
-import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
+import test from "node:test";
 import { runCli } from "../src/cli.js";
 import { withStore } from "./helpers.js";
 
@@ -15,8 +15,19 @@ test("CLI prints help for an unknown command", async () => {
 test("CLI sessions start creates a session and prints id + title", async () => {
   await withStore(async (store) => {
     const result = await runCli(
-      ["sessions", "start", "--agent", "bede", "--title", "CLI start", "--harness", "hermes", "--project", "the-librarian"],
-      store
+      [
+        "sessions",
+        "start",
+        "--agent",
+        "bede",
+        "--title",
+        "CLI start",
+        "--harness",
+        "hermes",
+        "--project",
+        "the-librarian",
+      ],
+      store,
     );
     assert.match(result.stdout, /ses_/);
     assert.match(result.stdout, /CLI start/);
@@ -33,8 +44,18 @@ test("CLI sessions start creates a session and prints id + title", async () => {
 test("CLI sessions start --private creates an agent_private session", async () => {
   await withStore(async (store) => {
     await runCli(
-      ["sessions", "start", "--agent", "bede", "--title", "Private", "--harness", "hermes", "--private"],
-      store
+      [
+        "sessions",
+        "start",
+        "--agent",
+        "bede",
+        "--title",
+        "Private",
+        "--harness",
+        "hermes",
+        "--private",
+      ],
+      store,
     );
     const sessions = store.listSessions({ agent_id: "bede" }).sessions;
     assert.equal(sessions[0].visibility, "agent_private");
@@ -45,7 +66,7 @@ test("CLI sessions start --json emits a parseable session payload", async () => 
   await withStore(async (store) => {
     const result = await runCli(
       ["sessions", "start", "--agent", "bede", "--title", "JSON", "--harness", "hermes", "--json"],
-      store
+      store,
     );
     const payload = JSON.parse(result.stdout);
     assert.ok(payload.session.id.startsWith("ses_"));
@@ -84,7 +105,7 @@ test("CLI sessions show prints session details", async () => {
       title: "Showable",
       harness: "hermes",
       project_key: "the-librarian",
-      start_summary: "Showing things."
+      start_summary: "Showing things.",
     });
 
     const result = await runCli(["sessions", "show", session.id, "--agent", "bede"], store);
@@ -96,7 +117,10 @@ test("CLI sessions show prints session details", async () => {
 
 test("CLI sessions show returns a clear message for unknown sessions", async () => {
   await withStore(async (store) => {
-    const result = await runCli(["sessions", "show", "ses_does_not_exist", "--agent", "bede"], store);
+    const result = await runCli(
+      ["sessions", "show", "ses_does_not_exist", "--agent", "bede"],
+      store,
+    );
     assert.match(result.stdout, /not found|no session/i);
     assert.notEqual(result.exitCode, 0);
   });
@@ -112,10 +136,14 @@ test("CLI rebuild still works after the subcommand refactor", async () => {
 
 test("CLI sessions checkpoint with --summary updates rolling_summary", async () => {
   await withStore(async (store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Checkpointable", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Checkpointable",
+      harness: "hermes",
+    });
     const result = await runCli(
       ["sessions", "checkpoint", session.id, "--agent", "bede", "--summary", "Mid-progress."],
-      store
+      store,
     );
     assert.match(result.stdout, /[Cc]heckpoint/);
     assert.equal(store.getSession(session.id).rolling_summary, "Mid-progress.");
@@ -124,13 +152,17 @@ test("CLI sessions checkpoint with --summary updates rolling_summary", async () 
 
 test("CLI sessions checkpoint --summary-file reads the summary from disk", async () => {
   await withStore(async (store, dataDir) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "FromFile", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "FromFile",
+      harness: "hermes",
+    });
     const summaryPath = path.join(dataDir, "checkpoint.md");
     fs.writeFileSync(summaryPath, "Loaded from file.\nMulti-line summary.\n", "utf8");
 
     await runCli(
       ["sessions", "checkpoint", session.id, "--agent", "bede", "--summary-file", summaryPath],
-      store
+      store,
     );
     const reloaded = store.getSession(session.id);
     assert.match(reloaded.rolling_summary, /Loaded from file\./);
@@ -140,10 +172,14 @@ test("CLI sessions checkpoint --summary-file reads the summary from disk", async
 
 test("CLI sessions pause marks the session paused", async () => {
   await withStore(async (store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Pausable", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Pausable",
+      harness: "hermes",
+    });
     const result = await runCli(
       ["sessions", "pause", session.id, "--agent", "bede", "--summary", "Day's end."],
-      store
+      store,
     );
     assert.match(result.stdout, /[Pp]aused/);
     const reloaded = store.getSession(session.id);
@@ -154,10 +190,14 @@ test("CLI sessions pause marks the session paused", async () => {
 
 test("CLI sessions end writes end_summary and marks the session ended", async () => {
   await withStore(async (store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Endable", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Endable",
+      harness: "hermes",
+    });
     const result = await runCli(
       ["sessions", "end", session.id, "--agent", "bede", "--summary", "Wrapped up."],
-      store
+      store,
     );
     assert.match(result.stdout, /[Ee]nded/);
     const reloaded = store.getSession(session.id);
@@ -172,17 +212,23 @@ test("CLI sessions attach swaps the current harness/source/cwd", async () => {
       agent_id: "bede",
       title: "Attachable",
       harness: "hermes",
-      source_ref: "discord:1:2"
+      source_ref: "discord:1:2",
     });
     await runCli(
       [
-        "sessions", "attach", session.id,
-        "--agent", "codex",
-        "--harness", "codex",
-        "--source-ref", "codex:r1:cwd:/dev",
-        "--cwd", "/dev"
+        "sessions",
+        "attach",
+        session.id,
+        "--agent",
+        "codex",
+        "--harness",
+        "codex",
+        "--source-ref",
+        "codex:r1:cwd:/dev",
+        "--cwd",
+        "/dev",
       ],
-      store
+      store,
     );
     const reloaded = store.getSession(session.id);
     assert.equal(reloaded.current_harness, "codex");
@@ -199,30 +245,40 @@ test("CLI sessions continue returns handover text and attaches by default", asyn
       title: "Handover via CLI",
       harness: "hermes",
       project_key: "the-librarian",
-      start_summary: "Investigating CLI handover."
+      start_summary: "Investigating CLI handover.",
     });
     store.checkpointSession({
       agent_id: "bede",
       session_id: session.id,
       summary: "Drafted CLI handover.",
-      next_steps: ["Verify with tests"]
+      next_steps: ["Verify with tests"],
     });
 
     const result = await runCli(
       [
-        "sessions", "continue", session.id,
-        "--agent", "codex",
-        "--target-harness", "codex",
-        "--target-source-ref", "codex:r1:cwd:/dev",
-        "--target-cwd", "/dev"
+        "sessions",
+        "continue",
+        session.id,
+        "--agent",
+        "codex",
+        "--target-harness",
+        "codex",
+        "--target-source-ref",
+        "codex:r1:cwd:/dev",
+        "--target-cwd",
+        "/dev",
       ],
-      store
+      store,
     );
 
     assert.match(result.stdout, /Handover via CLI/);
     assert.match(result.stdout, /Drafted CLI handover/);
     const reloaded = store.getSession(session.id);
-    assert.equal(reloaded.current_harness, "codex", "default attach=true should switch current harness");
+    assert.equal(
+      reloaded.current_harness,
+      "codex",
+      "default attach=true should switch current harness",
+    );
   });
 });
 
@@ -231,17 +287,21 @@ test("CLI sessions continue --no-attach leaves current harness untouched", async
     const { session } = store.startSession({
       agent_id: "bede",
       title: "Preview",
-      harness: "hermes"
+      harness: "hermes",
     });
 
     await runCli(
       [
-        "sessions", "continue", session.id,
-        "--agent", "codex",
-        "--target-harness", "codex",
-        "--no-attach"
+        "sessions",
+        "continue",
+        session.id,
+        "--agent",
+        "codex",
+        "--target-harness",
+        "codex",
+        "--no-attach",
       ],
-      store
+      store,
     );
     const reloaded = store.getSession(session.id);
     assert.equal(reloaded.current_harness, "hermes");
@@ -254,18 +314,27 @@ test("CLI sessions continue --format markdown produces the spec template", async
       agent_id: "bede",
       title: "Markdown CLI",
       harness: "hermes",
-      start_summary: "Start"
+      start_summary: "Start",
     });
     store.checkpointSession({
       agent_id: "bede",
       session_id: session.id,
       summary: "Mid",
-      decisions: ["A decision"]
+      decisions: ["A decision"],
     });
 
     const result = await runCli(
-      ["sessions", "continue", session.id, "--agent", "bede", "--format", "markdown", "--no-attach"],
-      store
+      [
+        "sessions",
+        "continue",
+        session.id,
+        "--agent",
+        "bede",
+        "--format",
+        "markdown",
+        "--no-attach",
+      ],
+      store,
     );
     assert.match(result.stdout, /# Librarian Session Handover/);
     assert.match(result.stdout, /## Decisions/);
@@ -275,11 +344,12 @@ test("CLI sessions continue --format markdown produces the spec template", async
 
 test("CLI sessions archive hides the session from default list", async () => {
   await withStore(async (store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Archive me", harness: "hermes" });
-    await runCli(
-      ["sessions", "archive", session.id, "--agent", "bede", "--reason", "tidy"],
-      store
-    );
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Archive me",
+      harness: "hermes",
+    });
+    await runCli(["sessions", "archive", session.id, "--agent", "bede", "--reason", "tidy"], store);
 
     const list = await runCli(["sessions", "list", "--agent", "bede"], store);
     assert.doesNotMatch(list.stdout, /Archive me/);
@@ -288,7 +358,11 @@ test("CLI sessions archive hides the session from default list", async () => {
 
 test("CLI sessions delete and restore round-trip an owned session", async () => {
   await withStore(async (store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Round trip", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Round trip",
+      harness: "hermes",
+    });
     await runCli(["sessions", "delete", session.id, "--agent", "bede"], store);
     assert.equal(store.getSession(session.id).status, "deleted");
 
@@ -299,11 +373,12 @@ test("CLI sessions delete and restore round-trip an owned session", async () => 
 
 test("CLI sessions delete refuses non-owner without --admin and surfaces a clear error", async () => {
   await withStore(async (store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Bede's", harness: "hermes" });
-    const result = await runCli(
-      ["sessions", "delete", session.id, "--agent", "codex"],
-      store
-    );
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Bede's",
+      harness: "hermes",
+    });
+    const result = await runCli(["sessions", "delete", session.id, "--agent", "codex"], store);
     assert.notEqual(result.exitCode, 0);
     assert.match(result.stdout, /owner|admin|permission/i);
     assert.equal(store.getSession(session.id).status, "active");
@@ -316,22 +391,33 @@ test("CLI sessions search finds sessions by event content", async () => {
       agent_id: "bede",
       title: "BM25 work",
       harness: "hermes",
-      start_summary: "Investigating BM25 recall."
+      start_summary: "Investigating BM25 recall.",
     });
 
-    const result = await runCli(
-      ["sessions", "search", "BM25", "--agent", "bede"],
-      store
-    );
+    const result = await runCli(["sessions", "search", "BM25", "--agent", "bede"], store);
     assert.match(result.stdout, /BM25 work/);
   });
 });
 
 test("CLI sessions events lists the per-session event stream with --type filter", async () => {
   await withStore(async (store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Events", harness: "hermes" });
-    store.recordSessionEvent({ agent_id: "bede", session_id: session.id, type: "decision", summary: "Decision A" });
-    store.recordSessionEvent({ agent_id: "bede", session_id: session.id, type: "command", summary: "npm test" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Events",
+      harness: "hermes",
+    });
+    store.recordSessionEvent({
+      agent_id: "bede",
+      session_id: session.id,
+      type: "decision",
+      summary: "Decision A",
+    });
+    store.recordSessionEvent({
+      agent_id: "bede",
+      session_id: session.id,
+      type: "command",
+      summary: "npm test",
+    });
 
     const all = await runCli(["sessions", "events", session.id, "--agent", "bede"], store);
     assert.match(all.stdout, /Decision A/);
@@ -339,7 +425,7 @@ test("CLI sessions events lists the per-session event stream with --type filter"
 
     const decisions = await runCli(
       ["sessions", "events", session.id, "--agent", "bede", "--type", "decision"],
-      store
+      store,
     );
     assert.match(decisions.stdout, /Decision A/);
     assert.doesNotMatch(decisions.stdout, /npm test/);

--- a/test/healthcheck.test.js
+++ b/test/healthcheck.test.js
@@ -1,7 +1,7 @@
-import test from "node:test";
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import path from "node:path";
+import test from "node:test";
 
 function runHealthcheck(extraArgs = []) {
   return new Promise((resolve, reject) => {
@@ -11,15 +11,19 @@ function runHealthcheck(extraArgs = []) {
       {
         cwd: path.resolve("."),
         env: { ...process.env, NO_COLOR: "1" },
-        stdio: ["ignore", "pipe", "pipe"]
-      }
+        stdio: ["ignore", "pipe", "pipe"],
+      },
     );
     let stdout = "";
     let stderr = "";
     child.stdout.setEncoding("utf8");
     child.stderr.setEncoding("utf8");
-    child.stdout.on("data", (chunk) => { stdout += chunk; });
-    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
     child.on("error", reject);
     child.on("exit", (code) => resolve({ code, stdout, stderr }));
   });
@@ -27,7 +31,11 @@ function runHealthcheck(extraArgs = []) {
 
 test("npm run healthcheck exits 0 on a clean system", async () => {
   const result = await runHealthcheck();
-  assert.equal(result.code, 0, `healthcheck failed:\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+  assert.equal(
+    result.code,
+    0,
+    `healthcheck failed:\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
 });
 
 test("healthcheck output names each documented check", async () => {
@@ -38,7 +46,7 @@ test("healthcheck output names each documented check", async () => {
     /SQLite rebuild/i,
     /session lifecycle/i,
     /MCP stdio/i,
-    /HTTP MCP/i
+    /HTTP MCP/i,
   ]) {
     assert.match(text, probe, `healthcheck output should mention ${probe}`);
   }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,9 +1,9 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
-import { spawn } from "node:child_process";
-import assert from "node:assert/strict";
 import { LibrarianStore } from "../src/store.js";
 
 export function makeTempDir() {
@@ -122,8 +122,7 @@ function waitForExit(child) {
     if (child.exitCode !== null || child.signalCode !== null) return resolve();
     child.once("exit", () => resolve());
     setTimeout(() => {
-      if (child.exitCode === null && child.signalCode === null)
-        child.kill("SIGKILL");
+      if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
       resolve();
     }, 2000);
   });

--- a/test/http.test.js
+++ b/test/http.test.js
@@ -1,14 +1,8 @@
-import test from "node:test";
 import assert from "node:assert/strict";
-import fs from "node:fs";
-import path from "node:path";
 import { spawn } from "node:child_process";
-import {
-  cleanupTempDir,
-  makeTempDir,
-  postJson,
-  startHttpServer,
-} from "./helpers.js";
+import path from "node:path";
+import test from "node:test";
+import { cleanupTempDir, makeTempDir, postJson, startHttpServer } from "./helpers.js";
 
 test("HTTP service exposes dashboard/API without auth and protects MCP with auth", async () => {
   const dataDir = makeTempDir();
@@ -228,12 +222,9 @@ test("HTTP dashboard can create proposals, approve them, and recall through MCP"
     assert.equal(create.response.status, 200);
     assert.equal(create.json.status, "proposed");
 
-    const approve = await postJson(
-      `${server.url}/api/proposals/${create.json.memory.id}/approve`,
-      {
-        agent_id: "dashboard",
-      },
-    );
+    const approve = await postJson(`${server.url}/api/proposals/${create.json.memory.id}/approve`, {
+      agent_id: "dashboard",
+    });
     assert.equal(approve.response.status, 200);
     assert.equal(approve.json.status, "active");
 
@@ -255,10 +246,7 @@ test("HTTP dashboard can create proposals, approve them, and recall through MCP"
     );
 
     assert.equal(context.response.status, 200);
-    assert.match(
-      context.json.result.content[0].text,
-      /Protected identity memories/,
-    );
+    assert.match(context.json.result.content[0].text, /Protected identity memories/);
   } finally {
     await server.stop();
     cleanupTempDir(dataDir);
@@ -267,7 +255,11 @@ test("HTTP dashboard can create proposals, approve them, and recall through MCP"
 
 test("HTTP dashboard can edit active protected memories as the admin surface", async () => {
   const dataDir = makeTempDir();
-  const server = await startHttpServer({ dataDir, token: "protected-edit-token", agentToken: "protected-edit-agent-token" });
+  const server = await startHttpServer({
+    dataDir,
+    token: "protected-edit-token",
+    agentToken: "protected-edit-agent-token",
+  });
   try {
     const create = await postJson(`${server.url}/api/memories`, {
       agent_id: "dashboard",
@@ -277,13 +269,13 @@ test("HTTP dashboard can edit active protected memories as the admin surface", a
       visibility: "common",
       scope: "global",
       priority: "core",
-      tags: ["relationship"]
+      tags: ["relationship"],
     });
     assert.equal(create.response.status, 200);
     assert.equal(create.json.status, "proposed");
 
     const approve = await postJson(`${server.url}/api/proposals/${create.json.memory.id}/approve`, {
-      agent_id: "dashboard"
+      agent_id: "dashboard",
     });
     assert.equal(approve.response.status, 200);
     assert.equal(approve.json.status, "active");
@@ -292,13 +284,16 @@ test("HTTP dashboard can edit active protected memories as the admin surface", a
       agent_id: "dashboard",
       patch: {
         body: "Dashboard edits can directly refine active protected memories.",
-        tags: ["relationship", "dashboard-edit"]
-      }
+        tags: ["relationship", "dashboard-edit"],
+      },
     });
     assert.equal(update.response.status, 200);
     assert.equal(update.json.status, "active");
     assert.equal(update.json.category, "relationship");
-    assert.equal(update.json.body, "Dashboard edits can directly refine active protected memories.");
+    assert.equal(
+      update.json.body,
+      "Dashboard edits can directly refine active protected memories.",
+    );
     assert.deepEqual(update.json.tags, ["relationship", "dashboard-edit"]);
   } finally {
     await server.stop();
@@ -328,20 +323,17 @@ test("HTTP dashboard API can update ordinary memory routing fields", async () =>
     assert.equal(create.response.status, 200);
     assert.equal(create.json.status, "active");
 
-    const update = await postJson(
-      `${server.url}/api/memories/${create.json.memory.id}/update`,
-      {
-        agent_id: "dashboard",
-        patch: {
-          agent_id: "codex",
-          category: "projects",
-          visibility: "agent_private",
-          scope: "project",
-          project_key: "memory-system",
-          tags: ["dashboard", "editing", "routing"],
-        },
+    const update = await postJson(`${server.url}/api/memories/${create.json.memory.id}/update`, {
+      agent_id: "dashboard",
+      patch: {
+        agent_id: "codex",
+        category: "projects",
+        visibility: "agent_private",
+        scope: "project",
+        project_key: "memory-system",
+        tags: ["dashboard", "editing", "routing"],
       },
-    );
+    });
 
     assert.equal(update.response.status, 200);
     assert.equal(update.json.agent_id, "codex");
@@ -372,7 +364,9 @@ test("HTTP event log is paginated, filterable, and records empty or unhelpful re
     assert.equal(emptyRecall.response.status, 200);
     assert.deepEqual(emptyRecall.json.memories, []);
 
-    const emptyEvents = await fetch(`${server.url}/api/events?type=memory.recall_empty&agent_id=codex&limit=2&offset=0`);
+    const emptyEvents = await fetch(
+      `${server.url}/api/events?type=memory.recall_empty&agent_id=codex&limit=2&offset=0`,
+    );
     assert.equal(emptyEvents.status, 200);
     const emptyJson = await emptyEvents.json();
     assert.equal(emptyJson.total, 1);
@@ -414,14 +408,18 @@ test("HTTP event log is paginated, filterable, and records empty or unhelpful re
       assert.equal(verification.response.status, 200);
     }
 
-    const wrongEvents = await fetch(`${server.url}/api/events?type=memory.verified&result=wrong&query=wrong%20recall&limit=1`);
+    const wrongEvents = await fetch(
+      `${server.url}/api/events?type=memory.verified&result=wrong&query=wrong%20recall&limit=1`,
+    );
     assert.equal(wrongEvents.status, 200);
     const wrongJson = await wrongEvents.json();
     assert.equal(wrongJson.total, 1);
     assert.equal(wrongJson.events[0].payload.result, "wrong");
     assert.equal(wrongJson.events[0].payload.note, "wrong recall feedback");
 
-    const notUsefulEvents = await fetch(`${server.url}/api/events?type=memory.verified&result=not_useful&limit=1`);
+    const notUsefulEvents = await fetch(
+      `${server.url}/api/events?type=memory.verified&result=not_useful&limit=1`,
+    );
     assert.equal(notUsefulEvents.status, 200);
     const notUsefulJson = await notUsefulEvents.json();
     assert.equal(notUsefulJson.total, 1);
@@ -588,9 +586,7 @@ test("HTTP per-agent bearer tokens prevent agent_id impersonation", async () => 
     assert.equal(remember.response.status, 200);
 
     const state = await fetch(`${server.url}/api/state`);
-    const saved = (await state.json()).memories.find(
-      (memory) => memory.title === "Spoofed writer",
-    );
+    const saved = (await state.json()).memories.find((memory) => memory.title === "Spoofed writer");
     assert.equal(saved.agent_id, "codex");
   } finally {
     await server.stop();
@@ -652,10 +648,7 @@ test("HTTP service refuses non-local binds without an auth token", async () => {
   try {
     const { code, stderr } = await waitForExit(child);
     assert.equal(code, 1);
-    assert.match(
-      stderr,
-      /Refusing to start without LIBRARIAN_ADMIN_TOKEN or LIBRARIAN_AUTH_TOKEN/,
-    );
+    assert.match(stderr, /Refusing to start without LIBRARIAN_ADMIN_TOKEN or LIBRARIAN_AUTH_TOKEN/);
   } finally {
     cleanupTempDir(dataDir);
   }
@@ -692,9 +685,30 @@ test("GET /api/aggregates returns dimension counts", async () => {
   const dataDir = makeTempDir();
   const server = await startHttpServer({ dataDir });
   try {
-    await postJson(`${server.url}/api/memories`, { agent_id: "codex", title: "Codex memory one", body: "Body text one", category: "tools", visibility: "agent_private", scope: "tool" });
-    await postJson(`${server.url}/api/memories`, { agent_id: "codex", title: "Codex memory two", body: "Body text two", category: "tools", visibility: "agent_private", scope: "tool" });
-    await postJson(`${server.url}/api/memories`, { agent_id: "claude", title: "Claude memory one", body: "Body text three", category: "tools", visibility: "agent_private", scope: "tool" });
+    await postJson(`${server.url}/api/memories`, {
+      agent_id: "codex",
+      title: "Codex memory one",
+      body: "Body text one",
+      category: "tools",
+      visibility: "agent_private",
+      scope: "tool",
+    });
+    await postJson(`${server.url}/api/memories`, {
+      agent_id: "codex",
+      title: "Codex memory two",
+      body: "Body text two",
+      category: "tools",
+      visibility: "agent_private",
+      scope: "tool",
+    });
+    await postJson(`${server.url}/api/memories`, {
+      agent_id: "claude",
+      title: "Claude memory one",
+      body: "Body text three",
+      category: "tools",
+      visibility: "agent_private",
+      scope: "tool",
+    });
 
     const res = await fetch(`${server.url}/api/aggregates`);
     assert.equal(res.status, 200);
@@ -717,9 +731,18 @@ test("GET /api/aggregates excludes deleted memories", async () => {
   const dataDir = makeTempDir();
   const server = await startHttpServer({ dataDir });
   try {
-    const create = await postJson(`${server.url}/api/memories`, { agent_id: "codex", title: "Memory to delete", body: "Will be deleted", category: "tools", visibility: "common", scope: "tool" });
+    const create = await postJson(`${server.url}/api/memories`, {
+      agent_id: "codex",
+      title: "Memory to delete",
+      body: "Will be deleted",
+      category: "tools",
+      visibility: "common",
+      scope: "tool",
+    });
     assert.equal(create.json.status, "active");
-    await postJson(`${server.url}/api/memories/${create.json.memory.id}/delete`, { agent_id: "dashboard" });
+    await postJson(`${server.url}/api/memories/${create.json.memory.id}/delete`, {
+      agent_id: "dashboard",
+    });
 
     const res = await fetch(`${server.url}/api/aggregates`);
     assert.equal(res.status, 200);
@@ -787,12 +810,24 @@ test("GET /api/memories with date range filtering", async () => {
   const dataDir = makeTempDir();
   const server = await startHttpServer({ dataDir });
   try {
-    await postJson(`${server.url}/api/memories`, { title: "Memory A before filter", body: "Created before the filter", category: "tools", visibility: "common", scope: "tool" });
+    await postJson(`${server.url}/api/memories`, {
+      title: "Memory A before filter",
+      body: "Created before the filter",
+      category: "tools",
+      visibility: "common",
+      scope: "tool",
+    });
 
     await new Promise((r) => setTimeout(r, 5));
     const T2 = new Date().toISOString();
 
-    const createB = await postJson(`${server.url}/api/memories`, { title: "Memory B after filter", body: "Created after the filter", category: "tools", visibility: "common", scope: "tool" });
+    const createB = await postJson(`${server.url}/api/memories`, {
+      title: "Memory B after filter",
+      body: "Created after the filter",
+      category: "tools",
+      visibility: "common",
+      scope: "tool",
+    });
     assert.equal(createB.json.status, "active");
 
     const res = await fetch(`${server.url}/api/memories?from=${encodeURIComponent(T2)}`);
@@ -811,9 +846,27 @@ test("GET /api/memories with sort and pagination", async () => {
   const dataDir = makeTempDir();
   const server = await startHttpServer({ dataDir });
   try {
-    await postJson(`${server.url}/api/memories`, { title: "Banana memory", body: "Second alphabetically", category: "tools", visibility: "common", scope: "tool" });
-    await postJson(`${server.url}/api/memories`, { title: "Apple memory", body: "First alphabetically", category: "tools", visibility: "common", scope: "tool" });
-    await postJson(`${server.url}/api/memories`, { title: "Cherry memory", body: "Third alphabetically", category: "tools", visibility: "common", scope: "tool" });
+    await postJson(`${server.url}/api/memories`, {
+      title: "Banana memory",
+      body: "Second alphabetically",
+      category: "tools",
+      visibility: "common",
+      scope: "tool",
+    });
+    await postJson(`${server.url}/api/memories`, {
+      title: "Apple memory",
+      body: "First alphabetically",
+      category: "tools",
+      visibility: "common",
+      scope: "tool",
+    });
+    await postJson(`${server.url}/api/memories`, {
+      title: "Cherry memory",
+      body: "Third alphabetically",
+      category: "tools",
+      visibility: "common",
+      scope: "tool",
+    });
 
     const page1 = await fetch(`${server.url}/api/memories?sort=title&order=asc&limit=2&offset=0`);
     assert.equal(page1.status, 200);

--- a/test/integrations.test.js
+++ b/test/integrations.test.js
@@ -1,7 +1,7 @@
-import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
+import test from "node:test";
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "..");
 const INTEGRATIONS_DIR = path.join(REPO_ROOT, "integrations");
@@ -19,7 +19,11 @@ function assertNonEmptyFile(p) {
 
 function assertReferencesLib(p) {
   const content = fs.readFileSync(p, "utf8");
-  assert.match(content, /\/lib:session/, `${path.relative(REPO_ROOT, p)} should reference the /lib:session slash command surface`);
+  assert.match(
+    content,
+    /\/lib:session/,
+    `${path.relative(REPO_ROOT, p)} should reference the /lib:session slash command surface`,
+  );
 }
 
 test("integrations/README.md exists and references each supported harness", () => {
@@ -37,7 +41,7 @@ test("integrations/hermes package ships the documented files", () => {
     "AGENTS.append.md",
     "slash-commands.md",
     "config.example.yaml",
-    "healthcheck.md"
+    "healthcheck.md",
   ]) {
     assertNonEmptyFile(pkgPath("hermes", file));
   }
@@ -58,7 +62,7 @@ test("integrations/claude-code package ships the documented files", () => {
     "slash-commands.md",
     "mcp.example.json",
     "wrapper.sh",
-    "healthcheck.md"
+    "healthcheck.md",
   ]) {
     assertNonEmptyFile(pkgPath("claude-code", file));
   }
@@ -87,21 +91,50 @@ test("integrations/claude-code mcp.example.json is valid JSON and references the
 
 test("integrations/claude-code ships one native slash command per session verb", () => {
   const verbs = [
-    "start", "list", "resume", "checkpoint", "pause", "end",
-    "archive", "restore", "delete", "search", "status"
+    "start",
+    "list",
+    "resume",
+    "checkpoint",
+    "pause",
+    "end",
+    "archive",
+    "restore",
+    "delete",
+    "search",
+    "status",
   ];
   for (const verb of verbs) {
     assertNonEmptyFile(pkgPath("claude-code", "commands", `lib-session-${verb}.md`));
   }
-  const startCmd = fs.readFileSync(pkgPath("claude-code", "commands", "lib-session-start.md"), "utf8");
-  assert.match(startCmd, /start_session/, "lib-session-start command must name the MCP tool it calls");
-  assert.match(startCmd, /sensitivity/i, "lib-session-start must remind about the sensitivity check");
+  const startCmd = fs.readFileSync(
+    pkgPath("claude-code", "commands", "lib-session-start.md"),
+    "utf8",
+  );
+  assert.match(
+    startCmd,
+    /start_session/,
+    "lib-session-start command must name the MCP tool it calls",
+  );
+  assert.match(
+    startCmd,
+    /sensitivity/i,
+    "lib-session-start must remind about the sensitivity check",
+  );
 });
 
 test("repo-local .claude/commands ships the same per-verb commands", () => {
   const verbs = [
-    "start", "list", "resume", "checkpoint", "pause", "end",
-    "archive", "restore", "delete", "search", "status"
+    "start",
+    "list",
+    "resume",
+    "checkpoint",
+    "pause",
+    "end",
+    "archive",
+    "restore",
+    "delete",
+    "search",
+    "status",
   ];
   for (const verb of verbs) {
     const p = path.join(REPO_ROOT, ".claude", "commands", `lib-session-${verb}.md`);
@@ -116,7 +149,7 @@ test("integrations/codex package ships the documented files", () => {
     "slash-commands.md",
     "mcp.example.json",
     "wrapper.sh",
-    "healthcheck.md"
+    "healthcheck.md",
   ]) {
     assertNonEmptyFile(pkgPath("codex", file));
   }
@@ -139,7 +172,7 @@ test("integrations/pi package ships the documented files", () => {
     "slash-commands.md",
     "config.example.yaml",
     "wrapper.sh",
-    "healthcheck.md"
+    "healthcheck.md",
   ]) {
     assertNonEmptyFile(pkgPath("pi", file));
   }
@@ -170,7 +203,7 @@ test("integrations/opencode package ships the documented files", () => {
     "opencode.example.json",
     "commands.example.json",
     "wrapper.sh",
-    "healthcheck.md"
+    "healthcheck.md",
   ]) {
     assertNonEmptyFile(pkgPath("opencode", file));
   }
@@ -178,38 +211,72 @@ test("integrations/opencode package ships the documented files", () => {
 });
 
 test("integrations/opencode example configs are valid JSON", () => {
-  const opencode = JSON.parse(fs.readFileSync(pkgPath("opencode", "opencode.example.json"), "utf8"));
+  const opencode = JSON.parse(
+    fs.readFileSync(pkgPath("opencode", "opencode.example.json"), "utf8"),
+  );
   assert.ok(opencode, "opencode.example.json must parse");
   const flat = JSON.stringify(opencode);
   assert.match(flat, /librarian/i);
   assert.match(flat, /\/mcp/);
 
-  const commands = JSON.parse(fs.readFileSync(pkgPath("opencode", "commands.example.json"), "utf8"));
+  const commands = JSON.parse(
+    fs.readFileSync(pkgPath("opencode", "commands.example.json"), "utf8"),
+  );
   assert.ok(commands, "commands.example.json must parse");
   assert.ok(commands.command, "commands.example.json must use OpenCode's `command` key");
   for (const verb of [
-    "start", "list", "resume", "checkpoint", "pause", "end",
-    "archive", "restore", "delete", "search", "status"
+    "start",
+    "list",
+    "resume",
+    "checkpoint",
+    "pause",
+    "end",
+    "archive",
+    "restore",
+    "delete",
+    "search",
+    "status",
   ]) {
     assert.ok(
       commands.command[`lib-session-${verb}`],
-      `commands.example.json must define lib-session-${verb}`
+      `commands.example.json must define lib-session-${verb}`,
     );
   }
 });
 
 test("integrations/opencode ships one native slash command markdown per session verb", () => {
   const verbs = [
-    "start", "list", "resume", "checkpoint", "pause", "end",
-    "archive", "restore", "delete", "search", "status"
+    "start",
+    "list",
+    "resume",
+    "checkpoint",
+    "pause",
+    "end",
+    "archive",
+    "restore",
+    "delete",
+    "search",
+    "status",
   ];
   for (const verb of verbs) {
     assertNonEmptyFile(pkgPath("opencode", "commands", `lib-session-${verb}.md`));
   }
   const startCmd = fs.readFileSync(pkgPath("opencode", "commands", "lib-session-start.md"), "utf8");
-  assert.match(startCmd, /start_session/, "lib-session-start command must name the MCP tool it calls");
-  assert.match(startCmd, /sensitivity/i, "lib-session-start must remind about the sensitivity check");
-  assert.match(startCmd, /harness: "opencode"/, "lib-session-start must default harness to opencode");
+  assert.match(
+    startCmd,
+    /start_session/,
+    "lib-session-start command must name the MCP tool it calls",
+  );
+  assert.match(
+    startCmd,
+    /sensitivity/i,
+    "lib-session-start must remind about the sensitivity check",
+  );
+  assert.match(
+    startCmd,
+    /harness: "opencode"/,
+    "lib-session-start must default harness to opencode",
+  );
 });
 
 test("integrations/opencode wrapper.sh is executable and records attachment", () => {

--- a/test/mcp.test.js
+++ b/test/mcp.test.js
@@ -1,14 +1,24 @@
-import test from "node:test";
 import assert from "node:assert/strict";
+import test from "node:test";
 import { handleMcpPayload } from "../src/mcp.js";
 import { withStore } from "./helpers.js";
 
 test("MCP exposes the expected server identity and tool surface", async () => {
   await withStore(async (store) => {
-    const init = await handleMcpPayload(store, { jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+    const init = await handleMcpPayload(store, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {},
+    });
     assert.equal(init.result.serverInfo.name, "the-librarian");
 
-    const list = await handleMcpPayload(store, { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} });
+    const list = await handleMcpPayload(store, {
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/list",
+      params: {},
+    });
     const toolNames = list.result.tools.map((tool) => tool.name);
     for (const expected of [
       "start_context",
@@ -17,7 +27,7 @@ test("MCP exposes the expected server identity and tool surface", async () => {
       "propose_memory",
       "update_memory",
       "verify_memory",
-      "list_proposals"
+      "list_proposals",
     ]) {
       assert.ok(toolNames.includes(expected), `expected memory tool ${expected}`);
     }
@@ -25,7 +35,11 @@ test("MCP exposes the expected server identity and tool surface", async () => {
     assert.ok(!toolNames.includes("delete_memory"));
     assert.ok(!toolNames.includes("resolve_conflict"));
 
-    const adminList = await handleMcpPayload(store, { jsonrpc: "2.0", id: 3, method: "tools/list", params: {} }, { role: "admin" });
+    const adminList = await handleMcpPayload(
+      store,
+      { jsonrpc: "2.0", id: 3, method: "tools/list", params: {} },
+      { role: "admin" },
+    );
     const adminToolNames = adminList.result.tools.map((tool) => tool.name);
     assert.ok(adminToolNames.includes("approve_proposal"));
     assert.ok(adminToolNames.includes("delete_memory"));
@@ -48,9 +62,9 @@ test("MCP remember protects identity memories and ordinary recall returns clean 
           category: "identity",
           visibility: "common",
           scope: "global",
-          priority: "core"
-        }
-      }
+          priority: "core",
+        },
+      },
     });
 
     assert.match(protectedWrite.result.content[0].text, /proposal for review/);
@@ -69,9 +83,9 @@ test("MCP remember protects identity memories and ordinary recall returns clean 
           category: "tools",
           visibility: "common",
           scope: "tool",
-          tags: ["mcp", "http"]
-        }
-      }
+          tags: ["mcp", "http"],
+        },
+      },
     });
 
     const recall = await handleMcpPayload(store, {
@@ -84,9 +98,9 @@ test("MCP remember protects identity memories and ordinary recall returns clean 
           agent_id: "codex",
           query: "remote agents POST JSON-RPC",
           categories: ["tools"],
-          limit: 3
-        }
-      }
+          limit: 3,
+        },
+      },
     });
 
     const text = recall.result.content[0].text;
@@ -104,7 +118,7 @@ test("MCP start_context always includes approved identity and relationship conte
       category: "identity",
       visibility: "common",
       scope: "global",
-      priority: "core"
+      priority: "core",
     });
     const relationship = store.createMemory({
       agent_id: "dashboard",
@@ -113,7 +127,7 @@ test("MCP start_context always includes approved identity and relationship conte
       category: "relationship",
       visibility: "common",
       scope: "global",
-      priority: "core"
+      priority: "core",
     });
     store.approveProposal(identity.memory.id, "approve", {}, "dashboard");
     store.approveProposal(relationship.memory.id, "approve", {}, "dashboard");
@@ -126,9 +140,9 @@ test("MCP start_context always includes approved identity and relationship conte
         name: "start_context",
         arguments: {
           agent_id: "codex",
-          task_summary: "write deployment tests"
-        }
-      }
+          task_summary: "write deployment tests",
+        },
+      },
     });
 
     const text = context.result.content[0].text;
@@ -145,7 +159,7 @@ test("MCP returns JSON-RPC errors for unknown methods instead of throwing outwar
       jsonrpc: "2.0",
       id: 99,
       method: "does/not/exist",
-      params: {}
+      params: {},
     });
 
     assert.equal(result.id, 99);
@@ -162,7 +176,7 @@ test("MCP agent role cannot approve proposals or delete memories", async () => {
       body: "This must remain proposed until an admin approves it.",
       category: "identity",
       visibility: "common",
-      scope: "global"
+      scope: "global",
     });
 
     const approve = await handleMcpPayload(store, {
@@ -173,9 +187,9 @@ test("MCP agent role cannot approve proposals or delete memories", async () => {
         name: "approve_proposal",
         arguments: {
           agent_id: "codex",
-          memory_id: proposal.memory.id
-        }
-      }
+          memory_id: proposal.memory.id,
+        },
+      },
     });
 
     assert.match(approve.error.message, /requires admin authorization/);
@@ -187,7 +201,7 @@ test("MCP agent role cannot approve proposals or delete memories", async () => {
       body: "An agent token should not be able to delete this.",
       category: "tools",
       visibility: "common",
-      scope: "tool"
+      scope: "tool",
     });
 
     const deletion = await handleMcpPayload(store, {
@@ -198,9 +212,9 @@ test("MCP agent role cannot approve proposals or delete memories", async () => {
         name: "delete_memory",
         arguments: {
           agent_id: "codex",
-          memory_id: ordinary.memory.id
-        }
-      }
+          memory_id: ordinary.memory.id,
+        },
+      },
     });
 
     assert.match(deletion.error.message, /requires admin authorization/);
@@ -216,7 +230,7 @@ test("MCP memory resource does not leak other agents private memories", async ()
       body: "Common memory should be visible through the resource.",
       category: "tools",
       visibility: "common",
-      scope: "global"
+      scope: "global",
     });
     store.createMemory({
       agent_id: "codex",
@@ -224,7 +238,7 @@ test("MCP memory resource does not leak other agents private memories", async ()
       body: "Codex should use pnpm for local workspace commands.",
       category: "tools",
       visibility: "agent_private",
-      scope: "global"
+      scope: "global",
     });
     store.createMemory({
       agent_id: "claude",
@@ -232,37 +246,45 @@ test("MCP memory resource does not leak other agents private memories", async ()
       body: "Claude should use uv for isolated Python command checks.",
       category: "tools",
       visibility: "agent_private",
-      scope: "global"
+      scope: "global",
     });
 
     const sharedAgent = await handleMcpPayload(store, {
       jsonrpc: "2.0",
       id: 1,
       method: "resources/read",
-      params: { uri: "librarian://memories" }
+      params: { uri: "librarian://memories" },
     });
     const sharedText = sharedAgent.result.contents[0].text;
     assert.match(sharedText, /Common memory/);
     assert.doesNotMatch(sharedText, /Codex private memory/);
     assert.doesNotMatch(sharedText, /Claude private memory/);
 
-    const codexAgent = await handleMcpPayload(store, {
-      jsonrpc: "2.0",
-      id: 2,
-      method: "resources/read",
-      params: { uri: "librarian://memories" }
-    }, { role: "agent", agentId: "codex" });
+    const codexAgent = await handleMcpPayload(
+      store,
+      {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "resources/read",
+        params: { uri: "librarian://memories" },
+      },
+      { role: "agent", agentId: "codex" },
+    );
     const codexText = codexAgent.result.contents[0].text;
     assert.match(codexText, /Common memory/);
     assert.match(codexText, /Codex private memory/);
     assert.doesNotMatch(codexText, /Claude private memory/);
 
-    const admin = await handleMcpPayload(store, {
-      jsonrpc: "2.0",
-      id: 3,
-      method: "resources/read",
-      params: { uri: "librarian://memories" }
-    }, { role: "admin" });
+    const admin = await handleMcpPayload(
+      store,
+      {
+        jsonrpc: "2.0",
+        id: 3,
+        method: "resources/read",
+        params: { uri: "librarian://memories" },
+      },
+      { role: "admin" },
+    );
     const adminText = admin.result.contents[0].text;
     assert.match(adminText, /Common memory/);
     assert.match(adminText, /Codex private memory/);

--- a/test/sessions.http.test.js
+++ b/test/sessions.http.test.js
@@ -1,12 +1,7 @@
-import test from "node:test";
 import assert from "node:assert/strict";
-import {
-  cleanupTempDir,
-  makeTempDir,
-  postJson,
-  startHttpServer
-} from "./helpers.js";
+import test from "node:test";
 import { LibrarianStore } from "../src/store.js";
+import { cleanupTempDir, makeTempDir, postJson, startHttpServer } from "./helpers.js";
 
 async function seedSession(dataDir, overrides = {}) {
   const store = new LibrarianStore({ dataDir });
@@ -17,7 +12,7 @@ async function seedSession(dataDir, overrides = {}) {
       harness: overrides.harness || "hermes",
       project_key: overrides.project_key || "the-librarian",
       visibility: overrides.visibility || "common",
-      start_summary: overrides.start_summary || "HTTP smoke test."
+      start_summary: overrides.start_summary || "HTTP smoke test.",
     }).session;
   } finally {
     store.close();
@@ -99,8 +94,18 @@ test("GET /api/sessions/:id/events returns the per-session event stream", async 
   const session = await seedSession(dataDir, { title: "Events" });
   const store = new LibrarianStore({ dataDir });
   try {
-    store.recordSessionEvent({ agent_id: "bede", session_id: session.id, type: "decision", summary: "D1" });
-    store.recordSessionEvent({ agent_id: "bede", session_id: session.id, type: "command", summary: "npm test" });
+    store.recordSessionEvent({
+      agent_id: "bede",
+      session_id: session.id,
+      type: "decision",
+      summary: "D1",
+    });
+    store.recordSessionEvent({
+      agent_id: "bede",
+      session_id: session.id,
+      type: "command",
+      summary: "npm test",
+    });
   } finally {
     store.close();
   }
@@ -124,7 +129,9 @@ test("POST /api/sessions/search runs an FTS search", async () => {
   await seedSession(dataDir, { title: "Other", start_summary: "Refactor the dashboard." });
   const server = await startHttpServer({ dataDir });
   try {
-    const { response, json } = await postJson(`${server.url}/api/sessions/search`, { query: "BM25" });
+    const { response, json } = await postJson(`${server.url}/api/sessions/search`, {
+      query: "BM25",
+    });
     assert.equal(response.status, 200);
     assert.equal(json.sessions.length, 1);
     assert.equal(json.sessions[0].title, "BM25 finder");
@@ -139,9 +146,12 @@ test("POST /api/sessions/:id/checkpoint updates rolling_summary", async () => {
   const session = await seedSession(dataDir);
   const server = await startHttpServer({ dataDir });
   try {
-    const { response, json } = await postJson(`${server.url}/api/sessions/${session.id}/checkpoint`, {
-      summary: "Made progress."
-    });
+    const { response, json } = await postJson(
+      `${server.url}/api/sessions/${session.id}/checkpoint`,
+      {
+        summary: "Made progress.",
+      },
+    );
     assert.equal(response.status, 200);
     assert.equal(json.session.rolling_summary, "Made progress.");
     assert.equal(json.session.status, "active");
@@ -157,10 +167,14 @@ test("POST /api/sessions/:id/pause and /end transition the session", async () =>
   const ended = await seedSession(dataDir, { title: "End me" });
   const server = await startHttpServer({ dataDir });
   try {
-    const pauseResp = await postJson(`${server.url}/api/sessions/${paused.id}/pause`, { summary: "EOD" });
+    const pauseResp = await postJson(`${server.url}/api/sessions/${paused.id}/pause`, {
+      summary: "EOD",
+    });
     assert.equal(pauseResp.json.session.status, "paused");
 
-    const endResp = await postJson(`${server.url}/api/sessions/${ended.id}/end`, { summary: "Done" });
+    const endResp = await postJson(`${server.url}/api/sessions/${ended.id}/end`, {
+      summary: "Done",
+    });
     assert.equal(endResp.json.session.status, "ended");
     assert.equal(endResp.json.session.end_summary, "Done");
   } finally {
@@ -174,7 +188,9 @@ test("POST /api/sessions/:id/archive hides from default list", async () => {
   const session = await seedSession(dataDir, { title: "Archivable" });
   const server = await startHttpServer({ dataDir });
   try {
-    const archive = await postJson(`${server.url}/api/sessions/${session.id}/archive`, { reason: "tidy" });
+    const archive = await postJson(`${server.url}/api/sessions/${session.id}/archive`, {
+      reason: "tidy",
+    });
     assert.equal(archive.json.session.status, "archived");
 
     const list = await (await fetch(`${server.url}/api/sessions`)).json();
@@ -190,7 +206,9 @@ test("POST /api/sessions/:id/restore and /delete round-trip a session", async ()
   const session = await seedSession(dataDir, { title: "Round trip" });
   const server = await startHttpServer({ dataDir });
   try {
-    const del = await postJson(`${server.url}/api/sessions/${session.id}/delete`, { reason: "test" });
+    const del = await postJson(`${server.url}/api/sessions/${session.id}/delete`, {
+      reason: "test",
+    });
     assert.equal(del.json.session.status, "deleted");
 
     const restore = await postJson(`${server.url}/api/sessions/${session.id}/restore`, {});
@@ -210,7 +228,7 @@ test("POST /api/sessions/:id/continue returns a handover package and attaches by
       agent_id: "bede",
       session_id: session.id,
       summary: "Drafted handover.",
-      next_steps: ["Add tests"]
+      next_steps: ["Add tests"],
     });
   } finally {
     store.close();
@@ -221,11 +239,15 @@ test("POST /api/sessions/:id/continue returns a handover package and attaches by
       target_harness: "codex",
       target_source_ref: "codex:r1",
       target_cwd: "/dev",
-      format: "markdown"
+      format: "markdown",
     });
     assert.equal(response.status, 200);
     assert.match(json.text, /Librarian Session Handover/);
-    assert.equal(json.session.current_harness, "codex", "default attach should switch current harness");
+    assert.equal(
+      json.session.current_harness,
+      "codex",
+      "default attach should switch current harness",
+    );
   } finally {
     await server.stop();
     cleanupTempDir(dataDir);
@@ -243,8 +265,8 @@ test("POST /api/sessions/:id/promote creates an active memory for non-protected 
         body: "From a dashboard request.",
         category: "tools",
         visibility: "common",
-        scope: "tool"
-      }
+        scope: "tool",
+      },
     });
     assert.equal(response.status, 200);
     assert.equal(json.status, "active");
@@ -288,8 +310,8 @@ test("POST /api/sessions/:id/promote routes protected categories through the pro
         body: "Jim runs The Librarian as the shared session backend.",
         category: "identity",
         visibility: "common",
-        scope: "global"
-      }
+        scope: "global",
+      },
     });
     assert.equal(json.status, "proposed");
   } finally {

--- a/test/sessions.mcp.test.js
+++ b/test/sessions.mcp.test.js
@@ -1,5 +1,5 @@
-import test from "node:test";
 import assert from "node:assert/strict";
+import test from "node:test";
 import { handleMcpPayload } from "../src/mcp.js";
 import { withStore } from "./helpers.js";
 
@@ -7,28 +7,47 @@ function callTool(store, name, args, context = {}) {
   return handleMcpPayload(
     store,
     { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name, arguments: args } },
-    context
+    context,
   );
 }
 
 test("MCP tools/list exposes the session read-tool surface", async () => {
   await withStore(async (store) => {
-    const list = await handleMcpPayload(store, { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} });
+    const list = await handleMcpPayload(store, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/list",
+      params: {},
+    });
     const names = list.result.tools.map((tool) => tool.name);
-    for (const expected of ["start_session", "get_session", "list_sessions", "list_session_events", "search_sessions"]) {
-      assert.ok(names.includes(expected), `expected ${expected} in tool list, got ${names.join(", ")}`);
+    for (const expected of [
+      "start_session",
+      "get_session",
+      "list_sessions",
+      "list_session_events",
+      "search_sessions",
+    ]) {
+      assert.ok(
+        names.includes(expected),
+        `expected ${expected} in tool list, got ${names.join(", ")}`,
+      );
     }
   });
 });
 
 test("MCP start_session creates a session attributed to the authenticated agent", async () => {
   await withStore(async (store) => {
-    const response = await callTool(store, "start_session", {
-      title: "MCP foundational test",
-      harness: "hermes",
-      project_key: "the-librarian",
-      start_summary: "Investigating MCP tool surface."
-    }, { role: "agent", agentId: "bede" });
+    const response = await callTool(
+      store,
+      "start_session",
+      {
+        title: "MCP foundational test",
+        harness: "hermes",
+        project_key: "the-librarian",
+        start_summary: "Investigating MCP tool surface.",
+      },
+      { role: "agent", agentId: "bede" },
+    );
 
     const text = response.result.content[0].text;
     assert.match(text, /ses_/, "session id should be returned");
@@ -43,11 +62,16 @@ test("MCP start_session creates a session attributed to the authenticated agent"
 
 test("MCP start_session refuses to honour a caller-supplied agent_id (no impersonation)", async () => {
   await withStore(async (store) => {
-    await callTool(store, "start_session", {
-      agent_id: "imposter",
-      title: "Impersonation attempt",
-      harness: "hermes"
-    }, { role: "agent", agentId: "bede" });
+    await callTool(
+      store,
+      "start_session",
+      {
+        agent_id: "imposter",
+        title: "Impersonation attempt",
+        harness: "hermes",
+      },
+      { role: "agent", agentId: "bede" },
+    );
 
     const sessions = store.listSessions({ agent_id: "bede" }).sessions;
     assert.equal(sessions.length, 1);
@@ -58,10 +82,15 @@ test("MCP start_session refuses to honour a caller-supplied agent_id (no imperso
 
 test("MCP start_session output is clean prose and does not leak internal event ids", async () => {
   await withStore(async (store) => {
-    const response = await callTool(store, "start_session", {
-      title: "Cleanliness check",
-      harness: "hermes"
-    }, { role: "agent", agentId: "bede" });
+    const response = await callTool(
+      store,
+      "start_session",
+      {
+        title: "Cleanliness check",
+        harness: "hermes",
+      },
+      { role: "agent", agentId: "bede" },
+    );
 
     const text = response.result.content[0].text;
     assert.doesNotMatch(text, /sevt_/);
@@ -87,7 +116,12 @@ test("MCP list_sessions returns numbered selectable sessions and tells the agent
 test("MCP list_sessions does not include another agent's private sessions", async () => {
   await withStore(async (store) => {
     store.startSession({ agent_id: "bede", title: "Bede shared", harness: "hermes" });
-    store.startSession({ agent_id: "codex", title: "Codex private", harness: "codex", visibility: "agent_private" });
+    store.startSession({
+      agent_id: "codex",
+      title: "Codex private",
+      harness: "codex",
+      visibility: "agent_private",
+    });
 
     const response = await callTool(store, "list_sessions", {}, { role: "agent", agentId: "bede" });
     const text = response.result.content[0].text;
@@ -102,14 +136,14 @@ test("MCP get_session hides agent_private sessions from non-owner callers", asyn
       agent_id: "codex",
       title: "Codex private session",
       harness: "codex",
-      visibility: "agent_private"
+      visibility: "agent_private",
     });
 
     const asBede = await callTool(
       store,
       "get_session",
       { session_id: session.id },
-      { role: "agent", agentId: "bede" }
+      { role: "agent", agentId: "bede" },
     );
     const bedeText = asBede.result.content[0].text;
     assert.doesNotMatch(bedeText, /Codex private session/);
@@ -119,7 +153,7 @@ test("MCP get_session hides agent_private sessions from non-owner callers", asyn
       store,
       "get_session",
       { session_id: session.id },
-      { role: "agent", agentId: "codex" }
+      { role: "agent", agentId: "codex" },
     );
     assert.match(asCodex.result.content[0].text, /Codex private session/);
   });
@@ -131,13 +165,13 @@ test("MCP get_session admin can see another agent's private session", async () =
       agent_id: "codex",
       title: "Codex private",
       harness: "codex",
-      visibility: "agent_private"
+      visibility: "agent_private",
     });
     const response = await callTool(
       store,
       "get_session",
       { session_id: session.id },
-      { role: "admin" }
+      { role: "admin" },
     );
     assert.match(response.result.content[0].text, /Codex private/);
   });
@@ -149,20 +183,20 @@ test("MCP list_session_events hides events from non-owners of agent_private sess
       agent_id: "codex",
       title: "Codex priv",
       harness: "codex",
-      visibility: "agent_private"
+      visibility: "agent_private",
     });
     store.recordSessionEvent({
       agent_id: "codex",
       session_id: session.id,
       type: "decision",
-      summary: "Codex secret decision."
+      summary: "Codex secret decision.",
     });
 
     const asBede = await callTool(
       store,
       "list_session_events",
       { session_id: session.id },
-      { role: "agent", agentId: "bede" }
+      { role: "agent", agentId: "bede" },
     );
     const text = asBede.result.content[0].text;
     assert.doesNotMatch(text, /Codex secret decision/);
@@ -177,14 +211,14 @@ test("MCP search_sessions does not leak private content from other agents", asyn
       title: "Codex BM25 work",
       harness: "codex",
       visibility: "agent_private",
-      start_summary: "Investigate BM25 recall in private."
+      start_summary: "Investigate BM25 recall in private.",
     });
 
     const asBede = await callTool(
       store,
       "search_sessions",
       { query: "BM25" },
-      { role: "agent", agentId: "bede" }
+      { role: "agent", agentId: "bede" },
     );
     const text = asBede.result.content[0].text;
     assert.doesNotMatch(text, /Codex BM25/);
@@ -193,7 +227,12 @@ test("MCP search_sessions does not leak private content from other agents", asyn
 
 test("MCP tools/list exposes session mutation tools", async () => {
   await withStore(async (store) => {
-    const list = await handleMcpPayload(store, { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} });
+    const list = await handleMcpPayload(store, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/list",
+      params: {},
+    });
     const names = list.result.tools.map((tool) => tool.name);
     for (const expected of [
       "record_session_event",
@@ -201,7 +240,7 @@ test("MCP tools/list exposes session mutation tools", async () => {
       "pause_session",
       "end_session",
       "attach_session",
-      "continue_session"
+      "continue_session",
     ]) {
       assert.ok(names.includes(expected), `expected ${expected} in tool list`);
     }
@@ -210,18 +249,26 @@ test("MCP tools/list exposes session mutation tools", async () => {
 
 test("MCP record_session_event appends a typed event to a visible session", async () => {
   await withStore(async (store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Recordable", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Recordable",
+      harness: "hermes",
+    });
 
     const response = await callTool(
       store,
       "record_session_event",
       { session_id: session.id, type: "decision", summary: "Default attach=true." },
-      { role: "agent", agentId: "bede" }
+      { role: "agent", agentId: "bede" },
     );
 
     assert.match(response.result.content[0].text, /record|decision/i);
     const events = store.listSessionEvents({ session_id: session.id });
-    assert.ok(events.events.some((event) => event.type === "decision" && event.summary === "Default attach=true."));
+    assert.ok(
+      events.events.some(
+        (event) => event.type === "decision" && event.summary === "Default attach=true.",
+      ),
+    );
   });
 });
 
@@ -231,14 +278,14 @@ test("MCP record_session_event refuses to mutate another agent's private session
       agent_id: "codex",
       title: "Codex private",
       harness: "codex",
-      visibility: "agent_private"
+      visibility: "agent_private",
     });
 
     const response = await callTool(
       store,
       "record_session_event",
       { session_id: session.id, type: "note", summary: "I shouldn't be here." },
-      { role: "agent", agentId: "bede" }
+      { role: "agent", agentId: "bede" },
     );
 
     assert.match(response.result.content[0].text, /not found|no session/i);
@@ -249,7 +296,11 @@ test("MCP record_session_event refuses to mutate another agent's private session
 
 test("MCP checkpoint_session updates rolling_summary and keeps the session active", async () => {
   await withStore(async (store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Checkpointable", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Checkpointable",
+      harness: "hermes",
+    });
 
     const response = await callTool(
       store,
@@ -257,9 +308,9 @@ test("MCP checkpoint_session updates rolling_summary and keeps the session activ
       {
         session_id: session.id,
         summary: "Mid-progress snapshot.",
-        next_steps: ["Wire MCP tools"]
+        next_steps: ["Wire MCP tools"],
       },
-      { role: "agent", agentId: "bede" }
+      { role: "agent", agentId: "bede" },
     );
 
     const text = response.result.content[0].text;
@@ -272,13 +323,17 @@ test("MCP checkpoint_session updates rolling_summary and keeps the session activ
 
 test("MCP pause_session marks the session paused", async () => {
   await withStore(async (store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Pausable", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Pausable",
+      harness: "hermes",
+    });
 
     const response = await callTool(
       store,
       "pause_session",
       { session_id: session.id, summary: "Stopping for the day." },
-      { role: "agent", agentId: "bede" }
+      { role: "agent", agentId: "bede" },
     );
 
     assert.match(response.result.content[0].text, /paused/i);
@@ -290,13 +345,17 @@ test("MCP pause_session marks the session paused", async () => {
 
 test("MCP end_session writes end_summary and marks the session ended", async () => {
   await withStore(async (store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Endable", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Endable",
+      harness: "hermes",
+    });
 
     const response = await callTool(
       store,
       "end_session",
       { session_id: session.id, summary: "All done." },
-      { role: "agent", agentId: "bede" }
+      { role: "agent", agentId: "bede" },
     );
 
     assert.match(response.result.content[0].text, /ended/i);
@@ -312,7 +371,7 @@ test("MCP attach_session updates the current harness and source_ref", async () =
       agent_id: "bede",
       title: "Attachable",
       harness: "hermes",
-      source_ref: "discord:1:2"
+      source_ref: "discord:1:2",
     });
 
     await callTool(
@@ -322,9 +381,9 @@ test("MCP attach_session updates the current harness and source_ref", async () =
         session_id: session.id,
         harness: "codex",
         source_ref: "codex:r1:cwd:/dev",
-        cwd: "/dev"
+        cwd: "/dev",
       },
-      { role: "agent", agentId: "codex" }
+      { role: "agent", agentId: "codex" },
     );
 
     const reloaded = store.getSession(session.id);
@@ -342,13 +401,13 @@ test("MCP continue_session returns a handover package and (default) attaches", a
       title: "Handover via MCP",
       harness: "hermes",
       project_key: "the-librarian",
-      start_summary: "Designing the layer."
+      start_summary: "Designing the layer.",
     });
     store.checkpointSession({
       agent_id: "bede",
       session_id: session.id,
       summary: "Wired the foundation.",
-      next_steps: ["Add MCP tools"]
+      next_steps: ["Add MCP tools"],
     });
 
     const response = await callTool(
@@ -358,9 +417,9 @@ test("MCP continue_session returns a handover package and (default) attaches", a
         session_id: session.id,
         target_harness: "codex",
         target_source_ref: "codex:r1:cwd:/dev",
-        target_cwd: "/dev"
+        target_cwd: "/dev",
       },
-      { role: "agent", agentId: "codex" }
+      { role: "agent", agentId: "codex" },
     );
 
     const text = response.result.content[0].text;
@@ -368,7 +427,11 @@ test("MCP continue_session returns a handover package and (default) attaches", a
     assert.match(text, /Wired the foundation/);
 
     const reloaded = store.getSession(session.id);
-    assert.equal(reloaded.current_harness, "codex", "default attach=true should switch current harness");
+    assert.equal(
+      reloaded.current_harness,
+      "codex",
+      "default attach=true should switch current harness",
+    );
     assert.equal(reloaded.current_agent_id, "codex");
   });
 });
@@ -379,20 +442,20 @@ test("MCP continue_session honours format=markdown", async () => {
       agent_id: "bede",
       title: "Markdown via MCP",
       harness: "hermes",
-      start_summary: "Starting."
+      start_summary: "Starting.",
     });
     store.checkpointSession({
       agent_id: "bede",
       session_id: session.id,
       summary: "Mid.",
-      decisions: ["Decision X"]
+      decisions: ["Decision X"],
     });
 
     const response = await callTool(
       store,
       "continue_session",
       { session_id: session.id, target_harness: "claude-code", format: "markdown", attach: false },
-      { role: "agent", agentId: "bede" }
+      { role: "agent", agentId: "bede" },
     );
 
     const text = response.result.content[0].text;
@@ -408,25 +471,34 @@ test("MCP continue_session refuses to attach to another agent's private session"
       agent_id: "codex",
       title: "Codex private",
       harness: "codex",
-      visibility: "agent_private"
+      visibility: "agent_private",
     });
 
     const response = await callTool(
       store,
       "continue_session",
       { session_id: session.id, target_harness: "hermes" },
-      { role: "agent", agentId: "bede" }
+      { role: "agent", agentId: "bede" },
     );
 
     assert.match(response.result.content[0].text, /not found|no session/i);
     const reloaded = store.getSession(session.id);
-    assert.equal(reloaded.current_harness, "codex", "private session must remain on its original harness");
+    assert.equal(
+      reloaded.current_harness,
+      "codex",
+      "private session must remain on its original harness",
+    );
   });
 });
 
 test("MCP tools/list exposes session hide tools", async () => {
   await withStore(async (store) => {
-    const list = await handleMcpPayload(store, { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} });
+    const list = await handleMcpPayload(store, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/list",
+      params: {},
+    });
     const names = list.result.tools.map((tool) => tool.name);
     for (const expected of ["archive_session", "restore_session", "delete_session"]) {
       assert.ok(names.includes(expected), `expected ${expected} in tool list`);
@@ -436,13 +508,17 @@ test("MCP tools/list exposes session hide tools", async () => {
 
 test("MCP archive_session hides a session from default list_sessions", async () => {
   await withStore(async (store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Archive me", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Archive me",
+      harness: "hermes",
+    });
 
     const response = await callTool(
       store,
       "archive_session",
       { session_id: session.id, reason: "throwaway spike" },
-      { role: "agent", agentId: "bede" }
+      { role: "agent", agentId: "bede" },
     );
     assert.match(response.result.content[0].text, /archived/i);
 
@@ -453,13 +529,17 @@ test("MCP archive_session hides a session from default list_sessions", async () 
 
 test("MCP delete_session lets the owner delete their own session", async () => {
   await withStore(async (store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Owner deletes own", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Owner deletes own",
+      harness: "hermes",
+    });
 
     const response = await callTool(
       store,
       "delete_session",
       { session_id: session.id },
-      { role: "agent", agentId: "bede" }
+      { role: "agent", agentId: "bede" },
     );
     assert.match(response.result.content[0].text, /deleted/i);
     assert.equal(store.getSession(session.id).status, "deleted");
@@ -472,14 +552,14 @@ test("MCP delete_session refuses a non-owner agent on a visible common session",
       agent_id: "bede",
       title: "Bede's common session",
       harness: "hermes",
-      visibility: "common"
+      visibility: "common",
     });
 
     const response = await callTool(
       store,
       "delete_session",
       { session_id: session.id },
-      { role: "agent", agentId: "codex" }
+      { role: "agent", agentId: "codex" },
     );
 
     assert.ok(response.error, "non-owner delete should produce a JSON-RPC error");
@@ -494,14 +574,14 @@ test("MCP delete_session on another agent's private session returns 'not found' 
       agent_id: "codex",
       title: "Codex private",
       harness: "codex",
-      visibility: "agent_private"
+      visibility: "agent_private",
     });
 
     const response = await callTool(
       store,
       "delete_session",
       { session_id: session.id },
-      { role: "agent", agentId: "bede" }
+      { role: "agent", agentId: "bede" },
     );
 
     assert.equal(response.error, undefined, "must not leak ownership error for invisible sessions");
@@ -512,13 +592,17 @@ test("MCP delete_session on another agent's private session returns 'not found' 
 
 test("MCP delete_session as admin can delete sessions owned by other agents", async () => {
   await withStore(async (store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Bede's", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Bede's",
+      harness: "hermes",
+    });
 
     const response = await callTool(
       store,
       "delete_session",
       { session_id: session.id, reason: "admin cleanup" },
-      { role: "admin" }
+      { role: "admin" },
     );
     assert.match(response.result.content[0].text, /deleted/i);
     assert.equal(store.getSession(session.id).status, "deleted");
@@ -527,7 +611,11 @@ test("MCP delete_session as admin can delete sessions owned by other agents", as
 
 test("MCP restore_session by owner returns the session to its prior status", async () => {
   await withStore(async (store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Restorable", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Restorable",
+      harness: "hermes",
+    });
     store.pauseSession({ agent_id: "bede", session_id: session.id, summary: "Pause." });
     store.archiveSession({ agent_id: "bede", session_id: session.id, reason: "tidy" });
 
@@ -535,7 +623,7 @@ test("MCP restore_session by owner returns the session to its prior status", asy
       store,
       "restore_session",
       { session_id: session.id },
-      { role: "agent", agentId: "bede" }
+      { role: "agent", agentId: "bede" },
     );
 
     assert.match(response.result.content[0].text, /restore|paused|active/i);
@@ -545,14 +633,18 @@ test("MCP restore_session by owner returns the session to its prior status", asy
 
 test("MCP restore_session refuses non-owner non-admin callers", async () => {
   await withStore(async (store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Bede's", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Bede's",
+      harness: "hermes",
+    });
     store.archiveSession({ agent_id: "bede", session_id: session.id, reason: "tidy" });
 
     const response = await callTool(
       store,
       "restore_session",
       { session_id: session.id },
-      { role: "agent", agentId: "codex" }
+      { role: "agent", agentId: "codex" },
     );
 
     assert.ok(response.error);
@@ -563,7 +655,12 @@ test("MCP restore_session refuses non-owner non-admin callers", async () => {
 
 test("MCP tools/list exposes promote_session_fact", async () => {
   await withStore(async (store) => {
-    const list = await handleMcpPayload(store, { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} });
+    const list = await handleMcpPayload(store, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/list",
+      params: {},
+    });
     const names = list.result.tools.map((tool) => tool.name);
     assert.ok(names.includes("promote_session_fact"));
   });
@@ -571,7 +668,11 @@ test("MCP tools/list exposes promote_session_fact", async () => {
 
 test("MCP promote_session_fact creates an active durable memory for non-protected categories", async () => {
   await withStore(async (store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Promote test", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Promote test",
+      harness: "hermes",
+    });
 
     const response = await callTool(
       store,
@@ -583,15 +684,16 @@ test("MCP promote_session_fact creates an active durable memory for non-protecte
           body: "Avoids harness slash command collisions.",
           category: "tools",
           visibility: "common",
-          scope: "tool"
-        }
+          scope: "tool",
+        },
       },
-      { role: "agent", agentId: "bede" }
+      { role: "agent", agentId: "bede" },
     );
 
     const text = response.result.content[0].text;
     assert.match(text, /promoted|memory|active/i);
-    const active = store._listAll({ status: "active" })
+    const active = store
+      ._listAll({ status: "active" })
       .filter((memory) => memory.title === "Use lib: prefix for session commands");
     assert.equal(active.length, 1);
   });
@@ -599,7 +701,11 @@ test("MCP promote_session_fact creates an active durable memory for non-protecte
 
 test("MCP promote_session_fact routes protected categories through the proposal flow even for non-admin agents", async () => {
   await withStore(async (store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Protected promote", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Protected promote",
+      harness: "hermes",
+    });
 
     const response = await callTool(
       store,
@@ -611,14 +717,15 @@ test("MCP promote_session_fact routes protected categories through the proposal 
           body: "Jim asked for terse output across sessions.",
           category: "identity",
           visibility: "common",
-          scope: "global"
-        }
+          scope: "global",
+        },
       },
-      { role: "agent", agentId: "bede" }
+      { role: "agent", agentId: "bede" },
     );
 
     assert.match(response.result.content[0].text, /proposal|proposed/i);
-    const proposed = store._listAll({ status: "proposed" })
+    const proposed = store
+      ._listAll({ status: "proposed" })
       .filter((memory) => memory.title === "User prefers terse responses");
     assert.equal(proposed.length, 1);
   });
@@ -630,7 +737,7 @@ test("MCP promote_session_fact refuses to promote from another agent's private s
       agent_id: "codex",
       title: "Codex private",
       harness: "codex",
-      visibility: "agent_private"
+      visibility: "agent_private",
     });
 
     const response = await callTool(
@@ -643,14 +750,15 @@ test("MCP promote_session_fact refuses to promote from another agent's private s
           body: "Should not be created.",
           category: "tools",
           visibility: "common",
-          scope: "tool"
-        }
+          scope: "tool",
+        },
       },
-      { role: "agent", agentId: "bede" }
+      { role: "agent", agentId: "bede" },
     );
 
     assert.match(response.result.content[0].text, /not found|no session/i);
-    const stolen = store._listAll({ status: "active" })
+    const stolen = store
+      ._listAll({ status: "active" })
       .filter((memory) => memory.title === "Stolen fact");
     assert.equal(stolen.length, 0);
   });

--- a/test/sessions.test.js
+++ b/test/sessions.test.js
@@ -1,8 +1,8 @@
-import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import test from "node:test";
 import { LibrarianStore } from "../src/store.js";
 import { withStore } from "./helpers.js";
 
@@ -18,7 +18,7 @@ test("startSession creates an active common session with the supplied fields", a
       cwd: "/home/jim/the-librarian",
       capture_mode: "summary",
       start_summary: "Sketch the session layer.",
-      tags: ["sessions", "librarian"]
+      tags: ["sessions", "librarian"],
     });
 
     const session = result.session;
@@ -56,13 +56,13 @@ test("startSession generates a placeholder title when one is not supplied", asyn
     const fromProject = store.startSession({
       agent_id: "bede",
       project_key: "the-librarian",
-      harness: "codex"
+      harness: "codex",
     });
     assert.match(fromProject.session.title, /^the-librarian session @ /);
 
     const fromHarness = store.startSession({
       agent_id: "bede",
-      harness: "codex"
+      harness: "codex",
     });
     assert.match(fromHarness.session.title, /^codex session @ /);
   });
@@ -82,7 +82,7 @@ test("startSession accepts an explicit agent_private visibility", async () => {
       agent_id: "bede",
       title: "Private spike",
       harness: "hermes",
-      visibility: "agent_private"
+      visibility: "agent_private",
     });
     assert.equal(result.session.visibility, "agent_private");
   });
@@ -96,7 +96,7 @@ test("startSession appends a session.started event to sessions.jsonl and inserts
     const result = store.startSession({
       agent_id: "bede",
       title: "Event projection",
-      harness: "hermes"
+      harness: "hermes",
     });
 
     const lines = fs.readFileSync(sessionsPath, "utf8").trim().split("\n").filter(Boolean);
@@ -138,12 +138,20 @@ test("memory writes do not touch the session projection (and vice versa)", async
       body: "Adding sessions must not regress memory writes.",
       category: "tools",
       visibility: "common",
-      scope: "tool"
+      scope: "tool",
     });
     store.startSession({ agent_id: "bede", title: "Session still works", harness: "hermes" });
 
-    const memEvents = fs.readFileSync(path.join(dataDir, "events.jsonl"), "utf8").trim().split("\n").filter(Boolean);
-    const sessEvents = fs.readFileSync(path.join(dataDir, "sessions.jsonl"), "utf8").trim().split("\n").filter(Boolean);
+    const memEvents = fs
+      .readFileSync(path.join(dataDir, "events.jsonl"), "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean);
+    const sessEvents = fs
+      .readFileSync(path.join(dataDir, "sessions.jsonl"), "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean);
     assert.equal(memEvents.length, 1, "memory event ledger should only have one entry");
     assert.equal(sessEvents.length, 1, "session event ledger should only have one entry");
   });
@@ -171,13 +179,13 @@ test("listSessions ranks sessions matching the caller project_key first", async 
       agent_id: "bede",
       title: "Other project",
       harness: "hermes",
-      project_key: "other-repo"
+      project_key: "other-repo",
     });
     const target = store.startSession({
       agent_id: "bede",
       title: "Target project",
       harness: "hermes",
-      project_key: "the-librarian"
+      project_key: "the-librarian",
     });
 
     const result = store.listSessions({ agent_id: "bede", project_key: "the-librarian" });
@@ -194,20 +202,20 @@ test("listSessions ranks source-matching sessions ahead of non-matching when pro
       title: "Same proj, other cwd",
       harness: "hermes",
       project_key: "the-librarian",
-      cwd: "/somewhere/else"
+      cwd: "/somewhere/else",
     });
     const sameProjSameSrc = store.startSession({
       agent_id: "bede",
       title: "Same proj, same cwd",
       harness: "hermes",
       project_key: "the-librarian",
-      cwd: "/home/jim/the-librarian"
+      cwd: "/home/jim/the-librarian",
     });
 
     const result = store.listSessions({
       agent_id: "bede",
       project_key: "the-librarian",
-      cwd: "/home/jim/the-librarian"
+      cwd: "/home/jim/the-librarian",
     });
 
     assert.equal(result.sessions[0].id, sameProjSameSrc.session.id);
@@ -221,18 +229,18 @@ test("listSessions matches by source_ref as well as cwd when ranking source", as
       agent_id: "bede",
       title: "Different thread",
       harness: "hermes",
-      source_ref: "discord:channel:1:thread:2"
+      source_ref: "discord:channel:1:thread:2",
     });
     const matchingSrc = store.startSession({
       agent_id: "bede",
       title: "Matching thread",
       harness: "hermes",
-      source_ref: "discord:channel:9:thread:42"
+      source_ref: "discord:channel:9:thread:42",
     });
 
     const result = store.listSessions({
       agent_id: "bede",
-      source_ref: "discord:channel:9:thread:42"
+      source_ref: "discord:channel:9:thread:42",
     });
 
     assert.equal(result.sessions[0].id, matchingSrc.session.id);
@@ -246,19 +254,19 @@ test("listSessions hides agent_private sessions from other agents", async () => 
       agent_id: "bede",
       title: "Shared",
       harness: "hermes",
-      visibility: "common"
+      visibility: "common",
     });
     const bedePrivate = store.startSession({
       agent_id: "bede",
       title: "Bede private",
       harness: "hermes",
-      visibility: "agent_private"
+      visibility: "agent_private",
     });
     const codexPrivate = store.startSession({
       agent_id: "codex",
       title: "Codex private",
       harness: "codex",
-      visibility: "agent_private"
+      visibility: "agent_private",
     });
 
     const asBede = store.listSessions({ agent_id: "bede" }).sessions.map((s) => s.id);
@@ -279,7 +287,7 @@ test("listSessions admin override sees agent_private sessions from any agent", a
       agent_id: "codex",
       title: "Codex private",
       harness: "codex",
-      visibility: "agent_private"
+      visibility: "agent_private",
     });
 
     const asAdmin = store.listSessions({ agent_id: "bede", admin: true }).sessions.map((s) => s.id);
@@ -310,7 +318,7 @@ test("listSessions returns the most recently active session first when all ranki
     const result = store.listSessions({ agent_id: "bede" });
     assert.deepEqual(
       result.sessions.map((s) => s.id),
-      [third.session.id, second.session.id, first.session.id]
+      [third.session.id, second.session.id, first.session.id],
     );
   });
 });
@@ -328,7 +336,11 @@ test("listSessions filters by harness when supplied", async () => {
 
 test("recordSessionEvent appends a typed evidence event and bumps last_activity_at", async () => {
   await withStore(async (store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Recording", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Recording",
+      harness: "hermes",
+    });
     const initialActivity = session.last_activity_at;
 
     await new Promise((resolve) => setTimeout(resolve, 5));
@@ -339,7 +351,7 @@ test("recordSessionEvent appends a typed evidence event and bumps last_activity_
       harness: "hermes",
       type: "decision",
       summary: "Use list-and-select rather than latest-inference.",
-      payload: { confidence: "confirmed" }
+      payload: { confidence: "confirmed" },
     });
 
     assert.equal(event.event_type, "session.event_recorded");
@@ -357,15 +369,20 @@ test("recordSessionEvent appends a typed evidence event and bumps last_activity_
 
 test("recordSessionEvent rejects unknown payload types", async () => {
   await withStore((store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Reject", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Reject",
+      harness: "hermes",
+    });
     assert.throws(
-      () => store.recordSessionEvent({
-        agent_id: "bede",
-        session_id: session.id,
-        type: "garbage",
-        summary: "x"
-      }),
-      /payload type/i
+      () =>
+        store.recordSessionEvent({
+          agent_id: "bede",
+          session_id: session.id,
+          type: "garbage",
+          summary: "x",
+        }),
+      /payload type/i,
     );
   });
 });
@@ -373,25 +390,50 @@ test("recordSessionEvent rejects unknown payload types", async () => {
 test("recordSessionEvent throws for unknown session_id", async () => {
   await withStore((store) => {
     assert.throws(
-      () => store.recordSessionEvent({
-        agent_id: "bede",
-        session_id: "ses_nope",
-        type: "note",
-        summary: "x"
-      }),
-      /session/i
+      () =>
+        store.recordSessionEvent({
+          agent_id: "bede",
+          session_id: "ses_nope",
+          type: "note",
+          summary: "x",
+        }),
+      /session/i,
     );
   });
 });
 
 test("listSessionEvents returns events with pagination and type filter", async () => {
   await withStore((store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Listing", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Listing",
+      harness: "hermes",
+    });
 
-    store.recordSessionEvent({ agent_id: "bede", session_id: session.id, type: "decision", summary: "d1" });
-    store.recordSessionEvent({ agent_id: "bede", session_id: session.id, type: "command", summary: "c1" });
-    store.recordSessionEvent({ agent_id: "bede", session_id: session.id, type: "decision", summary: "d2" });
-    store.recordSessionEvent({ agent_id: "bede", session_id: session.id, type: "note", summary: "n1" });
+    store.recordSessionEvent({
+      agent_id: "bede",
+      session_id: session.id,
+      type: "decision",
+      summary: "d1",
+    });
+    store.recordSessionEvent({
+      agent_id: "bede",
+      session_id: session.id,
+      type: "command",
+      summary: "c1",
+    });
+    store.recordSessionEvent({
+      agent_id: "bede",
+      session_id: session.id,
+      type: "decision",
+      summary: "d2",
+    });
+    store.recordSessionEvent({
+      agent_id: "bede",
+      session_id: session.id,
+      type: "note",
+      summary: "n1",
+    });
 
     const all = store.listSessionEvents({ session_id: session.id });
     assert.equal(all.total, 5, "start event + 4 record events");
@@ -413,9 +455,19 @@ test("listSessionEvents returns events in chronological order (oldest first)", a
   await withStore(async (store) => {
     const { session } = store.startSession({ agent_id: "bede", title: "Order", harness: "hermes" });
     await new Promise((resolve) => setTimeout(resolve, 2));
-    store.recordSessionEvent({ agent_id: "bede", session_id: session.id, type: "note", summary: "first" });
+    store.recordSessionEvent({
+      agent_id: "bede",
+      session_id: session.id,
+      type: "note",
+      summary: "first",
+    });
     await new Promise((resolve) => setTimeout(resolve, 2));
-    store.recordSessionEvent({ agent_id: "bede", session_id: session.id, type: "note", summary: "second" });
+    store.recordSessionEvent({
+      agent_id: "bede",
+      session_id: session.id,
+      type: "note",
+      summary: "second",
+    });
 
     const result = store.listSessionEvents({ session_id: session.id, type: "note" });
     assert.equal(result.events[0].summary, "first");
@@ -433,7 +485,11 @@ test("listSessionEvents returns empty for unknown session_id", async () => {
 
 test("checkpointSession overwrites rolling_summary and keeps the session active", async () => {
   await withStore((store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Checkpoint", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Checkpoint",
+      harness: "hermes",
+    });
 
     const result = store.checkpointSession({
       agent_id: "bede",
@@ -443,7 +499,7 @@ test("checkpointSession overwrites rolling_summary and keeps the session active"
       next_steps: ["Implement session event projection"],
       files_touched: ["src/store.js"],
       commands_run: ["npm test"],
-      open_questions: ["Do we need fts on lifecycle events?"]
+      open_questions: ["Do we need fts on lifecycle events?"],
     });
 
     assert.equal(result.session.status, "active");
@@ -453,7 +509,7 @@ test("checkpointSession overwrites rolling_summary and keeps the session active"
     store.checkpointSession({
       agent_id: "bede",
       session_id: session.id,
-      summary: "Newer snapshot."
+      summary: "Newer snapshot.",
     });
     assert.equal(store.getSession(session.id).rolling_summary, "Newer snapshot.");
   });
@@ -461,12 +517,16 @@ test("checkpointSession overwrites rolling_summary and keeps the session active"
 
 test("pauseSession marks the session paused, updates rolling_summary, and sets paused_at", async () => {
   await withStore((store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Pause me", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Pause me",
+      harness: "hermes",
+    });
 
     const result = store.pauseSession({
       agent_id: "bede",
       session_id: session.id,
-      summary: "Stepping away."
+      summary: "Stepping away.",
     });
 
     assert.equal(result.session.status, "paused");
@@ -477,7 +537,11 @@ test("pauseSession marks the session paused, updates rolling_summary, and sets p
 
 test("recording an event on a paused session implicitly resumes it", async () => {
   await withStore((store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Implicit resume", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Implicit resume",
+      harness: "hermes",
+    });
     store.pauseSession({ agent_id: "bede", session_id: session.id, summary: "Pause." });
     assert.equal(store.getSession(session.id).status, "paused");
 
@@ -485,7 +549,7 @@ test("recording an event on a paused session implicitly resumes it", async () =>
       agent_id: "bede",
       session_id: session.id,
       type: "note",
-      summary: "Back at it."
+      summary: "Back at it.",
     });
 
     const reloaded = store.getSession(session.id);
@@ -496,13 +560,17 @@ test("recording an event on a paused session implicitly resumes it", async () =>
 
 test("checkpointing a paused session implicitly resumes it", async () => {
   await withStore((store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Resume via checkpoint", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Resume via checkpoint",
+      harness: "hermes",
+    });
     store.pauseSession({ agent_id: "bede", session_id: session.id, summary: "Pause." });
 
     store.checkpointSession({
       agent_id: "bede",
       session_id: session.id,
-      summary: "Picking back up."
+      summary: "Picking back up.",
     });
 
     const reloaded = store.getSession(session.id);
@@ -514,11 +582,15 @@ test("checkpointing a paused session implicitly resumes it", async () => {
 
 test("endSession writes end_summary, freezes rolling_summary, and marks the session ended", async () => {
   await withStore((store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "End me", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "End me",
+      harness: "hermes",
+    });
     store.checkpointSession({
       agent_id: "bede",
       session_id: session.id,
-      summary: "Midway snapshot."
+      summary: "Midway snapshot.",
     });
 
     const result = store.endSession({
@@ -526,7 +598,7 @@ test("endSession writes end_summary, freezes rolling_summary, and marks the sess
       session_id: session.id,
       summary: "All done.",
       decisions: ["Final decision"],
-      next_steps: ["Open the PR"]
+      next_steps: ["Open the PR"],
     });
 
     assert.equal(result.session.status, "ended");
@@ -534,7 +606,7 @@ test("endSession writes end_summary, freezes rolling_summary, and marks the sess
     assert.equal(
       result.session.rolling_summary,
       "Midway snapshot.",
-      "rolling_summary should be frozen at the final checkpoint"
+      "rolling_summary should be frozen at the final checkpoint",
     );
     assert.deepEqual(result.session.next_steps, ["Open the PR"]);
     assert.ok(result.session.ended_at);
@@ -543,36 +615,50 @@ test("endSession writes end_summary, freezes rolling_summary, and marks the sess
 
 test("ended sessions reject checkpoint, pause, end, and record_event", async () => {
   await withStore((store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Sealed", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Sealed",
+      harness: "hermes",
+    });
     store.endSession({ agent_id: "bede", session_id: session.id, summary: "Done." });
 
     assert.throws(
       () => store.checkpointSession({ agent_id: "bede", session_id: session.id, summary: "x" }),
-      /ended|status|transition/i
+      /ended|status|transition/i,
     );
     assert.throws(
       () => store.pauseSession({ agent_id: "bede", session_id: session.id, summary: "x" }),
-      /ended|status|transition/i
+      /ended|status|transition/i,
     );
     assert.throws(
       () => store.endSession({ agent_id: "bede", session_id: session.id, summary: "x" }),
-      /ended|status|transition/i
+      /ended|status|transition/i,
     );
     assert.throws(
-      () => store.recordSessionEvent({ agent_id: "bede", session_id: session.id, type: "note", summary: "x" }),
-      /ended|status|terminal|transition/i
+      () =>
+        store.recordSessionEvent({
+          agent_id: "bede",
+          session_id: session.id,
+          type: "note",
+          summary: "x",
+        }),
+      /ended|status|terminal|transition/i,
     );
   });
 });
 
 test("archiveSession records prior_status and hides from default list", async () => {
   await withStore((store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Archive me", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Archive me",
+      harness: "hermes",
+    });
 
     const result = store.archiveSession({
       agent_id: "bede",
       session_id: session.id,
-      reason: "throwaway spike"
+      reason: "throwaway spike",
     });
 
     assert.equal(result.session.status, "archived");
@@ -580,13 +666,20 @@ test("archiveSession records prior_status and hides from default list", async ()
     assert.ok(result.session.archived_at);
 
     assert.equal(store.listSessions({ agent_id: "bede" }).sessions.length, 0);
-    assert.equal(store.listSessions({ agent_id: "bede", include_archived: true }).sessions.length, 1);
+    assert.equal(
+      store.listSessions({ agent_id: "bede", include_archived: true }).sessions.length,
+      1,
+    );
   });
 });
 
 test("restoreSession returns an archived session to its prior_status and clears archived_at", async () => {
   await withStore((store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Restore me", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Restore me",
+      harness: "hermes",
+    });
     store.pauseSession({ agent_id: "bede", session_id: session.id, summary: "Pause." });
     store.archiveSession({ agent_id: "bede", session_id: session.id, reason: "x" });
     assert.equal(store.getSession(session.id).status, "archived");
@@ -602,12 +695,16 @@ test("restoreSession returns an archived session to its prior_status and clears 
 
 test("deleteSession soft-deletes and hides from default list (visible with include_deleted)", async () => {
   await withStore((store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Delete me", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Delete me",
+      harness: "hermes",
+    });
 
     const result = store.deleteSession({
       agent_id: "bede",
       session_id: session.id,
-      reason: "test session"
+      reason: "test session",
     });
 
     assert.equal(result.session.status, "deleted");
@@ -617,18 +714,22 @@ test("deleteSession soft-deletes and hides from default list (visible with inclu
     assert.equal(store.listSessions({ agent_id: "bede" }).sessions.length, 0);
     assert.equal(
       store.listSessions({ agent_id: "bede", include_deleted: true }).sessions.length,
-      1
+      1,
     );
   });
 });
 
 test("deleteSession refuses non-owner callers without admin role", async () => {
   await withStore((store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Bede's", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Bede's",
+      harness: "hermes",
+    });
 
     assert.throws(
       () => store.deleteSession({ agent_id: "codex", session_id: session.id, reason: "x" }),
-      /owner|permission|admin/i
+      /owner|permission|admin/i,
     );
     assert.equal(store.getSession(session.id).status, "active");
   });
@@ -636,12 +737,16 @@ test("deleteSession refuses non-owner callers without admin role", async () => {
 
 test("admin role can delete sessions owned by other agents", async () => {
   await withStore((store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Bede's", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Bede's",
+      harness: "hermes",
+    });
     const result = store.deleteSession({
       agent_id: "dashboard",
       session_id: session.id,
       admin: true,
-      reason: "admin cleanup"
+      reason: "admin cleanup",
     });
     assert.equal(result.session.status, "deleted");
   });
@@ -649,12 +754,16 @@ test("admin role can delete sessions owned by other agents", async () => {
 
 test("restoreSession refuses non-owner callers without admin role", async () => {
   await withStore((store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Bede's", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Bede's",
+      harness: "hermes",
+    });
     store.archiveSession({ agent_id: "bede", session_id: session.id, reason: "x" });
 
     assert.throws(
       () => store.restoreSession({ agent_id: "codex", session_id: session.id }),
-      /owner|permission|admin/i
+      /owner|permission|admin/i,
     );
     assert.equal(store.getSession(session.id).status, "archived");
   });
@@ -662,7 +771,11 @@ test("restoreSession refuses non-owner callers without admin role", async () => 
 
 test("deleting an archived session preserves the original prior_status and round-trips through restore", async () => {
   await withStore((store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Two hops", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Two hops",
+      harness: "hermes",
+    });
     store.endSession({ agent_id: "bede", session_id: session.id, summary: "Done." });
     store.archiveSession({ agent_id: "bede", session_id: session.id, reason: "tidy" });
     assert.equal(store.getSession(session.id).prior_status, "ended");
@@ -671,7 +784,7 @@ test("deleting an archived session preserves the original prior_status and round
     assert.equal(
       store.getSession(session.id).prior_status,
       "ended",
-      "prior_status should not be overwritten when transitioning between hidden states"
+      "prior_status should not be overwritten when transitioning between hidden states",
     );
 
     const restored = store.restoreSession({ agent_id: "bede", session_id: session.id });
@@ -682,12 +795,20 @@ test("deleting an archived session preserves the original prior_status and round
 
 test("ended sessions can still be archived or deleted", async () => {
   await withStore((store) => {
-    const { session: a } = store.startSession({ agent_id: "bede", title: "End-then-archive", harness: "hermes" });
+    const { session: a } = store.startSession({
+      agent_id: "bede",
+      title: "End-then-archive",
+      harness: "hermes",
+    });
     store.endSession({ agent_id: "bede", session_id: a.id, summary: "Done." });
     const archived = store.archiveSession({ agent_id: "bede", session_id: a.id, reason: "tidy" });
     assert.equal(archived.session.status, "archived");
 
-    const { session: b } = store.startSession({ agent_id: "bede", title: "End-then-delete", harness: "hermes" });
+    const { session: b } = store.startSession({
+      agent_id: "bede",
+      title: "End-then-delete",
+      harness: "hermes",
+    });
     store.endSession({ agent_id: "bede", session_id: b.id, summary: "Done." });
     const deleted = store.deleteSession({ agent_id: "bede", session_id: b.id });
     assert.equal(deleted.session.status, "deleted");
@@ -701,7 +822,7 @@ test("attachSession overwrites current_harness/current_agent_id/source_ref/cwd a
       title: "Attach me",
       harness: "hermes",
       source_ref: "discord:channel:1:thread:2",
-      cwd: "/old/path"
+      cwd: "/old/path",
     });
 
     const result = store.attachSession({
@@ -709,7 +830,7 @@ test("attachSession overwrites current_harness/current_agent_id/source_ref/cwd a
       agent_id: "codex",
       harness: "codex",
       source_ref: "codex:run:r1:cwd:/new/path",
-      cwd: "/new/path"
+      cwd: "/new/path",
     });
 
     assert.equal(result.session.current_agent_id, "codex");
@@ -726,11 +847,15 @@ test("attachSession overwrites current_harness/current_agent_id/source_ref/cwd a
 
 test("attachSession refuses ended or archived sessions", async () => {
   await withStore((store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Sealed", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Sealed",
+      harness: "hermes",
+    });
     store.endSession({ agent_id: "bede", session_id: session.id, summary: "Done." });
     assert.throws(
       () => store.attachSession({ session_id: session.id, agent_id: "codex", harness: "codex" }),
-      /ended|status/i
+      /ended|status/i,
     );
   });
 });
@@ -744,7 +869,7 @@ test("continueSession returns a handover with original and current harness/sourc
       project_key: "the-librarian",
       source_ref: "discord:channel:1:thread:2",
       cwd: "/home/jim/the-librarian",
-      start_summary: "Designing the session layer."
+      start_summary: "Designing the session layer.",
     });
     store.checkpointSession({
       agent_id: "bede",
@@ -754,13 +879,13 @@ test("continueSession returns a handover with original and current harness/sourc
       files_touched: ["src/store.js"],
       commands_run: ["npm test"],
       open_questions: ["Aggregate across paused sessions?"],
-      next_steps: ["Add tests for restore"]
+      next_steps: ["Add tests for restore"],
     });
     store.recordSessionEvent({
       agent_id: "bede",
       session_id: session.id,
       type: "decision",
-      summary: "Use prose as default format"
+      summary: "Use prose as default format",
     });
 
     const result = store.continueSession({
@@ -769,7 +894,7 @@ test("continueSession returns a handover with original and current harness/sourc
       target_harness: "codex",
       target_source_ref: "codex:run:r1:cwd:/dev",
       target_cwd: "/dev",
-      attach: true
+      attach: true,
     });
 
     assert.equal(result.session.current_harness, "codex");
@@ -802,7 +927,7 @@ test("continueSession with attach=false leaves current_harness untouched", async
       agent_id: "bede",
       title: "Preview only",
       harness: "hermes",
-      source_ref: "discord:1:2"
+      source_ref: "discord:1:2",
     });
 
     const result = store.continueSession({
@@ -810,7 +935,7 @@ test("continueSession with attach=false leaves current_harness untouched", async
       session_id: session.id,
       target_harness: "codex",
       target_source_ref: "codex:r1",
-      attach: false
+      attach: false,
     });
 
     assert.equal(result.session.current_harness, "hermes");
@@ -826,7 +951,7 @@ test("continueSession does not append an attach event when target matches curren
       agent_id: "bede",
       title: "Same place",
       harness: "hermes",
-      source_ref: "discord:1:2"
+      source_ref: "discord:1:2",
     });
     const before = store.listSessionEvents({ session_id: session.id }).total;
 
@@ -835,7 +960,7 @@ test("continueSession does not append an attach event when target matches curren
       session_id: session.id,
       target_harness: "hermes",
       target_source_ref: "discord:1:2",
-      attach: true
+      attach: true,
     });
 
     const after = store.listSessionEvents({ session_id: session.id }).total;
@@ -850,7 +975,7 @@ test("continueSession with format=markdown renders the spec's handover sections"
       title: "Markdown render",
       harness: "hermes",
       project_key: "the-librarian",
-      start_summary: "Starting."
+      start_summary: "Starting.",
     });
     store.checkpointSession({
       agent_id: "bede",
@@ -860,7 +985,7 @@ test("continueSession with format=markdown renders the spec's handover sections"
       files_touched: ["src/store.js"],
       commands_run: ["npm test"],
       open_questions: ["Q1?"],
-      next_steps: ["Next A"]
+      next_steps: ["Next A"],
     });
 
     const result = store.continueSession({
@@ -868,7 +993,7 @@ test("continueSession with format=markdown renders the spec's handover sections"
       session_id: session.id,
       target_harness: "claude-code",
       format: "markdown",
-      attach: false
+      attach: false,
     });
 
     assert.ok(result.text.includes("# Librarian Session Handover"));
@@ -887,7 +1012,7 @@ test("continueSession on an ended session works with attach=false but throws wit
     const { session } = store.startSession({
       agent_id: "bede",
       title: "Done",
-      harness: "hermes"
+      harness: "hermes",
     });
     store.endSession({ agent_id: "bede", session_id: session.id, summary: "Done." });
 
@@ -895,18 +1020,19 @@ test("continueSession on an ended session works with attach=false but throws wit
       agent_id: "codex",
       session_id: session.id,
       target_harness: "codex",
-      attach: false
+      attach: false,
     });
     assert.equal(preview.handover.status, "ended");
 
     assert.throws(
-      () => store.continueSession({
-        agent_id: "codex",
-        session_id: session.id,
-        target_harness: "codex",
-        attach: true
-      }),
-      /ended|status/i
+      () =>
+        store.continueSession({
+          agent_id: "codex",
+          session_id: session.id,
+          target_harness: "codex",
+          attach: true,
+        }),
+      /ended|status/i,
     );
   });
 });
@@ -917,13 +1043,13 @@ test("searchSessions finds sessions whose event summaries contain matching token
       agent_id: "bede",
       title: "Findable",
       harness: "hermes",
-      start_summary: "Investigate BM25 recall trade-offs."
+      start_summary: "Investigate BM25 recall trade-offs.",
     });
     store.startSession({
       agent_id: "bede",
       title: "Other",
       harness: "hermes",
-      start_summary: "Refactor the dashboard layout."
+      start_summary: "Refactor the dashboard layout.",
     });
 
     const result = store.searchSessions({ agent_id: "bede", query: "BM25" });
@@ -935,11 +1061,15 @@ test("searchSessions finds sessions whose event summaries contain matching token
 
 test("searchSessions finds sessions by checkpoint summary content", async () => {
   await withStore((store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Search target", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Search target",
+      harness: "hermes",
+    });
     store.checkpointSession({
       agent_id: "bede",
       session_id: session.id,
-      summary: "Decided to use BM25 ranking for recall."
+      summary: "Decided to use BM25 ranking for recall.",
     });
 
     const result = store.searchSessions({ agent_id: "bede", query: "BM25" });
@@ -953,7 +1083,7 @@ test("searchSessions excludes archived sessions by default and shows them with i
       agent_id: "bede",
       title: "Findable archived",
       harness: "hermes",
-      start_summary: "Investigate BM25 recall."
+      start_summary: "Investigate BM25 recall.",
     });
     store.archiveSession({ agent_id: "bede", session_id: session.id, reason: "tidy" });
 
@@ -971,7 +1101,7 @@ test("searchSessions excludes deleted sessions and only admins may opt them in",
       agent_id: "bede",
       title: "Findable deleted",
       harness: "hermes",
-      start_summary: "Investigate BM25 recall."
+      start_summary: "Investigate BM25 recall.",
     });
     store.deleteSession({ agent_id: "bede", session_id: session.id });
 
@@ -981,7 +1111,7 @@ test("searchSessions excludes deleted sessions and only admins may opt them in",
     const nonAdmin = store.searchSessions({
       agent_id: "bede",
       query: "BM25",
-      include_deleted: true
+      include_deleted: true,
     });
     assert.equal(nonAdmin.sessions.length, 0, "non-admin include_deleted should be ignored");
 
@@ -989,7 +1119,7 @@ test("searchSessions excludes deleted sessions and only admins may opt them in",
       agent_id: "dashboard",
       query: "BM25",
       include_deleted: true,
-      admin: true
+      admin: true,
     });
     assert.equal(admin.sessions.length, 1);
   });
@@ -1002,7 +1132,7 @@ test("searchSessions hides agent_private sessions belonging to other agents", as
       title: "Codex priv",
       harness: "codex",
       visibility: "agent_private",
-      start_summary: "Investigate BM25 recall."
+      start_summary: "Investigate BM25 recall.",
     });
 
     const asBede = store.searchSessions({ agent_id: "bede", query: "BM25" });
@@ -1021,20 +1151,20 @@ test("searchSessions filters by project_key when supplied", async () => {
       title: "Project alpha",
       harness: "hermes",
       project_key: "alpha",
-      start_summary: "Investigate BM25 recall."
+      start_summary: "Investigate BM25 recall.",
     });
     store.startSession({
       agent_id: "bede",
       title: "Project beta",
       harness: "hermes",
       project_key: "beta",
-      start_summary: "Investigate BM25 recall."
+      start_summary: "Investigate BM25 recall.",
     });
 
     const alpha = store.searchSessions({
       agent_id: "bede",
       query: "BM25",
-      project_key: "alpha"
+      project_key: "alpha",
     });
     assert.equal(alpha.sessions.length, 1);
     assert.equal(alpha.sessions[0].project_key, "alpha");
@@ -1052,7 +1182,11 @@ test("searchSessions returns an empty result for a blank query", async () => {
 
 test("promoteSessionFact creates an active memory for non-protected categories and records the link", async () => {
   await withStore((store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Promote test", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Promote test",
+      harness: "hermes",
+    });
 
     const result = store.promoteSessionFact({
       agent_id: "bede",
@@ -1063,8 +1197,8 @@ test("promoteSessionFact creates an active memory for non-protected categories a
         category: "tools",
         visibility: "common",
         scope: "tool",
-        project_key: "the-librarian"
-      }
+        project_key: "the-librarian",
+      },
     });
 
     assert.equal(result.status, "active");
@@ -1081,7 +1215,11 @@ test("promoteSessionFact creates an active memory for non-protected categories a
 
 test("promoteSessionFact routes protected categories through the proposal flow", async () => {
   await withStore((store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Protected promote", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Protected promote",
+      harness: "hermes",
+    });
 
     const result = store.promoteSessionFact({
       agent_id: "bede",
@@ -1091,8 +1229,8 @@ test("promoteSessionFact routes protected categories through the proposal flow",
         body: "Jim asked for terse output across multiple sessions.",
         category: "identity",
         visibility: "common",
-        scope: "global"
-      }
+        scope: "global",
+      },
     });
 
     assert.equal(result.status, "proposed");
@@ -1102,12 +1240,16 @@ test("promoteSessionFact routes protected categories through the proposal flow",
 
 test("promoteSessionFact stores session_event_id on the promotion event when supplied", async () => {
   await withStore((store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Link event", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Link event",
+      harness: "hermes",
+    });
     const decision = store.recordSessionEvent({
       agent_id: "bede",
       session_id: session.id,
       type: "decision",
-      summary: "Source decision."
+      summary: "Source decision.",
     });
 
     const result = store.promoteSessionFact({
@@ -1118,8 +1260,8 @@ test("promoteSessionFact stores session_event_id on the promotion event when sup
         title: "Lifted source decision",
         body: "Promoting the decision recorded earlier in this session.",
         category: "lessons",
-        visibility: "common"
-      }
+        visibility: "common",
+      },
     });
 
     assert.equal(result.session_event_id, decision.event_id);
@@ -1132,26 +1274,32 @@ test("promoteSessionFact stores session_event_id on the promotion event when sup
 test("promoteSessionFact throws for unknown session_id", async () => {
   await withStore((store) => {
     assert.throws(
-      () => store.promoteSessionFact({
-        agent_id: "bede",
-        session_id: "ses_nope",
-        memory: { title: "x", body: "x", category: "tools" }
-      }),
-      /session/i
+      () =>
+        store.promoteSessionFact({
+          agent_id: "bede",
+          session_id: "ses_nope",
+          memory: { title: "x", body: "x", category: "tools" },
+        }),
+      /session/i,
     );
   });
 });
 
 test("promoteSessionFact does not create the memory when the input lacks both title and body", async () => {
   await withStore((store) => {
-    const { session } = store.startSession({ agent_id: "bede", title: "Empty input", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Empty input",
+      harness: "hermes",
+    });
     assert.throws(
-      () => store.promoteSessionFact({
-        agent_id: "bede",
-        session_id: session.id,
-        memory: { category: "tools" }
-      }),
-      /title|body|memory/i
+      () =>
+        store.promoteSessionFact({
+          agent_id: "bede",
+          session_id: session.id,
+          memory: { category: "tools" },
+        }),
+      /title|body|memory/i,
     );
   });
 });
@@ -1166,25 +1314,25 @@ test("session state rebuilds from sessions.jsonl when the store is reopened", as
       title: "Will survive restart",
       harness: "hermes",
       project_key: "the-librarian",
-      start_summary: "Initial sketch."
+      start_summary: "Initial sketch.",
     });
     sessionId = session.id;
     store.checkpointSession({
       agent_id: "bede",
       session_id: sessionId,
       summary: "Drafted handover.",
-      next_steps: ["Wire CLI"]
+      next_steps: ["Wire CLI"],
     });
     store.recordSessionEvent({
       agent_id: "bede",
       session_id: sessionId,
       type: "decision",
-      summary: "Default attach=true."
+      summary: "Default attach=true.",
     });
     store.pauseSession({
       agent_id: "bede",
       session_id: sessionId,
-      summary: "Pausing for the day."
+      summary: "Pausing for the day.",
     });
   } finally {
     store.close();
@@ -1210,7 +1358,10 @@ test("session state rebuilds from sessions.jsonl when the store is reopened", as
     assert.ok(types.includes("paused"));
 
     const hit = rebuilt.searchSessions({ agent_id: "bede", query: "handover" });
-    assert.ok(hit.sessions.some((s) => s.id === sessionId), "FTS should also be rebuilt");
+    assert.ok(
+      hit.sessions.some((s) => s.id === sessionId),
+      "FTS should also be rebuilt",
+    );
   } finally {
     rebuilt.close();
     fs.rmSync(dataDir, { recursive: true, force: true });
@@ -1225,18 +1376,18 @@ test("rebuildIndex restores both memory and session projections after a DB wipe"
       body: "Persisted in events.jsonl.",
       category: "tools",
       visibility: "common",
-      scope: "tool"
+      scope: "tool",
     });
     const { session } = store.startSession({
       agent_id: "bede",
       title: "Session under rebuild",
       harness: "hermes",
-      start_summary: "Recovery test."
+      start_summary: "Recovery test.",
     });
 
     store.db.exec(
       "DELETE FROM sessions; DELETE FROM session_events; DELETE FROM session_events_fts;" +
-      "DELETE FROM memories; DELETE FROM memories_fts; DELETE FROM events;"
+        "DELETE FROM memories; DELETE FROM memories_fts; DELETE FROM events;",
     );
     assert.equal(store.getSession(session.id), null, "wipe should leave the projection empty");
 

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -1,7 +1,7 @@
-import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
+import test from "node:test";
 import { LibrarianStore } from "../src/store.js";
 import { assertIncludes, withStore } from "./helpers.js";
 
@@ -15,21 +15,30 @@ test("protected identity and relationship memories are proposed until approved",
       visibility: "common",
       scope: "global",
       priority: "core",
-      confidence: "working"
+      confidence: "working",
     });
 
     assert.equal(result.status, "proposed");
-    assert.equal(store.searchMemories({ query: "relational continuity", categories: ["relationship"] }).length, 0);
+    assert.equal(
+      store.searchMemories({ query: "relational continuity", categories: ["relationship"] }).length,
+      0,
+    );
 
-    const approved = store.approveProposal(result.memory.id, "approve", {
-      body: "The user wants durable relationship context preserved carefully and reviewed before activation."
-    }, "dashboard");
+    const approved = store.approveProposal(
+      result.memory.id,
+      "approve",
+      {
+        body: "The user wants durable relationship context preserved carefully and reviewed before activation.",
+      },
+      "dashboard",
+    );
 
     assert.equal(approved.status, "active");
     assertIncludes(store.startContext({ agent_id: "codex" }).text, "durable relationship context");
     assert.throws(
-      () => store.updateMemory(approved.id, { body: "Direct edits should not be allowed." }, "codex"),
-      /Protected memories/
+      () =>
+        store.updateMemory(approved.id, { body: "Direct edits should not be allowed." }, "codex"),
+      /Protected memories/,
     );
   });
 });
@@ -42,12 +51,12 @@ test("generic updates cannot activate or convert protected memories", async () =
       body: "Relationship memories must wait for approval.",
       category: "relationship",
       visibility: "common",
-      scope: "global"
+      scope: "global",
     });
 
     assert.throws(
       () => store.updateMemory(proposed.memory.id, { status: "active" }, "codex"),
-      /status changes/
+      /status changes/,
     );
     assert.equal(store.getMemory(proposed.memory.id).status, "proposed");
 
@@ -57,12 +66,12 @@ test("generic updates cannot activate or convert protected memories", async () =
       body: "This starts as a tool note.",
       category: "tools",
       visibility: "common",
-      scope: "tool"
+      scope: "tool",
     });
 
     assert.throws(
       () => store.updateMemory(ordinary.memory.id, { category: "identity" }, "codex"),
-      /Protected memory categories/
+      /Protected memory categories/,
     );
     assert.equal(store.getMemory(ordinary.memory.id).category, "tools");
   });
@@ -80,17 +89,26 @@ test("ordinary memories are active, searchable, snapshotted, and rebuildable fro
       visibility: "common",
       scope: "project",
       project_key: "the-librarian",
-      tags: ["jsonl", "sqlite"]
+      tags: ["jsonl", "sqlite"],
     });
 
     assert.equal(result.status, "active");
-    assert.equal(store.searchMemories({ query: "event ledger sqlite", project_key: "the-librarian" })[0].id, result.memory.id);
-    assertIncludes(fs.readFileSync(path.join(dataDir, "memories.md"), "utf8"), "JSONL is canonical");
+    assert.equal(
+      store.searchMemories({ query: "event ledger sqlite", project_key: "the-librarian" })[0].id,
+      result.memory.id,
+    );
+    assertIncludes(
+      fs.readFileSync(path.join(dataDir, "memories.md"), "utf8"),
+      "JSONL is canonical",
+    );
 
     store.close();
     const rebuilt = new LibrarianStore({ dataDir });
     try {
-      const recalled = rebuilt.searchMemories({ query: "Markdown rebuilt", project_key: "the-librarian" });
+      const recalled = rebuilt.searchMemories({
+        query: "Markdown rebuilt",
+        project_key: "the-librarian",
+      });
       assert.equal(recalled[0].id, result.memory.id);
     } finally {
       rebuilt.close();
@@ -112,7 +130,7 @@ test("common memory is shared but agent-private memory stays private", async () 
       category: "projects",
       visibility: "common",
       scope: "project",
-      project_key: "the-librarian"
+      project_key: "the-librarian",
     });
     const privateResult = store.createMemory({
       agent_id: "codex",
@@ -121,16 +139,29 @@ test("common memory is shared but agent-private memory stays private", async () 
       category: "lessons",
       visibility: "agent_private",
       scope: "project",
-      project_key: "the-librarian"
+      project_key: "the-librarian",
     });
 
-    const codex = store.searchMemories({ agent_id: "codex", query: "behavior tests MCP", project_key: "the-librarian" });
+    const codex = store.searchMemories({
+      agent_id: "codex",
+      query: "behavior tests MCP",
+      project_key: "the-librarian",
+    });
     assert.ok(codex.some((memory) => memory.id === privateResult.memory.id));
 
-    const claude = store.searchMemories({ agent_id: "claude", query: "behavior tests MCP", project_key: "the-librarian" });
+    const claude = store.searchMemories({
+      agent_id: "claude",
+      query: "behavior tests MCP",
+      project_key: "the-librarian",
+    });
     assert.ok(!claude.some((memory) => memory.id === privateResult.memory.id));
 
-    const noPrivate = store.searchMemories({ agent_id: "codex", query: "behavior tests MCP", project_key: "the-librarian", include_private: false });
+    const noPrivate = store.searchMemories({
+      agent_id: "codex",
+      query: "behavior tests MCP",
+      project_key: "the-librarian",
+      include_private: false,
+    });
     assert.ok(!noPrivate.some((memory) => memory.id === privateResult.memory.id));
   });
 });
@@ -144,7 +175,7 @@ test("project filters prevent unrelated project memories from leaking into recal
       category: "projects",
       visibility: "common",
       scope: "project",
-      project_key: "alpha"
+      project_key: "alpha",
     });
     const beta = store.createMemory({
       agent_id: "codex",
@@ -153,7 +184,7 @@ test("project filters prevent unrelated project memories from leaking into recal
       category: "projects",
       visibility: "common",
       scope: "project",
-      project_key: "beta"
+      project_key: "beta",
     });
 
     const alphaRecall = store.searchMemories({ query: "deploy command", project_key: "alpha" });
@@ -171,15 +202,32 @@ test("delete tombstones memories and verification changes usefulness without era
       category: "tools",
       visibility: "common",
       scope: "project",
-      project_key: "the-librarian"
+      project_key: "the-librarian",
     });
 
-    assert.equal(store.verifyMemory(result.memory.id, "useful", "Helped pick a test.", "codex").usefulness_score, 1);
-    assert.equal(store.verifyMemory(result.memory.id, "wrong", "Command was removed.", "codex").usefulness_score, -1);
+    assert.equal(
+      store.verifyMemory(result.memory.id, "useful", "Helped pick a test.", "codex")
+        .usefulness_score,
+      1,
+    );
+    assert.equal(
+      store.verifyMemory(result.memory.id, "wrong", "Command was removed.", "codex")
+        .usefulness_score,
+      -1,
+    );
     assert.equal(store.deleteMemory(result.memory.id, "dashboard").status, "deleted");
 
-    assert.equal(store.searchMemories({ query: "old-test", project_key: "the-librarian" }).length, 0);
-    assert.ok(store.readEvents().some((event) => event.event_type === "memory.deleted" && event.memory_id === result.memory.id));
+    assert.equal(
+      store.searchMemories({ query: "old-test", project_key: "the-librarian" }).length,
+      0,
+    );
+    assert.ok(
+      store
+        .readEvents()
+        .some(
+          (event) => event.event_type === "memory.deleted" && event.memory_id === result.memory.id,
+        ),
+    );
   });
 });
 
@@ -193,7 +241,7 @@ test("conflicting memories are returned for resolution instead of silently saved
       visibility: "common",
       scope: "project",
       project_key: "the-librarian",
-      tags: ["dashboard", "memory", "review", "controls"]
+      tags: ["dashboard", "memory", "review", "controls"],
     });
 
     const conflict = store.createMemory({
@@ -204,7 +252,7 @@ test("conflicting memories are returned for resolution instead of silently saved
       visibility: "common",
       scope: "project",
       project_key: "the-librarian",
-      tags: ["dashboard", "memory", "review", "controls"]
+      tags: ["dashboard", "memory", "review", "controls"],
     });
 
     assert.equal(conflict.status, "conflict");


### PR DESCRIPTION
Implements **T1.2** of Phase 1 in [specs/maintainability-overhaul-tasks.md](specs/maintainability-overhaul-tasks.md). Establishes the linting + formatting layer plus a Lefthook pre-commit hook so malformed or lint-failing changes are caught before they hit CI.

## Summary

- **`eslint.config.mjs` (flat config):** `@eslint/js` recommended, `typescript-eslint` recommended for `.ts/.tsx`, `eslint-plugin-import` (order + duplicates), a small subset of `eslint-plugin-unicorn` (`prefer-node-protocol`, `no-instanceof-builtins`), and `@vitest/eslint-plugin` wired for test files.
- **Hard rules for TS files (currently dormant; light up in P3):**
  - `@typescript-eslint/no-explicit-any: error`
  - `@typescript-eslint/ban-ts-comment: error` — `@ts-ignore` and `@ts-nocheck` banned; `@ts-expect-error` only allowed with a ≥10-char description
- **`.prettierrc`:** `printWidth: 100`, double quotes, `trailingComma: "all"`.
- **`.prettierignore`:** ignores `data/`, `public/`, lockfiles, generated JSONL/SQLite, and `**/*.md` — Prettier's table padding mangles spec tables, so markdown stays hand-authored.
- **`.editorconfig`:** 2-space indent, LF, UTF-8, trim trailing whitespace.
- **`lefthook.yml`:** `pre-commit` runs `prettier --check` + `eslint --max-warnings 0` on staged files only. `pnpm prepare` runs `lefthook install` so hooks self-install on clone.
- **One-time formatting pass:** `pnpm format` applied across the existing JS tree (trailing commas, re-wrap at width 100). Removed one unused `fs` import in [test/http.test.js](test/http.test.js). No logic changed.

New scripts: `pnpm lint`, `pnpm lint:fix`, `pnpm format`, `pnpm format:check`.

## Test plan

- [x] `pnpm install` — devDeps install, `lefthook install` runs in `prepare`
- [x] `pnpm lint` — zero errors, zero warnings
- [x] `pnpm format:check` — all matched files match house style
- [x] `pnpm test` — 177 / 177 `node:test` passing
- [x] `pnpm test:vitest` — empty suite, exit 0
- [x] `pnpm run smoke` — passes
- [x] `pnpm run healthcheck` — 5 / 5 checks pass
- [x] Manual: staging a file with Prettier-violating whitespace + running `lefthook run pre-commit` blocks with `exit status 1` from the prettier task
- [x] Manual: the actual commit on this branch ran through the same hook cleanly (`prettier ✔️`, `eslint ✔️`)
- [ ] CI green on this PR

## Notes for reviewers

- **The +4871/-1350 line count is mostly mechanical.** Breakdown:
  - `pnpm-lock.yaml`: new devDeps (eslint, prettier, lefthook, typescript-eslint, plugins). Skim.
  - `src/`, `test/`, `scripts/`: trailing commas + width-100 re-wrap from `pnpm format`. No logic changed. Verification is `pnpm test` / `pnpm run smoke` / `pnpm run healthcheck` all green.
  - Hand-written changes: the five new config files at the repo root, plus `package.json` (devDeps + scripts), plus `test/http.test.js` (unused `fs` import removed).
- **Markdown is excluded from Prettier on purpose.** The first `pnpm format` run reformatted every spec table with massive column padding — bloating the spec files badly. The cleaner fix was to drop `**/*.md` from Prettier's scope rather than fight Prettier's table renderer.
- The Lefthook risk noted in [specs/maintainability-overhaul-plan.md](specs/maintainability-overhaul-plan.md) — "blocks all commits if too strict from day one" — is mitigated by the fact that the existing tree passes `lint` and `format:check` cleanly before this PR merges, so the hook only fires on genuine violations from PR-C onward.
- ESLint plugin versions are pinned at caret ranges: `eslint ^9.17`, `typescript-eslint ^8.19`, `eslint-plugin-import ^2.31`, `eslint-plugin-unicorn ^57`, `@vitest/eslint-plugin ^1.1`, `globals ^15.14`, `prettier ^3.4`, `lefthook ^1.10`.