### PR TITLE
feat(core): Zod schemas + inferred types (T3.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 data/
 .DS_Store
 .env
+dist/

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,11 +8,19 @@
   "exports": {
     ".": "./src/index.js",
     "./constants": "./src/constants.js",
-    "./store": "./src/store.js"
+    "./store": "./src/store.js",
+    "./schemas": {
+      "types": "./dist/schemas/index.d.ts",
+      "import": "./dist/schemas/index.js"
+    }
   },
   "scripts": {
+    "build": "tsc -p tsconfig.json",
     "test": "node --no-warnings --test tests/*.test.js",
     "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "zod": "^4.0.1"
   },
   "devDependencies": {
     "typescript": "catalog:",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,1 +1,6 @@
-export {};
+// Foundation for the Phase 3 TS port of `@librarian/core`.
+//
+// For now this re-exports the Zod schemas added in T3.1; the runtime store +
+// constants are still served by `./index.js` (the package's `main` entry).
+// T3.5 unifies the two entries when the JS modules port to TS.
+export * from "./schemas/index.js";

--- a/packages/core/src/schemas/common.ts
+++ b/packages/core/src/schemas/common.ts
@@ -1,0 +1,122 @@
+// Shared enums and primitive schemas used by both memory and session schemas.
+//
+// The `as const` arrays are the source of truth for the runtime values; the
+// corresponding `*Schema` exports turn them into Zod enums whose inferred types
+// are the narrow literal unions (not just `string`). When constants.js is
+// ported to TS in T3.5, the duplicated arrays here collapse into the values
+// these schemas already define.
+
+import { z } from "zod";
+
+export const CATEGORIES = [
+  "identity",
+  "relationship",
+  "preferences",
+  "projects",
+  "environment",
+  "tools",
+  "lessons",
+  "people",
+  "open_threads",
+] as const;
+export const CategorySchema = z.enum(CATEGORIES);
+export type Category = z.infer<typeof CategorySchema>;
+
+export const PROTECTED_CATEGORIES = ["identity", "relationship"] as const;
+export type ProtectedCategory = (typeof PROTECTED_CATEGORIES)[number];
+
+export const VISIBILITIES = ["common", "agent_private"] as const;
+export const VisibilitySchema = z.enum(VISIBILITIES);
+export type Visibility = z.infer<typeof VisibilitySchema>;
+
+export const SCOPES = ["global", "project", "environment", "tool", "session"] as const;
+export const ScopeSchema = z.enum(SCOPES);
+export type Scope = z.infer<typeof ScopeSchema>;
+
+export const MEMORY_STATUSES = [
+  "active",
+  "proposed",
+  "conflicted",
+  "archived",
+  "deleted",
+  "rejected",
+] as const;
+export const MemoryStatusSchema = z.enum(MEMORY_STATUSES);
+export type MemoryStatus = z.infer<typeof MemoryStatusSchema>;
+
+export const PRIORITIES = ["low", "normal", "high", "core"] as const;
+export const PrioritySchema = z.enum(PRIORITIES);
+export type Priority = z.infer<typeof PrioritySchema>;
+
+export const CONFIDENCES = ["tentative", "working", "strong"] as const;
+export const ConfidenceSchema = z.enum(CONFIDENCES);
+export type Confidence = z.infer<typeof ConfidenceSchema>;
+
+export const SESSION_STATUSES = ["active", "paused", "ended", "archived", "deleted"] as const;
+export const SessionStatusSchema = z.enum(SESSION_STATUSES);
+export type SessionStatus = z.infer<typeof SessionStatusSchema>;
+
+export const SESSION_CAPTURE_MODES = ["off", "summary", "log"] as const;
+export const SessionCaptureModeSchema = z.enum(SESSION_CAPTURE_MODES);
+export type SessionCaptureMode = z.infer<typeof SessionCaptureModeSchema>;
+
+export const SESSION_PAYLOAD_TYPES = [
+  "message",
+  "command",
+  "file",
+  "error",
+  "decision",
+  "question",
+  "checkpoint",
+  "handover",
+  "note",
+] as const;
+export const SessionPayloadTypeSchema = z.enum(SESSION_PAYLOAD_TYPES);
+export type SessionPayloadType = z.infer<typeof SessionPayloadTypeSchema>;
+
+export const SESSION_EVENT_TYPES = [
+  "session.started",
+  "session.attached_to_harness",
+  "session.event_recorded",
+  "session.checkpointed",
+  "session.paused",
+  "session.ended",
+  "session.archived",
+  "session.restored",
+  "session.deleted",
+  "session.promoted_to_memory",
+] as const;
+export const SessionEventTypeSchema = z.enum(SESSION_EVENT_TYPES);
+export type SessionEventType = z.infer<typeof SessionEventTypeSchema>;
+
+export const MEMORY_EVENT_TYPES = [
+  "memory.created",
+  "memory.proposed",
+  "memory.updated",
+  "memory.approved",
+  "memory.rejected",
+  "memory.deleted",
+  "memory.archived",
+  "memory.recalled",
+  "memory.recall_empty",
+  "memory.verified",
+  "memory.conflict_detected",
+  "memory.conflict_resolved",
+] as const;
+export const MemoryEventTypeSchema = z.enum(MEMORY_EVENT_TYPES);
+export type MemoryEventType = z.infer<typeof MemoryEventTypeSchema>;
+
+export const VERIFY_RESULTS = ["useful", "not_useful", "outdated"] as const;
+export const VerifyResultSchema = z.enum(VERIFY_RESULTS);
+export type VerifyResult = z.infer<typeof VerifyResultSchema>;
+
+// ISO 8601 UTC timestamps as emitted by `new Date().toISOString()`.
+export const IsoTimestampSchema = z.iso.datetime();
+
+// Opaque prefixed ids generated via crypto.randomUUID(), e.g. `mem_<uuid>`,
+// `ses_<uuid>`, `evt_<uuid>`. We treat them as strings for now; tightening to
+// `${prefix}_<uuid>` patterns is a Phase 3+ refinement.
+export const IdSchema = z.string().min(1);
+
+// Default sentinel for "no agent attribution available."
+export const DEFAULT_AGENT_ID = "unknown-agent";

--- a/packages/core/src/schemas/events.ts
+++ b/packages/core/src/schemas/events.ts
@@ -1,0 +1,259 @@
+// JSONL ledger entry schemas.
+//
+// The Librarian's source of truth is two append-only JSONL files:
+//   - events.jsonl     — memory-domain events
+//   - sessions.jsonl   — session-domain events
+//
+// Both share a common envelope (event_id, event_type, agent_id, created_at,
+// payload). The schemas below model each `event_type` as a separate object
+// schema and combine them with `z.discriminatedUnion` so consumers can match
+// on `event_type` to narrow `payload` without manual casts.
+
+import { z } from "zod";
+import { IdSchema, IsoTimestampSchema, MemoryStatusSchema, VerifyResultSchema } from "./common.js";
+import { MemoryPatchSchema, MemorySchema } from "./memory.js";
+import { SessionEventPayloadSchema, SessionSchema } from "./session.js";
+
+// ---------- Memory ledger entries (events.jsonl) ----------
+
+const memoryEventBase = {
+  event_id: IdSchema,
+  memory_id: IdSchema.nullable(),
+  agent_id: z.string().nullable(),
+  created_at: IsoTimestampSchema,
+};
+
+export const MemoryCreatedEventSchema = z.object({
+  ...memoryEventBase,
+  event_type: z.literal("memory.created"),
+  payload: z.object({ memory: MemorySchema }),
+});
+
+export const MemoryProposedEventSchema = z.object({
+  ...memoryEventBase,
+  event_type: z.literal("memory.proposed"),
+  payload: z.object({ memory: MemorySchema }),
+});
+
+export const MemoryUpdatedEventSchema = z.object({
+  ...memoryEventBase,
+  event_type: z.literal("memory.updated"),
+  payload: z.object({
+    memory_id: IdSchema,
+    agent_id: z.string(),
+    patch: MemoryPatchSchema,
+  }),
+});
+
+export const MemoryApprovedEventSchema = z.object({
+  ...memoryEventBase,
+  event_type: z.literal("memory.approved"),
+  payload: z.object({
+    memory_id: IdSchema,
+    agent_id: z.string(),
+    patch: MemoryPatchSchema.optional(),
+  }),
+});
+
+export const MemoryRejectedEventSchema = z.object({
+  ...memoryEventBase,
+  event_type: z.literal("memory.rejected"),
+  payload: z.object({ memory_id: IdSchema, agent_id: z.string() }),
+});
+
+export const MemoryDeletedEventSchema = z.object({
+  ...memoryEventBase,
+  event_type: z.literal("memory.deleted"),
+  payload: z.object({ memory_id: IdSchema, agent_id: z.string() }),
+});
+
+export const MemoryArchivedEventSchema = z.object({
+  ...memoryEventBase,
+  event_type: z.literal("memory.archived"),
+  payload: z.object({ memory_id: IdSchema, agent_id: z.string() }),
+});
+
+export const MemoryRecalledEventSchema = z.object({
+  ...memoryEventBase,
+  event_type: z.literal("memory.recalled"),
+  payload: z.object({
+    memory_ids: z.array(IdSchema),
+    agent_id: z.string(),
+    query: z.string().optional(),
+    note: z.string().optional(),
+  }),
+});
+
+export const MemoryRecallEmptyEventSchema = z.object({
+  ...memoryEventBase,
+  event_type: z.literal("memory.recall_empty"),
+  payload: z.object({
+    agent_id: z.string(),
+    query: z.string().optional(),
+    note: z.string().optional(),
+  }),
+});
+
+export const MemoryVerifiedEventSchema = z.object({
+  ...memoryEventBase,
+  event_type: z.literal("memory.verified"),
+  payload: z.object({
+    memory_id: IdSchema,
+    agent_id: z.string(),
+    result: VerifyResultSchema,
+    note: z.string().optional(),
+  }),
+});
+
+export const MemoryConflictDetectedEventSchema = z.object({
+  ...memoryEventBase,
+  event_type: z.literal("memory.conflict_detected"),
+  payload: z.object({
+    memory_id: IdSchema,
+    agent_id: z.string(),
+    conflicts_with: z.array(IdSchema),
+  }),
+});
+
+export const MemoryConflictResolvedEventSchema = z.object({
+  ...memoryEventBase,
+  event_type: z.literal("memory.conflict_resolved"),
+  payload: z.object({
+    memory_id: IdSchema,
+    agent_id: z.string(),
+    patch: MemoryPatchSchema.optional(),
+    status: MemoryStatusSchema.optional(),
+  }),
+});
+
+export const MemoryLedgerEntrySchema = z.discriminatedUnion("event_type", [
+  MemoryCreatedEventSchema,
+  MemoryProposedEventSchema,
+  MemoryUpdatedEventSchema,
+  MemoryApprovedEventSchema,
+  MemoryRejectedEventSchema,
+  MemoryDeletedEventSchema,
+  MemoryArchivedEventSchema,
+  MemoryRecalledEventSchema,
+  MemoryRecallEmptyEventSchema,
+  MemoryVerifiedEventSchema,
+  MemoryConflictDetectedEventSchema,
+  MemoryConflictResolvedEventSchema,
+]);
+export type MemoryLedgerEntry = z.infer<typeof MemoryLedgerEntrySchema>;
+
+// ---------- Session ledger entries (sessions.jsonl) ----------
+
+const sessionEventBase = {
+  event_id: IdSchema,
+  session_id: IdSchema,
+  agent_id: z.string().nullable(),
+  harness: z.string().nullable(),
+  source_ref: z.string().nullable(),
+  created_at: IsoTimestampSchema,
+};
+
+export const SessionStartedEventSchema = z.object({
+  ...sessionEventBase,
+  event_type: z.literal("session.started"),
+  payload: z.object({ session: SessionSchema }),
+});
+
+export const SessionAttachedEventSchema = z.object({
+  ...sessionEventBase,
+  event_type: z.literal("session.attached_to_harness"),
+  payload: z.object({
+    session: SessionSchema.optional(),
+    harness: z.string().optional(),
+    source_ref: z.string().optional(),
+    cwd: z.string().optional(),
+  }),
+});
+
+export const SessionEventRecordedEntrySchema = z.object({
+  ...sessionEventBase,
+  event_type: z.literal("session.event_recorded"),
+  payload: SessionEventPayloadSchema,
+});
+
+// Shared lifecycle envelope for checkpoint/pause/end — they all stamp a
+// summary plus the typical handover fields onto the session.
+const lifecyclePayload = z.object({
+  summary: z.string().nullable().optional(),
+  decisions: z.array(z.string()).optional(),
+  files_touched: z.array(z.string()).optional(),
+  commands_run: z.array(z.string()).optional(),
+  open_questions: z.array(z.string()).optional(),
+  next_steps: z.array(z.string()).optional(),
+  session: SessionSchema.optional(),
+});
+
+export const SessionCheckpointedEventSchema = z.object({
+  ...sessionEventBase,
+  event_type: z.literal("session.checkpointed"),
+  payload: lifecyclePayload,
+});
+
+export const SessionPausedEventSchema = z.object({
+  ...sessionEventBase,
+  event_type: z.literal("session.paused"),
+  payload: lifecyclePayload,
+});
+
+export const SessionEndedEventSchema = z.object({
+  ...sessionEventBase,
+  event_type: z.literal("session.ended"),
+  payload: lifecyclePayload,
+});
+
+export const SessionArchivedEventSchema = z.object({
+  ...sessionEventBase,
+  event_type: z.literal("session.archived"),
+  payload: z.object({
+    reason: z.string().nullable().optional(),
+    session: SessionSchema.optional(),
+  }),
+});
+
+export const SessionRestoredEventSchema = z.object({
+  ...sessionEventBase,
+  event_type: z.literal("session.restored"),
+  payload: z.object({
+    prior_status: z.string().nullable().optional(),
+    session: SessionSchema.optional(),
+  }),
+});
+
+export const SessionDeletedEventSchema = z.object({
+  ...sessionEventBase,
+  event_type: z.literal("session.deleted"),
+  payload: z.object({
+    reason: z.string().nullable().optional(),
+    session: SessionSchema.optional(),
+  }),
+});
+
+export const SessionPromotedToMemoryEventSchema = z.object({
+  ...sessionEventBase,
+  event_type: z.literal("session.promoted_to_memory"),
+  payload: z.object({
+    memory_id: IdSchema,
+    fact: z.string().optional(),
+    category: z.string().optional(),
+    session: SessionSchema.optional(),
+  }),
+});
+
+export const SessionLedgerEntrySchema = z.discriminatedUnion("event_type", [
+  SessionStartedEventSchema,
+  SessionAttachedEventSchema,
+  SessionEventRecordedEntrySchema,
+  SessionCheckpointedEventSchema,
+  SessionPausedEventSchema,
+  SessionEndedEventSchema,
+  SessionArchivedEventSchema,
+  SessionRestoredEventSchema,
+  SessionDeletedEventSchema,
+  SessionPromotedToMemoryEventSchema,
+]);
+export type SessionLedgerEntry = z.infer<typeof SessionLedgerEntrySchema>;

--- a/packages/core/src/schemas/events.ts
+++ b/packages/core/src/schemas/events.ts
@@ -16,27 +16,27 @@ import { SessionEventPayloadSchema, SessionSchema } from "./session.js";
 
 // ---------- Memory ledger entries (events.jsonl) ----------
 
-const memoryEventBase = {
+// Envelope shared by every memory ledger event. Exported so consumers can
+// peek at `event_type` (or any envelope field) without parsing the full
+// discriminated union — e.g., when scanning JSONL incrementally.
+export const MemoryEventBaseSchema = z.object({
   event_id: IdSchema,
   memory_id: IdSchema.nullable(),
   agent_id: z.string().nullable(),
   created_at: IsoTimestampSchema,
-};
+});
 
-export const MemoryCreatedEventSchema = z.object({
-  ...memoryEventBase,
+export const MemoryCreatedEventSchema = MemoryEventBaseSchema.extend({
   event_type: z.literal("memory.created"),
   payload: z.object({ memory: MemorySchema }),
 });
 
-export const MemoryProposedEventSchema = z.object({
-  ...memoryEventBase,
+export const MemoryProposedEventSchema = MemoryEventBaseSchema.extend({
   event_type: z.literal("memory.proposed"),
   payload: z.object({ memory: MemorySchema }),
 });
 
-export const MemoryUpdatedEventSchema = z.object({
-  ...memoryEventBase,
+export const MemoryUpdatedEventSchema = MemoryEventBaseSchema.extend({
   event_type: z.literal("memory.updated"),
   payload: z.object({
     memory_id: IdSchema,
@@ -45,8 +45,7 @@ export const MemoryUpdatedEventSchema = z.object({
   }),
 });
 
-export const MemoryApprovedEventSchema = z.object({
-  ...memoryEventBase,
+export const MemoryApprovedEventSchema = MemoryEventBaseSchema.extend({
   event_type: z.literal("memory.approved"),
   payload: z.object({
     memory_id: IdSchema,
@@ -55,26 +54,22 @@ export const MemoryApprovedEventSchema = z.object({
   }),
 });
 
-export const MemoryRejectedEventSchema = z.object({
-  ...memoryEventBase,
+export const MemoryRejectedEventSchema = MemoryEventBaseSchema.extend({
   event_type: z.literal("memory.rejected"),
   payload: z.object({ memory_id: IdSchema, agent_id: z.string() }),
 });
 
-export const MemoryDeletedEventSchema = z.object({
-  ...memoryEventBase,
+export const MemoryDeletedEventSchema = MemoryEventBaseSchema.extend({
   event_type: z.literal("memory.deleted"),
   payload: z.object({ memory_id: IdSchema, agent_id: z.string() }),
 });
 
-export const MemoryArchivedEventSchema = z.object({
-  ...memoryEventBase,
+export const MemoryArchivedEventSchema = MemoryEventBaseSchema.extend({
   event_type: z.literal("memory.archived"),
   payload: z.object({ memory_id: IdSchema, agent_id: z.string() }),
 });
 
-export const MemoryRecalledEventSchema = z.object({
-  ...memoryEventBase,
+export const MemoryRecalledEventSchema = MemoryEventBaseSchema.extend({
   event_type: z.literal("memory.recalled"),
   payload: z.object({
     memory_ids: z.array(IdSchema),
@@ -84,8 +79,7 @@ export const MemoryRecalledEventSchema = z.object({
   }),
 });
 
-export const MemoryRecallEmptyEventSchema = z.object({
-  ...memoryEventBase,
+export const MemoryRecallEmptyEventSchema = MemoryEventBaseSchema.extend({
   event_type: z.literal("memory.recall_empty"),
   payload: z.object({
     agent_id: z.string(),
@@ -94,8 +88,7 @@ export const MemoryRecallEmptyEventSchema = z.object({
   }),
 });
 
-export const MemoryVerifiedEventSchema = z.object({
-  ...memoryEventBase,
+export const MemoryVerifiedEventSchema = MemoryEventBaseSchema.extend({
   event_type: z.literal("memory.verified"),
   payload: z.object({
     memory_id: IdSchema,
@@ -105,8 +98,7 @@ export const MemoryVerifiedEventSchema = z.object({
   }),
 });
 
-export const MemoryConflictDetectedEventSchema = z.object({
-  ...memoryEventBase,
+export const MemoryConflictDetectedEventSchema = MemoryEventBaseSchema.extend({
   event_type: z.literal("memory.conflict_detected"),
   payload: z.object({
     memory_id: IdSchema,
@@ -115,8 +107,7 @@ export const MemoryConflictDetectedEventSchema = z.object({
   }),
 });
 
-export const MemoryConflictResolvedEventSchema = z.object({
-  ...memoryEventBase,
+export const MemoryConflictResolvedEventSchema = MemoryEventBaseSchema.extend({
   event_type: z.literal("memory.conflict_resolved"),
   payload: z.object({
     memory_id: IdSchema,
@@ -144,23 +135,23 @@ export type MemoryLedgerEntry = z.infer<typeof MemoryLedgerEntrySchema>;
 
 // ---------- Session ledger entries (sessions.jsonl) ----------
 
-const sessionEventBase = {
+// Envelope shared by every session ledger event. Exported for the same
+// reason as MemoryEventBaseSchema — envelope-only parsing.
+export const SessionEventBaseSchema = z.object({
   event_id: IdSchema,
   session_id: IdSchema,
   agent_id: z.string().nullable(),
   harness: z.string().nullable(),
   source_ref: z.string().nullable(),
   created_at: IsoTimestampSchema,
-};
+});
 
-export const SessionStartedEventSchema = z.object({
-  ...sessionEventBase,
+export const SessionStartedEventSchema = SessionEventBaseSchema.extend({
   event_type: z.literal("session.started"),
   payload: z.object({ session: SessionSchema }),
 });
 
-export const SessionAttachedEventSchema = z.object({
-  ...sessionEventBase,
+export const SessionAttachedEventSchema = SessionEventBaseSchema.extend({
   event_type: z.literal("session.attached_to_harness"),
   payload: z.object({
     session: SessionSchema.optional(),
@@ -170,15 +161,14 @@ export const SessionAttachedEventSchema = z.object({
   }),
 });
 
-export const SessionEventRecordedEntrySchema = z.object({
-  ...sessionEventBase,
+export const SessionEventRecordedEntrySchema = SessionEventBaseSchema.extend({
   event_type: z.literal("session.event_recorded"),
   payload: SessionEventPayloadSchema,
 });
 
-// Shared lifecycle envelope for checkpoint/pause/end — they all stamp a
+// Shared lifecycle payload for checkpoint/pause/end — they all stamp a
 // summary plus the typical handover fields onto the session.
-const lifecyclePayload = z.object({
+const SessionLifecyclePayloadSchema = z.object({
   summary: z.string().nullable().optional(),
   decisions: z.array(z.string()).optional(),
   files_touched: z.array(z.string()).optional(),
@@ -188,26 +178,22 @@ const lifecyclePayload = z.object({
   session: SessionSchema.optional(),
 });
 
-export const SessionCheckpointedEventSchema = z.object({
-  ...sessionEventBase,
+export const SessionCheckpointedEventSchema = SessionEventBaseSchema.extend({
   event_type: z.literal("session.checkpointed"),
-  payload: lifecyclePayload,
+  payload: SessionLifecyclePayloadSchema,
 });
 
-export const SessionPausedEventSchema = z.object({
-  ...sessionEventBase,
+export const SessionPausedEventSchema = SessionEventBaseSchema.extend({
   event_type: z.literal("session.paused"),
-  payload: lifecyclePayload,
+  payload: SessionLifecyclePayloadSchema,
 });
 
-export const SessionEndedEventSchema = z.object({
-  ...sessionEventBase,
+export const SessionEndedEventSchema = SessionEventBaseSchema.extend({
   event_type: z.literal("session.ended"),
-  payload: lifecyclePayload,
+  payload: SessionLifecyclePayloadSchema,
 });
 
-export const SessionArchivedEventSchema = z.object({
-  ...sessionEventBase,
+export const SessionArchivedEventSchema = SessionEventBaseSchema.extend({
   event_type: z.literal("session.archived"),
   payload: z.object({
     reason: z.string().nullable().optional(),
@@ -215,8 +201,7 @@ export const SessionArchivedEventSchema = z.object({
   }),
 });
 
-export const SessionRestoredEventSchema = z.object({
-  ...sessionEventBase,
+export const SessionRestoredEventSchema = SessionEventBaseSchema.extend({
   event_type: z.literal("session.restored"),
   payload: z.object({
     prior_status: z.string().nullable().optional(),
@@ -224,8 +209,7 @@ export const SessionRestoredEventSchema = z.object({
   }),
 });
 
-export const SessionDeletedEventSchema = z.object({
-  ...sessionEventBase,
+export const SessionDeletedEventSchema = SessionEventBaseSchema.extend({
   event_type: z.literal("session.deleted"),
   payload: z.object({
     reason: z.string().nullable().optional(),
@@ -233,8 +217,7 @@ export const SessionDeletedEventSchema = z.object({
   }),
 });
 
-export const SessionPromotedToMemoryEventSchema = z.object({
-  ...sessionEventBase,
+export const SessionPromotedToMemoryEventSchema = SessionEventBaseSchema.extend({
   event_type: z.literal("session.promoted_to_memory"),
   payload: z.object({
     memory_id: IdSchema,

--- a/packages/core/src/schemas/index.ts
+++ b/packages/core/src/schemas/index.ts
@@ -1,0 +1,4 @@
+export * from "./common.js";
+export * from "./memory.js";
+export * from "./session.js";
+export * from "./events.js";

--- a/packages/core/src/schemas/memory.ts
+++ b/packages/core/src/schemas/memory.ts
@@ -1,0 +1,72 @@
+// Memory row schema — the canonical shape of a row in the `memories` SQLite
+// table (after `rowToMemory` parses the JSON-encoded array columns) and the
+// `payload.memory` snapshot embedded in JSONL ledger events.
+
+import { z } from "zod";
+import {
+  CategorySchema,
+  ConfidenceSchema,
+  IdSchema,
+  IsoTimestampSchema,
+  MemoryStatusSchema,
+  PrioritySchema,
+  ScopeSchema,
+  VisibilitySchema,
+} from "./common.js";
+
+export const MemorySchema = z.object({
+  id: IdSchema,
+  title: z.string(),
+  body: z.string(),
+  category: CategorySchema,
+  visibility: VisibilitySchema,
+  agent_id: z.string().nullable(),
+  scope: ScopeSchema,
+  project_key: z.string().nullable(),
+  status: MemoryStatusSchema,
+  priority: PrioritySchema,
+  confidence: ConfidenceSchema,
+  tags: z.array(z.string()),
+  applies_to: z.array(z.string()),
+  supersedes: z.array(z.string()),
+  conflicts_with: z.array(z.string()),
+  created_at: IsoTimestampSchema,
+  updated_at: IsoTimestampSchema,
+  last_recalled_at: IsoTimestampSchema.nullable(),
+  recall_count: z.number().int().nonnegative(),
+  usefulness_score: z.number().int(),
+});
+export type Memory = z.infer<typeof MemorySchema>;
+
+// Partial patches applied via `memory.updated` / `memory.approved` /
+// `memory.conflict_resolved` ledger events. Field set mirrors the writable
+// columns; `id`, `created_at`, and projection-only counters are excluded.
+export const MemoryPatchSchema = MemorySchema.partial().omit({
+  id: true,
+  created_at: true,
+  recall_count: true,
+  usefulness_score: true,
+  last_recalled_at: true,
+});
+export type MemoryPatch = z.infer<typeof MemoryPatchSchema>;
+
+// User-facing input accepted by `createMemory` and the various proposal flows.
+// Currently lenient: fields beyond the documented set are tolerated (and
+// dropped by `normalizeMemoryInput` in store.js). T3.3 tightens this when the
+// memory-store module is extracted.
+export const MemoryInputSchema = z.object({
+  agent_id: z.string().optional(),
+  title: z.string().optional(),
+  body: z.string().optional(),
+  content: z.string().optional(),
+  category: CategorySchema.optional(),
+  visibility: VisibilitySchema.optional(),
+  scope: ScopeSchema.optional(),
+  project_key: z.string().optional(),
+  applies_to: z.array(z.string()).optional(),
+  priority: PrioritySchema.optional(),
+  confidence: ConfidenceSchema.optional(),
+  tags: z.array(z.string()).optional(),
+  status: MemoryStatusSchema.optional(),
+});
+export type MemoryInput = z.infer<typeof MemoryInputSchema>;

--- a/packages/core/src/schemas/session.ts
+++ b/packages/core/src/schemas/session.ts
@@ -1,0 +1,75 @@
+// Session row schema — canonical shape of a row in the `sessions` SQLite
+// table (after `rowToSession` parses JSON-encoded columns) and the
+// `payload.session` snapshot embedded in `session.*` JSONL ledger events.
+//
+// SessionEventRow is the canonical shape of a row in the `session_events`
+// table — i.e. the per-event projection of `session.event_recorded` ledger
+// entries (lifecycle events like `session.checkpointed` do not produce
+// session_events rows; they update the session row directly).
+
+import { z } from "zod";
+import {
+  IdSchema,
+  IsoTimestampSchema,
+  SessionCaptureModeSchema,
+  SessionPayloadTypeSchema,
+  SessionStatusSchema,
+  VisibilitySchema,
+} from "./common.js";
+
+export const SessionSchema = z.object({
+  id: IdSchema,
+  title: z.string(),
+  project_key: z.string().nullable(),
+  status: SessionStatusSchema,
+  prior_status: SessionStatusSchema.nullable(),
+  visibility: VisibilitySchema,
+  created_by_agent_id: z.string().nullable(),
+  current_agent_id: z.string().nullable(),
+  created_in_harness: z.string().nullable(),
+  current_harness: z.string().nullable(),
+  source_ref: z.string().nullable(),
+  cwd: z.string().nullable(),
+  start_summary: z.string().nullable(),
+  rolling_summary: z.string().nullable(),
+  end_summary: z.string().nullable(),
+  next_steps: z.array(z.string()),
+  tags: z.array(z.string()),
+  capture_mode: SessionCaptureModeSchema,
+  started_at: IsoTimestampSchema,
+  updated_at: IsoTimestampSchema,
+  last_activity_at: IsoTimestampSchema,
+  paused_at: IsoTimestampSchema.nullable(),
+  ended_at: IsoTimestampSchema.nullable(),
+  archived_at: IsoTimestampSchema.nullable(),
+  deleted_at: IsoTimestampSchema.nullable(),
+  metadata: z.record(z.string(), z.unknown()),
+});
+export type Session = z.infer<typeof SessionSchema>;
+
+// The shared shape of every session-event payload (regardless of type):
+//   { type, summary, agent_id, ...extra }
+// `extra` is callsite-defined and tolerated as unknown for now.
+export const SessionEventPayloadSchema = z
+  .object({
+    type: SessionPayloadTypeSchema,
+    summary: z.string(),
+    agent_id: z.string(),
+  })
+  .catchall(z.unknown());
+export type SessionEventPayload = z.infer<typeof SessionEventPayloadSchema>;
+
+// A row in the `session_events` table — the projection of every
+// `session.event_recorded` ledger entry.
+export const SessionEventRowSchema = z.object({
+  id: IdSchema,
+  session_id: IdSchema,
+  type: SessionPayloadTypeSchema,
+  agent_id: z.string().nullable(),
+  harness: z.string().nullable(),
+  source_ref: z.string().nullable(),
+  summary: z.string(),
+  payload: z.record(z.string(), z.unknown()),
+  created_at: IsoTimestampSchema,
+});
+export type SessionEventRow = z.infer<typeof SessionEventRowSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,10 @@ importers:
         version: 2.1.9
 
   packages/core:
+    dependencies:
+      zod:
+        specifier: ^4.0.1
+        version: 4.4.3
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -1739,6 +1743,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -3497,3 +3504,5 @@ snapshots:
   word-wrap@1.2.5: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@4.4.3: {}


### PR DESCRIPTION
## Spec / phase reference

Implements **T3.1 — Zod schemas + types** (Phase 3, first PR — per [specs/maintainability-overhaul.md](specs/maintainability-overhaul.md) and [specs/maintainability-overhaul-tasks.md](specs/maintainability-overhaul-tasks.md)).

This is the **foundation** for the Phase 3 TS port of `@librarian/core`. Per the spec: *"No code is using them yet — this is the foundation."* T3.2 pulls JSONL + projection helpers out of `store.js` and converts the rebuild tests to Vitest against these schemas; T3.3/T3.4 extract memory + session stores; T3.5 finalises the core facade and points `main` at the compiled TS output.

## Summary

- [packages/core/src/schemas/](packages/core/src/schemas/) — five TS files, all Zod 4:
  - **`common.ts`** — `as const` arrays + `z.enum` schemas for every taxonomy currently in `constants.js`: `CATEGORIES`, `VISIBILITIES`, `SCOPES`, `MEMORY_STATUSES`, `PRIORITIES`, `CONFIDENCES`, `SESSION_STATUSES`, `SESSION_CAPTURE_MODES`, `SESSION_PAYLOAD_TYPES`, `SESSION_EVENT_TYPES`, `MEMORY_EVENT_TYPES`, `VERIFY_RESULTS`. Plus `IsoTimestampSchema` (`z.iso.datetime()`), `IdSchema`, and the `DEFAULT_AGENT_ID` sentinel. The const arrays duplicate values from `constants.js` for now; T3.5 collapses the duplication.
  - **`memory.ts`** — `MemorySchema` (row shape after `rowToMemory` parses the JSON-encoded array columns), `MemoryPatchSchema` (writable subset for `memory.updated`/`memory.approved`/`memory.conflict_resolved` events), `MemoryInputSchema` (lenient user-facing input).
  - **`session.ts`** — `SessionSchema` (row shape after `rowToSession`), `SessionEventPayloadSchema` (`{ type, summary, agent_id, …catchall }` shared by every `session.event_recorded` payload), `SessionEventRowSchema` (row shape from the `session_events` table).
  - **`events.ts`** — two `z.discriminatedUnion("event_type", […])` schemas: `MemoryLedgerEntrySchema` (12 variants — `memory.created`, `memory.proposed`, `memory.updated`, `memory.approved`, `memory.rejected`, `memory.deleted`, `memory.archived`, `memory.recalled`, `memory.recall_empty`, `memory.verified`, `memory.conflict_detected`, `memory.conflict_resolved`) and `SessionLedgerEntrySchema` (10 variants — `session.started`, `session.attached_to_harness`, `session.event_recorded`, `session.checkpointed`, `session.paused`, `session.ended`, `session.archived`, `session.restored`, `session.deleted`, `session.promoted_to_memory`). Lifecycle events share an envelope schema rather than duplicating fields.
  - **`index.ts`** — re-exports.
- **Types inferred from schemas** — every type is `z.infer<typeof XSchema>`. No hand-written duplicates anywhere in the new code.

**Wiring:**

- [packages/core/package.json](packages/core/package.json):
  - New runtime dep `zod ^4.0.1`.
  - New script `"build": "tsc -p tsconfig.json"` (the package's tsconfig already had `outDir: "./dist"`, `declaration: true`).
  - New `exports["./schemas"]` pointing at compiled `./dist/schemas/index.{js,d.ts}`.
- [packages/core/src/index.ts](packages/core/src/index.ts) — was an empty `export {};` placeholder from PR-C; now re-exports `./schemas/index.js`. **The runtime entry (`./src/index.js`) is unchanged** — `main` still points at it, so today's JS consumers see exactly the same surface. T3.5 unifies the two entries.
- [.gitignore](.gitignore): `dist/` added.

**No code uses these schemas yet.** No `.js` file imports from `@librarian/core/schemas` or expects the new types. This is a pure foundation PR.

## Test plan

Spec verify block:

- [x] `pnpm --filter @librarian/core build` — clean tsc emit; `find packages/core/dist -type f` shows 24 files (`.js` + `.d.ts` + sourcemaps for each of 6 source files).
- [x] `pnpm --filter @librarian/core typecheck` — zero errors.

Schema sanity:

- [x] Loaded `packages/core/dist/schemas/index.js` and ran `MemoryLedgerEntrySchema.safeParse` + `SessionLedgerEntrySchema.safeParse` against every line of `test/fixtures/pre-migration/events.jsonl` (3 entries) and `test/fixtures/pre-migration/sessions.jsonl` (5 entries). All 8 entries parse cleanly through the discriminated unions.

Full pipeline (no regressions):

- [x] `pnpm install` — picks up `zod` (+1 package, +1 added).
- [x] `pnpm lint`, `pnpm format:check`, `pnpm typecheck` — clean.
- [x] `pnpm test` — 177/177 node:test passing.
- [x] `pnpm test:vitest` — 0 tests, exit 0.
- [x] `pnpm build` — `@librarian/core` emits, `@librarian/cli`'s `true` succeeds, other packages skipped.
- [x] `pnpm run smoke` — passes.
- [x] `pnpm run healthcheck` — 5/5.
- [x] `pnpm run check:test-count` — `OK: 177 tests >= floor 177`.
- [x] `pnpm run check:storage-fixture` — `OK: memoriesTotal=3, memoriesActive=2, memoriesProposed=1, sessionsTotal=2, sessionsActive=1, sessionsPaused=1`.
- [ ] CI green on this PR (waiting for first run).

## Quality gates

- [x] **No files over 400 LOC introduced.** Largest is [packages/core/src/schemas/events.ts](packages/core/src/schemas/events.ts) (~260 LOC — the 12 memory + 10 session discriminated-union variants); the others are all under 100 LOC.
- [x] **No new `any` / `@ts-ignore` introduced.** Catchall values use `z.unknown()` (`SessionEventPayloadSchema.catchall(z.unknown())`, `metadata: z.record(z.string(), z.unknown())`, `SessionEventRowSchema.payload`) — never `any`.

## Notes for the reviewer

- **Zod 4 (`^4.0.1`)** — confirmed via Context7 docs; uses `z.iso.datetime()` (the v4 replacement for `z.string().datetime()`), `z.discriminatedUnion("kind", [...])`, and `z.enum(arr as const)` for narrow literal unions. Imports are `import { z } from "zod"` (no v3/v4 subpath needed).
- **Why two entries (`src/index.js` runtime, `src/index.ts` schemas)?** The runtime entry can't currently import from a TS source — it's still pure JS. Rather than introduce a compile-then-run dependency for the JS runtime, this PR keeps the two side-by-side. `main` in `package.json` still points at `./src/index.js`, so today's `import { LibrarianStore } from "@librarian/core"` still works unchanged. Schemas are reachable via the `./schemas` subpath. T3.5 unifies.
- **Why the duplicated const arrays in `common.ts`?** The TS source can't import from `constants.js` (no `allowJs` in our tsconfig, and we don't want to flip that on globally). Duplicating the arrays in TS keeps the schemas self-contained and gives them narrow literal types. When `constants.js` ports to TS in T3.5, the arrays collapse to a single source of truth (probably re-exported from the schemas).
- **Discriminated unions vs single envelope** — I went with discriminated unions for both ledger types because the payload shapes differ enough per `event_type` that a single envelope would have to be `payload: z.unknown()`. Discriminated unions give consumers exhaustive `switch` and TS-narrowing without manual casts, which T3.2's projection module will lean on hard.
- **Optional/nullable choices** are deliberate: nullable for columns that the SQLite schema declares NULL-able, optional for payload fields that the current `appendEvent` callsites sometimes omit. Audited against the row-mapping functions and the actual `appendEvent` calls in `store.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)