### PR TITLE
refactor(core): schema-version sentinel for projection rebuilds (T3.6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Guard — storage compatibility fixture
         run: pnpm run check:storage-fixture
 
+      - name: Guard — projection schema version
+        run: pnpm run check:schema-version
+
       - name: Validate Docker Compose config
         env:
           LIBRARIAN_ADMIN_TOKEN: ci-admin-token

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "typecheck": "pnpm -r run typecheck",
     "build": "pnpm -r run build",
     "check:test-count": "node --no-warnings scripts/check-test-count.mjs",
-    "check:storage-fixture": "node --no-warnings scripts/check-storage-fixture.mjs"
+    "check:storage-fixture": "node --no-warnings scripts/check-storage-fixture.mjs",
+    "check:schema-version": "node --no-warnings scripts/check-schema-version.mjs"
   },
   "engines": {
     "node": ">=22.5.0",

--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { readJsonl } from "./jsonl.js";
 import { type MemoryStore, createMemoryStore } from "./memory-store.js";
-import { initSchema, rebuildMemoryIndex, rebuildSessionIndex } from "./projection.js";
+import { ensureSchema, rebuildMemoryIndex, rebuildSessionIndex } from "./projection.js";
 import { type SessionStore, createSessionStore } from "./session-store.js";
 
 const DEFAULT_DATA_DIR = path.join(process.cwd(), "data");
@@ -37,7 +37,7 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Libra
   if (!fs.existsSync(sessionsPath)) fs.writeFileSync(sessionsPath, "", "utf8");
 
   const db = new DatabaseSync(dbPath);
-  initSchema(db);
+  ensureSchema(db, { eventsPath, sessionsPath, snapshotPath });
 
   function rebuildMemoryProjection(): void {
     rebuildMemoryIndex({ db, eventsPath, snapshotPath });
@@ -46,7 +46,6 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Libra
     rebuildMemoryProjection();
     rebuildSessionIndex(db, sessionsPath);
   }
-  rebuildIndex();
 
   const memoryStore = createMemoryStore({
     db,

--- a/packages/core/src/store/projection.ts
+++ b/packages/core/src/store/projection.ts
@@ -44,6 +44,10 @@ function asArray(value: unknown): string[] {
 // the projection tables are dropped, recreated, and replayed from the
 // JSONL ledgers. The JSONL files are the canonical source of truth, so
 // the rebuild loses nothing.
+//
+// CI guard: `scripts/check-schema-version.mjs` hashes `SCHEMA_DDL` and
+// compares it to `test/schema-snapshot.json`. Editing the DDL without
+// bumping the version (and re-recording the fingerprint) fails CI.
 export const PROJECTION_SCHEMA_VERSION = 1;
 
 export function getSchemaVersion(db: DatabaseSync): number {
@@ -100,8 +104,11 @@ export function ensureSchema(db: DatabaseSync, paths: EnsureSchemaPaths): boolea
   return true;
 }
 
-export function initSchema(db: DatabaseSync): void {
-  db.exec(`
+// The canonical projection DDL. Exported so the CI guard
+// (`scripts/check-schema-version.mjs`) can hash it and verify that
+// edits ship alongside a `PROJECTION_SCHEMA_VERSION` bump + snapshot
+// update.
+export const SCHEMA_DDL = `
     CREATE TABLE IF NOT EXISTS memories (
       id TEXT PRIMARY KEY,
       title TEXT NOT NULL,
@@ -184,7 +191,10 @@ export function initSchema(db: DatabaseSync): void {
       summary,
       payload_text
     );
-  `);
+  `;
+
+export function initSchema(db: DatabaseSync): void {
+  db.exec(SCHEMA_DDL);
 }
 
 // ---------- Memory side ----------

--- a/packages/core/src/store/projection.ts
+++ b/packages/core/src/store/projection.ts
@@ -2,6 +2,9 @@
 // insert paths for both memory and session ledgers.
 //
 // Public surface:
+//   - PROJECTION_SCHEMA_VERSION             — bump when the SQLite shape changes
+//   - getSchemaVersion(db)                  — read PRAGMA user_version
+//   - ensureSchema(db, paths)               — version-gated rebuild on store open
 //   - initSchema(db)                        — CREATE TABLE / VIRTUAL TABLE
 //   - reduceMemoryLog(entries)              — pure: log → {memories, events}
 //   - rebuildMemoryIndex(db, paths)         — full rebuild from events.jsonl
@@ -34,6 +37,68 @@ function asArray(value: unknown): string[] {
 }
 
 // ---------- SQLite schema ----------
+
+// Bump whenever the SQLite shape changes (column add/drop/rename, new
+// table, new FTS surface, etc.). On store open `ensureSchema` compares
+// PRAGMA user_version to this constant; if the on-disk value is lower,
+// the projection tables are dropped, recreated, and replayed from the
+// JSONL ledgers. The JSONL files are the canonical source of truth, so
+// the rebuild loses nothing.
+export const PROJECTION_SCHEMA_VERSION = 1;
+
+export function getSchemaVersion(db: DatabaseSync): number {
+  const row = db.prepare("PRAGMA user_version").get() as { user_version: number };
+  return row.user_version;
+}
+
+function stampSchemaVersion(db: DatabaseSync): void {
+  db.exec(`PRAGMA user_version = ${PROJECTION_SCHEMA_VERSION}`);
+}
+
+function dropProjectionTables(db: DatabaseSync): void {
+  db.exec(`
+    DROP TABLE IF EXISTS memories_fts;
+    DROP TABLE IF EXISTS memories;
+    DROP TABLE IF EXISTS events;
+    DROP TABLE IF EXISTS session_events_fts;
+    DROP TABLE IF EXISTS session_events;
+    DROP TABLE IF EXISTS sessions;
+  `);
+}
+
+export interface EnsureSchemaPaths {
+  eventsPath: string;
+  sessionsPath: string;
+  snapshotPath: string;
+}
+
+/**
+ * Schema-version gate, run once per store open. If the on-disk
+ * `PRAGMA user_version` is below `PROJECTION_SCHEMA_VERSION`, the
+ * projection tables are dropped, recreated via `initSchema`, and
+ * replayed from the JSONL ledgers — then the version is stamped.
+ * Otherwise tables are ensured (idempotent CREATE IF NOT EXISTS) and
+ * the existing projection is trusted.
+ *
+ * Returns `true` if a rebuild ran.
+ */
+export function ensureSchema(db: DatabaseSync, paths: EnsureSchemaPaths): boolean {
+  const onDisk = getSchemaVersion(db);
+  if (onDisk >= PROJECTION_SCHEMA_VERSION) {
+    initSchema(db);
+    return false;
+  }
+  dropProjectionTables(db);
+  initSchema(db);
+  rebuildMemoryIndex({
+    db,
+    eventsPath: paths.eventsPath,
+    snapshotPath: paths.snapshotPath,
+  });
+  rebuildSessionIndex(db, paths.sessionsPath);
+  stampSchemaVersion(db);
+  return true;
+}
 
 export function initSchema(db: DatabaseSync): void {
   db.exec(`

--- a/packages/core/tests/store/projection.test.ts
+++ b/packages/core/tests/store/projection.test.ts
@@ -161,3 +161,124 @@ describe("SQLite projection rebuild parity", () => {
     }
   });
 });
+
+describe("Schema-version sentinel (T3.6)", () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-schema-version-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  function readUserVersion(store: ReturnType<typeof createLibrarianStore>): number {
+    const row = store.db.prepare("PRAGMA user_version").get() as { user_version: number };
+    return row.user_version;
+  }
+
+  it("stamps PROJECTION_SCHEMA_VERSION on a fresh database", () => {
+    const store = createLibrarianStore({ dataDir });
+    try {
+      store.createMemory({
+        agent_id: "codex",
+        title: "Stamped on fresh DB",
+        body: "First write into a brand-new store.",
+        category: "tools",
+        visibility: "common",
+        scope: "tool",
+      });
+      expect(readUserVersion(store)).toBeGreaterThanOrEqual(1);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("auto-rebuilds the projection when the on-disk user_version is stale", () => {
+    let memoryId: string;
+    let sessionId: string;
+
+    {
+      const store = createLibrarianStore({ dataDir });
+      try {
+        memoryId = store.createMemory({
+          agent_id: "codex",
+          title: "Pre-bump memory",
+          body: "Was written under the previous schema.",
+          category: "tools",
+          visibility: "common",
+          scope: "tool",
+        }).memory.id;
+        sessionId = store.startSession({
+          agent_id: "bede",
+          title: "Pre-bump session",
+          harness: "hermes",
+        }).session.id;
+
+        // Simulate a schema bump by rolling the on-disk pragma back to 0.
+        // PRAGMA writes persist with the database file, so the next open
+        // will see the stale version and trigger a rebuild.
+        store.db.exec("PRAGMA user_version = 0");
+      } finally {
+        store.close();
+      }
+    }
+
+    {
+      const store = createLibrarianStore({ dataDir });
+      try {
+        expect(store.getMemory(memoryId)).toBeTruthy();
+        expect(store.getSession(sessionId)).toBeTruthy();
+        expect(readUserVersion(store)).toBeGreaterThanOrEqual(1);
+      } finally {
+        store.close();
+      }
+    }
+  });
+
+  it("does not rebuild when the on-disk user_version is already current", () => {
+    {
+      const store = createLibrarianStore({ dataDir });
+      try {
+        store.createMemory({
+          agent_id: "codex",
+          title: "Canonical memory",
+          body: "Written through the public surface, so it's in the JSONL ledger too.",
+          category: "tools",
+          visibility: "common",
+          scope: "tool",
+        });
+        expect(readUserVersion(store)).toBeGreaterThanOrEqual(1);
+
+        // Insert a row directly into SQLite without appending to the JSONL
+        // ledger. If the next open triggers a rebuild from JSONL, this row
+        // gets wiped. If the version gate works, the row survives.
+        store.db.exec(
+          `INSERT INTO memories (
+            id, title, body, category, visibility, agent_id, scope, project_key,
+            status, priority, confidence, tags_json, applies_to_json,
+            supersedes_json, conflicts_with_json, created_at, updated_at,
+            last_recalled_at, recall_count, usefulness_score
+          ) VALUES (
+            'mem_ghost', 'Ghost row', 'Not in JSONL.', 'tools', 'common', 'codex',
+            'tool', NULL, 'active', 'normal', 'working', '[]', '[]', '[]', '[]',
+            '2026-05-20T00:00:00.000Z', '2026-05-20T00:00:00.000Z', NULL, 0, 0
+          );`,
+        );
+      } finally {
+        store.close();
+      }
+    }
+
+    {
+      const store = createLibrarianStore({ dataDir });
+      try {
+        const ghost = store.db.prepare("SELECT id FROM memories WHERE id = ?").get("mem_ghost");
+        expect(ghost).toBeTruthy();
+      } finally {
+        store.close();
+      }
+    }
+  });
+});

--- a/scripts/check-schema-version.mjs
+++ b/scripts/check-schema-version.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// Schema-version guard.
+//
+// Hashes the canonical projection DDL (`SCHEMA_DDL` from
+// `@librarian/core/store-internal`) and compares it to the recorded
+// fingerprint in `test/schema-snapshot.json`. The snapshot records
+// `{ version, fingerprint }` — the contract is: if you change the DDL
+// you must also bump `PROJECTION_SCHEMA_VERSION` and update the
+// snapshot in the same PR.
+//
+// Without this guard, a contributor can change the SQLite shape (add a
+// column, new table) and forget to bump the version sentinel — leaving
+// existing installs with a stale projection that silently breaks.
+//
+// Run `node scripts/check-schema-version.mjs --update` after a
+// deliberate schema change to regenerate the snapshot. CI runs the
+// check without `--update`.
+
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const snapshotPath = path.join(repoRoot, "test", "schema-snapshot.json");
+
+const { PROJECTION_SCHEMA_VERSION, SCHEMA_DDL } = await import("@librarian/core/store-internal");
+
+const currentFingerprint = sha256(SCHEMA_DDL);
+const update = process.argv.includes("--update");
+
+if (update) {
+  const next = { version: PROJECTION_SCHEMA_VERSION, fingerprint: currentFingerprint };
+  fs.writeFileSync(snapshotPath, JSON.stringify(next, null, 2) + "\n", "utf8");
+  console.log(
+    `[check-schema-version] snapshot updated: version=${next.version} fingerprint=${next.fingerprint}`,
+  );
+  process.exit(0);
+}
+
+if (!fs.existsSync(snapshotPath)) {
+  console.error(
+    `[check-schema-version] FAIL: ${snapshotPath} does not exist. ` +
+      "Run `node scripts/check-schema-version.mjs --update` to create it.",
+  );
+  process.exit(1);
+}
+
+const snapshot = JSON.parse(fs.readFileSync(snapshotPath, "utf8"));
+const fingerprintMatches = snapshot.fingerprint === currentFingerprint;
+const versionMatches = snapshot.version === PROJECTION_SCHEMA_VERSION;
+
+if (fingerprintMatches && versionMatches) {
+  console.log(
+    `[check-schema-version] OK: version=${PROJECTION_SCHEMA_VERSION} fingerprint=${currentFingerprint}`,
+  );
+  process.exit(0);
+}
+
+const lines = ["[check-schema-version] FAIL:"];
+
+if (!fingerprintMatches) {
+  lines.push(
+    `  SCHEMA_DDL fingerprint changed`,
+    `    recorded: ${snapshot.fingerprint}`,
+    `    current:  ${currentFingerprint}`,
+    "",
+    "  The projection schema has been edited. You must:",
+    "    1. Bump PROJECTION_SCHEMA_VERSION in packages/core/src/store/projection.ts",
+    "    2. Run `node scripts/check-schema-version.mjs --update` to refresh the snapshot",
+    "    3. Re-run this check",
+  );
+}
+
+if (!versionMatches && fingerprintMatches) {
+  lines.push(
+    `  PROJECTION_SCHEMA_VERSION (${PROJECTION_SCHEMA_VERSION}) does not match the snapshot ` +
+      `(${snapshot.version}) but the DDL fingerprint is unchanged.`,
+    "  Either revert the version change or update the snapshot via " +
+      "`node scripts/check-schema-version.mjs --update`.",
+  );
+} else if (!versionMatches && !fingerprintMatches) {
+  lines.push(
+    "",
+    `  Note: PROJECTION_SCHEMA_VERSION is ${PROJECTION_SCHEMA_VERSION}, snapshot is ${snapshot.version}.`,
+  );
+}
+
+console.error(lines.join("\n"));
+process.exit(1);
+
+function sha256(input) {
+  return createHash("sha256").update(input, "utf8").digest("hex");
+}

--- a/test/schema-snapshot.json
+++ b/test/schema-snapshot.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "fingerprint": "476aa975ba8ca96ad25ccafab4f4195d64525ece435356b6cb82d2f519b6f63b"
+}


### PR DESCRIPTION
## Spec / phase reference

Implements **T3.6 — Schema-version sentinel for projection rebuilds** (Phase 3 of `specs/maintainability-overhaul-tasks.md`). Came out of PR #11 review as the alternative to introducing an ORM.

## Summary

- Add `PROJECTION_SCHEMA_VERSION = 1` plus `getSchemaVersion(db)` + `ensureSchema(db, paths)` to `packages/core/src/store/projection.ts`. `ensureSchema` checks `PRAGMA user_version`; on a fresh or stale DB (`onDisk < PROJECTION_SCHEMA_VERSION`) it drops the projection tables, recreates them via `initSchema`, replays from the JSONL ledgers, then stamps the current version. On a current DB it just ensures tables exist idempotently and trusts the existing projection.
- `createLibrarianStore` now calls `ensureSchema(db, paths)` once on open instead of unconditionally calling `rebuildIndex()`. Steady-state opens skip the rebuild; stale or fresh DBs trigger one transparently. The `store.rebuildIndex()` escape hatch remains for forced manual replays (`cli rebuild`).
- Bump `PROJECTION_SCHEMA_VERSION` whenever the SQLite shape changes (column add/drop/rename, new table, FTS surface change). Existing installs on the previous version get a one-time rebuild from JSONL on next open — no migration code, no ALTER statements.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — core, mcp-server, cli, dashboard all green
- [x] `pnpm test` — 112 node:test + 84 vitest = **196 tests** (floor 177)
- [x] `pnpm build` — clean `.d.ts` emitted
- [x] `pnpm run check:test-count` — OK: 196 ≥ 177
- [x] `pnpm run check:storage-fixture` — OK (existing fixture replays cleanly under the new gate)
- [x] `pnpm run healthcheck` — 5/5 (the SQLite-rebuild check still passes — when the .sqlite file is deleted, `ensureSchema` sees `user_version = 0` and rebuilds from JSONL)
- [x] `pnpm run smoke` — passed

New vitest cases (`tests/store/projection.test.ts`):

1. **Fresh DB stamps the version** — open a brand-new store, write a memory, confirm `PRAGMA user_version >= 1`.
2. **Stale version auto-rebuilds** — write a memory + session via the store, manually roll the on-disk pragma back to 0, close + reopen, confirm both records are still queryable and the version is re-stamped.
3. **Current version is a no-op** — write a memory via the store, then insert a "ghost" row directly into SQLite that isn't in the JSONL ledger. Close + reopen; confirm the ghost row survives. If the gate were broken and the rebuild ran, the ghost row would be wiped by the DELETE-and-replay.

## Quality gates

- [x] **No files over 400 LOC introduced** in this PR
- [x] **No new `any` or `@ts-ignore` introduced**

## Notes for the reviewer

- **Behavior change worth calling out:** pre-T3.6, every store open rebuilt the projection from JSONL unconditionally — SQLite was a disposable cache. Post-T3.6, the SQLite state is trusted across restarts when the schema version matches. Net effect: faster opens, plus any code that hand-edits SQLite outside the JSONL ledger now persists (it shouldn't anyway — JSONL is canonical). `store.rebuildIndex()` still works as the manual-rebuild escape hatch.
- The version-check approach also covers the "developer deletes librarian.sqlite to force a rebuild" workflow — a missing file opens as a fresh DB with `user_version = 0`, which `ensureSchema` treats as stale and rebuilds.
- Bumping the constant in the future is a one-line PR: change `1` → `2`, and the next time anyone opens their store the rebuild runs automatically. No data migration files, no version-skew handling.
- `ensureSchema` is exported so it can be called directly in tests (and the rebuild paths via `rebuildMemoryIndex` / `rebuildSessionIndex` remain exported for the same reason). The `dropProjectionTables` + `stampSchemaVersion` helpers are module-private — they're implementation details of the gate.
- This closes out Phase 3. Next up: **T4.1** — TS port of the HTTP server + auth middleware in `@librarian/mcp-server`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)