### PR TITLE
docs: clarify 400 LOC cap applies to production source only

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,7 +30,7 @@ Keep the sections; trim or expand the contents as the change requires.
 
 ## Quality gates
 
-- [ ] **No files over 400 LOC introduced** (or each exception noted with rationale below)
+- [ ] **No production source file over 400 LOC introduced** (or each exception noted with rationale below — applies to `packages/*/src/` and `apps/*/src/`, not tests)
 - [ ] **No new `any` or `@ts-ignore` introduced** (or each exception noted with rationale below)
 
 <!--

--- a/specs/maintainability-overhaul-plan.md
+++ b/specs/maintainability-overhaul-plan.md
@@ -210,7 +210,7 @@ These don't belong to a single phase; they need ongoing care.
 |---|---|---|
 | Test count never decreases | Every PR | CI asserts `pnpm test` reports ≥ baseline test count. Baseline updates only when a test is deliberately removed (with a PR note). |
 | Type coverage never decreases | P3 onward | CI runs `tsc --noEmit` with `strict: true`. Per-PR diff: no new `any`, no new `@ts-ignore` without a comment. |
-| File LOC cap | P3 onward | Soft lint rule warning at 400 LOC; review-blocking discussion at 500. |
+| File LOC cap (production source only) | P3 onward | Soft lint rule warning at 400 LOC; review-blocking discussion at 500. Applies to `packages/*/src/` and `apps/*/src/`; tests are exempt. |
 | Existing integration wrappers pass | P5 onward | Each integration package's `healthcheck.md` script runs in CI against the new build. |
 | Storage compatibility | All phases | The store's `appendEvent` / `appendSessionEvent` JSON shape never changes. CI loads a fixture `events.jsonl` + `sessions.jsonl` from before the migration and asserts the projection rebuild succeeds. |
 

--- a/specs/maintainability-overhaul-tasks.md
+++ b/specs/maintainability-overhaul-tasks.md
@@ -68,7 +68,7 @@ Draft for review.
   2. **Integration wrapper smoke:** CI matrix step that runs each `integrations/<harness>/wrapper.sh` against a local MCP server with `echo ok` as the wrapped command. Catches CLI surface regressions.
   3. **Storage compatibility fixture:** `test/fixtures/pre-migration/events.jsonl` and `sessions.jsonl` (frozen snapshots from before the migration). CI loads them, runs `rebuildIndex`, asserts the projection produces the expected memory and session counts.
 
-  **PR template** at `.github/pull_request_template.md` with required sections: spec/phase reference, summary, test plan, plus two checkboxes that authors must tick: "no files over 400 LOC introduced (or noted if so)" and "no new `any` / `@ts-ignore` introduced (or noted if so)".
+  **PR template** at `.github/pull_request_template.md` with required sections: spec/phase reference, summary, test plan, plus two checkboxes that authors must tick: "no production source file over 400 LOC introduced (or noted if so) — applies to `packages/*/src/` and `apps/*/src/`, not tests" and "no new `any` / `@ts-ignore` introduced (or noted if so)".
 
   CI passes on a noop PR. Status badge added to `README.md`.
 - **Verify:** Open a noop PR; CI green on all three guards plus the standard quartet; the new PR template auto-populates the body. `README.md` shows the badge.

--- a/specs/maintainability-overhaul.md
+++ b/specs/maintainability-overhaul.md
@@ -222,7 +222,7 @@ export function createSessionStore(deps: SessionStoreDeps): SessionStore {
 
 Conventions:
 
-- **One concern per file.** Files cap at ~400 LOC. Functions cap at ~50 LOC (soft).
+- **One concern per file.** Production source files cap at ~400 LOC (applies to `packages/*/src/` and `apps/*/src/`; tests are exempt). Functions cap at ~50 LOC (soft).
 - **Function-style modules.** Prefer `createX(deps)` factories over classes. Class is fine when shape genuinely needs `new` (e.g. `LibrarianStore` continues to be a class for the public surface, but its guts are factored into composable function modules).
 - **Imports sorted** by `eslint-plugin-import` / Prettier import order.
 - **Path aliases** (`@/`) within each package only. No cross-package aliases (use the package name).
@@ -276,7 +276,7 @@ The overhaul is done when **all** of these are true:
 2. `docker compose up -d` produces a working dashboard at the documented port, with `/mcp` reachable and authenticated, against a mounted `data/` volume.
 3. `pnpm test` runs all tests (porting the existing 177 + any new) and they pass on CI.
 4. `pnpm lint`, `pnpm typecheck`, `pnpm format --check` all pass on `main`. CI gates each.
-5. No file in `packages/` or `apps/` exceeds 400 LOC. `store.ts` is decomposed into focused modules under `packages/core/src/store/`.
+5. No production source file in `packages/*/src/` or `apps/*/src/` exceeds 400 LOC (tests are exempt). `store.ts` is decomposed into focused modules under `packages/core/src/store/`.
 6. Zero `any`, zero `@ts-ignore` without an inline comment naming the reason and a ticket / TODO reference.
 7. Dependency directions are enforced (ESLint rule + per-package `dependencies`) — the dashboard cannot import from `@librarian/core`.
 8. Pre-commit hook prevents commits that fail lint/format/typecheck.


### PR DESCRIPTION
## Spec / phase reference

Docs-only cleanup of the file-size invariant from `specs/maintainability-overhaul-plan.md`. Surfaced during PR #17 review: the cap is meant for production source code, not tests.

## Summary

- PR template checkbox now reads "**No production source file over 400 LOC introduced** … applies to `packages/*/src/` and `apps/*/src/`, not tests" instead of the looser "No files over 400 LOC introduced".
- Spec docs (`maintainability-overhaul.md`, `maintainability-overhaul-plan.md`, `maintainability-overhaul-tasks.md`) updated with the same wording so future edits stay spec-faithful and reviewers see a consistent rule.

## Test plan

Pure docs. No code paths touched. Pre-commit ran Prettier; no other checks apply.

## Quality gates

- [x] **No production source file over 400 LOC introduced**
- [x] **No new `any` or `@ts-ignore` introduced**

## Notes for the reviewer

- Trigger was PR #17: a 928-LOC ported test file led me to flag a quality-gate exception that didn't actually exist under the intended rule. Tightening the docs now so the same confusion doesn't recur on future Vitest ports of large test suites.
- Cap value (400 LOC soft, 500 LOC review-blocking) is unchanged — only the scope wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)