### PR TITLE
docs(todo): generate auth tokens from the dashboard (#16)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -62,6 +62,15 @@ Active session at time of writing: `ses_e4e7fc21-0096-42b4-b091-5701c84539e5` ("
 
     **Trigger to revisit:** purge — item #12 (physical purge of soft-deleted sessions) is the seam where append-only starts to hurt, since purging requires rewriting the JSONL, which isn't append-only anymore. If purge becomes urgent, that's the right moment to reconsider the paradigm.
 
+## Dashboard / UI
+
+16. **Generate auth tokens from the dashboard instead of static env vars.** Today admin + agent tokens are baked into `LIBRARIAN_ADMIN_TOKEN`, `LIBRARIAN_AGENT_TOKEN`, and `LIBRARIAN_AGENT_TOKENS` at boot — one admin token, no rotation without a restart, no per-token audit. Belongs in the dashboard rebuild scope (not a migration of the existing dashboard — see the standing redesign feedback). Sketch:
+    - **Token model:** name/description, role (`admin` / `agent`), bound `agent_id` for agent tokens, optional expiry, created_at, last_used_at, revoked_at. Persisted to the JSONL ledger as `auth.token_issued` / `auth.token_revoked` events so the audit trail comes for free.
+    - **Bootstrap:** on first boot with no tokens recorded, generate a single one-shot admin token and print it once to stderr (or a write-protected file) so the operator can sign in. After that, all token management happens through the dashboard.
+    - **Dashboard surface:** "Tokens" panel under settings — list active tokens with last-used + role, "Generate" button (dropdown for role + agent_id when role=agent), "Revoke" action. Prefer dropdowns for known-value fields (role, agent_id) per the global UI feedback.
+    - **Server side:** auth middleware (T4.1's `authenticateMcp`) consults the token table instead of comparing against env-var constants. Env vars can still seed the table on first boot for backwards compatibility, then become advisory.
+    - **Pairs with:** #4 (per-agent tokens become trivial — admin can mint one per agent from the UI); #9 (the dashboard REST auth gap — once `/api/*` is authenticated, the dashboard itself uses its own session token, which can be a long-lived dashboard token issued the same way).
+
 ## Priority read
 
 - **#9 is the only real risk.** Everything else is polish or exercise.


### PR DESCRIPTION
## Spec / phase reference

Docs-only follow-up surfaced 2026-05-20. Adds a TODO entry for an auth-token UX upgrade flagged after PR #15 landed and the dashboard rebuild scope was discussed.

## Summary

- Add **#16 — Generate auth tokens from the dashboard instead of static env vars** to `TODO.md` (in a new "Dashboard / UI" section). Records the model (`auth.token_issued` / `auth.token_revoked` ledger events for a free audit trail), bootstrap flow (one-shot admin token printed on first boot), the dashboard surface (Tokens panel with role + agent_id dropdowns, per the standing UI redesign feedback), and the server-side wiring (T4.1's `authenticateMcp` consults a token table instead of env-var constants).
- Cross-references the two related items it unblocks: **#4** (per-agent token mapping becomes trivial — admin mints them from the UI) and **#9** (the dashboard REST auth gap — `/api/*` authenticates against the same token table).

## Test plan

Pure docs. No code paths touched. Pre-commit ran Prettier; no other checks apply.

## Quality gates

- [x] **No production source file over 400 LOC introduced**
- [x] **No new `any` or `@ts-ignore` introduced**

## Notes for the reviewer

- Deliberately "park this thought" — the item isn't asking anyone to act today, just preserving the design sketch so it isn't expensive to reconstruct when the dashboard rebuild begins.
- Lands cleanly on top of `c67a847` (the merged #14 + #15 additions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)