### PR TITLE
feat(mcp-server): tRPC scaffold + health.ping (T4.3)

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -23,7 +23,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@librarian/core": "workspace:*"
+    "@librarian/core": "workspace:*",
+    "@trpc/server": "^11.17.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.5",

--- a/packages/mcp-server/src/http/routes.ts
+++ b/packages/mcp-server/src/http/routes.ts
@@ -8,7 +8,10 @@ import fs from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
 import { DEFAULT_AGENT_ID, type LibrarianStore } from "@librarian/core";
+import { createHTTPHandler } from "@trpc/server/adapters/standalone";
 import { handleMcpPayload } from "../mcp/rpc.js";
+import { createContextFactory } from "../trpc/context.js";
+import { appRouter } from "../trpc/router.js";
 import { type AuthConfig, authenticateMcp, isAllowedOrigin } from "./auth.js";
 
 export interface RouteDeps {
@@ -22,6 +25,12 @@ export function createRouteHandler(
   deps: RouteDeps,
 ): (req: IncomingMessage, res: ServerResponse) => Promise<void> {
   const { store, auth, publicDir, maxBodyBytes } = deps;
+
+  const trpcHandler = createHTTPHandler({
+    router: appRouter,
+    createContext: createContextFactory({ store, auth }),
+    basePath: "/trpc/",
+  });
 
   return async function handle(req, res) {
     try {
@@ -38,6 +47,10 @@ export function createRouteHandler(
       }
 
       if (!isAllowedOrigin(req, auth)) return sendJson(res, { error: "Origin not allowed" }, 403);
+
+      if (url.pathname.startsWith("/trpc/")) {
+        return trpcHandler(req, res);
+      }
 
       if (url.pathname === "/mcp") {
         const result = authenticateMcp(req, auth);

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -13,3 +13,4 @@ export {
 export { dispatchMcp, tools } from "./mcp/dispatch.js";
 export { handleMcpMessage, handleMcpPayload } from "./mcp/rpc.js";
 export type { ToolContext, ToolDefinition, McpTextResult } from "./mcp/tool.js";
+export type { AppRouter } from "./trpc/router.js";

--- a/packages/mcp-server/src/trpc/context.ts
+++ b/packages/mcp-server/src/trpc/context.ts
@@ -1,0 +1,34 @@
+// tRPC context.
+//
+// Resolves the caller's admin role from the `LIBRARIAN_ADMIN_TOKEN`
+// bearer. Reuses the existing MCP auth path so token comparison stays
+// in one place. The `store` is threaded through so future routers
+// (memories, sessions) can call it without reaching for globals.
+
+import type { LibrarianStore } from "@librarian/core";
+import type { CreateHTTPContextOptions } from "@trpc/server/adapters/standalone";
+import { type AuthConfig, authenticateMcp } from "../http/auth.js";
+
+export type TrpcRole = "admin" | "anonymous";
+
+export interface TrpcContext {
+  role: TrpcRole;
+  store: LibrarianStore;
+}
+
+export interface TrpcContextDeps {
+  store: LibrarianStore;
+  auth: AuthConfig;
+}
+
+export function createContextFactory(
+  deps: TrpcContextDeps,
+): (opts: CreateHTTPContextOptions) => TrpcContext {
+  return function createContext({ req }) {
+    const result = authenticateMcp(req, deps.auth);
+    return {
+      role: result?.role === "admin" ? "admin" : "anonymous",
+      store: deps.store,
+    };
+  };
+}

--- a/packages/mcp-server/src/trpc/health.ts
+++ b/packages/mcp-server/src/trpc/health.ts
@@ -1,0 +1,11 @@
+// Health router.
+//
+// `health.ping` is a typed-client smoke-test procedure. It is public
+// (no admin gate) so a dashboard or external probe can verify the
+// tRPC mount is alive before configuring credentials.
+
+import { publicProcedure, router } from "./trpc.js";
+
+export const healthRouter = router({
+  ping: publicProcedure.query(() => ({ ok: true as const })),
+});

--- a/packages/mcp-server/src/trpc/router.ts
+++ b/packages/mcp-server/src/trpc/router.ts
@@ -1,0 +1,17 @@
+// tRPC app router.
+//
+// Composes the per-domain routers (memories, sessions) plus the
+// health probe. T4.3 lands the scaffold only — memories/sessions are
+// intentionally empty and get populated in T4.4 and T4.5. The
+// `AppRouter` type is the public contract the dashboard imports.
+
+import { healthRouter } from "./health.js";
+import { router } from "./trpc.js";
+
+export const appRouter = router({
+  health: healthRouter,
+  memories: router({}),
+  sessions: router({}),
+});
+
+export type AppRouter = typeof appRouter;

--- a/packages/mcp-server/src/trpc/trpc.ts
+++ b/packages/mcp-server/src/trpc/trpc.ts
@@ -1,0 +1,21 @@
+// tRPC initialiser.
+//
+// Pins the context type to `TrpcContext` so every router/procedure
+// gets typed access to `role` and `store`. `adminProcedure` is the
+// gateway middleware that future memory/session routers will use to
+// require an admin bearer token; the public router for health probes
+// stays on `publicProcedure`.
+
+import { TRPCError, initTRPC } from "@trpc/server";
+import type { TrpcContext } from "./context.js";
+
+const t = initTRPC.context<TrpcContext>().create();
+
+export const router = t.router;
+export const publicProcedure = t.procedure;
+export const adminProcedure = t.procedure.use(function requireAdmin(opts) {
+  if (opts.ctx.role !== "admin") {
+    throw new TRPCError({ code: "UNAUTHORIZED" });
+  }
+  return opts.next({ ctx: opts.ctx });
+});

--- a/packages/mcp-server/tests/trpc/health.test.ts
+++ b/packages/mcp-server/tests/trpc/health.test.ts
@@ -1,0 +1,59 @@
+// tRPC mount integration tests.
+//
+// Spawns `dist/bin/http.js` and verifies the tRPC adapter is wired at
+// /trpc/*. health.ping is public; the admin-token gate on the context
+// is exercised indirectly here (no token still resolves the public
+// procedure) — proper admin-gated procedures land in T4.4/T4.5.
+
+import { describe, expect, it } from "vitest";
+import { cleanupTempDir, makeTempDir, startHttpServer } from "../../../../test/helpers.js";
+
+interface TrpcOkResponse {
+  result: { data: { ok: true } };
+}
+
+describe("tRPC /trpc surface", () => {
+  it("health.ping returns { ok: true } without auth", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const response = await fetch(`${server.url}/trpc/health.ping`);
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as TrpcOkResponse;
+      expect(body.result.data.ok).toBe(true);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("health.ping accepts an admin bearer token", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const response = await fetch(`${server.url}/trpc/health.ping`, {
+        headers: { authorization: `Bearer ${server.token}` },
+      });
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as TrpcOkResponse;
+      expect(body.result.data.ok).toBe(true);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("returns a tRPC error for an unknown procedure", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const response = await fetch(`${server.url}/trpc/health.unknown`);
+      expect(response.status).toBe(404);
+      const body = (await response.json()) as { error?: { message?: string } };
+      expect(body.error?.message).toMatch(/No.+procedure/i);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
       '@librarian/core':
         specifier: workspace:*
         version: link:../core
+      '@trpc/server':
+        specifier: ^11.17.0
+        version: 11.17.0(typescript@5.9.3)
     devDependencies:
       '@types/node':
         specifier: ^22.10.5
@@ -450,6 +453,12 @@ packages:
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@trpc/server@11.17.0':
+    resolution: {integrity: sha512-jbAOUe0PpUTCYqziyu+8vYXZdDXPudZgnEhWCQ2NjKnVEjfE93RqHTt1oycZJv/HNf51YlRXfEEwSIAbb161rw==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.7.2'
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -1978,6 +1987,10 @@ snapshots:
     optional: true
 
   '@rtsao/scc@1.1.0': {}
+
+  '@trpc/server@11.17.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
 
   '@types/estree@1.0.8': {}
 


### PR DESCRIPTION
## Spec / phase reference

Implements **T4.3 — tRPC scaffold** (Phase 4 of `specs/maintainability-overhaul.md`). Blocks T4.4, T4.5, T6.2.

## Summary

- Lands the empty admin API skeleton so the per-domain procedures in T4.4/T4.5 have a typed home and the dashboard can lock in the client wiring in T6.2.
- `appRouter` (under `packages/mcp-server/src/trpc/router.ts`) composes empty `memories` + `sessions` sub-routers and the public `health.ping` probe. `AppRouter` is re-exported from `@librarian/mcp-server` for dashboard consumption.
- Context resolves admin role via `LIBRARIAN_ADMIN_TOKEN` by delegating to the existing `authenticateMcp` — token comparison stays in one place, and `adminProcedure` middleware is ready for the next two PRs.
- Mounted at `/trpc/*` on the existing `node:http` server via `createHTTPHandler({ basePath: '/trpc/' })`, dispatched immediately after the origin gate.

## Test plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm lint`
- [x] `pnpm -r run typecheck`
- [x] `pnpm test` — 42 node:test + 156 vitest = **198/198** (3 new tRPC tests; baseline floor 177)
- [x] `pnpm run check:test-count` / `check:storage-fixture` / `check:schema-version` — all green
- [x] `pnpm run smoke` — passed
- [x] `pnpm run healthcheck` — 5/5
- [x] All four wrappers (`integrations/{claude-code,codex,opencode,pi}/wrapper.sh ... -- echo ok`) — green
- [x] tRPC verify per spec: `curl http://127.0.0.1:port/trpc/health.ping` returns `{"result":{"data":{"ok":true}}}` (covered by `tests/trpc/health.test.ts`)

New tests cover anonymous ping, admin-bearer ping, and an unknown-procedure 404.

## Quality gates

- [x] **No production source file over 400 LOC introduced.** New files: `context.ts` (34), `trpc.ts` (21), `health.ts` (11), `router.ts` (17). `http/routes.ts` grew from 345 → 357 LOC (still well under the cap).
- [x] **No new `any` or `@ts-ignore` introduced.**

## Notes for the reviewer

- The tRPC handler is constructed once per `createRouteHandler` call (i.e. once per HTTP server), not per request.
- `memories` and `sessions` are deliberately empty sub-routers — they get filled in T4.4 and T4.5 respectively. Mounting them now means the `AppRouter` shape the dashboard imports in T6.2 is stable even before any procedure exists.
- `adminProcedure` (in `trpc.ts`) is unused inside this PR. It is added now so T4.4/T4.5 procedures can declare admin-gating inline without another round-trip through the auth module.
- The new tRPC mount sits **after** the origin gate but **before** `/mcp`. The order is incidental — both have non-overlapping path prefixes — but I kept it close to the `/mcp` block to make the gating model easy to read.