### PR TITLE
feat(mcp-server): tRPC memory procedures (T4.4)

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -24,7 +24,8 @@
   },
   "dependencies": {
     "@librarian/core": "workspace:*",
-    "@trpc/server": "^11.17.0"
+    "@trpc/server": "^11.17.0",
+    "zod": "^4.0.1"
   },
   "devDependencies": {
     "@types/node": "^22.10.5",

--- a/packages/mcp-server/src/trpc/memories.ts
+++ b/packages/mcp-server/src/trpc/memories.ts
@@ -8,7 +8,15 @@
 //
 // All procedures are admin-gated. Dashboard callers authenticate with
 // LIBRARIAN_ADMIN_TOKEN; the gate runs once in `adminProcedure`.
+//
+// Note on `as Record<string, unknown>` casts: the store APIs in
+// @librarian/core (createMemory, listMemories, updateMemory, …) still
+// accept loose record inputs because the JS-era surface hasn't been
+// tightened yet. Tightening core's signatures is tracked as a Phase 4
+// follow-up; the casts at this boundary are safe because the Zod input
+// schemas validate before the cast runs.
 
+import { DEFAULT_AGENT_ID } from "@librarian/core";
 import {
   CategorySchema,
   MemoryInputSchema,
@@ -22,6 +30,7 @@ import { z } from "zod";
 import { adminProcedure, router } from "./trpc.js";
 
 const DASHBOARD_AGENT_ID = "dashboard";
+const RECALL_DEFAULT_LIMIT = 12;
 
 const SortFieldSchema = z.enum(["created_at", "updated_at", "title", "priority"]);
 const SortOrderSchema = z.enum(["asc", "desc"]);
@@ -78,11 +87,25 @@ const RejectProposalInputSchema = z.object({
 const RecallInputSchema = z.object({
   agent_id: z.string().optional(),
   query: z.string().optional(),
-  categories: z.array(z.string()).optional(),
+  categories: z.array(CategorySchema).optional(),
   project_key: z.string().optional(),
   include_private: z.boolean().optional(),
   limit: z.number().int().min(1).max(50).optional(),
 });
+
+// The store throws plain Error with this prefix when a row is missing.
+// We rewrap into a tRPC NOT_FOUND so admin callers see the right HTTP
+// status. Any other error propagates as INTERNAL_SERVER_ERROR.
+function rethrowAsNotFound<T>(fn: () => T, message: string): T {
+  try {
+    return fn();
+  } catch (error) {
+    if (error instanceof Error && /No memory found/i.test(error.message)) {
+      throw new TRPCError({ code: "NOT_FOUND", message });
+    }
+    throw error;
+  }
+}
 
 export const memoriesRouter = router({
   list: adminProcedure
@@ -105,53 +128,67 @@ export const memoriesRouter = router({
     .input(MemoryInputSchema)
     .mutation(({ ctx, input }) => ctx.store.createMemory(input as Record<string, unknown>)),
 
-  update: adminProcedure.input(UpdateMemoryInputSchema).mutation(({ ctx, input }) => {
-    const result = ctx.store.updateMemory(
-      input.id,
-      input.patch as Record<string, unknown>,
-      input.agent_id ?? DASHBOARD_AGENT_ID,
-      { allowProtected: true },
-    );
-    if (!result) throw new TRPCError({ code: "NOT_FOUND", message: "Memory not found" });
-    return result;
-  }),
+  update: adminProcedure
+    .input(UpdateMemoryInputSchema)
+    .mutation(({ ctx, input }) =>
+      rethrowAsNotFound(
+        () =>
+          ctx.store.updateMemory(
+            input.id,
+            input.patch as Record<string, unknown>,
+            input.agent_id ?? DASHBOARD_AGENT_ID,
+            { allowProtected: true },
+          ),
+        "Memory not found",
+      ),
+    ),
 
-  delete: adminProcedure.input(DeleteMemoryInputSchema).mutation(({ ctx, input }) => {
-    const result = ctx.store.deleteMemory(input.id, input.agent_id ?? DASHBOARD_AGENT_ID);
-    if (!result) throw new TRPCError({ code: "NOT_FOUND", message: "Memory not found" });
-    return result;
-  }),
+  delete: adminProcedure
+    .input(DeleteMemoryInputSchema)
+    .mutation(({ ctx, input }) =>
+      rethrowAsNotFound(
+        () => ctx.store.deleteMemory(input.id, input.agent_id ?? DASHBOARD_AGENT_ID),
+        "Memory not found",
+      ),
+    ),
 
-  approve: adminProcedure.input(ApproveProposalInputSchema).mutation(({ ctx, input }) => {
-    const result = ctx.store.approveProposal(
-      input.id,
-      "approve",
-      (input.patch ?? {}) as Record<string, unknown>,
-      input.agent_id ?? DASHBOARD_AGENT_ID,
-    );
-    if (!result) throw new TRPCError({ code: "NOT_FOUND", message: "Proposal not found" });
-    return result;
-  }),
+  approve: adminProcedure
+    .input(ApproveProposalInputSchema)
+    .mutation(({ ctx, input }) =>
+      rethrowAsNotFound(
+        () =>
+          ctx.store.approveProposal(
+            input.id,
+            "approve",
+            (input.patch ?? {}) as Record<string, unknown>,
+            input.agent_id ?? DASHBOARD_AGENT_ID,
+          ),
+        "Proposal not found",
+      ),
+    ),
 
-  reject: adminProcedure.input(RejectProposalInputSchema).mutation(({ ctx, input }) => {
-    const result = ctx.store.approveProposal(
-      input.id,
-      "reject",
-      {},
-      input.agent_id ?? DASHBOARD_AGENT_ID,
-    );
-    if (!result) throw new TRPCError({ code: "NOT_FOUND", message: "Proposal not found" });
-    return result;
-  }),
+  reject: adminProcedure
+    .input(RejectProposalInputSchema)
+    .mutation(({ ctx, input }) =>
+      rethrowAsNotFound(
+        () =>
+          ctx.store.approveProposal(input.id, "reject", {}, input.agent_id ?? DASHBOARD_AGENT_ID),
+        "Proposal not found",
+      ),
+    ),
 
   recall: adminProcedure.input(RecallInputSchema.optional()).mutation(({ ctx, input }) => {
-    const params = (input ?? {}) as Record<string, unknown>;
-    const memories = ctx.store.searchMemories(params);
-    ctx.store.recordRecall(
-      memories,
-      (params.agent_id as string | undefined) ?? undefined,
-      (params.query as string | undefined) ?? "",
-    );
+    const agentId = input?.agent_id ?? DEFAULT_AGENT_ID;
+    const query = input?.query ?? "";
+    const memories = ctx.store.searchMemories({
+      agent_id: agentId,
+      query,
+      categories: input?.categories ?? [],
+      project_key: input?.project_key ?? "",
+      include_private: input?.include_private ?? true,
+      limit: input?.limit ?? RECALL_DEFAULT_LIMIT,
+    });
+    ctx.store.recordRecall(memories, agentId, query);
     return { memories };
   }),
 });

--- a/packages/mcp-server/src/trpc/memories.ts
+++ b/packages/mcp-server/src/trpc/memories.ts
@@ -1,0 +1,157 @@
+// Memory tRPC procedures (T4.4).
+//
+// Mirrors the legacy /api/memories*, /api/proposals*, /api/events,
+// /api/aggregates, /api/recall, and /api/memories/:id/related REST
+// endpoints with typed Zod inputs. The old REST routes stay live and
+// are deleted in T7.1; until then the dashboard can migrate
+// procedure-by-procedure.
+//
+// All procedures are admin-gated. Dashboard callers authenticate with
+// LIBRARIAN_ADMIN_TOKEN; the gate runs once in `adminProcedure`.
+
+import {
+  CategorySchema,
+  MemoryInputSchema,
+  MemoryPatchSchema,
+  MemoryStatusSchema,
+  ScopeSchema,
+  VisibilitySchema,
+} from "@librarian/core/schemas";
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+import { adminProcedure, router } from "./trpc.js";
+
+const DASHBOARD_AGENT_ID = "dashboard";
+
+const SortFieldSchema = z.enum(["created_at", "updated_at", "title", "priority"]);
+const SortOrderSchema = z.enum(["asc", "desc"]);
+
+const ListMemoriesInputSchema = z.object({
+  status: MemoryStatusSchema.optional(),
+  agent_id: z.string().optional(),
+  project_key: z.string().optional(),
+  category: CategorySchema.optional(),
+  visibility: VisibilitySchema.optional(),
+  scope: ScopeSchema.optional(),
+  from: z.string().optional(),
+  to: z.string().optional(),
+  sort: SortFieldSchema.optional(),
+  order: SortOrderSchema.optional(),
+  limit: z.number().int().min(1).max(200).optional(),
+  offset: z.number().int().nonnegative().optional(),
+});
+
+const ListEventsInputSchema = z.object({
+  type: z.string().optional(),
+  agent_id: z.string().optional(),
+  memory_id: z.string().optional(),
+  result: z.string().optional(),
+  query: z.string().optional(),
+  limit: z.number().int().min(1).max(100).optional(),
+  offset: z.number().int().nonnegative().optional(),
+});
+
+const IdInputSchema = z.object({ id: z.string().min(1) });
+
+const UpdateMemoryInputSchema = z.object({
+  id: z.string().min(1),
+  patch: MemoryPatchSchema,
+  agent_id: z.string().optional(),
+});
+
+const DeleteMemoryInputSchema = z.object({
+  id: z.string().min(1),
+  agent_id: z.string().optional(),
+});
+
+const ApproveProposalInputSchema = z.object({
+  id: z.string().min(1),
+  patch: MemoryPatchSchema.optional(),
+  agent_id: z.string().optional(),
+});
+
+const RejectProposalInputSchema = z.object({
+  id: z.string().min(1),
+  agent_id: z.string().optional(),
+});
+
+const RecallInputSchema = z.object({
+  agent_id: z.string().optional(),
+  query: z.string().optional(),
+  categories: z.array(z.string()).optional(),
+  project_key: z.string().optional(),
+  include_private: z.boolean().optional(),
+  limit: z.number().int().min(1).max(50).optional(),
+});
+
+export const memoriesRouter = router({
+  list: adminProcedure
+    .input(ListMemoriesInputSchema.optional())
+    .query(({ ctx, input }) => ctx.store.listMemories((input ?? {}) as Record<string, unknown>)),
+
+  aggregates: adminProcedure.query(({ ctx }) => ctx.store.getAggregates()),
+
+  events: adminProcedure
+    .input(ListEventsInputSchema.optional())
+    .query(({ ctx, input }) => ctx.store.listEvents((input ?? {}) as Record<string, unknown>)),
+
+  related: adminProcedure.input(IdInputSchema).query(({ ctx, input }) => {
+    const result = ctx.store.getRelated(input.id);
+    if (!result) throw new TRPCError({ code: "NOT_FOUND", message: "Memory not found" });
+    return result;
+  }),
+
+  create: adminProcedure
+    .input(MemoryInputSchema)
+    .mutation(({ ctx, input }) => ctx.store.createMemory(input as Record<string, unknown>)),
+
+  update: adminProcedure.input(UpdateMemoryInputSchema).mutation(({ ctx, input }) => {
+    const result = ctx.store.updateMemory(
+      input.id,
+      input.patch as Record<string, unknown>,
+      input.agent_id ?? DASHBOARD_AGENT_ID,
+      { allowProtected: true },
+    );
+    if (!result) throw new TRPCError({ code: "NOT_FOUND", message: "Memory not found" });
+    return result;
+  }),
+
+  delete: adminProcedure.input(DeleteMemoryInputSchema).mutation(({ ctx, input }) => {
+    const result = ctx.store.deleteMemory(input.id, input.agent_id ?? DASHBOARD_AGENT_ID);
+    if (!result) throw new TRPCError({ code: "NOT_FOUND", message: "Memory not found" });
+    return result;
+  }),
+
+  approve: adminProcedure.input(ApproveProposalInputSchema).mutation(({ ctx, input }) => {
+    const result = ctx.store.approveProposal(
+      input.id,
+      "approve",
+      (input.patch ?? {}) as Record<string, unknown>,
+      input.agent_id ?? DASHBOARD_AGENT_ID,
+    );
+    if (!result) throw new TRPCError({ code: "NOT_FOUND", message: "Proposal not found" });
+    return result;
+  }),
+
+  reject: adminProcedure.input(RejectProposalInputSchema).mutation(({ ctx, input }) => {
+    const result = ctx.store.approveProposal(
+      input.id,
+      "reject",
+      {},
+      input.agent_id ?? DASHBOARD_AGENT_ID,
+    );
+    if (!result) throw new TRPCError({ code: "NOT_FOUND", message: "Proposal not found" });
+    return result;
+  }),
+
+  recall: adminProcedure.input(RecallInputSchema.optional()).mutation(({ ctx, input }) => {
+    const params = (input ?? {}) as Record<string, unknown>;
+    const memories = ctx.store.searchMemories(params);
+    ctx.store.recordRecall(
+      memories,
+      (params.agent_id as string | undefined) ?? undefined,
+      (params.query as string | undefined) ?? "",
+    );
+    return { memories };
+  }),
+});

--- a/packages/mcp-server/src/trpc/router.ts
+++ b/packages/mcp-server/src/trpc/router.ts
@@ -6,11 +6,12 @@
 // `AppRouter` type is the public contract the dashboard imports.
 
 import { healthRouter } from "./health.js";
+import { memoriesRouter } from "./memories.js";
 import { router } from "./trpc.js";
 
 export const appRouter = router({
   health: healthRouter,
-  memories: router({}),
+  memories: memoriesRouter,
   sessions: router({}),
 });
 

--- a/packages/mcp-server/tests/trpc/memories.test.ts
+++ b/packages/mcp-server/tests/trpc/memories.test.ts
@@ -1,0 +1,282 @@
+// Memory tRPC procedure integration tests (T4.4).
+//
+// Spawns the real HTTP bin and exercises the typed surface end-to-end:
+// admin gating, list/aggregates/events, related (incl. 404), full CRUD
+// (create/update/delete), proposal approve/reject, and recall.
+
+import { createLibrarianStore } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+import { cleanupTempDir, makeTempDir, startHttpServer } from "../../../../test/helpers.js";
+
+interface TrpcOk<T> {
+  result: { data: T };
+}
+
+interface TrpcErr {
+  error: { code?: number; message?: string; data?: { httpStatus?: number; code?: string } };
+}
+
+interface MemoryRow {
+  id: string;
+  title: string;
+  body: string;
+  status: string;
+  category: string;
+}
+
+interface ListMemoriesResult {
+  memories: MemoryRow[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+interface CreateMemoryResult {
+  status: string;
+  memory?: MemoryRow;
+}
+
+interface ServerHandle {
+  url: string;
+  token: string;
+  stop: () => Promise<void>;
+}
+
+async function trpcGet<T>(server: ServerHandle, path: string, input?: unknown): Promise<T> {
+  const url = new URL(`${server.url}/trpc/${path}`);
+  if (input !== undefined) url.searchParams.set("input", JSON.stringify(input));
+  const response = await fetch(url, {
+    headers: { authorization: `Bearer ${server.token}` },
+  });
+  const json = (await response.json()) as TrpcOk<T> | TrpcErr;
+  if (response.status >= 400 || "error" in json) {
+    throw new Error(`trpc GET ${path} failed: ${JSON.stringify(json)}`);
+  }
+  return (json as TrpcOk<T>).result.data;
+}
+
+async function trpcPost<T>(server: ServerHandle, path: string, input?: unknown): Promise<T> {
+  const response = await fetch(`${server.url}/trpc/${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${server.token}`,
+    },
+    body: input === undefined ? undefined : JSON.stringify(input),
+  });
+  const json = (await response.json()) as TrpcOk<T> | TrpcErr;
+  if (response.status >= 400 || "error" in json) {
+    throw new Error(`trpc POST ${path} failed: ${JSON.stringify(json)}`);
+  }
+  return (json as TrpcOk<T>).result.data;
+}
+
+function seedMemory(
+  dataDir: string,
+  overrides: Partial<{ title: string; body: string; category: string; agent_id: string }> = {},
+): MemoryRow {
+  const store = createLibrarianStore({ dataDir });
+  try {
+    const result = store.createMemory({
+      agent_id: overrides.agent_id || "bede",
+      title: overrides.title || "Seeded memory",
+      body: overrides.body || "Body text",
+      category: overrides.category || "lessons",
+    });
+    if (result.status === "conflict") throw new Error("Unexpected conflict during seed");
+    return result.memory as unknown as MemoryRow;
+  } finally {
+    store.close();
+  }
+}
+
+describe("tRPC memories surface", () => {
+  it("rejects unauthenticated calls with UNAUTHORIZED", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const response = await fetch(`${server.url}/trpc/memories.list`);
+      expect(response.status).toBe(401);
+      const body = (await response.json()) as TrpcErr;
+      expect(body.error?.data?.code).toBe("UNAUTHORIZED");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("memories.list returns paginated memories", async () => {
+    const dataDir = makeTempDir();
+    seedMemory(dataDir, { title: "Alpha" });
+    seedMemory(dataDir, { title: "Beta" });
+    const server = await startHttpServer({ dataDir });
+    try {
+      const data = await trpcGet<ListMemoriesResult>(server, "memories.list");
+      expect(data.total).toBe(2);
+      expect(data.memories.map((m) => m.title).sort()).toEqual(["Alpha", "Beta"]);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("memories.list applies filters", async () => {
+    const dataDir = makeTempDir();
+    seedMemory(dataDir, { title: "Alpha", category: "lessons" });
+    seedMemory(dataDir, { title: "Beta", category: "tools" });
+    const server = await startHttpServer({ dataDir });
+    try {
+      const data = await trpcGet<ListMemoriesResult>(server, "memories.list", {
+        category: "tools",
+      });
+      expect(data.total).toBe(1);
+      expect(data.memories[0]?.title).toBe("Beta");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("memories.aggregates returns tallies", async () => {
+    const dataDir = makeTempDir();
+    seedMemory(dataDir, { title: "Alpha", category: "lessons" });
+    seedMemory(dataDir, { title: "Beta", category: "tools" });
+    const server = await startHttpServer({ dataDir });
+    try {
+      const data = await trpcGet<{
+        total: number;
+        categories: { value: unknown; count: number }[];
+      }>(server, "memories.aggregates");
+      expect(data.total).toBe(2);
+      const tools = data.categories.find((c) => c.value === "tools");
+      expect(tools?.count).toBe(1);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("memories.events returns paginated event ledger", async () => {
+    const dataDir = makeTempDir();
+    seedMemory(dataDir, { title: "Alpha" });
+    seedMemory(dataDir, { title: "Beta" });
+    const server = await startHttpServer({ dataDir });
+    try {
+      const data = await trpcGet<{
+        events: { event_type: string }[];
+        total: number;
+      }>(server, "memories.events", { limit: 10 });
+      expect(data.total).toBeGreaterThanOrEqual(2);
+      expect(data.events.every((e) => typeof e.event_type === "string")).toBe(true);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("memories.related returns 404 for unknown id", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const response = await fetch(
+        `${server.url}/trpc/memories.related?input=${encodeURIComponent(
+          JSON.stringify({ id: "mem_nope" }),
+        )}`,
+        {
+          headers: { authorization: `Bearer ${server.token}` },
+        },
+      );
+      expect(response.status).toBe(404);
+      const body = (await response.json()) as TrpcErr;
+      expect(body.error?.data?.code).toBe("NOT_FOUND");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("memories.create then memories.update mutates the row", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const created = await trpcPost<CreateMemoryResult>(server, "memories.create", {
+        agent_id: "bede",
+        title: "Created via tRPC",
+        body: "Original body",
+        category: "lessons",
+      });
+      expect(created.status).toBe("active");
+      const id = created.memory?.id;
+      expect(id).toBeTypeOf("string");
+
+      const updated = await trpcPost<MemoryRow>(server, "memories.update", {
+        id,
+        patch: { body: "Patched body" },
+      });
+      expect(updated.body).toBe("Patched body");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("memories.delete marks the memory as deleted", async () => {
+    const dataDir = makeTempDir();
+    const memory = seedMemory(dataDir, { title: "Disposable" });
+    const server = await startHttpServer({ dataDir });
+    try {
+      const result = await trpcPost<MemoryRow>(server, "memories.delete", { id: memory.id });
+      expect(result.status).toBe("deleted");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("memories.approve transitions a proposal to active", async () => {
+    const dataDir = makeTempDir();
+    const proposal = seedMemory(dataDir, { title: "Who", category: "identity" });
+    expect(proposal.status).toBe("proposed");
+    const server = await startHttpServer({ dataDir });
+    try {
+      const result = await trpcPost<MemoryRow>(server, "memories.approve", { id: proposal.id });
+      expect(result.status).toBe("active");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("memories.reject transitions a proposal to rejected", async () => {
+    const dataDir = makeTempDir();
+    const proposal = seedMemory(dataDir, { title: "Reject me", category: "identity" });
+    expect(proposal.status).toBe("proposed");
+    const server = await startHttpServer({ dataDir });
+    try {
+      const result = await trpcPost<MemoryRow>(server, "memories.reject", { id: proposal.id });
+      expect(result.status).toBe("rejected");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("memories.recall returns matching memories and records the recall", async () => {
+    const dataDir = makeTempDir();
+    seedMemory(dataDir, { title: "Coffee preferences", body: "Espresso, no sugar." });
+    seedMemory(dataDir, { title: "Other", body: "Unrelated." });
+    const server = await startHttpServer({ dataDir });
+    try {
+      const data = await trpcPost<{ memories: MemoryRow[] }>(server, "memories.recall", {
+        agent_id: "bede",
+        query: "coffee",
+        limit: 5,
+      });
+      expect(data.memories.length).toBeGreaterThanOrEqual(1);
+      expect(data.memories.some((m) => m.title === "Coffee preferences")).toBe(true);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+});

--- a/packages/mcp-server/tests/trpc/memories.test.ts
+++ b/packages/mcp-server/tests/trpc/memories.test.ts
@@ -84,7 +84,7 @@ function seedMemory(
       category: overrides.category || "lessons",
     });
     if (result.status === "conflict") throw new Error("Unexpected conflict during seed");
-    return result.memory as unknown as MemoryRow;
+    return result.memory as MemoryRow;
   } finally {
     store.close();
   }
@@ -274,6 +274,102 @@ describe("tRPC memories surface", () => {
       });
       expect(data.memories.length).toBeGreaterThanOrEqual(1);
       expect(data.memories.some((m) => m.title === "Coffee preferences")).toBe(true);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("memories.recall against an empty store returns no memories and records a recall_empty event", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const data = await trpcPost<{ memories: MemoryRow[] }>(server, "memories.recall", {
+        agent_id: "bede",
+        query: "nothing here",
+      });
+      expect(data.memories).toEqual([]);
+      const events = await trpcGet<{ events: { event_type: string }[] }>(
+        server,
+        "memories.events",
+        { type: "memory.recall_empty" },
+      );
+      expect(events.events.length).toBe(1);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("memories.create surfaces the conflict path when two memories disagree", async () => {
+    const dataDir = makeTempDir();
+    seedMemory(dataDir, {
+      title: "API style preference",
+      body: "Prefer typed tRPC APIs over hand-rolled REST.",
+      category: "lessons",
+    });
+    const server = await startHttpServer({ dataDir });
+    try {
+      const created = await trpcPost<{ status: string; message?: string }>(
+        server,
+        "memories.create",
+        {
+          agent_id: "bede",
+          title: "API style preference",
+          body: "Avoid typed tRPC APIs; prefer hand-rolled REST.",
+          category: "lessons",
+        },
+      );
+      expect(created.status).toBe("conflict");
+      expect(typeof created.message).toBe("string");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("memories.list applies status + category filters together", async () => {
+    const dataDir = makeTempDir();
+    seedMemory(dataDir, { title: "Active lesson", category: "lessons" });
+    seedMemory(dataDir, { title: "Active tool", category: "tools" });
+    const proposal = seedMemory(dataDir, { title: "Proposed", category: "identity" });
+    expect(proposal.status).toBe("proposed");
+    const server = await startHttpServer({ dataDir });
+    try {
+      const data = await trpcGet<ListMemoriesResult>(server, "memories.list", {
+        status: "active",
+        category: "lessons",
+      });
+      expect(data.total).toBe(1);
+      expect(data.memories[0]?.title).toBe("Active lesson");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("memories.update / delete / approve / reject return NOT_FOUND for unknown ids", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      for (const [path, body] of [
+        ["memories.update", { id: "mem_nope", patch: { body: "x" } }],
+        ["memories.delete", { id: "mem_nope" }],
+        ["memories.approve", { id: "mem_nope" }],
+        ["memories.reject", { id: "mem_nope" }],
+      ] as const) {
+        const response = await fetch(`${server.url}/trpc/${path}`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${server.token}`,
+          },
+          body: JSON.stringify(body),
+        });
+        expect(response.status).toBe(404);
+        const json = (await response.json()) as TrpcErr;
+        expect(json.error?.data?.code).toBe("NOT_FOUND");
+      }
     } finally {
       await server.stop();
       cleanupTempDir(dataDir);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ importers:
       '@trpc/server':
         specifier: ^11.17.0
         version: 11.17.0(typescript@5.9.3)
+      zod:
+        specifier: ^4.0.1
+        version: 4.4.3
     devDependencies:
       '@types/node':
         specifier: ^22.10.5


### PR DESCRIPTION
## Spec / phase reference

Implements **T4.4 — tRPC memory procedures** (Phase 4 of `specs/maintainability-overhaul.md`). Blocks T6.3, T6.4. Builds on the T4.3 scaffold.

## Summary

- Mirrors `/api/memories*`, `/api/proposals*`, `/api/events`, `/api/aggregates`, `/api/recall`, `/api/memories/:id/related` as typed procedures on `appRouter.memories`. REST routes stay live (deletion is T7.1).
- Inputs are derived from `@librarian/core` Zod schemas, so the dashboard gets the same enum narrowing the rest of the codebase already has. `list`'s `sort`/`order` are typed enums (closes the follow-up offered on PR #12).
- All procedures admin-gated via the `adminProcedure` middleware from T4.3.

## Procedures

| Procedure | Kind | Mirrors |
|---|---|---|
| `memories.list` | query | `GET /api/memories?…` |
| `memories.aggregates` | query | `GET /api/aggregates` |
| `memories.events` | query | `GET /api/events?…` |
| `memories.related` | query | `GET /api/memories/:id/related` |
| `memories.create` | mutation | `POST /api/memories` |
| `memories.update` | mutation | `POST /api/memories/:id/update` |
| `memories.delete` | mutation | `POST /api/memories/:id/delete` |
| `memories.approve` | mutation | `POST /api/proposals/:id/approve` |
| `memories.reject` | mutation | `POST /api/proposals/:id/reject` |
| `memories.recall` | mutation | `POST /api/recall` |

Unknown ids surface as `TRPCError({ code: 'NOT_FOUND' })`.

## Test plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm lint`
- [x] `pnpm -r run typecheck`
- [x] `pnpm test` — 42 node:test + 167 vitest = **209/209** (11 new memory tests; baseline floor 177)
- [x] `pnpm run check:test-count` / `check:storage-fixture` / `check:schema-version` — green
- [x] `pnpm run smoke` — passed
- [x] `pnpm run healthcheck` — 5/5
- [x] All four wrappers (`integrations/{claude-code,codex,opencode,pi}/wrapper.sh ... -- echo ok`) — green

New tests cover: missing-token 401, list, list+filter, aggregates, events, related-404, create→update, delete, approve, reject, recall.

## Quality gates

- [x] **No production source file over 400 LOC introduced.** `memories.ts` is 157 LOC.
- [x] **No new `any` or `@ts-ignore` introduced.** A small number of `as Record<string, unknown>` casts at the store boundary — the store APIs still accept loose records (pre-tightening is a separate follow-up).

## Notes for the reviewer

- `agent_id` defaults to `"dashboard"` for mutations that don't receive one, mirroring the REST code path.
- `memories.recall` returns `{ memories }` — same shape as the REST endpoint, minus the deprecated `text` field the dashboard never consumed.
- `priority` is intentionally not on the recall input schema — `searchMemories` doesn't read it; the REST endpoint silently ignored it too.
- `/api/state` from the legacy router is **not** mirrored: it's not listed in the T4.4 spec, and consumers can compose `memories.list` + `memories.events`.