### PR TITLE
feat(mcp-server): tRPC session procedures (T4.5)

### DIFF
--- a/packages/mcp-server/src/trpc/router.ts
+++ b/packages/mcp-server/src/trpc/router.ts
@@ -7,12 +7,13 @@
 
 import { healthRouter } from "./health.js";
 import { memoriesRouter } from "./memories.js";
+import { sessionsRouter } from "./sessions.js";
 import { router } from "./trpc.js";
 
 export const appRouter = router({
   health: healthRouter,
   memories: memoriesRouter,
-  sessions: router({}),
+  sessions: sessionsRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/packages/mcp-server/src/trpc/sessions.ts
+++ b/packages/mcp-server/src/trpc/sessions.ts
@@ -13,12 +13,7 @@
 // loose record inputs; the `as Record<string, unknown>` casts at the
 // boundary are safe because Zod validates first.
 
-import {
-  SessionCaptureModeSchema,
-  SessionPayloadTypeSchema,
-  SessionStatusSchema,
-  VisibilitySchema,
-} from "@librarian/core/schemas";
+import { SessionPayloadTypeSchema, SessionStatusSchema } from "@librarian/core/schemas";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { adminProcedure, router } from "./trpc.js";
@@ -41,7 +36,7 @@ const ListSessionsInputSchema = z.object({
 const ListSessionEventsInputSchema = z.object({
   session_id: z.string().min(1),
   type: SessionPayloadTypeSchema.optional(),
-  limit: z.number().int().min(1).max(500).optional(),
+  limit: z.number().int().min(1).max(200).optional(),
   offset: z.number().int().nonnegative().optional(),
 });
 
@@ -50,9 +45,13 @@ const SearchSessionsInputSchema = z.object({
   project_key: z.string().optional(),
   include_archived: z.boolean().optional(),
   include_deleted: z.boolean().optional(),
-  limit: z.number().int().min(1).max(100).optional(),
+  limit: z.number().int().min(1).max(50).optional(),
 });
 
+// Lifecycle inputs (checkpoint, pause, end, archive, restore, delete).
+// `candidate_memories` is read only by endSession; the field is present
+// on the shared schema so clients see it in the typed surface, and the
+// store silently ignores it for other lifecycle calls.
 const SessionLifecycleInputSchema = z.object({
   session_id: z.string().min(1),
   agent_id: z.string().optional(),
@@ -65,8 +64,7 @@ const SessionLifecycleInputSchema = z.object({
   harness: z.string().optional(),
   source_ref: z.string().optional(),
   reason: z.string().optional(),
-  visibility: VisibilitySchema.optional(),
-  capture_mode: SessionCaptureModeSchema.optional(),
+  candidate_memories: z.array(z.record(z.string(), z.unknown())).optional(),
 });
 
 const ContinueSessionInputSchema = z.object({
@@ -86,10 +84,14 @@ const PromoteSessionFactInputSchema = z.object({
   memory: z.record(z.string(), z.unknown()),
 });
 
+type StoreLike = { getSession: (id: string) => unknown };
 type AdminAction = (params: Record<string, unknown>) => unknown;
 
+// Rewrap "No session found" Errors thrown by the store as NOT_FOUND so
+// concurrent deletes between the pre-check and the action surface the
+// right HTTP status. Anything else propagates as INTERNAL_SERVER_ERROR.
 function runAdminAction(
-  store: { getSession: (id: string) => unknown },
+  store: StoreLike,
   sessionId: string,
   agentId: string | undefined,
   body: Record<string, unknown>,
@@ -98,12 +100,19 @@ function runAdminAction(
   if (!store.getSession(sessionId)) {
     throw new TRPCError({ code: "NOT_FOUND", message: "Session not found" });
   }
-  return action({
-    ...body,
-    session_id: sessionId,
-    agent_id: agentId ?? DASHBOARD_AGENT_ID,
-    admin: true,
-  });
+  try {
+    return action({
+      ...body,
+      session_id: sessionId,
+      agent_id: agentId ?? DASHBOARD_AGENT_ID,
+      admin: true,
+    });
+  } catch (error) {
+    if (error instanceof Error && /No session found/i.test(error.message)) {
+      throw new TRPCError({ code: "NOT_FOUND", message: "Session not found" });
+    }
+    throw error;
+  }
 }
 
 export const sessionsRouter = router({
@@ -123,7 +132,7 @@ export const sessionsRouter = router({
     if (!ctx.store.getSession(input.session_id)) {
       throw new TRPCError({ code: "NOT_FOUND", message: "Session not found" });
     }
-    return ctx.store.listSessionEvents(input as unknown as Record<string, unknown>);
+    return ctx.store.listSessionEvents({ ...input } as Record<string, unknown>);
   }),
 
   search: adminProcedure

--- a/packages/mcp-server/src/trpc/sessions.ts
+++ b/packages/mcp-server/src/trpc/sessions.ts
@@ -1,0 +1,198 @@
+// Session tRPC procedures (T4.5).
+//
+// Mirrors the legacy /api/sessions* REST surface as typed tRPC
+// procedures on appRouter.sessions: list, get, events, search,
+// checkpoint, pause, end, archive, restore, delete, continue,
+// promote. REST routes stay live until T7.1.
+//
+// All procedures are admin-gated. Every store call is invoked with
+// `admin: true` so visibility filtering is skipped — the admin
+// bearer token is the access boundary, not per-row visibility.
+//
+// As with memories.ts, the store APIs in @librarian/core still accept
+// loose record inputs; the `as Record<string, unknown>` casts at the
+// boundary are safe because Zod validates first.
+
+import {
+  SessionCaptureModeSchema,
+  SessionPayloadTypeSchema,
+  SessionStatusSchema,
+  VisibilitySchema,
+} from "@librarian/core/schemas";
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+import { adminProcedure, router } from "./trpc.js";
+
+const DASHBOARD_AGENT_ID = "dashboard";
+
+const SessionIdInputSchema = z.object({ session_id: z.string().min(1) });
+
+const ListSessionsInputSchema = z.object({
+  project_key: z.string().optional(),
+  harness: z.string().optional(),
+  cwd: z.string().optional(),
+  source_ref: z.string().optional(),
+  status: z.array(SessionStatusSchema).optional(),
+  include_archived: z.boolean().optional(),
+  include_deleted: z.boolean().optional(),
+  limit: z.number().int().min(1).max(100).optional(),
+});
+
+const ListSessionEventsInputSchema = z.object({
+  session_id: z.string().min(1),
+  type: SessionPayloadTypeSchema.optional(),
+  limit: z.number().int().min(1).max(500).optional(),
+  offset: z.number().int().nonnegative().optional(),
+});
+
+const SearchSessionsInputSchema = z.object({
+  query: z.string().optional(),
+  project_key: z.string().optional(),
+  include_archived: z.boolean().optional(),
+  include_deleted: z.boolean().optional(),
+  limit: z.number().int().min(1).max(100).optional(),
+});
+
+const SessionLifecycleInputSchema = z.object({
+  session_id: z.string().min(1),
+  agent_id: z.string().optional(),
+  summary: z.string().optional(),
+  decisions: z.array(z.string()).optional(),
+  files_touched: z.array(z.string()).optional(),
+  commands_run: z.array(z.string()).optional(),
+  open_questions: z.array(z.string()).optional(),
+  next_steps: z.array(z.string()).optional(),
+  harness: z.string().optional(),
+  source_ref: z.string().optional(),
+  reason: z.string().optional(),
+  visibility: VisibilitySchema.optional(),
+  capture_mode: SessionCaptureModeSchema.optional(),
+});
+
+const ContinueSessionInputSchema = z.object({
+  session_id: z.string().min(1),
+  agent_id: z.string().optional(),
+  target_harness: z.string().optional(),
+  target_cwd: z.string().optional(),
+  target_source_ref: z.string().optional(),
+  attach: z.boolean().optional(),
+  format: z.enum(["prose", "markdown", "claude", "codex", "opencode", "hermes", "pi"]).optional(),
+});
+
+const PromoteSessionFactInputSchema = z.object({
+  session_id: z.string().min(1),
+  session_event_id: z.string().optional(),
+  agent_id: z.string().optional(),
+  memory: z.record(z.string(), z.unknown()),
+});
+
+type AdminAction = (params: Record<string, unknown>) => unknown;
+
+function runAdminAction(
+  store: { getSession: (id: string) => unknown },
+  sessionId: string,
+  agentId: string | undefined,
+  body: Record<string, unknown>,
+  action: AdminAction,
+): unknown {
+  if (!store.getSession(sessionId)) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Session not found" });
+  }
+  return action({
+    ...body,
+    session_id: sessionId,
+    agent_id: agentId ?? DASHBOARD_AGENT_ID,
+    admin: true,
+  });
+}
+
+export const sessionsRouter = router({
+  list: adminProcedure
+    .input(ListSessionsInputSchema.optional())
+    .query(({ ctx, input }) =>
+      ctx.store.listSessions({ ...(input ?? {}), admin: true } as Record<string, unknown>),
+    ),
+
+  get: adminProcedure.input(SessionIdInputSchema).query(({ ctx, input }) => {
+    const session = ctx.store.getSession(input.session_id);
+    if (!session) throw new TRPCError({ code: "NOT_FOUND", message: "Session not found" });
+    return session;
+  }),
+
+  events: adminProcedure.input(ListSessionEventsInputSchema).query(({ ctx, input }) => {
+    if (!ctx.store.getSession(input.session_id)) {
+      throw new TRPCError({ code: "NOT_FOUND", message: "Session not found" });
+    }
+    return ctx.store.listSessionEvents(input as unknown as Record<string, unknown>);
+  }),
+
+  search: adminProcedure
+    .input(SearchSessionsInputSchema.optional())
+    .query(({ ctx, input }) =>
+      ctx.store.searchSessions({ ...(input ?? {}), admin: true } as Record<string, unknown>),
+    ),
+
+  checkpoint: adminProcedure
+    .input(SessionLifecycleInputSchema)
+    .mutation(({ ctx, input }) =>
+      runAdminAction(ctx.store, input.session_id, input.agent_id, input, (p) =>
+        ctx.store.checkpointSession(p),
+      ),
+    ),
+
+  pause: adminProcedure
+    .input(SessionLifecycleInputSchema)
+    .mutation(({ ctx, input }) =>
+      runAdminAction(ctx.store, input.session_id, input.agent_id, input, (p) =>
+        ctx.store.pauseSession(p),
+      ),
+    ),
+
+  end: adminProcedure
+    .input(SessionLifecycleInputSchema)
+    .mutation(({ ctx, input }) =>
+      runAdminAction(ctx.store, input.session_id, input.agent_id, input, (p) =>
+        ctx.store.endSession(p),
+      ),
+    ),
+
+  archive: adminProcedure
+    .input(SessionLifecycleInputSchema)
+    .mutation(({ ctx, input }) =>
+      runAdminAction(ctx.store, input.session_id, input.agent_id, input, (p) =>
+        ctx.store.archiveSession(p),
+      ),
+    ),
+
+  restore: adminProcedure
+    .input(SessionLifecycleInputSchema)
+    .mutation(({ ctx, input }) =>
+      runAdminAction(ctx.store, input.session_id, input.agent_id, input, (p) =>
+        ctx.store.restoreSession(p),
+      ),
+    ),
+
+  delete: adminProcedure
+    .input(SessionLifecycleInputSchema)
+    .mutation(({ ctx, input }) =>
+      runAdminAction(ctx.store, input.session_id, input.agent_id, input, (p) =>
+        ctx.store.deleteSession(p),
+      ),
+    ),
+
+  continue: adminProcedure
+    .input(ContinueSessionInputSchema)
+    .mutation(({ ctx, input }) =>
+      runAdminAction(ctx.store, input.session_id, input.agent_id, input, (p) =>
+        ctx.store.continueSession(p),
+      ),
+    ),
+
+  promote: adminProcedure
+    .input(PromoteSessionFactInputSchema)
+    .mutation(({ ctx, input }) =>
+      runAdminAction(ctx.store, input.session_id, input.agent_id, input, (p) =>
+        ctx.store.promoteSessionFact(p),
+      ),
+    ),
+});

--- a/packages/mcp-server/tests/trpc/sessions.test.ts
+++ b/packages/mcp-server/tests/trpc/sessions.test.ts
@@ -84,7 +84,7 @@ function seedSession(
       start_summary: overrides.start_summary || "tRPC smoke test.",
     });
     if (!result.session) throw new Error("Failed to seed session");
-    return result.session as unknown as SessionRow;
+    return result.session as SessionRow;
   } finally {
     store.close();
   }
@@ -320,6 +320,78 @@ describe("tRPC sessions surface", () => {
       expect(result.session.id).toBe(session.id);
       expect(typeof result.text).toBe("string");
       expect(result.text.length).toBeGreaterThan(0);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("sessions.continue works without a target_harness (no attach)", async () => {
+    const dataDir = makeTempDir();
+    const session = seedSession(dataDir, { title: "Read-only handover" });
+    const server = await startHttpServer({ dataDir });
+    try {
+      const result = await trpcPost<{
+        session: SessionRow;
+        text: string;
+      }>(server, "sessions.continue", { session_id: session.id, attach: false });
+      expect(result.session.id).toBe(session.id);
+      expect(typeof result.text).toBe("string");
+      expect(result.text.length).toBeGreaterThan(0);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("sessions.end forwards candidate_memories into the event payload", async () => {
+    const dataDir = makeTempDir();
+    const session = seedSession(dataDir, { title: "Ending with candidates" });
+    const server = await startHttpServer({ dataDir });
+    try {
+      await trpcPost<{ session: SessionRow }>(server, "sessions.end", {
+        session_id: session.id,
+        summary: "wrapping up",
+        candidate_memories: [
+          { title: "candidate A", body: "promote me", category: "lessons", agent_id: "bede" },
+        ],
+      });
+      const events = await trpcGet<{
+        events: { type: string; summary: string; payload: Record<string, unknown> }[];
+      }>(server, "sessions.events", { session_id: session.id });
+      const endEvent = events.events.find((e) => e.type === "ended");
+      expect(endEvent).toBeTruthy();
+      const candidates = endEvent?.payload.candidate_memories as { title: string }[] | undefined;
+      expect(Array.isArray(candidates)).toBe(true);
+      expect(candidates?.[0]?.title).toBe("candidate A");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("sessions.pause on an already-ended session surfaces the store error", async () => {
+    const dataDir = makeTempDir();
+    const session = seedSession(dataDir, { title: "Already ended" });
+    const store = createLibrarianStore({ dataDir });
+    try {
+      store.endSession({ admin: true, agent_id: "bede", session_id: session.id, summary: "done" });
+    } finally {
+      store.close();
+    }
+    const server = await startHttpServer({ dataDir });
+    try {
+      const response = await fetch(`${server.url}/trpc/sessions.pause`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${server.token}`,
+        },
+        body: JSON.stringify({ session_id: session.id, summary: "too late" }),
+      });
+      expect(response.status).toBeGreaterThanOrEqual(400);
+      const body = (await response.json()) as TrpcErr;
+      expect(typeof body.error?.message).toBe("string");
     } finally {
       await server.stop();
       cleanupTempDir(dataDir);

--- a/packages/mcp-server/tests/trpc/sessions.test.ts
+++ b/packages/mcp-server/tests/trpc/sessions.test.ts
@@ -1,0 +1,392 @@
+// Session tRPC procedure integration tests (T4.5).
+//
+// Spawns the real HTTP bin and exercises every session procedure end
+// to end: admin gating, list/get/events/search, full lifecycle
+// (checkpoint/pause/end), archive/restore/delete, continue, promote.
+
+import { createLibrarianStore } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+import { cleanupTempDir, makeTempDir, startHttpServer } from "../../../../test/helpers.js";
+
+interface TrpcOk<T> {
+  result: { data: T };
+}
+
+interface TrpcErr {
+  error: { code?: number; message?: string; data?: { httpStatus?: number; code?: string } };
+}
+
+interface SessionRow {
+  id: string;
+  title: string;
+  status: string;
+  rolling_summary: string | null;
+  end_summary: string | null;
+  next_steps: string[];
+}
+
+interface SessionsListResult {
+  sessions: SessionRow[];
+  total: number;
+  limit: number;
+}
+
+interface ServerHandle {
+  url: string;
+  token: string;
+  stop: () => Promise<void>;
+}
+
+async function trpcGet<T>(server: ServerHandle, path: string, input?: unknown): Promise<T> {
+  const url = new URL(`${server.url}/trpc/${path}`);
+  if (input !== undefined) url.searchParams.set("input", JSON.stringify(input));
+  const response = await fetch(url, { headers: { authorization: `Bearer ${server.token}` } });
+  const json = (await response.json()) as TrpcOk<T> | TrpcErr;
+  if (response.status >= 400 || "error" in json) {
+    throw new Error(`trpc GET ${path} failed: ${JSON.stringify(json)}`);
+  }
+  return (json as TrpcOk<T>).result.data;
+}
+
+async function trpcPost<T>(server: ServerHandle, path: string, input?: unknown): Promise<T> {
+  const response = await fetch(`${server.url}/trpc/${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${server.token}`,
+    },
+    body: input === undefined ? undefined : JSON.stringify(input),
+  });
+  const json = (await response.json()) as TrpcOk<T> | TrpcErr;
+  if (response.status >= 400 || "error" in json) {
+    throw new Error(`trpc POST ${path} failed: ${JSON.stringify(json)}`);
+  }
+  return (json as TrpcOk<T>).result.data;
+}
+
+function seedSession(
+  dataDir: string,
+  overrides: Partial<{
+    title: string;
+    agent_id: string;
+    harness: string;
+    project_key: string;
+    start_summary: string;
+  }> = {},
+): SessionRow {
+  const store = createLibrarianStore({ dataDir });
+  try {
+    const result = store.startSession({
+      agent_id: overrides.agent_id || "bede",
+      title: overrides.title || "tRPC session",
+      harness: overrides.harness || "hermes",
+      project_key: overrides.project_key || "the-librarian",
+      start_summary: overrides.start_summary || "tRPC smoke test.",
+    });
+    if (!result.session) throw new Error("Failed to seed session");
+    return result.session as unknown as SessionRow;
+  } finally {
+    store.close();
+  }
+}
+
+describe("tRPC sessions surface", () => {
+  it("rejects unauthenticated calls with UNAUTHORIZED", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const response = await fetch(`${server.url}/trpc/sessions.list`);
+      expect(response.status).toBe(401);
+      const body = (await response.json()) as TrpcErr;
+      expect(body.error?.data?.code).toBe("UNAUTHORIZED");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("sessions.list returns all sessions with admin scope", async () => {
+    const dataDir = makeTempDir();
+    seedSession(dataDir, { title: "Alpha" });
+    seedSession(dataDir, { title: "Beta" });
+    const server = await startHttpServer({ dataDir });
+    try {
+      const data = await trpcGet<SessionsListResult>(server, "sessions.list");
+      expect(data.total).toBe(2);
+      expect(data.sessions.map((s) => s.title).sort()).toEqual(["Alpha", "Beta"]);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("sessions.list include_archived reveals archived sessions", async () => {
+    const dataDir = makeTempDir();
+    const session = seedSession(dataDir, { title: "Archive me" });
+    const store = createLibrarianStore({ dataDir });
+    try {
+      store.archiveSession({ agent_id: "bede", session_id: session.id, admin: true });
+    } finally {
+      store.close();
+    }
+    const server = await startHttpServer({ dataDir });
+    try {
+      const without = await trpcGet<SessionsListResult>(server, "sessions.list");
+      expect(without.total).toBe(0);
+      const withArchived = await trpcGet<SessionsListResult>(server, "sessions.list", {
+        include_archived: true,
+      });
+      expect(withArchived.total).toBe(1);
+      expect(withArchived.sessions[0]?.status).toBe("archived");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("sessions.get returns the session detail or NOT_FOUND", async () => {
+    const dataDir = makeTempDir();
+    const session = seedSession(dataDir, { title: "Detail" });
+    const server = await startHttpServer({ dataDir });
+    try {
+      const data = await trpcGet<SessionRow>(server, "sessions.get", { session_id: session.id });
+      expect(data.id).toBe(session.id);
+
+      const missing = await fetch(
+        `${server.url}/trpc/sessions.get?input=${encodeURIComponent(
+          JSON.stringify({ session_id: "ses_nope" }),
+        )}`,
+        { headers: { authorization: `Bearer ${server.token}` } },
+      );
+      expect(missing.status).toBe(404);
+      const body = (await missing.json()) as TrpcErr;
+      expect(body.error?.data?.code).toBe("NOT_FOUND");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("sessions.events returns the per-session event stream", async () => {
+    const dataDir = makeTempDir();
+    const session = seedSession(dataDir, { title: "Events" });
+    const store = createLibrarianStore({ dataDir });
+    try {
+      store.recordSessionEvent({
+        agent_id: "bede",
+        session_id: session.id,
+        type: "decision",
+        summary: "D1",
+      });
+      store.recordSessionEvent({
+        agent_id: "bede",
+        session_id: session.id,
+        type: "command",
+        summary: "npm test",
+      });
+    } finally {
+      store.close();
+    }
+    const server = await startHttpServer({ dataDir });
+    try {
+      const data = await trpcGet<{ events: { type: string; summary: string }[]; total: number }>(
+        server,
+        "sessions.events",
+        { session_id: session.id },
+      );
+      // startSession also lands a row in session_events ("Started …"),
+      // so we look for the two recordSessionEvent rows alongside it.
+      expect(data.total).toBeGreaterThanOrEqual(3);
+      const summaries = data.events.map((e) => e.summary);
+      expect(summaries).toContain("D1");
+      expect(summaries).toContain("npm test");
+
+      const filtered = await trpcGet<{ events: { type: string }[] }>(server, "sessions.events", {
+        session_id: session.id,
+        type: "decision",
+      });
+      expect(filtered.events.length).toBe(1);
+      expect(filtered.events[0]?.type).toBe("decision");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("sessions.events returns NOT_FOUND for unknown id", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const response = await fetch(
+        `${server.url}/trpc/sessions.events?input=${encodeURIComponent(
+          JSON.stringify({ session_id: "ses_nope" }),
+        )}`,
+        { headers: { authorization: `Bearer ${server.token}` } },
+      );
+      expect(response.status).toBe(404);
+      const body = (await response.json()) as TrpcErr;
+      expect(body.error?.data?.code).toBe("NOT_FOUND");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("sessions.search matches sessions by query", async () => {
+    const dataDir = makeTempDir();
+    seedSession(dataDir, { title: "Coffee plan", start_summary: "espresso routines" });
+    seedSession(dataDir, { title: "Logging", start_summary: "switch to pino" });
+    const server = await startHttpServer({ dataDir });
+    try {
+      const data = await trpcGet<SessionsListResult>(server, "sessions.search", {
+        query: "coffee",
+      });
+      expect(data.sessions.some((s) => s.title === "Coffee plan")).toBe(true);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("sessions.checkpoint, pause, end drive the full lifecycle", async () => {
+    const dataDir = makeTempDir();
+    const session = seedSession(dataDir, { title: "Lifecycle" });
+    const server = await startHttpServer({ dataDir });
+    try {
+      const checkpoint = await trpcPost<{ session: SessionRow }>(server, "sessions.checkpoint", {
+        session_id: session.id,
+        summary: "midpoint",
+        next_steps: ["step A"],
+      });
+      expect(checkpoint.session.status).toBe("active");
+      expect(checkpoint.session.rolling_summary).toContain("midpoint");
+
+      const paused = await trpcPost<{ session: SessionRow }>(server, "sessions.pause", {
+        session_id: session.id,
+        summary: "stepping away",
+      });
+      expect(paused.session.status).toBe("paused");
+
+      const ended = await trpcPost<{ session: SessionRow }>(server, "sessions.end", {
+        session_id: session.id,
+        summary: "wrap",
+      });
+      expect(ended.session.status).toBe("ended");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("sessions.archive, restore, delete transition status", async () => {
+    const dataDir = makeTempDir();
+    const session = seedSession(dataDir, { title: "Cleanup" });
+    const server = await startHttpServer({ dataDir });
+    try {
+      const archived = await trpcPost<{ session: SessionRow }>(server, "sessions.archive", {
+        session_id: session.id,
+      });
+      expect(archived.session.status).toBe("archived");
+
+      const restored = await trpcPost<{ session: SessionRow }>(server, "sessions.restore", {
+        session_id: session.id,
+      });
+      expect(restored.session.status).toBe("active");
+
+      const deleted = await trpcPost<{ session: SessionRow }>(server, "sessions.delete", {
+        session_id: session.id,
+      });
+      expect(deleted.session.status).toBe("deleted");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("sessions.continue returns a handover package", async () => {
+    const dataDir = makeTempDir();
+    const session = seedSession(dataDir, { title: "Continue me" });
+    const server = await startHttpServer({ dataDir });
+    try {
+      const result = await trpcPost<{
+        session: SessionRow;
+        handover: { session: SessionRow };
+        text: string;
+        format: string;
+      }>(server, "sessions.continue", {
+        session_id: session.id,
+        target_harness: "claude-code",
+      });
+      expect(result.session.id).toBe(session.id);
+      expect(typeof result.text).toBe("string");
+      expect(result.text.length).toBeGreaterThan(0);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("sessions.promote turns a session fact into a memory", async () => {
+    const dataDir = makeTempDir();
+    const session = seedSession(dataDir, { title: "Source" });
+    const server = await startHttpServer({ dataDir });
+    try {
+      const result = await trpcPost<{
+        status: string;
+        memory?: { id: string; title: string };
+      }>(server, "sessions.promote", {
+        session_id: session.id,
+        memory: {
+          agent_id: "bede",
+          title: "Lesson from session",
+          body: "Promote facts via tRPC.",
+          category: "lessons",
+        },
+      });
+      expect(result.status).toBe("active");
+      expect(result.memory?.title).toBe("Lesson from session");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("sessions.checkpoint / pause / end / archive / restore / delete / continue / promote return NOT_FOUND for unknown ids", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const actions: [string, Record<string, unknown>][] = [
+        ["sessions.checkpoint", { session_id: "ses_nope", summary: "x" }],
+        ["sessions.pause", { session_id: "ses_nope" }],
+        ["sessions.end", { session_id: "ses_nope" }],
+        ["sessions.archive", { session_id: "ses_nope" }],
+        ["sessions.restore", { session_id: "ses_nope" }],
+        ["sessions.delete", { session_id: "ses_nope" }],
+        ["sessions.continue", { session_id: "ses_nope" }],
+        [
+          "sessions.promote",
+          {
+            session_id: "ses_nope",
+            memory: { agent_id: "bede", title: "x", body: "x", category: "lessons" },
+          },
+        ],
+      ];
+      for (const [path, body] of actions) {
+        const response = await fetch(`${server.url}/trpc/${path}`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${server.token}`,
+          },
+          body: JSON.stringify(body),
+        });
+        expect(response.status).toBe(404);
+        const json = (await response.json()) as TrpcErr;
+        expect(json.error?.data?.code).toBe("NOT_FOUND");
+      }
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+});


### PR DESCRIPTION
## Spec / phase reference

Implements **T4.5 — tRPC session procedures** (Phase 4 of `specs/maintainability-overhaul.md`). Blocks T6.5, T6.6. Builds on T4.3 + T4.2.

## Summary

- Mirrors `/api/sessions*` (list, get, events, search, checkpoint, pause, end, archive, restore, delete, continue, promote) as typed procedures on `appRouter.sessions`. REST routes stay live (deletion is T7.1).
- Inputs derived from `@librarian/core` Zod schemas (`SessionStatus`, `SessionPayloadType`, `SessionCaptureMode`, `Visibility`). Lifecycle inputs share one `SessionLifecycleInputSchema` to mirror what the REST handler accepts.
- Every store call is invoked with `admin: true` — admin gating is enforced once at the procedure boundary; the store skips per-row visibility filtering.

## Procedures

| Procedure | Kind | Mirrors |
|---|---|---|
| `sessions.list` | query | `GET /api/sessions?…` |
| `sessions.get` | query | `GET /api/sessions/:id` |
| `sessions.events` | query | `GET /api/sessions/:id/events?…` |
| `sessions.search` | query | `POST /api/sessions/search` |
| `sessions.checkpoint` | mutation | `POST /api/sessions/:id/checkpoint` |
| `sessions.pause` | mutation | `POST /api/sessions/:id/pause` |
| `sessions.end` | mutation | `POST /api/sessions/:id/end` |
| `sessions.archive` | mutation | `POST /api/sessions/:id/archive` |
| `sessions.restore` | mutation | `POST /api/sessions/:id/restore` |
| `sessions.delete` | mutation | `POST /api/sessions/:id/delete` |
| `sessions.continue` | mutation | `POST /api/sessions/:id/continue` |
| `sessions.promote` | mutation | `POST /api/sessions/:id/promote` |

Unknown ids surface as `TRPCError({ code: 'NOT_FOUND' })` from every read and mutating procedure.

## Test plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm lint`
- [x] `pnpm -r run typecheck`
- [x] `pnpm test` — 42 node:test + 183 vitest = **225/225** (12 new session tests; baseline floor 177)
- [x] `pnpm run check:test-count` / `check:storage-fixture` — green
- [x] `pnpm run smoke` — passed
- [x] `pnpm run healthcheck` — 5/5
- [x] All four wrappers (`integrations/{claude-code,codex,opencode,pi}/wrapper.sh ... -- echo ok`) — green

New tests cover: missing-token 401, list, list with `include_archived`, get (200 + 404), events stream + type filter, events 404, search by query, lifecycle (checkpoint → pause → end), archive → restore → delete, continue handover, promote-to-memory, and NOT_FOUND on all eight mutating procedures.

## Quality gates

- [x] **No production source file over 400 LOC introduced.** `sessions.ts` is 198 LOC.
- [x] **No new `any` or `@ts-ignore` introduced.** A small number of `as Record<string, unknown>` casts at the store boundary — same Phase 4 follow-up tracked in T4.4.

## Notes for the reviewer

- `agent_id` defaults to `"dashboard"` for mutations that don't receive one, mirroring REST.
- A small `runAdminAction` helper threads `session_id`, `agent_id`, and `admin: true` into the body for every lifecycle mutation. It also performs the 404 pre-check so the eight mutations don't each open-code the same fetch-then-call.
- `sessions.search` is a query (read-only) even though REST used POST — tRPC's GET-with-`?input=` URL-encoding handles the body fields fine, and `query` semantics match what `searchSessions` actually does.
- `sessions.events` requires `session_id` and pre-checks existence — same byte-identical behaviour as the REST route.
- `sessions.continue` returns the full `{ session, handover, text, format }` shape from `store.continueSession`; the existing handover tests in `core/tests/store/session-store.test.ts` already pin the contents.