### PR TITLE
feat(dashboard): tRPC client + admin auth wiring (T6.2)

### DIFF
--- a/apps/dashboard/app/health/page.tsx
+++ b/apps/dashboard/app/health/page.tsx
@@ -1,0 +1,20 @@
+import { serverTRPC } from "@/lib/trpc-server";
+
+export const dynamic = "force-dynamic";
+
+export default async function HealthPage() {
+  let payload: { ok: boolean; error?: string };
+  try {
+    const result = await serverTRPC.health.ping.query();
+    payload = result;
+  } catch (err) {
+    payload = { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+  return (
+    <main className="flex min-h-screen items-center justify-center p-8">
+      <pre className="rounded-md border bg-card p-6 font-mono text-sm text-card-foreground">
+        {JSON.stringify(payload)}
+      </pre>
+    </main>
+  );
+}

--- a/apps/dashboard/app/layout.tsx
+++ b/apps/dashboard/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { Providers } from "@/components/providers";
 import { ThemeProvider } from "@/components/theme-provider";
 import "./globals.css";
 
@@ -18,7 +19,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           enableSystem
           disableTransitionOnChange
         >
-          {children}
+          <Providers>{children}</Providers>
         </ThemeProvider>
       </body>
     </html>

--- a/apps/dashboard/components/providers.tsx
+++ b/apps/dashboard/components/providers.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { createBrowserTRPCClient, trpc } from "@/lib/trpc-client";
+
+export function Providers({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient());
+  const [trpcClient] = useState(() => createBrowserTRPCClient());
+  return (
+    <trpc.Provider client={trpcClient} queryClient={queryClient}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </trpc.Provider>
+  );
+}

--- a/apps/dashboard/lib/trpc-client.ts
+++ b/apps/dashboard/lib/trpc-client.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import type { AppRouter } from "@librarian/mcp-server";
+import { httpBatchLink } from "@trpc/client";
+import { createTRPCReact } from "@trpc/react-query";
+
+export const trpc = createTRPCReact<AppRouter>();
+
+export function createBrowserTRPCClient() {
+  return trpc.createClient({
+    links: [
+      httpBatchLink({
+        url: "/api/trpc",
+      }),
+    ],
+  });
+}

--- a/apps/dashboard/lib/trpc-server.ts
+++ b/apps/dashboard/lib/trpc-server.ts
@@ -2,13 +2,28 @@ import "server-only";
 import type { AppRouter } from "@librarian/mcp-server";
 import { createTRPCClient, httpBatchLink } from "@trpc/client";
 
+const DEFAULT_SERVER_URL = "http://127.0.0.1:3838";
+
 function resolveServerUrl(): string {
-  return process.env.LIBRARIAN_SERVER_URL ?? "http://127.0.0.1:3838";
+  return process.env.LIBRARIAN_SERVER_URL ?? DEFAULT_SERVER_URL;
 }
 
 function authHeaders(): Record<string, string> {
   const token = process.env.LIBRARIAN_ADMIN_TOKEN;
   return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+// Surface misconfiguration once at cold start so admin-gated procedures
+// don't silently return 401 in T6.3+ without a clue why.
+if (!process.env.LIBRARIAN_SERVER_URL) {
+  process.stderr.write(
+    `[trpc-server] LIBRARIAN_SERVER_URL unset; falling back to ${DEFAULT_SERVER_URL} (dev only).\n`,
+  );
+}
+if (!process.env.LIBRARIAN_ADMIN_TOKEN) {
+  process.stderr.write(
+    "[trpc-server] LIBRARIAN_ADMIN_TOKEN unset; admin tRPC calls will receive 401 until set.\n",
+  );
 }
 
 export function createServerTRPC() {

--- a/apps/dashboard/lib/trpc-server.ts
+++ b/apps/dashboard/lib/trpc-server.ts
@@ -1,0 +1,25 @@
+import "server-only";
+import type { AppRouter } from "@librarian/mcp-server";
+import { createTRPCClient, httpBatchLink } from "@trpc/client";
+
+function resolveServerUrl(): string {
+  return process.env.LIBRARIAN_SERVER_URL ?? "http://127.0.0.1:3838";
+}
+
+function authHeaders(): Record<string, string> {
+  const token = process.env.LIBRARIAN_ADMIN_TOKEN;
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+export function createServerTRPC() {
+  return createTRPCClient<AppRouter>({
+    links: [
+      httpBatchLink({
+        url: `${resolveServerUrl()}/trpc`,
+        headers: authHeaders,
+      }),
+    ],
+  });
+}
+
+export const serverTRPC = createServerTRPC();

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -15,6 +15,10 @@
     "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-slot": "^1.1.1",
     "@radix-ui/react-tabs": "^1.1.2",
+    "@tanstack/react-query": "^5.62.11",
+    "@trpc/client": "^11.0.0-rc.660",
+    "@trpc/react-query": "^11.0.0-rc.660",
+    "@trpc/server": "^11.0.0-rc.660",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.469.0",
@@ -22,9 +26,11 @@
     "next-themes": "^0.4.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "server-only": "^0.0.1",
     "tailwind-merge": "^2.6.0"
   },
   "devDependencies": {
+    "@librarian/mcp-server": "workspace:*",
     "@next/eslint-plugin-next": "^15.1.4",
     "@tailwindcss/postcss": "^4.0.0",
     "@types/node": "^22.10.5",

--- a/apps/dashboard/tests/health-page.test.tsx
+++ b/apps/dashboard/tests/health-page.test.tsx
@@ -1,0 +1,29 @@
+import { renderToString } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const pingMock = vi.fn();
+
+vi.mock("@/lib/trpc-server", () => ({
+  serverTRPC: {
+    health: { ping: { query: () => pingMock() } },
+  },
+}));
+
+const { default: HealthPage } = await import("../app/health/page");
+
+describe("apps/dashboard/app/health/page.tsx", () => {
+  afterEach(() => pingMock.mockReset());
+
+  it('renders {"ok":true} when the tRPC health.ping call succeeds', async () => {
+    pingMock.mockResolvedValueOnce({ ok: true });
+    const html = renderToString(await HealthPage());
+    expect(html).toMatch(/&quot;ok&quot;:true/);
+  });
+
+  it("renders the error payload when the call fails", async () => {
+    pingMock.mockRejectedValueOnce(new Error("boom"));
+    const html = renderToString(await HealthPage());
+    expect(html).toMatch(/&quot;ok&quot;:false/);
+    expect(html).toMatch(/boom/);
+  });
+});

--- a/apps/dashboard/tsconfig.json
+++ b/apps/dashboard/tsconfig.json
@@ -10,6 +10,8 @@
     "allowJs": true,
     "incremental": true,
     "verbatimModuleSyntax": false,
+    "declaration": false,
+    "declarationMap": false,
     "paths": {
       "@/*": ["./*"]
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,18 @@ importers:
       '@radix-ui/react-tabs':
         specifier: ^1.1.2
         version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@tanstack/react-query':
+        specifier: ^5.62.11
+        version: 5.100.11(react@19.2.6)
+      '@trpc/client':
+        specifier: ^11.0.0-rc.660
+        version: 11.17.0(@trpc/server@11.17.0(typescript@5.9.3))(typescript@5.9.3)
+      '@trpc/react-query':
+        specifier: ^11.0.0-rc.660
+        version: 11.17.0(@tanstack/react-query@5.100.11(react@19.2.6))(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@5.9.3))(typescript@5.9.3))(@trpc/server@11.17.0(typescript@5.9.3))(react@19.2.6)(typescript@5.9.3)
+      '@trpc/server':
+        specifier: ^11.0.0-rc.660
+        version: 11.17.0(typescript@5.9.3)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -89,10 +101,16 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.6(react@19.2.6)
+      server-only:
+        specifier: ^0.0.1
+        version: 0.0.1
       tailwind-merge:
         specifier: ^2.6.0
         version: 2.6.1
     devDependencies:
+      '@librarian/mcp-server':
+        specifier: workspace:*
+        version: link:../../packages/mcp-server
       '@next/eslint-plugin-next':
         specifier: ^15.1.4
         version: 15.5.18
@@ -1143,6 +1161,30 @@ packages:
 
   '@tailwindcss/postcss@4.3.0':
     resolution: {integrity: sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w==}
+
+  '@tanstack/query-core@5.100.11':
+    resolution: {integrity: sha512-lmE0994apShXPj8CUxgx4ch5yUJhE9k/+tVwihBvPOyerACWdBocfFg24t8+0RhtlTd7tEgchDkhlCxNssvDxw==}
+
+  '@tanstack/react-query@5.100.11':
+    resolution: {integrity: sha512-J0f9s5x3LE1450nNNfYx+e/n0DMa0uOBdFJUy5r0RvmsXd4nB/n0rbHtHI1vYXhikNFan+wf51p6Tmp4c8ucrg==}
+    peerDependencies:
+      react: ^18 || ^19
+
+  '@trpc/client@11.17.0':
+    resolution: {integrity: sha512-KpJBFrbKTDeVCFv/3ckL1XBBH5Yssn8hethI/rUy7GIpTj+VzjtPjykDqJpzobuVOz+d26cXCSu1t4I6MYI5Zg==}
+    hasBin: true
+    peerDependencies:
+      '@trpc/server': 11.17.0
+      typescript: '>=5.7.2'
+
+  '@trpc/react-query@11.17.0':
+    resolution: {integrity: sha512-AGcl5YAF8NnhBmyJ6PqJqKb1M5VTGSoNRNqJ3orct4o4epdcg0GWhW+qT9q6gPzs/2ImIwYCdfFpgNGdZ9yLHA==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.80.3
+      '@trpc/client': 11.17.0
+      '@trpc/server': 11.17.0
+      react: '>=18.2.0'
+      typescript: '>=5.7.2'
 
   '@trpc/server@11.17.0':
     resolution: {integrity: sha512-jbAOUe0PpUTCYqziyu+8vYXZdDXPudZgnEhWCQ2NjKnVEjfE93RqHTt1oycZJv/HNf51YlRXfEEwSIAbb161rw==}
@@ -2520,6 +2562,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
+
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
@@ -3644,6 +3689,26 @@ snapshots:
       '@tailwindcss/oxide': 4.3.0
       postcss: 8.5.14
       tailwindcss: 4.3.0
+
+  '@tanstack/query-core@5.100.11': {}
+
+  '@tanstack/react-query@5.100.11(react@19.2.6)':
+    dependencies:
+      '@tanstack/query-core': 5.100.11
+      react: 19.2.6
+
+  '@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@5.9.3))(typescript@5.9.3)':
+    dependencies:
+      '@trpc/server': 11.17.0(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@trpc/react-query@11.17.0(@tanstack/react-query@5.100.11(react@19.2.6))(@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@5.9.3))(typescript@5.9.3))(@trpc/server@11.17.0(typescript@5.9.3))(react@19.2.6)(typescript@5.9.3)':
+    dependencies:
+      '@tanstack/react-query': 5.100.11(react@19.2.6)
+      '@trpc/client': 11.17.0(@trpc/server@11.17.0(typescript@5.9.3))(typescript@5.9.3)
+      '@trpc/server': 11.17.0(typescript@5.9.3)
+      react: 19.2.6
+      typescript: 5.9.3
 
   '@trpc/server@11.17.0(typescript@5.9.3)':
     dependencies:
@@ -5184,6 +5249,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.8.0: {}
+
+  server-only@0.0.1: {}
 
   set-function-length@1.2.2:
     dependencies:


### PR DESCRIPTION
## Summary

- Wires two tRPC client surfaces to `@librarian/mcp-server` from `apps/dashboard`:
  - **`lib/trpc-server.ts`** — `server-only` vanilla tRPC HTTP client; reads `LIBRARIAN_SERVER_URL` (default `http://127.0.0.1:3838`) + `LIBRARIAN_ADMIN_TOKEN`, attaches `Authorization: Bearer …` per request.
  - **`lib/trpc-client.ts`** — `createTRPCReact<AppRouter>()` + `@tanstack/react-query`, pointing at the dashboard's own `/api/trpc` origin so the admin token never reaches the browser. The browser→server proxy route handler lands in T6.3.
- Adds a `Providers` Client Component (QueryClientProvider + trpc.Provider) mounted in the root layout.
- Adds a `/health` Server Component that calls `health.ping` via the server caller and renders the JSON payload. Verified live: `curl http://127.0.0.1:3000/health` → `{"ok":true}`.

## Acceptance (from `specs/maintainability-overhaul-tasks.md` T6.2)

- [x] Dashboard imports `AppRouter` (type-only) from `@librarian/mcp-server`.
- [x] Server-side caller in `apps/dashboard/lib/trpc-server.ts`.
- [x] Browser-side client in `apps/dashboard/lib/trpc-client.ts` via `@tanstack/react-query`.
- [x] Both authenticate with `LIBRARIAN_ADMIN_TOKEN` (server caller direct; browser via same-origin proxy that lands in T6.3).
- [x] Demo Server Component on `/health` renders `health.ping` result.

## Notable choices

- **Same-origin browser client.** The browser tRPC client points at `/api/trpc` on the dashboard origin (not the mcp-server directly). The route handler that proxies these requests server-to-server with the admin Bearer attached lands in T6.3 — that's the first PR that genuinely needs browser-side data fetching (memories list). Surface exists now so T6.3 only adds the proxy, not the client setup.
- **`server-only` guard.** `lib/trpc-server.ts` imports `server-only` so accidentally importing it from a Client Component throws at build time. Keeps the admin token from leaking client-side.
- **`declaration: false` on the dashboard tsconfig.** TS2742 fires when the inferred tRPC types reach into internal `@trpc/react-query` files that aren't reachable from the public surface (e.g., `getQueryKey.d-*.mjs`). The dashboard is an app and emits no `.d.ts`, so the declaration-portability check is moot. Scoped only to `apps/dashboard/`.
- **`@librarian/mcp-server` as a `devDependencies` entry.** Type-only import, never reached at runtime — devDep is the correct shape.
- **`force-dynamic` on `/health`.** The page calls a live mcp-server; static prerendering would freeze the response. Forces SSR.

## Verification

- [x] `pnpm install` (lockfile committed)
- [x] `pnpm --filter @librarian/dashboard build` — clean Next.js build (`/health` is `ƒ` Dynamic, as intended)
- [x] `pnpm typecheck` workspace-wide
- [x] `pnpm lint` workspace-wide
- [x] `pnpm format:check`
- [x] `pnpm test` — 252 tests (250 → 252), floor 177
- [x] `pnpm run check:test-count` (252 ≥ 177)
- [x] Live: `LIBRARIAN_ADMIN_TOKEN=… pnpm --filter @librarian/mcp-server serve` + `LIBRARIAN_SERVER_URL=… pnpm --filter @librarian/dashboard dev` + `curl http://127.0.0.1:3000/health` → `{"ok":true}`
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)