### PR TITLE
feat(dashboard): memories tabs — analytics, proposals, conflicts, archive, logs (T6.4)

### DIFF
--- a/apps/dashboard/app/(memories)/actions.ts
+++ b/apps/dashboard/app/(memories)/actions.ts
@@ -87,11 +87,20 @@ export async function updateMemoryAction(id: string, form: FormData): Promise<Ac
   }
 }
 
+function revalidateMemoryRoutes(): void {
+  // Approve/reject can move a row between the active list, the proposals
+  // queue, conflicts, and archive — revalidate all the views that read
+  // status-filtered memories so a navigation back doesn't show stale rows.
+  revalidatePath("/");
+  revalidatePath("/proposals");
+  revalidatePath("/conflicts");
+  revalidatePath("/archive");
+}
+
 export async function approveProposalAction(id: string): Promise<ActionResult> {
   try {
     await serverTRPC.memories.approve.mutate({ id });
-    revalidatePath("/");
-    revalidatePath("/proposals");
+    revalidateMemoryRoutes();
     return { ok: true };
   } catch (err) {
     return fail(err instanceof Error ? err.message : String(err));
@@ -101,7 +110,7 @@ export async function approveProposalAction(id: string): Promise<ActionResult> {
 export async function rejectProposalAction(id: string): Promise<ActionResult> {
   try {
     await serverTRPC.memories.reject.mutate({ id });
-    revalidatePath("/proposals");
+    revalidateMemoryRoutes();
     return { ok: true };
   } catch (err) {
     return fail(err instanceof Error ? err.message : String(err));

--- a/apps/dashboard/app/(memories)/actions.ts
+++ b/apps/dashboard/app/(memories)/actions.ts
@@ -87,6 +87,27 @@ export async function updateMemoryAction(id: string, form: FormData): Promise<Ac
   }
 }
 
+export async function approveProposalAction(id: string): Promise<ActionResult> {
+  try {
+    await serverTRPC.memories.approve.mutate({ id });
+    revalidatePath("/");
+    revalidatePath("/proposals");
+    return { ok: true };
+  } catch (err) {
+    return fail(err instanceof Error ? err.message : String(err));
+  }
+}
+
+export async function rejectProposalAction(id: string): Promise<ActionResult> {
+  try {
+    await serverTRPC.memories.reject.mutate({ id });
+    revalidatePath("/proposals");
+    return { ok: true };
+  } catch (err) {
+    return fail(err instanceof Error ? err.message : String(err));
+  }
+}
+
 export async function deleteMemoryAction(id: string): Promise<ActionResult> {
   try {
     await serverTRPC.memories.delete.mutate({ id });

--- a/apps/dashboard/app/(memories)/analytics/page.tsx
+++ b/apps/dashboard/app/(memories)/analytics/page.tsx
@@ -1,0 +1,78 @@
+import { serverTRPC } from "@/lib/trpc-server";
+
+export const dynamic = "force-dynamic";
+
+interface Slice {
+  value: unknown;
+  count: number;
+}
+
+const DIMENSIONS = [
+  { key: "agents", label: "By agent" },
+  { key: "categories", label: "By category" },
+  { key: "projects", label: "By project" },
+  { key: "statuses", label: "By status" },
+  { key: "scopes", label: "By scope" },
+] as const;
+
+export default async function AnalyticsPage() {
+  let aggregates: Awaited<ReturnType<typeof serverTRPC.memories.aggregates.query>> | null = null;
+  let error: string | null = null;
+  try {
+    aggregates = await serverTRPC.memories.aggregates.query();
+  } catch (err) {
+    error = err instanceof Error ? err.message : String(err);
+  }
+  return (
+    <main className="flex flex-col gap-6 p-6">
+      <h1 className="text-2xl font-semibold tracking-tight">Analytics</h1>
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+      {aggregates ? (
+        <div className="grid gap-6 lg:grid-cols-2">
+          {DIMENSIONS.map(({ key, label }) => (
+            <DimensionCard
+              key={key}
+              label={label}
+              data={(aggregates as unknown as Record<string, Slice[]>)[key] ?? []}
+            />
+          ))}
+        </div>
+      ) : null}
+    </main>
+  );
+}
+
+function DimensionCard({ label, data }: { label: string; data: Slice[] }) {
+  const total = data.reduce((sum, slice) => sum + slice.count, 0);
+  return (
+    <section className="rounded-md border bg-card p-4">
+      <header className="mb-3 flex items-baseline justify-between">
+        <h2 className="font-semibold">{label}</h2>
+        <span className="text-xs text-muted-foreground">total {total}</span>
+      </header>
+      {data.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No data.</p>
+      ) : (
+        <ul className="flex flex-col gap-2 text-sm">
+          {data.map((slice) => {
+            const pct = total === 0 ? 0 : Math.round((slice.count / total) * 100);
+            const value = slice.value == null ? "(none)" : String(slice.value);
+            return (
+              <li key={value} className="flex flex-col gap-1">
+                <div className="flex items-baseline justify-between gap-2">
+                  <span className="truncate">{value}</span>
+                  <span className="tabular-nums text-muted-foreground">
+                    {slice.count} · {pct}%
+                  </span>
+                </div>
+                <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+                  <div className="h-full rounded-full bg-primary" style={{ width: `${pct}%` }} />
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/apps/dashboard/app/(memories)/analytics/page.tsx
+++ b/apps/dashboard/app/(memories)/analytics/page.tsx
@@ -7,14 +7,6 @@ interface Slice {
   count: number;
 }
 
-const DIMENSIONS = [
-  { key: "agents", label: "By agent" },
-  { key: "categories", label: "By category" },
-  { key: "projects", label: "By project" },
-  { key: "statuses", label: "By status" },
-  { key: "scopes", label: "By scope" },
-] as const;
-
 export default async function AnalyticsPage() {
   let aggregates: Awaited<ReturnType<typeof serverTRPC.memories.aggregates.query>> | null = null;
   let error: string | null = null;
@@ -23,18 +15,23 @@ export default async function AnalyticsPage() {
   } catch (err) {
     error = err instanceof Error ? err.message : String(err);
   }
+  const dimensions = aggregates
+    ? [
+        { label: "By agent", data: aggregates.agents as Slice[] },
+        { label: "By category", data: aggregates.categories as Slice[] },
+        { label: "By project", data: aggregates.projects as Slice[] },
+        { label: "By status", data: aggregates.statuses as Slice[] },
+        { label: "By scope", data: aggregates.scopes as Slice[] },
+      ]
+    : [];
   return (
     <main className="flex flex-col gap-6 p-6">
       <h1 className="text-2xl font-semibold tracking-tight">Analytics</h1>
       {error ? <p className="text-sm text-destructive">{error}</p> : null}
-      {aggregates ? (
+      {dimensions.length > 0 ? (
         <div className="grid gap-6 lg:grid-cols-2">
-          {DIMENSIONS.map(({ key, label }) => (
-            <DimensionCard
-              key={key}
-              label={label}
-              data={(aggregates as unknown as Record<string, Slice[]>)[key] ?? []}
-            />
+          {dimensions.map(({ label, data }) => (
+            <DimensionCard key={label} label={label} data={data} />
           ))}
         </div>
       ) : null}

--- a/apps/dashboard/app/(memories)/archive/page.tsx
+++ b/apps/dashboard/app/(memories)/archive/page.tsx
@@ -1,0 +1,26 @@
+import { SimpleMemoryList } from "@/components/memories/simple-list";
+import type { MemoryRow } from "@/components/memories/types";
+import { serverTRPC } from "@/lib/trpc-server";
+
+export const dynamic = "force-dynamic";
+
+export default async function ArchivePage() {
+  let memories: MemoryRow[] = [];
+  let error: string | null = null;
+  try {
+    const result = await serverTRPC.memories.list.query({
+      status: "archived",
+      limit: 100,
+    } as Parameters<typeof serverTRPC.memories.list.query>[0]);
+    memories = result.memories as MemoryRow[];
+  } catch (err) {
+    error = err instanceof Error ? err.message : String(err);
+  }
+  return (
+    <main className="flex flex-col gap-4 p-6">
+      <h1 className="text-2xl font-semibold tracking-tight">Archive</h1>
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+      <SimpleMemoryList memories={memories} emptyMessage="No archived memories." />
+    </main>
+  );
+}

--- a/apps/dashboard/app/(memories)/conflicts/page.tsx
+++ b/apps/dashboard/app/(memories)/conflicts/page.tsx
@@ -1,0 +1,26 @@
+import { SimpleMemoryList } from "@/components/memories/simple-list";
+import type { MemoryRow } from "@/components/memories/types";
+import { serverTRPC } from "@/lib/trpc-server";
+
+export const dynamic = "force-dynamic";
+
+export default async function ConflictsPage() {
+  let memories: MemoryRow[] = [];
+  let error: string | null = null;
+  try {
+    const result = await serverTRPC.memories.list.query({
+      status: "conflicted",
+      limit: 100,
+    } as Parameters<typeof serverTRPC.memories.list.query>[0]);
+    memories = result.memories as MemoryRow[];
+  } catch (err) {
+    error = err instanceof Error ? err.message : String(err);
+  }
+  return (
+    <main className="flex flex-col gap-4 p-6">
+      <h1 className="text-2xl font-semibold tracking-tight">Conflicts</h1>
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+      <SimpleMemoryList memories={memories} emptyMessage="No conflicted memories." />
+    </main>
+  );
+}

--- a/apps/dashboard/app/(memories)/layout.tsx
+++ b/apps/dashboard/app/(memories)/layout.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from "react";
+import { TabNav } from "@/components/memories/tab-nav";
+
+export default function MemoriesLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <TabNav />
+      {children}
+    </div>
+  );
+}

--- a/apps/dashboard/app/(memories)/logs/page.tsx
+++ b/apps/dashboard/app/(memories)/logs/page.tsx
@@ -1,0 +1,12 @@
+import { LogsView } from "@/components/memories/logs-view";
+
+export const dynamic = "force-dynamic";
+
+export default function LogsPage() {
+  return (
+    <main className="flex flex-col gap-4 p-6">
+      <h1 className="text-2xl font-semibold tracking-tight">Logs</h1>
+      <LogsView />
+    </main>
+  );
+}

--- a/apps/dashboard/app/(memories)/proposals/page.tsx
+++ b/apps/dashboard/app/(memories)/proposals/page.tsx
@@ -1,0 +1,26 @@
+import { ProposalsView } from "@/components/memories/proposals-view";
+import type { MemoryRow } from "@/components/memories/types";
+import { serverTRPC } from "@/lib/trpc-server";
+
+export const dynamic = "force-dynamic";
+
+export default async function ProposalsPage() {
+  let memories: MemoryRow[] = [];
+  let error: string | null = null;
+  try {
+    const result = await serverTRPC.memories.list.query({
+      status: "proposed",
+      limit: 100,
+    } as Parameters<typeof serverTRPC.memories.list.query>[0]);
+    memories = result.memories as MemoryRow[];
+  } catch (err) {
+    error = err instanceof Error ? err.message : String(err);
+  }
+  return (
+    <main className="flex flex-col gap-4 p-6">
+      <h1 className="text-2xl font-semibold tracking-tight">Proposals</h1>
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+      <ProposalsView memories={memories} />
+    </main>
+  );
+}

--- a/apps/dashboard/components/memories/logs-view.tsx
+++ b/apps/dashboard/components/memories/logs-view.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { trpc } from "@/lib/trpc-client";
+
+const EVENT_TYPES = [
+  "memory.recall_empty",
+  "memory.recalled",
+  "memory.verified",
+  "memory.created",
+  "memory.proposed",
+  "memory.updated",
+  "memory.deleted",
+  "memory.approved",
+  "memory.rejected",
+  "memory.conflict_detected",
+  "memory.conflict_resolved",
+] as const;
+
+const PAGE_SIZE = 25;
+
+export function LogsView() {
+  const [type, setType] = useState("");
+  const [agentId, setAgentId] = useState("");
+  const [query, setQuery] = useState("");
+  const [offset, setOffset] = useState(0);
+
+  const input = {
+    limit: PAGE_SIZE,
+    offset,
+    ...(type ? { type } : {}),
+    ...(agentId ? { agent_id: agentId } : {}),
+    ...(query ? { query } : {}),
+  } as Parameters<typeof trpc.memories.events.useQuery>[0];
+
+  const eventsQuery = trpc.memories.events.useQuery(input);
+  const events = eventsQuery.data?.events ?? [];
+  const total = eventsQuery.data?.total ?? 0;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-end gap-3 rounded-md border bg-card p-3 text-sm">
+        <label className="flex flex-col gap-1">
+          <span className="text-xs text-muted-foreground">Event type</span>
+          <select
+            className="h-9 rounded-md border border-input bg-background px-2"
+            value={type}
+            onChange={(e) => {
+              setType(e.target.value);
+              setOffset(0);
+            }}
+          >
+            <option value="">All event types</option>
+            {EVENT_TYPES.map((t) => (
+              <option key={t}>{t}</option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-xs text-muted-foreground">Agent</span>
+          <Input
+            value={agentId}
+            placeholder="agent id"
+            onChange={(e) => {
+              setAgentId(e.target.value);
+              setOffset(0);
+            }}
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-xs text-muted-foreground">Search</span>
+          <Input
+            value={query}
+            placeholder="log search"
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setOffset(0);
+            }}
+          />
+        </label>
+        <div className="ml-auto flex items-center gap-2 text-xs text-muted-foreground">
+          {total
+            ? `${offset + 1}–${Math.min(offset + events.length, total)} of ${total}`
+            : "0 logs"}
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={offset === 0}
+            onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+          >
+            Previous
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={offset + events.length >= total}
+            onClick={() => setOffset(offset + PAGE_SIZE)}
+          >
+            Next
+          </Button>
+        </div>
+      </div>
+      {eventsQuery.isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : eventsQuery.isError ? (
+        <p className="text-sm text-destructive">Failed to load logs: {eventsQuery.error.message}</p>
+      ) : events.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No logs match these filters.</p>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {events.map((event) => (
+            <li key={event.event_id} className="rounded-md border bg-card p-3 text-sm">
+              <div className="flex items-baseline justify-between gap-2">
+                <div className="flex items-center gap-2">
+                  <Badge variant="outline">{event.event_type}</Badge>
+                  <span className="text-xs text-muted-foreground">{event.agent_id}</span>
+                </div>
+                <span className="text-xs text-muted-foreground">
+                  {new Date(event.created_at).toLocaleString()}
+                </span>
+              </div>
+              <pre className="mt-2 overflow-x-auto rounded-md bg-muted/40 p-2 text-xs">
+                {JSON.stringify(event.payload, null, 2)}
+              </pre>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/dashboard/components/memories/logs-view.tsx
+++ b/apps/dashboard/components/memories/logs-view.tsx
@@ -20,11 +20,15 @@ const EVENT_TYPES = [
   "memory.conflict_resolved",
 ] as const;
 
+const VERIFICATION_RESULTS = ["useful", "not_useful", "outdated", "wrong"] as const;
+
 const PAGE_SIZE = 25;
 
 export function LogsView() {
   const [type, setType] = useState("");
+  const [result, setResult] = useState("");
   const [agentId, setAgentId] = useState("");
+  const [memoryId, setMemoryId] = useState("");
   const [query, setQuery] = useState("");
   const [offset, setOffset] = useState(0);
 
@@ -32,7 +36,9 @@ export function LogsView() {
     limit: PAGE_SIZE,
     offset,
     ...(type ? { type } : {}),
+    ...(result ? { result } : {}),
     ...(agentId ? { agent_id: agentId } : {}),
+    ...(memoryId ? { memory_id: memoryId } : {}),
     ...(query ? { query } : {}),
   } as Parameters<typeof trpc.memories.events.useQuery>[0];
 
@@ -55,7 +61,27 @@ export function LogsView() {
           >
             <option value="">All event types</option>
             {EVENT_TYPES.map((t) => (
-              <option key={t}>{t}</option>
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-xs text-muted-foreground">Verification result</span>
+          <select
+            className="h-9 rounded-md border border-input bg-background px-2"
+            value={result}
+            onChange={(e) => {
+              setResult(e.target.value);
+              setOffset(0);
+            }}
+          >
+            <option value="">All results</option>
+            {VERIFICATION_RESULTS.map((r) => (
+              <option key={r} value={r}>
+                {r}
+              </option>
             ))}
           </select>
         </label>
@@ -66,6 +92,17 @@ export function LogsView() {
             placeholder="agent id"
             onChange={(e) => {
               setAgentId(e.target.value);
+              setOffset(0);
+            }}
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-xs text-muted-foreground">Memory ID</span>
+          <Input
+            value={memoryId}
+            placeholder="memory id"
+            onChange={(e) => {
+              setMemoryId(e.target.value);
               setOffset(0);
             }}
           />

--- a/apps/dashboard/components/memories/proposals-view.tsx
+++ b/apps/dashboard/components/memories/proposals-view.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { SimpleMemoryList } from "./simple-list";
+import type { MemoryRow } from "./types";
+import { approveProposalAction, rejectProposalAction } from "@/app/(memories)/actions";
+
+export function ProposalsView({ memories }: { memories: MemoryRow[] }) {
+  const router = useRouter();
+  return (
+    <SimpleMemoryList
+      memories={memories}
+      emptyMessage="No proposals pending."
+      actions={[
+        {
+          label: "Approve",
+          variant: "default",
+          onAction: async (id) => {
+            await approveProposalAction(id);
+            router.refresh();
+          },
+        },
+        {
+          label: "Reject",
+          variant: "destructive",
+          onAction: async (id) => {
+            await rejectProposalAction(id);
+            router.refresh();
+          },
+        },
+      ]}
+    />
+  );
+}

--- a/apps/dashboard/components/memories/simple-list.tsx
+++ b/apps/dashboard/components/memories/simple-list.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useTransition } from "react";
+import type { MemoryRow } from "./types";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+interface Action {
+  label: string;
+  variant?: "default" | "destructive" | "outline" | "secondary";
+  onAction: (id: string) => Promise<void>;
+}
+
+interface Props {
+  memories: MemoryRow[];
+  emptyMessage: string;
+  actions?: Action[];
+}
+
+export function SimpleMemoryList({ memories, emptyMessage, actions = [] }: Props) {
+  const [pending, startTransition] = useTransition();
+  if (memories.length === 0) {
+    return <p className="text-sm text-muted-foreground">{emptyMessage}</p>;
+  }
+  return (
+    <ul className="flex flex-col gap-2">
+      {memories.map((memory) => (
+        <li key={memory.id} className="rounded-md border bg-card p-3">
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0">
+              <h3 className="truncate font-medium">{memory.title || "(untitled)"}</h3>
+              <p className="line-clamp-2 text-sm text-muted-foreground">{memory.body}</p>
+              <div className="mt-1 flex flex-wrap items-center gap-1 text-xs text-muted-foreground">
+                <Badge variant="outline">{memory.category}</Badge>
+                <span>{memory.visibility}</span>
+                <span>·</span>
+                <span>{memory.scope}</span>
+                {memory.agent_id ? (
+                  <>
+                    <span>·</span>
+                    <span>{memory.agent_id}</span>
+                  </>
+                ) : null}
+                <span>·</span>
+                <span>{new Date(memory.updated_at).toLocaleDateString()}</span>
+              </div>
+            </div>
+            {actions.length > 0 ? (
+              <div className="flex shrink-0 gap-2">
+                {actions.map((action) => (
+                  <Button
+                    key={action.label}
+                    variant={action.variant ?? "outline"}
+                    size="sm"
+                    disabled={pending}
+                    onClick={() => startTransition(() => action.onAction(memory.id))}
+                  >
+                    {action.label}
+                  </Button>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/dashboard/components/memories/simple-list.tsx
+++ b/apps/dashboard/components/memories/simple-list.tsx
@@ -53,7 +53,11 @@ export function SimpleMemoryList({ memories, emptyMessage, actions = [] }: Props
                     variant={action.variant ?? "outline"}
                     size="sm"
                     disabled={pending}
-                    onClick={() => startTransition(() => action.onAction(memory.id))}
+                    onClick={() =>
+                      startTransition(async () => {
+                        await action.onAction(memory.id);
+                      })
+                    }
                   >
                     {action.label}
                   </Button>

--- a/apps/dashboard/components/memories/tab-nav.tsx
+++ b/apps/dashboard/components/memories/tab-nav.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const TABS = [
+  { href: "/", label: "Browse", match: (p: string) => p === "/" },
+  { href: "/sessions", label: "Sessions", match: (p: string) => p.startsWith("/sessions") },
+  { href: "/analytics", label: "Analytics", match: (p: string) => p === "/analytics" },
+  { href: "/proposals", label: "Proposals", match: (p: string) => p === "/proposals" },
+  { href: "/conflicts", label: "Conflicts", match: (p: string) => p === "/conflicts" },
+  { href: "/archive", label: "Archive", match: (p: string) => p === "/archive" },
+  { href: "/logs", label: "Logs", match: (p: string) => p === "/logs" },
+] as const;
+
+export function TabNav() {
+  const pathname = usePathname();
+  return (
+    <nav className="flex flex-wrap items-center gap-1 border-b bg-muted/20 px-4 py-2 text-sm">
+      {TABS.map((tab) => {
+        const active = tab.match(pathname);
+        return (
+          <Link
+            key={tab.href}
+            href={tab.href}
+            aria-current={active ? "page" : undefined}
+            className={`rounded-md px-3 py-1.5 transition-colors ${
+              active
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            {tab.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary

- Lands the remaining Browse-tab siblings as Next routes under the `(memories)` route group, sharing a `TabNav` layout.
- New pages: `/analytics`, `/proposals` (with approve/reject actions), `/conflicts`, `/archive`, `/logs`.
- Extends Server Actions with `approveProposalAction` / `rejectProposalAction`.

## Acceptance (T6.4)

- [x] All remaining tabs of the legacy dashboard land as routes under `app/`: `/analytics`, `/proposals`, `/conflicts`, `/archive`, `/logs`.
- [x] Each matches the legacy behaviour (proposals approve/reject, conflicts/archive read-only lists, logs with event-type / agent / search filters + pagination).
- [x] Analytics dependency justified (see "Notable choices").

## Notable choices

- **Recharts intentionally not added.** Spec wrote "Recharts (or similar)". Five CSS bar lists carry the same signal as the legacy doughnut grid without pulling in a ~200 kB chart library. If we later need real charts (time series, stacked, etc.), adding Recharts is a focused follow-up PR. Decision called out so reviewer can push back if they disagree.

- **Shared `(memories)` layout for the tab nav.** Route groups don't add URL segments, so `(memories)/layout.tsx` wraps Browse (`/`) + each tab without changing the routes. `TabNav` is a Client Component (needs `usePathname` for active-state). Sessions is included in the nav even though its route handler lands in T6.5/T6.6 — clicking it currently 404s; that's the natural seam to test the nav once T6.5 lands.

- **`router.refresh()` after proposal actions.** Server Actions revalidate the path, then the client component triggers `router.refresh()` so the list re-fetches without a full navigation.

- **`SimpleMemoryList`** is the shared row renderer used by proposals/conflicts/archive — same memory shape, optional row-level actions, no detail panel (legacy didn't have one on those tabs either).

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm test` — 257 (no new tests this PR; existing 8 dashboard + 249 workspace)
- [x] `pnpm --filter @librarian/dashboard build` — clean; routes `/`, `/analytics`, `/api/trpc/[trpc]`, `/archive`, `/conflicts`, `/health`, `/logs`, `/proposals` all dynamic (`ƒ`)
- [x] `pnpm run check:test-count` (257 ≥ 177)
- [ ] CI green
- [ ] Live side-by-side with the legacy dashboard during Jim's review

🤖 Generated with [Claude Code](https://claude.com/claude-code)