### PR TITLE
feat(dashboard): session detail + lifecycle + handover + promote (T6.6)

### DIFF
--- a/apps/dashboard/app/sessions/[id]/actions.ts
+++ b/apps/dashboard/app/sessions/[id]/actions.ts
@@ -119,6 +119,24 @@ export async function deleteSessionAction(
 
 export type ContinueResult = { ok: true; handover: unknown } | { ok: false; error: string };
 
+type HandoverFormat = "prose" | "markdown" | "claude" | "codex" | "opencode" | "hermes" | "pi";
+const ALLOWED_FORMATS: readonly HandoverFormat[] = [
+  "prose",
+  "markdown",
+  "claude",
+  "codex",
+  "opencode",
+  "hermes",
+  "pi",
+];
+
+function resolveFormat(form: FormData): HandoverFormat {
+  const raw = asString(form, "format");
+  return (ALLOWED_FORMATS as readonly string[]).includes(raw ?? "")
+    ? (raw as HandoverFormat)
+    : "prose";
+}
+
 export async function continueSessionAction(
   sessionId: string,
   form: FormData,
@@ -130,6 +148,7 @@ export async function continueSessionAction(
       target_cwd: asString(form, "target_cwd"),
       target_source_ref: asString(form, "target_source_ref"),
       attach: form.get("attach") === "on",
+      format: resolveFormat(form),
     });
     revalidateSession(sessionId);
     return { ok: true, handover };

--- a/apps/dashboard/app/sessions/[id]/actions.ts
+++ b/apps/dashboard/app/sessions/[id]/actions.ts
@@ -1,0 +1,164 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { serverTRPC } from "@/lib/trpc-server";
+
+type ActionResult = { ok: true } | { ok: false; error: string };
+
+function fail(message: string): ActionResult {
+  return { ok: false, error: message };
+}
+
+function asString(form: FormData, key: string): string | undefined {
+  const value = form.get(key);
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function asList(form: FormData, key: string): string[] | undefined {
+  const raw = form.get(key);
+  if (typeof raw !== "string") return undefined;
+  const items = raw
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  return items.length > 0 ? items : undefined;
+}
+
+function revalidateSession(id: string): void {
+  revalidatePath("/sessions");
+  revalidatePath(`/sessions/${id}`);
+}
+
+function lifecycleInput(sessionId: string, form: FormData) {
+  return {
+    session_id: sessionId,
+    summary: asString(form, "summary"),
+    decisions: asList(form, "decisions"),
+    files_touched: asList(form, "files_touched"),
+    commands_run: asList(form, "commands_run"),
+    open_questions: asList(form, "open_questions"),
+    next_steps: asList(form, "next_steps"),
+    reason: asString(form, "reason"),
+  };
+}
+
+export async function checkpointSessionAction(
+  sessionId: string,
+  form: FormData,
+): Promise<ActionResult> {
+  try {
+    await serverTRPC.sessions.checkpoint.mutate(lifecycleInput(sessionId, form));
+    revalidateSession(sessionId);
+    return { ok: true };
+  } catch (err) {
+    return fail(err instanceof Error ? err.message : String(err));
+  }
+}
+
+export async function pauseSessionAction(sessionId: string, form: FormData): Promise<ActionResult> {
+  try {
+    await serverTRPC.sessions.pause.mutate(lifecycleInput(sessionId, form));
+    revalidateSession(sessionId);
+    return { ok: true };
+  } catch (err) {
+    return fail(err instanceof Error ? err.message : String(err));
+  }
+}
+
+export async function endSessionAction(sessionId: string, form: FormData): Promise<ActionResult> {
+  try {
+    await serverTRPC.sessions.end.mutate(lifecycleInput(sessionId, form));
+    revalidateSession(sessionId);
+    return { ok: true };
+  } catch (err) {
+    return fail(err instanceof Error ? err.message : String(err));
+  }
+}
+
+export async function archiveSessionAction(
+  sessionId: string,
+  reason?: string,
+): Promise<ActionResult> {
+  try {
+    await serverTRPC.sessions.archive.mutate({
+      session_id: sessionId,
+      ...(reason ? { reason } : {}),
+    });
+    revalidateSession(sessionId);
+    return { ok: true };
+  } catch (err) {
+    return fail(err instanceof Error ? err.message : String(err));
+  }
+}
+
+export async function restoreSessionAction(sessionId: string): Promise<ActionResult> {
+  try {
+    await serverTRPC.sessions.restore.mutate({ session_id: sessionId });
+    revalidateSession(sessionId);
+    return { ok: true };
+  } catch (err) {
+    return fail(err instanceof Error ? err.message : String(err));
+  }
+}
+
+export async function deleteSessionAction(
+  sessionId: string,
+  reason?: string,
+): Promise<ActionResult> {
+  try {
+    await serverTRPC.sessions.delete.mutate({
+      session_id: sessionId,
+      ...(reason ? { reason } : {}),
+    });
+    revalidateSession(sessionId);
+    return { ok: true };
+  } catch (err) {
+    return fail(err instanceof Error ? err.message : String(err));
+  }
+}
+
+export type ContinueResult = { ok: true; handover: unknown } | { ok: false; error: string };
+
+export async function continueSessionAction(
+  sessionId: string,
+  form: FormData,
+): Promise<ContinueResult> {
+  try {
+    const handover = await serverTRPC.sessions.continue.mutate({
+      session_id: sessionId,
+      target_harness: asString(form, "target_harness"),
+      target_cwd: asString(form, "target_cwd"),
+      target_source_ref: asString(form, "target_source_ref"),
+      attach: form.get("attach") === "on",
+    });
+    revalidateSession(sessionId);
+    return { ok: true, handover };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export async function promoteSessionFactAction(
+  sessionId: string,
+  form: FormData,
+): Promise<ActionResult> {
+  const title = asString(form, "memory_title");
+  const body = asString(form, "memory_body");
+  if (!title || !body) return fail("Memory title and body are required.");
+  try {
+    await serverTRPC.sessions.promote.mutate({
+      session_id: sessionId,
+      memory: {
+        title,
+        body,
+        category: asString(form, "memory_category") ?? "lessons",
+        visibility: asString(form, "memory_visibility") ?? "common",
+        scope: asString(form, "memory_scope") ?? "global",
+      },
+    });
+    revalidateSession(sessionId);
+    return { ok: true };
+  } catch (err) {
+    return fail(err instanceof Error ? err.message : String(err));
+  }
+}

--- a/apps/dashboard/app/sessions/[id]/page.tsx
+++ b/apps/dashboard/app/sessions/[id]/page.tsx
@@ -1,0 +1,32 @@
+import { notFound } from "next/navigation";
+import { SessionDetailView } from "@/components/sessions/detail-view";
+import type { SessionRow } from "@/components/sessions/types";
+import { serverTRPC } from "@/lib/trpc-server";
+
+export const dynamic = "force-dynamic";
+
+export default async function SessionDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  let session: SessionRow | null = null;
+  let error: string | null = null;
+  try {
+    const result = await serverTRPC.sessions.get.query({ session_id: id });
+    session = result.session as SessionRow;
+  } catch (err) {
+    if (err instanceof Error && /not found/i.test(err.message)) notFound();
+    error = err instanceof Error ? err.message : String(err);
+  }
+  if (!session) {
+    return (
+      <main className="flex flex-col gap-4 p-6">
+        <h1 className="text-2xl font-semibold tracking-tight">Session</h1>
+        <p className="text-sm text-destructive">Failed to load session: {error ?? "not found"}</p>
+      </main>
+    );
+  }
+  return (
+    <main className="flex flex-col gap-6 p-6">
+      <SessionDetailView session={session} />
+    </main>
+  );
+}

--- a/apps/dashboard/app/sessions/[id]/page.tsx
+++ b/apps/dashboard/app/sessions/[id]/page.tsx
@@ -11,7 +11,7 @@ export default async function SessionDetailPage({ params }: { params: Promise<{ 
   let error: string | null = null;
   try {
     const result = await serverTRPC.sessions.get.query({ session_id: id });
-    session = result.session as SessionRow;
+    session = result as SessionRow;
   } catch (err) {
     if (err instanceof Error && /not found/i.test(err.message)) notFound();
     error = err instanceof Error ? err.message : String(err);

--- a/apps/dashboard/components/sessions/detail-view.tsx
+++ b/apps/dashboard/components/sessions/detail-view.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { EventsStream } from "./events-stream";
+import { HandoverForm } from "./handover-form";
+import { LifecycleActions } from "./lifecycle-actions";
+import { PromoteForm } from "./promote-form";
+import { isStale, type SessionRow } from "./types";
+import { Badge } from "@/components/ui/badge";
+
+export function SessionDetailView({ session }: { session: SessionRow }) {
+  const stale = isStale(session);
+  return (
+    <div className="flex flex-col gap-6">
+      <header className="flex flex-col gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant={badgeVariantForStatus(session.status)}>{session.status}</Badge>
+          {stale ? <Badge variant="destructive">stale</Badge> : null}
+          <h1 className="text-2xl font-semibold tracking-tight">{session.title || "(untitled)"}</h1>
+        </div>
+        <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-muted-foreground md:grid-cols-3 lg:grid-cols-4">
+          <Field label="id" value={session.id} mono />
+          <Field label="project" value={session.project_key ?? "(none)"} />
+          <Field label="visibility" value={session.visibility} />
+          <Field
+            label="harness"
+            value={session.current_harness ?? session.created_in_harness ?? "(unattached)"}
+          />
+          <Field
+            label="agent"
+            value={session.current_agent_id ?? session.created_by_agent_id ?? "(no agent)"}
+          />
+          <Field label="source" value={session.source_ref ?? "(none)"} />
+          <Field label="started" value={new Date(session.started_at).toLocaleString()} />
+          <Field
+            label="last activity"
+            value={new Date(session.last_activity_at).toLocaleString()}
+          />
+        </dl>
+      </header>
+
+      <SummarySection
+        startSummary={session.start_summary}
+        rollingSummary={session.rolling_summary}
+        endSummary={session.end_summary}
+        nextSteps={session.next_steps}
+      />
+
+      <LifecycleActions session={session} />
+
+      <section className="rounded-md border bg-card p-4">
+        <h2 className="mb-3 text-lg font-semibold">Events</h2>
+        <EventsStream sessionId={session.id} />
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        <HandoverForm sessionId={session.id} />
+        <PromoteForm sessionId={session.id} />
+      </section>
+    </div>
+  );
+}
+
+function SummarySection({
+  startSummary,
+  rollingSummary,
+  endSummary,
+  nextSteps,
+}: {
+  startSummary: string | null;
+  rollingSummary: string | null;
+  endSummary: string | null;
+  nextSteps: readonly string[];
+}) {
+  return (
+    <section className="grid gap-3 md:grid-cols-3">
+      <SummaryCard label="Start summary" body={startSummary} />
+      <SummaryCard label="Rolling summary" body={rollingSummary} />
+      <SummaryCard label="End summary" body={endSummary} />
+      <div className="md:col-span-3">
+        <h3 className="mb-2 text-sm font-medium text-muted-foreground">Next steps</h3>
+        {nextSteps.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No next steps recorded.</p>
+        ) : (
+          <ul className="list-inside list-disc text-sm">
+            {nextSteps.map((step, idx) => (
+              <li key={idx}>{step}</li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function SummaryCard({ label, body }: { label: string; body: string | null }) {
+  return (
+    <div className="rounded-md border bg-card p-3">
+      <h3 className="mb-2 text-sm font-medium text-muted-foreground">{label}</h3>
+      {body ? (
+        <p className="whitespace-pre-wrap text-sm">{body}</p>
+      ) : (
+        <p className="text-sm text-muted-foreground">(none)</p>
+      )}
+    </div>
+  );
+}
+
+function Field({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div className="flex flex-col">
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className={mono ? "font-mono text-foreground" : "text-foreground"}>{value}</dd>
+    </div>
+  );
+}
+
+function badgeVariantForStatus(
+  status: SessionRow["status"],
+): "default" | "secondary" | "destructive" | "outline" {
+  if (status === "active") return "default";
+  if (status === "paused") return "secondary";
+  if (status === "deleted") return "destructive";
+  if (status === "archived") return "secondary";
+  return "outline";
+}

--- a/apps/dashboard/components/sessions/events-stream.tsx
+++ b/apps/dashboard/components/sessions/events-stream.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { trpc } from "@/lib/trpc-client";
+
+const PAGE_SIZE = 50;
+
+export function EventsStream({ sessionId }: { sessionId: string }) {
+  const events = trpc.sessions.events.useQuery({ session_id: sessionId, limit: PAGE_SIZE });
+  const rows = events.data?.events ?? [];
+
+  if (events.isLoading) {
+    return <p className="text-sm text-muted-foreground">Loading events…</p>;
+  }
+  if (events.isError) {
+    return (
+      <p className="text-sm text-destructive">Failed to load events: {events.error.message}</p>
+    );
+  }
+  if (rows.length === 0) {
+    return <p className="text-sm text-muted-foreground">No events recorded yet.</p>;
+  }
+  return (
+    <div className="flex flex-col gap-2">
+      <ul className="flex flex-col gap-2">
+        {rows.map((event) => (
+          <li key={event.id} className="rounded-md border bg-background p-3 text-sm">
+            <div className="flex items-baseline justify-between gap-2">
+              <div className="flex items-center gap-2">
+                <Badge variant="outline">{event.type}</Badge>
+                <span className="text-xs text-muted-foreground">{event.agent_id ?? "—"}</span>
+              </div>
+              <span className="text-xs text-muted-foreground">
+                {new Date(event.created_at).toLocaleString()}
+              </span>
+            </div>
+            <pre className="mt-2 overflow-x-auto rounded-md bg-muted/40 p-2 text-xs">
+              {JSON.stringify(event.payload, null, 2)}
+            </pre>
+          </li>
+        ))}
+      </ul>
+      <Button variant="ghost" size="sm" onClick={() => events.refetch()}>
+        Refresh
+      </Button>
+    </div>
+  );
+}

--- a/apps/dashboard/components/sessions/handover-form.tsx
+++ b/apps/dashboard/components/sessions/handover-form.tsx
@@ -6,10 +6,18 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
 const HARNESSES = ["claude-code", "codex", "opencode", "hermes", "pi"] as const;
+const FORMATS = ["prose", "markdown", "claude", "codex", "opencode", "hermes", "pi"] as const;
+
+interface HandoverPayload {
+  text?: string;
+  format?: string;
+  handover?: unknown;
+}
 
 export function HandoverForm({ sessionId }: { sessionId: string }) {
   const [error, setError] = useState<string | null>(null);
-  const [handover, setHandover] = useState<unknown>(null);
+  const [payload, setPayload] = useState<HandoverPayload | null>(null);
+  const [showRaw, setShowRaw] = useState(false);
   const [pending, startTransition] = useTransition();
   return (
     <section className="rounded-md border bg-card p-4">
@@ -23,31 +31,48 @@ export function HandoverForm({ sessionId }: { sessionId: string }) {
           startTransition(async () => {
             const result = await continueSessionAction(sessionId, form);
             if (result.ok) {
-              setHandover(result.handover);
+              setPayload(result.handover as HandoverPayload);
               setError(null);
+              setShowRaw(false);
             } else {
               setError(result.error);
-              setHandover(null);
+              setPayload(null);
             }
           })
         }
         className="flex flex-col gap-3 text-sm"
       >
-        <label className="flex flex-col gap-1">
-          <span className="text-muted-foreground">Target harness</span>
-          <select
-            name="target_harness"
-            className="h-9 rounded-md border border-input bg-background px-2"
-            defaultValue=""
-          >
-            <option value="">(unchanged)</option>
-            {HARNESSES.map((h) => (
-              <option key={h} value={h}>
-                {h}
-              </option>
-            ))}
-          </select>
-        </label>
+        <div className="grid grid-cols-2 gap-3">
+          <label className="flex flex-col gap-1">
+            <span className="text-muted-foreground">Target harness</span>
+            <select
+              name="target_harness"
+              className="h-9 rounded-md border border-input bg-background px-2"
+              defaultValue=""
+            >
+              <option value="">(unchanged)</option>
+              {HARNESSES.map((h) => (
+                <option key={h} value={h}>
+                  {h}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-muted-foreground">Format</span>
+            <select
+              name="format"
+              defaultValue="prose"
+              className="h-9 rounded-md border border-input bg-background px-2"
+            >
+              {FORMATS.map((f) => (
+                <option key={f} value={f}>
+                  {f}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
         <label className="flex flex-col gap-1">
           <span className="text-muted-foreground">Target cwd</span>
           <Input name="target_cwd" placeholder="/absolute/path" />
@@ -65,10 +90,24 @@ export function HandoverForm({ sessionId }: { sessionId: string }) {
           {pending ? "Building…" : "Continue session"}
         </Button>
       </form>
-      {handover ? (
-        <pre className="mt-3 max-h-72 overflow-auto rounded-md bg-muted/40 p-3 text-xs">
-          {JSON.stringify(handover, null, 2)}
-        </pre>
+      {payload?.text ? (
+        <div className="mt-3 flex flex-col gap-2">
+          <pre className="max-h-72 overflow-auto rounded-md bg-muted/40 p-3 text-xs whitespace-pre-wrap">
+            {payload.text}
+          </pre>
+          <button
+            type="button"
+            className="self-start text-xs text-muted-foreground hover:text-foreground"
+            onClick={() => setShowRaw((v) => !v)}
+          >
+            {showRaw ? "Hide" : "Show"} raw handover JSON
+          </button>
+          {showRaw ? (
+            <pre className="max-h-72 overflow-auto rounded-md bg-muted/40 p-3 text-xs">
+              {JSON.stringify(payload.handover, null, 2)}
+            </pre>
+          ) : null}
+        </div>
       ) : null}
     </section>
   );

--- a/apps/dashboard/components/sessions/handover-form.tsx
+++ b/apps/dashboard/components/sessions/handover-form.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { continueSessionAction } from "@/app/sessions/[id]/actions";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+const HARNESSES = ["claude-code", "codex", "opencode", "hermes", "pi"] as const;
+
+export function HandoverForm({ sessionId }: { sessionId: string }) {
+  const [error, setError] = useState<string | null>(null);
+  const [handover, setHandover] = useState<unknown>(null);
+  const [pending, startTransition] = useTransition();
+  return (
+    <section className="rounded-md border bg-card p-4">
+      <h2 className="mb-2 text-lg font-semibold">Continue / handover</h2>
+      <p className="mb-3 text-sm text-muted-foreground">
+        Build a handover packet for a new agent. Set the target harness to format the payload for
+        that runtime.
+      </p>
+      <form
+        action={(form) =>
+          startTransition(async () => {
+            const result = await continueSessionAction(sessionId, form);
+            if (result.ok) {
+              setHandover(result.handover);
+              setError(null);
+            } else {
+              setError(result.error);
+              setHandover(null);
+            }
+          })
+        }
+        className="flex flex-col gap-3 text-sm"
+      >
+        <label className="flex flex-col gap-1">
+          <span className="text-muted-foreground">Target harness</span>
+          <select
+            name="target_harness"
+            className="h-9 rounded-md border border-input bg-background px-2"
+            defaultValue=""
+          >
+            <option value="">(unchanged)</option>
+            {HARNESSES.map((h) => (
+              <option key={h} value={h}>
+                {h}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-muted-foreground">Target cwd</span>
+          <Input name="target_cwd" placeholder="/absolute/path" />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-muted-foreground">Target source ref</span>
+          <Input name="target_source_ref" placeholder="claude:session:… / cwd:…" />
+        </label>
+        <label className="flex items-center gap-2">
+          <input type="checkbox" name="attach" />
+          <span>Attach this session to the new caller on success</span>
+        </label>
+        {error ? <p className="text-sm text-destructive">{error}</p> : null}
+        <Button type="submit" disabled={pending}>
+          {pending ? "Building…" : "Continue session"}
+        </Button>
+      </form>
+      {handover ? (
+        <pre className="mt-3 max-h-72 overflow-auto rounded-md bg-muted/40 p-3 text-xs">
+          {JSON.stringify(handover, null, 2)}
+        </pre>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/dashboard/components/sessions/lifecycle-actions.tsx
+++ b/apps/dashboard/components/sessions/lifecycle-actions.tsx
@@ -20,9 +20,9 @@ export function LifecycleActions({ session }: { session: SessionRow }) {
   const [error, setError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
   const router = useRouter();
-  const isActive = session.status === "active";
-  const isPaused = session.status === "paused";
+  const isLifecycleActive = session.status === "active" || session.status === "paused";
   const isArchivedOrDeleted = session.status === "archived" || session.status === "deleted";
+  const isDeleted = session.status === "deleted";
 
   const handle =
     (action: (id: string, form: FormData) => Promise<{ ok: boolean; error?: string }>) =>
@@ -66,7 +66,7 @@ export function LifecycleActions({ session }: { session: SessionRow }) {
     <section className="flex flex-col gap-3 rounded-md border bg-card p-4">
       <h2 className="text-lg font-semibold">Lifecycle</h2>
       <div className="flex flex-wrap gap-2">
-        {isActive ? (
+        {isLifecycleActive ? (
           <>
             <Button variant="outline" onClick={() => setMode("checkpoint")} disabled={pending}>
               Checkpoint
@@ -79,11 +79,6 @@ export function LifecycleActions({ session }: { session: SessionRow }) {
             </Button>
           </>
         ) : null}
-        {isPaused ? (
-          <Button variant="outline" onClick={() => setMode("end")} disabled={pending}>
-            End
-          </Button>
-        ) : null}
         {!isArchivedOrDeleted ? (
           <Button variant="outline" onClick={archive} disabled={pending}>
             Archive
@@ -94,9 +89,11 @@ export function LifecycleActions({ session }: { session: SessionRow }) {
             Restore
           </Button>
         ) : null}
-        <Button variant="destructive" onClick={remove} disabled={pending}>
-          Delete
-        </Button>
+        {!isDeleted ? (
+          <Button variant="destructive" onClick={remove} disabled={pending}>
+            Delete
+          </Button>
+        ) : null}
       </div>
       {mode ? (
         <LifecycleForm

--- a/apps/dashboard/components/sessions/lifecycle-actions.tsx
+++ b/apps/dashboard/components/sessions/lifecycle-actions.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import type { SessionRow } from "./types";
+import {
+  archiveSessionAction,
+  checkpointSessionAction,
+  deleteSessionAction,
+  endSessionAction,
+  pauseSessionAction,
+  restoreSessionAction,
+} from "@/app/sessions/[id]/actions";
+import { Button } from "@/components/ui/button";
+
+type Mode = null | "checkpoint" | "pause" | "end";
+
+export function LifecycleActions({ session }: { session: SessionRow }) {
+  const [mode, setMode] = useState<Mode>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+  const router = useRouter();
+  const isActive = session.status === "active";
+  const isPaused = session.status === "paused";
+  const isArchivedOrDeleted = session.status === "archived" || session.status === "deleted";
+
+  const handle =
+    (action: (id: string, form: FormData) => Promise<{ ok: boolean; error?: string }>) =>
+    (form: FormData) =>
+      startTransition(async () => {
+        const result = await action(session.id, form);
+        if (result.ok) {
+          setMode(null);
+          setError(null);
+          router.refresh();
+        } else {
+          setError(result.error ?? "Unknown error");
+        }
+      });
+
+  const archive = () =>
+    startTransition(async () => {
+      const reason = window.prompt("Archive reason (optional):") ?? undefined;
+      const result = await archiveSessionAction(session.id, reason);
+      if (result.ok) router.refresh();
+      else setError(result.error);
+    });
+
+  const restore = () =>
+    startTransition(async () => {
+      const result = await restoreSessionAction(session.id);
+      if (result.ok) router.refresh();
+      else setError(result.error);
+    });
+
+  const remove = () =>
+    startTransition(async () => {
+      if (!window.confirm(`Delete session "${session.title}"?`)) return;
+      const reason = window.prompt("Delete reason (optional):") ?? undefined;
+      const result = await deleteSessionAction(session.id, reason);
+      if (result.ok) router.refresh();
+      else setError(result.error);
+    });
+
+  return (
+    <section className="flex flex-col gap-3 rounded-md border bg-card p-4">
+      <h2 className="text-lg font-semibold">Lifecycle</h2>
+      <div className="flex flex-wrap gap-2">
+        {isActive ? (
+          <>
+            <Button variant="outline" onClick={() => setMode("checkpoint")} disabled={pending}>
+              Checkpoint
+            </Button>
+            <Button variant="outline" onClick={() => setMode("pause")} disabled={pending}>
+              Pause
+            </Button>
+            <Button variant="outline" onClick={() => setMode("end")} disabled={pending}>
+              End
+            </Button>
+          </>
+        ) : null}
+        {isPaused ? (
+          <Button variant="outline" onClick={() => setMode("end")} disabled={pending}>
+            End
+          </Button>
+        ) : null}
+        {!isArchivedOrDeleted ? (
+          <Button variant="outline" onClick={archive} disabled={pending}>
+            Archive
+          </Button>
+        ) : null}
+        {isArchivedOrDeleted ? (
+          <Button variant="outline" onClick={restore} disabled={pending}>
+            Restore
+          </Button>
+        ) : null}
+        <Button variant="destructive" onClick={remove} disabled={pending}>
+          Delete
+        </Button>
+      </div>
+      {mode ? (
+        <LifecycleForm
+          label={mode}
+          onSubmit={
+            mode === "checkpoint"
+              ? handle(checkpointSessionAction)
+              : mode === "pause"
+                ? handle(pauseSessionAction)
+                : handle(endSessionAction)
+          }
+          onCancel={() => setMode(null)}
+          pending={pending}
+        />
+      ) : null}
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+    </section>
+  );
+}
+
+function LifecycleForm({
+  label,
+  onSubmit,
+  onCancel,
+  pending,
+}: {
+  label: string;
+  onSubmit: (form: FormData) => void;
+  onCancel: () => void;
+  pending: boolean;
+}) {
+  return (
+    <form action={onSubmit} className="grid gap-3 text-sm md:grid-cols-2">
+      <label className="md:col-span-2 flex flex-col gap-1">
+        <span className="text-muted-foreground">Summary</span>
+        <textarea
+          name="summary"
+          className="min-h-[80px] rounded-md border border-input bg-background p-2"
+        />
+      </label>
+      <ListField name="decisions" label="Decisions (one per line)" />
+      <ListField name="files_touched" label="Files touched (one per line)" />
+      <ListField name="commands_run" label="Commands run (one per line)" />
+      <ListField name="next_steps" label="Next steps (one per line)" />
+      <ListField name="open_questions" label="Open questions (one per line)" />
+      <label className="md:col-span-2 flex flex-col gap-1">
+        <span className="text-muted-foreground">Reason (optional)</span>
+        <input name="reason" className="h-9 rounded-md border border-input bg-background px-2" />
+      </label>
+      <div className="md:col-span-2 flex gap-2">
+        <Button type="submit" disabled={pending}>
+          {pending ? "Working…" : `Submit ${label}`}
+        </Button>
+        <Button type="button" variant="ghost" onClick={onCancel}>
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+function ListField({ name, label }: { name: string; label: string }) {
+  return (
+    <label className="flex flex-col gap-1">
+      <span className="text-muted-foreground">{label}</span>
+      <textarea
+        name={name}
+        className="min-h-[60px] rounded-md border border-input bg-background p-2"
+      />
+    </label>
+  );
+}

--- a/apps/dashboard/components/sessions/promote-form.tsx
+++ b/apps/dashboard/components/sessions/promote-form.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { promoteSessionFactAction } from "@/app/sessions/[id]/actions";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+const CATEGORIES = [
+  "lessons",
+  "preferences",
+  "projects",
+  "environment",
+  "tools",
+  "people",
+  "open_threads",
+] as const;
+
+export function PromoteForm({ sessionId }: { sessionId: string }) {
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+  const [pending, startTransition] = useTransition();
+  const router = useRouter();
+  return (
+    <section className="rounded-md border bg-card p-4">
+      <h2 className="mb-2 text-lg font-semibold">Promote to memory</h2>
+      <p className="mb-3 text-sm text-muted-foreground">
+        Lift a durable fact out of this session into the memory store.
+      </p>
+      <form
+        action={(form) =>
+          startTransition(async () => {
+            const result = await promoteSessionFactAction(sessionId, form);
+            if (result.ok) {
+              setError(null);
+              setSaved(true);
+              router.refresh();
+            } else {
+              setError(result.error);
+              setSaved(false);
+            }
+          })
+        }
+        className="flex flex-col gap-3 text-sm"
+      >
+        <label className="flex flex-col gap-1">
+          <span className="text-muted-foreground">Title</span>
+          <Input name="memory_title" required />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-muted-foreground">Body</span>
+          <textarea
+            name="memory_body"
+            required
+            className="min-h-[100px] rounded-md border border-input bg-background p-2"
+          />
+        </label>
+        <div className="grid grid-cols-3 gap-2">
+          <label className="flex flex-col gap-1">
+            <span className="text-muted-foreground">Category</span>
+            <select
+              name="memory_category"
+              defaultValue="lessons"
+              className="h-9 rounded-md border border-input bg-background px-2"
+            >
+              {CATEGORIES.map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-muted-foreground">Visibility</span>
+            <select
+              name="memory_visibility"
+              defaultValue="common"
+              className="h-9 rounded-md border border-input bg-background px-2"
+            >
+              <option value="common">common</option>
+              <option value="agent_private">agent_private</option>
+            </select>
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-muted-foreground">Scope</span>
+            <select
+              name="memory_scope"
+              defaultValue="global"
+              className="h-9 rounded-md border border-input bg-background px-2"
+            >
+              <option value="global">global</option>
+              <option value="project">project</option>
+              <option value="environment">environment</option>
+              <option value="tool">tool</option>
+              <option value="session">session</option>
+            </select>
+          </label>
+        </div>
+        {error ? <p className="text-sm text-destructive">{error}</p> : null}
+        {saved ? <p className="text-sm text-foreground">Memory promoted.</p> : null}
+        <Button type="submit" disabled={pending}>
+          {pending ? "Saving…" : "Promote"}
+        </Button>
+      </form>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

- `/sessions/[id]/page.tsx` — Server Component fetching the session via `serverTRPC.sessions.get.query`, falling through to `notFound()` on 404.
- Client subtree: `SessionDetailView`, `LifecycleActions`, `EventsStream`, `HandoverForm`, `PromoteForm`.
- Server Actions for checkpoint / pause / end / archive / restore / delete / continue / promote in `app/sessions/[id]/actions.ts`.

## Acceptance (T6.6)

- [x] Header (title, status, ids).
- [x] Summaries (start / rolling / end) + next-steps list.
- [x] Event stream.
- [x] Lifecycle controls (checkpoint / pause / end / archive / restore / delete with confirm).
- [x] Continue / handover form (renders the returned handover JSON).
- [x] Promote-to-memory form.
- [x] All write actions via Server Actions calling tRPC.

## Notable choices

- **Lifecycle button gating mirrors session status.** Active sessions show Checkpoint / Pause / End. Paused sessions can End. Archived/Deleted sessions can Restore. Delete is always available (matches legacy).
- **Inline lifecycle form** for checkpoint/pause/end keeps the multi-field summary submission in one flow; archive / restore / delete just confirm + optionally prompt for a reason.
- **`session.events`** uses the session-event shape (`id` / `type`), not the memory-event shape (`event_id` / `event_type`). Caught by typecheck on first run.
- **`notFound()`** on `get` rejection — exposes a real 404 rather than a 500 error page.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm format:check` clean
- [x] `pnpm test` — 257
- [x] `pnpm --filter @librarian/dashboard build` — clean; `/sessions/[id]` listed as dynamic
- [ ] CI green
- [ ] Live side-by-side w/ legacy detail panel during Jim's review

🤖 Generated with [Claude Code](https://claude.com/claude-code)