### PR TITLE
test(dashboard): Playwright e2e — memories, sessions, promote (T6.7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,11 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('apps/dashboard/package.json') }}
+          # Include the lockfile so Renovate / manual pnpm-up bumps that
+          # only touch pnpm-lock.yaml still invalidate the browser cache.
+          key: playwright-${{ runner.os }}-${{ hashFiles('apps/dashboard/package.json', 'pnpm-lock.yaml') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
 
       - name: Install Playwright browser
         run: pnpm --filter @librarian/dashboard test:e2e:install
@@ -118,6 +122,14 @@ jobs:
         with:
           name: playwright-report
           path: apps/dashboard/playwright-report
+          retention-days: 7
+
+      - name: Upload Playwright traces on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: apps/dashboard/test-results
           retention-days: 7
 
   integration-wrappers:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,55 @@ jobs:
           LIBRARIAN_AGENT_TOKEN: ci-agent-token
         run: docker compose config
 
+  e2e:
+    name: Dashboard e2e (Playwright)
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.17.1"
+
+      - name: Enable corepack (pnpm)
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.15.0 --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build workspace
+        run: pnpm build
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('apps/dashboard/package.json') }}
+
+      - name: Install Playwright browser
+        run: pnpm --filter @librarian/dashboard test:e2e:install
+
+      - name: Run e2e suite
+        env:
+          LIBRARIAN_E2E_ADMIN_TOKEN: e2e-admin-token
+          LIBRARIAN_E2E_DATA_DIR: ${{ runner.temp }}/librarian-e2e-data
+        run: pnpm --filter @librarian/dashboard test:e2e
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: apps/dashboard/playwright-report
+          retention-days: 7
+
   integration-wrappers:
     name: Integration wrapper smoke (${{ matrix.harness }})
     needs: build

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,7 @@ data/
 dist/
 .next/
 *.tsbuildinfo
+.e2e/
+apps/dashboard/playwright-report/
+apps/dashboard/test-results/
 

--- a/apps/dashboard/app/api/trpc/[trpc]/route.ts
+++ b/apps/dashboard/app/api/trpc/[trpc]/route.ts
@@ -18,7 +18,7 @@ function isSameOrigin(req: NextRequest): boolean {
   return req.headers.get("sec-fetch-site") === "same-origin";
 }
 
-async function proxy(req: NextRequest, segments: string[]): Promise<Response> {
+async function proxy(req: NextRequest, segment: string): Promise<Response> {
   if (!ALLOWED_METHODS.has(req.method)) {
     return new Response("Method Not Allowed", { status: 405 });
   }
@@ -26,7 +26,7 @@ async function proxy(req: NextRequest, segments: string[]): Promise<Response> {
     return new Response("Forbidden", { status: 403 });
   }
 
-  const upstream = new URL(`${serverUrl()}/trpc/${segments.join("/")}`);
+  const upstream = new URL(`${serverUrl()}/trpc/${segment}`);
   for (const [k, v] of req.nextUrl.searchParams.entries()) upstream.searchParams.append(k, v);
 
   const headers = new Headers();
@@ -53,7 +53,7 @@ async function proxy(req: NextRequest, segments: string[]): Promise<Response> {
   });
 }
 
-type Params = { params: Promise<{ trpc: string[] }> };
+type Params = { params: Promise<{ trpc: string }> };
 
 async function handler(req: NextRequest, ctx: Params): Promise<Response> {
   const { trpc } = await ctx.params;

--- a/apps/dashboard/e2e/fixtures.ts
+++ b/apps/dashboard/e2e/fixtures.ts
@@ -1,0 +1,100 @@
+import { request, type APIRequestContext } from "@playwright/test";
+
+const SERVER_URL = process.env.LIBRARIAN_E2E_SERVER_URL ?? "http://127.0.0.1:3838";
+const ADMIN_TOKEN = process.env.LIBRARIAN_E2E_ADMIN_TOKEN ?? "e2e-admin-token";
+
+async function adminContext(): Promise<APIRequestContext> {
+  return request.newContext({
+    baseURL: SERVER_URL,
+    extraHTTPHeaders: { Authorization: `Bearer ${ADMIN_TOKEN}` },
+  });
+}
+
+// tRPC single-call HTTP shape (no transformer, no batch): the request
+// body is the raw input JSON, the response is `{ result: { data: <out> } }`.
+async function trpcMutation<T>(
+  ctx: APIRequestContext,
+  procedure: string,
+  input: unknown,
+): Promise<T> {
+  const response = await ctx.post(`/trpc/${procedure}`, {
+    data: input as object,
+    headers: { "content-type": "application/json" },
+  });
+  if (!response.ok()) {
+    throw new Error(`tRPC ${procedure} failed: ${response.status()} ${await response.text()}`);
+  }
+  const body = (await response.json()) as { result?: { data?: T } };
+  return body.result?.data as T;
+}
+
+async function mcpCallText(
+  ctx: APIRequestContext,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<string> {
+  // MCP `tools/call` returns `{ content: [{ type: "text", text: "..." }] }`
+  // by convention. The Librarian's start_session embeds the new session id
+  // in that prose payload as `ID: ses_…`, which we parse out below.
+  const response = await ctx.post("/mcp", {
+    data: {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name, arguments: args },
+    },
+    headers: { "content-type": "application/json" },
+  });
+  if (!response.ok()) {
+    throw new Error(`MCP ${name} failed: ${response.status()} ${await response.text()}`);
+  }
+  const body = (await response.json()) as {
+    result?: { content?: Array<{ type: string; text?: string }> };
+    error?: { message?: string };
+  };
+  if (body.error) throw new Error(`MCP ${name} returned error: ${body.error.message}`);
+  return body.result?.content?.map((c) => c.text ?? "").join("") ?? "";
+}
+
+interface CreatedMemory {
+  memory: { id: string; title: string };
+}
+
+export async function createTestMemory(title: string, body: string): Promise<{ id: string }> {
+  const ctx = await adminContext();
+  try {
+    const result = await trpcMutation<CreatedMemory>(ctx, "memories.create", {
+      title,
+      body,
+      category: "lessons",
+      visibility: "common",
+      scope: "global",
+    });
+    if (!result?.memory?.id) {
+      throw new Error(`createMemory returned no id: ${JSON.stringify(result)}`);
+    }
+    return { id: result.memory.id };
+  } finally {
+    await ctx.dispose();
+  }
+}
+
+export async function createTestSession(title: string): Promise<{ id: string }> {
+  // `start_session` is only on the MCP surface (not tRPC), so we drive it
+  // via the JSON-RPC `tools/call` endpoint with the admin bearer.
+  const ctx = await adminContext();
+  try {
+    const text = await mcpCallText(ctx, "start_session", {
+      title,
+      harness: "claude-code",
+      source_ref: "e2e:test",
+      cwd: "/tmp/e2e",
+      project_key: "the-librarian",
+    });
+    const match = text.match(/ID:\s*(ses_[a-z0-9-]+)/i);
+    if (!match) throw new Error(`start_session text did not contain an id: ${text}`);
+    return { id: match[1]! };
+  } finally {
+    await ctx.dispose();
+  }
+}

--- a/apps/dashboard/e2e/logs.spec.ts
+++ b/apps/dashboard/e2e/logs.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "@playwright/test";
+import { createTestMemory } from "./fixtures";
+
+test.describe("logs page (browser-side tRPC events query)", () => {
+  test("renders memory events created during the run", async ({ page }) => {
+    // Creating a memory emits `memory.created` into the event ledger;
+    // the /logs page consumes `trpc.memories.events.useQuery` via the
+    // same-origin proxy and renders the event row.
+    await createTestMemory(
+      `e2e-logs-${Date.now()}`,
+      "Body to verify the logs page renders an event row through the proxy.",
+    );
+
+    await page.goto("/logs");
+    await expect(page.getByRole("heading", { name: "Logs", level: 1 })).toBeVisible();
+    // The event row renders the payload as a `<pre>` block. Targeting the
+    // pre avoids matching the same event-type string inside the filter
+    // <option> elements that share the dropdown.
+    await expect(page.locator("ul pre").first()).toBeVisible({ timeout: 15_000 });
+  });
+});

--- a/apps/dashboard/e2e/memories.spec.ts
+++ b/apps/dashboard/e2e/memories.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+import { createTestMemory } from "./fixtures";
+
+test.describe("memories list + detail", () => {
+  let memoryTitle: string;
+
+  test.beforeAll(async () => {
+    memoryTitle = `e2e-memory-${Date.now()}`;
+    await createTestMemory(
+      memoryTitle,
+      "Body for the e2e test memory. The list should render this and clicking should open the detail panel.",
+    );
+  });
+
+  test("renders the memory and opens the detail panel on click", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(page.getByRole("heading", { name: "Memories", level: 1 })).toBeVisible();
+    const row = page.getByRole("button", { name: new RegExp(memoryTitle) });
+    await expect(row).toBeVisible();
+
+    await row.click();
+    // The detail panel renders an aside with the memory title as an h2.
+    await expect(page.getByRole("heading", { name: memoryTitle, level: 2 })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Edit" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Delete" })).toBeVisible();
+  });
+});

--- a/apps/dashboard/e2e/promote.spec.ts
+++ b/apps/dashboard/e2e/promote.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "@playwright/test";
+import { createTestSession } from "./fixtures";
+
+test.describe("promote-to-memory", () => {
+  let sessionId: string;
+  let promotedTitle: string;
+
+  test.beforeAll(async () => {
+    const session = await createTestSession(`e2e-promote-source-${Date.now()}`);
+    sessionId = session.id;
+    promotedTitle = `e2e-promoted-${Date.now()}`;
+  });
+
+  test("promote form submits and the memory appears on the Memories tab", async ({ page }) => {
+    await page.goto(`/sessions/${sessionId}`);
+
+    const promoteSection = page.getByRole("heading", { name: "Promote to memory" });
+    await expect(promoteSection).toBeVisible();
+
+    const form = promoteSection.locator("xpath=ancestor::section");
+    await form.getByLabel("Title").fill(promotedTitle);
+    await form
+      .getByLabel("Body")
+      .fill(
+        "Promoted via the e2e suite — verifies the round-trip from session detail to the memories list.",
+      );
+    await form.getByRole("button", { name: "Promote" }).click();
+
+    await expect(form.getByText("Memory promoted.")).toBeVisible({ timeout: 15_000 });
+
+    await page.goto("/");
+    await expect(page.getByText(promotedTitle)).toBeVisible();
+  });
+});

--- a/apps/dashboard/e2e/sessions.spec.ts
+++ b/apps/dashboard/e2e/sessions.spec.ts
@@ -32,4 +32,13 @@ test.describe("sessions list + archive/restore", () => {
       timeout: 15_000,
     });
   });
+
+  test("search box drives the sessions.search browser tRPC path", async ({ page }) => {
+    // Exercises the second sessions browser-tRPC path that the T6.3 proxy
+    // bug had silently broken. Empty query uses `.list`, populating the
+    // search input flips to `.search` — we verify the row still resolves.
+    await page.goto("/sessions");
+    await page.getByPlaceholder("title, summary, decisions, notes").fill(sessionTitle);
+    await expect(page.getByText(sessionTitle)).toBeVisible({ timeout: 15_000 });
+  });
 });

--- a/apps/dashboard/e2e/sessions.spec.ts
+++ b/apps/dashboard/e2e/sessions.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "@playwright/test";
+import { createTestSession } from "./fixtures";
+
+test.describe("sessions list + archive/restore", () => {
+  let sessionId: string;
+  let sessionTitle: string;
+
+  test.beforeAll(async () => {
+    sessionTitle = `e2e-session-${Date.now()}`;
+    const session = await createTestSession(sessionTitle);
+    sessionId = session.id;
+  });
+
+  test("archives and restores a session", async ({ page }) => {
+    page.on("dialog", (dialog) => dialog.accept(""));
+
+    await page.goto("/sessions");
+    await expect(page.getByRole("heading", { name: "Sessions", level: 1 })).toBeVisible();
+    await expect(page.getByText(sessionTitle)).toBeVisible();
+
+    await page.goto(`/sessions/${sessionId}`);
+    await expect(page.getByRole("heading", { name: sessionTitle, level: 1 })).toBeVisible();
+    await expect(page.getByText("active", { exact: true }).first()).toBeVisible();
+
+    await page.getByRole("button", { name: "Archive" }).click();
+    await expect(page.getByText("archived", { exact: true }).first()).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await page.getByRole("button", { name: "Restore" }).click();
+    await expect(page.getByText("active", { exact: true }).first()).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+});

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -8,6 +8,8 @@
     "build": "next build",
     "start": "next start -p 3000",
     "test:vitest": "vitest run",
+    "test:e2e": "playwright test",
+    "test:e2e:install": "playwright install --with-deps chromium",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
@@ -32,6 +34,7 @@
   "devDependencies": {
     "@librarian/mcp-server": "workspace:*",
     "@next/eslint-plugin-next": "^15.1.4",
+    "@playwright/test": "^1.49.1",
     "@tailwindcss/postcss": "^4.0.0",
     "@types/node": "^22.10.5",
     "@types/react": "^19.0.4",

--- a/apps/dashboard/playwright.config.ts
+++ b/apps/dashboard/playwright.config.ts
@@ -1,0 +1,75 @@
+import os from "node:os";
+import path from "node:path";
+import { defineConfig, devices } from "@playwright/test";
+
+// Playwright loads this file in CommonJS mode (the dashboard package isn't
+// `"type": "module"` so Next.js can keep its own runtime semantics), so
+// `import.meta.url` is unavailable. `process.cwd()` is the dashboard's
+// own directory when invoked via `pnpm --filter @librarian/dashboard`.
+const dashboardDir = process.cwd();
+const workspaceRoot = path.resolve(dashboardDir, "../..");
+
+const E2E_ADMIN_TOKEN = process.env.LIBRARIAN_E2E_ADMIN_TOKEN ?? "e2e-admin-token";
+// Resolve a fresh data dir per run at config-load time. The webServer
+// launches the mcp-server BEFORE any test code (or globalSetup) executes,
+// so the dir must already point somewhere unused — wiping it later would
+// pull SQLite out from under the live server. CI passes its own dir via
+// LIBRARIAN_E2E_DATA_DIR (runner.temp); local runs get a tmp-suffixed dir.
+const E2E_DATA_DIR =
+  process.env.LIBRARIAN_E2E_DATA_DIR ??
+  path.join(os.tmpdir(), `librarian-e2e-${process.pid}-${Date.now()}`);
+const E2E_SERVER_URL = process.env.LIBRARIAN_E2E_SERVER_URL ?? "http://127.0.0.1:3838";
+const E2E_DASHBOARD_URL = process.env.LIBRARIAN_E2E_DASHBOARD_URL ?? "http://127.0.0.1:3000";
+
+// Expose the resolved values back to tests + globalSetup.
+process.env.LIBRARIAN_E2E_DATA_DIR = E2E_DATA_DIR;
+process.env.LIBRARIAN_E2E_ADMIN_TOKEN = E2E_ADMIN_TOKEN;
+process.env.LIBRARIAN_E2E_SERVER_URL = E2E_SERVER_URL;
+process.env.LIBRARIAN_E2E_DASHBOARD_URL = E2E_DASHBOARD_URL;
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI ? "github" : "list",
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  use: {
+    baseURL: E2E_DASHBOARD_URL,
+    trace: "on-first-retry",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: [
+    {
+      command: "pnpm --filter @librarian/mcp-server serve",
+      cwd: workspaceRoot,
+      url: `${E2E_SERVER_URL}/healthz`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 60_000,
+      env: {
+        ...(process.env as Record<string, string>),
+        LIBRARIAN_ADMIN_TOKEN: E2E_ADMIN_TOKEN,
+        LIBRARIAN_DATA_DIR: E2E_DATA_DIR,
+        LIBRARIAN_PORT: new URL(E2E_SERVER_URL).port || "3838",
+      },
+    },
+    {
+      // `next start` emits a "use the standalone server" warning under
+      // `output: "standalone"` — the standalone artefact is missing the
+      // workspace-cwd static assets, so we stick with `next start` for
+      // e2e parity with the dev server. The warning is benign.
+      command: "pnpm --filter @librarian/dashboard start",
+      cwd: workspaceRoot,
+      url: E2E_DASHBOARD_URL,
+      reuseExistingServer: !process.env.CI,
+      timeout: 90_000,
+      env: {
+        ...(process.env as Record<string, string>),
+        LIBRARIAN_ADMIN_TOKEN: E2E_ADMIN_TOKEN,
+        LIBRARIAN_SERVER_URL: E2E_SERVER_URL,
+      },
+    },
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,7 +91,7 @@ importers:
         version: 0.469.0(react@19.2.6)
       next:
         specifier: ^15.1.4
-        version: 15.5.18(@babel/core@7.29.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 15.5.18(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next-themes:
         specifier: ^0.4.4
         version: 0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -114,6 +114,9 @@ importers:
       '@next/eslint-plugin-next':
         specifier: ^15.1.4
         version: 15.5.18
+      '@playwright/test':
+        specifier: ^1.49.1
+        version: 1.60.0
       '@tailwindcss/postcss':
         specifier: ^4.0.0
         version: 4.3.0
@@ -711,6 +714,11 @@ packages:
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
@@ -1786,6 +1794,11 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2393,6 +2406,16 @@ packages:
 
   pino@10.3.1:
     resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
     hasBin: true
 
   pluralize@8.0.0:
@@ -3336,6 +3359,10 @@ snapshots:
       fastq: 1.20.1
 
   '@pinojs/redact@0.4.0': {}
+
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
 
   '@radix-ui/primitive@1.1.3': {}
 
@@ -4480,6 +4507,9 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -4891,7 +4921,7 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  next@15.5.18(@babel/core@7.29.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next@15.5.18(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@next/env': 15.5.18
       '@swc/helpers': 0.5.15
@@ -4909,6 +4939,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.5.18
       '@next/swc-win32-arm64-msvc': 15.5.18
       '@next/swc-win32-x64-msvc': 15.5.18
+      '@playwright/test': 1.60.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -5059,6 +5090,14 @@ snapshots:
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.1
       thread-stream: 4.2.0
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pluralize@8.0.0: {}
 


### PR DESCRIPTION
## Summary

Adds the final Phase 6 piece: Playwright e2e coverage for the dashboard. Three specs match the spec's acceptance set, with a CI job that runs them headless in chromium.

## Acceptance (T6.7)

- [x] Playwright installed in `apps/dashboard`.
- [x] Three e2e tests:
  1. Memories list renders with at least one memory; clicking opens the detail panel.
  2. Sessions list renders; archive/restore round-trip on a test session.
  3. Promote-to-memory form submits and the new memory appears in the Memories tab.
- [x] CI runs Playwright headless against a built `apps/dashboard` + a fresh `mcp-server` with a temp data dir.

## Notable choices

- **`os.tmpdir() + Date.now()` data dir per run.** Resolved at config-load time so the dir is fresh before `webServer` launches the mcp-server. Wiping inside `globalSetup` would race the live SQLite handle.
- **Fixtures call mcp-server directly** with the admin Bearer (`request.newContext` from Playwright) rather than driving the dashboard's same-origin proxy. Keeps the fixture path independent of the UI under test.
- **Sessions seeded via `start_session` over MCP** since it isn't on the tRPC surface. Memories seeded via the tRPC single-call shape (`POST /trpc/memories.create` with the input body, no transformer).
- **One worker, no parallelism.** Tests share the mcp-server's data dir; serializing them keeps assertions deterministic. Re-evaluate if/when the suite grows.
- **`reuseExistingServer: !CI`** — locally, Playwright reuses an already-running mcp-server / dashboard, so re-running the suite is fast. CI always boots fresh.
- **Playwright report uploaded on failure** so CI failures are debuggable.

## Latent bug uncovered

The same-origin proxy at `app/api/trpc/[trpc]/route.ts` was treating `params.trpc` as `string[]` and calling `.join("/")` on it. Next.js's `[trpc]` (single dynamic segment, not catch-all `[...trpc]`) returns a `string`. **The browser-side tRPC has been broken since T6.3** — every list/event query through the dashboard's proxy crashed with `TypeError: b.join is not a function` in the route handler. There was no test covering the browser-tRPC path until now; the fix is one line. CI ran green on the affected PRs because nothing exercised the browser path. Worth a moment of reflection on what other test gaps the e2e suite might surface.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm format:check` clean
- [x] `pnpm test` — 257 unit tests
- [x] `pnpm --filter @librarian/dashboard build` — clean
- [x] `pnpm --filter @librarian/dashboard test:e2e` — 3/3 passing locally
- [ ] CI green (new `e2e` job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)