### PR TITLE
feat(docker): Dockerfiles for mcp-server and dashboard (T8.1)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,30 @@
 .git
+.github
 .DS_Store
 node_modules
 data
-npm-debug.log
 *.sqlite
 *.sqlite-shm
 *.sqlite-wal
+npm-debug.log
+
+# Build outputs (regenerated inside the image)
+packages/*/dist
+apps/*/.next
+apps/*/dist
+
+# Editor / IDE
+.vscode
+.idea
+.claude
+
+# Local-only files
+.env
+.env.local
+*.log
+
+# Test artefacts
+coverage
+playwright-report
+test-results
+apps/dashboard/test-results

--- a/docker/dashboard.Dockerfile
+++ b/docker/dashboard.Dockerfile
@@ -1,0 +1,54 @@
+# syntax=docker/dockerfile:1.7
+
+# ---------- builder ----------
+FROM node:22.17.1-bookworm-slim AS builder
+
+WORKDIR /app
+
+RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY packages/core/package.json ./packages/core/package.json
+COPY packages/mcp-server/package.json ./packages/mcp-server/package.json
+COPY packages/cli/package.json ./packages/cli/package.json
+COPY apps/dashboard/package.json ./apps/dashboard/package.json
+
+RUN pnpm install --frozen-lockfile --ignore-scripts
+
+COPY tsconfig.base.json ./
+COPY packages/core ./packages/core
+COPY packages/mcp-server ./packages/mcp-server
+COPY apps/dashboard ./apps/dashboard
+
+# The dashboard imports types from @librarian/mcp-server; both core and
+# mcp-server must build first so .d.ts files are emitted under dist/.
+RUN pnpm --filter @librarian/core --filter @librarian/mcp-server run build \
+  && pnpm --filter @librarian/dashboard run build
+
+# ---------- runtime ----------
+# Next.js produces a self-contained server bundle under .next/standalone.
+# It already includes a pruned node_modules tree, so we ship just that
+# plus the static assets and the public/ folder.
+FROM node:22.17.1-bookworm-slim AS runtime
+
+WORKDIR /app
+
+ENV NODE_ENV=production \
+    PORT=3000 \
+    HOSTNAME=0.0.0.0 \
+    NEXT_TELEMETRY_DISABLED=1
+
+COPY --from=builder /app/apps/dashboard/.next/standalone ./
+COPY --from=builder /app/apps/dashboard/.next/static ./apps/dashboard/.next/static
+COPY --from=builder /app/apps/dashboard/public ./apps/dashboard/public
+
+RUN chown -R node:node /app
+
+USER node
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=15s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:3000/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
+
+CMD ["node", "apps/dashboard/server.js"]

--- a/docker/mcp-server.Dockerfile
+++ b/docker/mcp-server.Dockerfile
@@ -1,0 +1,61 @@
+# syntax=docker/dockerfile:1.7
+
+# ---------- builder ----------
+FROM node:22.17.1-bookworm-slim AS builder
+
+WORKDIR /app
+
+RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
+
+# Workspace manifests first so the install layer is cacheable across
+# source-only changes.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY packages/core/package.json ./packages/core/package.json
+COPY packages/mcp-server/package.json ./packages/mcp-server/package.json
+COPY packages/cli/package.json ./packages/cli/package.json
+COPY apps/dashboard/package.json ./apps/dashboard/package.json
+
+# We only need core + mcp-server for the runtime image; install everything
+# so workspace symlinks resolve cleanly, then prune later.
+RUN pnpm install --frozen-lockfile --ignore-scripts
+
+COPY tsconfig.base.json ./
+COPY packages/core ./packages/core
+COPY packages/mcp-server ./packages/mcp-server
+
+RUN pnpm --filter @librarian/core --filter @librarian/mcp-server run build
+
+# Drop dev dependencies before copying into the runtime stage. `pnpm deploy`
+# would also work but the workspace symlinks are simpler to reason about.
+RUN pnpm install --prod --frozen-lockfile --ignore-scripts \
+  && pnpm store prune
+
+# ---------- runtime ----------
+FROM node:22.17.1-bookworm-slim AS runtime
+
+WORKDIR /app
+
+ENV NODE_ENV=production \
+    LIBRARIAN_DATA_DIR=/data \
+    LIBRARIAN_HOST=0.0.0.0 \
+    LIBRARIAN_PORT=3838
+
+COPY --from=builder /app/package.json /app/pnpm-workspace.yaml ./
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/packages/core/package.json ./packages/core/package.json
+COPY --from=builder /app/packages/core/dist ./packages/core/dist
+COPY --from=builder /app/packages/core/node_modules ./packages/core/node_modules
+COPY --from=builder /app/packages/mcp-server/package.json ./packages/mcp-server/package.json
+COPY --from=builder /app/packages/mcp-server/dist ./packages/mcp-server/dist
+COPY --from=builder /app/packages/mcp-server/node_modules ./packages/mcp-server/node_modules
+
+RUN mkdir -p /data && chown -R node:node /app /data
+
+USER node
+
+EXPOSE 3838
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:3838/healthz').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
+
+CMD ["node", "--no-warnings", "packages/mcp-server/dist/bin/http.js"]


### PR DESCRIPTION
## Summary

Phase 8.1 of the maintainability overhaul. Adds the two Dockerfiles that match the post-T7.1 two-service shape.

- `docker/mcp-server.Dockerfile` — multi-stage, ships `@librarian/core` + `@librarian/mcp-server` only. Runs `node packages/mcp-server/dist/bin/http.js` on port 3838 as the unprivileged `node` user, with `/data` writable for the JSONL ledgers and SQLite projection. `HEALTHCHECK` probes `/healthz`.
- `docker/dashboard.Dockerfile` — multi-stage, uses Next.js `output: "standalone"` to produce a self-contained server bundle. Runs `node apps/dashboard/server.js` on port 3000. `HEALTHCHECK` probes `/health`. Reads `LIBRARIAN_SERVER_URL` + `LIBRARIAN_ADMIN_TOKEN` at runtime; both stay server-side.

`.dockerignore` expanded so the build context excludes generated `dist/` / `.next/` trees and the `data/` volume. Empty `apps/dashboard/public/` directory added with a `.gitkeep` so the COPY in `dashboard.Dockerfile` doesn't fail.

The root `Dockerfile` + `compose.yaml` are intentionally left in place — T8.2 retires them in the same PR that introduces `docker/docker-compose.yml`.

## Test plan

- [x] `docker build -f docker/mcp-server.Dockerfile -t librarian-mcp:dev .`
- [x] `docker build -f docker/dashboard.Dockerfile -t librarian-dashboard:dev .`
- [x] `docker run … librarian-mcp:dev` → `/healthz` 200, `tools/list` 200 with bearer token
- [x] `docker run … librarian-dashboard:dev` → `/` 200, `/health` 200