### PR TITLE
docs: CONTRIBUTING + key ADRs (T9.1)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,175 @@
+# Contributing to The Librarian
+
+Thanks for picking this up. The codebase is small enough that you should be productive in under an hour. This guide is the fastest path to "I know where to add my thing."
+
+## Prerequisites
+
+- **Node 22.5 or newer.** We rely on the built-in `node:sqlite`, which lands properly in 22.5.
+- **pnpm 9.15.x.** Bootstrapped via Corepack:
+
+  ```sh
+  corepack enable
+  corepack prepare pnpm@9.15.0 --activate
+  ```
+
+- **Docker + Docker Compose** (optional, but required to run the production-shaped stack from `docker/docker-compose.yml`).
+- A POSIX shell (zsh, bash). Scripts assume the usual `find`/`grep`/`openssl`.
+
+## Clone + install (under 5 minutes)
+
+```sh
+git clone git@github.com:JimJafar/the-librarian.git
+cd the-librarian
+corepack enable && corepack prepare pnpm@9.15.0 --activate
+pnpm install
+pnpm run seed              # writes sample memories/sessions into ./data
+```
+
+Verify everything is wired up:
+
+```sh
+pnpm run healthcheck       # 5/5 checks: JSONL append, SQLite rebuild, lifecycle, stdio MCP, HTTP MCP+auth
+pnpm test                  # full test suite (Vitest across all packages + root test/)
+```
+
+Run the stack locally (two services):
+
+```sh
+pnpm run serve                              # mcp-server at http://127.0.0.1:3838
+pnpm --filter @librarian/dashboard dev      # dashboard at http://127.0.0.1:3000
+```
+
+The dashboard reads `LIBRARIAN_SERVER_URL` (defaults to `http://127.0.0.1:3838`) and `LIBRARIAN_ADMIN_TOKEN` from env. Without an admin token, tRPC procedures return 401 — set `LIBRARIAN_ADMIN_TOKEN=dev-admin-token` in the env that starts both services.
+
+## Workspace layout
+
+```text
+the-librarian/
+├── apps/
+│   └── dashboard/         # Next.js 14 admin UI (port 3000)
+├── packages/
+│   ├── core/              # Storage engine, schemas, formatters (no I/O outside the data dir)
+│   ├── mcp-server/        # /mcp JSON-RPC, /trpc/* admin API, /healthz (port 3838)
+│   └── cli/               # `the-librarian` binary (sessions verbs, seed, rebuild)
+├── scripts/               # healthcheck, smoke, guards (test-count, storage-fixture, schema-version)
+├── test/                  # cross-cutting Vitest tests (healthcheck script, integrations)
+├── docker/                # mcp-server.Dockerfile, dashboard.Dockerfile, docker-compose.yml
+├── docs/
+│   ├── adr/               # Architecture decision records
+│   └── slash-commands.md  # Cross-harness /lib:session contract
+├── integrations/          # Per-harness setup packages (Hermes, Claude Code, Codex, OpenCode, Pi)
+├── skills/                # Reusable agent skill describing the memory protocol
+└── specs/                 # Long-form specs the overhaul phases reference
+```
+
+### Data flow at a glance
+
+```
+   agent ──────────►  mcp-server (3838)
+   (bearer token)        │   /mcp        ┐
+                         │   /trpc/*     │── @librarian/core ──► ./data/{events,sessions}.jsonl  (canonical)
+                         │   /healthz    │                       ./data/librarian.sqlite        (rebuildable projection)
+                                         ┘                       ./data/memories.md             (snapshot)
+                            ▲
+                            │ admin-token bearer (server-side only)
+                            │
+   browser ────►  dashboard (3000)
+                      │  Server Actions   ───► mcp-server tRPC (direct, server-side)
+                      │  Browser tRPC     ───► /api/trpc/[trpc] same-origin proxy ───► mcp-server tRPC
+```
+
+The JSONL ledgers are the source of truth. SQLite is a rebuildable projection — `pnpm rebuild` or restarting the mcp-server with `librarian.sqlite` missing replays both ledgers into a fresh index. See [`docs/adr/0001-separate-services.md`](./docs/adr/0001-separate-services.md) and [`docs/adr/0002-trpc-admin-api.md`](./docs/adr/0002-trpc-admin-api.md) for the architecture decisions behind this split.
+
+## Where to add what
+
+### A new MCP tool
+
+1. Define the input/output schema in `packages/mcp-server/src/mcp/tools/schemas.ts` (Zod, derived from the core enums where possible).
+2. Add a handler file under `packages/mcp-server/src/mcp/tools/<name>.ts`. Export a `ToolDefinition` whose `handler` takes a `ToolContext` and returns either text or a structured result.
+3. Register it in `packages/mcp-server/src/mcp/tools/index.ts`.
+4. If the tool is admin-only, set `adminOnly: true` on the definition.
+5. Write tests under `packages/mcp-server/tests/mcp/<name>.test.ts` that go through the dispatch layer.
+
+The MCP dispatcher (`dispatch.ts`) is intentionally <100 LOC — every behaviour lives in the per-tool file.
+
+### A new tRPC procedure
+
+1. Pick the namespace: `memories` (in `packages/mcp-server/src/trpc/memories.ts`) or `sessions` (in `sessions.ts`). New namespaces go in their own file and are wired into `router.ts`.
+2. Add the procedure under `adminProcedure`. Inputs are Zod schemas; output types are inferred.
+3. Map store errors to `TRPCError` codes (`NOT_FOUND`, `BAD_REQUEST`, etc.) — keeps HTTP status codes correct.
+4. Write tests under `packages/mcp-server/tests/trpc/<namespace>.test.ts`.
+
+If the dashboard needs it, the type flows automatically: `apps/dashboard/lib/trpc-client.ts` (browser) and `lib/trpc-server.ts` (Server Actions) both import `AppRouter` from `@librarian/mcp-server`.
+
+### A new dashboard page
+
+1. Add a route under `apps/dashboard/app/<segment>/page.tsx` (Next.js App Router).
+2. Read via the server-side tRPC client (`createServerTRPC` in `lib/trpc-server.ts`) inside the server component. Pass data to client components as props.
+3. Writes: define a Server Action in `app/<segment>/actions.ts` (or a colocated `actions.ts` inside a route group). Call the server-side tRPC client and `revalidatePath` on success.
+4. UI primitives live under `apps/dashboard/components/ui/` (shadcn). Feature components go under `components/<feature>/`.
+5. Write a Vitest + RTL component test under `apps/dashboard/tests/components/<name>.test.tsx`. Playwright e2e is for end-to-end happy paths only; prefer component tests.
+
+### A new CLI verb
+
+1. Add a command file under `packages/cli/src/commands/<verb>.ts`.
+2. Register it in `packages/cli/src/commands/index.ts`.
+3. Reuse `parse-flags.ts` for flag handling; reuse formatters from `@librarian/mcp-server` for output that should match the slash-command surface.
+4. Tests: snapshot the help text in `tests/snapshots.test.ts`; behavioural tests in `tests/cli.test.ts`.
+
+## Test layering
+
+We use Vitest exclusively. The pyramid:
+
+- **Unit + integration tests** (per-package, `tests/`) — most of the suite. Hit the store directly or go through dispatch/router.
+- **Component tests** (`apps/dashboard/tests/components/`) — Vitest + RTL + jsdom. Prefer these over Playwright when feasible.
+- **Playwright e2e** (`apps/dashboard/e2e/`) — golden-path coverage only. Runs as its own CI job.
+
+The `pnpm test` script chains: build everything → run each package's Vitest config → run the root `test/` config. Workspace-wide totals are floored by `scripts/check-test-count.mjs` (currently ≥ 177).
+
+## Lint / format / typecheck
+
+```sh
+pnpm run lint              # ESLint flat config across the workspace
+pnpm run format            # Prettier write
+pnpm run format:check      # Prettier check (CI)
+pnpm run typecheck         # tsc --noEmit per package
+pnpm run build             # tsc per package + Next.js build for the dashboard
+```
+
+Lefthook runs the lint + prettier on staged files in `pre-commit` (configured in `lefthook.yml`). Don't bypass with `--no-verify` unless you understand what you're skipping.
+
+## Quality gates (PR-level)
+
+- **400 LOC per file (production source).** Tests are exempt. If a file gets close, look for an extraction. This is a PR-template checkbox; CI doesn't enforce it.
+- **No `any`, no `@ts-ignore` in production source.** See [`docs/adr/0003-no-any.md`](./docs/adr/0003-no-any.md). One `any` is allowed in test helpers with an inline disable + rationale.
+- **Test-count floor.** `scripts/check-test-count.mjs` rejects PRs that drop below the workspace baseline.
+- **Storage compatibility fixture.** `scripts/check-storage-fixture.mjs` re-projects a frozen pre-migration JSONL fixture into SQLite and checks the row counts match. Any change to the projection logic that breaks this fixture must explicitly migrate the fixture and bump the schema sentinel.
+- **Schema-version sentinel.** `scripts/check-schema-version.mjs` keeps the projection schema version in sync with the migration the code emits.
+
+## PR conventions
+
+Follow the user's repo-wide PR conventions in `~/.claude/CLAUDE.md` if you're contributing through a Claude Code agent. In short:
+
+- **Conventional Commits** for messages: `<type>(<scope>): <description>` where `<type>` is one of `fix`, `feat`, `chore`, `test`, `style`, `refactor`, and `<scope>` matches the workspace touched (e.g. `feat(mcp-server): …`, `refactor(core): …`).
+- **PR title** under 70 characters. Detail goes in the body.
+- **Body sections**: `Summary` (what + why) and `Test plan` (a checklist of what you verified).
+- Open as **Draft** if it's not ready for review.
+- Use `gh pr merge --rebase --delete-branch`; squash and merge-commit are blocked on this repo.
+- Reviewer-bot findings get amended in the same PR before merge.
+
+## Debugging tips
+
+- **MCP dispatch issues.** `packages/mcp-server/src/mcp/dispatch.ts` is intentionally tiny — any tool-specific logic lives in its `tools/<name>.ts` file. Add a console-style log via `logger` from `packages/mcp-server/src/logging.ts` (pino) rather than `console.log`.
+- **tRPC 401s.** First check `LIBRARIAN_ADMIN_TOKEN` is set in the process running the dashboard or test. The `trpc-server.ts` module logs a one-liner on cold start if it's missing.
+- **SQLite "experimental" warnings.** Expected — `node:sqlite` is experimental in Node 22. Suppress with `--no-warnings` in production-style scripts (`pnpm run serve` does this).
+- **`fail to load url sqlite`** in a new Vitest config. Vite 5's SSR transformer strips the `node:` prefix from `node:sqlite`. The fix lives in `vitest.config.ts` / `packages/core/vitest.config.ts`: externalise the `@librarian/core` dist tree.
+- **Dashboard build failures referencing `@librarian/mcp-server` types.** Run `pnpm --filter @librarian/core --filter @librarian/mcp-server run build` first; the dashboard imports `AppRouter` types from the compiled `dist/`.
+- **Healthcheck against a deployed instance.** `pnpm healthcheck -- --remote http://host:3838 --agent-token <t>` skips the in-process checks and only probes the remote URL.
+
+## Where to read next
+
+- [`docs/adr/`](./docs/adr/) — architecture decisions: the two-service split, tRPC, the `any` ban.
+- [`specs/maintainability-overhaul.md`](./specs/maintainability-overhaul.md) — what the 30-PR overhaul was solving and why.
+- [`specs/session-layer-and-harness-packages.md`](./specs/session-layer-and-harness-packages.md) — the session-layer contract that drives the harness integrations.
+- [`docs/slash-commands.md`](./docs/slash-commands.md) — the cross-harness `/lib:session` surface.
+- [`DEPLOYMENT.md`](./DEPLOYMENT.md) — operating the compose stack on a personal VPS.

--- a/docs/adr/0001-separate-services.md
+++ b/docs/adr/0001-separate-services.md
@@ -1,0 +1,51 @@
+# ADR 0001 — Separate `mcp-server` and `dashboard` services
+
+- **Status:** Accepted
+- **Date:** 2026-05-20
+- **Phase context:** Maintainability overhaul, Phases 6–8.
+
+## Context
+
+The pre-overhaul Librarian was one Node process serving three concerns from the same port (3838):
+
+1. The MCP JSON-RPC endpoint (`/mcp`) for agents.
+2. The legacy admin dashboard (static `public/` + `/api/*` JSON endpoints).
+3. The healthcheck (`/healthz`).
+
+That worked for a low-traffic personal VPS but pinned several decisions together that should be independent:
+
+- The dashboard had to be plain hand-written HTML/CSS/JS because the runtime didn't include a bundler. Anything richer (typed client, modern UI primitives, server-side data fetching) required adding a build step to the same process.
+- The admin REST endpoints under `/api/*` lacked authentication while `/mcp` required a bearer token. Tightening that gap (see `issues/001-dashboard-rest-no-auth.md`) inside a single process meant either auth-gating browser routes (breaks the "open dashboard" assumption) or pushing browser auth state through cookies/sessions (large change for limited benefit).
+- Deploys coupled UI iteration to MCP-server availability. A typo in admin HTML restarted the MCP endpoint that agents depend on.
+- The MCP server, which serves machine traffic that should be small and stable, was bloated by Next.js-grade dependencies anyone bringing a real admin UI would need.
+
+## Decision
+
+Split into two services:
+
+- **`@librarian/mcp-server`** (Node 22) — JSON-RPC at `/mcp`, typed admin API at `/trpc/*`, liveness at `/healthz`. Port `3838`. Owns the data directory.
+- **`@librarian/dashboard`** (Next.js 14 / React) — the admin UI. Reads via browser tRPC through a same-origin `/api/trpc/[trpc]` proxy that injects the admin token server-side; writes via Server Actions that call the mcp-server's tRPC over HTTP. Port `3000`. Stateless.
+
+Both ship as separate Dockerfiles (`docker/mcp-server.Dockerfile`, `docker/dashboard.Dockerfile`) and run together via `docker/docker-compose.yml`. The dashboard reaches the mcp-server through the internal compose network (`LIBRARIAN_SERVER_URL=http://mcp-server:3838`).
+
+## Consequences
+
+**Positive**
+
+- The admin token never reaches the browser. The dashboard proxy + Server Actions are the only callers of `/trpc/*`; the bearer is held by the dashboard server process.
+- UI iteration doesn't risk MCP availability. Restarting the dashboard container leaves agents connected to `/mcp`.
+- The mcp-server image stays small (no React, no Next.js, no Tailwind). The dashboard image only ships the Next.js standalone bundle.
+- The dashboard is a regular Next.js app, so it benefits from the framework's caching, routing, and Server Actions without bolting any of that onto the MCP server.
+- The `issues/001-dashboard-rest-no-auth.md` gap closes naturally: the `/api/*` routes are gone (T7.1), and `/trpc/*` is admin-gated.
+
+**Negative**
+
+- Two containers to operate instead of one. We mitigate this by shipping a single `docker compose` file and a `pnpm healthcheck -- --remote` mode that probes a deployed stack.
+- Two builds to keep in sync. The dashboard imports `AppRouter` types from `@librarian/mcp-server` at compile time; if the mcp-server's tRPC surface changes incompatibly, the dashboard build will fail before either ships.
+- An extra hop for browser reads: browser → dashboard proxy → mcp-server. Acceptable for an admin UI; latency budget is generous.
+
+## Alternatives considered
+
+- **Single Next.js app that also serves `/mcp`.** Rejected: pulls Next.js into the agent-traffic path, mixes the small JSON-RPC server's failure modes with the dashboard's, and complicates the stdio MCP entrypoint, which has nothing to do with HTTP.
+- **Embed a richer admin UI inside the existing Node HTTP server.** Rejected: would require introducing a bundler into a service whose job is "answer JSON-RPC over HTTP." The mcp-server's surface is intentionally small.
+- **Keep `/api/*` and just add auth.** Rejected: the new typed admin API (tRPC) is a strict improvement over hand-maintained REST + ad-hoc Zod, and once we had tRPC there was nothing keeping the legacy `/api/*` alive.

--- a/docs/adr/0002-trpc-admin-api.md
+++ b/docs/adr/0002-trpc-admin-api.md
@@ -1,0 +1,58 @@
+# ADR 0002 — tRPC for the dashboard admin API
+
+- **Status:** Accepted
+- **Date:** 2026-05-20
+- **Phase context:** Maintainability overhaul, Phase 4 (T4.3–T4.5) and Phase 6 (T6.2).
+
+## Context
+
+The pre-overhaul Librarian exposed two HTTP surfaces:
+
+- `/mcp` — JSON-RPC, bearer-token authenticated. Agents call it.
+- `/api/*` — hand-written REST endpoints in `dashboard.js`, unauthenticated. The legacy dashboard called these.
+
+The REST surface was painful in several specific ways:
+
+- Each endpoint had to be discovered by reading `dashboard.js`; there was no schema.
+- Inputs were parsed ad-hoc — no shared validation between client and server.
+- The browser client (`public/app.js`) had no static types for any of it.
+- Cross-cutting concerns (admin gating, error shape) were repeated in every handler.
+
+When designing the Next.js dashboard, we wanted:
+
+- A single source of truth for procedure signatures (input/output shape).
+- Type-safe browser calls without manually maintaining a client.
+- Easy admin gating at the procedure level, not per-route.
+- A boundary that lets the dashboard fan out reads (browser) and writes (Server Actions) at the same procedures.
+
+## Decision
+
+Adopt **tRPC v11** as the admin API surface, served at `/trpc/*` on the mcp-server. The dashboard imports the `AppRouter` type from `@librarian/mcp-server` and uses two client shapes:
+
+- **Browser reads** — `createTRPCReact<AppRouter>()` wired through a same-origin `/api/trpc/[trpc]` proxy that injects the admin token server-side. Browser callers never see the bearer.
+- **Server-side writes** — `createTRPCClient<AppRouter>()` in Server Actions, talking directly to the mcp-server with the admin token attached server-side.
+
+All procedures sit under `adminProcedure`, which checks the bearer once. Inputs are Zod schemas; outputs flow through `superjson` for richer types. Error shape is the standard tRPC error envelope, mapped onto HTTP status codes by the standalone adapter.
+
+The MCP JSON-RPC endpoint stays untouched — it speaks the MCP protocol that the wider ecosystem expects.
+
+## Consequences
+
+**Positive**
+
+- One source of truth (`packages/mcp-server/src/trpc/router.ts`) covers every dashboard procedure. The dashboard imports its types via `pnpm` workspaces with zero codegen.
+- Admin gating, error mapping, and superjson serialisation are written once in `adminProcedure`. Per-procedure files stay focused on the store call.
+- Browser autocompletion + type errors catch dashboard regressions at compile time. We were burned twice during Phase 6 by misaligned input shapes that tRPC's Zod gate surfaced immediately.
+- The browser proxy gives us one place to enforce the `Sec-Fetch-Site: same-origin` rule and strip inbound `authorization` / `cookie` headers.
+
+**Negative**
+
+- Two clients to keep aware of: the React Query browser client and the plain `createTRPCClient` Server Action client. We documented why in `apps/dashboard/lib/trpc-client.ts` / `trpc-server.ts`.
+- tRPC v11 release candidates moved fast during Phase 4. We pinned to a tested RC and accepted that future bumps need verification rather than blind upgrades.
+
+## Alternatives considered
+
+- **REST + OpenAPI codegen.** Rejected: the codegen overhead and the structural mismatch between REST verbs and our store's verbs (e.g. `promote_session_fact`) would have left us writing Zod schemas, OpenAPI schemas, *and* hand-rolled clients.
+- **GraphQL.** Rejected: the dashboard's query shape is tabular and procedure-style — sessions, memories, events, recall results. We weren't going to benefit from the field-selection mechanic, and a GraphQL server is a much heavier dependency than a tRPC router.
+- **Plain JSON over `fetch`, with Zod on both sides.** Rejected: tRPC is essentially this with the wiring written for us. We'd have re-implemented a worse version of the React Query bridge.
+- **Direct MCP JSON-RPC calls from the dashboard.** Rejected: the MCP transport is for agents — its output is text content blocks intended for an LLM, not structured rows for a UI. The two consumers want different shapes from the same store.

--- a/docs/adr/0003-no-any.md
+++ b/docs/adr/0003-no-any.md
@@ -1,0 +1,61 @@
+# ADR 0003 — Ban `any` (and `@ts-ignore`) in production source
+
+- **Status:** Accepted
+- **Date:** 2026-05-20
+- **Phase context:** Maintainability overhaul, Phase 1 (T1.4) and Phase 3 onward.
+
+## Context
+
+The Librarian started as plain JavaScript, then migrated to TypeScript during Phases 3–5 of the maintainability overhaul. During the port we explicitly decided that the value of TypeScript depends on never reaching for the escape hatches:
+
+- `any` makes a value silently incompatible with every reachable type. One `any` in a hot helper can erode types across an entire module without a single TS error.
+- `@ts-ignore` / `@ts-expect-error` silence the type checker at the line, not at the boundary. Used in production source they become technical debt nobody removes.
+
+Without a hard rule, the temptation during a 30-PR overhaul was to use `any` "just for this PR" and never come back.
+
+## Decision
+
+In **production source** (`packages/*/src/`, `apps/*/src/`):
+
+- `any` is banned. ESLint reports `@typescript-eslint/no-explicit-any` as an error.
+- `@ts-ignore` and `@ts-expect-error` are banned. Comments suppressing TS errors are an error.
+- `unknown` is the correct escape hatch — explicit, narrowable, and the compiler keeps tracking it.
+- If a third-party library forces an awkward shape, write a small local typed adapter; do not leak `any` into call sites.
+
+In **test code** (`packages/*/tests/`, `apps/*/tests/`, `test/`):
+
+- One `any` is allowed *with an inline ESLint disable + rationale* when dealing with intentionally untyped JSON shapes (e.g. dynamic JSON-RPC responses in `callTool` helpers). Reviewers should still push back.
+- `@ts-ignore` in tests stays banned — there's almost always a typed way.
+
+The PR template requires the author to confirm "no new `any` or `@ts-ignore`" before merge. The 400-LOC quality gate complements this: long files are pressure to look the other way, so we keep production files small enough to read.
+
+## Consequences
+
+**Positive**
+
+- The store layer (`@librarian/core`), MCP dispatch, tRPC procedures, and dashboard components are all typed end-to-end. Refactors propagate through the compiler instead of getting silently lost.
+- Adding a new MCP tool, new tRPC procedure, or new dashboard form forces the author to think about the input shape rather than YOLOing through with `any`.
+- When `unknown` does appear, it's a signal: a real boundary (JSON parsing, third-party SDK return value) that wants narrowing or a Zod parse right there.
+
+**Negative**
+
+- The first port of `dashboard.js` → `routes.ts` required writing several Zod schemas / explicit types where the old code accepted shapeless objects. That cost was real.
+- A handful of test helpers carry an inline disable + comment. That's the agreed exception, but new tests do still occasionally need the same disable; reviewers must check that the comment explains *why*.
+- Library upgrades that ship `any` in their `.d.ts` make us write tiny typed adapter layers. Worth it.
+
+## Alternatives considered
+
+- **`strict: true` only.** Rejected: `strict` accepts explicit `any` and `@ts-ignore`. We wanted those banned, not configured to compile.
+- **Allow `any` in tests freely.** Rejected: tests are where regressions get caught; sloppy types in tests mask real shape changes.
+- **Allow `any` in production with a TODO.** Rejected: TODOs in this layer have never been removed historically.
+
+## Enforcement
+
+ESLint flat config in `eslint.config.mjs`:
+
+```js
+"@typescript-eslint/no-explicit-any": "error",
+"@typescript-eslint/ban-ts-comment": "error",
+```
+
+CI runs `pnpm run lint` on every PR; the workflow gates merge on a clean run. The PR template's "no new `any`/`@ts-ignore`" checkbox is an additional human gate.


### PR DESCRIPTION
## Summary

Phase 9.1 — write down what a fresh contributor (human or agent) needs to be productive on this codebase, and pin the three architectural decisions the overhaul made.

- `CONTRIBUTING.md` covers: prerequisites, clone+install (under 5 minutes), workspace layout, a data-flow diagram, the "where to add what" recipes (new MCP tool / tRPC procedure / dashboard page / CLI verb), test layering, lint/format/typecheck, the quality gates, the PR conventions, and a debugging-tips section seeded with the specific traps the overhaul surfaced.
- `docs/adr/0001-separate-services.md` — why `mcp-server` and `dashboard` are two services. Captures failure modes of the pre-overhaul single-process shape and the boundaries the split enforces.
- `docs/adr/0002-trpc-admin-api.md` — why tRPC, not REST or GraphQL. Documents the browser-proxy + Server Action split that keeps the admin token server-side.
- `docs/adr/0003-no-any.md` — why `any` and `@ts-ignore` are banned in production source, the test-helper exception, and the ESLint enforcement.

## Test plan

- [x] CONTRIBUTING walkthrough: a fresh `pnpm install` → `pnpm run healthcheck` → `pnpm test` works from a clean checkout
- [x] Every internal link in CONTRIBUTING resolves (`docs/adr/*`, `specs/*`, `DEPLOYMENT.md`)
- [x] Each ADR follows the format: Status, Date, Context, Decision, Consequences, Alternatives