### PR TITLE
docs: README polish + TODO/spec sweep (T9.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,28 +25,24 @@ The admin token never reaches the browser. The dashboard is the only consumer of
 
 ## Quick Start
 
-> **Package manager: pnpm.** The repo migrated from `npm` to `pnpm` workspaces as part of the maintainability overhaul. `package-lock.json` is gone; `pnpm-lock.yaml` is the source of truth. If you have an existing checkout, delete `node_modules/` and run `pnpm install` once. pnpm is bootstrapped via Node's built-in Corepack: `corepack enable && corepack prepare pnpm@9.15.0 --activate`.
+Requirements: **Node 22.5+** (for the built-in `node:sqlite`) and **pnpm 9.15.x** via Corepack:
+
+```sh
+corepack enable && corepack prepare pnpm@9.15.0 --activate
+```
+
+Local dev (two services):
 
 ```sh
 pnpm install
 pnpm run seed
-pnpm run serve              # mcp-server at http://127.0.0.1:3838
-pnpm --filter @librarian/dashboard dev   # dashboard at http://127.0.0.1:3000
+pnpm run serve                              # mcp-server at http://127.0.0.1:3838
+pnpm --filter @librarian/dashboard dev      # dashboard at http://127.0.0.1:3000
 ```
 
-Open the dashboard at:
+The MCP-compatible JSON-RPC-over-HTTP endpoint is at `http://127.0.0.1:3838/mcp`. The MCP stdio server runs via `pnpm start`.
 
-```text
-http://127.0.0.1:3000
-```
-
-Run the MCP stdio server:
-
-```sh
-pnpm start
-```
-
-Run the production-style HTTP service with auth tokens:
+Production-style local boot with auth tokens:
 
 ```sh
 LIBRARIAN_ADMIN_TOKEN=dev-admin-token \
@@ -54,19 +50,25 @@ LIBRARIAN_AGENT_TOKEN=dev-agent-token \
 pnpm run serve
 ```
 
-The MCP-compatible JSON-RPC-over-HTTP endpoint is available at:
-
-```text
-http://127.0.0.1:3838/mcp
-```
-
-For Docker/Compose deployment of both services, see [DEPLOYMENT.md](./DEPLOYMENT.md).
-
-Verify a deployment end-to-end:
+Verify end-to-end:
 
 ```sh
-pnpm run healthcheck
+pnpm run healthcheck                                          # 5/5 local checks
+pnpm run healthcheck -- --remote http://host:3838             # against a deployed instance
 ```
+
+### Docker (recommended for VPS)
+
+```sh
+cp .env.example .env                                          # set tokens
+docker compose -f docker/docker-compose.yml up -d --build
+```
+
+See [DEPLOYMENT.md](./DEPLOYMENT.md) for the full Tailnet-friendly setup, env vars, backups, and recovery procedures.
+
+### Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for workspace layout, "where to add what" recipes (new MCP tool / tRPC procedure / dashboard page / CLI verb), test layering, and the PR conventions.
 
 ## Data Layout
 
@@ -75,7 +77,7 @@ By default, data is stored in `./data`.
 Override with:
 
 ```sh
-LIBRARIAN_DATA_DIR=/path/to/librarian-data npm start
+LIBRARIAN_DATA_DIR=/path/to/librarian-data pnpm start
 ```
 
 Files:
@@ -85,7 +87,7 @@ Files:
 - `librarian.sqlite` — generated SQLite index (memories + sessions + FTS)
 - `memories.md` — generated human-readable snapshot of memories
 
-The JSONL logs are the source of truth. SQLite and Markdown can be rebuilt at any time via `npm run rebuild`. Memory writes never touch the session projection and vice versa — each ledger has its own incremental projection path so traffic on one side does not regress the other.
+The JSONL logs are the source of truth. SQLite and Markdown can be rebuilt at any time via `pnpm run rebuild`. Memory writes never touch the session projection and vice versa — each ledger has its own incremental projection path so traffic on one side does not regress the other.
 
 ## MCP Tools
 
@@ -132,7 +134,7 @@ The session layer is the neutral handover surface across harnesses. Full spec: [
 - **Explicit lifecycle.** `active` → `paused` / `ended`, with `archived` and `deleted` as hidden states. Restore returns a session to its `prior_status` (paused as a fallback). Recording activity on a paused session implicitly resumes it.
 - **Common by default.** Visibility defaults to `common` because cross-agent handover is the point. Agents scan for sensitivity signals (identity, secrets, personal context, sensitive debugging) and confirm before starting a `common` session whose content looks private. `agent_private` is opt-in.
 - **Evidence, not memory.** Session history is evidence; durable facts are promoted explicitly via `promote_session_fact` (or via `end_session`'s `candidate_memories`). Nothing auto-promotes.
-- **Both ledgers rebuild.** `npm run rebuild` replays `events.jsonl` and `sessions.jsonl` into the SQLite projection. Deleting `librarian.sqlite` is recoverable.
+- **Both ledgers rebuild.** `pnpm run rebuild` replays `events.jsonl` and `sessions.jsonl` into the SQLite projection. Deleting `librarian.sqlite` is recoverable.
 
 ## CLI
 
@@ -216,8 +218,8 @@ pnpm --filter @librarian/dashboard dev    # dashboard at :3000
 pnpm run seed                             # seed sample memories
 pnpm run rebuild                          # replay both JSONL ledgers into the SQLite projection
 pnpm run healthcheck                      # five-check end-to-end smoke (JSONL append, rebuild, lifecycle, stdio MCP, HTTP MCP+auth)
+pnpm run healthcheck -- --remote <url>    # probe a deployed stack via /healthz + /mcp
 pnpm test                                 # full test suite (Vitest across all packages + root test/)
-pnpm run smoke                            # legacy smoke test (pre-session-layer)
 ```
 
 ## Remote Server

--- a/TODO.md
+++ b/TODO.md
@@ -1,14 +1,12 @@
 # The Librarian — Outstanding work
 
-Snapshot taken 2026-05-18 after shipping Phases 1–6 of `specs/session-layer-and-harness-packages.md` (commits `0d7a329..42935b7`, all on `main`). Items reflect what was open at that point; check the active session's `next_steps` for fresher movement before relying on this list.
+Snapshot taken 2026-05-21 after closing out the maintainability overhaul (all 30 task PRs landed; `specs/maintainability-overhaul-*.md` now read "Implemented"). Items here are the leftovers — verbs still to exercise, the per-agent token wiring, polish, and deferred cross-harness work.
 
-## Open from the active session
-
-Active session at time of writing: `ses_e4e7fc21-0096-42b4-b091-5701c84539e5` ("Verifying /lib-session-* native commands").
+## Open from sessions / operator follow-ups
 
 1. **Exercise the remaining `/lib-session-*` verbs end-to-end** (resume, checkpoint, pause, archive, restore, delete, search) to confirm Claude Code dispatches each natively. Start was verified. Status was verified.
-2. **Run `npm run healthcheck` against the deployed canonical instance.** It passes locally — needs a run against the production Librarian to validate the actual deployment.
-3. **Click through the Sessions dashboard tab in a real browser.** Server-side wiring is covered by HTTP + curl smoke; visual layout and button handlers have never been exercised interactively.
+2. **Run `pnpm run healthcheck -- --remote https://<canonical>:3838 --agent-token <token>` against the deployed canonical instance.** Passes locally — needs a run against the production Librarian to validate the actual deployment.
+3. **Click through the Sessions dashboard tab in a real browser against a real dataset.** Server-side wiring is covered by tRPC integration tests, component tests, and Playwright e2e, but operator-style "is the surface usable" exercise is still pending. (Tied to #17 — likely subsumed by the redesign.)
 4. **Configure `LIBRARIAN_AGENT_TOKENS` on the canonical server** so Claude Code session calls attribute to a real `agent_id`. Today they record as `unknown-agent` because no per-agent token is mapped for the Claude Code client.
 5. **Decide whether to promote any of yesterday's decisions into durable memory.** My read so far is that none meet the bar (the substantive work is in git, the operational facts are observable from the dashboard), but worth a deliberate pass.
 
@@ -18,26 +16,15 @@ Active session at time of writing: `ses_e4e7fc21-0096-42b4-b091-5701c84539e5` ("
 7. **Codex slash surface (shelved).** Codex CLI has no user-invokable slash command primitive. Future call: ship a single `lib-session` skill that primes the agent on the verb surface, build a `UserPromptSubmit` hook that intercepts `/lib-session-*` and shells out, or wait for Codex to add native commands.
 8. **Pi runtime (shelved).** Spec defers Pi's runtime as an open question. Revisit once Pi's interface is defined.
 
-## Open repo issue
-
-9. **`issues/001-dashboard-rest-no-auth.md` — REST endpoints lack authentication.** Discovered 2026-05-12 by Joseph. The `/api/*` routes on the dashboard have no auth gate while `/mcp` requires a Bearer token. The Phase 4.1 work I shipped (`/api/sessions/*`) extends this surface without fixing the underlying auth gap. Worth prioritising — this is the only outstanding item that's a real security risk rather than polish.
-
-## Documentation cleanup
-
-10. **Residual `/lib:session` references.** A few places still use the old `/lib:session <verb>` form where they should now use the per-verb name (`/lib-session-<verb>`). Confirmed offenders (run `rg "/lib:session"` to refresh):
-    - `integrations/claude-code/CLAUDE.md` line 45 (`/lib:session resume <id>` → `/lib-session-resume <id>`) and line 57 (`/lib:session end`'s candidates → `/lib-session-end`'s candidate memories).
-    - `integrations/claude-code/slash-commands.md` line 38 ("Hermes and OpenCode register a single `/lib:session` command…") — OpenCode is now per-verb too; that line needs to drop OpenCode and reference the canonical doc instead.
-    - References that mention `/lib:session <verb>` as the **abstract cross-harness contract surface** are correct (e.g. `docs/slash-commands.md`, the "canonical contract" lines in each commands `.md`) and should stay.
-
 ## Spec open questions (deferred)
 
-11. **`harness_private` visibility.** Add later if sandbox/test traffic patterns demand it.
-12. **Physical purge of soft-deleted sessions.** Retention policy + admin UI.
-13. **`session.split` / `session.merged` event types.** Revisit once usage patterns emerge.
+9. **`harness_private` visibility.** Add later if sandbox/test traffic patterns demand it.
+10. **Physical purge of soft-deleted sessions.** Retention policy + admin UI.
+11. **`session.split` / `session.merged` event types.** Revisit once usage patterns emerge.
 
 ## Harness integration ideas
 
-14. **Auto-manage Librarian sessions via Claude Code lifecycle hooks.** Investigate whether Claude Code's hook surface can drive the Librarian lifecycle without the user typing `/lib-session-*` verbs manually. Sketch:
+12. **Auto-manage Librarian sessions via Claude Code lifecycle hooks.** Investigate whether Claude Code's hook surface can drive the Librarian lifecycle without the user typing `/lib-session-*` verbs manually. Sketch:
     - **`SessionEnd` → auto-pause** the attached Librarian session, but only when the user had resumed/attached one in this conversation. The `/lib-session-resume` skill already keeps the resumed `session_id` in conversational state — the hook would read that to decide whether to fire.
     - **`PostCompact` → auto-checkpoint** with the rolling summary so the compacted-away context lands in the ledger before it's gone. Likely the highest-value hook of the three since compaction is exactly where session evidence is most at risk.
     - **`TaskCompleted` (or equivalent) → auto-checkpoint** at a finer grain. Lower priority — risk of noisy ledger if every micro-task fires a checkpoint; might gate on "task touched ≥ N files" or similar.
@@ -45,7 +32,7 @@ Active session at time of writing: `ses_e4e7fc21-0096-42b4-b091-5701c84539e5` ("
 
 ## Architecture — revisit later
 
-15. **Re-evaluate JSONL append-only as the session-storage paradigm.** Raised 2026-05-20 during the T3.6 PR. We copied the memory architecture (JSONL ledger as canonical source of truth, SQLite as a rebuildable projection) for sessions too. It works, but the fit is partial. Worth a deliberate decision when the seam below starts to hurt.
+13. **Re-evaluate JSONL append-only as the session-storage paradigm.** Raised 2026-05-20 during the T3.6 PR. We copied the memory architecture (JSONL ledger as canonical source of truth, SQLite as a rebuildable projection) for sessions too. It works, but the fit is partial. Worth a deliberate decision when the seam below starts to hurt.
 
     **Where it fits cleanly:**
     - Genuine timeline events — `session.note`, `session.decision`, `session.attached` (cross-harness handoff). These benefit from an immutable audit trail you can replay.
@@ -54,27 +41,40 @@ Active session at time of writing: `ses_e4e7fc21-0096-42b4-b091-5701c84539e5` ("
 
     **Where it's awkward:**
     - About half the session event types (`started`, `checkpointed`, `paused`, `resumed`, `ended`) are really **state transitions**, not events. We shoehorn "rolling_summary updated" into a `session.checkpointed` ledger entry because that's the shape we have. A mutable row with `updated_at` would fit the metadata more naturally.
-    - **High write rate.** Each checkpoint is a full JSONL line. The hook ideas in item #14 (auto-checkpoint on PostCompact / TaskCompleted) would multiply that further. Memories grow slowly; sessions grow with usage intensity.
+    - **High write rate.** Each checkpoint is a full JSONL line. The hook ideas in item #12 (auto-checkpoint on PostCompact / TaskCompleted) would multiply that further. Memories grow slowly; sessions grow with usage intensity.
     - **Cold-rebuild cost is linear forever.** Memories tend to plateau; sessions just keep coming, and the JSONL has no purge story today.
     - The primary read surface (`getSession`, `listSessions`, `searchSessions`) reads the **projection**, not the log. `listSessionEvents` is the only call that genuinely reads the timeline.
 
     **A more natural split if we ever break the symmetry:** mutable `sessions` row in SQLite (updated in place) + append-only `session_events.jsonl` for timeline-shaped events only (notes, decisions, handovers; optionally status transitions if we want the audit). Classic chat/collab pattern. Cost: SQLite becomes authoritative for the session row, so backup/portability/rebuild stories split between the two stores.
 
-    **Trigger to revisit:** purge — item #12 (physical purge of soft-deleted sessions) is the seam where append-only starts to hurt, since purging requires rewriting the JSONL, which isn't append-only anymore. If purge becomes urgent, that's the right moment to reconsider the paradigm.
+    **Trigger to revisit:** purge — item #10 (physical purge of soft-deleted sessions) is the seam where append-only starts to hurt, since purging requires rewriting the JSONL, which isn't append-only anymore. If purge becomes urgent, that's the right moment to reconsider the paradigm.
 
 ## Dashboard / UI
 
-16. **Generate auth tokens from the dashboard instead of static env vars.** Today admin + agent tokens are baked into `LIBRARIAN_ADMIN_TOKEN`, `LIBRARIAN_AGENT_TOKEN`, and `LIBRARIAN_AGENT_TOKENS` at boot — one admin token, no rotation without a restart, no per-token audit. Belongs in the dashboard rebuild scope (not a migration of the existing dashboard — see the standing redesign feedback). Sketch:
+14. **Generate auth tokens from the dashboard instead of static env vars.** Today admin + agent tokens are baked into `LIBRARIAN_ADMIN_TOKEN`, `LIBRARIAN_AGENT_TOKEN`, and `LIBRARIAN_AGENT_TOKENS` at boot — one admin token, no rotation without a restart, no per-token audit. Belongs in the dashboard rebuild scope (not a migration of the existing dashboard — see #15). Sketch:
     - **Token model:** name/description, role (`admin` / `agent`), bound `agent_id` for agent tokens, optional expiry, created_at, last_used_at, revoked_at. Persisted to the JSONL ledger as `auth.token_issued` / `auth.token_revoked` events so the audit trail comes for free.
     - **Bootstrap:** on first boot with no tokens recorded, generate a single one-shot admin token and print it once to stderr (or a write-protected file) so the operator can sign in. After that, all token management happens through the dashboard.
     - **Dashboard surface:** "Tokens" panel under settings — list active tokens with last-used + role, "Generate" button (dropdown for role + agent_id when role=agent), "Revoke" action. Prefer dropdowns for known-value fields (role, agent_id) per the global UI feedback.
     - **Server side:** auth middleware (T4.1's `authenticateMcp`) consults the token table instead of comparing against env-var constants. Env vars can still seed the table on first boot for backwards compatibility, then become advisory.
-    - **Pairs with:** #4 (per-agent tokens become trivial — admin can mint one per agent from the UI); #9 (the dashboard REST auth gap — once `/api/*` is authenticated, the dashboard itself uses its own session token, which can be a long-lived dashboard token issued the same way).
+    - **Pairs with:** #4 (per-agent tokens become trivial — admin can mint one per agent from the UI).
+
+## Dashboard review follow-ups (2026-05-20)
+
+15. **UI redesign** — from scratch, not a migration. Aligns with the standing redesign feedback referenced in #14.
+16. **Simplification** — dashboard components carry too many states and methods; consolidate.
+17. **More component tests, less Playwright** — rebalance toward Vitest + RTL + jsdom; trim the e2e surface. The two queued component-test additions (LifecycleActions interaction + `startTransition(async)` pending regression) land here.
+
+## Resolved in the maintainability overhaul
+
+These items appeared on earlier snapshots and have been closed naturally — recorded here for the next person reading old PRs or session ledgers.
+
+- ~~**Dashboard REST endpoints lack auth** (`issues/001-dashboard-rest-no-auth.md`).~~ Resolved 2026-05-20 in T7.1 — the legacy `/api/*` REST surface is deleted. The replacement admin API (`/trpc/*`) is admin-gated; the new Next.js dashboard injects the bearer server-side via its same-origin proxy + Server Actions, so the admin token never reaches the browser.
+- ~~**Residual `/lib:session` references in `integrations/claude-code/`.**~~ Swept 2026-05-21 in T9.2. Abstract cross-harness contract references in `docs/slash-commands.md` are intentionally retained.
+- ~~**One-Node-process Dockerfile / `compose.yaml`.**~~ Retired 2026-05-21 in T8.2. The new compose stack lives under `docker/` (`mcp-server.Dockerfile`, `dashboard.Dockerfile`, `docker-compose.yml`); see [`DEPLOYMENT.md`](./DEPLOYMENT.md).
 
 ## Priority read
 
-- **#9 is the only real risk.** Everything else is polish or exercise.
-- **#4** is the easiest win — once tokens are mapped, dashboard logs and session ownership checks become useful.
-- **#2 and #3** are the spec checkpoints that were never formally closed.
-- **#10** is small but worth knocking out next time anyone touches the integration packages.
-- The rest can wait until the layer is next touched.
+- **#4** is the easiest operational win — once tokens are mapped, dashboard logs and session ownership checks become useful.
+- **#15–#17** is the next substantive engineering block (the dashboard redesign + tests rebalance). Will likely subsume #3 and pair with #14.
+- **#1, #2, #5** are operator/verification chores — small.
+- Everything else is deferred / observational.

--- a/integrations/claude-code/CLAUDE.md
+++ b/integrations/claude-code/CLAUDE.md
@@ -42,7 +42,7 @@ The wrapper script in this package will populate `LIBRARIAN_SESSION_ID` for chil
 Claude's `--resume` continues a Claude session inside Claude. The Librarian session is a **neutral handover layer** that lets the work cross harnesses (Hermes, Codex, OpenCode, Pi). Both can coexist:
 
 - For in-Claude continuity, use `--resume`.
-- For cross-harness or out-of-Claude review/handover, use `/lib:session resume <id>` or fetch the handover via `the-librarian sessions continue <id> --format claude`.
+- For cross-harness or out-of-Claude review/handover, use `/lib-session-resume <id>` or fetch the handover via `the-librarian sessions continue <id> --format claude`.
 
 ## Capture mode
 
@@ -54,6 +54,6 @@ Sessions default to `common` because cross-agent handover is the point of the la
 
 ## Boundaries
 
-- Session history is **evidence**, not durable memory. Promote selectively via `/lib:session end`'s candidates or `promote_session_fact`.
+- Session history is **evidence**, not durable memory. Promote selectively via `/lib-session-end`'s candidates or `promote_session_fact`.
 - Use `remember` / `propose_memory` for durable facts. Protected categories (identity, relationship) always route to proposals.
 - Do not auto-promote anything from session content.

--- a/integrations/claude-code/slash-commands.md
+++ b/integrations/claude-code/slash-commands.md
@@ -35,7 +35,7 @@ Claude Code's custom-command system gives one prompt per markdown file with nati
 - The agent never has to "recognise" the command from chat text — Claude Code dispatches it directly.
 - Each command's prompt is tiny and focused (one verb, one tool, one set of defaults).
 
-Hermes and OpenCode register a single `/lib:session` command and parse the remainder because their slash systems favour that pattern. The MCP tool surface is identical either way.
+Hermes registers a single `/lib:session` command and parses the remainder because its slash system favours that pattern. OpenCode ships per-verb commands like Claude Code. The cross-harness contract is documented in [`docs/slash-commands.md`](../../docs/slash-commands.md); the MCP tool surface is identical either way.
 
 ## Numbered selection
 

--- a/specs/maintainability-overhaul-plan.md
+++ b/specs/maintainability-overhaul-plan.md
@@ -4,7 +4,7 @@ Companion to [`specs/maintainability-overhaul.md`](./maintainability-overhaul.md
 
 ## Status
 
-Draft for review.
+Implemented 2026-05-21 — the plan executed in serial as documented; mid-flight scope changes are recorded in the corresponding PR descriptions, not retroactively in this file.
 
 ## Component dependency graph
 

--- a/specs/maintainability-overhaul-tasks.md
+++ b/specs/maintainability-overhaul-tasks.md
@@ -4,7 +4,7 @@ Per-PR breakdown of [`specs/maintainability-overhaul.md`](./maintainability-over
 
 ## Status
 
-Draft for review.
+Implemented 2026-05-21 — all 30 tasks landed on `main`. The per-task acceptance criteria below are kept as a historical record; do not edit them retroactively. New maintainability work should propose a new spec rather than amending this one.
 
 ## Conventions
 

--- a/specs/maintainability-overhaul.md
+++ b/specs/maintainability-overhaul.md
@@ -2,6 +2,8 @@
 
 ## Status
 
+Implemented 2026-05-21 (all 30 PRs landed; see `git log --grep "T[1-9]\\."`). Spec retained for the historical context behind the overhaul; current operating docs live in [`../README.md`](../README.md), [`../CONTRIBUTING.md`](../CONTRIBUTING.md), [`../DEPLOYMENT.md`](../DEPLOYMENT.md), and [`../docs/adr/`](../docs/adr/).
+
 Approved 2026-05-18.
 
 ## Objective


### PR DESCRIPTION
## Summary

Final PR of the maintainability overhaul (30/30). Sweeps the public docs now that all task PRs have landed.

- **README.md** — drops the months-old `npm → pnpm` migration note, restructures Quick Start into a linear flow (prerequisites → local dev → production boot → healthcheck → Docker → contributing), fixes `npm` strays under Data Layout / Sessions / Commands, advertises the new `pnpm healthcheck -- --remote` mode.
- **specs/maintainability-overhaul*.md** — status moved from "Approved" / "Draft for review" → "Implemented 2026-05-21" with pointers to the authoritative ops docs (README, CONTRIBUTING, DEPLOYMENT, ADRs).
- **integrations/claude-code/CLAUDE.md + slash-commands.md** — residual `/lib:session <verb>` references in instructional copy converted to the per-verb form. Abstract cross-harness contract references intentionally kept.
- **TODO.md sweep** — renumber 1–17, move the dashboard REST auth gap, the `/lib:session` residuals, and the legacy single-process Dockerfile/compose retirement into a new "Resolved in the maintainability overhaul" section. Refresh #2 (healthcheck command), rephrase #3 (coverage now exists; operator-style exercise is what's left), update the Priority read.

## Test plan

- [x] `pnpm test` — full suite still green
- [x] `pnpm run lint` — clean
- [x] `pnpm run healthcheck` — 5/5 local PASS
- [x] All README internal links resolve (CONTRIBUTING.md, DEPLOYMENT.md, docs/adr/*, specs/*)