### PR TITLE
fix(ops): pull-and-restart.sh + docs work with the two-service compose

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -53,7 +53,7 @@ LIBRARIAN_DASHBOARD_PUBLISHED_HOST=100.x.y.z
 Build and start the stack:
 
 ```sh
-docker compose -f docker/docker-compose.yml up -d --build
+docker compose --env-file .env -f docker/docker-compose.yml up -d --build
 ```
 
 Verify it's up:
@@ -71,9 +71,9 @@ If the dashboard health check fails first time, give it ~15 seconds to start —
 If you see `permission denied, open '/data/events.jsonl'` on the mcp-server:
 
 ```sh
-docker compose -f docker/docker-compose.yml down
+docker compose --env-file .env -f docker/docker-compose.yml down
 sudo chown -R 1000:1000 /var/lib/docker/volumes/librarian_data/_data
-docker compose -f docker/docker-compose.yml up -d
+docker compose --env-file .env -f docker/docker-compose.yml up -d
 ```
 
 ## URLs
@@ -108,7 +108,7 @@ Same-origin browser requests are allowed by default. If you front the dashboard 
 
 ```sh
 LIBRARIAN_ALLOWED_ORIGINS=https://librarian.example.com
-docker compose -f docker/docker-compose.yml up -d
+docker compose --env-file .env -f docker/docker-compose.yml up -d
 ```
 
 ## Backups
@@ -131,9 +131,9 @@ docker run --rm -v librarian_data:/data -v ~/librarian-backups:/backup busybox \
 The SQLite file is a projection; deleting it is recoverable. The mcp-server rebuilds the projection automatically on startup if `librarian.sqlite` is missing. So the recovery sequence is:
 
 ```sh
-docker compose -f docker/docker-compose.yml down
+docker compose --env-file .env -f docker/docker-compose.yml down
 docker run --rm -v librarian_data:/data busybox rm -f /data/librarian.sqlite
-docker compose -f docker/docker-compose.yml up -d
+docker compose --env-file .env -f docker/docker-compose.yml up -d
 ```
 
 The next boot replays `events.jsonl` and `sessions.jsonl` into a fresh `librarian.sqlite`. Check the logs (`docker compose ... logs mcp-server`) for the projection-rebuild line.
@@ -143,26 +143,26 @@ The next boot replays `events.jsonl` and `sessions.jsonl` into a fresh `libraria
 View logs:
 
 ```sh
-docker compose -f docker/docker-compose.yml logs -f
+docker compose --env-file .env -f docker/docker-compose.yml logs -f
 ```
 
 Upgrade:
 
 ```sh
 git pull
-docker compose -f docker/docker-compose.yml up -d --build
+docker compose --env-file .env -f docker/docker-compose.yml up -d --build
 ```
 
 Stop:
 
 ```sh
-docker compose -f docker/docker-compose.yml down
+docker compose --env-file .env -f docker/docker-compose.yml down
 ```
 
 Stop and wipe the data volume (destructive):
 
 ```sh
-docker compose -f docker/docker-compose.yml down -v
+docker compose --env-file .env -f docker/docker-compose.yml down -v
 ```
 
 Do not put the data volume on NFS or another unreliable network filesystem. Keep the active SQLite file on local disk and back the JSONL ledgers up off-server.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ pnpm run healthcheck -- --remote http://host:3838             # against a deploy
 
 ```sh
 cp .env.example .env                                          # set tokens
-docker compose -f docker/docker-compose.yml up -d --build
+docker compose --env-file .env -f docker/docker-compose.yml up -d --build
 ```
 
 See [DEPLOYMENT.md](./DEPLOYMENT.md) for the full Tailnet-friendly setup, env vars, backups, and recovery procedures.

--- a/pull-and-restart.sh
+++ b/pull-and-restart.sh
@@ -1,3 +1,51 @@
-git pull
-docker compose down
-docker compose up -d --build --force-recreate
+#!/usr/bin/env bash
+# Pull main and rebuild the two-service Docker stack in place.
+#
+# Run from anywhere on the VPS; the script chdirs into the repo root
+# and passes `--env-file .env` so the compose stack picks up the
+# tokens. The data volume (`librarian_data`) is preserved across the
+# restart.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$REPO_ROOT"
+
+COMPOSE_FILE="docker/docker-compose.yml"
+
+if [ ! -f .env ]; then
+  echo "error: .env not found in $REPO_ROOT — copy .env.example and set tokens before running" >&2
+  exit 1
+fi
+
+echo "==> git pull"
+git pull --ff-only
+
+echo "==> docker compose down (preserving data volume)"
+docker compose --env-file .env -f "$COMPOSE_FILE" down
+
+echo "==> docker compose up --build"
+docker compose --env-file .env -f "$COMPOSE_FILE" up -d --build
+
+echo "==> waiting for healthchecks"
+# "<container>:<compose service>" — service name is used for log fetches.
+for pair in "librarian-mcp:mcp-server" "librarian-dashboard:dashboard"; do
+  container="${pair%%:*}"
+  service="${pair#*:}"
+  status=""
+  for _ in $(seq 1 30); do
+    status="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$container" 2>/dev/null || echo "missing")"
+    case "$status" in
+      healthy) echo "  $service: healthy"; break ;;
+      unhealthy) echo "  $service: unhealthy" >&2; docker compose --env-file .env -f "$COMPOSE_FILE" logs --tail=50 "$service" >&2; exit 1 ;;
+      *) sleep 2 ;;
+    esac
+  done
+  if [ "$status" != "healthy" ]; then
+    echo "  $service: did not reach healthy state within 60s" >&2
+    docker compose --env-file .env -f "$COMPOSE_FILE" logs --tail=50 "$service" >&2
+    exit 1
+  fi
+done
+
+echo "==> done"


### PR DESCRIPTION
## Summary

`pull-and-restart.sh` and the `docker compose` invocations in DEPLOYMENT.md / README.md were left over from the single-process compose layout and don't pick up `.env` after the T8.2 move.

Compose v2 looks for `.env` next to the compose file (i.e. `docker/.env`) by default — without `--env-file .env`, the required-token interpolation in `docker/docker-compose.yml` fails (`LIBRARIAN_ADMIN_TOKEN is missing a value`).

Fixes:

- `pull-and-restart.sh` rewritten:
  - shebang + `set -euo pipefail`
  - chdir into the script's own directory so it works from anywhere on the VPS
  - pass `--env-file .env` to every `docker compose` invocation
  - refuse to run if `.env` is missing
  - drop the redundant `--force-recreate`
  - preserve the data volume on `down` (no `-v`)
  - wait for both `librarian-mcp` and `librarian-dashboard` to report `healthy` before exiting; print the last 50 log lines and exit 1 on timeout or unhealthy
- `DEPLOYMENT.md` + `README.md` — every `docker compose -f docker/...` invocation now carries `--env-file .env`.

## Test plan

- [x] `bash -n pull-and-restart.sh` — syntax OK
- [x] `docker compose --env-file .env -f docker/docker-compose.yml up -d --build` brings both services up
- [x] The new healthcheck wait loop reports `mcp-server: healthy` then `dashboard: healthy`
- [x] `docker compose --env-file .env -f docker/docker-compose.yml down -v` tears the stack down cleanly