### PR TITLE
docs(spec): fold conflict cleanup into memory simplification

### DIFF
--- a/specs/memory-simplification.md
+++ b/specs/memory-simplification.md
@@ -6,22 +6,24 @@ Draft for review, 2026-05-21.
 
 ## Objective
 
-Make memory maintenance pleasant for agents. Concretely:
+Make memory maintenance pleasant for agents and cut the state model down to what's actually load-bearing. Concretely:
 
 - `verify_memory` becomes load-bearing: `useful` / `not_useful` move recall rank, `outdated` archives.
-- Collapse `archived` and `deleted` into a single hidden state — `archived`. One way to hide a memory, one ledger event type for it going forward.
+- Collapse the six memory statuses (`active`, `proposed`, `conflicted`, `archived`, `deleted`, `rejected`) down to three: `active`, `proposed`, `archived`. The *reason* a memory is archived (outdated / rejected / superseded / explicit) lives in the events ledger, not the enum.
 - Rename the admin-only memory removal tool from `delete_memory` to `archive_memory` so the name matches the verb.
+- Delete the dead conflict-detection machinery: the `seemsConflict` keyword heuristic in `createMemory`, the `MemoryStatus.Conflicted` projection branch (never reachable for new memories — the candidate isn't in the projection at conflict time), the `resolve_conflict` MCP tool, and the dashboard `/conflicts` tab.
 - Backfill the 82-memory cleanup so the agent's existing `outdated` verdicts take effect.
 
-**Success means:** an agent who notices a duplicate or stale memory can call `verify_memory result=outdated` and trust that the memory drops out of subsequent recall — no admin involvement, no direct SQLite access, no separate archive tool to learn.
+**Success means:** an agent who notices a duplicate or stale memory can call `verify_memory result=outdated` and trust that the memory drops out of subsequent recall — no admin involvement, no direct SQLite access, no separate archive tool to learn. Saving a new memory always succeeds — `createMemory` returns `duplicates: Memory[]` as informational signal but never refuses the write.
 
 ## Non-goals
 
-- **Not changing the storage format.** `events.jsonl` and `sessions.jsonl` stay byte-compatible. Existing `memory.deleted` events stay in the ledger; the projection just maps them to `archived` going forward.
+- **Not changing the storage format.** `events.jsonl` and `sessions.jsonl` stay byte-compatible. Existing `memory.deleted` / `memory.rejected` / `memory.conflict_detected` / `memory.conflict_resolved` events stay in the ledger; the projection maps them to the new state model.
 - **Not adding a restore-from-archive verb.** If you want an archived memory back, an admin can `update_memory` it with `status: active`. Add restore only if a real need surfaces.
 - **Not adding a hard-purge tool.** Nothing removes data from the JSONL ledger. The ledger remains the immutable source of truth.
 - **Not adding `consolidate_memories` as an atomic tool.** Consolidation is `update_memory` (merge content into canonical) + `verify_memory result=outdated` (on the duplicates). The manual two-step is fine until usage proves otherwise.
-- **Not changing the protected-categories workflow.** `proposed` / `conflicted` / `rejected` statuses stay; they're orthogonal to the active/archived dichotomy.
+- **Not changing the protected-categories workflow.** `proposed` status, `propose_memory`, and `approve_proposal` stay. Identity and relationship categories continue to require admin approval before becoming active.
+- **Not designing a replacement conflict-detection UX.** The current detector is too lossy to keep, but a deliberate replacement (e.g. surface near-duplicates at recall time) is its own design problem. Out of scope here.
 
 ## Decisions (resolved)
 
@@ -36,8 +38,12 @@ Make memory maintenance pleasant for agents. Concretely:
   score = text_match + priority_bonus + project_match + clamp(usefulness_score, -3, +3)
   ```
   Same magnitude range as the existing scoring bands (`priority=core` = +3, project match = +3), so a maxed-out `usefulness_score` lets a "normal" memory compete with a `core` one.
-- **Collapse `deleted` into `archived`.** Remove `MemoryStatus.Deleted` from the enum. `MemoryEventType.Deleted` stays as a historical event-type variant in the projection so old ledger lines still parse; the projection maps `memory.deleted` events to `status: archived`.
+- **Collapse `deleted`, `rejected`, and `conflicted` into `archived`.** Remove all three from `MemoryStatus`. The corresponding event-type variants (`memory.deleted`, `memory.rejected`, `memory.conflict_detected`, `memory.conflict_resolved`) stay in the projection so old ledger lines parse; the handlers all set `status: archived` (or no-op for `conflict_detected`, which historically never resolved to a saved row). After this:
+  ```
+  MemoryStatus = active | proposed | archived
+  ```
 - **Rename the admin removal tool: `delete_memory` → `archive_memory` (admin-only).** Sets `status: archived`, appends `memory.archived` event. Tool description updated to match. Pre-1.0; integration packages don't hardcode this name.
+- **Delete the conflict-detection machinery.** Drop the `seemsConflict` function in `memory-store.ts`. `createMemory` no longer takes a `conflicts` branch — every call saves and returns `{ status, memory, duplicates }`. The `duplicates` field (ratio ≥ 0.55 via `detectRelated`, which uses real token-overlap not the keyword heuristic) is retained as informational signal so an agent can decide whether to consolidate manually. Drop the `resolve_conflict` MCP tool, its tRPC procedure, and the dashboard `/conflicts` route (which queries `status: "conflicted"` and would always return zero rows under the new model anyway).
 - **Backfill the 82-memory cleanup as a one-shot script.** `scripts/replay-verify-outcomes.mjs` replays `events.jsonl`, finds the most recent verify event per memory, and applies the new semantics: archive on last-verdict-was-outdated, increment/decrement (clamped) usefulness_score for useful/not_useful events. Idempotent. Operator runs it once on the canonical instance; the projection rebuild picks up the changes on next mcp-server restart.
 
 ## Tech stack
@@ -62,36 +68,58 @@ Make verify outcomes do what they say.
   - Recall: a memory with `usefulness_score: 3` outranks an otherwise-identical memory with `usefulness_score: 0` for the same query.
 - **Acceptance:** `verify_memory` events change the projection; recall sort respects usefulness; archived memories drop out of default recall.
 
-### Phase 2 — Collapse `deleted` → `archived` + rename `delete_memory` → `archive_memory` (V1.2)
+### Phase 2 — State collapse + propose/conflict cleanup (V1.2)
 
-State collapse and tool rename land together — both are name-and-shape changes touching the same surface.
+The biggest PR in the sequence. Collapses three redundant statuses, renames the admin tool, and deletes the dead conflict machinery. All of it touches the same files (memory enum, store, projection, MCP tools registry, tRPC router, dashboard memory pages) so landing it together avoids two intermediate states where the code is half-migrated.
 
-State collapse:
+**State collapse (`deleted`, `rejected`, `conflicted` → `archived`):**
 
-- Remove `MemoryStatus.Deleted` from `packages/core/src/schemas/common.ts`.
-- Update the projection: `case MemoryEventType.Deleted` sets `status: archived` (was `deleted`) and clears `deleted_at`. `MemoryEventType.Deleted` stays as a historical event-type literal in the discriminated union so old ledger lines parse — but no new code emits it.
-- Update store callsites that referenced `MemoryStatus.Deleted` (filters, list queries, dashboard tabs) to treat it as `archived`.
-- Dashboard: drop the separate `deleted` filter from the memory list / archive tab; `archived` is the only hidden state.
-- Storage fixture (`scripts/check-storage-fixture.mjs`) updated to reflect the collapsed projection. Fixture file regenerated with one rebuild round.
-- Schema-version sentinel (`scripts/check-schema-version.mjs`) bumped — the projection shape changed enough that the rebuild guard should re-verify.
+- Remove `MemoryStatus.Deleted`, `MemoryStatus.Rejected`, `MemoryStatus.Conflicted` from `packages/core/src/schemas/common.ts`. After this, `MemoryStatus = active | proposed | archived`.
+- Update the projection (`packages/core/src/store/projection.ts`):
+  - `MemoryEventType.Deleted` → sets `status: archived` (was `deleted`); clear `deleted_at`.
+  - `MemoryEventType.Rejected` → sets `status: archived` (was `rejected`).
+  - `MemoryEventType.ConflictDetected` → no-op on status (event is still appended, but no status mutation; the historical branch was unreachable for new memories and harmful when the candidate eventually was saved).
+  - `MemoryEventType.ConflictResolved` → for `resolution: "archive" | "supersede"` (non-canonical id), set `status: archived`; for `keep_both` / canonical id, set `status: active`. Same behaviour as today, just without the dead `conflicted` intermediate.
+- The event-type variants stay in the discriminated union so old ledger lines parse — they just project to the new state model. No new code emits `memory.deleted`, `memory.rejected`, `memory.conflict_detected`, or `memory.conflict_resolved`.
+- Update store callsites and dashboard pages that filtered on the removed statuses; they all collapse to `archived`.
+- Storage fixture (`scripts/check-storage-fixture.mjs`) regenerated with one rebuild round.
+- Schema-version sentinel (`scripts/check-schema-version.mjs`) bumped.
 
-Tool rename:
+**Tool rename:**
 
-- Rename `packages/mcp-server/src/mcp/tools/delete-memory.ts` → `archive-memory.ts`. Update the tool name + description. Behavior: admin-only, sets `status: archived`, appends `memory.archived` event (not `memory.deleted` anymore — emitting `archived` directly is cleaner now that the two events project to the same status).
+- Rename `packages/mcp-server/src/mcp/tools/delete-memory.ts` → `archive-memory.ts`. Admin-only; sets `status: archived`, appends `memory.archived` event (not `memory.deleted` — emitting the new event type directly is cleaner now).
 - Update `tools/index.ts` registry. The MCP `tools/list` response no longer includes `delete_memory`.
-- Update integration docs (`integrations/*/AGENTS.md`, `skills/use-the-librarian/SKILL.md`) where they reference `delete_memory`.
-- Update README MCP tools list.
-- Update the tRPC equivalent in `packages/mcp-server/src/trpc/memories.ts`: rename `delete` procedure to `archive`. The dashboard's "Delete memory" admin action becomes "Archive memory" — wording change in the LifecycleActions surface.
+- tRPC: rename `memories.delete` procedure to `memories.archive` in `packages/mcp-server/src/trpc/memories.ts`. Dashboard's "Delete memory" admin action becomes "Archive memory".
 
-Tests:
+**Conflict cleanup:**
 
-- Replay a fixture containing `memory.deleted` events; assert the rebuilt projection has those memories with `status: archived`, not `deleted`.
-- Existing tests that asserted `status === "deleted"` change to `status === "archived"`.
-- MCP integration test: `archive_memory` produces a `memory.archived` event and sets `status: archived`.
-- tRPC test: `memories.archive` procedure round-trips.
-- Remove the obsolete `delete_memory` MCP test, or convert it to verify the tool is no longer in `tools/list`.
+- Delete the `seemsConflict` function in `memory-store.ts`.
+- Update `createMemory`: drop the `related.conflicts.length && !options.allowConflict` branch and the `{status: "conflict", ...}` return. Every call saves. The return shape becomes:
+  ```ts
+  { status: "active" | "proposed"; memory: Memory; duplicates: Memory[] }
+  ```
+  `duplicates` (from `detectRelated`, ratio ≥ 0.55, real token overlap) is kept as informational signal.
+- Delete `detectRelated`'s `conflicts` calculation. It only feeds the now-dead branch and the per-call `seemsConflict` invocation. Keep the `duplicates` calculation.
+- Delete the `resolveConflict` store method and its `MemoryEventType.ConflictResolved` emission path. The event-type variant stays in the projection handler for historical replay; no new code emits it.
+- Delete the `resolve_conflict` MCP tool (`packages/mcp-server/src/mcp/tools/resolve-conflict.ts`) and remove from the registry.
+- Delete the `memories.resolve` tRPC procedure (if present) — check during implementation.
+- Delete the dashboard `/conflicts` route (`apps/dashboard/app/(memories)/conflicts/page.tsx`) and remove the tab from the memories nav.
+- The `allowConflict` option on `createMemory` becomes dead — drop it from the signature.
 
-**Acceptance:** zero references to `MemoryStatus.Deleted` in production source; `tools/list` shows `archive_memory`, not `delete_memory`; dashboard admin action is "Archive"; storage-fixture + schema-version guards green; rebuild from existing canonical-instance ledger doesn't break (verified locally against a copy of canonical's `events.jsonl`).
+**Integration docs:**
+
+- Update `skills/use-the-librarian/SKILL.md` to describe the new three-state model and drop references to conflict resolution.
+- Update README MCP tools list: drop `delete_memory` + `resolve_conflict`, add `archive_memory`.
+
+**Tests:**
+
+- Projection: replay a fixture with `memory.deleted`, `memory.rejected`, `memory.conflict_resolved` events; assert all rebuild to `status: archived` (or `active` for `keep_both`).
+- `createMemory` no longer returns `{status: "conflict"}` for any input. Test removes the existing assertion that conflict input is refused.
+- MCP integration test: `archive_memory` produces `memory.archived` and sets `status: archived`. `resolve_conflict` is no longer in `tools/list`.
+- tRPC test: `memories.archive` round-trips. `memories.resolve` is gone.
+- Dashboard: `/conflicts` route 404s; conflicts tab not rendered.
+
+**Acceptance:** zero references to `MemoryStatus.Deleted | Rejected | Conflicted` in production source; zero references to `seemsConflict` or `resolveConflict`; `tools/list` shows `archive_memory` and not `delete_memory` / `resolve_conflict`; dashboard memories nav has no conflicts tab; storage-fixture + schema-version guards green; rebuild from existing canonical-instance ledger doesn't break.
 
 ### Phase 3 — Backfill script for 82-memory cleanup (V1.3)
 
@@ -115,8 +143,8 @@ Apply the new semantics to existing verify history.
 
 Update the writing.
 
-- README "MCP Tools" → memory tools section reflects `verify_memory`'s new semantics + the `archive_memory` rename. Drop `delete_memory`.
-- `skills/use-the-librarian/SKILL.md` — the agent-facing guidance — clarifies the new `verify` semantics and the absence of a separate archive verb.
+- README "MCP Tools" → memory tools section reflects `verify_memory`'s new semantics + the `archive_memory` rename. Drop `delete_memory` and `resolve_conflict`. Document the three-state model (`active` / `proposed` / `archived`) explicitly so the absence of `conflicted` doesn't come as a surprise to anyone reading old PRs.
+- `skills/use-the-librarian/SKILL.md` — the agent-facing guidance — clarifies the new `verify` semantics, the absence of a separate archive verb, and that `createMemory` always saves (returning `duplicates` for informational use).
 - `specs/memory-simplification.md` (this file) status → "Implemented YYYY-MM-DD".
 - `TODO.md`: items #15–#17 (dashboard) stay; this spec doesn't address them. Maintenance-cleanup follow-ups (#10 physical purge) explicitly noted as still deferred.
 - **Acceptance:** stranger walkthrough — read the README's memory section, can you describe what each verify outcome does in one sentence?
@@ -126,7 +154,7 @@ Update the writing.
 | Phase | PR | What |
 |---|---|---|
 | 1 | V1.1 | Live `verify_memory` + recall scoring |
-| 2 | V1.2 | Collapse `deleted` → `archived` + rename `delete_memory` → `archive_memory` |
+| 2 | V1.2 | State collapse (`deleted` / `rejected` / `conflicted` → `archived`) + `delete_memory` rename + delete conflict machinery |
 | 3 | V1.3 | 82-memory backfill script |
 | 4 | V1.4 | Docs polish |
 


### PR DESCRIPTION
## Summary

Refinement to `specs/memory-simplification.md` (PR #41) after auditing the propose/conflict flow.

**Findings:**

- `MemoryStatus.Conflicted` is dead in practice. The projection branch that would set it spreads `...existing`, but `createMemory` doesn't save the candidate on the conflict path — so the handler is unreachable for new memories. The dashboard `/conflicts` tab always shows zero rows.
- `MemoryStatus.Rejected` carries no information that isn't already in the `memory.rejected` event.
- `seemsConflict` is a naive keyword heuristic ("prefer dark theme" + "prefer Vim" both trip it because they share "prefer"). False-positive rate is net-negative.

**What V1.2 now covers:**

- Collapse `deleted` / `rejected` / `conflicted` → `archived` (down from 6 statuses to 3: `active | proposed | archived`)
- Rename `delete_memory` → `archive_memory` (admin tool)
- Delete `seemsConflict` + the conflict branch in `createMemory` — every save succeeds, `duplicates: Memory[]` returned for informational use
- Delete `resolve_conflict` MCP tool, `memories.resolve` tRPC procedure, dashboard `/conflicts` route

**Untouched:** the propose/approve flow for protected categories (`identity`, `relationship`) — that's the one piece of admin gating that earns its keep.

PR count unchanged at 4; V1.2 is now the chunkiest of the four.

## Test plan

This is a spec-only update; behavioural verification still lands in V1.1–V1.4.

- [x] Objective + non-goals updated for the broader scope
- [x] Decisions block covers all three status drops
- [x] Phase 2 description covers the state collapse, tool rename, AND conflict-machinery deletion as one PR
- [x] Acceptance criteria call out specific grep targets (`MemoryStatus.Deleted | Rejected | Conflicted`, `seemsConflict`, `resolveConflict`)