### PR TITLE
feat(core): live verify_memory + scoring (V1.1)

### DIFF
--- a/apps/dashboard/components/memories/list.tsx
+++ b/apps/dashboard/components/memories/list.tsx
@@ -3,6 +3,11 @@
 import type { MemoryRow } from "./types";
 import { Badge } from "@/components/ui/badge";
 
+function formatScore(score: number): string {
+  if (score > 0) return `+${score}`;
+  return String(score);
+}
+
 interface Props {
   memories: MemoryRow[];
   isLoading: boolean;
@@ -73,6 +78,10 @@ export function MemoriesList({
                 ) : null}
                 <span>·</span>
                 <span>updated {new Date(memory.updated_at).toLocaleDateString()}</span>
+                <span>·</span>
+                <span title="Usefulness score (clamped ±3)">
+                  score {formatScore(memory.usefulness_score)}
+                </span>
               </div>
             </button>
           </li>

--- a/apps/dashboard/components/memories/logs-view.tsx
+++ b/apps/dashboard/components/memories/logs-view.tsx
@@ -20,7 +20,15 @@ const EVENT_TYPES = [
   "memory.conflict_resolved",
 ] as const;
 
-const VERIFICATION_RESULTS = ["useful", "not_useful", "outdated", "wrong"] as const;
+// "wrong" stays in the filter set so historical events remain discoverable,
+// but the live `verify_memory` tool no longer accepts it — new events only
+// carry useful / not_useful / outdated.
+const VERIFICATION_RESULTS = [
+  { value: "useful", label: "useful" },
+  { value: "not_useful", label: "not_useful" },
+  { value: "outdated", label: "outdated" },
+  { value: "wrong", label: "wrong (legacy)" },
+] as const;
 
 const PAGE_SIZE = 25;
 
@@ -79,8 +87,8 @@ export function LogsView() {
           >
             <option value="">All results</option>
             {VERIFICATION_RESULTS.map((r) => (
-              <option key={r} value={r}>
-                {r}
+              <option key={r.value} value={r.value}>
+                {r.label}
               </option>
             ))}
           </select>

--- a/packages/core/src/store/memory-store.ts
+++ b/packages/core/src/store/memory-store.ts
@@ -432,6 +432,10 @@ export function createMemoryStore(deps: MemoryStoreDeps): MemoryStore {
         if (memory.priority === "core") score += 3;
         if (memory.priority === "high") score += 1;
         if (memory.project_key && memory.project_key === project_key) score += 3;
+        // Usefulness score (clamped ±3) sits in the same magnitude band as
+        // priority + project match, so a maxed-out memory can compete with
+        // a `core` one on recall sort.
+        score += Math.max(-3, Math.min(3, Number(memory.usefulness_score || 0)));
         return { memory, score };
       })
       .filter((item) => item.score > 0);
@@ -582,6 +586,16 @@ export function createMemoryStore(deps: MemoryStoreDeps): MemoryStore {
       { memory_id: id, agent_id, result, note },
       { memory_id: id, agent_id },
     );
+    // Outdated is load-bearing — the agent saying "this memory is stale"
+    // moves the row out of default recall by appending a paired archive
+    // event. The verify event still records the verdict for audit.
+    if (result === "outdated") {
+      appendEvent(
+        MemoryEventType.Archived,
+        { memory_id: id, agent_id, reason: "verify_outdated" },
+        { memory_id: id, agent_id },
+      );
+    }
     return getMemory(id);
   }
 

--- a/packages/core/src/store/projection.ts
+++ b/packages/core/src/store/projection.ts
@@ -291,12 +291,20 @@ export function reduceMemoryLog(events: MemoryLogEvent[]): {
         });
         break;
       case MemoryEventType.Verified: {
+        // Useful / not_useful nudge the usefulness_score by ±1, clamped to
+        // ±3 — the same range as the priority and project-match bands in
+        // recall scoring. Outdated is handled by the paired memory.archived
+        // event below; it leaves the score alone. Legacy "wrong" verdicts
+        // in older ledgers project as not_useful so replay stays meaningful.
         const result = payload.result;
-        const delta =
-          result === VerifyResult.Useful ? 1 : result === VerifyResult.NotUseful ? -1 : -2;
+        let delta = 0;
+        if (result === VerifyResult.Useful) delta = 1;
+        else if (result === VerifyResult.NotUseful || result === "wrong") delta = -1;
+        const current = Number(existing.usefulness_score || 0);
+        const next = Math.max(-3, Math.min(3, current + delta));
         memories.set(id, {
           ...existing,
-          usefulness_score: Number(existing.usefulness_score || 0) + delta,
+          usefulness_score: next,
           updated_at: event.created_at,
         });
         break;

--- a/packages/core/tests/store/memory-store.test.ts
+++ b/packages/core/tests/store/memory-store.test.ts
@@ -200,9 +200,9 @@ describe("LibrarianStore memory CRUD", () => {
         .usefulness_score,
     ).toBe(1);
     expect(
-      store.verifyMemory(result.memory.id, "wrong", "Command was removed.", "codex")
+      store.verifyMemory(result.memory.id, "not_useful", "Command was removed.", "codex")
         .usefulness_score,
-    ).toBe(-1);
+    ).toBe(0);
     expect(store.deleteMemory(result.memory.id, "dashboard").status).toBe("deleted");
 
     expect(store.searchMemories({ query: "old-test", project_key: "the-librarian" }).length).toBe(

--- a/packages/core/tests/store/verify-scoring.test.ts
+++ b/packages/core/tests/store/verify-scoring.test.ts
@@ -1,0 +1,196 @@
+// V1.1 — Live verify_memory + recall scoring.
+//
+// Pins the load-bearing semantics introduced by the memory-simplification
+// spec:
+//   - verify(useful)     → usefulness_score += 1, clamped to ≤ +3
+//   - verify(not_useful) → usefulness_score -= 1, clamped to ≥ -3
+//   - verify(outdated)   → status → archived, score unchanged
+//   - recall scoring     → includes clamp(usefulness_score, -3, +3)
+//   - projection rebuild → preserves all of the above from the JSONL ledger
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { type LibrarianStore, createLibrarianStore } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+interface Scope {
+  store: LibrarianStore;
+  dataDir: string;
+}
+
+function makeScope(): Scope {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-verify-"));
+  const store = createLibrarianStore({ dataDir });
+  return { store, dataDir };
+}
+
+function teardown(scope: Scope | null): void {
+  if (!scope) return;
+  try {
+    scope.store.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(scope.dataDir, { recursive: true, force: true });
+}
+
+function makeMemory(store: LibrarianStore, overrides: Record<string, unknown> = {}) {
+  return store.createMemory({
+    agent_id: "codex",
+    title: "Test tool flag",
+    body: "Use --watch for the local test runner to keep results fresh.",
+    category: "tools",
+    visibility: "common",
+    scope: "project",
+    project_key: "the-librarian",
+    ...overrides,
+  });
+}
+
+describe("V1.1 — verify_memory + scoring", () => {
+  let scope: Scope | null = null;
+
+  beforeEach(() => {
+    scope = makeScope();
+  });
+
+  afterEach(() => {
+    teardown(scope);
+    scope = null;
+  });
+
+  it("useful increments usefulness_score by 1", () => {
+    const { store } = scope!;
+    const { memory } = makeMemory(store);
+    expect(memory.usefulness_score).toBe(0);
+    const verified = store.verifyMemory(memory.id, "useful", "", "codex");
+    expect(verified!.usefulness_score).toBe(1);
+  });
+
+  it("not_useful decrements usefulness_score by 1", () => {
+    const { store } = scope!;
+    const { memory } = makeMemory(store);
+    const verified = store.verifyMemory(memory.id, "not_useful", "", "codex");
+    expect(verified!.usefulness_score).toBe(-1);
+  });
+
+  it("useful clamps at +3 (5x useful still yields +3)", () => {
+    const { store } = scope!;
+    const { memory } = makeMemory(store);
+    let final = memory;
+    for (let i = 0; i < 5; i++) {
+      final = store.verifyMemory(memory.id, "useful", "", "codex")!;
+    }
+    expect(final.usefulness_score).toBe(3);
+  });
+
+  it("not_useful clamps at -3", () => {
+    const { store } = scope!;
+    const { memory } = makeMemory(store);
+    let final = memory;
+    for (let i = 0; i < 5; i++) {
+      final = store.verifyMemory(memory.id, "not_useful", "", "codex")!;
+    }
+    expect(final.usefulness_score).toBe(-3);
+  });
+
+  it("outdated archives the memory and leaves usefulness_score unchanged", () => {
+    const { store } = scope!;
+    const { memory } = makeMemory(store);
+    store.verifyMemory(memory.id, "useful", "", "codex"); // score → 1
+    const verified = store.verifyMemory(memory.id, "outdated", "stale", "codex");
+    expect(verified!.status).toBe("archived");
+    expect(verified!.usefulness_score).toBe(1);
+  });
+
+  it("archived memories drop out of default recall", () => {
+    const { store } = scope!;
+    const { memory } = makeMemory(store, {
+      title: "Outdated CLI flag",
+      body: "The deploy CLI used to take --legacy; that flag has been removed.",
+    });
+    expect(
+      store.searchMemories({ query: "deploy CLI legacy flag", project_key: "the-librarian" })
+        .length,
+    ).toBe(1);
+    store.verifyMemory(memory.id, "outdated", "", "codex");
+    expect(
+      store.searchMemories({ query: "deploy CLI legacy flag", project_key: "the-librarian" })
+        .length,
+    ).toBe(0);
+  });
+
+  it("outdated emits both memory.verified and memory.archived events", () => {
+    const { store } = scope!;
+    const { memory } = makeMemory(store);
+    store.verifyMemory(memory.id, "outdated", "", "codex");
+    const events = store.readEvents() as { event_type: string; memory_id: string }[];
+    const forMemory = events.filter((e) => e.memory_id === memory.id);
+    expect(forMemory.some((e) => e.event_type === "memory.verified")).toBe(true);
+    expect(forMemory.some((e) => e.event_type === "memory.archived")).toBe(true);
+  });
+
+  it("recall ranks higher usefulness_score above an otherwise-identical memory", () => {
+    const { store } = scope!;
+    const popular = store.createMemory({
+      agent_id: "codex",
+      title: "Popular tooling note",
+      body: "Run pnpm test before pushing to catch broken specs.",
+      category: "tools",
+      visibility: "common",
+      scope: "project",
+      project_key: "popular-proj",
+    });
+    const ignored = store.createMemory({
+      agent_id: "codex",
+      title: "Ignored tooling note",
+      body: "Run pnpm test before pushing to catch broken specs.",
+      category: "tools",
+      visibility: "common",
+      scope: "project",
+      project_key: "ignored-proj",
+    });
+    for (let i = 0; i < 3; i++) {
+      store.verifyMemory(popular.memory.id, "useful", "", "codex");
+    }
+
+    const results = store.searchMemories({
+      query: "pnpm test broken specs",
+      project_key: "",
+      limit: 8,
+    });
+    const popularIdx = results.findIndex((m) => m.id === popular.memory.id);
+    const ignoredIdx = results.findIndex((m) => m.id === ignored.memory.id);
+    expect(popularIdx).toBeGreaterThanOrEqual(0);
+    expect(ignoredIdx).toBeGreaterThanOrEqual(0);
+    expect(popularIdx).toBeLessThan(ignoredIdx);
+  });
+
+  it("projection rebuild preserves usefulness_score and archive status", () => {
+    const { store, dataDir } = scope!;
+    const ranked = makeMemory(store, { title: "Survives rebuild" });
+    const archived = makeMemory(store, {
+      title: "Outdated after rebuild",
+      body: "The legacy_flag CLI option no longer exists.",
+    });
+    for (let i = 0; i < 4; i++) {
+      store.verifyMemory(ranked.memory.id, "useful", "", "codex");
+    }
+    store.verifyMemory(archived.memory.id, "outdated", "", "codex");
+    store.close();
+
+    fs.unlinkSync(path.join(dataDir, "librarian.sqlite"));
+    const rebuilt = createLibrarianStore({ dataDir });
+    try {
+      const rankedRow = rebuilt.getMemory(ranked.memory.id)!;
+      expect(rankedRow.usefulness_score).toBe(3);
+      const archivedRow = rebuilt.getMemory(archived.memory.id)!;
+      expect(archivedRow.status).toBe("archived");
+    } finally {
+      rebuilt.close();
+      scope = null;
+      fs.rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/mcp-server/src/mcp/tools/verify-memory.ts
+++ b/packages/mcp-server/src/mcp/tools/verify-memory.ts
@@ -5,14 +5,17 @@ import { scopeAgentArgs } from "../visibility.js";
 
 const verifyMemory: ToolDefinition = {
   name: "verify_memory",
-  description: "Record whether a memory was useful, stale, wrong, or not useful.",
+  description:
+    "Record a verdict against a memory after using it. " +
+    "`useful` raises its recall rank, `not_useful` lowers it (both clamped to ±3), " +
+    "`outdated` archives the memory so it drops out of default recall.",
   inputSchema: {
     type: "object",
     required: ["memory_id", "result"],
     properties: {
       agent_id: { type: "string" },
       memory_id: { type: "string" },
-      result: { type: "string", enum: ["useful", "not_useful", "outdated", "wrong"] },
+      result: { type: "string", enum: ["useful", "not_useful", "outdated"] },
       note: { type: "string" },
     },
   },


### PR DESCRIPTION
## Spec / phase reference

Implements V1.1 — Live `verify_memory` + scoring (Phase 1 of `specs/memory-simplification.md`).

## Summary

- `verify_memory` is now load-bearing. `useful` / `not_useful` move `usefulness_score` by ±1 (clamped to ±3); `outdated` emits a paired `memory.archived` event so the row drops out of default recall. The verdict is otherwise unchanged: the original `memory.verified` event still records the audit trail.
- Recall ranking includes `clamp(usefulness_score, -3, +3)` so verdicts actually affect future results. The band is sized to compete with the existing priority + project bonuses.
- Legacy `"wrong"` verdicts in older ledgers project as `not_useful` so rebuilds remain meaningful; the live tool schema drops `"wrong"`. Dashboard events log keeps it as `wrong (legacy)` so historical events stay searchable.
- Dashboard memory list shows the score inline (`score +2` / `score -1` / `score 0`).

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` — 255 tests pass (9 new cases in `verify-scoring.test.ts`: deltas, both clamps, archive-on-outdated, paired-event emission, recall ranking, rebuild-from-JSONL parity)
- [x] `pnpm --filter @librarian/dashboard build`
- [x] `pnpm run check:schema-version`
- [x] `pnpm run check:storage-fixture`

## Quality gates

- [x] **No production source file over 400 LOC introduced** — only touched files already in tree; largest diff is `projection.ts` at ~870 LOC, unchanged in size.
- [x] **No new `any` or `@ts-ignore` introduced**

## Notes for the reviewer

This is the first of four PRs implementing `specs/memory-simplification.md`. V1.2 (state collapse + tool rename + conflict cleanup) is the biggest one and follows next. The schema version is unchanged in V1.1 — only the projection's `Verified` handler logic changed, not the SQLite shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)