### PR TITLE
feat(dashboard): editorial design system foundations (D1.0)

### DIFF
--- a/apps/dashboard/app/globals.css
+++ b/apps/dashboard/app/globals.css
@@ -1,14 +1,22 @@
 @import "tailwindcss";
+@import "../styles/tokens.css";
 
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  --background: hsl(0 0% 100%);
-  --foreground: hsl(240 10% 3.9%);
-  --card: hsl(0 0% 100%);
-  --card-foreground: hsl(240 10% 3.9%);
-  --popover: hsl(0 0% 100%);
-  --popover-foreground: hsl(240 10% 3.9%);
+  /* D1.0 — editorial palette overrides shadcn light bg/fg + the
+     two card/popover surfaces that would otherwise read as pure
+     white panels against the warm paper body. The remaining shadcn
+     tokens (--primary, --secondary, --muted, --accent, --border,
+     etc.) keep their defaults so existing components still render
+     — D1.1+ migrates per-surface components onto the full ink-*
+     palette in styles/tokens.css. */
+  --background: #f5f1e8;
+  --foreground: #1a1612;
+  --card: var(--ink-surface);
+  --card-foreground: var(--foreground);
+  --popover: var(--ink-surface);
+  --popover-foreground: var(--foreground);
   --primary: hsl(240 5.9% 10%);
   --primary-foreground: hsl(0 0% 98%);
   --secondary: hsl(240 4.8% 95.9%);
@@ -26,12 +34,14 @@
 }
 
 .dark {
-  --background: hsl(240 10% 3.9%);
-  --foreground: hsl(0 0% 98%);
-  --card: hsl(240 10% 3.9%);
-  --card-foreground: hsl(0 0% 98%);
-  --popover: hsl(240 10% 3.9%);
-  --popover-foreground: hsl(0 0% 98%);
+  /* D1.0 — editorial dark palette overrides shadcn dark bg/fg +
+     card/popover (same rationale as light :root above). */
+  --background: #1c1814;
+  --foreground: #e8e0d0;
+  --card: var(--ink-surface);
+  --card-foreground: var(--foreground);
+  --popover: var(--ink-surface);
+  --popover-foreground: var(--foreground);
   --primary: hsl(0 0% 98%);
   --primary-foreground: hsl(240 5.9% 10%);
   --secondary: hsl(240 3.7% 15.9%);
@@ -50,6 +60,17 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  /* Editorial palette under `ink-` to avoid clashing with shadcn's
+     own --accent (a pale grey hover background). New ui-v2 components
+     use `bg-ink-accent`, `border-ink-hairline`, etc. */
+  --color-ink-surface: var(--ink-surface);
+  --color-ink-hairline: var(--ink-hairline);
+  --color-ink-mono-fill: var(--ink-mono-fill);
+  --color-ink-accent: var(--ink-accent);
+  --color-ink-accent-subdued: var(--ink-accent-subdued);
+  --font-display: var(--font-display);
+  --font-sans: var(--font-body);
+  --font-mono: var(--font-mono);
   --color-card: var(--card);
   --color-card-foreground: var(--card-foreground);
   --color-popover: var(--popover);
@@ -74,6 +95,10 @@
   * {
     border-color: var(--border);
   }
+  /* D1.0: editorial tokens drive only body bg + fg for now. Phases
+     D1.1+ migrate per-surface components onto the rest of the
+     palette. The legacy shadcn variables above stay until then so
+     existing components keep rendering. */
   body {
     background-color: var(--background);
     color: var(--foreground);

--- a/apps/dashboard/app/layout.tsx
+++ b/apps/dashboard/app/layout.tsx
@@ -1,8 +1,30 @@
 import type { Metadata } from "next";
+import { Fraunces, IBM_Plex_Mono, Newsreader } from "next/font/google";
 import type { ReactNode } from "react";
 import { Providers } from "@/components/providers";
 import { ThemeProvider } from "@/components/theme-provider";
 import "./globals.css";
+
+// D1.0 — free fallback per the redesign spec (PP Editorial New /
+// PP Neue Montreal are licensed and gated on a per-workstation
+// purchase). IBM Plex Mono is free and lands the editorial-mono
+// pairing for technical strings.
+const fraunces = Fraunces({
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-display",
+});
+const newsreader = Newsreader({
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-body",
+});
+const plexMono = IBM_Plex_Mono({
+  subsets: ["latin"],
+  weight: ["400", "500"],
+  display: "swap",
+  variable: "--font-mono",
+});
 
 export const metadata: Metadata = {
   title: "Librarian Dashboard",
@@ -10,13 +32,14 @@ export const metadata: Metadata = {
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
+  const fontVars = `${fraunces.variable} ${newsreader.variable} ${plexMono.variable}`;
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" className={fontVars} suppressHydrationWarning>
       <body>
         <ThemeProvider
           attribute="class"
-          defaultTheme="system"
-          enableSystem
+          defaultTheme="light"
+          enableSystem={false}
           disableTransitionOnChange
         >
           <Providers>{children}</Providers>

--- a/apps/dashboard/components/memories/tab-nav.tsx
+++ b/apps/dashboard/components/memories/tab-nav.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { ThemeToggle } from "@/components/theme-toggle";
 
 const TABS = [
   { href: "/", label: "Browse", match: (p: string) => p === "/" },
@@ -33,6 +34,9 @@ export function TabNav() {
           </Link>
         );
       })}
+      <span className="ml-auto">
+        <ThemeToggle />
+      </span>
     </nav>
   );
 }

--- a/apps/dashboard/components/ui-v2/button.tsx
+++ b/apps/dashboard/components/ui-v2/button.tsx
@@ -1,0 +1,32 @@
+// Editorial-style button stub for the D1.x dashboard redesign.
+//
+// Per spec: outline default, optional primary variant for the one
+// real action per surface. No drop shadows; hairline border + ink
+// foreground. Real interaction logic lives downstream in D1.1–D1.4.
+
+import { forwardRef, type ButtonHTMLAttributes } from "react";
+
+type Variant = "outline" | "primary" | "ghost";
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: Variant;
+}
+
+const variants: Record<Variant, string> = {
+  outline: "border border-foreground/20 bg-transparent text-foreground hover:bg-foreground/[0.04]",
+  primary: "border border-ink-accent bg-transparent text-ink-accent hover:bg-ink-accent/[0.06]",
+  ghost: "border border-transparent text-foreground hover:bg-foreground/[0.04]",
+};
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  { variant = "outline", className = "", children, ...rest },
+  ref,
+) {
+  const base =
+    "inline-flex items-center gap-2 rounded-none px-3 py-1.5 text-sm font-sans transition-colors disabled:cursor-not-allowed disabled:opacity-50";
+  return (
+    <button ref={ref} className={`${base} ${variants[variant]} ${className}`.trim()} {...rest}>
+      {children}
+    </button>
+  );
+});

--- a/apps/dashboard/components/ui-v2/command-palette.tsx
+++ b/apps/dashboard/components/ui-v2/command-palette.tsx
@@ -1,0 +1,33 @@
+// Cmd-K command palette stub.
+//
+// D1.0 pins the open/close shape and the dialog role so the rest of
+// the redesign can register actions against it. The actions registry,
+// fuzzy search, and keyboard wiring all land in D1.4 — until then the
+// dialog opens but only renders a placeholder line.
+
+"use client";
+
+import * as Dialog from "@radix-ui/react-dialog";
+
+interface CommandPaletteProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-foreground/20" />
+        <Dialog.Content className="fixed left-1/2 top-[20%] z-50 w-[min(640px,90vw)] -translate-x-1/2 border border-foreground/15 bg-background p-4 font-sans">
+          <Dialog.Title className="font-display text-lg text-foreground">
+            Command palette
+          </Dialog.Title>
+          <Dialog.Description className="mt-1 text-xs text-foreground/70">
+            Actions register here in D1.4. Press Escape to close.
+          </Dialog.Description>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/apps/dashboard/components/ui-v2/filter-chip.tsx
+++ b/apps/dashboard/components/ui-v2/filter-chip.tsx
@@ -1,0 +1,33 @@
+// Filter pill rendered above each list surface.
+//
+// One chip per applied filter, sitting in a horizontal row above the
+// table or card stack. The dropdown that drives the value lives in
+// D1.1 (data-driven distinctValues); this stub renders the chosen
+// state and a remove handle.
+
+import type { MouseEventHandler } from "react";
+
+interface FilterChipProps {
+  label: string;
+  value: string;
+  onRemove?: MouseEventHandler<HTMLButtonElement>;
+}
+
+export function FilterChip({ label, value, onRemove }: FilterChipProps) {
+  return (
+    <span className="inline-flex items-center gap-2 border border-foreground/15 bg-foreground/[0.03] px-2 py-1 text-xs">
+      <span className="font-sans text-foreground/70">{label}</span>
+      <span className="font-mono text-foreground">{value}</span>
+      {onRemove ? (
+        <button
+          type="button"
+          aria-label={`Remove ${label} filter`}
+          onClick={onRemove}
+          className="text-foreground/60 hover:text-ink-accent"
+        >
+          ×
+        </button>
+      ) : null}
+    </span>
+  );
+}

--- a/apps/dashboard/components/ui-v2/hairline.tsx
+++ b/apps/dashboard/components/ui-v2/hairline.tsx
@@ -1,0 +1,13 @@
+// 1px-at-12%-opacity rule used in place of solid borders.
+//
+// Editorial direction calls for hairlines over heavier separators.
+// One element so the rest of the redesign can drop these in lists,
+// inspectors, and the top-bar bottom edge without re-declaring opacity.
+
+import type { HTMLAttributes } from "react";
+
+export function Hairline({ className = "", ...rest }: HTMLAttributes<HTMLHRElement>) {
+  return (
+    <hr className={`my-0 h-px w-full border-0 bg-foreground/10 ${className}`.trim()} {...rest} />
+  );
+}

--- a/apps/dashboard/components/ui-v2/inspector.tsx
+++ b/apps/dashboard/components/ui-v2/inspector.tsx
@@ -1,0 +1,26 @@
+// Right-rail container used by every D1.x surface for selected-row detail.
+//
+// Stubs the structure (aside + heading + scrollable body) so the
+// memories/sessions/recall surfaces can drop their detail content
+// in without re-implementing the chrome. Collapse behaviour and the
+// `[` shortcut wiring land in D1.4.
+
+import type { ReactNode } from "react";
+
+interface InspectorProps {
+  title: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export function Inspector({ title, children, className = "" }: InspectorProps) {
+  return (
+    <aside
+      aria-label={title}
+      className={`flex h-full w-full flex-col gap-3 border-l border-foreground/10 bg-foreground/[0.02] p-4 ${className}`.trim()}
+    >
+      <h2 className="font-display text-xl text-foreground">{title}</h2>
+      <div className="flex-1 overflow-y-auto text-sm text-foreground">{children}</div>
+    </aside>
+  );
+}

--- a/apps/dashboard/components/ui-v2/key-hint.tsx
+++ b/apps/dashboard/components/ui-v2/key-hint.tsx
@@ -1,0 +1,19 @@
+// Inline keyboard-shortcut hint rendered next to primary buttons.
+//
+// Editorial direction: every action has a shortcut, and the shortcut
+// reads in vermilion (light) / saffron (dark) right next to its
+// trigger so the user doesn't have to invoke the cheatsheet to learn
+// the map. D1.4 wires the matching keypress; this stub just renders
+// the kbd element with the accent.
+
+interface KeyHintProps {
+  shortcut: string;
+}
+
+export function KeyHint({ shortcut }: KeyHintProps) {
+  return (
+    <kbd className="ml-1 inline-flex min-w-[1.25rem] items-center justify-center border border-ink-accent/40 px-1 py-0 font-mono text-[10px] uppercase leading-none text-ink-accent">
+      {shortcut}
+    </kbd>
+  );
+}

--- a/apps/dashboard/components/ui-v2/pill.tsx
+++ b/apps/dashboard/components/ui-v2/pill.tsx
@@ -1,0 +1,22 @@
+// Mono-style chip for technical strings (mem_…, ses_…, timestamps).
+//
+// Real "click to copy" interaction lands in D1.1; this stub only
+// pins the typography (mono) and the chip background so the rest
+// of the redesign can rely on it.
+
+import type { HTMLAttributes, ReactNode } from "react";
+
+interface PillProps extends HTMLAttributes<HTMLSpanElement> {
+  children: ReactNode;
+}
+
+export function Pill({ children, className = "", ...rest }: PillProps) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-none bg-foreground/[0.06] px-1.5 py-0.5 font-mono text-xs leading-none text-foreground ${className}`.trim()}
+      {...rest}
+    >
+      {children}
+    </span>
+  );
+}

--- a/apps/dashboard/styles/tokens.css
+++ b/apps/dashboard/styles/tokens.css
@@ -1,0 +1,38 @@
+/*
+ * D1.0 — editorial palette for the dashboard redesign.
+ *
+ * Two themes ship from day one. The default is light ("Manuscript")
+ * because warm paper reads as a tool for slow, deliberate work; the
+ * dark theme ("Scriptorium") opts in via the `.dark` class that
+ * next-themes already sets on <html>. Both share component shapes —
+ * only the palette changes.
+ *
+ * Token names live under an `ink-` namespace so they coexist with the
+ * legacy shadcn tokens during the rolling D1.x migration. D1.0 only
+ * wires the body background + foreground from the editorial palette
+ * (via globals.css); per-surface components in D1.1–D1.5 reference
+ * the additional tokens here (`--ink-surface`, `--ink-hairline`, etc.)
+ * either via Tailwind utility classes mapped in globals.css or via
+ * `var(--ink-…)` directly.
+ *
+ * Display + body + mono fonts come from next/font in app/layout.tsx
+ * as `--font-display`, `--font-body`, `--font-mono`. Tailwind's
+ * `font-display` / `font-sans` / `font-mono` resolve via the theme
+ * block in globals.css.
+ */
+
+:root {
+  --ink-surface: #faf7f0;
+  --ink-hairline: rgba(26, 22, 18, 0.12);
+  --ink-mono-fill: #ede7d8;
+  --ink-accent: #d14b2a;
+  --ink-accent-subdued: #7b8b6f;
+}
+
+.dark {
+  --ink-surface: #231e18;
+  --ink-hairline: rgba(232, 224, 208, 0.14);
+  --ink-mono-fill: #2a241d;
+  --ink-accent: #e6a33d;
+  --ink-accent-subdued: #7a8b5c;
+}

--- a/apps/dashboard/tests/components/ui-v2/ui-v2.test.tsx
+++ b/apps/dashboard/tests/components/ui-v2/ui-v2.test.tsx
@@ -1,0 +1,77 @@
+// D1.0 — smoke tests for the editorial design-system stubs.
+//
+// One test per stub. The goal is to pin existence + a minimal
+// rendering contract (role, key text, key attribute) so that the
+// later phases (D1.1+) can extend each component without losing
+// the baseline shape that the rest of the dashboard imports.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Button } from "@/components/ui-v2/button";
+import { CommandPalette } from "@/components/ui-v2/command-palette";
+import { FilterChip } from "@/components/ui-v2/filter-chip";
+import { Hairline } from "@/components/ui-v2/hairline";
+import { Inspector } from "@/components/ui-v2/inspector";
+import { KeyHint } from "@/components/ui-v2/key-hint";
+import { Pill } from "@/components/ui-v2/pill";
+
+describe("ui-v2 primitives", () => {
+  it("Button renders a button with its label", () => {
+    render(<Button>Save</Button>);
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+  });
+
+  it("Button applies the primary variant when requested", () => {
+    render(<Button variant="primary">Apply</Button>);
+    const btn = screen.getByRole("button", { name: "Apply" });
+    expect(btn.className).toMatch(/ink-accent/);
+  });
+
+  it("Button applies the ghost variant when requested", () => {
+    render(<Button variant="ghost">Cancel</Button>);
+    const btn = screen.getByRole("button", { name: "Cancel" });
+    expect(btn.className).toMatch(/border-transparent/);
+  });
+
+  it("Pill renders mono-styled content", () => {
+    render(<Pill>mem_abc</Pill>);
+    const pill = screen.getByText("mem_abc");
+    expect(pill).toBeInTheDocument();
+    expect(pill.className).toMatch(/font-mono/);
+  });
+
+  it("Hairline renders a divider element", () => {
+    const { container } = render(<Hairline />);
+    expect(container.querySelector("hr")).not.toBeNull();
+  });
+
+  it("Inspector renders the supplied title and children in an aside", () => {
+    render(
+      <Inspector title="Detail">
+        <p>body</p>
+      </Inspector>,
+    );
+    expect(screen.getByRole("complementary")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Detail" })).toBeInTheDocument();
+    expect(screen.getByText("body")).toBeInTheDocument();
+  });
+
+  it("CommandPalette renders a dialog when open, hidden when closed", () => {
+    const { rerender } = render(<CommandPalette open={false} onOpenChange={() => {}} />);
+    expect(screen.queryByRole("dialog")).toBeNull();
+    rerender(<CommandPalette open={true} onOpenChange={() => {}} />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("FilterChip renders the label and value", () => {
+    render(<FilterChip label="Agent" value="claude-code" />);
+    expect(screen.getByText("Agent")).toBeInTheDocument();
+    expect(screen.getByText("claude-code")).toBeInTheDocument();
+  });
+
+  it("KeyHint renders the key as a kbd element", () => {
+    render(<KeyHint shortcut="a" />);
+    const kbd = screen.getByText("a");
+    expect(kbd.tagName.toLowerCase()).toBe("kbd");
+  });
+});


### PR DESCRIPTION
## Spec / phase reference

Implements **D1.0** — Phase 0 of [\`specs/dashboard-redesign.md\`](../blob/main/specs/dashboard-redesign.md). Pure scaffolding for the editorial dashboard redesign. D1.1 (Memories surface) is the next phase that actually moves user-facing pages.

## Summary

- **Editorial palette under an \`ink-*\` namespace** (\`styles/tokens.css\`) so it coexists with the legacy shadcn tokens during the rolling D1.x migration. Two themes ship from day one — light \"Manuscript\" (\`#f5f1e8\` paper + \`#1a1612\` ink) and dark \"Scriptorium\" (\`#1c1814\` walnut + \`#e8e0d0\` cream).
- **Only body bg + fg + the two card/popover surfaces flip** in this PR. All other shadcn tokens keep their defaults so existing components render unchanged.
- **Fonts via next/font/google:** Fraunces (display), Newsreader (body), IBM Plex Mono (mono). Free fallback per the spec — the licensed PP Editorial New / PP Neue Montreal can swap in later without touching component code (variables already exposed via \`@theme inline\`).
- **Theme toggle wired** into the shared \`TabNav\` (already existed under \`components/theme-toggle.tsx\` — D1.0 just surfaces it).
- **Seven stub components** under \`components/ui-v2/\`: \`Button\`, \`Pill\`, \`Hairline\`, \`Inspector\`, \`CommandPalette\`, \`FilterChip\`, \`KeyHint\`. Each minimal — pins the structural contract (role / heading / aside / kbd) so D1.1+ extends without rewriting the chrome.

## Test plan

- [x] \`pnpm install --frozen-lockfile\`
- [x] \`pnpm test\` — 235 tests pass across the monorepo (90 core + 70 mcp-server + 45 cli + 30 dashboard, including 9 new ui-v2 tests).
- [x] \`pnpm --filter @librarian/dashboard typecheck\` — green.
- [x] \`pnpm --filter @librarian/dashboard build\` — \`next build\` green.
- [x] \`pnpm --filter @librarian/dashboard test:e2e\` — all 5 Playwright tests pass.
- [x] No visual regression on existing pages — bg flips to warm paper, every other component keeps its shape.

## Quality gates

- [x] **No production source file over 400 LOC introduced.** Total new production source: 222 LOC across 7 stubs + 1 token sheet.
- [x] **No new \`any\` or \`@ts-ignore\` introduced.**

## Notes for the reviewer

- **Licensed-font deferral.** Spec calls for PP Editorial New + PP Neue Montreal (per-workstation purchase). D1.0 uses the documented free fallback (Fraunces / Newsreader). Swap in later by replacing the \`next/font/google\` imports with \`next/font/local\` — token mapping in \`@theme inline\` already exposes \`--font-display\` / \`--font-sans\` / \`--font-mono\` so the swap doesn't touch any component.
- **Why \`ink-*\` namespace?** Shadcn's own \`--accent\` is a pale grey hover background. Renaming the editorial vermilion accent to \`--ink-accent\` avoids clashing while keeping shadcn-styled surfaces visually quiet during the migration. D1.5 cleanup can drop \`components/ui/\` and consolidate to the editorial palette.
- **Card / popover surfaces** were nudged onto \`var(--ink-surface)\` after the agent review caught that pure-white panels on warm paper would read as a regression.
- **One review suggestion was deferred:** the spec's open question on \`Newsreader\` weight axis. Will revisit in D1.5 once D1.1–D1.4 have settled on weights they actually use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)