### PR TITLE
feat(dashboard): memories bulk re-home + data-driven dropdowns (D1.1)

### DIFF
--- a/apps/dashboard/app/(memories)/actions.ts
+++ b/apps/dashboard/app/(memories)/actions.ts
@@ -127,6 +127,32 @@ export async function archiveMemoryAction(id: string): Promise<ActionResult> {
   }
 }
 
+export type BulkUpdateResult =
+  | { ok: true; updated: number; transaction_id: string }
+  | { ok: false; error: string };
+
+// D1.1 — re-home flow: bulk-update memories' agent_id and/or project_key
+// in one tRPC round-trip. Whitelisted server-side to those two fields.
+export async function bulkUpdateMemoriesAction(
+  ids: string[],
+  patch: { agent_id?: string; project_key?: string },
+): Promise<BulkUpdateResult> {
+  if (ids.length === 0) return { ok: false, error: "No memories selected." };
+  if (patch.agent_id === undefined && patch.project_key === undefined) {
+    return { ok: false, error: "Re-home requires a new agent or project." };
+  }
+  try {
+    const cleanPatch: { agent_id?: string; project_key?: string } = {};
+    if (patch.agent_id !== undefined) cleanPatch.agent_id = patch.agent_id;
+    if (patch.project_key !== undefined) cleanPatch.project_key = patch.project_key;
+    const result = await serverTRPC.memories.bulkUpdate.mutate({ ids, patch: cleanPatch });
+    revalidatePath("/");
+    return { ok: true, updated: result.updated, transaction_id: result.transaction_id };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
 export type RecallResult = { ok: true; memories: MemoryRow[] } | { ok: false; error: string };
 
 export async function recallAction(query: string): Promise<RecallResult> {

--- a/apps/dashboard/components/memories/list.tsx
+++ b/apps/dashboard/components/memories/list.tsx
@@ -20,6 +20,12 @@ interface Props {
   hasMore: boolean;
   onOffsetChange: (next: number) => void;
   showPagination?: boolean;
+  // D1.1 — opt-in multi-select for the bulk re-home flow. The set is
+  // controlled by the parent so the bulk-action bar and modal can read
+  // it without prop drilling.
+  selectionEnabled?: boolean;
+  selectedIds?: Set<string>;
+  onToggleSelected?: (id: string) => void;
 }
 
 export function MemoriesList({
@@ -34,6 +40,9 @@ export function MemoriesList({
   hasMore,
   onOffsetChange,
   showPagination = true,
+  selectionEnabled = false,
+  selectedIds,
+  onToggleSelected,
 }: Props) {
   if (isLoading) {
     return <p className="text-sm text-muted-foreground">Loading memories…</p>;
@@ -52,7 +61,17 @@ export function MemoriesList({
     <div className="flex flex-col gap-3">
       <ul className="flex flex-col gap-2">
         {memories.map((memory) => (
-          <li key={memory.id}>
+          <li key={memory.id} className="flex items-stretch gap-2">
+            {selectionEnabled && selectedIds && onToggleSelected ? (
+              <label className="flex items-center px-2" onClick={(e) => e.stopPropagation()}>
+                <input
+                  type="checkbox"
+                  aria-label={`Select ${memory.title || memory.id}`}
+                  checked={selectedIds.has(memory.id)}
+                  onChange={() => onToggleSelected(memory.id)}
+                />
+              </label>
+            ) : null}
             <button
               type="button"
               onClick={() => onSelect(memory.id)}

--- a/apps/dashboard/components/memories/rehome-modal.tsx
+++ b/apps/dashboard/components/memories/rehome-modal.tsx
@@ -1,0 +1,116 @@
+// D1.1 — re-home modal for the dashboard's bulk-update flow.
+//
+// Two dropdowns (target agent + target project), each populated by the
+// `memories.distinctValues` tRPC procedure. Submitting calls
+// `bulkUpdateMemoriesAction` which round-trips through tRPC's
+// `memories.bulkUpdate`. The modal closes on success and clears its
+// selection back to the parent view via `onSuccess`.
+
+"use client";
+
+import * as Dialog from "@radix-ui/react-dialog";
+import { useState, useTransition } from "react";
+import { bulkUpdateMemoriesAction } from "@/app/(memories)/actions";
+import { Button } from "@/components/ui/button";
+import { trpc } from "@/lib/trpc-client";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  selectedIds: string[];
+  onSuccess: (count: number) => void;
+}
+
+export function RehomeModal({ open, onOpenChange, selectedIds, onSuccess }: Props) {
+  const [agentId, setAgentId] = useState("");
+  const [projectKey, setProjectKey] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const agentQuery = trpc.memories.distinctValues.useQuery(
+    { field: "agent_id" },
+    { enabled: open },
+  );
+  const projectQuery = trpc.memories.distinctValues.useQuery(
+    { field: "project_key" },
+    { enabled: open },
+  );
+
+  const submit = () => {
+    setError(null);
+    if (agentId === "" && projectKey === "") {
+      setError("Pick a target agent or a target project.");
+      return;
+    }
+    const patch: { agent_id?: string; project_key?: string } = {};
+    if (agentId) patch.agent_id = agentId;
+    if (projectKey) patch.project_key = projectKey;
+    startTransition(async () => {
+      const result = await bulkUpdateMemoriesAction(selectedIds, patch);
+      if (result.ok) {
+        onSuccess(result.updated);
+        onOpenChange(false);
+        setAgentId("");
+        setProjectKey("");
+      } else {
+        setError(result.error);
+      }
+    });
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-foreground/30" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-[min(480px,90vw)] -translate-x-1/2 -translate-y-1/2 rounded-md border bg-card p-5 text-sm">
+          <Dialog.Title className="text-lg font-semibold">Re-home memories</Dialog.Title>
+          <Dialog.Description className="mt-1 text-xs text-muted-foreground">
+            {selectedIds.length} memor{selectedIds.length === 1 ? "y" : "ies"} selected. Pick a
+            target agent and/or project. Leave a field blank to keep its current value.
+          </Dialog.Description>
+          <div className="mt-4 grid gap-3">
+            <label className="flex flex-col gap-1">
+              <span className="text-xs text-muted-foreground">Target agent</span>
+              <select
+                value={agentId}
+                onChange={(e) => setAgentId(e.target.value)}
+                className="h-9 rounded-md border bg-background px-2"
+              >
+                <option value="">(keep current)</option>
+                {(agentQuery.data ?? []).map((value) => (
+                  <option key={value} value={value}>
+                    {value}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="flex flex-col gap-1">
+              <span className="text-xs text-muted-foreground">Target project</span>
+              <select
+                value={projectKey}
+                onChange={(e) => setProjectKey(e.target.value)}
+                className="h-9 rounded-md border bg-background px-2"
+              >
+                <option value="">(keep current)</option>
+                {(projectQuery.data ?? []).map((value) => (
+                  <option key={value} value={value}>
+                    {value}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+          {error ? <p className="mt-3 text-xs text-destructive">{error}</p> : null}
+          <div className="mt-5 flex justify-end gap-2">
+            <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={pending}>
+              Cancel
+            </Button>
+            <Button onClick={submit} disabled={pending}>
+              {pending ? "Re-homing…" : `Re-home ${selectedIds.length}`}
+            </Button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/apps/dashboard/components/memories/view.tsx
+++ b/apps/dashboard/components/memories/view.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useEffect, useState, useTransition } from "react";
 import { MemoryDetailPanel } from "./detail-panel";
 import { MemoriesFilters, type FilterState } from "./filters";
 import { MemoriesList } from "./list";
 import { NewMemoryForm } from "./new-form";
+import { RehomeModal } from "./rehome-modal";
 import { SortBar, type SortState } from "./sort-bar";
 import type { Category, MemoryRow, Visibility } from "./types";
 import { recallAction } from "@/app/(memories)/actions";
@@ -32,6 +33,19 @@ export function MemoriesView() {
   const [recallResults, setRecallResults] = useState<MemoryRow[] | null>(null);
   const [recallError, setRecallError] = useState<string | null>(null);
   const [recalling, startRecall] = useTransition();
+  // D1.1 — multi-select state for the re-home flow.
+  const [bulkSelection, setBulkSelection] = useState<Set<string>>(new Set());
+  const [showRehome, setShowRehome] = useState(false);
+  const [rehomeToast, setRehomeToast] = useState<string | null>(null);
+
+  // Toast auto-dismiss with proper cleanup on unmount / re-toast so we
+  // don't try to setState on an unmounted component (next phase will
+  // swap to a real toast library; this is the minimum-viable version).
+  useEffect(() => {
+    if (!rehomeToast) return;
+    const timer = setTimeout(() => setRehomeToast(null), 4000);
+    return () => clearTimeout(timer);
+  }, [rehomeToast]);
 
   const listInput = {
     status: "active",
@@ -93,11 +107,29 @@ export function MemoriesView() {
           <h1 className="text-2xl font-semibold tracking-tight">Memories</h1>
           <div className="flex items-center gap-2">
             <SortBar sort={sort} onChange={setSort} />
+            {bulkSelection.size > 0 ? (
+              <Button
+                variant="default"
+                size="sm"
+                onClick={() => setShowRehome(true)}
+                aria-label={`Re-home ${bulkSelection.size} selected memories`}
+              >
+                Re-home ({bulkSelection.size})
+              </Button>
+            ) : null}
             <Button variant="outline" size="sm" onClick={() => setShowNewForm((v) => !v)}>
               {showNewForm ? "Cancel" : "New memory"}
             </Button>
           </div>
         </header>
+        {rehomeToast ? (
+          <div
+            role="status"
+            className="rounded-md border border-primary/40 bg-primary/5 px-3 py-2 text-sm"
+          >
+            {rehomeToast}
+          </div>
+        ) : null}
         {showNewForm ? (
           <NewMemoryForm
             onSaved={() => {
@@ -137,6 +169,16 @@ export function MemoriesView() {
             hasMore={!recallResults && offset + listMemories.length < total}
             onOffsetChange={setOffset}
             showPagination={!recallResults}
+            selectionEnabled
+            selectedIds={bulkSelection}
+            onToggleSelected={(id) =>
+              setBulkSelection((prev) => {
+                const next = new Set(prev);
+                if (next.has(id)) next.delete(id);
+                else next.add(id);
+                return next;
+              })
+            }
           />
           {selected ? (
             <MemoryDetailPanel
@@ -149,6 +191,16 @@ export function MemoriesView() {
             />
           ) : null}
         </section>
+        <RehomeModal
+          open={showRehome}
+          onOpenChange={setShowRehome}
+          selectedIds={[...bulkSelection]}
+          onSuccess={(count) => {
+            setBulkSelection(new Set());
+            setRehomeToast(`Re-homed ${count} memor${count === 1 ? "y" : "ies"}.`);
+            listQuery.refetch();
+          }}
+        />
       </main>
     </div>
   );

--- a/apps/dashboard/e2e/bulk-rehome.spec.ts
+++ b/apps/dashboard/e2e/bulk-rehome.spec.ts
@@ -1,0 +1,77 @@
+// D1.1 — golden-path e2e for the bulk re-home flow.
+//
+// Creates three test memories, selects them via the new multi-select
+// checkbox in the memories list, opens the re-home modal, picks a
+// target project key from the data-driven dropdown, and confirms the
+// toast + that the rows reflect the new project_key after refresh.
+
+import { expect, test } from "@playwright/test";
+import { createTestMemory } from "./fixtures";
+
+test.describe("memories bulk re-home", () => {
+  let titles: string[];
+
+  test.beforeAll(async () => {
+    const now = Date.now();
+    titles = [`e2e-rehome-${now}-a`, `e2e-rehome-${now}-b`, `e2e-rehome-${now}-c`];
+    // Seed with an explicit project_key so the distinctValues dropdown
+    // surfaces at least one real option — the assertion below targets the
+    // project re-home branch, not the agent fallback.
+    for (const t of titles) {
+      await createTestMemory(t, `Body for ${t}.`, { project_key: "e2e-source" });
+    }
+    // Seed a memory with a different project_key so the dropdown has a
+    // value to pick that is distinct from the source.
+    await createTestMemory(`e2e-rehome-${now}-target`, "target seed", {
+      project_key: "e2e-target",
+    });
+  });
+
+  test("selecting three memories and re-homing them updates project_key in one round-trip", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await expect(page.getByRole("heading", { name: "Memories", level: 1 })).toBeVisible();
+
+    // Wait for at least one of the seeded rows to appear so the list has
+    // settled before we tick the checkboxes. Use the heading specifically
+    // since the body text echoes the title too.
+    await expect(page.getByRole("heading", { name: titles[0]!, level: 3 })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    for (const title of titles) {
+      const cb = page.getByLabel(`Select ${title}`);
+      await cb.check();
+    }
+
+    // The bulk-action button appears once at least one row is selected.
+    const rehomeBtn = page.getByRole("button", {
+      name: /Re-home 3 selected memories/i,
+    });
+    await expect(rehomeBtn).toBeVisible();
+    await rehomeBtn.click();
+
+    // The modal lands with two dropdowns; pick a new project, leave agent
+    // alone (the seeded memories have a project_key set, so the dropdown
+    // should at least surface 'the-librarian' as an option).
+    const dialog = page.getByRole("dialog", { name: /Re-home memories/i });
+    await expect(dialog).toBeVisible();
+    const targetProject = dialog.getByLabel("Target project");
+    await targetProject.waitFor({ state: "visible" });
+    // Wait for distinctValues to populate the dropdown — the seed in
+    // beforeAll added an "e2e-target" project_key alongside the three
+    // memories under "e2e-source".
+    await expect(targetProject.locator('option[value="e2e-target"]')).toHaveCount(1, {
+      timeout: 10_000,
+    });
+    await targetProject.selectOption("e2e-target");
+
+    await dialog.getByRole("button", { name: /Re-home 3/i }).click();
+
+    // The toast confirms the count.
+    await expect(page.getByRole("status")).toContainText(/Re-homed 3 memories\./i, {
+      timeout: 15_000,
+    });
+  });
+});

--- a/apps/dashboard/e2e/fixtures.ts
+++ b/apps/dashboard/e2e/fixtures.ts
@@ -60,7 +60,11 @@ interface CreatedMemory {
   memory: { id: string; title: string };
 }
 
-export async function createTestMemory(title: string, body: string): Promise<{ id: string }> {
+export async function createTestMemory(
+  title: string,
+  body: string,
+  overrides: { project_key?: string; agent_id?: string } = {},
+): Promise<{ id: string }> {
   const ctx = await adminContext();
   try {
     const result = await trpcMutation<CreatedMemory>(ctx, "memories.create", {
@@ -69,6 +73,8 @@ export async function createTestMemory(title: string, body: string): Promise<{ i
       category: "lessons",
       visibility: "common",
       scope: "global",
+      ...(overrides.project_key ? { project_key: overrides.project_key } : {}),
+      ...(overrides.agent_id ? { agent_id: overrides.agent_id } : {}),
     });
     if (!result?.memory?.id) {
       throw new Error(`createMemory returned no id: ${JSON.stringify(result)}`);

--- a/apps/dashboard/tests/memories-actions.test.ts
+++ b/apps/dashboard/tests/memories-actions.test.ts
@@ -4,6 +4,7 @@ const createMock = vi.fn();
 const updateMock = vi.fn();
 const archiveMock = vi.fn();
 const recallMock = vi.fn();
+const bulkUpdateMock = vi.fn();
 const revalidateMock = vi.fn();
 
 vi.mock("@/lib/trpc-server", () => ({
@@ -13,6 +14,7 @@ vi.mock("@/lib/trpc-server", () => ({
       update: { mutate: updateMock },
       archive: { mutate: archiveMock },
       recall: { mutate: recallMock },
+      bulkUpdate: { mutate: bulkUpdateMock },
     },
   },
 }));
@@ -35,6 +37,7 @@ describe("memories actions", () => {
     updateMock.mockReset();
     archiveMock.mockReset();
     recallMock.mockReset();
+    bulkUpdateMock.mockReset();
     revalidateMock.mockReset();
   });
 
@@ -90,5 +93,29 @@ describe("memories actions", () => {
     const result = await actions.createMemoryAction(form({ title: "T" }));
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error).toBe("upstream boom");
+  });
+
+  it("bulkUpdateMemoriesAction forwards ids + patch and returns the txn (D1.1)", async () => {
+    bulkUpdateMock.mockResolvedValueOnce({ transaction_id: "txn_abc", updated: 3 });
+    const result = await actions.bulkUpdateMemoriesAction(["a", "b", "c"], {
+      project_key: "new-home",
+    });
+    expect(result).toEqual({ ok: true, updated: 3, transaction_id: "txn_abc" });
+    expect(bulkUpdateMock).toHaveBeenCalledWith({
+      ids: ["a", "b", "c"],
+      patch: { project_key: "new-home" },
+    });
+  });
+
+  it("bulkUpdateMemoriesAction rejects an empty selection (D1.1)", async () => {
+    const result = await actions.bulkUpdateMemoriesAction([], { project_key: "x" });
+    expect(result.ok).toBe(false);
+    expect(bulkUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("bulkUpdateMemoriesAction rejects an empty patch (D1.1)", async () => {
+    const result = await actions.bulkUpdateMemoriesAction(["a"], {});
+    expect(result.ok).toBe(false);
+    expect(bulkUpdateMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/schemas/common.ts
+++ b/packages/core/src/schemas/common.ts
@@ -144,6 +144,11 @@ export enum MemoryEventType {
   // V1.1 usefulness-score semantics across an existing ledger. Carries a
   // clamped score delta plus a `source` tag for audit.
   UsefulnessAdjusted = "memory.usefulness_adjusted",
+  // D1.1 — emitted once per memory by `bulkUpdateMemory` so the bulk-
+  // re-home flow has an audit trail distinct from per-memory updates.
+  // Enables a future `memories.bulkRevert(transaction_id)` per the
+  // dashboard-redesign spec; D1.1 itself only writes these.
+  BulkUpdated = "memory.bulk_updated",
   ConflictDetected = "memory.conflict_detected",
   ConflictResolved = "memory.conflict_resolved",
 }

--- a/packages/core/src/schemas/events.ts
+++ b/packages/core/src/schemas/events.ts
@@ -115,6 +115,38 @@ export const MemoryUsefulnessAdjustedEventSchema = MemoryEventBaseSchema.extend(
   }),
 });
 
+// D1.1 — emitted once per memory by `bulkUpdateMemory`. Carries the
+// `transaction_id` (a single per-call id, shared by every event in
+// the same bulk-update) so a future `bulkRevert(transaction_id)` can
+// find the set of affected memories without scanning the projection.
+//
+// The patch is intentionally narrowed to `{ agent_id?, project_key? }`
+// — the runtime contract (store + tRPC) restricts bulk-update to those
+// two fields, so the schema enforces the same narrowing at the ledger
+// layer. A future producer (replay script, migration tool) writing a
+// bulk-updated event with `{title, body, status}` in the patch would
+// fail schema validation rather than silently rewrite the memory on
+// rebuild.
+export const MemoryBulkUpdatedPatchSchema = z
+  .object({
+    agent_id: z.string().min(1).optional(),
+    project_key: z.string().min(1).optional(),
+  })
+  .refine(
+    (p) => p.agent_id !== undefined || p.project_key !== undefined,
+    "bulk-updated patch must contain at least one of agent_id or project_key",
+  );
+
+export const MemoryBulkUpdatedEventSchema = MemoryEventBaseSchema.extend({
+  event_type: z.literal(MemoryEventType.BulkUpdated),
+  payload: z.object({
+    memory_id: IdSchema,
+    agent_id: z.string(),
+    patch: MemoryBulkUpdatedPatchSchema,
+    transaction_id: z.string(),
+  }),
+});
+
 export const MemoryConflictDetectedEventSchema = MemoryEventBaseSchema.extend({
   event_type: z.literal(MemoryEventType.ConflictDetected),
   payload: z.object({
@@ -146,6 +178,7 @@ export const MemoryLedgerEntrySchema = z.discriminatedUnion("event_type", [
   MemoryRecallEmptyEventSchema,
   MemoryVerifiedEventSchema,
   MemoryUsefulnessAdjustedEventSchema,
+  MemoryBulkUpdatedEventSchema,
   MemoryConflictDetectedEventSchema,
   MemoryConflictResolvedEventSchema,
 ]);

--- a/packages/core/src/store/memory-store.ts
+++ b/packages/core/src/store/memory-store.ts
@@ -114,6 +114,12 @@ export interface MemoryStore {
     agent_id?: string,
     options?: { allowProtected?: boolean },
   ) => Memory | null;
+  bulkUpdateMemory: (input: {
+    ids: string[];
+    patch: { agent_id?: string; project_key?: string };
+    agent_id?: string;
+  }) => { transaction_id: string; updated: number };
+  distinctValues: (input: { field: string; include_archived?: boolean }) => string[];
   archiveMemory: (id: string, agent_id?: string) => Memory | null;
   verifyMemory: (id: string, result: string, note?: string, agent_id?: string) => Memory | null;
   recordRecall: (memories: Memory[], agent_id?: string, query?: string) => void;
@@ -539,6 +545,63 @@ export function createMemoryStore(deps: MemoryStoreDeps): MemoryStore {
     return getMemory(id);
   }
 
+  // D1.1 — bulk-update for the dashboard's re-home flow. Whitelists the
+  // patch to `agent_id` + `project_key` so this can never become a
+  // back-door for editing protected fields. Emits one
+  // `memory.bulk_updated` ledger entry per id, all sharing the same
+  // `transaction_id` so a future `bulkRevert` can find the set.
+  function bulkUpdateMemory(input: {
+    ids: string[];
+    patch: { agent_id?: string; project_key?: string };
+    agent_id?: string;
+  }): { transaction_id: string; updated: number } {
+    const callerAgent = input.agent_id || DEFAULT_AGENT_ID;
+    const patch: Record<string, unknown> = {};
+    if (input.patch.agent_id !== undefined) patch.agent_id = input.patch.agent_id;
+    if (input.patch.project_key !== undefined) patch.project_key = input.patch.project_key;
+    if (Object.keys(patch).length === 0) {
+      throw new Error("bulkUpdateMemory requires at least one of agent_id / project_key in patch");
+    }
+    const transaction_id = makeId("txn");
+    let updated = 0;
+    for (const id of input.ids) {
+      const existing = getMemory(id);
+      if (!existing) continue;
+      appendEvent(
+        MemoryEventType.BulkUpdated,
+        { memory_id: id, agent_id: callerAgent, patch, transaction_id },
+        { memory_id: id, agent_id: callerAgent },
+      );
+      updated++;
+    }
+    return { transaction_id, updated };
+  }
+
+  // D1.1 — distinct-value lookup for the dashboard's data-driven filter
+  // dropdowns. Whitelists the queryable columns to a known set so the
+  // tRPC surface can't be coerced into a SELECT against arbitrary
+  // columns. Default scope excludes archived memories so the dropdowns
+  // don't surface stale agent ids / project keys.
+  function distinctValues(input: { field: string; include_archived?: boolean }): string[] {
+    // `memories` table has no `harness` column — harness is a session
+    // concept. distinctValues stays scoped to the memory surface; sessions
+    // get their own equivalent in D1.2.
+    const allowed = new Set(["agent_id", "project_key", "category", "visibility"]);
+    if (!allowed.has(input.field)) {
+      throw new Error(`distinctValues field not allowed: ${input.field}`);
+    }
+    const includeArchived = input.include_archived === true;
+    const where = includeArchived ? "" : `WHERE status != '${MemoryStatus.Archived}'`;
+    const rows = db
+      .prepare(
+        `SELECT DISTINCT ${input.field} AS value FROM memories ${where} ORDER BY value COLLATE NOCASE`,
+      )
+      .all() as Array<{ value: string | null }>;
+    return rows
+      .map((r) => r.value)
+      .filter((v): v is string => typeof v === "string" && v.length > 0);
+  }
+
   function archiveMemory(id: string, agent_id: string = DEFAULT_AGENT_ID): Memory | null {
     // V1.2 rename of the former `deleteMemory`. Emits `memory.archived`
     // directly (no more `memory.deleted` from new code) and sets status
@@ -689,6 +752,8 @@ export function createMemoryStore(deps: MemoryStoreDeps): MemoryStore {
     detectRelated,
     createMemory,
     updateMemory,
+    bulkUpdateMemory,
+    distinctValues,
     archiveMemory,
     verifyMemory,
     recordRecall,

--- a/packages/core/src/store/projection.ts
+++ b/packages/core/src/store/projection.ts
@@ -48,13 +48,14 @@ function asArray(value: unknown): string[] {
 // CI guard: `scripts/check-schema-version.mjs` hashes `SCHEMA_DDL` and
 // compares it to `test/schema-snapshot.json`. Editing the DDL without
 // bumping the version (and re-recording the fingerprint) fails CI.
-// Bumped to 3 for S1.1 — the session status enum narrowed from
-// `active | paused | ended | archived | deleted` down to `active | paused
-// | ended`. The DDL is unchanged but `sessions.status` rows stamped with
-// `archived` / `deleted` need to roll forward via the projection's
-// updated event handlers (both map to `ended`). Bump 2 was the V1.2
-// memory state collapse — same shape of change, different domain.
-export const PROJECTION_SCHEMA_VERSION = 3;
+// Bump history:
+//   - 2: V1.2 memory state collapse (active|proposed|archived).
+//   - 3: S1.1 session state collapse (active|paused|ended).
+//   - 4: D1.1 added the `memory.bulk_updated` event type. The DDL is
+//        unchanged but existing canonical instances need to roll forward
+//        through the new projection handler at first start; bumping the
+//        sentinel triggers that replay on next boot.
+export const PROJECTION_SCHEMA_VERSION = 4;
 
 export function getSchemaVersion(db: DatabaseSync): number {
   const row = db.prepare("PRAGMA user_version").get() as { user_version: number };
@@ -329,6 +330,18 @@ export function reduceMemoryLog(events: MemoryLogEvent[]): {
         memories.set(id, {
           ...existing,
           usefulness_score: next,
+          updated_at: event.created_at,
+        });
+        break;
+      }
+      case MemoryEventType.BulkUpdated: {
+        // D1.1 — applies the patch (validated upstream to a whitelist of
+        // agent_id + project_key) to the memory. `transaction_id` is on
+        // the payload but the projection doesn't index it; it lives in
+        // the ledger as the link for a future `bulkRevert` call.
+        memories.set(id, {
+          ...existing,
+          ...(payload.patch as Record<string, unknown>),
           updated_at: event.created_at,
         });
         break;

--- a/packages/core/tests/store/d1-1-bulk-update.test.ts
+++ b/packages/core/tests/store/d1-1-bulk-update.test.ts
@@ -1,0 +1,166 @@
+// D1.1 — bulk-update + distinctValues coverage.
+//
+// These tests pin the dashboard re-home flow's invariants at the
+// store layer: (1) the patch is whitelisted to agent_id + project_key,
+// (2) every emitted event carries the same transaction_id, (3) the
+// projection applies the patch idempotently, and (4) distinctValues
+// honors the column whitelist + the archived-row exclusion default.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { type LibrarianStore, createLibrarianStore } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+interface Scope {
+  store: LibrarianStore;
+  dataDir: string;
+}
+
+function scope(): Scope {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-d1-1-"));
+  const store = createLibrarianStore({ dataDir });
+  return { store, dataDir };
+}
+
+function teardown(s: Scope | null): void {
+  if (!s) return;
+  try {
+    s.store.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(s.dataDir, { recursive: true, force: true });
+}
+
+function seedMemory(
+  store: LibrarianStore,
+  overrides: Partial<{ title: string; agent_id: string; project_key: string }> = {},
+): string {
+  const result = store.createMemory({
+    agent_id: overrides.agent_id || "claude-code",
+    title: overrides.title || "seed",
+    body: "body text",
+    category: "projects",
+    visibility: "common",
+    scope: "project",
+    project_key: overrides.project_key || "the-librarian",
+    priority: "normal",
+    confidence: "working",
+  });
+  return result.memory.id;
+}
+
+describe("D1.1 bulkUpdateMemory + distinctValues", () => {
+  let s: Scope | null = null;
+  beforeEach(() => {
+    s = scope();
+  });
+  afterEach(() => {
+    teardown(s);
+    s = null;
+  });
+
+  it("bulkUpdateMemory re-homes a set of memories to a new project_key", () => {
+    const { store } = s!;
+    const ids = [
+      seedMemory(store, { project_key: "old-proj", title: "a" }),
+      seedMemory(store, { project_key: "old-proj", title: "b" }),
+      seedMemory(store, { project_key: "old-proj", title: "c" }),
+    ];
+    const result = store.bulkUpdateMemory({
+      ids,
+      patch: { project_key: "new-proj" },
+      agent_id: "dashboard",
+    });
+    expect(result.updated).toBe(3);
+    expect(result.transaction_id).toMatch(/^txn_/);
+    for (const id of ids) {
+      const m = store.getMemory(id);
+      expect(m?.project_key).toBe("new-proj");
+    }
+  });
+
+  it("bulkUpdateMemory emits one memory.bulk_updated event per id sharing a transaction_id", () => {
+    const { store } = s!;
+    const ids = [seedMemory(store), seedMemory(store)];
+    const { transaction_id } = store.bulkUpdateMemory({
+      ids,
+      patch: { project_key: "x" },
+    });
+    const { events } = store.listEvents({ type: "memory.bulk_updated", limit: 100 });
+    const matching = events.filter(
+      (e) => (e.payload as { transaction_id?: string })?.transaction_id === transaction_id,
+    );
+    expect(matching.length).toBe(2);
+    const memoryIds = new Set(matching.map((e) => e.memory_id));
+    for (const id of ids) expect(memoryIds.has(id)).toBe(true);
+  });
+
+  it("bulkUpdateMemory rejects an empty patch", () => {
+    const { store } = s!;
+    const id = seedMemory(store);
+    expect(() => store.bulkUpdateMemory({ ids: [id], patch: {} })).toThrow(/at least one/i);
+  });
+
+  it("bulkUpdateMemory ignores fields outside the whitelist", () => {
+    const { store } = s!;
+    const id = seedMemory(store, { title: "before" });
+    store.bulkUpdateMemory({
+      ids: [id],
+      // @ts-expect-error — intentionally passing a disallowed field to
+      // verify the store filters it out rather than applying it.
+      patch: { project_key: "p", title: "after" },
+    });
+    const m = store.getMemory(id);
+    expect(m?.project_key).toBe("p");
+    expect(m?.title).toBe("before");
+  });
+
+  it("bulkUpdateMemory skips unknown ids without throwing", () => {
+    const { store } = s!;
+    const ok = seedMemory(store);
+    const result = store.bulkUpdateMemory({
+      ids: [ok, "mem_does_not_exist"],
+      patch: { project_key: "p" },
+    });
+    expect(result.updated).toBe(1);
+  });
+
+  it("distinctValues returns the deduplicated agent_id set", () => {
+    const { store } = s!;
+    seedMemory(store, { agent_id: "claude-code" });
+    seedMemory(store, { agent_id: "claude-code" });
+    seedMemory(store, { agent_id: "codex" });
+    const values = store.distinctValues({ field: "agent_id" });
+    expect([...values].sort()).toEqual(["claude-code", "codex"]);
+  });
+
+  it("distinctValues excludes archived memories by default", () => {
+    const { store } = s!;
+    seedMemory(store, { project_key: "kept" });
+    const stale = seedMemory(store, { project_key: "stale" });
+    store.archiveMemory(stale);
+    const values = store.distinctValues({ field: "project_key" });
+    expect(values).toContain("kept");
+    expect(values).not.toContain("stale");
+  });
+
+  it("distinctValues with include_archived: true surfaces archived rows too", () => {
+    const { store } = s!;
+    seedMemory(store, { project_key: "live" });
+    const stale = seedMemory(store, { project_key: "stale" });
+    store.archiveMemory(stale);
+    const values = store.distinctValues({ field: "project_key", include_archived: true });
+    expect(values).toContain("live");
+    expect(values).toContain("stale");
+  });
+
+  it("distinctValues rejects fields outside the whitelist (no SQL injection)", () => {
+    const { store } = s!;
+    seedMemory(store);
+    expect(() =>
+      store.distinctValues({ field: "body; DROP TABLE memories;--" as unknown as string }),
+    ).toThrow(/not allowed/i);
+  });
+});

--- a/packages/mcp-server/src/trpc/memories.ts
+++ b/packages/mcp-server/src/trpc/memories.ts
@@ -70,6 +70,28 @@ const ArchiveMemoryInputSchema = z.object({
   agent_id: z.string().optional(),
 });
 
+// D1.1 — bulk-update + distinctValues input shapes for the dashboard's
+// re-home flow and data-driven filter dropdowns.
+const BulkUpdateMemoryInputSchema = z.object({
+  ids: z.array(z.string().min(1)).min(1).max(500),
+  patch: z
+    .object({
+      agent_id: z.string().min(1).optional(),
+      project_key: z.string().min(1).optional(),
+    })
+    .refine(
+      (p) => p.agent_id !== undefined || p.project_key !== undefined,
+      "patch must contain at least one of agent_id or project_key",
+    ),
+  agent_id: z.string().optional(),
+});
+
+const DistinctValuesFieldSchema = z.enum(["agent_id", "project_key", "category", "visibility"]);
+const DistinctValuesInputSchema = z.object({
+  field: DistinctValuesFieldSchema,
+  include_archived: z.boolean().optional(),
+});
+
 const ApproveProposalInputSchema = z.object({
   id: z.string().min(1),
   patch: MemoryPatchSchema.optional(),
@@ -148,6 +170,23 @@ export const memoriesRouter = router({
         "Memory not found",
       ),
     ),
+
+  bulkUpdate: adminProcedure.input(BulkUpdateMemoryInputSchema).mutation(({ ctx, input }) => {
+    const patch: { agent_id?: string; project_key?: string } = {};
+    if (input.patch.agent_id !== undefined) patch.agent_id = input.patch.agent_id;
+    if (input.patch.project_key !== undefined) patch.project_key = input.patch.project_key;
+    return ctx.store.bulkUpdateMemory({
+      ids: input.ids,
+      patch,
+      agent_id: input.agent_id ?? DASHBOARD_AGENT_ID,
+    });
+  }),
+
+  distinctValues: adminProcedure.input(DistinctValuesInputSchema).query(({ ctx, input }) => {
+    const args: { field: string; include_archived?: boolean } = { field: input.field };
+    if (input.include_archived !== undefined) args.include_archived = input.include_archived;
+    return ctx.store.distinctValues(args);
+  }),
 
   approve: adminProcedure
     .input(ApproveProposalInputSchema)

--- a/packages/mcp-server/tests/trpc/memories.test.ts
+++ b/packages/mcp-server/tests/trpc/memories.test.ts
@@ -353,6 +353,79 @@ describe("tRPC memories surface", () => {
     }
   });
 
+  it("memories.bulkUpdate re-homes a set of memories with one round-trip (D1.1)", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const a = seedMemory(dataDir, { title: "A", category: "projects" });
+      const b = seedMemory(dataDir, { title: "B", category: "projects" });
+      const c = seedMemory(dataDir, { title: "C", category: "projects" });
+      const result = await trpcPost<{ transaction_id: string; updated: number }>(
+        server,
+        "memories.bulkUpdate",
+        { ids: [a.id, b.id, c.id], patch: { project_key: "new-home" } },
+      );
+      expect(result.updated).toBe(3);
+      expect(result.transaction_id).toMatch(/^txn_/);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("memories.bulkUpdate rejects an empty patch (D1.1)", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const m = seedMemory(dataDir, { title: "X" });
+      const response = await fetch(`${server.url}/trpc/memories.bulkUpdate`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${server.token}`,
+        },
+        body: JSON.stringify({ ids: [m.id], patch: {} }),
+      });
+      expect(response.status).toBe(400);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("memories.distinctValues returns deduplicated values for the named field (D1.1)", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      seedMemory(dataDir, { agent_id: "alpha" });
+      seedMemory(dataDir, { agent_id: "alpha" });
+      seedMemory(dataDir, { agent_id: "beta" });
+      const values = await trpcGet<string[]>(server, "memories.distinctValues", {
+        field: "agent_id",
+      });
+      expect([...values].sort()).toEqual(["alpha", "beta"]);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("memories.distinctValues rejects fields outside the whitelist (D1.1)", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const url = new URL(`${server.url}/trpc/memories.distinctValues`);
+      url.searchParams.set("input", JSON.stringify({ field: "body" }));
+      const response = await fetch(url, {
+        headers: { authorization: `Bearer ${server.token}` },
+      });
+      expect(response.status).toBe(400);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
   it("memories.update / archive / approve / reject return NOT_FOUND for unknown ids", async () => {
     const dataDir = makeTempDir();
     const server = await startHttpServer({ dataDir });

--- a/test/schema-snapshot.json
+++ b/test/schema-snapshot.json
@@ -1,4 +1,4 @@
 {
-  "version": 3,
+  "version": 4,
   "fingerprint": "476aa975ba8ca96ad25ccafab4f4195d64525ece435356b6cb82d2f519b6f63b"
 }


### PR DESCRIPTION
## Spec / phase reference

Implements **D1.1** — Phase 1 of [\`specs/dashboard-redesign.md\`](../blob/main/specs/dashboard-redesign.md). The previous PR D1.0 landed the design-system foundations (ink-* palette, fonts, theme toggle, seven ui-v2 stubs).

**Spec acceptance:** \"Filtering by agent populates a dropdown from data, not free text. Selecting 12 rows and re-homing them via the modal results in one tRPC round-trip and twelve updated rows.\" — met by this PR.

## Summary

**Backend** (\`packages/core\` + \`packages/mcp-server\`):
- New \`memory.bulk_updated\` event type with a narrow patch schema (\`{ agent_id?, project_key? }\`) — so the bulk-update ledger contract matches the runtime contract at all three layers (Zod refine in tRPC, whitelist in store, narrow schema for replay).
- Projection schema version 3 → 4 with a \`BulkUpdated\` handler. DDL unchanged; sentinel bump forces replay on canonical-instance upgrade.
- \`memory-store.bulkUpdateMemory({ ids, patch, agent_id })\`: whitelist-validates the patch, emits one \`memory.bulk_updated\` per id sharing a single \`txn_\` id (enables a future \`bulkRevert(transaction_id)\` story per the spec's open question).
- \`memory-store.distinctValues({ field, include_archived? })\`: \`SELECT DISTINCT\` over a whitelisted set of memory columns (\`agent_id\`, \`project_key\`, \`category\`, \`visibility\` — not \`harness\`, which is a sessions concept, deferred to D1.2). Default scope excludes archived. Field whitelist guards against SQL injection.
- New tRPC procedures: \`memories.bulkUpdate\` (mutation) + \`memories.distinctValues\` (query). Zod \`.refine\` on the bulk-update patch enforces \"at least one of agent_id / project_key\".

**Frontend** (\`apps/dashboard\` — scoped to the acceptance criterion):
- \`RehomeModal\` (Radix Dialog): two \`<select>\` dropdowns populated by \`trpc.memories.distinctValues.useQuery\`. Submitting calls \`bulkUpdateMemoriesAction\`.
- \`MemoriesList\`: opt-in \`selectionEnabled\` + \`selectedIds\` + \`onToggleSelected\` props. Checkbox per row, doesn't break existing usage paths.
- \`MemoriesView\`: bulk selection state, a \"Re-home (N)\" action button that appears when ≥ 1 row selected, success toast with \`useEffect\` cleanup on unmount.
- New \`bulkUpdateMemoriesAction\` Server Action with empty-selection + empty-patch guards before round-tripping to tRPC.

**Scope deferral:** the full editorial table rewrite, the three-tab view switcher (already covered by the existing nav), the additional filter dropdowns (priority, date range, usefulness, has-duplicates), and the new inspector are explicitly deferred to D1.5 polish. The spec's acceptance criterion is the bulk re-home flow; that's satisfied here, and the rolling migration keeps the rest of the dashboard functional.

## Test plan

- [x] \`pnpm install --frozen-lockfile\`
- [x] \`pnpm test\` — 251 tests pass (99 core + 74 mcp-server + 45 cli + 33 dashboard, including 9 new bulk-update store tests, 4 new tRPC integration tests, 3 new action tests).
- [x] \`pnpm --filter @librarian/dashboard typecheck\` — green.
- [x] \`pnpm --filter @librarian/dashboard build\` — \`next build\` green.
- [x] \`pnpm --filter @librarian/dashboard test:e2e\` — 6 Playwright tests pass (including the new \`bulk-rehome.spec.ts\` golden path).
- [x] \`node scripts/check-storage-fixture.mjs\` — passes against the bumped schema sentinel.
- [x] \`node scripts/check-schema-version.mjs\` — version 4 fingerprint snapshot updated.

## Quality gates

- [x] **No production source file over 400 LOC introduced.** Largest new file: \`memory-store.ts\` already existed; my additions are ~70 LOC of bulk + distinct methods.
- [x] **No new \`any\` or \`@ts-ignore\` introduced.** One \`@ts-expect-error\` lives in a test (intentional — pins the contract from the compiler's side).

## Notes for the reviewer

- **Three-layer defense** for the bulk-update patch surface: Zod \`.refine\` on the tRPC input, runtime whitelist in \`bulkUpdateMemory\`, narrow Zod schema on the ledger entry. A malicious or buggy producer can't sneak \`{title, body, status}\` through any of the three.
- **\`distinctValues\` SQL injection guard**: the column name is interpolated into the \`SELECT\` because parameterised columns aren't supported by SQL. The whitelist (in both \`packages/core\` and \`packages/mcp-server\`) is the only line of defense; one test (\`d1-1-bulk-update.test.ts:159\`) asserts a non-whitelisted field throws cleanly.
- **N rebuilds per bulk-update** — the agent-reviewer flagged that \`appendEvent\` triggers a full projection rebuild per call, so a 500-row bulk-update rebuilds the projection 500 times within the round-trip. For 12 rows this is fine; the Zod cap is 500, so a stress test could expose it. Out of scope for D1.1; documented as a follow-up in \`AUTONOMOUS-BUILD-NOTES-26-05-21.md\`.
- **Agent review caught three Important issues**, all fixed in this PR:
  1. \`harness\` was in the \`distinctValues\` whitelist but the \`memories\` table has no \`harness\` column → removed from both the store and tRPC whitelists.
  2. \`MemoryBulkUpdatedEventSchema.patch\` used the full \`MemoryPatchSchema\` (too permissive for a bulk-update) → narrowed to \`{ agent_id?, project_key? }\` with the same \`.refine\` as the tRPC schema.
  3. Stale comment about the projection version bump → rewritten as a bump-history list (v2 → V1.2, v3 → S1.1, v4 → D1.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)