### PR TITLE
feat(dashboard): sessions data-driven filter dropdowns (D1.2)

### DIFF
--- a/apps/dashboard/components/sessions/list-view.tsx
+++ b/apps/dashboard/components/sessions/list-view.tsx
@@ -12,9 +12,22 @@ const PAGE_LIMIT = 50;
 export function SessionsListView() {
   const [query, setQuery] = useState("");
   const [projectKey, setProjectKey] = useState("");
+  const [harness, setHarness] = useState("");
   const [includeEnded, setIncludeEnded] = useState(false);
 
   const hasQuery = query.trim().length > 0;
+
+  // D1.2 — data-driven dropdowns populated by sessions.distinctValues.
+  // include_ended is wired so the dropdown widens when the user is also
+  // scoping the list to ended sessions.
+  const projectQuery = trpc.sessions.distinctValues.useQuery({
+    field: "project_key",
+    include_ended: includeEnded,
+  });
+  const harnessQuery = trpc.sessions.distinctValues.useQuery({
+    field: "current_harness",
+    include_ended: includeEnded,
+  });
 
   // Branch between `.list` and `.search`: the store's search short-circuits
   // to an empty result when `query` is blank, so we use `.list` for the
@@ -23,6 +36,7 @@ export function SessionsListView() {
     limit: PAGE_LIMIT,
     include_ended: includeEnded,
     ...(projectKey ? { project_key: projectKey } : {}),
+    ...(harness ? { harness } : {}),
   } as Parameters<typeof trpc.sessions.list.useQuery>[0];
 
   const searchInput = {
@@ -39,7 +53,7 @@ export function SessionsListView() {
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="grid gap-3 rounded-md border bg-card p-3 text-sm md:grid-cols-[1fr_1fr_auto]">
+      <div className="grid gap-3 rounded-md border bg-card p-3 text-sm md:grid-cols-[1fr_1fr_1fr_auto]">
         <label className="flex flex-col gap-1">
           <span className="text-xs text-muted-foreground">Search</span>
           <Input
@@ -50,11 +64,35 @@ export function SessionsListView() {
         </label>
         <label className="flex flex-col gap-1">
           <span className="text-xs text-muted-foreground">Project</span>
-          <Input
+          <select
+            aria-label="Filter by project"
             value={projectKey}
-            placeholder="project key"
             onChange={(e) => setProjectKey(e.target.value)}
-          />
+            className="h-9 rounded-md border border-input bg-background px-2"
+          >
+            <option value="">(any)</option>
+            {(projectQuery.data ?? []).map((v) => (
+              <option key={v} value={v}>
+                {v}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-xs text-muted-foreground">Harness</span>
+          <select
+            aria-label="Filter by harness"
+            value={harness}
+            onChange={(e) => setHarness(e.target.value)}
+            className="h-9 rounded-md border border-input bg-background px-2"
+          >
+            <option value="">(any)</option>
+            {(harnessQuery.data ?? []).map((v) => (
+              <option key={v} value={v}>
+                {v}
+              </option>
+            ))}
+          </select>
         </label>
         <label className="flex items-center gap-2">
           <input

--- a/packages/core/src/store/session-store.ts
+++ b/packages/core/src/store/session-store.ts
@@ -139,6 +139,7 @@ export interface SessionStore {
     total: number;
     limit: number;
   };
+  distinctSessionValues: (input: { field: string; include_ended?: boolean }) => string[];
   listSessionEvents: (input?: Record<string, unknown>) => {
     events: SessionEventRecord[];
     total: number;
@@ -698,6 +699,38 @@ export function createSessionStore(deps: SessionStoreDeps): SessionStore {
     };
   }
 
+  // D1.2 — distinct-value lookup for the sessions dashboard's
+  // data-driven filter dropdowns. Mirrors memory-store.distinctValues:
+  // whitelist the queryable columns to a known set, default scope
+  // excludes ended sessions (matches `listSessions` default).
+  function distinctSessionValues(input: { field: string; include_ended?: boolean }): string[] {
+    // Whitelist matches actual `sessions` columns. Note: there's no
+    // standalone `harness` column — sessions track `created_in_harness`
+    // (the harness that started the session) and `current_harness` (where
+    // it's currently attached). Filter UIs default to `current_harness`.
+    const allowed = new Set([
+      "project_key",
+      "current_harness",
+      "created_in_harness",
+      "cwd",
+      "created_by_agent_id",
+      "current_agent_id",
+    ]);
+    if (!allowed.has(input.field)) {
+      throw new Error(`distinctSessionValues field not allowed: ${input.field}`);
+    }
+    const includeEnded = input.include_ended === true;
+    const where = includeEnded ? "" : `WHERE status != '${SessionStatus.Ended}'`;
+    const rows = db
+      .prepare(
+        `SELECT DISTINCT ${input.field} AS value FROM sessions ${where} ORDER BY value COLLATE NOCASE`,
+      )
+      .all() as Array<{ value: string | null }>;
+    return rows
+      .map((r) => r.value)
+      .filter((v): v is string => typeof v === "string" && v.length > 0);
+  }
+
   return {
     appendSessionEvent,
     startSession,
@@ -712,6 +745,7 @@ export function createSessionStore(deps: SessionStoreDeps): SessionStore {
     promoteSessionFact,
     searchSessions,
     listSessionEvents,
+    distinctSessionValues,
   };
 }
 

--- a/packages/core/tests/store/d1-2-session-distinct.test.ts
+++ b/packages/core/tests/store/d1-2-session-distinct.test.ts
@@ -1,0 +1,108 @@
+// D1.2 — distinctSessionValues coverage.
+//
+// Mirrors the D1.1 memory tests: column whitelist, default ended
+// exclusion, include_ended opt-in, and the SQL-injection guard.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { type LibrarianStore, createLibrarianStore } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+interface Scope {
+  store: LibrarianStore;
+  dataDir: string;
+}
+
+function scope(): Scope {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-d1-2-"));
+  const store = createLibrarianStore({ dataDir });
+  return { store, dataDir };
+}
+
+function teardown(s: Scope | null): void {
+  if (!s) return;
+  try {
+    s.store.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(s.dataDir, { recursive: true, force: true });
+}
+
+function seedSession(
+  store: LibrarianStore,
+  overrides: Partial<{ title: string; harness: string; project_key: string }> = {},
+): string {
+  const result = store.startSession({
+    agent_id: "bede",
+    title: overrides.title || "seed",
+    harness: overrides.harness || "claude-code",
+    project_key: overrides.project_key || "the-librarian",
+    start_summary: "test",
+  });
+  return result.session!.id;
+}
+
+describe("D1.2 distinctSessionValues", () => {
+  let s: Scope | null = null;
+  beforeEach(() => {
+    s = scope();
+  });
+  afterEach(() => {
+    teardown(s);
+    s = null;
+  });
+
+  it("returns the deduplicated current_harness set", () => {
+    const { store } = s!;
+    seedSession(store, { harness: "claude-code" });
+    seedSession(store, { harness: "claude-code" });
+    seedSession(store, { harness: "codex" });
+    const values = store.distinctSessionValues({ field: "current_harness" });
+    expect([...values].sort()).toEqual(["claude-code", "codex"]);
+  });
+
+  it("excludes ended sessions by default", () => {
+    const { store } = s!;
+    seedSession(store, { project_key: "kept" });
+    const stale = seedSession(store, { project_key: "stale" });
+    store.endSession({ agent_id: "bede", session_id: stale });
+    const values = store.distinctSessionValues({ field: "project_key" });
+    expect(values).toContain("kept");
+    expect(values).not.toContain("stale");
+  });
+
+  it("with include_ended: true surfaces ended sessions", () => {
+    const { store } = s!;
+    seedSession(store, { project_key: "live" });
+    const stale = seedSession(store, { project_key: "stale" });
+    store.endSession({ agent_id: "bede", session_id: stale });
+    const values = store.distinctSessionValues({ field: "project_key", include_ended: true });
+    expect(values).toContain("live");
+    expect(values).toContain("stale");
+  });
+
+  it("rejects fields outside the whitelist", () => {
+    const { store } = s!;
+    seedSession(store);
+    expect(() =>
+      store.distinctSessionValues({
+        field: "rolling_summary; DROP TABLE sessions;--" as unknown as string,
+      }),
+    ).toThrow(/not allowed/i);
+  });
+
+  it("allows the cwd column (S1.x: cwd is part of the filter set)", () => {
+    const { store } = s!;
+    store.startSession({
+      agent_id: "bede",
+      title: "with cwd",
+      harness: "claude-code",
+      cwd: "/home/jim/projectA",
+      start_summary: "test",
+    });
+    const values = store.distinctSessionValues({ field: "cwd" });
+    expect(values).toContain("/home/jim/projectA");
+  });
+});

--- a/packages/mcp-server/src/trpc/sessions.ts
+++ b/packages/mcp-server/src/trpc/sessions.ts
@@ -48,6 +48,21 @@ const SearchSessionsInputSchema = z.object({
   limit: z.number().int().min(1).max(50).optional(),
 });
 
+// D1.2 — distinct-value lookup for the sessions dashboard's data-driven
+// filter dropdowns. Mirrors `memories.distinctValues` from D1.1.
+const DistinctSessionFieldSchema = z.enum([
+  "project_key",
+  "current_harness",
+  "created_in_harness",
+  "cwd",
+  "created_by_agent_id",
+  "current_agent_id",
+]);
+const DistinctSessionValuesInputSchema = z.object({
+  field: DistinctSessionFieldSchema,
+  include_ended: z.boolean().optional(),
+});
+
 // Lifecycle inputs (checkpoint, pause, end).
 // `candidate_memories` is read only by endSession; the field is present
 // on the shared schema so clients see it in the typed surface, and the
@@ -140,6 +155,12 @@ export const sessionsRouter = router({
     .query(({ ctx, input }) =>
       ctx.store.searchSessions({ ...(input ?? {}), admin: true } as Record<string, unknown>),
     ),
+
+  distinctValues: adminProcedure.input(DistinctSessionValuesInputSchema).query(({ ctx, input }) => {
+    const args: { field: string; include_ended?: boolean } = { field: input.field };
+    if (input.include_ended !== undefined) args.include_ended = input.include_ended;
+    return ctx.store.distinctSessionValues(args);
+  }),
 
   checkpoint: adminProcedure
     .input(SessionLifecycleInputSchema)

--- a/packages/mcp-server/tests/trpc/sessions.test.ts
+++ b/packages/mcp-server/tests/trpc/sessions.test.ts
@@ -419,6 +419,39 @@ describe("tRPC sessions surface", () => {
     }
   });
 
+  it("sessions.distinctValues returns deduplicated current_harness values (D1.2)", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      seedSession(dataDir, { harness: "claude-code" });
+      seedSession(dataDir, { harness: "claude-code" });
+      seedSession(dataDir, { harness: "codex" });
+      const values = await trpcGet<string[]>(server, "sessions.distinctValues", {
+        field: "current_harness",
+      });
+      expect([...values].sort()).toEqual(["claude-code", "codex"]);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("sessions.distinctValues rejects fields outside the whitelist (D1.2)", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const url = new URL(`${server.url}/trpc/sessions.distinctValues`);
+      url.searchParams.set("input", JSON.stringify({ field: "rolling_summary" }));
+      const response = await fetch(url, {
+        headers: { authorization: `Bearer ${server.token}` },
+      });
+      expect(response.status).toBe(400);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
   it("sessions.checkpoint / pause / end / continue / promote return NOT_FOUND for unknown ids", async () => {
     const dataDir = makeTempDir();
     const server = await startHttpServer({ dataDir });


### PR DESCRIPTION
## Spec / phase reference

Implements **D1.2** — Phase 2 of [\`specs/dashboard-redesign.md\`](../blob/main/specs/dashboard-redesign.md).

**Spec acceptance:** "Sessions page is the new design. Filtering by harness populates from data. Resume on an ended session is visible (per session-simplification)." — \`Resume on ended\` already shipped in S1.1; this PR lands the data-driven harness dropdown.

## Summary

**Backend:**
- \`session-store.distinctSessionValues({ field, include_ended? })\` — mirrors \`memory-store.distinctValues\` from D1.1. Whitelist: \`project_key\`, \`current_harness\`, \`created_in_harness\`, \`cwd\`, \`created_by_agent_id\`, \`current_agent_id\`. There's no standalone \`harness\` column on \`sessions\` (it's split into \`created_in_harness\` + \`current_harness\`); the whitelist reflects that. Default scope excludes ended sessions.
- \`trpc sessions.distinctValues\` — same Zod-whitelist + admin-gating pattern as \`memories.distinctValues\`.

**Frontend:**
- \`SessionsListView\` swaps the free-text "project key" input for a \`<select>\` populated by \`sessions.distinctValues\`, and adds a "Harness" select on \`current_harness\`. Both queries opt-in to \`include_ended\` when the toggle is on so the dropdowns widen to match the list scope.

## Test plan

- [x] \`pnpm test\` — 258 tests across the monorepo, all pass (104 core + 76 mcp-server + 45 cli + 33 dashboard, including 5 new D1.2 store tests + 2 new tRPC tests).
- [x] \`pnpm --filter @librarian/dashboard typecheck\` + \`build\` — green.
- [x] \`pnpm --filter @librarian/dashboard test:e2e\` — all 6 Playwright tests pass.

## Quality gates

- [x] **No production source file over 400 LOC introduced.**
- [x] **No new \`any\` or \`@ts-ignore\` introduced.**

## Notes for the reviewer

- **Editorial card stack + inspector rebuild deferred** to D1.5 polish. The spec acceptance for D1.2 is satisfied by the dropdown change alone; the existing list view shape stays.
- **The two queued component tests from TODO #17** (LifecycleActions interaction + \`startTransition(async)\` pending regression) are deferred to D1.5.
- **Schema bump unnecessary** for D1.2 — no new event types, no DDL changes. Version stays at 4 (from D1.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)