### PR TITLE
feat(dashboard): promote Recall to a top-level surface (D1.3)

### DIFF
--- a/apps/dashboard/app/recall/page.tsx
+++ b/apps/dashboard/app/recall/page.tsx
@@ -1,0 +1,23 @@
+// D1.3 — top-level Recall surface.
+//
+// Promoted from `(memories)/logs` because recall is its own thing — a
+// per-query timeline with the memories returned pinned to the right.
+// The old logs page stays for now and will be retired in D1.5 once the
+// stranger-test confirms feature parity (per the spec's open question).
+
+import { TabNav } from "@/components/memories/tab-nav";
+import { RecallView } from "@/components/recall/view";
+
+export const dynamic = "force-dynamic";
+
+export default function RecallPage() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <TabNav />
+      <main className="flex flex-col gap-4 p-6">
+        <h1 className="text-2xl font-semibold tracking-tight">Recall</h1>
+        <RecallView />
+      </main>
+    </div>
+  );
+}

--- a/apps/dashboard/components/memories/tab-nav.tsx
+++ b/apps/dashboard/components/memories/tab-nav.tsx
@@ -7,6 +7,7 @@ import { ThemeToggle } from "@/components/theme-toggle";
 const TABS = [
   { href: "/", label: "Browse", match: (p: string) => p === "/" },
   { href: "/sessions", label: "Sessions", match: (p: string) => p.startsWith("/sessions") },
+  { href: "/recall", label: "Recall", match: (p: string) => p === "/recall" },
   { href: "/analytics", label: "Analytics", match: (p: string) => p === "/analytics" },
   { href: "/proposals", label: "Proposals", match: (p: string) => p === "/proposals" },
   { href: "/archive", label: "Archive", match: (p: string) => p === "/archive" },

--- a/apps/dashboard/components/recall/view.tsx
+++ b/apps/dashboard/components/recall/view.tsx
@@ -1,0 +1,235 @@
+// D1.3 — Recall surface.
+//
+// Two-pane layout: query timeline on the left (every recall + empty
+// recall event, newest first), pinned memory list on the right (the
+// memory_ids the selected event recorded, hydrated via the D1.3
+// `memories.byIds` procedure). An insights strip at the top shows the
+// three counts the spec calls out: recalls in window, empty-recall
+// rate, top three queries.
+
+"use client";
+
+import { useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { trpc } from "@/lib/trpc-client";
+
+interface RecallEventPayload {
+  agent_id?: string;
+  query?: string;
+  memory_ids?: string[];
+  note?: string;
+}
+
+interface RecallEvent {
+  event_id: string;
+  event_type: string;
+  agent_id: string;
+  created_at: string;
+  payload: RecallEventPayload;
+}
+
+const PAGE_LIMIT = 100;
+
+export function RecallView() {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const recalledQuery = trpc.memories.events.useQuery({
+    type: "memory.recalled",
+    limit: PAGE_LIMIT,
+  });
+  const emptyQuery = trpc.memories.events.useQuery({
+    type: "memory.recall_empty",
+    limit: PAGE_LIMIT,
+  });
+
+  const events = useMemo(() => {
+    const a = (recalledQuery.data?.events ?? []) as RecallEvent[];
+    const b = (emptyQuery.data?.events ?? []) as RecallEvent[];
+    return [...a, ...b].sort((x, y) => y.created_at.localeCompare(x.created_at));
+  }, [recalledQuery.data, emptyQuery.data]);
+
+  const selected = events.find((e) => e.event_id === selectedId) ?? events[0] ?? null;
+  const selectedIds = selected?.payload.memory_ids ?? [];
+
+  const detail = trpc.memories.byIds.useQuery(
+    { ids: selectedIds },
+    { enabled: selectedIds.length > 0 },
+  );
+
+  const totalRecalls = events.length;
+  const emptyCount = events.filter((e) => e.event_type === "memory.recall_empty").length;
+  const emptyRate = totalRecalls === 0 ? 0 : Math.round((emptyCount / totalRecalls) * 100);
+  const topQueries = useMemo(() => topNQueries(events, 3), [events]);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <section
+        aria-label="Recall insights"
+        className="flex flex-wrap items-baseline gap-6 rounded-md border bg-card px-4 py-3 text-sm"
+      >
+        <Stat label="Recalls" value={String(totalRecalls)} />
+        <Stat label="Empty rate" value={`${emptyRate}%`} accent={emptyRate >= 30} />
+        <Stat
+          label="Top queries"
+          value={
+            topQueries.length ? topQueries.map((q) => `${q.query} (${q.count})`).join(" · ") : "—"
+          }
+        />
+      </section>
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-[1fr_1fr]">
+        <ul
+          aria-label="Recall timeline"
+          className="flex max-h-[70vh] flex-col gap-1 overflow-y-auto"
+        >
+          {events.length === 0 ? (
+            <li className="text-sm text-muted-foreground">No recall events yet.</li>
+          ) : (
+            events.map((e) => {
+              const isEmpty = e.event_type === "memory.recall_empty";
+              const isSelected = (selected?.event_id ?? "") === e.event_id;
+              return (
+                <li key={e.event_id}>
+                  <button
+                    type="button"
+                    onClick={() => setSelectedId(e.event_id)}
+                    aria-pressed={isSelected}
+                    className={`flex w-full flex-col gap-1 rounded-md border bg-card p-2 text-left text-sm transition-colors hover:bg-accent ${
+                      isSelected ? "ring-2 ring-ring" : ""
+                    }`}
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="font-mono text-xs">
+                        {e.payload.query || "(empty query)"}
+                      </span>
+                      {isEmpty ? (
+                        <Badge variant="destructive">empty</Badge>
+                      ) : (
+                        <Badge variant="outline">{e.payload.memory_ids?.length ?? 0}</Badge>
+                      )}
+                    </div>
+                    <div className="flex justify-between text-xs text-muted-foreground">
+                      <span>{e.agent_id}</span>
+                      <span>{new Date(e.created_at).toLocaleString()}</span>
+                    </div>
+                  </button>
+                </li>
+              );
+            })
+          )}
+        </ul>
+        <aside
+          aria-label="Recall detail"
+          className="flex flex-col gap-2 rounded-md border bg-card p-4 text-sm"
+        >
+          {!selected ? (
+            <p className="text-muted-foreground">
+              Pick a recall on the left to see what came back.
+            </p>
+          ) : selected.event_type === "memory.recall_empty" ? (
+            <EmptyRecallDetail query={selected.payload.query || ""} />
+          ) : detail.isLoading ? (
+            <p className="text-muted-foreground">Loading memories…</p>
+          ) : (
+            <RecallMemoriesDetail
+              query={selected.payload.query || ""}
+              memories={detail.data?.memories ?? []}
+            />
+          )}
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  accent = false,
+}: {
+  label: string;
+  value: string;
+  accent?: boolean;
+}) {
+  return (
+    <div className="flex flex-col">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      <span className={`font-display text-xl ${accent ? "text-ink-accent" : "text-foreground"}`}>
+        {value}
+      </span>
+    </div>
+  );
+}
+
+interface MemoryDetail {
+  id: string;
+  title?: string | null;
+  usefulness_score?: number;
+  status?: string;
+}
+
+function RecallMemoriesDetail({ query, memories }: { query: string; memories: MemoryDetail[] }) {
+  if (memories.length === 0) {
+    return (
+      <p className="text-muted-foreground">
+        Returned no live memories — they may have been archived since the recall.
+      </p>
+    );
+  }
+  return (
+    <>
+      <p className="text-xs text-muted-foreground">
+        Query: <span className="font-mono">{query}</span>
+      </p>
+      <ol className="flex flex-col gap-2">
+        {memories.map((m, i) => (
+          <li
+            key={m.id}
+            className="flex items-center justify-between gap-2 rounded-md border px-3 py-2 text-sm"
+          >
+            <span>
+              <span className="text-muted-foreground">{i + 1}.</span> {m.title || "(untitled)"}
+            </span>
+            <span className="font-mono text-xs">
+              score {formatScore(m.usefulness_score ?? 0)}{" "}
+              {m.status === "archived" ? "· archived" : ""}
+            </span>
+          </li>
+        ))}
+      </ol>
+    </>
+  );
+}
+
+function EmptyRecallDetail({ query }: { query: string }) {
+  return (
+    <div className="flex flex-col gap-3">
+      <p>
+        This recall returned <span className="font-semibold">no memories</span> for the query:
+      </p>
+      <p className="font-mono text-xs">{query || "(empty)"}</p>
+      <a
+        href={`/?recall_query=${encodeURIComponent(query)}`}
+        className="rounded-md border border-ink-accent px-3 py-1.5 text-center text-ink-accent hover:bg-ink-accent/[0.06]"
+      >
+        Create a memory for this query
+      </a>
+    </div>
+  );
+}
+
+function formatScore(score: number): string {
+  return score > 0 ? `+${score}` : String(score);
+}
+
+function topNQueries(events: RecallEvent[], n: number): Array<{ query: string; count: number }> {
+  const counts = new Map<string, number>();
+  for (const e of events) {
+    const q = (e.payload.query || "").trim();
+    if (!q) continue;
+    counts.set(q, (counts.get(q) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, n)
+    .map(([query, count]) => ({ query, count }));
+}

--- a/packages/mcp-server/src/trpc/memories.ts
+++ b/packages/mcp-server/src/trpc/memories.ts
@@ -92,6 +92,15 @@ const DistinctValuesInputSchema = z.object({
   include_archived: z.boolean().optional(),
 });
 
+// D1.3 — batch get-by-id for the recall surface. The recall timeline
+// pins the memories returned for a given recall event into the right
+// pane; the payload only stores `memory_ids`, so we need a way to
+// hydrate them in one round-trip without sticking each id through the
+// per-row `memories.related` procedure.
+const ByIdsInputSchema = z.object({
+  ids: z.array(z.string().min(1)).min(1).max(50),
+});
+
 const ApproveProposalInputSchema = z.object({
   id: z.string().min(1),
   patch: MemoryPatchSchema.optional(),
@@ -186,6 +195,15 @@ export const memoriesRouter = router({
     const args: { field: string; include_archived?: boolean } = { field: input.field };
     if (input.include_archived !== undefined) args.include_archived = input.include_archived;
     return ctx.store.distinctValues(args);
+  }),
+
+  byIds: adminProcedure.input(ByIdsInputSchema).query(({ ctx, input }) => {
+    // Preserve the input order so the dashboard's recall right-pane can
+    // render the memories in the same ranking the recall event recorded.
+    const memories = input.ids
+      .map((id) => ctx.store.getMemory(id))
+      .filter((m): m is NonNullable<typeof m> => m !== null);
+    return { memories };
   }),
 
   approve: adminProcedure

--- a/packages/mcp-server/tests/trpc/memories.test.ts
+++ b/packages/mcp-server/tests/trpc/memories.test.ts
@@ -426,6 +426,23 @@ describe("tRPC memories surface", () => {
     }
   });
 
+  it("memories.byIds returns memories in input order, skipping unknown ids (D1.3)", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const a = seedMemory(dataDir, { title: "A" });
+      const b = seedMemory(dataDir, { title: "B" });
+      const c = seedMemory(dataDir, { title: "C" });
+      const result = await trpcGet<{ memories: Array<{ id: string }> }>(server, "memories.byIds", {
+        ids: [b.id, "mem_nope", c.id, a.id],
+      });
+      expect(result.memories.map((m) => m.id)).toEqual([b.id, c.id, a.id]);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
   it("memories.update / archive / approve / reject return NOT_FOUND for unknown ids", async () => {
     const dataDir = makeTempDir();
     const server = await startHttpServer({ dataDir });


### PR DESCRIPTION
## Spec / phase reference

Implements **D1.3** — Phase 3 of [\`specs/dashboard-redesign.md\`](../blob/main/specs/dashboard-redesign.md).

**Spec acceptance:** \"Recall is its own top-level surface. Selecting a recall in the timeline pins its memories to the right pane. Empty-recall rate is visible in the insights strip.\" — all three met.

## Summary

**Frontend:**
- New \`/recall\` route + \`RecallView\` component with the spec's two-pane layout:
  - **Insights strip**: recalls in window, empty-recall rate (vermilion accent when ≥ 30%), top three queries.
  - **Timeline (left)**: every \`memory.recalled\` + \`memory.recall_empty\` event, newest first. Each row shows the query (mono), agent, timestamp, and a \"hits\" or \"empty\" badge.
  - **Detail (right)**: clicking a row pins the memories it returned. Empty-recall rows show a \"Create a memory for this query\" shortcut that hands the query to the existing new-memory form via \`/?recall_query=...\`.
- \`TabNav\` adds a Recall tab between Sessions and Analytics.

**Backend:**
- New \`memories.byIds({ ids })\` tRPC procedure (admin-gated, Zod-validated, ≤ 50 ids per call). Preserves input order so the recall ranking survives the round-trip. Skips unknown ids — a memory archived since the recall doesn't 404 the whole call, it just doesn't appear in the right pane.

**Scope:**
- The old \`/logs\` route stays for now (still useful for the broader event log). Per the spec, it retires in D1.5 once stranger-test feature parity is confirmed.
- No new event types, no schema bump. Schema version stays at 4.

## Test plan

- [x] \`pnpm test\` — 259 tests pass across the monorepo (104 core + 77 mcp-server + 45 cli + 33 dashboard, including a new \`memories.byIds\` tRPC test for input-order preservation + unknown-id tolerance).
- [x] \`pnpm --filter @librarian/dashboard typecheck\` + \`build\` — green.
- [x] \`pnpm --filter @librarian/dashboard test:e2e\` — all 6 Playwright tests pass.

## Quality gates

- [x] **No production source file over 400 LOC introduced.** Largest new file: \`recall/view.tsx\` (~230 LOC).
- [x] **No new \`any\` or \`@ts-ignore\` introduced.**

## Notes for the reviewer

- **Why a new \`byIds\` procedure** when \`memories.related\` exists? The latter takes one id; the recall right-pane needs N ids hydrated in one round-trip with preserved order. Adding a focused procedure was cleaner than calling related N times client-side.
- **Empty-recall \"Create memory\" shortcut** routes to \`/?recall_query=...\` — the existing new-memory form already reads this param (out of scope for the route to confirm, but the URL contract stays the same).
- **Insights are computed client-side** over the timeline (in-window aggregate). A server-side \`memories.recallInsights\` could land in D1.5 if the volume of recall events grows past \`limit: 100\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)