### PR TITLE
feat: propagate V1.x memory verbs into integration docs (I1)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -12,3 +12,6 @@ package-lock.json
 
 # Markdown is hand-authored; Prettier's table padding mangles spec tables.
 **/*.md
+
+# Local Claude Code settings (gitignored anyway).
+.claude/settings.local.json

--- a/AUTONOMOUS-BUILD-NOTES-26-05-21-implementations.md
+++ b/AUTONOMOUS-BUILD-NOTES-26-05-21-implementations.md
@@ -1,0 +1,33 @@
+# Autonomous Build Notes — 2026-05-21 (specs implementation run)
+
+Sibling to `AUTONOMOUS-BUILD-NOTES-26-05-21.md` (which covered the V1.x / S1.x / D1.x autonomous run earlier today). This run implements the three new specs drafted at the end of that run:
+
+- `specs/integration-docs-memory-verbs.md` — 1 PR (I1)
+- `specs/ui-library-consolidation.md` — 3 PRs (U1, U2, U3)
+- `specs/session-storage-rearchitecture.md` — 4 PRs (R1, R2, R3, R4)
+
+**Order chosen:** I1 → U1 → U2 → U3 → R1 → R2 → R3 → R4.
+
+- I1 first: small, docs-only, validates the autonomous flow on a fresh PR before bigger architectural work.
+- U before R: U is independent (dashboard internals); R is the biggest architectural change in the codebase's history. Warm up on U.
+- Within each group: spec order (the phases are designed to land serially).
+
+## Run progress
+
+(in progress)
+
+## Decisions made autonomously
+
+(to be filled)
+
+## Open questions for you
+
+(to be filled)
+
+## Follow-ups for you
+
+(to be filled)
+
+## Stranger-test checklist
+
+(to be filled)

--- a/integrations/claude-code/CLAUDE.md
+++ b/integrations/claude-code/CLAUDE.md
@@ -11,7 +11,7 @@ The Librarian's HTTP MCP server is connected. Available session tools:
 - `attach_session`, `continue_session`
 - `promote_session_fact`
 
-The full memory tool surface (`start_context`, `recall`, `remember`, `propose_memory`, etc.) is also available — unchanged from before the session layer landed.
+The full memory tool surface is also available: `start_context`, `recall`, `remember`, `propose_memory`, `update_memory`, `verify_memory`, `list_proposals`. (`archive_memory` and `approve_proposal` are admin-only — they appear only when authenticated with an admin token.)
 
 ## The `/lib-session-*` slash commands
 
@@ -24,6 +24,18 @@ This package ships **native Claude Code slash commands** — one per verb — un
 - `/lib-session-search <query>` — full-text search across session events.
 
 Sessions are always in one of three states: `active`, `paused`, or `ended`. The legacy `archived`, `deleted`, and `status` verbs were removed when the three-state model landed — `end` covers archive/delete, `resume` covers restore, and `list` scoped to the current harness covers status.
+
+Memories are in one of three states: `active`, `proposed`, or `archived`. `active` is the recall pool; `proposed` is awaiting human approval (auto-routed for protected categories like `identity` and `relationship`); `archived` is the soft-deleted bucket. The retired verbs `delete_memory`, `confirm_memory`, `reject_memory`, and the conflict-resolution surface were removed when the three-state model landed — `archive_memory` covers deletion, proposals are accepted or rejected through the dashboard or `update_memory`, and conflict detection is gone.
+
+## Verify-after-recall
+
+When `recall` returns hits and you use one, call `verify_memory` afterwards with a usefulness verdict so the store learns:
+
+- `useful` — the hit was load-bearing for the answer. Boosts recall rank by 3.
+- `not_useful` — the hit was a distractor or stale framing. Drops recall rank by 3.
+- `outdated` — the memory is factually wrong now. Archives it.
+
+The verdict is a single MCP call; don't skip it because the recall already gave you the answer. The whole memory-quality loop depends on these signals.
 
 The hyphenated names match Claude Code's command-naming conventions; the canonical cross-harness contract uses `/lib:session <verb>` as the abstract surface (see [`docs/slash-commands.md`](../../docs/slash-commands.md)), but each harness implements it with whatever native pattern best fits — for Claude Code that's per-verb commands.
 

--- a/integrations/claude-code/healthcheck.md
+++ b/integrations/claude-code/healthcheck.md
@@ -16,6 +16,8 @@ End-to-end smoke test for the Claude Code ↔ Librarian session integration.
    ```
    Expected: the agent reports `start_session`, `list_sessions`, `continue_session`, `checkpoint_session`, `pause_session`, `end_session`, `search_sessions`, `get_session`, `list_session_events`, `record_session_event`, `attach_session`, `promote_session_fact` in the tool surface (alongside the memory tools). The retired tools `archive_session`, `restore_session`, `delete_session` should NOT be in the list.
 
+   Expected memory tools (V1.x surface): `start_context`, `recall`, `remember`, `propose_memory`, `update_memory`, `verify_memory`, `list_proposals`. The retired tools `delete_memory`, `confirm_memory`, `reject_memory`, `resolve_conflict` should NOT be in the list. `archive_memory` and `approve_proposal` only surface for admin-token callers.
+
 2. **Start a session.**
    ```
    /lib:session start "Claude healthcheck"

--- a/integrations/codex/AGENTS.md
+++ b/integrations/codex/AGENTS.md
@@ -6,7 +6,7 @@ Drop this file into the project root (or merge with an existing `AGENTS.md`). Co
 
 The Librarian's HTTP MCP server is connected. Available session tools include `start_session`, `list_sessions`, `continue_session`, `checkpoint_session`, `pause_session`, `end_session`, `search_sessions`, `get_session`, `list_session_events`, `record_session_event`, `attach_session`, `promote_session_fact`.
 
-The full memory tool surface (`start_context`, `recall`, `remember`, `propose_memory`, etc.) is also available — unchanged from before the session layer landed.
+The full memory tool surface is also available: `start_context`, `recall`, `remember`, `propose_memory`, `update_memory`, `verify_memory`, `list_proposals`. (`archive_memory` and `approve_proposal` are admin-only — they appear only when authenticated with an admin token.)
 
 ## The `/lib:session` surface
 
@@ -21,6 +21,18 @@ The canonical contract lives in [`docs/slash-commands.md`](../../docs/slash-comm
 - `/lib:session search <query>` — full-text search across session events.
 
 Sessions are in one of three states: `active`, `paused`, `ended`. The retired verbs `archive`, `restore`, `delete`, `status` were removed when the three-state model landed — `end` covers archive/delete, `resume` covers restore, and `list` scoped to the current harness covers status.
+
+Memories are in one of three states: `active`, `proposed`, or `archived`. `active` is the recall pool; `proposed` is awaiting human approval (auto-routed for protected categories like `identity` and `relationship`); `archived` is the soft-deleted bucket. The retired verbs `delete_memory`, `confirm_memory`, `reject_memory`, and the conflict-resolution surface were removed when the three-state model landed — `archive_memory` covers deletion, proposals are accepted or rejected through the dashboard or `update_memory`, and conflict detection is gone.
+
+## Verify-after-recall
+
+When `recall` returns hits and you use one, call `verify_memory` afterwards with a usefulness verdict so the store learns:
+
+- `useful` — the hit was load-bearing for the answer. Boosts recall rank by 3.
+- `not_useful` — the hit was a distractor or stale framing. Drops recall rank by 3.
+- `outdated` — the memory is factually wrong now. Archives it.
+
+The verdict is a single MCP call; don't skip it because the recall already gave you the answer. The whole memory-quality loop depends on these signals.
 
 ## `source_ref` for Codex
 

--- a/integrations/codex/healthcheck.md
+++ b/integrations/codex/healthcheck.md
@@ -16,6 +16,8 @@ End-to-end smoke test for the Codex ↔ Librarian session integration.
    ```
    Expected: the agent lists `start_session`, `list_sessions`, `continue_session`, `checkpoint_session`, `pause_session`, `end_session`, `search_sessions`, `get_session`, `list_session_events`, `record_session_event`, `attach_session`, `promote_session_fact` alongside the memory tools. The retired tools `archive_session`, `restore_session`, `delete_session` should NOT be in the list.
 
+   Expected memory tools (V1.x surface): `start_context`, `recall`, `remember`, `propose_memory`, `update_memory`, `verify_memory`, `list_proposals`. The retired tools `delete_memory`, `confirm_memory`, `reject_memory`, `resolve_conflict` should NOT be in the list. `archive_memory` and `approve_proposal` only surface for admin-token callers.
+
 2. **Start a session.**
    ```
    /lib:session start "Codex healthcheck"

--- a/integrations/hermes/AGENTS.append.md
+++ b/integrations/hermes/AGENTS.append.md
@@ -14,6 +14,18 @@ All session lifecycle goes through `/lib:session <verb>`. The canonical contract
 
 Sessions are in one of three states: `active`, `paused`, `ended`. The retired verbs `archive`, `restore`, `delete`, `status` were removed when the three-state model landed — `end` covers archive/delete, `resume` covers restore, and `list` scoped to the current harness covers status.
 
+Memories are in one of three states: `active`, `proposed`, or `archived`. `active` is the recall pool; `proposed` is awaiting human approval (auto-routed for protected categories like `identity` and `relationship`); `archived` is the soft-deleted bucket. The retired verbs `delete_memory`, `confirm_memory`, `reject_memory`, and the conflict-resolution surface were removed when the three-state model landed — `archive_memory` covers deletion, proposals are accepted or rejected through the dashboard or `update_memory`, and conflict detection is gone.
+
+## Verify-after-recall
+
+When `recall` returns hits and you use one, call `verify_memory` afterwards with a usefulness verdict so the store learns:
+
+- `useful` — the hit was load-bearing for the answer. Boosts recall rank by 3.
+- `not_useful` — the hit was a distractor or stale framing. Drops recall rank by 3.
+- `outdated` — the memory is factually wrong now. Archives it.
+
+The verdict is a single MCP call; don't skip it because the recall already gave you the answer. The whole memory-quality loop depends on these signals.
+
 ## `source_ref` for Hermes
 
 Use the Discord channel + thread identifiers as the source reference:

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -18,7 +18,7 @@ Wires Hermes (Discord-fronted multi-agent runtime) into The Librarian's session 
 ## What this package does NOT change
 
 - The session layer is additive. Hermes's native Discord thread continuation keeps working — `/lib:session` exists alongside it, not in place of it.
-- Durable memory (`remember`, `propose_memory`, etc.) is unchanged; this package only adds session lifecycle on top.
+- Durable memory tools: `start_context`, `recall`, `remember`, `propose_memory`, `update_memory`, `verify_memory`, `list_proposals` (and admin-only `archive_memory` / `approve_proposal`). Three-state model: `active | proposed | archived`. After a useful recall hit, agents are expected to call `verify_memory` with a verdict so the store learns.
 
 ## See also
 

--- a/integrations/hermes/healthcheck.md
+++ b/integrations/hermes/healthcheck.md
@@ -54,10 +54,7 @@ End-to-end smoke test for the Hermes ↔ Librarian session integration. Run afte
    ```
    /lib:session end
    ```
-   Then archive or delete depending on whether you want this session findable later:
-   ```
-   /lib:session archive <session_id>
-   ```
+   Expected: the session moves to `ended` and disappears from default `list_sessions` results. The bare-call (no summary) abandonment path is supported. The session can later be brought back via `/lib:session resume <session_id>` (which flips it back to `paused`).
 
 ## Pass/fail
 

--- a/integrations/opencode/AGENTS.md
+++ b/integrations/opencode/AGENTS.md
@@ -4,7 +4,9 @@ Drop this file into the project root (or merge with an existing `AGENTS.md`).
 
 ## What you have access to
 
-The Librarian's HTTP MCP server is connected. Available session tools include `start_session`, `list_sessions`, `continue_session`, `checkpoint_session`, `pause_session`, `end_session`, `search_sessions`, `get_session`, `list_session_events`, `record_session_event`, `attach_session`, `promote_session_fact`, plus the full memory tool surface.
+The Librarian's HTTP MCP server is connected. Available session tools include `start_session`, `list_sessions`, `continue_session`, `checkpoint_session`, `pause_session`, `end_session`, `search_sessions`, `get_session`, `list_session_events`, `record_session_event`, `attach_session`, `promote_session_fact`.
+
+The full memory tool surface is also available: `start_context`, `recall`, `remember`, `propose_memory`, `update_memory`, `verify_memory`, `list_proposals`. (`archive_memory` and `approve_proposal` are admin-only — they appear only when authenticated with an admin token.)
 
 ## The `/lib-session-*` slash commands
 
@@ -19,6 +21,18 @@ The 7 commands:
 - `/lib-session-search <query>`.
 
 Sessions are in one of three states: `active`, `paused`, `ended`. The retired verbs `archive`, `restore`, `delete`, `status` were removed when the three-state model landed.
+
+Memories are in one of three states: `active`, `proposed`, or `archived`. `active` is the recall pool; `proposed` is awaiting human approval (auto-routed for protected categories like `identity` and `relationship`); `archived` is the soft-deleted bucket. The retired verbs `delete_memory`, `confirm_memory`, `reject_memory`, and the conflict-resolution surface were removed when the three-state model landed — `archive_memory` covers deletion, proposals are accepted or rejected through the dashboard or `update_memory`, and conflict detection is gone.
+
+## Verify-after-recall
+
+When `recall` returns hits and you use one, call `verify_memory` afterwards with a usefulness verdict so the store learns:
+
+- `useful` — the hit was load-bearing for the answer. Boosts recall rank by 3.
+- `not_useful` — the hit was a distractor or stale framing. Drops recall rank by 3.
+- `outdated` — the memory is factually wrong now. Archives it.
+
+The verdict is a single MCP call; don't skip it because the recall already gave you the answer. The whole memory-quality loop depends on these signals.
 
 The hyphenated names match OpenCode's filename-as-command convention; the canonical cross-harness contract uses `/lib:session <verb>` as the abstract surface (see [`docs/slash-commands.md`](../../docs/slash-commands.md)) and each harness implements it with whichever native pattern best fits.
 

--- a/integrations/opencode/healthcheck.md
+++ b/integrations/opencode/healthcheck.md
@@ -19,6 +19,8 @@ End-to-end smoke test for the OpenCode ↔ Librarian session integration.
    ```
    Expected: agent reports `start_session`, `list_sessions`, `continue_session`, `checkpoint_session`, `pause_session`, `end_session`, `search_sessions`, `get_session`, `list_session_events`, `record_session_event`, `attach_session`, `promote_session_fact`. The retired tools `archive_session`, `restore_session`, `delete_session` should NOT be in the list.
 
+   Expected memory tools (V1.x surface): `start_context`, `recall`, `remember`, `propose_memory`, `update_memory`, `verify_memory`, `list_proposals`. The retired tools `delete_memory`, `confirm_memory`, `reject_memory`, `resolve_conflict` should NOT be in the list. `archive_memory` and `approve_proposal` only surface for admin-token callers.
+
 3. **Start a session.**
    ```
    /lib:session start "OpenCode healthcheck"

--- a/integrations/pi/AGENTS.md
+++ b/integrations/pi/AGENTS.md
@@ -6,6 +6,8 @@ Minimal system-prompt snippet for Pi-hosted agents.
 
 The Librarian's session and memory tools are available. Use `/lib:session` (textual command, recognised in user input) for the session lifecycle and `remember` / `propose_memory` for durable facts.
 
+The memory tool surface: `start_context`, `recall`, `remember`, `propose_memory`, `update_memory`, `verify_memory`, `list_proposals`. (`archive_memory` and `approve_proposal` are admin-only.)
+
 ## The `/lib:session` surface
 
 `/lib:session` commands are **textual commands handled by the agent**. The canonical contract lives in [`docs/slash-commands.md`](../../docs/slash-commands.md):
@@ -17,6 +19,18 @@ The Librarian's session and memory tools are available. Use `/lib:session` (text
 - `/lib:session search <query>`.
 
 Sessions are in one of three states: `active`, `paused`, `ended`. The retired verbs `archive`, `restore`, `delete`, `status` were removed when the three-state model landed.
+
+Memories are in one of three states: `active`, `proposed`, or `archived`. `active` is the recall pool; `proposed` is awaiting human approval (auto-routed for protected categories like `identity` and `relationship`); `archived` is the soft-deleted bucket. The retired verbs `delete_memory`, `confirm_memory`, `reject_memory`, and the conflict-resolution surface were removed when the three-state model landed — `archive_memory` covers deletion, proposals are accepted or rejected through the dashboard or `update_memory`, and conflict detection is gone.
+
+## Verify-after-recall
+
+When `recall` returns hits and you use one, call `verify_memory` afterwards with a usefulness verdict so the store learns:
+
+- `useful` — the hit was load-bearing for the answer. Boosts recall rank by 3.
+- `not_useful` — the hit was a distractor or stale framing. Drops recall rank by 3.
+- `outdated` — the memory is factually wrong now. Archives it.
+
+The verdict is a single MCP call; don't skip it because the recall already gave you the answer. The whole memory-quality loop depends on these signals.
 
 ## `source_ref` for Pi
 

--- a/scripts/healthcheck.js
+++ b/scripts/healthcheck.js
@@ -16,7 +16,52 @@ const LOCAL_CHECKS = [
   { name: "SQLite rebuild", fn: checkSqliteRebuild },
   { name: "Session lifecycle", fn: checkSessionLifecycle },
   { name: "MCP stdio reachability", fn: checkMcpStdio },
+  { name: "MCP tool surface", fn: checkMcpToolSurface },
   { name: "HTTP MCP reachability + auth", fn: () => checkHttpMcpLocal() },
+];
+
+// Expected tool surface post-V1.x (memory) + post-S1.x (session). The
+// memory section enforces the V1.x renames (`delete_memory` →
+// `archive_memory`) and the new load-bearing `verify_memory`; the
+// session section enforces the S1.x collapse. Surfaced as a
+// healthcheck so doc/spec drift is caught at boot, not by an agent
+// quietly calling a tool that no longer exists.
+const EXPECTED_TOOLS = {
+  memory: [
+    "start_context",
+    "recall",
+    "remember",
+    "propose_memory",
+    "update_memory",
+    "archive_memory",
+    "verify_memory",
+    "list_proposals",
+    "approve_proposal",
+  ],
+  session: [
+    "start_session",
+    "get_session",
+    "list_sessions",
+    "list_session_events",
+    "search_sessions",
+    "record_session_event",
+    "checkpoint_session",
+    "pause_session",
+    "end_session",
+    "attach_session",
+    "continue_session",
+    "promote_session_fact",
+  ],
+};
+
+const RETIRED_TOOLS = [
+  "delete_memory",
+  "confirm_memory",
+  "reject_memory",
+  "resolve_conflict",
+  "archive_session",
+  "restore_session",
+  "delete_session",
 ];
 
 async function main() {
@@ -290,6 +335,78 @@ async function checkMcpStdio() {
   }
 }
 
+async function checkMcpToolSurface() {
+  const dir = makeTempDir();
+  // Spawn with admin role so the listing includes `archive_memory` and
+  // `approve_proposal` (both `adminOnly: true`); under the default
+  // agent role the dispatcher filters them out.
+  const child = spawn(process.execPath, ["--no-warnings", STDIO_BIN], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, LIBRARIAN_DATA_DIR: dir, LIBRARIAN_STDIO_ROLE: "admin" },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  const messages = [];
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => {
+    for (const line of chunk.split("\n").filter(Boolean)) {
+      try {
+        messages.push(JSON.parse(line));
+      } catch {
+        /* ignore non-JSON */
+      }
+    }
+  });
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+
+  try {
+    child.stdin.write(
+      JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} }) + "\n",
+    );
+    child.stdin.write(
+      JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} }) + "\n",
+    );
+
+    const deadline = Date.now() + 3000;
+    let listMessage;
+    while (Date.now() < deadline) {
+      listMessage = messages.find((m) => m.id === 2 && Array.isArray(m.result?.tools));
+      if (listMessage) break;
+      await wait(50);
+    }
+    if (!listMessage) {
+      throw hint(
+        new Error("MCP stdio did not respond to tools/list."),
+        `stderr:\n${stderr || "(empty)"}`,
+      );
+    }
+
+    const advertised = new Set(listMessage.result.tools.map((t) => t.name));
+    const missing = [];
+    for (const name of [...EXPECTED_TOOLS.memory, ...EXPECTED_TOOLS.session]) {
+      if (!advertised.has(name)) missing.push(name);
+    }
+    const present = RETIRED_TOOLS.filter((name) => advertised.has(name));
+
+    if (missing.length || present.length) {
+      const lines = [];
+      if (missing.length) lines.push(`missing: ${missing.join(", ")}`);
+      if (present.length) lines.push(`retired tools still advertised: ${present.join(", ")}`);
+      throw hint(
+        new Error(`MCP tool surface drifted from the V1.x / S1.x contract.`),
+        `${lines.join(" | ")}. See specs/done/memory-simplification.md + specs/done/session-simplification.md.`,
+      );
+    }
+  } finally {
+    child.kill("SIGTERM");
+    await waitForExit(child);
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 async function checkHttpMcpLocal() {
   const dir = makeTempDir();
   const port = await getFreePort();
@@ -436,6 +553,7 @@ function usage() {
     "  - SQLite rebuild from JSONL",
     "  - Session lifecycle round-trip (start → checkpoint → pause → resume → end)",
     "  - MCP stdio reachability (packages/mcp-server/dist/bin/stdio.js)",
+    "  - MCP tool surface (V1.x memory verbs + S1.x session verbs; retired tools absent)",
     "  - HTTP MCP reachability + auth (packages/mcp-server/dist/bin/http.js)",
     "",
     "Remote mode (--remote http://host:port) skips in-process checks and only",

--- a/test/healthcheck.test.ts
+++ b/test/healthcheck.test.ts
@@ -65,11 +65,19 @@ describe("healthcheck script", () => {
       /SQLite rebuild/i,
       /session lifecycle/i,
       /MCP stdio/i,
+      /MCP tool surface/i,
       /HTTP MCP/i,
     ]) {
       expect(text).toMatch(probe);
     }
     expect(text).toMatch(/PASS/);
+  });
+
+  it("MCP tool surface check passes when the registry matches V1.x + S1.x", async () => {
+    const result = await runHealthcheck();
+    const text = result.stdout + result.stderr;
+    expect(text).toMatch(/PASS\s{2}MCP tool surface/);
+    expect(text).not.toMatch(/FAIL\s{2}MCP tool surface/);
   });
 
   it("--help describes its purpose without running checks", async () => {


### PR DESCRIPTION
## Summary

- Closes the V1.x doc gap in harness agent docs: each of the five harness `AGENTS.md` / `CLAUDE.md` / `AGENTS.append.md` files now carries a Memory three-state paragraph mirroring the existing Session paragraph, plus explicit `verify_memory` post-recall guidance with the three usefulness verdicts (`useful` / `not_useful` / `outdated`).
- Updates each tool-list snippet to enumerate the V1.x memory surface (`start_context`, `recall`, `remember`, `propose_memory`, `update_memory`, `verify_memory`, `list_proposals`) and call out the admin-only tools (`archive_memory`, `approve_proposal`).
- Adds a new `MCP tool surface` healthcheck that asserts the registry matches the V1.x + S1.x contract — runs at `pnpm run healthcheck` against the stdio bin in admin role, fails loudly if any expected tool is missing or any retired tool is still advertised. Catches drift at boot instead of when an agent tries to call a tool that no longer exists.
- Cleans up the stale `/lib:session archive` reference in `integrations/hermes/healthcheck.md` (retired in S1.2).
- Adds `.claude/settings.local.json` to `.prettierignore` (local-only Claude Code settings file; already gitignored, was tripping `pnpm format:check`).

## Test plan

- [x] `pnpm vitest run test/healthcheck.test.ts` — 6 passed (added `MCP tool surface check passes when the registry matches V1.x + S1.x`)
- [x] `pnpm test` — 288 tests, all green
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm format:check`
- [x] `pnpm build`
- [x] `pnpm run smoke`, `pnpm run healthcheck` (locally — 6 of 6 checks pass including the new one)
- [x] `pnpm run check:schema-version`, `pnpm run check:test-count`

Implements **specs/integration-docs-memory-verbs.md** (drafted at the end of the 2026-05-21 autonomous run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)