### PR TITLE
feat(dashboard): migrate Sessions surface to ui-v2 atoms (U2)

### DIFF
--- a/apps/dashboard/components/sessions/detail-view.tsx
+++ b/apps/dashboard/components/sessions/detail-view.tsx
@@ -5,7 +5,7 @@ import { HandoverForm } from "./handover-form";
 import { LifecycleActions } from "./lifecycle-actions";
 import { PromoteForm } from "./promote-form";
 import { isStale, type SessionRow } from "./types";
-import { Badge } from "@/components/ui/badge";
+import { Pill } from "@/components/ui-v2/pill";
 
 export function SessionDetailView({ session }: { session: SessionRow }) {
   const stale = isStale(session);
@@ -13,8 +13,8 @@ export function SessionDetailView({ session }: { session: SessionRow }) {
     <div className="flex flex-col gap-6">
       <header className="flex flex-col gap-2">
         <div className="flex flex-wrap items-center gap-2">
-          <Badge variant={badgeVariantForStatus(session.status)}>{session.status}</Badge>
-          {stale ? <Badge variant="destructive">stale</Badge> : null}
+          <Pill variant={pillVariantForStatus(session.status)}>{session.status}</Pill>
+          {stale ? <Pill variant="accent">stale</Pill> : null}
           <h1 className="text-2xl font-semibold tracking-tight">{session.title || "(untitled)"}</h1>
         </div>
         <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-muted-foreground md:grid-cols-3 lg:grid-cols-4">
@@ -114,10 +114,8 @@ function Field({ label, value, mono }: { label: string; value: string; mono?: bo
   );
 }
 
-function badgeVariantForStatus(
-  status: SessionRow["status"],
-): "default" | "secondary" | "destructive" | "outline" {
-  if (status === "active") return "default";
-  if (status === "paused") return "secondary";
-  return "outline";
+function pillVariantForStatus(status: SessionRow["status"]): "default" | "accent" | "muted" {
+  if (status === "active") return "accent";
+  if (status === "paused") return "muted";
+  return "default";
 }

--- a/apps/dashboard/components/sessions/events-stream.tsx
+++ b/apps/dashboard/components/sessions/events-stream.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/ui-v2/button";
+import { Pill } from "@/components/ui-v2/pill";
 import { trpc } from "@/lib/trpc-client";
 
 const PAGE_SIZE = 50;
@@ -28,7 +28,7 @@ export function EventsStream({ sessionId }: { sessionId: string }) {
           <li key={event.id} className="rounded-md border bg-background p-3 text-sm">
             <div className="flex items-baseline justify-between gap-2">
               <div className="flex items-center gap-2">
-                <Badge variant="outline">{event.type}</Badge>
+                <Pill>{event.type}</Pill>
                 <span className="text-xs text-muted-foreground">{event.agent_id ?? "—"}</span>
               </div>
               <span className="text-xs text-muted-foreground">
@@ -41,7 +41,7 @@ export function EventsStream({ sessionId }: { sessionId: string }) {
           </li>
         ))}
       </ul>
-      <Button variant="ghost" size="sm" onClick={() => events.refetch()}>
+      <Button variant="ghost" onClick={() => events.refetch()}>
         Refresh
       </Button>
     </div>

--- a/apps/dashboard/components/sessions/handover-form.tsx
+++ b/apps/dashboard/components/sessions/handover-form.tsx
@@ -2,8 +2,8 @@
 
 import { useState, useTransition } from "react";
 import { continueSessionAction } from "@/app/sessions/[id]/actions";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui-v2/button";
+import { Input } from "@/components/ui-v2/input";
 
 const HARNESSES = ["claude-code", "codex", "opencode", "hermes", "pi"] as const;
 const FORMATS = ["prose", "markdown", "claude", "codex", "opencode", "hermes", "pi"] as const;
@@ -86,7 +86,7 @@ export function HandoverForm({ sessionId }: { sessionId: string }) {
           <span>Attach this session to the new caller on success</span>
         </label>
         {error ? <p className="text-sm text-destructive">{error}</p> : null}
-        <Button type="submit" disabled={pending}>
+        <Button type="submit" variant="primary" disabled={pending}>
           {pending ? "Building…" : "Continue session"}
         </Button>
       </form>

--- a/apps/dashboard/components/sessions/lifecycle-actions.tsx
+++ b/apps/dashboard/components/sessions/lifecycle-actions.tsx
@@ -9,7 +9,7 @@ import {
   pauseSessionAction,
   resumeSessionAction,
 } from "@/app/sessions/[id]/actions";
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/ui-v2/button";
 
 type Mode = null | "checkpoint" | "pause" | "end";
 
@@ -114,7 +114,7 @@ function LifecycleForm({
         <input name="reason" className="h-9 rounded-md border border-input bg-background px-2" />
       </label>
       <div className="md:col-span-2 flex gap-2">
-        <Button type="submit" disabled={pending}>
+        <Button type="submit" variant="primary" disabled={pending}>
           {pending ? "Working…" : `Submit ${label}`}
         </Button>
         <Button type="button" variant="ghost" onClick={onCancel}>

--- a/apps/dashboard/components/sessions/list-view.tsx
+++ b/apps/dashboard/components/sessions/list-view.tsx
@@ -3,8 +3,8 @@
 import Link from "next/link";
 import { useState } from "react";
 import { isStale, type SessionRow } from "./types";
-import { Badge } from "@/components/ui/badge";
-import { Input } from "@/components/ui/input";
+import { Input } from "@/components/ui-v2/input";
+import { Pill } from "@/components/ui-v2/pill";
 import { trpc } from "@/lib/trpc-client";
 
 const PAGE_LIMIT = 50;
@@ -130,8 +130,8 @@ function SessionRowItem({ session }: { session: SessionRow }) {
         className="flex flex-col gap-1 rounded-md border bg-card p-3 transition-colors hover:bg-accent"
       >
         <div className="flex flex-wrap items-center gap-2">
-          <Badge variant={badgeVariantForStatus(session.status)}>{session.status}</Badge>
-          {stale ? <Badge variant="destructive">stale</Badge> : null}
+          <Pill variant={pillVariantForStatus(session.status)}>{session.status}</Pill>
+          {stale ? <Pill variant="accent">stale</Pill> : null}
           <h3 className="truncate font-medium">{session.title || "(untitled)"}</h3>
         </div>
         <dl className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
@@ -172,10 +172,8 @@ function Field({ label, value }: { label: string; value: string | null | undefin
   );
 }
 
-function badgeVariantForStatus(
-  status: SessionRow["status"],
-): "default" | "secondary" | "destructive" | "outline" {
-  if (status === "active") return "default";
-  if (status === "paused") return "secondary";
-  return "outline";
+function pillVariantForStatus(status: SessionRow["status"]): "default" | "accent" | "muted" {
+  if (status === "active") return "accent";
+  if (status === "paused") return "muted";
+  return "default";
 }

--- a/apps/dashboard/components/sessions/promote-form.tsx
+++ b/apps/dashboard/components/sessions/promote-form.tsx
@@ -3,8 +3,8 @@
 import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
 import { promoteSessionFactAction } from "@/app/sessions/[id]/actions";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui-v2/button";
+import { Input } from "@/components/ui-v2/input";
 
 const CATEGORIES = [
   "lessons",
@@ -98,7 +98,7 @@ export function PromoteForm({ sessionId }: { sessionId: string }) {
         </div>
         {error ? <p className="text-sm text-destructive">{error}</p> : null}
         {saved ? <p className="text-sm text-foreground">Memory promoted.</p> : null}
-        <Button type="submit" disabled={pending}>
+        <Button type="submit" variant="primary" disabled={pending}>
           {pending ? "Saving…" : "Promote"}
         </Button>
       </form>

--- a/apps/dashboard/components/ui-v2/pill.tsx
+++ b/apps/dashboard/components/ui-v2/pill.tsx
@@ -1,21 +1,30 @@
 // Mono-style chip for technical strings (mem_…, ses_…, timestamps).
 //
-// Real "click to copy" interaction lands in D1.1; this stub only
-// pins the typography (mono) and the chip background so the rest
-// of the redesign can rely on it.
+// Variants (U2): `default` (mono-fill, neutral — for ids, timestamps,
+// event types), `accent` (vermilion/saffron — for the one state per
+// view that matters), `muted` (sage — for secondary/paused state).
+// Editorial palette is deliberately restrained; if more variants are
+// needed, lean on a Hairline + label instead of inventing colours.
 
 import type { HTMLAttributes, ReactNode } from "react";
 
+type Variant = "default" | "accent" | "muted";
+
 interface PillProps extends HTMLAttributes<HTMLSpanElement> {
+  variant?: Variant;
   children: ReactNode;
 }
 
-export function Pill({ children, className = "", ...rest }: PillProps) {
+const variants: Record<Variant, string> = {
+  default: "bg-foreground/[0.06] text-foreground font-mono",
+  accent: "border border-ink-accent text-ink-accent font-sans",
+  muted: "border border-ink-accent-subdued text-ink-accent-subdued font-sans",
+};
+
+export function Pill({ variant = "default", children, className = "", ...rest }: PillProps) {
+  const base = "inline-flex items-center gap-1 rounded-none px-1.5 py-0.5 text-xs leading-none";
   return (
-    <span
-      className={`inline-flex items-center gap-1 rounded-none bg-foreground/[0.06] px-1.5 py-0.5 font-mono text-xs leading-none text-foreground ${className}`.trim()}
-      {...rest}
-    >
+    <span className={`${base} ${variants[variant]} ${className}`.trim()} {...rest}>
       {children}
     </span>
   );

--- a/apps/dashboard/tests/components/ui-v2/ui-v2.test.tsx
+++ b/apps/dashboard/tests/components/ui-v2/ui-v2.test.tsx
@@ -53,6 +53,18 @@ describe("ui-v2 primitives", () => {
     expect(pill.className).toMatch(/font-mono/);
   });
 
+  it("Pill applies the accent variant when requested", () => {
+    render(<Pill variant="accent">active</Pill>);
+    const pill = screen.getByText("active");
+    expect(pill.className).toMatch(/ink-accent/);
+  });
+
+  it("Pill applies the muted variant when requested", () => {
+    render(<Pill variant="muted">paused</Pill>);
+    const pill = screen.getByText("paused");
+    expect(pill.className).toMatch(/ink-accent-subdued/);
+  });
+
   it("Hairline renders a divider element", () => {
     const { container } = render(<Hairline />);
     expect(container.querySelector("hr")).not.toBeNull();


### PR DESCRIPTION
## Summary

- Swaps all six Sessions component files off `@/components/ui/*` and onto the editorial `ui-v2/*` atoms from U1: `handover-form`, `lifecycle-actions`, `promote-form`, `detail-view`, `events-stream`, `list-view`.
- Extends `Pill` with `accent` / `muted` variants (per the U2 acceptance criteria) so session status can be carried without the legacy `badgeVariants`.
- Status mapping: `active` → `accent` (vermilion catches the eye), `paused` → `muted` (subdued sage), `ended` → `default` (neutral mono-fill). The stale indicator stays `accent` since it's the attention-grabbing case.
- Drops the legacy `size="sm"` on the Events refresh button — the editorial direction prefers consistent sizing.

Net result: `rg "@/components/ui/" apps/dashboard/components/sessions/` returns zero hits. The legacy directory itself is still in place for the Memories migration (U3).

## Test plan

- [x] `pnpm test` — 26 root + 45 dashboard tests pass, including the 2 new Pill variant tests
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm format:check`
- [x] `pnpm build` — Sessions detail page bundle dropped from 5.49 kB → 4.39 kB (legacy Badge / Button class-variance-authority removed from this surface's tree)
- [x] `pnpm run smoke`
- [x] Existing `tests/components/lifecycle-actions.test.tsx` still green (uses `getByRole("button", { name: "..." })` — style-agnostic)

Implements **Phase 2 (U2)** of `specs/ui-library-consolidation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)