### PR TITLE
feat(core): sessions.state_version + session_state_changes audit (R1)

### DIFF
--- a/packages/core/src/store/projection.ts
+++ b/packages/core/src/store/projection.ts
@@ -55,7 +55,10 @@ function asArray(value: unknown): string[] {
 //        unchanged but existing canonical instances need to roll forward
 //        through the new projection handler at first start; bumping the
 //        sentinel triggers that replay on next boot.
-export const PROJECTION_SCHEMA_VERSION = 4;
+//   - 5: R1 added `sessions.state_version` + `session_state_changes`.
+//        Dual-write (R1) keeps the JSONL ledger canonical; the new
+//        columns + audit table seed R3's SQLite-canonical cutover.
+export const PROJECTION_SCHEMA_VERSION = 5;
 
 export function getSchemaVersion(db: DatabaseSync): number {
   const row = db.prepare("PRAGMA user_version").get() as { user_version: number };
@@ -73,6 +76,7 @@ function dropProjectionTables(db: DatabaseSync): void {
     DROP TABLE IF EXISTS events;
     DROP TABLE IF EXISTS session_events_fts;
     DROP TABLE IF EXISTS session_events;
+    DROP TABLE IF EXISTS session_state_changes;
     DROP TABLE IF EXISTS sessions;
   `);
 }
@@ -179,8 +183,21 @@ export const SCHEMA_DDL = `
       ended_at TEXT,
       archived_at TEXT,
       deleted_at TEXT,
-      metadata_json TEXT NOT NULL
+      metadata_json TEXT NOT NULL,
+      state_version INTEGER NOT NULL DEFAULT 0
     );
+    CREATE TABLE IF NOT EXISTS session_state_changes (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL,
+      from_status TEXT,
+      to_status TEXT NOT NULL,
+      actor_agent_id TEXT,
+      at TEXT NOT NULL,
+      note TEXT,
+      FOREIGN KEY (session_id) REFERENCES sessions(id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_session_state_changes_session
+      ON session_state_changes(session_id, id);
     CREATE TABLE IF NOT EXISTS session_events (
       id TEXT PRIMARY KEY,
       session_id TEXT NOT NULL,
@@ -637,6 +654,9 @@ interface SessionSnapshot {
 }
 
 function insertSessionRow(db: DatabaseSync, session: SessionSnapshot): void {
+  // state_version seeds at 1 — startSession is itself the first
+  // transition, so the first row update sets it explicitly rather than
+  // relying on bumpStateVersion (which is called from update paths).
   db.prepare(
     `INSERT OR REPLACE INTO sessions (
       id, title, project_key, status, prior_status, visibility,
@@ -644,8 +664,8 @@ function insertSessionRow(db: DatabaseSync, session: SessionSnapshot): void {
       source_ref, cwd, start_summary, rolling_summary, end_summary,
       next_steps_json, tags_json, capture_mode,
       started_at, updated_at, last_activity_at,
-      paused_at, ended_at, archived_at, deleted_at, metadata_json
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      paused_at, ended_at, archived_at, deleted_at, metadata_json, state_version
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     session.id,
     session.title,
@@ -673,7 +693,32 @@ function insertSessionRow(db: DatabaseSync, session: SessionSnapshot): void {
     session.archived_at || null,
     session.deleted_at || null,
     JSON.stringify(session.metadata || {}),
+    1,
   );
+}
+
+// R1 — bump the row's state_version and (when the status actually changed)
+// append a row to session_state_changes. The state-change ledger only
+// records true status transitions (active↔paused, paused→active, *→ended,
+// ended→paused). Checkpoints and event-recorded calls bump the version
+// because they mutate the row, but skip the audit insert.
+function bumpStateVersion(db: DatabaseSync, sessionId: string): void {
+  db.prepare(`UPDATE sessions SET state_version = state_version + 1 WHERE id = ?`).run(sessionId);
+}
+
+function recordStateChange(
+  db: DatabaseSync,
+  sessionId: string,
+  from: string | null,
+  to: string,
+  actorAgentId: string | null,
+  at: string,
+  note: string | null,
+): void {
+  db.prepare(
+    `INSERT INTO session_state_changes (session_id, from_status, to_status, actor_agent_id, at, note)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run(sessionId, from, to, actorAgentId, at, note);
 }
 
 function insertSessionEventRow(
@@ -728,6 +773,15 @@ export function applySessionEvent(db: DatabaseSync, event: SessionLedgerEvent): 
     if (!session) return;
     insertSessionRow(db, session);
     insertSessionEventRow(db, event, eventSummary(event), shortType(type));
+    recordStateChange(
+      db,
+      session.id,
+      null,
+      session.status,
+      (payload.agent_id as string) || session.created_by_agent_id || null,
+      event.created_at,
+      (session.start_summary as string) || null,
+    );
     return;
   }
 
@@ -747,11 +801,24 @@ export function applySessionEvent(db: DatabaseSync, event: SessionLedgerEvent): 
       last_activity_at: event.created_at,
       updated_at: event.created_at,
     };
-    if (existing.status === SessionStatus.Ended) {
+    const wasEnded = existing.status === SessionStatus.Ended;
+    if (wasEnded) {
       updates.status = SessionStatus.Paused;
       updates.ended_at = null;
     }
     patchSessionRow(db, existing.id, updates);
+    bumpStateVersion(db, existing.id);
+    if (wasEnded) {
+      recordStateChange(
+        db,
+        existing.id,
+        SessionStatus.Ended,
+        SessionStatus.Paused,
+        (payload.agent_id as string) || existing.current_agent_id,
+        event.created_at,
+        `Attached to ${(payload.harness as string) || "unknown harness"}.`,
+      );
+    }
     insertSessionEventRow(
       db,
       event,
@@ -780,6 +847,18 @@ export function applySessionEvent(db: DatabaseSync, event: SessionLedgerEvent): 
       updates.ended_at = null;
     }
     patchSessionRow(db, existing.id, updates);
+    bumpStateVersion(db, existing.id);
+    if (shouldReactivate) {
+      recordStateChange(
+        db,
+        existing.id,
+        existing.status,
+        SessionStatus.Active,
+        (payload.agent_id as string) || existing.current_agent_id,
+        event.created_at,
+        summary || null,
+      );
+    }
     insertSessionEventRow(db, event, summary, payloadType ?? "event");
     return;
   }
@@ -792,7 +871,8 @@ export function applySessionEvent(db: DatabaseSync, event: SessionLedgerEvent): 
       last_activity_at: event.created_at,
       updated_at: event.created_at,
     };
-    if (existing.status === SessionStatus.Paused) {
+    const wasPaused = existing.status === SessionStatus.Paused;
+    if (wasPaused) {
       updates.status = SessionStatus.Active;
       updates.paused_at = null;
     }
@@ -800,6 +880,18 @@ export function applySessionEvent(db: DatabaseSync, event: SessionLedgerEvent): 
       updates.next_steps_json = JSON.stringify(asArray(nextSteps));
     }
     patchSessionRow(db, existing.id, updates);
+    bumpStateVersion(db, existing.id);
+    if (wasPaused) {
+      recordStateChange(
+        db,
+        existing.id,
+        SessionStatus.Paused,
+        SessionStatus.Active,
+        (payload.agent_id as string) || existing.current_agent_id,
+        event.created_at,
+        summary || null,
+      );
+    }
     insertSessionEventRow(db, event, summary || "Checkpoint.", shortType(type));
     return;
   }
@@ -818,6 +910,18 @@ export function applySessionEvent(db: DatabaseSync, event: SessionLedgerEvent): 
       updates.next_steps_json = JSON.stringify(asArray(nextSteps));
     }
     patchSessionRow(db, existing.id, updates);
+    bumpStateVersion(db, existing.id);
+    if (existing.status !== SessionStatus.Paused) {
+      recordStateChange(
+        db,
+        existing.id,
+        existing.status,
+        SessionStatus.Paused,
+        (payload.agent_id as string) || existing.current_agent_id,
+        event.created_at,
+        summary || null,
+      );
+    }
     insertSessionEventRow(db, event, summary || "Session paused.", shortType(type));
     return;
   }
@@ -836,6 +940,18 @@ export function applySessionEvent(db: DatabaseSync, event: SessionLedgerEvent): 
       updates.next_steps_json = JSON.stringify(asArray(nextSteps));
     }
     patchSessionRow(db, existing.id, updates);
+    bumpStateVersion(db, existing.id);
+    if (existing.status !== SessionStatus.Ended) {
+      recordStateChange(
+        db,
+        existing.id,
+        existing.status,
+        SessionStatus.Ended,
+        (payload.agent_id as string) || existing.current_agent_id,
+        event.created_at,
+        summary || null,
+      );
+    }
     insertSessionEventRow(db, event, summary || "Session ended.", shortType(type));
     return;
   }
@@ -851,6 +967,18 @@ export function applySessionEvent(db: DatabaseSync, event: SessionLedgerEvent): 
       last_activity_at: event.created_at,
       updated_at: event.created_at,
     });
+    bumpStateVersion(db, existing.id);
+    if (existing.status !== SessionStatus.Ended) {
+      recordStateChange(
+        db,
+        existing.id,
+        existing.status,
+        SessionStatus.Ended,
+        existing.current_agent_id,
+        event.created_at,
+        (payload.reason as string) || "Session archived.",
+      );
+    }
     insertSessionEventRow(
       db,
       event,
@@ -870,6 +998,18 @@ export function applySessionEvent(db: DatabaseSync, event: SessionLedgerEvent): 
       last_activity_at: event.created_at,
       updated_at: event.created_at,
     });
+    bumpStateVersion(db, existing.id);
+    if (existing.status !== SessionStatus.Ended) {
+      recordStateChange(
+        db,
+        existing.id,
+        existing.status,
+        SessionStatus.Ended,
+        existing.current_agent_id,
+        event.created_at,
+        (payload.reason as string) || "Session deleted.",
+      );
+    }
     insertSessionEventRow(
       db,
       event,
@@ -884,6 +1024,7 @@ export function applySessionEvent(db: DatabaseSync, event: SessionLedgerEvent): 
       last_activity_at: event.created_at,
       updated_at: event.created_at,
     });
+    bumpStateVersion(db, existing.id);
     const title = (payload.title as string) || "Promoted to memory.";
     insertSessionEventRow(db, event, title, shortType(type));
     return;
@@ -901,6 +1042,18 @@ export function applySessionEvent(db: DatabaseSync, event: SessionLedgerEvent): 
       last_activity_at: event.created_at,
       updated_at: event.created_at,
     });
+    bumpStateVersion(db, existing.id);
+    if (existing.status !== SessionStatus.Paused) {
+      recordStateChange(
+        db,
+        existing.id,
+        existing.status,
+        SessionStatus.Paused,
+        existing.current_agent_id,
+        event.created_at,
+        "Restored to paused.",
+      );
+    }
     insertSessionEventRow(db, event, "Restored to paused.", shortType(type));
   }
 }
@@ -918,7 +1071,11 @@ export function rebuildSessionIndex(db: DatabaseSync, sessionsPath: string): voi
   const rollback = db.prepare("ROLLBACK");
   tx.run();
   try {
-    db.exec("DELETE FROM sessions; DELETE FROM session_events; DELETE FROM session_events_fts;");
+    // FK: session_state_changes references sessions(id), so delete the
+    // child rows first.
+    db.exec(
+      "DELETE FROM session_state_changes; DELETE FROM session_events; DELETE FROM session_events_fts; DELETE FROM sessions;",
+    );
     for (const event of events) applySessionEvent(db, event);
     commit.run();
   } catch (error) {

--- a/packages/core/tests/store/projection.test.ts
+++ b/packages/core/tests/store/projection.test.ts
@@ -143,7 +143,10 @@ describe("SQLite projection rebuild parity", () => {
       });
 
       store.db.exec(
-        "DELETE FROM sessions; DELETE FROM session_events; DELETE FROM session_events_fts;" +
+        // R1: session_state_changes references sessions(id) — delete it
+        // first to keep the foreign-key constraint happy.
+        "DELETE FROM session_state_changes;" +
+          "DELETE FROM sessions; DELETE FROM session_events; DELETE FROM session_events_fts;" +
           "DELETE FROM memories; DELETE FROM memories_fts; DELETE FROM events;",
       );
       expect(store.getSession(session.id)).toBeNull();

--- a/packages/core/tests/store/r1-state-version.test.ts
+++ b/packages/core/tests/store/r1-state-version.test.ts
@@ -1,0 +1,154 @@
+// R1 — sessions get an authoritative SQLite `state_version` column and
+// a `session_state_changes` audit table populated by the projection.
+// JSONL-canonical stays in place for this phase; R3 will cut state
+// transitions over to SQLite-direct writes. These tests pin the new
+// schema + handler behaviour ahead of that cutover.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { type LibrarianStore, createLibrarianStore } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+interface ScopedStore {
+  store: LibrarianStore;
+  dataDir: string;
+}
+
+function makeScopedStore(): ScopedStore {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-r1-"));
+  const store = createLibrarianStore({ dataDir });
+  return { store, dataDir };
+}
+
+function teardown(scope: ScopedStore | null): void {
+  if (!scope) return;
+  try {
+    scope.store.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(scope.dataDir, { recursive: true, force: true });
+}
+
+interface StateChange {
+  from_status: string | null;
+  to_status: string;
+  actor_agent_id: string | null;
+  note: string | null;
+}
+
+function getStateVersion(store: LibrarianStore, sessionId: string): number {
+  const row = store.db.prepare("SELECT state_version FROM sessions WHERE id = ?").get(sessionId) as
+    | { state_version: number }
+    | undefined;
+  if (!row) throw new Error(`No session row for ${sessionId}`);
+  return row.state_version;
+}
+
+function listStateChanges(store: LibrarianStore, sessionId: string): StateChange[] {
+  return store.db
+    .prepare(
+      `SELECT from_status, to_status, actor_agent_id, note
+       FROM session_state_changes
+       WHERE session_id = ?
+       ORDER BY id ASC`,
+    )
+    .all(sessionId) as StateChange[];
+}
+
+describe("R1 — sessions.state_version + session_state_changes", () => {
+  let scope: ScopedStore | null = null;
+
+  beforeEach(() => {
+    scope = makeScopedStore();
+  });
+
+  afterEach(() => {
+    teardown(scope);
+    scope = null;
+  });
+
+  it("startSession produces state_version=1 and a null→active state-change row", () => {
+    const { store } = scope!;
+    const { session } = store.startSession({ agent_id: "bede", title: "r1 start" });
+    expect(session).not.toBeNull();
+    expect(getStateVersion(store, session!.id)).toBe(1);
+    const changes = listStateChanges(store, session!.id);
+    expect(changes).toHaveLength(1);
+    expect(changes[0]?.from_status).toBeNull();
+    expect(changes[0]?.to_status).toBe("active");
+    expect(changes[0]?.actor_agent_id).toBe("bede");
+  });
+
+  it("checkpointSession bumps state_version but doesn't insert a state-change row (status unchanged)", () => {
+    const { store } = scope!;
+    const { session } = store.startSession({ agent_id: "bede", title: "r1 cp" });
+    store.checkpointSession({ session_id: session!.id, summary: "midway" });
+    expect(getStateVersion(store, session!.id)).toBe(2);
+    expect(listStateChanges(store, session!.id)).toHaveLength(1);
+  });
+
+  it("pauseSession bumps state_version and inserts an active→paused row", () => {
+    const { store } = scope!;
+    const { session } = store.startSession({ agent_id: "bede", title: "r1 pause" });
+    store.pauseSession({ session_id: session!.id, summary: "pause" });
+    expect(getStateVersion(store, session!.id)).toBe(2);
+    const changes = listStateChanges(store, session!.id);
+    expect(changes).toHaveLength(2);
+    expect(changes[1]?.from_status).toBe("active");
+    expect(changes[1]?.to_status).toBe("paused");
+  });
+
+  it("endSession bumps state_version and inserts an active→ended row", () => {
+    const { store } = scope!;
+    const { session } = store.startSession({ agent_id: "bede", title: "r1 end" });
+    store.endSession({ session_id: session!.id });
+    expect(getStateVersion(store, session!.id)).toBe(2);
+    const changes = listStateChanges(store, session!.id);
+    expect(changes.at(-1)?.from_status).toBe("active");
+    expect(changes.at(-1)?.to_status).toBe("ended");
+  });
+
+  it("recordSessionEvent that resumes a paused session inserts a paused→active row", () => {
+    const { store } = scope!;
+    const { session } = store.startSession({ agent_id: "bede", title: "r1 implicit-resume" });
+    store.pauseSession({ session_id: session!.id, summary: "pause" });
+    store.recordSessionEvent({ session_id: session!.id, type: "note", summary: "back" });
+    expect(getStateVersion(store, session!.id)).toBe(3);
+    const changes = listStateChanges(store, session!.id);
+    expect(changes.at(-1)?.from_status).toBe("paused");
+    expect(changes.at(-1)?.to_status).toBe("active");
+  });
+
+  it("continueSession on an ended session inserts an ended→paused row", () => {
+    const { store } = scope!;
+    const { session } = store.startSession({ agent_id: "bede", title: "r1 resume-ended" });
+    store.endSession({ session_id: session!.id });
+    store.continueSession({ session_id: session!.id, target_harness: "claude-code" });
+    const changes = listStateChanges(store, session!.id);
+    expect(changes.at(-1)?.from_status).toBe("ended");
+    expect(changes.at(-1)?.to_status).toBe("paused");
+  });
+
+  it("rebuildIndex from JSONL reproduces state_version + state-change counts", () => {
+    const { store } = scope!;
+    const { session } = store.startSession({ agent_id: "bede", title: "r1 rebuild" });
+    store.checkpointSession({ session_id: session!.id, summary: "1" });
+    store.pauseSession({ session_id: session!.id, summary: "2" });
+    store.recordSessionEvent({ session_id: session!.id, type: "note", summary: "3" });
+    store.endSession({ session_id: session!.id });
+
+    const beforeVersion = getStateVersion(store, session!.id);
+    const beforeChanges = listStateChanges(store, session!.id);
+
+    store.rebuildIndex();
+
+    expect(getStateVersion(store, session!.id)).toBe(beforeVersion);
+    const afterChanges = listStateChanges(store, session!.id);
+    expect(afterChanges).toHaveLength(beforeChanges.length);
+    expect(afterChanges.map((c) => `${c.from_status}->${c.to_status}`)).toEqual(
+      beforeChanges.map((c) => `${c.from_status}->${c.to_status}`),
+    );
+  });
+});

--- a/test/schema-snapshot.json
+++ b/test/schema-snapshot.json
@@ -1,4 +1,4 @@
 {
-  "version": 4,
-  "fingerprint": "476aa975ba8ca96ad25ccafab4f4195d64525ece435356b6cb82d2f519b6f63b"
+  "version": 5,
+  "fingerprint": "bdd2adacb63ef1585c9c5b3f08e50929d3850e183af080641755e9cc45d18868"
 }


### PR DESCRIPTION
## Summary

Phase 1 of `specs/session-storage-rearchitecture.md` (TODO #13). Lays the SQLite schema foundation that R3 will eventually promote to authoritative; keeps the JSONL ledger as the canonical write path for this phase.

- New column **`sessions.state_version INTEGER NOT NULL DEFAULT 0`** — initial insert seeds at 1; every row mutation bumps via the new `bumpStateVersion` helper. Checkpoints and event-recorded calls bump even when status doesn't change, because they mutate the row.
- New table **`session_state_changes`** (`id, session_id, from_status, to_status, actor_agent_id, at, note`) — append-only audit trail of *actual* status transitions. Inserted by the projection handlers (Started, AttachedToHarness→ended-resume, EventRecorded→implicit-resume, Checkpointed→paused-resume, Paused, Ended, Archived, Deleted, Restored). Indexed on `(session_id, id)` for the dashboard's future Activity tab.
- **`PROJECTION_SCHEMA_VERSION` 4 → 5** so canonical instances rebuild the projection on first start with the new columns. Schema snapshot fingerprint refreshed.
- Rebuild SQL re-ordered so `session_state_changes` is deleted before `sessions` (the FK constraint would fail otherwise).

The new shadow state is not exposed via tRPC/MCP in this PR — that's R3 (`sessions.history` + `purge_session`). R2 (next) will ship the migration script + a CI divergence check that validates the SQLite-direct state matches the JSONL-replay state.

## Test plan

- [x] 7 new tests in `packages/core/tests/store/r1-state-version.test.ts`: startSession seeds state_version=1, checkpoint bumps without state-change row, pause/end/implicit-resume/continue-on-ended all record the correct state-change row, rebuild from JSONL reproduces version + state-change counts.
- [x] `pnpm test` — 304 tests, all green
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm format:check`
- [x] `pnpm build`
- [x] `pnpm run smoke`, `pnpm run check:storage-fixture`, `pnpm run check:schema-version` (now `version=5 fingerprint=bdd2adac…`), `pnpm run check:test-count` (304 ≥ floor 177)

Implements **Phase 1 (R1)** of `specs/session-storage-rearchitecture.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)