### PR TITLE
feat(r2): sessions migration script + divergence CI guard + runbook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Guard — projection schema version
         run: pnpm run check:schema-version
 
+      - name: Guard — session state divergence
+        run: pnpm run check:session-state-divergence
+
       - name: Validate Docker Compose config
         env:
           LIBRARIAN_ADMIN_TOKEN: ci-admin-token

--- a/docs/migration-sessions-storage.md
+++ b/docs/migration-sessions-storage.md
@@ -1,0 +1,136 @@
+# Operator runbook: sessions storage migration (R2)
+
+This document walks through the one-time conversion from the
+JSONL-canonical sessions model to the hybrid model where SQLite holds
+the authoritative current state and `session_events.jsonl` carries
+only the timeline events.
+
+Skip this page if you haven't yet pulled R2; come back when you do.
+
+## What changes
+
+| Before R2                          | After R2                                                                       |
+|------------------------------------|--------------------------------------------------------------------------------|
+| `data/sessions.jsonl` (canonical)  | `data/sessions.legacy.jsonl` (frozen, audit-only)                              |
+| —                                  | `data/session_events.jsonl` (new; timeline events only, no state transitions)  |
+| Session status = projection        | Session status = authoritative SQLite row (already true behaviourally post-R1) |
+| `librarian.sqlite` = projection    | `librarian.sqlite` = authoritative for sessions + projection for memories      |
+
+State-transition events (`session.started`, `session.checkpointed`,
+`session.paused`, `session.ended`, plus the historical
+`session.archived` / `session.deleted` / `session.restored`) are not
+copied into the new `session_events.jsonl`. They live in
+`session_state_changes` (added in R1) and the `sessions` row itself.
+
+Note: R2 ships **the migration script and runbook** only. The runtime
+still writes to `sessions.jsonl` until R3 lands. Running R2's
+migration with R3 unreleased means new sessions will keep producing
+state-transition lines in a freshly-recreated `sessions.jsonl` —
+that's expected and gets cleaned up when R3 cuts the runtime over.
+
+If you want to wait for R3 before migrating, that's fine — R2 is
+a tooling-only release.
+
+## Before you start
+
+1. **Back up your `data/` directory in full.** A `cp -a data data.pre-r2`
+   in the working directory is sufficient; you want a snapshot you can
+   restore from if anything goes wrong.
+2. **Stop the MCP server.** The migration mutates files under `data/`
+   and a concurrent write from the live process could leave the ledger
+   half-renamed.
+
+## Running the migration
+
+```sh
+# Dry-run first — prints the summary without changing any files.
+node scripts/migrate-sessions-to-authoritative-sqlite.mjs
+
+# When the dry-run numbers look right, commit the change.
+node scripts/migrate-sessions-to-authoritative-sqlite.mjs --apply
+```
+
+The script prints a summary like:
+
+```
+Sessions storage migration
+============================================================
+data dir:                /var/lib/librarian/data
+sessions.jsonl lines:    1247
+  → timeline (kept):     842
+  → state transitions:   405  (encoded in SQLite + session_state_changes)
+  → unparseable (drop):  0
+SQLite sessions:         63
+SQLite state changes:    405
+============================================================
+```
+
+Expectations to sanity-check:
+
+- `timeline + state transitions + unparseable` should equal the line
+  count of `sessions.jsonl`.
+- `SQLite state changes` should equal the `state transitions` count
+  (each historical transition produced exactly one
+  `session_state_changes` row via the R1 projection).
+- `SQLite sessions` should match what `list_sessions --include-ended`
+  returns from the CLI.
+
+If the numbers look off, **do not run `--apply`**. Investigate first;
+the dry run is non-destructive.
+
+## After the migration
+
+1. **Run the divergence check:**
+   ```sh
+   node scripts/check-session-state-divergence.mjs --data-dir ./data
+   ```
+   This walks every session and asserts that its `sessions.status`
+   matches the last `to_status` in `session_state_changes`. A clean
+   pass means the SQLite-authoritative state is internally consistent
+   with the audit trail.
+
+2. **Restart the MCP server.** Verify it boots cleanly. The R1 schema
+   sentinel (version 5) already migrated on first start, so this
+   restart is a no-op apart from re-opening the SQLite handle.
+
+3. **Verify a known session.** Pick a session id you've seen recently,
+   call `get_session` from the dashboard or CLI, and confirm the
+   `status`, `rolling_summary`, and timestamps look right.
+
+4. **Verify `list_sessions` defaults.** Should match pre-migration
+   counts (active + paused sessions).
+
+## Rollback
+
+If you need to undo:
+
+1. Stop the server.
+2. Restore the `data/` backup you took before starting.
+3. Restart the server. R1's projection rebuild reseeds
+   `session_state_changes` from JSONL on first start.
+
+The post-migration files are:
+
+- `data/sessions.legacy.jsonl` — frozen, can be safely deleted if the
+  backup above is intact.
+- `data/session_events.jsonl` — new timeline ledger, also safely
+  deletable (R3's purge would do the equivalent operation).
+- `data/librarian.sqlite` — keep this; it's the new authoritative
+  source post-R3.
+
+## Idempotency
+
+Running the migration script a second time is safe: it detects the
+renamed `sessions.legacy.jsonl` and exits without changes.
+
+## What's next
+
+- **R3** cuts the runtime over to write timeline events to
+  `session_events.jsonl` and stop emitting state-transition events to
+  any JSONL. SQLite becomes the only place state lives.
+- **R4** drops the vestigial `prior_status` column and tightens the
+  docs to reflect the new architecture.
+
+Until R3, the runtime keeps the old write path. That's deliberate —
+the migration is a tooling step, not a behaviour change. The R3 PR
+will reference this runbook as a prerequisite.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "build": "pnpm -r run build",
     "check:test-count": "node --no-warnings scripts/check-test-count.mjs",
     "check:storage-fixture": "node --no-warnings scripts/check-storage-fixture.mjs",
-    "check:schema-version": "node --no-warnings scripts/check-schema-version.mjs"
+    "check:schema-version": "node --no-warnings scripts/check-schema-version.mjs",
+    "check:session-state-divergence": "node --no-warnings scripts/check-session-state-divergence.mjs"
   },
   "engines": {
     "node": ">=22.5.0",

--- a/scripts/check-session-state-divergence.mjs
+++ b/scripts/check-session-state-divergence.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+// R2 — CI guard that catches divergence between the SQLite-authoritative
+// `sessions.status` and the audit trail in `session_state_changes`.
+//
+// For every session in SQLite:
+//   - read the last `to_status` from session_state_changes (the most
+//     recent recorded transition);
+//   - compare to `sessions.status`.
+//   - they must match. A session with zero state-change rows is treated
+//     as never-transitioned and skipped (shouldn't happen post-R1 since
+//     `startSession` always records a null→active row).
+//
+// Exits 0 on parity, 1 on divergence with a per-row report.
+//
+// Runs against a fresh temp store seeded with the storage fixture so CI
+// can call it deterministically. Operators can also point it at a live
+// data dir via `--data-dir`.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+
+const args = parseArgs(process.argv.slice(2));
+const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
+
+let cleanupDir = null;
+let dataDir;
+if (args.dataDir) {
+  dataDir = path.resolve(args.dataDir);
+} else {
+  // Default CI mode: seed a fresh temp dir from the pre-migration
+  // storage fixture so the check is reproducible without relying on
+  // the operator's live ledger. Mirrors check-storage-fixture.mjs.
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-r2-divergence-"));
+  cleanupDir = dataDir;
+  const fixtureDir = path.join(repoRoot, "test", "fixtures", "pre-migration");
+  if (fs.existsSync(fixtureDir)) {
+    for (const f of ["events.jsonl", "sessions.jsonl"]) {
+      const src = path.join(fixtureDir, f);
+      if (fs.existsSync(src)) fs.copyFileSync(src, path.join(dataDir, f));
+    }
+  }
+}
+
+const { createLibrarianStore } = await import("@librarian/core");
+const store = createLibrarianStore({ dataDir });
+
+const sessions = store.db.prepare("SELECT id, status FROM sessions").all();
+const divergences = [];
+
+for (const session of sessions) {
+  const lastChange = store.db
+    .prepare(
+      "SELECT to_status FROM session_state_changes WHERE session_id = ? ORDER BY id DESC LIMIT 1",
+    )
+    .get(session.id);
+  if (!lastChange) {
+    divergences.push({
+      session_id: session.id,
+      sqliteStatus: session.status,
+      lastTransition: null,
+      reason:
+        "no session_state_changes row (post-R1 sessions should always have at least the startSession row)",
+    });
+    continue;
+  }
+  if (lastChange.to_status !== session.status) {
+    divergences.push({
+      session_id: session.id,
+      sqliteStatus: session.status,
+      lastTransition: lastChange.to_status,
+      reason: "SQLite status does not match the last recorded transition",
+    });
+  }
+}
+
+store.close();
+if (cleanupDir) fs.rmSync(cleanupDir, { recursive: true, force: true });
+
+if (divergences.length) {
+  console.error(
+    `[check-session-state-divergence] FAIL: ${divergences.length} session(s) diverged from session_state_changes.`,
+  );
+  for (const d of divergences) {
+    console.error(
+      `  - ${d.session_id}: status=${d.sqliteStatus} lastTransition=${d.lastTransition ?? "(none)"} — ${d.reason}`,
+    );
+  }
+  process.exit(1);
+}
+
+console.log(`[check-session-state-divergence] OK: ${sessions.length} sessions, all in parity.`);
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--data-dir") out.dataDir = argv[++i];
+    else if (a.startsWith("--data-dir=")) out.dataDir = a.slice("--data-dir=".length);
+    else if (a === "--help" || a === "-h") {
+      console.log("Usage: node scripts/check-session-state-divergence.mjs [--data-dir <path>]");
+      process.exit(0);
+    }
+  }
+  return out;
+}

--- a/scripts/migrate-sessions-to-authoritative-sqlite.mjs
+++ b/scripts/migrate-sessions-to-authoritative-sqlite.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+// R2 — one-shot migration from JSONL-canonical sessions to the hybrid
+// model:
+//
+//   - SQLite `sessions` row is the source of current state (already
+//     true behaviourally — this just makes the relationship explicit
+//     by separating timeline events from state-transition events).
+//   - `session_events.jsonl` (new file) carries only timeline events:
+//     notes, decisions, attaches, handovers, payload events recorded
+//     via `record_session_event`, and `promote_session_fact` audits.
+//   - `sessions.legacy.jsonl` is the renamed original ledger, kept
+//     read-only as a pre-migration audit anchor.
+//
+// What the script does:
+//   1. Opens the store (which runs R1's ensureSchema → projection
+//      rebuild against the new state_version + session_state_changes
+//      columns). After this step the SQLite side is fully populated.
+//   2. Reads `data/sessions.jsonl` and splits each line by type:
+//        - timeline events → appended to `data/session_events.jsonl`
+//        - state-transition events (started, checkpointed, paused,
+//          ended, and the historical archived/deleted/restored) →
+//          skipped; their effect is already encoded in the SQLite
+//          state + the session_state_changes audit table.
+//   3. Renames `sessions.jsonl` to `sessions.legacy.jsonl`.
+//   4. Prints a summary report.
+//
+// Idempotent: a second run finds no `sessions.jsonl` to read and
+// reports zero changes. Re-running is safe.
+//
+// Dry-run by default. Use `--apply` to actually move files.
+//
+// Usage:
+//   node scripts/migrate-sessions-to-authoritative-sqlite.mjs            # dry-run
+//   node scripts/migrate-sessions-to-authoritative-sqlite.mjs --apply
+//   node scripts/migrate-sessions-to-authoritative-sqlite.mjs --data-dir ./data
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const args = parseArgs(process.argv.slice(2));
+const dataDir = path.resolve(args.dataDir ?? process.env.LIBRARIAN_DATA_DIR ?? "./data");
+const sessionsPath = path.join(dataDir, "sessions.jsonl");
+const sessionEventsPath = path.join(dataDir, "session_events.jsonl");
+const legacyPath = path.join(dataDir, "sessions.legacy.jsonl");
+const apply = args.apply === true;
+
+// Timeline event types — kept in `session_events.jsonl`. The rest
+// (Started / Checkpointed / Paused / Ended / Archived / Deleted /
+// Restored) are state transitions whose effect is fully captured by
+// SQLite + session_state_changes, so they're dropped from the new
+// timeline file.
+const TIMELINE_EVENT_TYPES = new Set([
+  "session.event_recorded",
+  "session.attached_to_harness",
+  "session.promoted_to_memory",
+]);
+
+if (!fs.existsSync(sessionsPath)) {
+  if (fs.existsSync(legacyPath)) {
+    console.log(
+      `[migrate-sessions] already migrated — ${path.relative(process.cwd(), legacyPath)} exists. Nothing to do.`,
+    );
+    process.exit(0);
+  }
+  console.error(`[migrate-sessions] FAIL: ${sessionsPath} not found.`);
+  process.exit(1);
+}
+
+// Open the store before we read JSONL so the R1 projection rebuild
+// populates session_state_changes for the historical events.
+const { createLibrarianStore } = await import("@librarian/core");
+const store = createLibrarianStore({ dataDir });
+
+let timelineLines = 0;
+let stateTransitionLines = 0;
+let unknownLines = 0;
+const timelineOut = [];
+
+const raw = fs.readFileSync(sessionsPath, "utf8");
+for (const line of raw.split("\n")) {
+  if (!line.trim()) continue;
+  let event;
+  try {
+    event = JSON.parse(line);
+  } catch {
+    unknownLines += 1;
+    continue;
+  }
+  const type = event.event_type;
+  if (TIMELINE_EVENT_TYPES.has(type)) {
+    timelineLines += 1;
+    timelineOut.push(line);
+  } else {
+    stateTransitionLines += 1;
+  }
+}
+
+const bar = "=".repeat(60);
+console.log("Sessions storage migration");
+console.log(bar);
+console.log(`data dir:                ${dataDir}`);
+console.log(`sessions.jsonl lines:    ${timelineLines + stateTransitionLines + unknownLines}`);
+console.log(`  → timeline (kept):     ${timelineLines}`);
+console.log(
+  `  → state transitions:   ${stateTransitionLines}  (encoded in SQLite + session_state_changes)`,
+);
+console.log(`  → unparseable (drop):  ${unknownLines}`);
+const sessionRows = store.db.prepare("SELECT COUNT(*) AS n FROM sessions").get().n;
+const stateChangeRows = store.db.prepare("SELECT COUNT(*) AS n FROM session_state_changes").get().n;
+console.log(`SQLite sessions:         ${sessionRows}`);
+console.log(`SQLite state changes:    ${stateChangeRows}`);
+console.log(bar);
+
+if (!apply) {
+  console.log(
+    "Dry run only. Re-run with --apply to write session_events.jsonl + rename sessions.jsonl.",
+  );
+  store.close();
+  process.exit(0);
+}
+
+if (fs.existsSync(sessionEventsPath)) {
+  console.error(
+    `[migrate-sessions] FAIL: ${sessionEventsPath} already exists. Refusing to overwrite — investigate before re-running.`,
+  );
+  store.close();
+  process.exit(1);
+}
+
+fs.writeFileSync(
+  sessionEventsPath,
+  timelineOut.join("\n") + (timelineOut.length ? "\n" : ""),
+  "utf8",
+);
+fs.renameSync(sessionsPath, legacyPath);
+store.close();
+
+console.log(
+  `Wrote ${timelineLines} timeline events to ${path.relative(process.cwd(), sessionEventsPath)}.`,
+);
+console.log(
+  `Renamed sessions.jsonl → ${path.relative(process.cwd(), legacyPath)} (frozen audit anchor).`,
+);
+console.log(
+  "R3 will cut the runtime write paths over to the new file shape; until R3 lands, the runtime still writes to sessions.jsonl on next session activity.",
+);
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--apply") out.apply = true;
+    else if (a === "--data-dir") out.dataDir = argv[++i];
+    else if (a.startsWith("--data-dir=")) out.dataDir = a.slice("--data-dir=".length);
+    else if (a === "--help" || a === "-h") {
+      console.log(
+        "Usage: node scripts/migrate-sessions-to-authoritative-sqlite.mjs [--data-dir <path>] [--apply]",
+      );
+      process.exit(0);
+    }
+  }
+  return out;
+}

--- a/test/r2-sessions-migration.test.ts
+++ b/test/r2-sessions-migration.test.ts
@@ -1,0 +1,165 @@
+// R2 — integration tests for the sessions storage migration script and
+// the divergence guard. Exercises the scripts as subprocesses against
+// temporary data dirs so the behaviour matches what an operator will
+// experience running them by hand.
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const REPO_ROOT = path.resolve(".");
+const MIGRATE_BIN = path.join(REPO_ROOT, "scripts", "migrate-sessions-to-authoritative-sqlite.mjs");
+const DIVERGENCE_BIN = path.join(REPO_ROOT, "scripts", "check-session-state-divergence.mjs");
+
+interface RunResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+function run(bin: string, args: string[] = []): Promise<RunResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ["--no-warnings", bin, ...args], {
+      cwd: REPO_ROOT,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout!.setEncoding("utf8");
+    child.stderr!.setEncoding("utf8");
+    child.stdout!.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr!.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("exit", (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+function seedDataDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-r2-test-"));
+  const fixtureDir = path.join(REPO_ROOT, "test", "fixtures", "pre-migration");
+  if (!fs.existsSync(fixtureDir)) throw new Error("pre-migration fixture missing");
+  for (const f of ["events.jsonl", "sessions.jsonl"]) {
+    fs.copyFileSync(path.join(fixtureDir, f), path.join(dir, f));
+  }
+  return dir;
+}
+
+describe("R2 — migrate-sessions-to-authoritative-sqlite", () => {
+  let dataDir: string | null = null;
+
+  beforeEach(() => {
+    dataDir = seedDataDir();
+  });
+
+  afterEach(() => {
+    if (dataDir) fs.rmSync(dataDir, { recursive: true, force: true });
+    dataDir = null;
+  });
+
+  it("dry run reports timeline + state-transition counts and leaves files untouched", async () => {
+    const before = fs.statSync(path.join(dataDir!, "sessions.jsonl")).size;
+    const result = await run(MIGRATE_BIN, ["--data-dir", dataDir!]);
+    expect(
+      result.code,
+      `dry run failed:\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    ).toBe(0);
+    expect(result.stdout).toMatch(/Sessions storage migration/);
+    expect(result.stdout).toMatch(/timeline \(kept\)/);
+    expect(result.stdout).toMatch(/state transitions/);
+    expect(result.stdout).toMatch(/Dry run only/);
+
+    // No file mutation in dry-run mode.
+    expect(fs.existsSync(path.join(dataDir!, "sessions.jsonl"))).toBe(true);
+    expect(fs.existsSync(path.join(dataDir!, "session_events.jsonl"))).toBe(false);
+    expect(fs.existsSync(path.join(dataDir!, "sessions.legacy.jsonl"))).toBe(false);
+    expect(fs.statSync(path.join(dataDir!, "sessions.jsonl")).size).toBe(before);
+  });
+
+  it("--apply renames sessions.jsonl and writes session_events.jsonl", async () => {
+    const result = await run(MIGRATE_BIN, ["--data-dir", dataDir!, "--apply"]);
+    expect(result.code, `apply failed:\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`).toBe(
+      0,
+    );
+
+    expect(fs.existsSync(path.join(dataDir!, "sessions.jsonl"))).toBe(false);
+    expect(fs.existsSync(path.join(dataDir!, "sessions.legacy.jsonl"))).toBe(true);
+    expect(fs.existsSync(path.join(dataDir!, "session_events.jsonl"))).toBe(true);
+
+    // Every line in session_events.jsonl is a timeline event (never a
+    // state transition).
+    const lines = fs
+      .readFileSync(path.join(dataDir!, "session_events.jsonl"), "utf8")
+      .split("\n")
+      .filter(Boolean);
+    const TIMELINE = new Set([
+      "session.event_recorded",
+      "session.attached_to_harness",
+      "session.promoted_to_memory",
+    ]);
+    for (const line of lines) {
+      const event = JSON.parse(line);
+      expect(TIMELINE.has(event.event_type), `non-timeline line: ${event.event_type}`).toBe(true);
+    }
+  });
+
+  it("a second --apply run is a no-op (idempotent)", async () => {
+    await run(MIGRATE_BIN, ["--data-dir", dataDir!, "--apply"]);
+    const second = await run(MIGRATE_BIN, ["--data-dir", dataDir!, "--apply"]);
+    expect(second.code).toBe(0);
+    expect(second.stdout).toMatch(/already migrated/);
+  });
+
+  it("refuses to overwrite an existing session_events.jsonl on --apply", async () => {
+    // Pre-create the file to simulate a partial / repeated migration.
+    fs.writeFileSync(path.join(dataDir!, "session_events.jsonl"), "{}\n", "utf8");
+    const result = await run(MIGRATE_BIN, ["--data-dir", dataDir!, "--apply"]);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toMatch(/already exists/);
+    // sessions.jsonl wasn't renamed since we aborted.
+    expect(fs.existsSync(path.join(dataDir!, "sessions.jsonl"))).toBe(true);
+    expect(fs.existsSync(path.join(dataDir!, "sessions.legacy.jsonl"))).toBe(false);
+  });
+});
+
+describe("R2 — check-session-state-divergence", () => {
+  it("exits 0 against the pre-migration fixture (clean SQLite ↔ state-changes parity)", async () => {
+    const result = await run(DIVERGENCE_BIN);
+    expect(
+      result.code,
+      `divergence check failed:\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    ).toBe(0);
+    expect(result.stdout).toMatch(/all in parity/);
+  });
+
+  it("exits 1 when SQLite status is forced out of sync with session_state_changes", async () => {
+    const dir = seedDataDir();
+    try {
+      // Open the store, force a divergence by directly mutating
+      // sessions.status without touching session_state_changes, close,
+      // and re-run the check.
+      const { createLibrarianStore } = await import("@librarian/core");
+      const store = createLibrarianStore({ dataDir: dir });
+      try {
+        const row = store.db.prepare("SELECT id FROM sessions LIMIT 1").get() as
+          | { id: string }
+          | undefined;
+        if (!row) throw new Error("no sessions in fixture");
+        store.db.prepare("UPDATE sessions SET status = ? WHERE id = ?").run("ended", row.id);
+      } finally {
+        store.close();
+      }
+
+      const result = await run(DIVERGENCE_BIN, ["--data-dir", dir]);
+      expect(result.code).toBe(1);
+      expect(result.stderr).toMatch(/diverged/);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 of `specs/session-storage-rearchitecture.md` — **tooling-only**, no runtime behaviour change. R3 will cut the runtime over to the new file shape; R2 just ships the conversion + verification machinery.

- `scripts/migrate-sessions-to-authoritative-sqlite.mjs` — one-shot migration. Reads `data/sessions.jsonl`, copies timeline events (`event_recorded`, `attached_to_harness`, `promoted_to_memory`) into a new `data/session_events.jsonl`, drops state-transition events (their effect is already encoded in SQLite + `session_state_changes` from R1), renames the original to `sessions.legacy.jsonl`. Dry-run by default; `--apply` commits. Idempotent.
- `scripts/check-session-state-divergence.mjs` — walks every session in SQLite and asserts `sessions.status` matches the last `to_status` in `session_state_changes`. Defaults to the pre-migration fixture so CI can run it without operator data. Wired into `.github/workflows/ci.yml`.
- `docs/migration-sessions-storage.md` — operator runbook (backup → dry-run → apply → post-migration validation → rollback).
- New `pnpm run check:session-state-divergence` workspace script.
- 6 new tests in `test/r2-sessions-migration.test.ts`.

## Test plan

- [x] `pnpm vitest run test/r2-sessions-migration.test.ts` — 6 passed
- [x] `pnpm test` — 312 tests total, all green
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm format:check`
- [x] `pnpm build`
- [x] `pnpm run check:session-state-divergence` — `OK: 2 sessions, all in parity`
- [x] `pnpm run smoke`, `pnpm run check:storage-fixture`, `pnpm run check:schema-version`

Implements **Phase 2 (R2)** of `specs/session-storage-rearchitecture.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)