### PR TITLE
feat(r3): sessions go SQLite-canonical; new purge_session tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ pnpm run serve                            # mcp-server (HTTP) at :3838
 pnpm --filter @librarian/dashboard dev    # dashboard at :3000
 pnpm run seed                             # seed sample memories
 pnpm run rebuild                          # replay both JSONL ledgers into the SQLite projection
-pnpm run healthcheck                      # five-check end-to-end smoke (JSONL append, rebuild, lifecycle, stdio MCP, HTTP MCP+auth)
+pnpm run healthcheck                      # end-to-end smoke (JSONL append, rebuild, lifecycle, stdio MCP, MCP tool surface, HTTP MCP+auth)
 pnpm run healthcheck -- --remote <url>    # probe a deployed stack via /healthz + /mcp
 pnpm test                                 # full test suite (Vitest across all packages + root test/)
 ```

--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -15,7 +15,12 @@ export interface LibrarianStoreOptions {
 export interface LibrarianStore extends MemoryStore, SessionStore {
   dataDir: string;
   eventsPath: string;
+  // R3 — sessionsPath is the timeline ledger (post-R3, new file).
+  // Legacy sessions.jsonl is preserved as sessions.legacy.jsonl for
+  // pre-migration ledger replay and operator backups; sessionsLegacyPath
+  // is the runtime handle for it.
   sessionsPath: string;
+  sessionsLegacyPath: string;
   dbPath: string;
   snapshotPath: string;
   db: DatabaseSync;
@@ -28,7 +33,18 @@ export interface LibrarianStore extends MemoryStore, SessionStore {
 export function createLibrarianStore(options: LibrarianStoreOptions = {}): LibrarianStore {
   const dataDir = options.dataDir || process.env.LIBRARIAN_DATA_DIR || DEFAULT_DATA_DIR;
   const eventsPath = path.join(dataDir, "events.jsonl");
-  const sessionsPath = path.join(dataDir, "sessions.jsonl");
+  // R3 — runtime writes timeline events to session_events.jsonl. State
+  // transitions stop appearing in any JSONL (they live in SQLite +
+  // session_state_changes). The pre-migration sessions.jsonl is renamed
+  // by `scripts/migrate-sessions-to-authoritative-sqlite.mjs` to
+  // sessions.legacy.jsonl and kept read-only as the historical anchor.
+  const sessionsPath = path.join(dataDir, "session_events.jsonl");
+  const sessionsLegacyPath = path.join(dataDir, "sessions.legacy.jsonl");
+  // Fallback: if the operator hasn't run the migration yet, the old
+  // `sessions.jsonl` may still be sitting in the data dir from a
+  // pre-R3 install. Treat it as the legacy ledger for rebuild
+  // purposes only (no writes ever go there post-R3).
+  const preMigrationLegacyPath = path.join(dataDir, "sessions.jsonl");
   const dbPath = path.join(dataDir, "librarian.sqlite");
   const snapshotPath = path.join(dataDir, "memories.md");
 
@@ -37,14 +53,25 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Libra
   if (!fs.existsSync(sessionsPath)) fs.writeFileSync(sessionsPath, "", "utf8");
 
   const db = new DatabaseSync(dbPath);
-  ensureSchema(db, { eventsPath, sessionsPath, snapshotPath });
+  ensureSchema(db, {
+    eventsPath,
+    sessionsPath,
+    sessionsLegacyPath: fs.existsSync(sessionsLegacyPath)
+      ? sessionsLegacyPath
+      : preMigrationLegacyPath,
+    snapshotPath,
+  });
 
   function rebuildMemoryProjection(): void {
     rebuildMemoryIndex({ db, eventsPath, snapshotPath });
   }
   function rebuildIndex(): void {
     rebuildMemoryProjection();
-    rebuildSessionIndex(db, sessionsPath);
+    rebuildSessionIndex(db, sessionsPath, {
+      sessionsLegacyPath: fs.existsSync(sessionsLegacyPath)
+        ? sessionsLegacyPath
+        : preMigrationLegacyPath,
+    });
   }
 
   const memoryStore = createMemoryStore({
@@ -64,6 +91,7 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Libra
     dataDir,
     eventsPath,
     sessionsPath,
+    sessionsLegacyPath,
     dbPath,
     snapshotPath,
     db,

--- a/packages/core/src/store/projection.ts
+++ b/packages/core/src/store/projection.ts
@@ -58,7 +58,12 @@ function asArray(value: unknown): string[] {
 //   - 5: R1 added `sessions.state_version` + `session_state_changes`.
 //        Dual-write (R1) keeps the JSONL ledger canonical; the new
 //        columns + audit table seed R3's SQLite-canonical cutover.
-export const PROJECTION_SCHEMA_VERSION = 5;
+//   - 6: R3 cuts the runtime over to SQLite-canonical sessions —
+//        timeline events go to `session_events.jsonl`, state
+//        transitions live in SQLite only. The DDL is unchanged; the
+//        bump forces a one-time replay from the legacy ledger so any
+//        existing sessions.jsonl rolls into the new shape.
+export const PROJECTION_SCHEMA_VERSION = 6;
 
 export function getSchemaVersion(db: DatabaseSync): number {
   const row = db.prepare("PRAGMA user_version").get() as { user_version: number };
@@ -70,6 +75,27 @@ function stampSchemaVersion(db: DatabaseSync): void {
 }
 
 function dropProjectionTables(db: DatabaseSync): void {
+  // R3 — `sessions` and `session_state_changes` are SQLite-authoritative
+  // and must survive schema-version bumps. Future DDL changes to those
+  // tables should use ALTER TABLE rather than the drop-and-rebuild
+  // pattern below. The other tables are projections (memory side stays
+  // JSONL-canonical; session_events is rebuilt from session_events.jsonl
+  // on every bump).
+  db.exec(`
+    DROP TABLE IF EXISTS memories_fts;
+    DROP TABLE IF EXISTS memories;
+    DROP TABLE IF EXISTS events;
+    DROP TABLE IF EXISTS session_events_fts;
+    DROP TABLE IF EXISTS session_events;
+  `);
+}
+
+function dropAllTablesIncludingSessions(db: DatabaseSync): void {
+  // Used only for the pre-R1 → post-R3 migration path. Pre-R1 instances
+  // have a `sessions` table without `state_version`, so the DDL has to
+  // be regenerated from scratch. The R1 sentinel bump did this last
+  // time around; we keep the helper for any operator who jumps two
+  // versions.
   db.exec(`
     DROP TABLE IF EXISTS memories_fts;
     DROP TABLE IF EXISTS memories;
@@ -84,6 +110,10 @@ function dropProjectionTables(db: DatabaseSync): void {
 export interface EnsureSchemaPaths {
   eventsPath: string;
   sessionsPath: string;
+  // R3 — read-only legacy ledger replayed alongside session_events.jsonl
+  // so an operator who hasn't yet run the migration script still gets a
+  // correct rebuild on a fresh DB.
+  sessionsLegacyPath?: string;
   snapshotPath: string;
 }
 
@@ -103,14 +133,26 @@ export function ensureSchema(db: DatabaseSync, paths: EnsureSchemaPaths): boolea
     initSchema(db);
     return false;
   }
-  dropProjectionTables(db);
+  // R3 — sessions table is SQLite-authoritative for instances at v5+.
+  // Pre-R1 instances (onDisk < 5) still need the full drop+rebuild path
+  // because their sessions table lacks `state_version`; the rebuild
+  // recovers everything from the JSONL ledger.
+  if (onDisk < 5) {
+    dropAllTablesIncludingSessions(db);
+  } else {
+    dropProjectionTables(db);
+  }
   initSchema(db);
   rebuildMemoryIndex({
     db,
     eventsPath: paths.eventsPath,
     snapshotPath: paths.snapshotPath,
   });
-  rebuildSessionIndex(db, paths.sessionsPath);
+  rebuildSessionIndex(
+    db,
+    paths.sessionsPath,
+    paths.sessionsLegacyPath ? { sessionsLegacyPath: paths.sessionsLegacyPath } : {},
+  );
   stampSchemaVersion(db);
   return true;
 }
@@ -1060,23 +1102,76 @@ export function applySessionEvent(db: DatabaseSync, event: SessionLedgerEvent): 
 
 /**
  * Full session-projection rebuild from the sessions JSONL ledger. Wipes the
- * sessions + session_events + FTS tables and replays every entry. Atomic
- * via SQLite transaction.
+ * sessions + session_events + state-changes + FTS tables and replays every
+ * entry. Atomic via SQLite transaction.
+ *
+ * R3 — accepts an optional second ledger (`sessionsLegacyPath`) so the
+ * pre-migration `sessions.jsonl` / `sessions.legacy.jsonl` can be merged
+ * with the new `session_events.jsonl` on rebuild. Events from both
+ * sources are sorted by `created_at` so historical state transitions land
+ * in the correct order. The legacy ledger is read-only at runtime;
+ * `appendSessionEvent` post-R3 only writes to `sessions.jsonl` for
+ * timeline events.
  */
-export function rebuildSessionIndex(db: DatabaseSync, sessionsPath: string): void {
-  const events = readJsonl<SessionLedgerEvent>(sessionsPath);
+export function rebuildSessionIndex(
+  db: DatabaseSync,
+  sessionsPath: string,
+  options: { sessionsLegacyPath?: string } = {},
+): void {
+  const timeline = readJsonl<SessionLedgerEvent>(sessionsPath);
+  const legacy = options.sessionsLegacyPath
+    ? readJsonl<SessionLedgerEvent>(options.sessionsLegacyPath)
+    : [];
+  // Merge by `created_at`. Both sources are append-only by time within
+  // themselves; combining them keeps the natural ordering when the
+  // operator has both files (post-migration) or just one (pre-migration
+  // or fresh install).
+  const events = [...legacy, ...timeline].sort((a, b) =>
+    (a.created_at || "").localeCompare(b.created_at || ""),
+  );
+
+  // R3 — sessions table is SQLite-authoritative. Determine whether the
+  // sessions row + state-changes audit need rebuilding by checking
+  // whether the table is populated already. If it is, we only refresh
+  // the timeline projection (`session_events` + FTS). If sessions is
+  // empty, we replay everything (this is the pre-R1 → R3 first-boot
+  // path where ensureSchema dropped the tables and we're rebuilding
+  // from scratch).
+  const existingSessions = (db.prepare("SELECT COUNT(*) AS n FROM sessions").get() as { n: number })
+    .n;
 
   const tx = db.prepare("BEGIN");
   const commit = db.prepare("COMMIT");
   const rollback = db.prepare("ROLLBACK");
   tx.run();
   try {
-    // FK: session_state_changes references sessions(id), so delete the
-    // child rows first.
-    db.exec(
-      "DELETE FROM session_state_changes; DELETE FROM session_events; DELETE FROM session_events_fts; DELETE FROM sessions;",
-    );
-    for (const event of events) applySessionEvent(db, event);
+    if (existingSessions === 0) {
+      // Cold rebuild: sessions is empty, so every applySessionEvent
+      // call inserts/updates as if the table started fresh.
+      db.exec(
+        "DELETE FROM session_state_changes; DELETE FROM session_events; DELETE FROM session_events_fts;",
+      );
+      for (const event of events) applySessionEvent(db, event);
+    } else {
+      // Warm rebuild: sessions data is canonical. Refresh ONLY the
+      // timeline projection (`session_events` + FTS). We can't call
+      // applySessionEvent because every handler would mutate the
+      // sessions row (last_activity_at, state_version, etc.) which
+      // post-R3 would double-count against the canonical state. The
+      // legacy ledger is implicitly skipped because it carries only
+      // state-transition events (post-migration); the new
+      // session_events.jsonl is timeline-only and goes straight back
+      // into the projection tables.
+      db.exec("DELETE FROM session_events; DELETE FROM session_events_fts;");
+      for (const event of events) {
+        if (event.event_type !== SessionEventType.EventRecorded) continue;
+        if (!event.session_id) continue;
+        const payload = (event.payload || {}) as Record<string, unknown>;
+        const summary = (payload.summary as string) || "";
+        const type = (payload.type as string) || "event";
+        insertSessionEventRow(db, event, summary, type);
+      }
+    }
     commit.run();
   } catch (error) {
     rollback.run();

--- a/packages/core/src/store/session-store.ts
+++ b/packages/core/src/store/session-store.ts
@@ -9,6 +9,7 @@
 // & { id: string }`) to match the memory-store conventions. Tightening to
 // the Zod-derived `Session` from @librarian/core/schemas is a follow-up.
 
+import fs from "node:fs";
 import type { DatabaseSync } from "node:sqlite";
 import {
   DEFAULT_AGENT_ID,
@@ -28,6 +29,18 @@ import {
 } from "../schemas/common.js";
 import { appendJsonl } from "./jsonl.js";
 import { applySessionEvent } from "./projection.js";
+
+// R3 — only timeline event types are written to `session_events.jsonl`.
+// State-transition events (Started, Checkpointed, Paused, Ended, plus
+// historical Archived / Deleted / Restored) live in SQLite + the
+// `session_state_changes` audit table only. The set mirrors the
+// migration script's `TIMELINE_EVENT_TYPES` so the runtime and the
+// migration agree on what belongs in the timeline ledger.
+const TIMELINE_EVENT_TYPES: ReadonlySet<string> = new Set<string>([
+  SessionEventType.EventRecorded,
+  SessionEventType.AttachedToHarness,
+  SessionEventType.PromotedToMemory,
+]);
 
 export type { HandoverPayload };
 
@@ -109,6 +122,13 @@ export interface SessionStoreDeps {
   createMemory: (input: Record<string, unknown>) => PromoteMemoryResult;
 }
 
+export interface PurgeSessionResult {
+  purged: true;
+  session_id: string;
+  events_removed: number;
+  state_changes_removed: number;
+}
+
 export interface SessionStore {
   appendSessionEvent: (
     eventType: SessionEventType,
@@ -134,6 +154,7 @@ export interface SessionStore {
     format: string;
   };
   promoteSessionFact: (input?: Record<string, unknown>) => PromoteSessionFactResult;
+  purgeSession: (input: { session_id: string }) => PurgeSessionResult;
   searchSessions: (input?: Record<string, unknown>) => {
     sessions: Session[];
     total: number;
@@ -179,7 +200,12 @@ export function createSessionStore(deps: SessionStoreDeps): SessionStore {
       created_at: nowIso(),
       payload,
     };
-    appendJsonl(sessionsPath, event);
+    // R3 — only timeline events go to JSONL. State transitions live in
+    // SQLite + session_state_changes. The projection handlers do the
+    // right thing in both cases.
+    if (TIMELINE_EVENT_TYPES.has(eventType)) {
+      appendJsonl(sessionsPath, event);
+    }
     applySessionEvent(db, event);
     return event;
   }
@@ -607,6 +633,72 @@ export function createSessionStore(deps: SessionStoreDeps): SessionStore {
     };
   }
 
+  // R3 — admin-only hard purge for an ended session. Deletes the SQLite
+  // row, the session_state_changes rows, and rewrites session_events.jsonl
+  // excluding lines for the target session. Refuses to purge active /
+  // paused sessions — those must be ended first. Idempotent: a purge of a
+  // session that's already gone is a no-op (returns counts of 0).
+  function purgeSession(input: { session_id: string }): PurgeSessionResult {
+    const sessionId = normalizeString(input.session_id);
+    if (!sessionId) throw new Error("purge_session requires session_id");
+    const existing = getSession(sessionId);
+    if (existing && existing.status !== SessionStatus.Ended) {
+      throw new Error(
+        `purge_session requires the session to be ended (current status: ${existing.status}).`,
+      );
+    }
+
+    const stateChanges = (
+      db
+        .prepare("SELECT COUNT(*) AS n FROM session_state_changes WHERE session_id = ?")
+        .get(sessionId) as { n: number }
+    ).n;
+    const eventsInDb = (
+      db
+        .prepare("SELECT COUNT(*) AS n FROM session_events WHERE session_id = ?")
+        .get(sessionId) as { n: number }
+    ).n;
+
+    db.exec("BEGIN");
+    try {
+      db.prepare("DELETE FROM session_state_changes WHERE session_id = ?").run(sessionId);
+      db.prepare("DELETE FROM session_events_fts WHERE session_id = ?").run(sessionId);
+      db.prepare("DELETE FROM session_events WHERE session_id = ?").run(sessionId);
+      db.prepare("DELETE FROM sessions WHERE id = ?").run(sessionId);
+      db.exec("COMMIT");
+    } catch (error) {
+      db.exec("ROLLBACK");
+      throw error;
+    }
+
+    // Rewrite the timeline ledger without the purged session's events.
+    // Append-only is broken here on purpose — purge is the deliberate
+    // "this never happened" admin path. The legacy ledger
+    // (sessions.legacy.jsonl) is left untouched as the audit trail.
+    if (fs.existsSync(sessionsPath)) {
+      const raw = fs.readFileSync(sessionsPath, "utf8");
+      const kept: string[] = [];
+      for (const line of raw.split("\n")) {
+        if (!line.trim()) continue;
+        try {
+          const event = JSON.parse(line) as { session_id?: string };
+          if (event.session_id === sessionId) continue;
+        } catch {
+          // Preserve unparseable lines; they aren't ours to drop.
+        }
+        kept.push(line);
+      }
+      fs.writeFileSync(sessionsPath, kept.join("\n") + (kept.length ? "\n" : ""), "utf8");
+    }
+
+    return {
+      purged: true,
+      session_id: sessionId,
+      events_removed: eventsInDb,
+      state_changes_removed: stateChanges,
+    };
+  }
+
   function searchSessions(input: Record<string, unknown> = {}) {
     const query = normalizeString(input.query);
     const agentId = normalizeString(input.agent_id);
@@ -743,6 +835,7 @@ export function createSessionStore(deps: SessionStoreDeps): SessionStore {
     attachSession,
     continueSession,
     promoteSessionFact,
+    purgeSession,
     searchSessions,
     listSessionEvents,
     distinctSessionValues,

--- a/packages/core/tests/store/projection.test.ts
+++ b/packages/core/tests/store/projection.test.ts
@@ -65,7 +65,14 @@ describe("SQLite projection rebuild parity", () => {
     }
   });
 
-  it("rebuilds session state + FTS from sessions.jsonl when the store is reopened", () => {
+  it("rebuilds the session timeline + FTS from session_events.jsonl when the store is reopened (R3)", () => {
+    // R3 — sessions row state is SQLite-authoritative. State
+    // transitions don't go to JSONL anymore. Wiping SQLite means
+    // losing session state; the JSONL ledger only carries timeline
+    // events (notes, decisions, attaches, promote-to-memory). This
+    // test pins the new contract: timeline events survive a reopen
+    // when SQLite is intact, and the sessions row itself stays
+    // populated because we don't delete `librarian.sqlite`.
     const store = createLibrarianStore({ dataDir });
     let sessionId: string;
     try {
@@ -98,8 +105,8 @@ describe("SQLite projection rebuild parity", () => {
       store.close();
     }
 
-    fs.unlinkSync(path.join(dataDir, "librarian.sqlite"));
-
+    // Reopen without wiping SQLite — sessions data is preserved by
+    // design.
     const rebuilt = createLibrarianStore({ dataDir });
     try {
       const reloaded = rebuilt.getSession(sessionId);
@@ -110,21 +117,17 @@ describe("SQLite projection rebuild parity", () => {
       expect(reloaded.next_steps).toEqual(["Wire CLI"]);
       expect(reloaded.paused_at).toBeTruthy();
 
-      const events = rebuilt.listSessionEvents({ session_id: sessionId });
-      const types = events.events.map((event: { type: string }) => event.type);
-      expect(types).toContain("started");
-      expect(types).toContain("checkpointed");
-      expect(types).toContain("decision");
-      expect(types).toContain("paused");
-
-      const hit = rebuilt.searchSessions({ agent_id: "bede", query: "handover" });
+      // Timeline projection survives. State-transition event types
+      // are no longer JSONL-backed, so we only assert that timeline
+      // event types replay correctly through the FTS index.
+      const hit = rebuilt.searchSessions({ agent_id: "bede", query: "attach" });
       expect(hit.sessions.some((s: { id: string }) => s.id === sessionId)).toBe(true);
     } finally {
       rebuilt.close();
     }
   });
 
-  it("rebuildIndex restores both memory and session projections after an in-place DB wipe", () => {
+  it("rebuildIndex preserves SQLite-authoritative session state and refreshes the timeline projection (R3)", () => {
     const store = createLibrarianStore({ dataDir });
     try {
       store.createMemory({
@@ -142,14 +145,15 @@ describe("SQLite projection rebuild parity", () => {
         start_summary: "Recovery test.",
       });
 
+      // Wipe the projection tables only — sessions + state_changes
+      // stay because they're authoritative post-R3. rebuildIndex
+      // refreshes the memory projection from events.jsonl and the
+      // timeline projection from session_events.jsonl without
+      // touching sessions data.
       store.db.exec(
-        // R1: session_state_changes references sessions(id) — delete it
-        // first to keep the foreign-key constraint happy.
-        "DELETE FROM session_state_changes;" +
-          "DELETE FROM sessions; DELETE FROM session_events; DELETE FROM session_events_fts;" +
+        "DELETE FROM session_events; DELETE FROM session_events_fts;" +
           "DELETE FROM memories; DELETE FROM memories_fts; DELETE FROM events;",
       );
-      expect(store.getSession(session.id)).toBeNull();
 
       store.rebuildIndex();
 
@@ -157,7 +161,9 @@ describe("SQLite projection rebuild parity", () => {
       expect(recovered).toBeTruthy();
       expect(recovered.title).toBe("Session under rebuild");
 
-      const memoryCount = store.db.prepare("SELECT COUNT(*) AS n FROM memories").get().n;
+      const memoryCount = (
+        store.db.prepare("SELECT COUNT(*) AS n FROM memories").get() as { n: number }
+      ).n;
       expect(memoryCount).toBe(1);
     } finally {
       store.close();
@@ -198,7 +204,12 @@ describe("Schema-version sentinel (T3.6)", () => {
     }
   });
 
-  it("auto-rebuilds the projection when the on-disk user_version is stale", () => {
+  it("auto-rebuilds the projection when the on-disk user_version is stale (R1→R3 path preserves sessions)", () => {
+    // R3 — for post-R1 instances (user_version >= 5) the rebuild
+    // preserves SQLite-authoritative sessions data. We simulate a
+    // sentinel-only bump (R1's `5` → R3's `6`) by setting user_version
+    // back to 5; the next open should re-init the projection tables
+    // without losing sessions or memory data.
     let memoryId: string;
     let sessionId: string;
 
@@ -219,10 +230,8 @@ describe("Schema-version sentinel (T3.6)", () => {
           harness: "hermes",
         }).session.id;
 
-        // Simulate a schema bump by rolling the on-disk pragma back to 0.
-        // PRAGMA writes persist with the database file, so the next open
-        // will see the stale version and trigger a rebuild.
-        store.db.exec("PRAGMA user_version = 0");
+        // Simulate the R3 sentinel bump.
+        store.db.exec("PRAGMA user_version = 5");
       } finally {
         store.close();
       }

--- a/packages/core/tests/store/session-store.test.ts
+++ b/packages/core/tests/store/session-store.test.ts
@@ -124,10 +124,15 @@ describe("LibrarianStore session lifecycle", () => {
     expect(result.session.visibility).toBe("agent_private");
   });
 
-  it("startSession appends a session.started event to sessions.jsonl and inserts a row in the projection", () => {
+  it("startSession inserts a row in the projection (post-R3 — state-transition events no longer hit JSONL)", () => {
     const { store, dataDir } = scope!;
-    const sessionsPath = path.join(dataDir, "sessions.jsonl");
-    expect(fs.existsSync(sessionsPath)).toBe(true);
+    // R3 — `session_events.jsonl` is the timeline ledger; the legacy
+    // `sessions.jsonl` is renamed to `sessions.legacy.jsonl` by the
+    // migration script and never reappears at runtime. `startSession`
+    // is a state-transition event and lives in SQLite + session_state_changes;
+    // it does NOT emit a JSONL line anymore.
+    const sessionEventsPath = path.join(dataDir, "session_events.jsonl");
+    expect(fs.existsSync(sessionEventsPath)).toBe(true);
 
     const result = store.startSession({
       agent_id: "bede",
@@ -135,18 +140,22 @@ describe("LibrarianStore session lifecycle", () => {
       harness: "hermes",
     });
 
-    const lines = fs.readFileSync(sessionsPath, "utf8").trim().split("\n").filter(Boolean);
-    expect(lines.length).toBe(1);
-    const event = JSON.parse(lines[0]);
-    expect(event.event_type).toBe("session.started");
-    expect(event.session_id).toBe(result.session.id);
-    expect(event.agent_id).toBe("bede");
-    expect(event.created_at).toBeTruthy();
-    expect(event.payload?.session?.id).toBeTruthy();
+    // Post-R3: session_events.jsonl is timeline-only. A bare
+    // startSession produces no timeline lines.
+    const timeline = fs.readFileSync(sessionEventsPath, "utf8").trim().split("\n").filter(Boolean);
+    expect(timeline.length).toBe(0);
 
     const fetched = store.getSession(result.session.id);
     expect(fetched.id).toBe(result.session.id);
     expect(fetched.title).toBe("Event projection");
+
+    // SQLite + session_state_changes encode the transition.
+    const change = store.db
+      .prepare(
+        "SELECT to_status FROM session_state_changes WHERE session_id = ? ORDER BY id DESC LIMIT 1",
+      )
+      .get(result.session.id);
+    expect(change.to_status).toBe("active");
   });
 
   it("getSession returns null for an unknown id and does not throw", () => {
@@ -173,7 +182,14 @@ describe("LibrarianStore session lifecycle", () => {
       visibility: "common",
       scope: "tool",
     });
-    store.startSession({ agent_id: "bede", title: "Session still works", harness: "hermes" });
+    const { session } = store.startSession({
+      agent_id: "bede",
+      title: "Session still works",
+      harness: "hermes",
+    });
+    // R3 — startSession doesn't write JSONL. Add a timeline event so
+    // we can confirm the two ledgers are independent.
+    store.recordSessionEvent({ session_id: session.id, type: "note", summary: "hello" });
 
     const memEvents = fs
       .readFileSync(path.join(dataDir, "events.jsonl"), "utf8")
@@ -181,7 +197,7 @@ describe("LibrarianStore session lifecycle", () => {
       .split("\n")
       .filter(Boolean);
     const sessEvents = fs
-      .readFileSync(path.join(dataDir, "sessions.jsonl"), "utf8")
+      .readFileSync(path.join(dataDir, "session_events.jsonl"), "utf8")
       .trim()
       .split("\n")
       .filter(Boolean);

--- a/packages/mcp-server/src/mcp/tools/index.ts
+++ b/packages/mcp-server/src/mcp/tools/index.ts
@@ -16,6 +16,7 @@ import listSessions from "./list-sessions.js";
 import pauseSession from "./pause-session.js";
 import promoteSessionFact from "./promote-session-fact.js";
 import proposeMemory from "./propose-memory.js";
+import purgeSession from "./purge-session.js";
 import recall from "./recall.js";
 import recordSessionEvent from "./record-session-event.js";
 import remember from "./remember.js";
@@ -47,6 +48,7 @@ export const tools: ToolDefinition[] = [
   attachSession,
   continueSession,
   promoteSessionFact,
+  purgeSession,
 ];
 
 export const toolsByName: Map<string, ToolDefinition> = new Map(

--- a/packages/mcp-server/src/mcp/tools/purge-session.ts
+++ b/packages/mcp-server/src/mcp/tools/purge-session.ts
@@ -1,0 +1,39 @@
+// R3 — admin-only hard purge for an ended session. Deletes the SQLite
+// row + session_state_changes audit + rewrites session_events.jsonl to
+// remove the purged session's events. Refuses to purge active / paused
+// sessions; ending must come first. There is no soft-delete equivalent
+// in the three-state model (`ended` already covers the hide-from-view
+// case), so this is the only path that ever removes a session
+// permanently.
+
+import { textResult } from "../result.js";
+import type { ToolDefinition } from "../tool.js";
+
+const purgeSession: ToolDefinition = {
+  name: "purge_session",
+  description:
+    "Permanently delete an ended session: SQLite row + state-change audit + timeline events on disk. " +
+    "Refuses to purge active / paused sessions. Admin-only.",
+  inputSchema: {
+    type: "object",
+    required: ["session_id", "confirm"],
+    properties: {
+      session_id: { type: "string" },
+      confirm: { type: "boolean", const: true },
+    },
+  },
+  adminOnly: true,
+  handler(store, args) {
+    const sessionId = (args as Record<string, unknown>).session_id as string;
+    const confirm = (args as Record<string, unknown>).confirm === true;
+    if (!confirm) {
+      throw new Error("purge_session requires `confirm: true` to proceed.");
+    }
+    const result = store.purgeSession({ session_id: sessionId });
+    return textResult(
+      `Purged session ${result.session_id}: ${result.events_removed} timeline events, ${result.state_changes_removed} state changes removed.`,
+    );
+  },
+};
+
+export default purgeSession;

--- a/packages/mcp-server/src/trpc/sessions.ts
+++ b/packages/mcp-server/src/trpc/sessions.ts
@@ -201,4 +201,23 @@ export const sessionsRouter = router({
         ctx.store.promoteSessionFact(p),
       ),
     ),
+
+  // R3 — hard purge for an ended session. Refuses to purge active /
+  // paused sessions; the caller has to end first. There's no soft-
+  // delete equivalent post-S1.1, so this is the only path that ever
+  // removes a session permanently.
+  purge: adminProcedure
+    .input(
+      z.object({
+        session_id: z.string().min(1),
+        confirm: z.literal(true),
+      }),
+    )
+    .mutation(({ ctx, input }) => {
+      const session = ctx.store.getSession(input.session_id);
+      if (!session) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Session not found." });
+      }
+      return ctx.store.purgeSession({ session_id: input.session_id });
+    }),
 });

--- a/scripts/healthcheck.js
+++ b/scripts/healthcheck.js
@@ -142,16 +142,28 @@ async function checkJsonlAppend() {
         visibility: "common",
         scope: "tool",
       });
-      store.startSession({
+      const { session } = store.startSession({
         agent_id: "healthcheck",
         title: "healthcheck session",
         harness: "test",
+      });
+      // R3 — startSession is a state transition and lives in SQLite,
+      // not JSONL. Record a timeline event so session_events.jsonl
+      // has something to assert on.
+      store.recordSessionEvent({
+        agent_id: "healthcheck",
+        session_id: session.id,
+        type: "note",
+        summary: "healthcheck note",
       });
     } finally {
       store.close();
     }
     assertNonEmpty(path.join(dir, "events.jsonl"), "events.jsonl is empty after createMemory");
-    assertNonEmpty(path.join(dir, "sessions.jsonl"), "sessions.jsonl is empty after startSession");
+    assertNonEmpty(
+      path.join(dir, "session_events.jsonl"),
+      "session_events.jsonl is empty after recordSessionEvent",
+    );
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -181,18 +193,19 @@ async function checkSqliteRebuild() {
       store.close();
     }
 
+    // R3 — sessions are SQLite-canonical, so wiping the SQLite file
+    // is a destructive operation that loses session state by design.
+    // We only assert that the memory side (still JSONL-canonical)
+    // survives a SQLite wipe. The session contract has changed.
     fs.unlinkSync(path.join(dir, "librarian.sqlite"));
 
     store = createLibrarianStore({ dataDir: dir });
     try {
-      const session = store.getSession(sessionId);
       const memory = store.getMemory(memoryId);
-      if (!session) {
-        throw hint(
-          new Error("Session did not survive a SQLite wipe."),
-          "sessions.jsonl is not being replayed on startup.",
-        );
-      }
+      // sessionId is intentionally NOT asserted post-R3: sessions
+      // are SQLite-canonical, so this destructive wipe is expected
+      // to lose session state. The check is now memory-only.
+      void sessionId;
       if (!memory) {
         throw hint(
           new Error("Memory did not survive a SQLite wipe."),

--- a/scripts/migrate-sessions-to-authoritative-sqlite.mjs
+++ b/scripts/migrate-sessions-to-authoritative-sqlite.mjs
@@ -120,12 +120,20 @@ if (!apply) {
   process.exit(0);
 }
 
+// R3 — the runtime creates an empty `session_events.jsonl` on store
+// init. Treat empty (or whitespace-only) as a non-conflict; refuse
+// only if the file has content (which would mean either a partial
+// previous migration or post-R3 timeline writes the operator should
+// merge by hand).
 if (fs.existsSync(sessionEventsPath)) {
-  console.error(
-    `[migrate-sessions] FAIL: ${sessionEventsPath} already exists. Refusing to overwrite — investigate before re-running.`,
-  );
-  store.close();
-  process.exit(1);
+  const existing = fs.readFileSync(sessionEventsPath, "utf8");
+  if (existing.trim().length > 0) {
+    console.error(
+      `[migrate-sessions] FAIL: ${sessionEventsPath} already has content. Refusing to overwrite — investigate before re-running.`,
+    );
+    store.close();
+    process.exit(1);
+  }
 }
 
 fs.writeFileSync(

--- a/test/r2-sessions-migration.test.ts
+++ b/test/r2-sessions-migration.test.ts
@@ -62,7 +62,7 @@ describe("R2 — migrate-sessions-to-authoritative-sqlite", () => {
     dataDir = null;
   });
 
-  it("dry run reports timeline + state-transition counts and leaves files untouched", async () => {
+  it("dry run reports timeline + state-transition counts and leaves the legacy ledger untouched", async () => {
     const before = fs.statSync(path.join(dataDir!, "sessions.jsonl")).size;
     const result = await run(MIGRATE_BIN, ["--data-dir", dataDir!]);
     expect(
@@ -74,11 +74,16 @@ describe("R2 — migrate-sessions-to-authoritative-sqlite", () => {
     expect(result.stdout).toMatch(/state transitions/);
     expect(result.stdout).toMatch(/Dry run only/);
 
-    // No file mutation in dry-run mode.
+    // No file mutation to the source ledger in dry-run mode. (The
+    // store initialiser may create an empty session_events.jsonl as a
+    // side effect of opening the DB — that's fine, the migration
+    // treats an empty file as a non-conflict on --apply.)
     expect(fs.existsSync(path.join(dataDir!, "sessions.jsonl"))).toBe(true);
-    expect(fs.existsSync(path.join(dataDir!, "session_events.jsonl"))).toBe(false);
     expect(fs.existsSync(path.join(dataDir!, "sessions.legacy.jsonl"))).toBe(false);
     expect(fs.statSync(path.join(dataDir!, "sessions.jsonl")).size).toBe(before);
+    if (fs.existsSync(path.join(dataDir!, "session_events.jsonl"))) {
+      expect(fs.readFileSync(path.join(dataDir!, "session_events.jsonl"), "utf8").trim()).toBe("");
+    }
   });
 
   it("--apply renames sessions.jsonl and writes session_events.jsonl", async () => {
@@ -115,12 +120,18 @@ describe("R2 — migrate-sessions-to-authoritative-sqlite", () => {
     expect(second.stdout).toMatch(/already migrated/);
   });
 
-  it("refuses to overwrite an existing session_events.jsonl on --apply", async () => {
-    // Pre-create the file to simulate a partial / repeated migration.
-    fs.writeFileSync(path.join(dataDir!, "session_events.jsonl"), "{}\n", "utf8");
+  it("refuses to overwrite a non-empty existing session_events.jsonl on --apply", async () => {
+    // Pre-create the file with content to simulate a partial /
+    // repeated migration. (An empty `session_events.jsonl` is fine —
+    // the runtime touches that file on init.)
+    fs.writeFileSync(
+      path.join(dataDir!, "session_events.jsonl"),
+      '{"event_id":"sevt_pre"}\n',
+      "utf8",
+    );
     const result = await run(MIGRATE_BIN, ["--data-dir", dataDir!, "--apply"]);
     expect(result.code).toBe(1);
-    expect(result.stderr).toMatch(/already exists/);
+    expect(result.stderr).toMatch(/already has content/);
     // sessions.jsonl wasn't renamed since we aborted.
     expect(fs.existsSync(path.join(dataDir!, "sessions.jsonl"))).toBe(true);
     expect(fs.existsSync(path.join(dataDir!, "sessions.legacy.jsonl"))).toBe(false);

--- a/test/schema-snapshot.json
+++ b/test/schema-snapshot.json
@@ -1,4 +1,4 @@
 {
-  "version": 5,
+  "version": 6,
   "fingerprint": "bdd2adacb63ef1585c9c5b3f08e50929d3850e183af080641755e9cc45d18868"
 }


### PR DESCRIPTION
## Summary

Phase 3 of `specs/session-storage-rearchitecture.md` — the runtime cutover. Sessions are now SQLite-canonical; timeline events live in a new `session_events.jsonl`; state-transition events don't hit JSONL at all.

**Store / projection (`@librarian/core`):**
- `appendSessionEvent` writes to JSONL only for timeline event types (`event_recorded`, `attached_to_harness`, `promoted_to_memory`). State transitions go straight to SQLite.
- `ensureSchema` is version-aware: pre-R1 instances do the full drop+rebuild from JSONL; v5+ instances preserve sessions across schema bumps.
- `rebuildSessionIndex` has cold (sessions empty) and warm (sessions populated) paths. Warm rebuild refreshes `session_events` + FTS without touching authoritative state.
- New `purgeSession({ session_id })` admin path: deletes SQLite row + `session_state_changes` + rewrites `session_events.jsonl` to drop the purged session. Refuses active/paused. Idempotent.
- `PROJECTION_SCHEMA_VERSION` 5 → 6.

**MCP / tRPC (`@librarian/mcp-server`):**
- New `purge_session` MCP tool (admin-only) with `confirm: true` guard.
- New `sessions.purge` tRPC procedure for the dashboard.

**Tests:**
- 310 tests pass across the monorepo.
- Rebuild-parity tests updated: SQLite-wipe is now lossy for sessions by design; the new "preserve authoritative state across reopen" path is asserted instead.
- Migration script's session_events.jsonl conflict guard tightened to "non-empty content" (the runtime creates the empty file on init).
- Healthcheck records a timeline event so session_events.jsonl has content; SQLite-wipe step is now memory-only.

**Out of scope:**
- Dashboard "Purge" button — deferred to a separate dashboard PR after this lands. The MCP + tRPC interface is the durable surface.
- Dedicated README "Backup strategy" section — R4 docs polish per the spec.

Implements **Phase 3 (R3)** of `specs/session-storage-rearchitecture.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)