### PR TITLE
docs(specs): re-review revisions + cross-spec implementation plan

### DIFF
--- a/docs/specs/agent-naming-contract-spec.md
+++ b/docs/specs/agent-naming-contract-spec.md
@@ -2,7 +2,7 @@
 
 **Author:** Guybrush, with Jim
 **Date:** 2026-05-23
-**Status:** Draft — revised after stronger-model review
+**Status:** Draft — revised after stronger-model review; open questions resolved in claude-code re-review (`claude-code` id kept distinct, single `actor_id` term, `dashboard-admin` now, `actor_kind` where feasible, condition-based hard enforcement) — 2026-05-23
 
 ---
 
@@ -49,9 +49,9 @@ For agent-facing surfaces, the compatibility field is:
 agent_id: string
 ```
 
-For internal/admin/system surfaces, the same canonical identity rules apply. The implementation may call it `agent_id`, `actor_id`, or `caller_id` internally, but persisted attribution should use one canonical string format.
+For internal/admin/system surfaces, the same canonical identity rules apply. The implementation may call it `agent_id` or `actor_id` internally, but persisted attribution should use one canonical string format.
 
-New internal code should prefer `actor_id`/`caller_id` for “who performed this operation”. Keep `agent_id` where it already means memory/session owner.
+New internal code should use `actor_id` for “who performed this operation” (a single term — `caller_id` is not used as a synonym). Keep `agent_id` where it already means memory/session owner.
 
 ### 3.2 Calls that must include identity
 
@@ -68,6 +68,7 @@ At minimum:
 - `start_session`
 - `list_sessions`
 - `continue_session`
+- `attach_session`
 - `checkpoint_session`
 - `pause_session`
 - `end_session`
@@ -171,7 +172,7 @@ Example config/table:
 ```yaml
 caller_aliases:
   guybrush-hermes: guybrush
-  claude-code: claude
+  bede: guybrush
 ```
 
 Resolution order:
@@ -236,7 +237,7 @@ If an admin token is used:
 
 Do not overload one field for both audit attribution and data ownership.
 
-- `actor_id` / `caller_id`: who performed this operation.
+- `actor_id`: who performed this operation.
 - `owner_agent_id`: which agent owns an agent-private memory/session.
 - `subject_agent_id`: which agent a filter/admin action is operating on.
 
@@ -370,8 +371,8 @@ Dashboard and tRPC changes:
 | Harness/agent | Canonical id | Notes |
 |---|---|---|
 | Hermes Guybrush | `guybrush` | Jim’s current Discord/Hermes agent. |
-| Hermes Bede | `guybrush` | If running as a distinct agent identity. |
-| Claude Code | `claude` | Use alias `claude-code → claude` only if Jim wants all Claude Code history collapsed under `claude`. |
+| Hermes Bede | `guybrush` | Legacy id; renamed/backfilled and aliased `bede → guybrush` (same actor, not distinct). |
+| Claude Code | `claude-code` | Harness-named id, consistent with `codex`/`opencode`/`pi`. Kept distinct from any future `claude` surface; no alias. |
 | Codex | `codex` | Stable across Codex CLI/app. |
 | OpenCode | `opencode` | Stable across OpenCode surfaces. |
 | Pi | `pi` | Until a more specific Pi agent name exists. |
@@ -435,6 +436,8 @@ backfill_aliases:
 ```
 
 ### Phase 4 — Hard enforcement
+
+Enter this phase only when the condition is met: all five integrations send identity **and** no new `unknown-agent` rows have appeared for 7 consecutive days.
 
 - Make `agent_id` required in schemas for identity-bearing tools.
 - Remove new-call fallback to `unknown-agent`.
@@ -518,14 +521,14 @@ Policy:
 - Do not use agent names as authentication secrets.
 - Do not infer identities from model names or user-agent strings.
 - Do not automatically map `unknown-agent` rows to named agents without evidence.
-- Do not expose private/off-record session markers through this contract; private mode means no Librarian call.
+- Do not expose private/off-record session markers through this contract; entering private mode makes no further Librarian calls beyond closing any active session (per the harness lifecycle spec).
 
 ---
 
 ## 14. Open questions
 
-1. Should `claude-code` be aliased to `claude`, or should the canonical id remain `claude-code` for precision?
-2. Should dashboard admin actions use `dashboard-admin` until user auth exists, or `jim-admin` now?
-3. Should system actors share the same `agent_id` column or should the schema grow an explicit `actor_kind` field?
-4. How long should soft-warning mode last before hard enforcement?
-5. Should `cli` remain an allowed default for manual local CLI mutations, or should even manual CLI require `--agent`?
+1. ~~Claude id~~ **Resolved:** canonical id remains `claude-code` (consistent with `codex`/`opencode`/`pi`); no alias to `claude`.
+2. ~~Dashboard admin id~~ **Resolved:** `dashboard-admin` now; switch to per-user ids (e.g. `jim-admin`) only if user accounts are added.
+3. ~~actor_kind field~~ **Resolved:** add an explicit `actor_kind` (`agent`/`admin`/`system`/`cli`) column where schema changes are feasible; otherwise enforce role at the resolver and include it in audit metadata (§6).
+4. ~~Soft→hard enforcement~~ **Resolved:** condition-based — hard-enforce once all five integrations send identity and no new `unknown-agent` rows appear for 7 consecutive days.
+5. ~~`cli` default~~ **Resolved:** `cli` stays the default for manual local operator mutations only; harness integration scripts must pass the real agent id (§7.3).

--- a/docs/specs/harness-commands-and-lifecycle-spec.md
+++ b/docs/specs/harness-commands-and-lifecycle-spec.md
@@ -2,7 +2,7 @@
 
 **Author:** Guybrush, with Jim
 **Date:** 2026-05-23
-**Status:** Draft — revised after stronger-model review
+**Status:** Draft — revised after stronger-model review; Codex & Pi promoted to first-class (real pre-prompt gates), OpenCode scoped to a plugin spike (no pre-prompt hook), private mode redefined as end-the-session-with-reason, and the privacy control collapsed to a single `/lib:toggle-private` command; plus per-harness marketplace distribution (claude-code re-review 2026-05-23)
 
 ---
 
@@ -30,9 +30,11 @@ When private/off-record mode is active, the harness/integration must make **zero
 - no session events;
 - no checkpoint/pause/end calls;
 - no `remember` or `propose_memory`;
-- no metadata stored saying a private session occurred.
+- no metadata stored about anything said off-record.
 
-This mode is not the same as `agent_private` visibility. `agent_private` data is stored. Off-record private data is not stored at all.
+There is exactly one permitted call at the **moment of transition into** private mode: if a public session is currently attached, it is **ended** with a short, content-free reason such as `"switching to private mode"` (see §4.3). That call closes the *public* session — it stores nothing about the off-record content that follows. Naming "went private" as the end reason is intentional: it gives an admin reviewing their session history visible confirmation that the system stopped recording when asked.
+
+This mode is not the same as `agent_private` visibility. `agent_private` data is stored. Off-record private data is not stored at all. There is no such thing as a "private session" — privacy means *no* session exists for that period.
 
 Privacy enforcement must happen before normal agent Librarian behaviour. Agent prompt instructions are only a fallback, not the primary guarantee.
 
@@ -42,25 +44,25 @@ If a harness cannot provide a synchronous pre-agent privacy gate, then that harn
 
 ## 3. Privacy triggers
 
-### 3.1 Canonical commands
+### 3.1 Canonical command
 
-Where the harness supports commands through a real command handler or pre-submit interceptor, expose these operations:
-
-```text
-/lib:session private      # enter off-record mode locally; do not call The Librarian
-/lib:session public       # leave off-record mode locally
-/lib:session mode         # may show local privacy/session state without storing anything
-```
-
-Harnesses with per-command file naming may expose aliases:
+Where the harness supports commands through a real command handler or pre-submit interceptor, expose **one** local command that toggles off-record mode:
 
 ```text
-/lib-session-private
-/lib-session-public
-/lib-session-mode
+/lib:toggle-private       # flip off-record mode; echo the resulting state ("now private" / "now public")
 ```
 
-`private` and `public` are local harness commands. They must not be implemented as Librarian MCP tools because calling an MCP tool to say “be private” would already touch The Librarian.
+Harnesses with per-command file naming expose it as:
+
+```text
+/lib-toggle-private
+```
+
+This mirrors the existing `/lib:session <verb>` ↔ `/lib-session-*` convention: `lib:` is the canonical prefix, and harnesses that name commands by file or otherwise reserve `:` (Claude Code, OpenCode, and Pi's command registry) render it with a hyphen.
+
+One verb, not three. The command flips the current mode and reports the state it landed in, so there is no separate "set private", "set public", or "show mode" verb to remember (objective: keep the surface minimal). For the unambiguous *enter-privacy* direction, the natural-language markers in §3.3 ("off the record", etc.) remain directional and are the primary path when certainty matters.
+
+`toggle-private` is a local harness command. It must not be implemented as a Librarian MCP tool, because calling an MCP tool to say “be private” would already touch The Librarian. The one Librarian call it may make is the public-session **end** described in §2/§4.3, when toggling *from* public *to* private with a session attached.
 
 Prompt-only command files are not enough for the privacy guarantee. They can improve discoverability, but the actual state change must happen in a synchronous local command handler, gateway middleware, prompt-submit hook, wrapper, or plugin that runs before the model can make any Librarian MCP/CLI call.
 
@@ -106,7 +108,7 @@ Same-message precedence is deliberately conservative:
 
 - if a prompt contains a private marker and substantive content, the whole prompt is treated as private and no Librarian call is made;
 - if a prompt contains an exit-private marker plus substantive content, the mode change is applied locally but the substantive content is not stored; public Librarian behaviour resumes from the next prompt;
-- pure command prompts such as `/lib:session public` may update local state immediately.
+- pure command prompts such as `/lib-toggle-private` may update local state immediately.
 
 ---
 
@@ -152,14 +154,14 @@ State directory permissions should be `0700`; state files should be `0600`; upda
 
 If a public Librarian session is attached and privacy is detected:
 
-1. set local `privacy = private`;
-2. keep `librarian_session_id` in local state but dormant;
-3. do not call checkpoint/pause/end;
+1. **end** the attached session with a short, content-free reason (e.g. `"switching to private mode"`);
+2. clear `librarian_session_id` from local state;
+3. set local `privacy = private` and record `entered_private_at`;
 4. suppress all future Librarian calls until public mode resumes.
 
-A stored Librarian session may remain active longer than reality. That is acceptable. The alternative is recording evidence about the private boundary, which is worse.
+Ending — rather than leaving the session "dormant" — is deliberate. A session that lingers `active` while the user has gone off-record misrepresents reality; a clean `ended` with a neutral reason is honest and reassures the admin that recording stopped on request. The end summary names *only* that the user went private; it carries nothing about what is said afterwards.
 
-When public mode resumes after a private segment, v1 should start a new public Librarian session by default rather than automatically reusing the dormant pre-private session. Reuse the old session only when Jim explicitly resumes it or when the public command is a pure local command immediately followed by an explicit “continue the previous public session” instruction.
+When public mode resumes after a private segment, a **new** public session starts on the next meaningful prompt. The previously ended session is never silently reattached; resuming it requires explicit user action (`/lib-session-resume <id>`), exactly as for any other ended session.
 
 ---
 
@@ -176,7 +178,8 @@ When public mode resumes after a private segment, v1 should start a new public L
 | Significant tool/file activity since last checkpoint | Checkpoint | Rate-limited. |
 | Harness exit/reset/long idle | Pause | Do not end in v1. |
 | Explicit `/lib:session end` | End | User/agent has intentionally ended the bounded work. |
-| Private mode active | No action | Zero interaction. |
+| Enter private mode while a session is attached | End (reason: switching to private mode) | One-time, user-initiated; then zero interaction. See §4.3. |
+| Private mode already active | No action | Zero interaction. |
 
 ### 5.2 Start/resume algorithm
 
@@ -220,15 +223,16 @@ These are defaults, not hard-coded constants.
 
 ### 5.4 End policy
 
-No automatic end in v1.
+No automatic *heuristic* end in v1. The system never ends a session on its own guess about whether work is "done".
 
 `end` happens only when:
 
 - Jim explicitly uses `/lib:session end` or equivalent;
+- Jim toggles into private mode while a session is attached (user-initiated — the session is ended with a neutral reason, see §4.3);
 - an agent deliberately ends after being asked to wrap up;
 - an admin marks a session ended in the dashboard/CLI.
 
-Harness reset/new/exit should pause, not end.
+Every one of these is an explicit user/admin action, not an inference. Harness reset/new/exit should pause, not end.
 
 ---
 
@@ -250,6 +254,7 @@ Responsibilities:
 - load/save local state;
 - detect privacy markers;
 - short-circuit when private;
+- end the attached public session (neutral reason) on the public→private transition;
 - call The Librarian CLI with consistent flags;
 - rate-limit checkpoints;
 - normalise source refs/cwd/project keys;
@@ -265,13 +270,11 @@ The shared helper should be dependency-light because it will run in several harn
 
 #### Commands
 
-Add command files:
+Add command file:
 
 ```text
 integrations/claude-code/.claude/commands/
-  lib-session-private.md
-  lib-session-public.md
-  lib-session-mode.md
+  lib-toggle-private.md
 ```
 
 Existing session commands remain:
@@ -286,7 +289,7 @@ lib-session-end.md
 lib-session-search.md
 ```
 
-Private/public command files are discoverability aids, not the enforcement mechanism. The actual privacy transition must be handled by `UserPromptSubmit` or another synchronous local command path before Claude can make Librarian calls. If that hook is unavailable or fails, automatic Librarian startup must be disabled for that turn.
+The `lib-toggle-private` command file is a discoverability aid, not the enforcement mechanism. The actual privacy transition (and the public-session end on going private) must be handled by `UserPromptSubmit` or another synchronous local command path before Claude can make Librarian calls. If that hook is unavailable or fails, automatic Librarian startup must be disabled for that turn.
 
 #### Hooks
 
@@ -305,7 +308,7 @@ Hook mapping:
 
 | Claude event | Action |
 |---|---|
-| `UserPromptSubmit` | Detect private/public markers and commands; update local state before other Librarian hooks do work. |
+| `UserPromptSubmit` | Privacy gate. Detect privacy markers and the toggle command; on entering private with a session attached, end it (neutral reason); update local state before other Librarian hooks run. |
 | `SessionStart` | Initialise local state only; start/resume only if a meaningful prompt is available or wrapper policy says to attach immediately. |
 | `PostCompact` | Checkpoint if public and attached. |
 | `TaskCompleted` | Gated checkpoint if public and attached. |
@@ -318,15 +321,13 @@ Do not depend on hooks exporting `LIBRARIAN_SESSION_ID` back to Claude. Use loca
 
 #### Commands
 
-Extend the Hermes `/lib:session` command parser:
+Add the toggle to the Hermes command parser:
 
 ```text
-/lib:session private
-/lib:session public
-/lib:session mode
+/lib:toggle-private
 ```
 
-`private` and `public` are handled by Hermes/gateway local state. They are not forwarded to The Librarian.
+`toggle-private` is handled by Hermes/gateway local state. It is not forwarded to The Librarian, except for the public-session end on the public→private transition.
 
 #### Gateway behaviour
 
@@ -337,13 +338,13 @@ integrations/hermes/middleware/librarian-lifecycle/
   ...
 ```
 
-Hermes gateway hooks are useful for non-blocking lifecycle work, but they are not sufficient as the privacy barrier. The private/public command and plain-text marker detection must run in the command/message path before `agent:start` and before any automatic Librarian call. If the middleware cannot evaluate privacy state, it must fail closed and suppress Librarian automation for that message.
+Hermes gateway hooks are useful for non-blocking lifecycle work, but they are not sufficient as the privacy barrier. The toggle command and plain-text marker detection must run in the command/message path before `agent:start` and before any automatic Librarian call. If the middleware cannot evaluate privacy state, it must fail closed and suppress Librarian automation for that message.
 
 Events:
 
 | Hermes event | Action |
 |---|---|
-| `command:*` | Recognise local private/public/status commands before agent execution. |
+| `command:*` | Recognise the local toggle-private command before agent execution. |
 | message pre-processing if available | Detect plain-text private/public markers. |
 | `agent:start` | Ensure a public session is attached before normal Librarian use. |
 | `agent:end` | Gated checkpoint if meaningful work occurred. |
@@ -365,55 +366,48 @@ Long Discord threads can contain multiple Librarian sessions over time. Automati
 
 ### 7.3 Codex
 
-#### Commands
+Codex is **first-class** when hooks are enabled: it ships a real synchronous `UserPromptSubmit` hook that runs *before user input is processed* and can return `{"decision": "block"}` to stop a prompt reaching the model — a genuine pre-agent privacy gate, equivalent to Claude Code's. Codex hooks are gated behind `codex_hooks = true` and configured in `hooks.json` or inline in `config.toml`; they are synchronous/blocking and receive JSON on `stdin`.
 
-Codex does not currently have a proven Claude/OpenCode-style custom command directory. Ship:
+#### Hooks (primary path)
 
-```text
-integrations/codex/skills/lib-session/SKILL.md
-```
-
-and strengthen:
-
-```text
-integrations/codex/AGENTS.md
-```
-
-The skill/instructions must cover:
-
-- `/lib:session <verb>` text recognition;
-- private/public phrases;
-- no Librarian calls in private mode;
-- explicit `agent_id` use once the naming contract lands.
-
-This instruction path is best-effort only. It does not satisfy the zero-call privacy guarantee by itself, because the model sees the prompt before obeying the instruction. For guaranteed privacy, Codex must run with `UserPromptSubmit` hooks enabled or through a wrapper that gates prompts before agent execution. Until then, disable Codex automatic Librarian startup by default.
-
-If future Codex releases add stable custom command files, add per-verb commands then.
-
-#### Hooks
-
-Codex hooks are behind `codex_hooks = true`. Ship optional hooks:
+Ship hooks under:
 
 ```text
 integrations/codex/hooks/librarian/
   user-prompt-submit.py
   session-start.py
+  pre-compact.py
+  post-compact.py
   stop.py
   pause-idle.py   # optional wrapper/timer helper, not a Codex hook event
 ```
 
-Mapping:
+Mapping (exact Codex event names):
 
 | Codex event | Action |
 |---|---|
-| `UserPromptSubmit` | Detect private/public markers and update local state. |
-| `SessionStart` | Initialise/start/resume if public and policy allows. |
+| `UserPromptSubmit` | Privacy gate. Detect markers / `toggle-private`; on entering private with a session attached, end it (neutral reason) and suppress; keep off-record content out of any Librarian call. |
+| `SessionStart` (`startup`/`resume`/`clear`/`compact`) | Initialise local state; start/resume if public and policy allows. |
+| `PreCompact` / `PostCompact` | Gated checkpoint if public and attached. |
 | `Stop` | Gated checkpoint or heartbeat only. Do **not** pause every turn. |
 | Wrapper exit / idle timer | Pause if public and attached. |
 
 Codex matching hooks may run concurrently. Scripts must use file locks around local state updates.
 
+#### Instruction fallback (only when hooks are off)
+
+When `codex_hooks` is not enabled, fall back to a skill + instructions:
+
+```text
+integrations/codex/skills/lib-session/SKILL.md
+integrations/codex/AGENTS.md
+```
+
+covering `/lib:toggle-private` text recognition, private/public phrases, no Librarian calls in private mode, and explicit `agent_id` use once the naming contract lands. This instruction path is **best-effort only** — the model sees the prompt before obeying — so with hooks off, automatic Librarian startup stays disabled and privacy is advertised as best-effort, not guaranteed.
+
 ### 7.4 OpenCode
+
+OpenCode is the **one harness with no synchronous pre-prompt hook**. Its plugin API exposes lifecycle, tool, and command events, but nothing that fires before the model processes a *natural-language* message (no `chat.message` / `prompt.before`). The closest is `tool.execute.before` — which gates tool calls, not input. The consequence is direct: **natural-language privacy markers cannot be guaranteed on OpenCode**, so OpenCode auto-start stays disabled and its privacy is best-effort until the gaps below are resolved by a spike.
 
 #### Commands
 
@@ -421,62 +415,78 @@ OpenCode supports custom Markdown commands. Add:
 
 ```text
 integrations/opencode/.opencode/commands/
-  lib-session-private.md
-  lib-session-public.md
-  lib-session-mode.md
+  lib-toggle-private.md
 ```
 
-Retain existing per-verb session commands.
-
-Command files may be prompt-based, so privacy must be enforced by the plugin or another synchronous pre-agent path. Without that plugin, OpenCode private commands are discoverability only and automatic Librarian startup should remain disabled.
+Retain existing per-verb session commands. Command files are prompt-based, so the toggle's privacy effect must be enforced by the plugin via a command event, not by the prompt expansion.
 
 #### Plugin
 
-Implement lifecycle in a plugin rather than waiting for Claude-style declarative hooks:
+Implement lifecycle in a plugin:
 
 ```text
 integrations/opencode/plugins/librarian-lifecycle.ts
 ```
 
-Use documented OpenCode plugin events, subject to validation in a spike:
+Plugins export functions returning a hooks object (`{ [eventName]: async (input, output) => {…} }`); handlers are async and can modify `output` before execution continues. Use these documented events (exact names), subject to a spike:
 
 | OpenCode event | Action |
 |---|---|
-| `command.executed` / `tui.command.execute` | Detect private/public commands. |
-| prompt/message event if exposed | Detect natural-language privacy markers. |
+| `tui.command.execute` / `command.executed` | Detect `/lib-toggle-private`. **Spike must confirm `tui.command.execute` fires *before* the agent runs** — only then is the command-driven toggle a real gate. |
 | `session.created` | Initialise local state and attach if public. |
 | `session.compacted` | Checkpoint if public and attached. |
 | `session.idle` | Pause after configured idle threshold. |
 | `session.updated` | Optional activity heartbeat. |
+| `tool.execute.before` | Available, but gates tools not input — not a prompt privacy gate. |
 
-Because plugin APIs evolve, include an integration test or manual smoke test against the installed OpenCode version before marking this Tier 1.
+There is **no** event for natural-language marker detection, so on OpenCode the §3.3 plain-text markers are best-effort only. The spike must (a) confirm whether `tui.command.execute` is synchronous and pre-agent, and (b) validate the session events fire on the installed version, before OpenCode privacy is advertised as anything more than best-effort.
 
 ### 7.5 Pi
 
-Pi is a minimal tool but has a great package repository with lots of add-ons but  it supports custom commands and many other features via extensions: https://pi.dev/docs/latest/extensions
+Pi is **first-class**. Despite first appearances it has a rich extension system: native TypeScript extensions (loaded via `jiti`, no build step) that receive an `ExtensionAPI`, discovered from `~/.pi/agent/extensions/*.ts`, `.pi/extensions/*.ts` (project-local), or `npm:`/`git:` refs in `settings.json`. Crucially it exposes a real synchronous pre-prompt gate and full session lifecycle events. Docs: https://pi.dev/docs/latest/extensions
 
-The extensions page mentions [Session Events](https://pi.dev/docs/latest/extensions#session-events), for example:
+#### Extension
 
-- session_start
-- session_before_compact (could be a good checkpoint trigger?)
-- session_shutdown
+Ship a native extension:
 
-Could we use those for our librarian session triggers?
+```text
+integrations/pi/extensions/librarian-lifecycle.ts
+```
 
-If not, there are many packages available. These ones look promising for session hooks:
+Privacy gate and lifecycle (exact event names / APIs):
 
-- https://pi.dev/packages/pi-yaml-hooks?name=hooks
-- https://pi.dev/packages/@vahor/pi-hooks?name=hooks
+| Pi event / API | Action |
+|---|---|
+| `input` | **Privacy gate.** Fires after extension commands are checked but *before* skill/template expansion and agent processing. Return `{ action: "handled" }` to swallow off-record input, or `{ action: "transform", text }` to rewrite. Detect markers / the toggle here. |
+| `before_agent_start` | Secondary pre-agent point for context decisions if needed. |
+| `pi.registerCommand("lib-toggle-private", …)` | Register the toggle natively. |
+| `session_start` (`reason: startup\|reload\|new\|resume\|fork`) | Initialise local state; start/resume if public. |
+| `session_before_compact` | Gated checkpoint if public and attached. |
+| `session_shutdown` | Pause if public and attached. |
 
-To ship:
+#### Packages are not a privacy shortcut
 
-- investigate the add-on options and pick the best suited;
-- recognise explicit private/public markers;
-- never call The Librarian in private mode.
+Jim flagged the package repository (e.g. [`pi-yaml-hooks`](https://pi.dev/packages/pi-yaml-hooks), [`@vahor/pi-hooks`](https://pi.dev/packages/@vahor/pi-hooks)). These are fine for *non-privacy* lifecycle convenience, but `pi-yaml-hooks` in particular **cannot** carry the privacy gate: it rejects `command:` actions at load time and exposes only `tool.*` / `session.*` / `file.changed` — it never intercepts user input before the agent. The privacy gate must live in the native extension's `input` handler. Do not wire privacy through a YAML-hooks package and assume it is safe.
 
-This is a best-effort agent instruction, not a privacy guarantee. Do not enable Pi automatic Librarian startup until there is a wrapper or runtime hook that can gate private markers before the agent runs.
+### 7.6 Distribution & installation (marketplaces)
 
-Revisit when Pi’s runtime exposes a stable command or hook API.
+Installation should be as close to one-click as each harness allows. Where a harness has a marketplace or package registry, **publish there**. Regardless of channel, every package must bundle the **`use-the-librarian` skill** (`skills/use-the-librarian/SKILL.md`) alongside the commands / hooks / extension / plugin **and** the MCP server registration, so a single install yields everything at once: the MCP connection, the session + `toggle-private` commands, the lifecycle gate, and the skill that teaches the agent how to use it. Installing the plumbing without the skill is not a complete install.
+
+| Harness | Channel | One package bundles | User install |
+|---|---|---|---|
+| **Claude Code** | Plugin marketplace (`.claude-plugin/marketplace.json`) | commands + hooks + skill + MCP server — all in one plugin | `/plugin marketplace add <org>/librarian-marketplace`, then `/plugin install librarian@<marketplace>` |
+| **Codex** | Plugin marketplace (`/plugins` browser) | skill + MCP server in the plugin; lifecycle hooks ship as a companion bundle | Install from `/plugins`; enable `codex_hooks` and add the hooks bundle |
+| **Pi** | npm, auto-indexed by pi.dev/packages (no submission step) | native extension (`input` gate + lifecycle) + registered command + skill | `pi install npm:@the-librarian/pi` (or a `git:` ref) |
+| **OpenCode** | npm + `opencode.json` `"plugin"` (ecosystem listing; no formal marketplace) | plugin (npm) + command files + skill | add the npm plugin to `opencode.json` `"plugin"`; package installs the commands + skill |
+| **Hermes** | First-party gateway (no marketplace) | gateway middleware + commands + skill | enabled in gateway config/deploy |
+
+Specifics:
+
+- **Claude Code** is the cleanest target: a single plugin carries `commands/`, `hooks/hooks.json`, `skills/use-the-librarian/`, and the MCP server (`.mcp.json` or `mcpServers` in `plugin.json`), referencing bundled files via `${CLAUDE_PLUGIN_ROOT}`. Ship a Librarian marketplace repo; optionally submit to the community marketplace (`anthropics/claude-plugins-community`). Run `claude plugin validate` before publishing.
+- **Codex** plugins bundle skills + MCP but **not** hooks/commands, so the plugin delivers the skill + MCP connection while the lifecycle hooks ship as a companion bundle enabled with `codex_hooks` (§7.3). List the plugin in the Codex `/plugins` marketplace.
+- **Pi** publishes the native extension as a package so one `pi install` pulls the `input`-gate extension, the registered command, and the skill. Discovery is automatic, not gated: publish to npm with `"keywords": ["pi-package"]` and a `pi` manifest listing `extensions` + `skills`, and the package appears in the pi.dev/packages gallery — no submit/approval flow. Do **not** route privacy through a `pi-yaml-hooks` package (§7.5).
+- **OpenCode** has no first-class marketplace today: ship an npm plugin referenced from `opencode.json` `"plugin"`, with the command markdown files and skill installed by the package. Keep auto-start disabled until the privacy spike clears (§7.4).
+- **Hermes** is first-party — no marketplace; the middleware, commands, and skill deploy with the gateway.
 
 ---
 
@@ -496,7 +506,7 @@ the-librarian sessions pause <session_id> --agent <agent> --summary-file <path>
 
 If a required CLI flag does not exist yet, implement it before wiring hooks around it.
 
-Private/public commands do not call this CLI. They update local state only.
+The `toggle-private` command updates local state directly; its only Librarian call is ending the attached public session (via this CLI) on the public→private transition.
 
 ---
 
@@ -559,6 +569,7 @@ Harness-specific config can override defaults, but `auto_end: false` should rema
 - false positives are not triggered by unrelated text;
 - public marker exits local private state;
 - when private, no mocked CLI/MCP call is made;
+- entering private while a session is attached ends that session with a neutral reason, then makes no further calls;
 - state directory/file permissions are `0700`/`0600`;
 - state read/write failure suppresses remote calls;
 - state writes are atomic;
@@ -576,35 +587,39 @@ Claude Code:
 
 Hermes:
 
-- `/lib:session private` is handled locally and not forwarded to The Librarian;
+- `/lib:toggle-private` is handled locally and not forwarded to The Librarian (except the public-session end on the public→private transition);
 - privacy handling runs in synchronous middleware, not only in a non-blocking hook;
 - Discord `source_ref` includes channel and thread where available;
 - long-thread attach chooses active/paused sessions only.
 
 Codex:
 
+- with `codex_hooks` enabled, `UserPromptSubmit` gates off-record prompts (returns `decision: block`);
 - hooks respect `codex_hooks` feature flag configuration;
-- without a pre-agent hook/wrapper, privacy is marked best-effort and auto-start remains disabled;
+- without hooks enabled, privacy is marked best-effort and auto-start remains disabled;
 - `Stop` does not pause every turn;
 - file locking prevents concurrent hook state corruption.
 
 OpenCode:
 
 - command files appear in command list;
-- plugin receives expected session events on installed version;
-- without the plugin/pre-agent path, privacy commands are not advertised as guaranteed;
+- plugin receives expected session events on the installed version;
+- spike confirms whether `tui.command.execute` fires before the agent (gate) or after (best-effort only);
+- natural-language markers are documented as best-effort (no pre-prompt hook);
 - `session.compacted` checkpoints; `session.idle` pauses after threshold.
 
 Pi:
 
-- integration docs include the privacy contract and text command recognition.
+- the `input` handler swallows off-record prompts (`action: handled`) and rewrites where needed (`action: transform`);
+- `session_start` / `session_before_compact` / `session_shutdown` map to start / checkpoint / pause;
+- `pi.registerCommand` exposes `/lib-toggle-private`.
 
 ### 11.3 Manual smoke tests
 
 For each implemented harness:
 
 1. Start a normal task; verify a Librarian session starts or resumes.
-2. Say “this is a private session”; verify no new Librarian calls occur.
+2. With a session active, say “this is a private session”; verify the session is ended with a neutral reason and no further Librarian calls occur.
 3. Say “you can remember again”; verify public behaviour resumes.
 4. Trigger compaction/task completion where possible; verify checkpoint quality.
 5. Exit/reset/idle; verify pause, not end.
@@ -615,28 +630,31 @@ For each implemented harness:
 
 1. Add shared privacy contract to all integration instruction files.
 2. Implement shared local state/privacy helper.
-3. Implement Claude Code private/public commands and hooks.
-4. Implement Hermes gateway private/public handling and lifecycle pause/checkpoint.
-5. Implement Codex optional hooks and skill/instruction improvements.
-6. Spike OpenCode plugin event payloads, then implement if confirmed.
-7. Leave Pi as docs-only until its runtime is defined.
-8. After one week of use, review session noise and checkpoint quality before increasing automation.
+3. Implement Claude Code toggle-private command and hooks.
+4. Implement Hermes gateway toggle-private handling and lifecycle pause/checkpoint.
+5. Implement Codex hooks (first-class when `codex_hooks` enabled); ship the skill/instruction fallback for hooks-off.
+6. Implement the Pi native extension (`input` gate + session lifecycle events).
+7. Spike OpenCode: confirm whether `tui.command.execute` is a pre-agent gate and that session events fire; implement the plugin, but keep auto-start disabled and natural-language privacy best-effort until the spike clears it.
+8. Package each integration for its marketplace/registry (Claude Code plugin, Codex plugin, Pi package, OpenCode npm plugin, Hermes gateway bundle), each bundling the `use-the-librarian` skill (§7.6).
+9. After one week of use, review session noise and checkpoint quality before increasing automation.
 
 ---
 
 ## 13. Success criteria
 
 - [ ] Every harness integration documents the zero-interaction private rule.
-- [ ] Harnesses with command support expose private/public controls.
+- [ ] Harnesses with command support expose the `/lib:toggle-private` control.
 - [ ] Plain-text private markers are detected before normal Librarian calls where synchronous hooks/gateway/wrappers support it.
 - [ ] Harnesses without a pre-agent privacy gate do not enable automatic Librarian startup.
 - [ ] Private mode suppresses sessions and memories.
 - [ ] First meaningful public interaction can start/resume a session automatically.
 - [ ] Compaction/task boundaries create useful checkpoints where supported.
 - [ ] Exit/reset/idle pauses sessions, not ends them.
-- [ ] No v1 automation auto-ends a session.
+- [ ] Entering private mode while a session is attached ends it with a neutral reason.
+- [ ] No v1 automation auto-ends a session by heuristic (the only end triggers are explicit: `/lib:session end`, an agent wrap-up, an admin action, or the user toggling into private mode).
 - [ ] Hook scripts/plugins use local state rather than environment-only state.
 - [ ] Automation is idempotent and safe under retries.
+- [ ] Each harness integration installs via its marketplace/registry where one exists, bundling the `use-the-librarian` skill with the commands/hooks/extension/plugin and the MCP registration.
 
 ---
 
@@ -645,15 +663,15 @@ For each implemented harness:
 - No raw transcript capture.
 - No server-side filtering as the main privacy mechanism.
 - No auto-end heuristics in v1.
-- No attempt to infer Pi lifecycle without a real API.
+- No reliance on natural-language privacy markers on OpenCode until a pre-agent gate is proven (it has no pre-prompt hook today).
 - No memory-curator behaviour in this spec; that is separate.
 
 ---
 
 ## 15. Open questions
 
-1. Should the canonical command be `/lib:session private`, `/private`, or both?
-2. What exact idle threshold fits Jim’s Discord usage?
-3. Should Hermes gateway privacy state persist across gateway restarts?
-4. Should Codex hooks be opt-in only until the feature flag graduates?
-5. Should OpenCode plugin support be treated as Tier 1 after a successful spike?
+1. ~~Command form~~ **Resolved:** a single local command, canonical `/lib:toggle-private` (rendered `/lib-toggle-private` by file-named harnesses); directional natural-language markers remain the unambiguous enter-privacy path.
+2. Idle threshold before auto-pause — default **6 hours**, configurable (§5.3/§10); revisit against real Discord usage after a week.
+3. ~~Hermes state persistence~~ **Resolved:** persist enough local state to survive gateway restarts (§4.2).
+4. ~~Codex opt-in~~ **Resolved:** Codex is first-class when `codex_hooks` is enabled; instruction-only fallback (auto-start off) when it is not.
+5. ~~OpenCode Tier 1~~ **Resolved:** not yet — OpenCode has no pre-prompt hook, so it stays best-effort/spike-gated; promote only if the spike proves `tui.command.execute` is a pre-agent gate.

--- a/docs/specs/implementation-plan.md
+++ b/docs/specs/implementation-plan.md
@@ -1,0 +1,149 @@
+# Implementation Plan: Curator, Harness Lifecycle, and Naming Contract
+
+**Author:** Guybrush, with Jim
+**Date:** 2026-05-23
+**Status:** Draft — sequencing agreed in claude-code planning session (2026-05-23)
+
+Covers the build order for the three specs:
+
+- [`memory-curator-spec.md`](./memory-curator-spec.md)
+- [`harness-commands-and-lifecycle-spec.md`](./harness-commands-and-lifecycle-spec.md)
+- [`agent-naming-contract-spec.md`](./agent-naming-contract-spec.md)
+
+---
+
+## 1. Sequencing principle
+
+The naming contract is **not a peer** of the other two — it *brackets* them. Its foundation must land first (both features depend on canonical caller identity), and its hard enforcement must land last (the enforcement trigger literally depends on the harness integrations being done). The two features sit in between and are independent of each other.
+
+```
+naming(core/soft) ──► curator ──► harness(all 5) ──► naming(backfill + hard-enforce)
+       │                 │              │                         ▲
+   unblocks all     small first    satisfies naming         condition met
+                    consumer       Phase 2 per harness    (integrations + 7 clean days)
+```
+
+**Invariants that hold across every stage:**
+
+- **No new MCP verbs.** Curation is scheduler-driven; privacy is local-only; naming only tightens existing schemas. (Objective #1.)
+- **Off-record private = zero Librarian calls** beyond closing any active session at the transition.
+- **Tokens authenticate, names identify.** Identity comes from the trusted boundary, never trusted from the model.
+- **Agent-facing simplicity.** The only thing an agent must do is send its `agent_id` (ideally wrapper-injected).
+
+---
+
+## 2. Stage 1 — Naming foundation (Phases 0–2, soft mode)
+
+Pure server-side work; nothing rejects yet, so no behaviour breaks. Unblocks both features.
+
+**Workstream 1.1 — Baseline audit (naming Phase 0)**
+- Enumerate distinct `agent_id` / `created_by_agent_id` / `current_agent_id` values.
+- Run `normaliseCallerId` in dry-run; produce collapse groups and collision candidates.
+- Leave `unknown-agent` untouched.
+
+**Workstream 1.2 — Resolver core**
+- `normaliseCallerId` (§4.2) + unit tests (§11).
+- `ResolveCallerInput` / `ResolvedCaller` resolver (§7.1): injected > authenticated > (soft) fallback; normalise; aliases; validate token binding / allowlist / reserved namespaces / role mismatch.
+- Alias config/table (§4.4) + reserved namespaces (`system-*`, `dashboard-*`, `cli`).
+
+**Workstream 1.3 — Store attribution**
+- Persist canonical ids in attribution fields (§7.4); raw ids only in metadata/audit.
+- Add `actor_kind` (`agent`/`admin`/`system`/`cli`) column where schema-feasible; else enforce at resolver + audit metadata.
+
+**Workstream 1.4 — Surface wiring (soft)**
+- MCP: resolve once at dispatch; never overwrite a supplied `agent_id`; reject mismatch + reserved misuse; session-lifecycle tools record the acting caller.
+- CLI: `--agent` / `LIBRARIAN_AGENT_ID`.
+- Dashboard/tRPC: canonical-id dropdowns, `unknown-agent` marked legacy, system actors grouped.
+- Run identity in **soft-warning** mode: log missing/odd identity, do not reject (except hard mismatch).
+
+**Exit criteria:** resolver live in soft mode; attribution being collected cleanly; token-bound mismatches rejected; no regressions.
+
+---
+
+## 3. Stage 2 — Memory curator
+
+The most self-contained feature and the cleanest first consumer of the naming contract (single `system-memory-curator` actor). Operates on existing stored memories — no dependency on the harness work.
+
+**Workstream 2.1 — Data model**
+- `memory_curation_runs` + `memory_curation_operations` tables (§8).
+- `curator_note` nullable column on `memories` carrying `{ text, supersedes, run_id, operation_id }`.
+
+**Workstream 2.2 — Evidence + detection**
+- Slice-scoped gathering (`common_global`, `common_project`, per-`agent_private`) with secret/cross-slice redaction before the LLM pass (§9).
+- Tombstone fingerprint pre-pass (normalised content hash) blocking resurrection (§9.1, §10.3).
+
+**Workstream 2.3 — LLM pass + governance**
+- Provider/endpoint/token/model config; prompt assembly system → evidence+candidates → admin addendum (advisory only) (§10.4).
+- Validation + apply policy (§10.5, §11): protected categories → **proposal** with `curator_note.supersedes`; protected pure-archive → skip+audit; non-protected → auto-apply under `default_auto_apply` (`safe_only` default) + confidence threshold; superseded sources archived **atomically**; slice/secret guards skip.
+
+**Workstream 2.4 — Trigger + worker**
+- `enqueueDueMemoryCurationRuns(reason: "schedule" | "manual" | "maintenance")` (§12).
+- Scheduler/worker firing at the admin-configured interval/time (default every 1 day at 03:00); input-hash skip; manual/maintenance may bypass skip (§10.2, §14).
+- Actor is `system-memory-curator` (consumes Stage 1).
+
+**Workstream 2.5 — Admin cockpit (dashboard)**
+- Enable/disable · schedule (`every N days at HH:MM`) · LLM config (token via admin secret-store) · advisory prompt addendum · read-only observability (per-action counts) · run-now (shares the scheduler enqueue path) (§7.1, §13).
+
+**Tests:** schedule, fingerprint/resurrection, addendum, run-now, protected proposal + supersedes, agent-private isolation (§15).
+
+**Exit criteria:** curator runs on schedule and via run-now; emits governed ops; admin can observe + configure; `safe_only` default; zero new MCP verbs.
+
+---
+
+## 4. Stage 3 — Harness commands & lifecycle
+
+The largest, riskiest, most cross-cutting piece. Build per the spec's §12 rollout order. Building each integration here also satisfies naming **Phase 2** (each harness starts sending its canonical `agent_id`).
+
+**Workstream 3.1 — Shared helper + CLI**
+- `integrations/shared/librarian-lifecycle/`: local state, privacy-marker detection, short-circuit, **end-active-session-on-private-transition**, CLI calls, checkpoint rate-limiting, ref/cwd/project normalisation, idempotent start/resume/pause (§6, §9).
+- Verify/extend the CLI capabilities the hooks depend on (§8).
+
+**Workstream 3.2 — Per-harness (spec §12 order)**
+1. Claude Code — `lib-toggle-private` command + hooks; `UserPromptSubmit` privacy gate.
+2. Hermes — gateway middleware (synchronous privacy barrier) + lifecycle.
+3. Codex — first-class hooks (`UserPromptSubmit` gate) behind `codex_hooks`; instruction fallback when off.
+4. Pi — native extension with the `input` gate + `session_*` lifecycle; `pi.registerCommand`.
+5. OpenCode — plugin + **spike** confirming whether `tui.command.execute` is a pre-agent gate; auto-start stays off and NL markers best-effort until it clears.
+
+**Workstream 3.3 — Lifecycle behaviour**
+- Start/resume on first meaningful public prompt; gated + rate-limited checkpoints; pause on exit/idle; **no heuristic auto-end**; private mode ends the active session with a neutral reason.
+
+**Workstream 3.4 — Distribution (§7.6)**
+- Package per channel (Claude Code plugin marketplace; Codex `/plugins`; Pi npm + `pi-package` keyword; OpenCode npm; Hermes gateway bundle), each **bundling the `use-the-librarian` skill** + commands/hooks/extension/plugin + MCP registration.
+
+**Tests:** shared + per-harness + manual smoke (§11).
+
+**Exit criteria:** privacy gate proven (or explicitly best-effort) per harness; auto session/checkpoint/pause working; packages installable; all integrations send canonical identity.
+
+---
+
+## 5. Stage 4 — Naming close-out (Phases 3–4, hard enforcement)
+
+Must be last — the enforcement trigger depends on Stage 3.
+
+**Workstream 4.1 — Backfill (Phase 3)**
+- Migration: normalise non-empty ids, apply approved aliases (incl. `bede → guybrush`), record before/after counts, do **not** guess `unknown-agent`, write an audit log.
+
+**Workstream 4.2 — Hard enforcement (Phase 4)**
+- **Entry condition:** all five integrations send identity **and** no new `unknown-agent` rows for 7 consecutive days.
+- Make `agent_id` required in identity-bearing schemas; remove new-call fallback to `unknown-agent`; keep `unknown-agent` only as a legacy value; dashboard warns on any new `unknown-agent` row.
+
+**Exit criteria:** hard mode on; new `unknown-agent` attribution impossible.
+
+---
+
+## 6. Housekeeping (fold in opportunistically)
+
+- Update [`docs/slash-commands.md`](../slash-commands.md) and the global `CLAUDE.md` to document `/lib:toggle-private` (sits outside the `/lib:session` family).
+- Optional: add a "superseded by the spec" header to the two research docs so future readers aren't misled.
+
+---
+
+## 7. Dependency summary
+
+| Stage | Depends on | Unblocks |
+|---|---|---|
+| 1 — Naming foundation | — | Curator, Harness |
+| 2 — Curator | Stage 1 (system actor + audit attribution) | — |
+| 3 — Harness | Stage 1 (`agent_id` / `--agent`) | Stage 4 trigger |
+| 4 — Naming enforcement | Stage 3 (all integrations sending identity) | — |

--- a/docs/specs/memory-curator-spec.md
+++ b/docs/specs/memory-curator-spec.md
@@ -2,7 +2,7 @@
 
 **Author:** Guybrush, with Jim
 **Date:** 2026-05-23
-**Status:** Draft — revised after stronger-model review
+**Status:** Draft — revised after stronger-model review; trigger model, admin cockpit (config + observability + run-now + prompt addendum), model config, apply policy, agent-private, tombstones, and rollout settled in claude-code re-review (2026-05-23)
 
 ---
 
@@ -25,16 +25,19 @@ The v1 outcome is simple: agents should receive cleaner, less duplicated, more c
 - Split memories that conflate unrelated facts.
 - Archive stale, contradicted, duplicate, or low-signal memories.
 - Surface durable facts from stored session summaries, decisions, and candidate memories.
-- Run only from internal application code: scheduled jobs, threshold checks, or trusted maintenance paths.
-- Store auditable curation-run and curation-operation records.
-- Apply safe operations automatically; route risky/protected operations to proposals.
+- Run unattended from the scheduled job (admin-configurable interval/time, default every 1 day at 03:00), plus a trusted maintenance path and an admin-only run-now control.
+- Apply non-protected operations at the curator's discretion; route protected-category corrections to proposals (annotated with superseded refs) and protected pure-deletions to skip + audit.
+- Add a `curator_note` field to the memory record so curator provenance and superseded references travel with proposals/memories.
+- Store auditable curation-run and curation-operation records, surfaced in an admin-only observability view.
+- Provide an admin-only dashboard surface: enable/disable, LLM config, prompt addendum, observability, run-now.
 
 ### Out of scope for v1
 
 - Raw transcript capture.
 - Changes to session storage shape.
-- Agent-facing MCP tools for memory curation.
-- Agent-facing slash commands for memory curation.
+- Consumer-agent MCP tools for memory curation.
+- Consumer-agent slash commands for memory curation.
+- A dedicated curation review/approval queue (protected items use the existing proposal lifecycle).
 - Cross-project inference.
 - Automatic session lifecycle management.
 - Rebuilding a whole parallel memory store for review/adoption.
@@ -77,32 +80,38 @@ The curator must never promote `agent_private` data into `common` output unless 
 
 ---
 
-## 5. Internal surfaces
+## 5. Surfaces
 
-The Memory Curator has no direct user or agent surface in v1. It is internal application behaviour inside The Librarian.
+The Memory Curator has **no consumer-agent surface** in v1. The only human surface is the **admin dashboard**, available to trusted admin operators. The governing boundary is:
 
-### Allowed internal surfaces
+> **Trusted admins may configure, observe, and manually trigger curation. Consumer agents and ordinary users may not — they only ever see the improved memory quality that results.**
+
+### Allowed surfaces
 
 | Surface | Caller | Purpose |
 |---|---|---|
-| Scheduler tick | The Librarian process or worker | Check which slices are due and enqueue/run curation. |
-| Threshold check | Memory/session write path or background worker | Notice enough new evidence has accumulated to justify a run. |
+| Scheduler tick | The Librarian process or worker | At the configured interval/time (default daily at 03:00), check which slices are due and run curation. |
+| Admin dashboard — configuration | Admin operator only | Enable/disable curation; set the schedule (every N days at HH:MM); set LLM provider, endpoint, token, model; edit the prompt addendum. |
+| Admin dashboard — observability | Admin operator only | Read-only view of past runs: timestamp, trigger, slice, and counts by action (archived, merged, split, synthesised, proposed, skipped, failed). |
+| Admin dashboard — run now | Admin operator only | Manually start a run for due/selected slices. Recorded under the `manual` trigger for audit. |
 | Trusted maintenance path | Deployment/bootstrap/test code | Run bounded maintenance without creating a public command surface. |
-| Existing memory/proposal store | Normal memory system | Receive created memories, archived duplicates, and review-required proposals. |
+| Existing memory/proposal store | Normal memory system | Receive created memories, archived duplicates, and protected-category proposals. |
+
+The scheduled tick (default daily at 03:00, admin-configurable) is the only *unattended* trigger. Beyond it, only a **trusted admin** (run-now) or **trusted internal code** (maintenance) may begin a run. There is no event/threshold trigger — **agent activity must never start a curation run, directly or indirectly.**
 
 ### Disallowed surfaces
 
 | Surface | Reason |
 |---|---|
 | MCP memory-curation tools | Would expose internal maintenance to consumer agents. |
-| Agent slash commands | Same problem; agents should not control curation runs. |
-| User-facing CLI commands | Turns curation into an operator feature rather than background hygiene. |
-| Dashboard run buttons or curation-control pages | Gives users a manual trigger for something that should be policy-driven code. |
-| Prompt-triggered “please curate memories now” behaviour | Makes privacy and audit boundaries fuzzy. |
+| Agent slash commands | Agents must not control curation runs. |
+| Consumer-facing CLI commands | Turns curation into an end-user feature rather than admin-governed hygiene. |
+| Non-admin dashboard controls | Run-now / config / observability are admin-only; ordinary users get no curation surface. |
+| Prompt-triggered “please curate memories now” behaviour | An agent prompt must never start a run; it would make privacy and audit boundaries fuzzy. |
 
-If Jim asks an agent to “clean up memories”, the agent should not call or point to a curation command. It can say that memory hygiene is handled internally by The Librarian, and then continue with the user’s actual task.
+If a consumer agent is asked to “clean up memories”, it must not call or point to any curation control. It can say that memory hygiene is handled internally by The Librarian, and continue with the user’s actual task. The run-now button is an admin affordance, not something an agent surfaces or invokes.
 
-The only user-visible result should be better memory quality: cleaner `start_context`, better `recall`, and ordinary memory proposals when protected or risky changes need review.
+The only consumer-visible result is better memory quality: cleaner `start_context`, better `recall`, and ordinary memory proposals when protected changes need review.
 
 ---
 
@@ -127,41 +136,65 @@ packages/core/src/memory-curator/
 
 packages/mcp-server/src/internal-jobs/
   memory-curator.ts        # Starts scheduler/worker inside the trusted server boundary
+
+packages/dashboard/...      # Admin-only curator page + admin API (see below)
+  curator settings          # Enable toggle, LLM provider/endpoint/token/model, prompt addendum
+  curator observability     # Read-only run/op history with action counts
+  curator run-now           # Admin-authenticated POST that enqueues a `manual` run
 ```
 
-Do not add Memory Curator files under any user/agent command surface:
+The admin dashboard pieces must sit behind the dashboard's existing **admin authentication/authorisation**, identical to other admin-only settings. The run-now endpoint enqueues a run through the same internal entrypoints as the scheduler — it must not contain its own copy of the curation logic.
+
+Do not add Memory Curator files under any consumer-agent command surface:
 
 - no `packages/mcp-server/src/mcp/tools/*` curation tools;
 - no `/lib:*` slash commands;
-- no `packages/cli/src/commands/*` curation commands;
-- no dashboard route or button for triggering curation.
+- no `packages/cli/src/commands/*` consumer curation commands;
+- no non-admin dashboard route or button for curation.
 
 ---
 
 ## 7. Configuration
 
-The exact config source should follow The Librarian’s existing config/env conventions. The logical config shape is:
+Configuration splits into two tiers.
+
+### 7.1 Admin-dashboard settings (operator-managed)
+
+The **enable toggle** and the **LLM connection** live in the admin dashboard, not in a static file, because they include a secret (the provider token) and because curation should be switchable without a redeploy.
+
+- Curation is **disabled by default**.
+- **Schedule.** Configured as *run every N days at HH:MM*. Default: **every 1 day at 03:00**. The dashboard exposes exactly two inputs — an interval in whole days (≥ 1) and a time of day — never raw cron syntax. The time is interpreted in the deployment's configured timezone. The scheduler computes the next run from the last completed run + interval + time-of-day.
+- To enable it, the admin must supply a complete LLM configuration: **provider**, **API endpoint**, **token**, and **model**.
+- If curation is enabled but any of provider/endpoint/token/model is missing, curation stays effectively off and the dashboard surfaces the incomplete configuration. The scheduler must never run a curation pass without a complete, validated LLM config.
+- The token is stored via The Librarian's existing admin secret-storage mechanism, never in plaintext config or in audit records.
+- **Prompt addendum (optional).** A free-text field appended to the curator's prompt so an admin can steer curation (e.g. "be more aggressive about archiving superseded TODOs", "prefer merging over archiving"). It is **length-bounded** (e.g. ≤ 2 KB) and **advisory only**: it influences what the LLM *suggests*, but cannot relax any code-enforced guard — boundary checks, protected-category routing, secret redaction, and the apply policy all run after the LLM returns regardless of addendum content. The addendum text is itself subject to secret redaction before being sent to the provider.
+
+These are **configuration and observability**, plus an explicit admin **run-now** trigger (§5). The dashboard exposes no curation control to non-admins, and an agent prompt can never start a run. See §13 for the observability view.
+
+### 7.2 Operational config (file/env)
+
+Non-secret operational knobs follow The Librarian's existing config/env conventions:
 
 ```yaml
 memory_curator:
-  enabled: true
-  schedule: "0 3 * * *"          # Used by the internal scheduler
-  min_sessions_since_run: 10
-  max_days_since_run: 7
+  # schedule is admin-managed (every N days at HH:MM, default every 1 day at 03:00) — see §7.1
+  min_sessions_since_run: 10      # Scheduler gate: skip the tick below this
+  max_days_since_run: 7           # Scheduler gate: force a run at least weekly
   max_sessions_per_run: 50
   max_memories_per_run: 200
   default_auto_apply: safe_only   # off | safe_only | high_confidence
   auto_apply_confidence: 0.90
-  model:
-    provider: deepseek
-    model: deepseek-v4-pro
   slices:
     common_global: true
     common_project: true
-    agent_private: false          # Curate only if explicitly enabled per agent
+    agent_private: true           # Curated in v1; each agent's slice stays isolated
 ```
 
-Recommended rollout: start with `default_auto_apply: off` or `safe_only` for the first production runs. Increase automation only after reviewing real output quality.
+Agent-private slices are curated in v1. Each run is strictly scoped to a single `agent_id`'s private slice, never reads or writes across agents, and never promotes `agent_private` content into `common` output (§3, §11).
+
+The scheduled tick self-gates on `min_sessions_since_run` / `max_days_since_run`, so an idle store produces no curation work and no LLM cost even when the interval comes due.
+
+Rollout posture for v1: `default_auto_apply: safe_only`. Only exact-duplicate archive/merge above the confidence threshold auto-applies; non-protected ops below that bar are skipped + audited, and protected corrections become proposals. Increase automation only after reviewing real output quality.
 
 ---
 
@@ -175,7 +208,7 @@ Use operation-level tables rather than a single opaque JSON blob. That makes aud
 CREATE TABLE memory_curation_runs (
   id TEXT PRIMARY KEY,
   status TEXT NOT NULL,              -- pending | running | completed | failed | cancelled
-  trigger TEXT NOT NULL,             -- schedule | threshold | maintenance
+  trigger TEXT NOT NULL,             -- schedule | manual | maintenance
   mode TEXT NOT NULL DEFAULT 'apply',-- apply | dry_run
   project_key TEXT,
   visibility TEXT NOT NULL,          -- common | agent_private
@@ -219,6 +252,29 @@ CREATE TABLE memory_curation_operations (
 
 The existing memory/event store remains authoritative for memory state. These tables explain why a curator suggested or performed an operation.
 
+### Memory-store addition: `curator_note`
+
+Add one nullable field to the **memory record** (which, per the three-state model, also covers `proposed` memories):
+
+```sql
+ALTER TABLE memories ADD COLUMN curator_note TEXT;  -- nullable JSON
+```
+
+`curator_note` carries curator provenance and, crucially, the **superseded reference** that makes a protected-correction proposal actionable:
+
+```jsonc
+{
+  "text": "Supersedes the older relationship note; the title/role changed after the 2026-05 reorg.",
+  "supersedes": ["mem_abc123"],     // memory ids this proposal is meant to replace
+  "run_id": "run_…",                // provenance: which curation run produced this
+  "operation_id": "op_…"
+}
+```
+
+- For a **protected correction** proposal, the apply layer populates `curator_note` from the operation (rationale + `source_memory_ids` → `supersedes`). The dashboard reads `supersedes` to render "accept this → then archive mem_abc123" and to warn if the superseded memory is still active after acceptance.
+- For an **auto-applied non-protected create**, `curator_note` may record lightweight provenance (`run_id`, `operation_id`) so curator-authored memories are distinguishable from agent-authored ones.
+- This is the **only** change to the memory store. It does not touch session storage.
+
 ---
 
 ## 9. Evidence gathering
@@ -229,7 +285,7 @@ A curation run gathers a bounded evidence bundle for one slice.
 
 - active `common` memories where `project_key = X`;
 - proposed `common` memories where `project_key = X`;
-- archived memory tombstones for `project_key = X` (id, title, category, archived date; body optional and capped);
+- archived memory tombstones for `project_key = X` (id, title, category, archived date, archive reason, and a **normalized content fingerprint**; full body excluded — see §9.1);
 - sessions with `project_key = X` and `visibility = common`;
 - session summaries, decisions, candidate memories, files touched, commands run.
 
@@ -241,7 +297,13 @@ A curation run gathers a bounded evidence bundle for one slice.
 ### Agent-private slice
 
 - same shape as above, but only for the specific `agent_id` and `visibility = agent_private`;
-- disabled by default for v1 unless Jim wants per-agent private cleanup.
+- enabled in v1; each run is scoped to exactly one `agent_id` and never reads another agent's private data.
+
+### 9.1 Tombstone fingerprints (resurrection prevention)
+
+Archived memories are passed to the prompt as **metadata-only tombstones** — id, title, category, slice, archived date, archive reason — plus a `content_fingerprint`: a hash of the normalized title+body (lowercased, whitespace-collapsed, punctuation-stripped). The full archived body is **not** sent to the LLM, so deliberately deleted content is not re-exposed.
+
+The deterministic pre-pass (§10.3) computes the same fingerprint for each new `create`/`merge` candidate and blocks any operation whose fingerprint or normalized title matches an existing tombstone. This catches exact and near-exact resurrection cheaply. Paraphrase-level (semantic/embedding) resurrection detection is deferred to v2.
 
 ### Evidence caps
 
@@ -290,9 +352,9 @@ The input hash should include:
 - memory ids + updated timestamps + statuses;
 - session ids + updated/last activity timestamps;
 - candidate memory content hashes;
-- curator prompt/version.
+- curator prompt/version **and the admin prompt addendum** (so editing the addendum permits a fresh run).
 
-If a completed **apply-mode** run with the same hash exists, skip by default. Internal maintenance code may explicitly bypass the skip only when it records a distinct `maintenance` trigger and rationale.
+If a completed **apply-mode** run with the same hash exists, skip by default. A `manual` (admin run-now) or `maintenance` run may explicitly bypass the skip, recording its trigger and rationale; this lets an admin force a re-run after changing the addendum or model.
 
 Dry-runs must not satisfy idempotency for later real runs. Store `mode = dry_run` on dry-run records and ignore those rows when deciding whether an apply-mode run has already completed.
 
@@ -303,13 +365,16 @@ Before calling an LLM, generate cheap candidates:
 - exact title/body duplicates after normalisation;
 - same title, near-identical body;
 - obvious obsolete “considering/maybe” memories contradicted by later decisions;
-- proposed memories matching active memories.
+- proposed memories matching active memories;
+- candidates whose content fingerprint or normalized title matches an archived tombstone (§9.1) — flagged as resurrection risks to suppress.
 
 The LLM receives these candidates instead of discovering everything from scratch.
 
 ### 10.4 LLM pass
 
 The LLM produces structured JSON only. No prose parsing.
+
+The prompt is assembled as: fixed curator system instructions → slice evidence + pre-pass candidates → **admin prompt addendum** (if set, §7.1). The addendum is positioned as operator guidance, never as authority to override the output schema or the apply policy. Whatever the LLM returns, §10.5 validation and §11 apply policy are enforced in code, so the addendum can only influence *which valid operations are suggested*, not bypass any guard.
 
 Required properties per operation:
 
@@ -339,7 +404,7 @@ Reject, skip, or route to review when:
 
 Boundary-changing operations are invalid/skipped in v1. Do not silently turn them into proposals; cross-boundary promotion needs its own future governed migration design.
 
-Protected-category operations are never auto-applied. They become review items/proposals through the same protected-memory governance path used by normal memory writes.
+Protected-category operations are never auto-applied. A protected `create`, `update`, `merge`, or `split` becomes a **proposal** through the same protected-memory governance path used by normal memory writes, with `curator_note.supersedes` set to any existing memory it should replace. A protected **pure `archive`** (deletion with no replacement) has no memory to propose, so it is skipped and audited for manual admin action (§11).
 
 Secret-looking values should cause the operation to be skipped and logged for review, not written to memory. Evidence gathering should already have redacted such values before the LLM pass.
 
@@ -347,83 +412,90 @@ Secret-looking values should cause the operation to be skipped and logged for re
 
 ## 11. Apply policy
 
-| Condition | Default result |
+The curator follows **the same governance the rest of the memory system already uses**: protected categories (`identity`, `relationship`, and anything on the store's central protected list) require a proposal; everything else is the curator's discretion to apply directly — exactly as ordinary agents may write non-protected memories without approval. There is no elaborate per-operation proposal routing.
+
+Two hard, code-enforced guards sit above that discretion and cannot be relaxed by confidence, category, or prompt addendum:
+
+- **Slice-boundary guard** — any operation that would change visibility/project/scope/owning agent, or otherwise cross a slice boundary, is **invalid/skipped**. Cross-boundary promotion needs its own future governed migration design.
+- **Secret guard** — any operation referencing secret-looking strings is **skipped and logged**, never written. (Evidence gathering should already have redacted these before the LLM pass.)
+
+Within those guards:
+
+| Condition | Result |
 |---|---|
-| Protected category (`identity`, `relationship`, or central protected list) | Review/proposal only; never auto-apply. |
-| Visibility/project/scope/agent boundary change | Invalid/skipped in v1. |
-| `split` operation | Proposal only in v1. |
-| `create` from session candidate memory with ordinary technical category and strong direct evidence | Auto-apply if confidence ≥ threshold, otherwise proposal. |
-| Exact duplicate archive/merge in same category/scope/visibility/project/owner with compatible `applies_to` | Auto-apply if confidence ≥ threshold. |
-| Semantic update of body/title | Proposal unless marked safe by deterministic pre-pass. |
-| Low confidence | Proposal or skip, depending on quality. |
-| Malformed/unsafe operation | Skip and record. |
+| Protected category (`identity`, `relationship`, central list) — `create`/`update`/`merge`/`split` | Routed to an ordinary memory **proposal** for the new/corrected memory, with `curator_note.supersedes` referencing any existing memory it replaces; never auto-applied. Admin rejects, or accepts and then archives the superseded memory. |
+| Protected category — pure `archive` (deletion, no replacement) | **skip + audit** — no replacement memory exists to propose; recorded as a recommendation for manual admin action. |
+| Non-protected operation, confidence ≥ threshold, permitted by current `default_auto_apply` level | **Auto-apply** via normal store methods. |
+| Non-protected operation, below threshold or above current `default_auto_apply` level | **Skip + audit** (recorded as a suggestion; not turned into a proposal). |
+| Malformed/unsafe operation | **Skip + record.** |
 
-Auto-applied operations must still use normal store methods:
+The `default_auto_apply` level (admin/config) sets how much non-protected discretion the curator exercises:
 
-- archive via existing memory archive/update pathway;
-- create via existing memory creation/proposal pathway;
-- update via existing memory update pathway;
-- merge/split as create/update/archive sequences with operation ids recorded.
+- `off` — apply nothing; record every suggested operation as audit-only. Pure observation.
+- `safe_only` (v1 default) — auto-apply only high-confidence **safe** operations: exact-duplicate archive/merge (same category/scope/visibility/project/owner, compatible `applies_to`) and strong-evidence `create`. Skip + audit everything else (semantic updates, fuzzy merges, splits).
+- `high_confidence` — auto-apply **any** non-protected operation at/above the confidence threshold, including `update`/`merge`/`split`. Below threshold → skip + audit.
 
-Do not bypass the store with raw SQL updates for memory mutations.
+Auto-applied operations must still use normal store methods — archive via the memory archive pathway, create via the memory creation pathway, update via the memory update pathway, merge/split as create+archive sequences with operation ids recorded. **Never** bypass the store with raw SQL for memory mutations.
 
-### 11.1 Review/proposal model
+For non-protected `merge`/`split`/`update`, the superseded source memories are archived **as part of the same operation** — there is never a window where the old and new memories are both active. The keep-old-until-the-admin-acts two-step is unique to **protected** proposals (where the curator may not archive the original itself).
 
-There is no dedicated curation review queue in v1. The apply policy has three outcomes:
+### 11.1 No curation review queue
 
-- safe operations are applied automatically through normal store methods;
-- review-worthy `create` operations become ordinary memory proposals, using the existing proposal lifecycle;
-- operations that require a bespoke curation UI or manual approval workflow are skipped or recorded as internal audit records, not exposed as a new user-facing queue.
+There is no dedicated curation review queue in v1. Outcomes are exactly three:
 
-If a future design adds a review queue, it must be specified separately. Do not smuggle one in as a dedicated dashboard surface for v1.
+- **auto-apply** — non-protected operations the curator is confident enough to make directly;
+- **proposal** — every protected `create`/`update`/`merge`/`split`, expressed through the *existing* memory-proposal lifecycle as a new/corrected memory carrying `curator_note.supersedes`. The admin rejects it, or accepts it and then archives the referenced memory. No bespoke curation approval surface is introduced — this is the same proposal queue the rest of the memory system uses;
+- **skip + audit** — non-protected ops below the apply bar, and protected pure-deletions, recorded in the curation tables and visible only in the admin observability view.
 
-Proposed memories included as evidence need their own lifecycle handling. A curator may suggest that an existing proposal is duplicate or stale, but it must not approve, reject, supersede, or merge an existing proposal unless the apply code explicitly supports that state transition through the normal proposal store methods.
+A non-protected operation never becomes a proposal — if the curator isn't confident enough to apply it, it is logged, not queued. If a future design wants a richer review queue (e.g. one-click apply for skipped suggestions, or auto-archive of the superseded memory on accept), it must be specified separately; do not smuggle one in for v1.
 
-Agent-private runs must enforce ownership from the run slice. `MemoryInput` does not carry ownership by itself; apply methods must pass the run’s `agent_id` and reject any operation that attempts to create/update another agent’s private memory.
+Proposed memories included as evidence need their own lifecycle handling. A curator may *suggest* that an existing proposal is duplicate or stale, but it must not approve, reject, supersede, or merge an existing proposal unless the apply code explicitly supports that transition through the normal proposal store methods.
+
+Agent-private runs must enforce ownership from the run slice. `MemoryInput` does not carry ownership by itself; apply methods must pass the run's `agent_id` and reject any operation that attempts to create/update another agent's private memory.
 
 ---
 
-## 12. Internal trigger contract
+## 12. Trigger contract
 
-There is deliberately no Memory Curator CLI, slash command, MCP tool, or dashboard trigger.
+There is deliberately no Memory Curator MCP tool, slash command, or consumer CLI. The only human trigger is the **admin run-now** control in the dashboard; everything else is internal.
 
-Curation is started by internal code paths only. Suggested entrypoints:
+Curation is started through a single set of internal entrypoints. The admin run-now endpoint and the scheduler both call the *same* enqueue path — run-now must not reimplement curation logic:
 
 ```ts
 scheduleMemoryCurationTick(now: Date): Promise<void>
-enqueueDueMemoryCurationRuns(reason: "schedule" | "threshold" | "maintenance"): Promise<void>
+enqueueDueMemoryCurationRuns(reason: "schedule" | "manual" | "maintenance"): Promise<void>
 runMemoryCurationWorker(): Promise<void>
 ```
 
-These functions are imported by the trusted Librarian server/worker runtime and by tests. They are not wrapped as user-facing commands.
+These functions are imported by the trusted Librarian server/worker runtime, the admin API, and tests. They are not wrapped as consumer-facing commands.
 
 Allowed trigger values:
 
 | Trigger | Source | Notes |
 |---|---|---|
-| `schedule` | Internal scheduler tick | Normal background hygiene. |
-| `threshold` | Internal evidence-count check | Runs when enough stored sessions or memory writes have accumulated. |
-| `maintenance` | Trusted deployment/bootstrap/test path | For bounded internal maintenance only; not exposed as a manual operator command. |
+| `schedule` | Internal scheduler tick at the admin-configured interval/time (default every 1 day at 03:00) | The only unattended trigger. Self-gates on `min_sessions_since_run` / `max_days_since_run`. |
+| `manual` | Admin run-now (authenticated dashboard action) | Trusted admin only. May bypass the input-hash skip (§10.2). Never reachable by a consumer agent or ordinary user. |
+| `maintenance` | Trusted deployment/bootstrap/test path | For bounded internal maintenance only; not exposed as a consumer command. |
 
-The implementation should keep all curation controls behind module boundaries and config, not behind public request handlers.
+There is deliberately **no evidence/threshold trigger** in v1. Curation must not be startable by agent activity, directly or indirectly — only the clock (`schedule`), a trusted admin (`manual`), or trusted internal code (`maintenance`) may begin a run.
+
+The implementation should keep all curation controls behind module boundaries, config, and admin authorisation — never behind a consumer-reachable request handler.
 
 ---
 
-## 13. Review and observability
+## 13. Observability (admin)
 
-Do not build a dedicated Memory Curator dashboard in v1.
+v1 ships a **read-only admin observability view** in the dashboard, backed by the `memory_curation_runs` / `memory_curation_operations` tables. It is admin-only and shows, per run:
 
-Curation should be observable internally through logs, database records, and tests. If a curation result needs human review, it should appear through existing memory proposal/review mechanisms as an ordinary proposal, not as a curation-control UI.
-
-Minimum internal audit data:
-
-- run status, slice, trigger, date;
+- timestamp, trigger (`schedule` | `manual` | `maintenance`), slice, status;
+- **counts by action**: archived, merged, split, synthesised (`create`), proposed, skipped, failed;
 - run summary and token usage;
-- operations grouped by status/type/risk;
-- memory ids created/updated/archived;
-- skipped/failed operations with reasons.
+- the operation list with type, status, risk, and rationale (so an admin can see *why* something was done or skipped);
+- memory ids created/updated/archived.
 
-Use internal tooling conventions if these records are later exposed in a read-only audit view. Do not include a “run now”, “force”, “replay”, or curation-control action in v1.
+This view is the MVP observability requirement: an admin can open it and see, at a glance, when curation last ran and what it did. It is **read-only** apart from the explicit **run-now** control (§5, §12); there is no "force", "replay", "edit operation", or "approve curation op" action in v1. Curation results that need human action surface only as ordinary memory proposals (protected categories) — never as a bespoke curation approval queue.
+
+Curation must also remain observable through ordinary logs and database records for non-dashboard contexts (CI, debugging).
 
 ---
 
@@ -432,8 +504,7 @@ Use internal tooling conventions if these records are later exposed in a read-on
 Preferred v1 deployment:
 
 - start a single internal scheduler/worker from The Librarian server process, or from a trusted worker process in the same deployment;
-- scheduler decides which slices are due based on config and last completed runs;
-- threshold checks enqueue due slices from inside normal memory/session write paths or a periodic background scan;
+- the scheduler fires at the admin-configured interval and time (default every 1 day at 03:00) and decides which slices are due based on config and last completed runs;
 - worker executes queued runs behind database locks.
 
 The scheduler must be safe if started in more than one process. Locking and input-hash idempotency are required.
@@ -444,36 +515,52 @@ The scheduler must be safe if started in more than one process. Locking and inpu
 
 ### Unit tests
 
+- the scheduler computes the next run from interval_days + time_of_day; default is every 1 day at 03:00; a due interval with too few new sessions still self-gates;
 - slice selection respects project, visibility, and agent boundaries;
 - evidence gathering excludes off-slice data;
 - evidence gathering redacts secret-looking values before prompt construction;
-- archived tombstones are included only in capped metadata form;
+- archived tombstones are included only as metadata + content fingerprint, never full body;
 - deterministic pre-pass detects exact duplicates;
+- pre-pass blocks a candidate whose fingerprint/normalized title matches a tombstone (resurrection prevention);
 - output parser rejects malformed operations;
-- risk classifier routes protected categories to proposals;
+- protected `create`/`update`/`merge`/`split` route to proposals with `curator_note.supersedes` set; protected pure-`archive` is skipped + audited;
+- non-protected ops are never turned into proposals (apply or skip + audit only);
+- `default_auto_apply` levels gate correctly: `off` applies nothing, `safe_only` applies only safe ops, `high_confidence` applies any non-protected op ≥ threshold;
 - apply policy never crosses visibility/project boundaries;
 - agent-private apply paths enforce the run owner `agent_id`;
-- idempotency skips identical completed input hash;
+- the prompt addendum is length-bounded, redacted, and cannot cause a boundary-crossing/protected/secret op to be applied;
+- the input hash changes when the addendum changes;
+- idempotency skips identical completed input hash; `manual`/`maintenance` may bypass the skip;
 - dry-runs do not cause later apply-mode runs to skip;
-- lock prevents concurrent same-slice runs.
+- lock prevents concurrent same-slice runs;
 - stale lock TTL allows crash recovery.
 
 ### Integration tests
 
 - seeded SQLite run deduplicates two ordinary project memories;
-- session decision creates/proposes a new project memory;
+- strong-evidence session decision auto-creates a non-protected project memory under `safe_only`;
 - protected identity candidate becomes a proposal;
+- protected `update`/`merge` of an existing memory becomes a proposal whose `curator_note.supersedes` references the old memory id (the old memory stays active until the admin archives it);
+- protected pure-`archive` produces a skip + audit record and no proposal;
 - exact duplicate archive is auto-applied under `safe_only`;
-- low-confidence semantic update is proposed, not applied;
+- low-confidence non-protected update is skipped + audited (neither applied nor proposed);
+- under `high_confidence`, a confident non-protected split is applied; under `safe_only` the same split is skipped + audited;
+- a candidate matching an archived tombstone is suppressed (no resurrection);
+- admin run-now enqueues a run recorded with trigger `manual`;
+- the observability view reports correct action counts (archived/merged/split/synthesised/proposed/skipped/failed) for a seeded run;
 - dry-run records no memory mutations;
 - existing proposed-memory duplicates can be rejected/superseded without treating them as active memories;
+- agent-private slice is curated and its operations never touch another agent's slice;
 - no MCP curation-management tool appears in `tools/list`.
 
 ### Regression tests for earlier contradictions
 
 - private/off-record data is not represented as a stored session in test fixtures;
 - `agent_private` evidence never creates `common` output;
-- no MCP tool, slash command, CLI command, dashboard trigger, or prompt-triggered path can start a curation run.
+- no MCP tool, slash command, consumer CLI, non-admin dashboard control, or prompt-triggered path can start a curation run;
+- the run-now endpoint rejects unauthenticated/non-admin callers;
+- no evidence/threshold or memory/session write-path hook can enqueue or start a run;
+- curation does not run when disabled, nor when the admin LLM config (provider/endpoint/token/model) is incomplete.
 
 ---
 
@@ -481,28 +568,36 @@ The scheduler must be safe if started in more than one process. Locking and inpu
 
 v1 is complete when:
 
-- [ ] due curation runs automatically from internal scheduler/worker code;
-- [ ] threshold-triggered curation can enqueue due slices without user or agent involvement;
-- [ ] no user-facing or agent-facing control can start, force, replay, or inspect curation as a feature-specific command;
-- [ ] every run and operation is auditable internally;
+- [ ] due curation runs automatically from the scheduled internal scheduler/worker tick (admin-configurable interval/time, default every 1 day at 03:00);
+- [ ] curation is disabled by default and only runs when an admin has enabled it with a complete provider/endpoint/token/model configuration;
+- [ ] no agent activity can start a curation run, directly or indirectly (no evidence/threshold trigger exists);
+- [ ] no consumer-agent MCP, slash command, CLI, or prompt path can start, force, or inspect curation;
+- [ ] an authenticated admin can trigger a run (run-now), set the schedule, configure the model, edit the prompt addendum, and view run history with action counts;
+- [ ] the prompt addendum steers suggestions but cannot bypass boundary/protected/secret guards;
+- [ ] every run and operation is auditable internally and visible in the admin observability view;
 - [ ] duplicate memories can be safely merged/archived;
-- [ ] conflated memories can be proposed as splits;
-- [ ] durable facts from stored session evidence can become memory proposals or safe ordinary memories;
-- [ ] protected categories always route to proposals;
-- [ ] curation is slice-local by default;
+- [ ] conflated memories can be split (auto-applied at `high_confidence`, else recorded as audit-only);
+- [ ] durable facts from stored session evidence become ordinary memories (non-protected) or proposals (protected);
+- [ ] protected corrections (`create`/`update`/`merge`/`split`) become proposals carrying `curator_note.supersedes`; protected pure-deletions are skip + audit;
+- [ ] the memory record has a `curator_note` field and the dashboard renders the superseded reference on a proposal;
+- [ ] archived memories are not resurrected (tombstone fingerprint check);
+- [ ] curation is slice-local; agent-private slices are curated in isolation;
 - [ ] repeated runs on unchanged evidence are idempotent;
-- [ ] no consumer-agent MCP or slash command surface exists for memory curation;
-- [ ] No session storage changes are required.
+- [ ] the only memory-store schema change is the `curator_note` column; no session storage changes are required.
 
 ---
 
 ## 17. Open questions before implementation
 
-1. Should the first production run be dry-run/proposal-only by default?
-2. Which model should be configured for v1?
-3. Should `agent_private` slices be disabled entirely at first?
-4. How much archived-memory tombstone detail is enough to prevent resurrection?
-5. Which operation types can be represented as ordinary memory proposals, and which should remain internal audit-only until a later design?
+All resolved in the 2026-05-23 claude-code re-review with Jim:
+
+- ~~First production run dry-run/proposal-only by default?~~ → No; v1 ships `default_auto_apply: safe_only`.
+- ~~Which model for v1?~~ → No hardcoded model. Provider/endpoint/token/model are configured per-deployment in the admin dashboard; curation is disabled until a complete config is supplied.
+- ~~Disable `agent_private` slices at first?~~ → No; agent-private slices are curated in v1, each scoped to one `agent_id` in isolation.
+- ~~How much tombstone detail to prevent resurrection?~~ → Metadata + normalized content fingerprint (no full body); pre-pass blocks fingerprint/title matches. Semantic/paraphrase detection is v2.
+- ~~Which op types are proposals vs audit-only?~~ → Keep existing governance: only protected categories (identity/relationship) become proposals; all non-protected ops are the curator's discretion (apply or skip + audit), never proposals. Protected corrections (`create`/`update`/`merge`/`split`) are expressed as proposals carrying a `curator_note.supersedes` reference (new memory field) so the admin can accept-then-clean-up or reject; protected pure-deletions remain skip + audit.
+
+No open questions remain blocking implementation.
 
 ---
 


### PR DESCRIPTION
## Summary

Re-reviews all three Librarian specs for completeness, simplicity, and usability, and adds an implementation plan sequencing them. All four anchoring objectives were verified intact: lean MCP (zero new verbs), curation internal-only, Pi/Codex first-class, agent-first simplicity.

### `memory-curator-spec.md`
- Admin cockpit: enable/disable, configurable **"every N days at HH:MM"** schedule (default 03:00), LLM config, advisory prompt addendum, observability, run-now. No MCP verbs.
- Protected categories → **proposals** carrying `curator_note.supersedes`; non-protected merge/split/update archive superseded sources **atomically**.
- Fingerprint tombstones; `agent_private` curated per-agent; `safe_only` default.

### `harness-commands-and-lifecycle-spec.md`
- Private mode now **ends the active session** with a neutral reason (no more dormant session); single **`/lib:toggle-private`** command.
- Capability-verified tiering: **Codex & Pi promoted to first-class** (real `UserPromptSubmit` / `input` pre-prompt gates); **OpenCode** scoped to a plugin spike (no pre-prompt hook).
- New **§7.6 marketplace distribution**; every package bundles the `use-the-librarian` skill.

### `agent-naming-contract-spec.md`
- All 5 open questions resolved: `claude-code` kept distinct, single **`actor_id`** term, `dashboard-admin` now, **condition-based** hard enforcement, `cli` manual-only.
- Cross-spec fixes: Bede legacy-alias correction, private-mode wording aligned, `attach_session` added.

### `implementation-plan.md` (new)
Sequence: **naming(core) → curator → harness → naming(enforce)** — the naming contract brackets the two features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)