### PR TITLE
feat(core): caller-identity resolver (naming contract Stage 1.2)

### DIFF
--- a/AUTONOMOUS-BUILD-NOTES-26-05-23.md
+++ b/AUTONOMOUS-BUILD-NOTES-26-05-23.md
@@ -1,0 +1,54 @@
+# Autonomous Build Notes — 2026-05-23
+
+**Task:** Implement `docs/specs/implementation-plan.md` (autonomous mode).
+**Branch:** `feat/naming-contract-foundation`
+**Driver:** Guybrush (claude-code, autonomous build)
+
+---
+
+## Scope decision for this run
+
+The implementation plan spans **four stages** (naming foundation → curator → harness
+integrations across 5 harnesses → naming hard-enforcement) — realistically weeks of work
+and far more than one safe, reviewable PR.
+
+Per the plan's own sequencing principle ("the naming contract … *brackets* them. Its
+foundation must land first"), this run delivers **Stage 1, Workstream 1.2 — the resolver
+core**: the pure, fully-tested, zero-regression-risk foundation that unblocks everything
+else. It adds new code in `@librarian/core` and wires nothing yet, so no existing
+behaviour changes.
+
+### Delivered this run
+
+- `normaliseCallerId(raw)` — §4.2 normalisation algorithm.
+- Alias resolution with loop/recursion rejection — §4.4.
+- Reserved-namespace constants + enforcement (`system-*`, `dashboard-*`, `cli`) — §4.4.
+- System actor ids — §6.
+- `resolveCaller(input): ResolvedCaller` — §7.1 (precedence, normalise, alias, validate).
+- Full unit-test coverage per §11 (unit-test list).
+
+### Deferred to follow-up increments (with rationale)
+
+These were intentionally **not** done in this PR to keep it focused and low-risk:
+
+1. **Workstream 1.1 — Baseline audit script.** Read-only dry-run over existing stored ids.
+   Easy follow-up; uses the resolver shipped here.
+2. **Workstream 1.3 — Store attribution.** Persisting canonical ids + `actor_kind`
+   column. Touches the store schema/projection; deserves its own migration-aware PR.
+3. **Workstream 1.4 — Surface wiring (soft mode).** MCP `scopeAgentArgs`
+   (`packages/mcp-server/src/mcp/visibility.ts:25` currently pins `agent_id` from auth
+   context), CLI `--agent`/`LIBRARIAN_AGENT_ID`, dashboard dropdowns. This rewires the
+   live identity path and several integration tests assert the current `unknown-agent`
+   behaviour — higher risk, wants a dedicated PR + soft-warning rollout.
+4. **Stages 2–4** (curator, harness integrations, hard enforcement) — sequenced after
+   Stage 1 lands per the plan.
+
+---
+
+## Points for Jim to consider
+
+_(populated as the build proceeds)_
+
+- [ ] **Two `DEFAULT_AGENT_ID` definitions.** `unknown-agent` is declared in *both*
+  `packages/core/src/constants.ts` and `packages/core/src/schemas/common.ts:173`
+  (same value, exported via different paths). Pre-existing; harmless but worth de-duping.

--- a/AUTONOMOUS-BUILD-NOTES-26-05-23.md
+++ b/AUTONOMOUS-BUILD-NOTES-26-05-23.md
@@ -45,10 +45,34 @@ These were intentionally **not** done in this PR to keep it focused and low-risk
 
 ---
 
+## Code review outcome
+
+A `code-reviewer` sub-agent reviewed the resolver across all five axes and probed 11+
+escalation/bypass vectors against the security boundary. Verdict: **ship-with-fixes** —
+**zero Critical, zero Important**; all findings Suggestion-tier. Confirmed: agent→reserved
+escalation is blocked via raw input, alias target, allowlist, and token-bound paths;
+token-binding can't be bypassed (injected mismatch rejected too); no ReDoS in the
+normalisation regexes (all linear).
+
+Suggestions actioned this run:
+
+- Added a cheap pre-normalisation length guard (`MAX_RAW_LENGTH = 1024`) so megabyte-scale
+  input is rejected before the Unicode/regex passes — matters once this is wired to the
+  attacker-facing MCP/CLI boundary.
+- Clarified the alias single-hop/chain-rejection comment.
+- Added tests: injected-vs-token mismatch, invalid token-bound id, raw-length guard,
+  `isReservedId` coverage, `dashboard-*` (non-`dashboard-admin`) classification. (150 tests.)
+
 ## Points for Jim to consider
 
-_(populated as the build proceeds)_
-
+- [ ] **`ResolvedCaller.alias_applied` semantics.** The spec (§7.1) only declares the field;
+  this implementation defines it as *the pre-alias normalised id* (set only when an alias
+  actually fired). When Workstream 1.3 persists it to the audit trail, confirm the store
+  consumer agrees on that meaning (pre-alias source vs. the literal alias key).
+- [ ] **`cli` reserved-id role gating.** The spec's role enum is `agent|admin|system` (no
+  `cli` role), but `cli` is a reserved id. I gated it as "not usable by `role: "agent"`"
+  (so admin/system/local-operator paths may use it). Confirm that matches your intent for
+  §7.3 manual CLI calls, or whether `cli` should get a first-class role.
 - [ ] **Two `DEFAULT_AGENT_ID` definitions.** `unknown-agent` is declared in *both*
   `packages/core/src/constants.ts` and `packages/core/src/schemas/common.ts:173`
   (same value, exported via different paths). Pre-existing; harmless but worth de-duping.

--- a/packages/core/src/caller-identity.ts
+++ b/packages/core/src/caller-identity.ts
@@ -1,0 +1,223 @@
+// Agent naming & caller-identity contract.
+//
+// Implements docs/specs/agent-naming-contract-spec.md: tokens authenticate,
+// names identify. Every identity-bearing call resolves to one canonical actor
+// id via `resolveCaller`, which normalises the supplied name (§4.2), applies
+// configured aliases (§4.4), enforces reserved namespaces (§4.4/§6), and
+// validates token binding / allowlists (§5.3).
+//
+// This module is pure: no I/O, no store access. The MCP / CLI / dashboard /
+// scheduler layers call `resolveCaller` once at their trust boundary and pass
+// the resulting `actor_id` down to the store.
+
+import { DEFAULT_AGENT_ID } from "./constants.js";
+
+const MAX_ID_LENGTH = 64;
+
+/** Caller roles recognised at the trust boundary. */
+export type CallerRole = "agent" | "admin" | "system";
+
+/**
+ * Persisted kind of an actor. Broader than {@link CallerRole}: `cli` is a
+ * distinct kind (a trusted local operator) even though it has no own role.
+ */
+export type ActorKind = "agent" | "admin" | "system" | "cli";
+
+/** Canonical ids for non-human system actors (§6). */
+export const SYSTEM_ACTOR_IDS = {
+  memoryCurator: "system-memory-curator",
+  scheduler: "system-scheduler",
+  migration: "system-migration",
+  dashboardAdmin: "dashboard-admin",
+  cli: "cli",
+} as const;
+
+const SYSTEM_PREFIX = "system-";
+const DASHBOARD_PREFIX = "dashboard-";
+const CLI_ACTOR_ID = "cli";
+
+/** A configured semantic alias map: normalised id → canonical id (§4.4). */
+export type CallerAliasMap = Readonly<Record<string, string>>;
+
+export interface ResolveCallerInput {
+  /** Untrusted, model/request-body supplied id. Lowest trust. */
+  rawAgentId?: string;
+  /** Id bound to the bearer token, when the token maps to one agent. */
+  authenticatedAgentId?: string;
+  /** Id injected by a trusted wrapper/transport. Highest trust. */
+  injectedAgentId?: string;
+  role: CallerRole;
+  /** Optional allowlist scoping which ids this token may act as. */
+  allowedAgentIds?: string[];
+  /** Configured semantic aliases (§4.4). */
+  aliases?: CallerAliasMap;
+  /**
+   * Soft-migration escape hatch: when no identity is supplied, resolve to the
+   * legacy `unknown-agent` sentinel instead of throwing. Off by default so new
+   * (hard-mode) calls fail loudly.
+   */
+  allowMissingDuringMigration?: boolean;
+}
+
+export interface ResolvedCaller {
+  actor_id: string;
+  raw_id?: string;
+  injected_id?: string;
+  authenticated_id?: string;
+  role: CallerRole;
+  /** The pre-alias normalised id, set only when an alias actually fired. */
+  alias_applied?: string;
+}
+
+/**
+ * Collapse a free-form caller name to the canonical syntax
+ * `^[a-z0-9]+(-[a-z0-9]+)*$` (§4.2). Punctuation and whitespace become
+ * separators rather than being deleted, so `Claude Code`, `claude.code`, and
+ * `claude_code` all collapse to `claude-code`. Throws on empty/overlong output.
+ */
+export function normaliseCallerId(raw: string): string {
+  const value = raw
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "") // drop combining marks
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+
+  if (!value) throw new Error("agent_id normalises to an empty value");
+  if (value.length > MAX_ID_LENGTH) {
+    throw new Error(`agent_id is too long after normalisation (>${MAX_ID_LENGTH} chars)`);
+  }
+  return value;
+}
+
+/** Whether an id sits in a reserved namespace (`system-*`, `dashboard-*`, `cli`). */
+export function isReservedId(id: string): boolean {
+  return id.startsWith(SYSTEM_PREFIX) || id.startsWith(DASHBOARD_PREFIX) || id === CLI_ACTOR_ID;
+}
+
+/** Classify a canonical id into its persisted {@link ActorKind} (§6). */
+export function actorKind(id: string): ActorKind {
+  if (id.startsWith(SYSTEM_PREFIX)) return "system";
+  if (id.startsWith(DASHBOARD_PREFIX)) return "admin";
+  if (id === CLI_ACTOR_ID) return "cli";
+  return "agent";
+}
+
+interface AliasResult {
+  id: string;
+  /** The input id, set only when it differed from the alias target. */
+  appliedFrom?: string;
+}
+
+/**
+ * Resolve a single alias hop (§4.4). Alias targets must themselves be valid
+ * canonical ids, and chains/loops are rejected rather than followed recursively.
+ */
+function applyAlias(id: string, aliases: CallerAliasMap): AliasResult {
+  const target = aliases[id];
+  if (target === undefined) return { id };
+
+  const canonicalTarget = normaliseCallerId(target);
+  if (canonicalTarget === id) return { id }; // self-alias is a harmless no-op
+  if (aliases[canonicalTarget] !== undefined) {
+    throw new Error(
+      `alias chain not allowed: ${id} -> ${canonicalTarget} -> ... (flatten the alias map)`,
+    );
+  }
+  return { id: canonicalTarget, appliedFrom: id };
+}
+
+/** Reject reserved ids that the caller's role is not entitled to (§4.4/§6). */
+function assertRoleMayUseId(id: string, role: CallerRole): void {
+  if (id.startsWith(SYSTEM_PREFIX)) {
+    if (role !== "system") {
+      throw new Error(`reserved id "${id}" is only valid for system actors`);
+    }
+    return;
+  }
+  if (id.startsWith(DASHBOARD_PREFIX)) {
+    if (role !== "admin") {
+      throw new Error(`reserved id "${id}" is only valid for dashboard/admin actors`);
+    }
+    return;
+  }
+  if (id === CLI_ACTOR_ID && role === "agent") {
+    throw new Error(`reserved id "${CLI_ACTOR_ID}" is not valid for ordinary agents`);
+  }
+}
+
+/** A non-empty string is "supplied"; `undefined` and blank strings are not. */
+function hasValue(value: string | undefined): value is string {
+  return value !== undefined && value.trim() !== "";
+}
+
+function firstSupplied(...values: (string | undefined)[]): string | undefined {
+  return values.find(hasValue);
+}
+
+/** Normalise then alias a raw id to its final canonical form (§4.2 + §4.4). */
+function toCanonicalId(raw: string, aliases: CallerAliasMap): string {
+  return applyAlias(normaliseCallerId(raw), aliases).id;
+}
+
+/**
+ * Resolve a canonical caller from the available identity sources (§7.1).
+ *
+ * Precedence: a trusted injected id beats an untrusted request-body id, which
+ * beats the token-bound id. The chosen id is normalised, aliased, checked
+ * against any token binding / allowlist, and gated against reserved namespaces.
+ * With no id at all this throws — unless `allowMissingDuringMigration` is set,
+ * in which case it falls back to the legacy `unknown-agent` sentinel.
+ */
+export function resolveCaller(input: ResolveCallerInput): ResolvedCaller {
+  const aliases = input.aliases ?? {};
+  const candidate = firstSupplied(
+    input.injectedAgentId,
+    input.rawAgentId,
+    input.authenticatedAgentId,
+  );
+
+  if (candidate === undefined) {
+    if (input.allowMissingDuringMigration) {
+      return { actor_id: DEFAULT_AGENT_ID, role: input.role };
+    }
+    throw new Error("caller identity is required (no injected, request, or token-bound id)");
+  }
+
+  const aliased = applyAlias(normaliseCallerId(candidate), aliases);
+  const actorId = aliased.id;
+
+  // Token binding: a token mapped to a specific agent may only act as that
+  // agent (compared after normalisation + aliasing) — §5.3.
+  if (hasValue(input.authenticatedAgentId)) {
+    const boundId = toCanonicalId(input.authenticatedAgentId, aliases);
+    if (actorId !== boundId) {
+      throw new Error(
+        `caller id "${actorId}" does not match token-bound id "${boundId}" (possible impersonation)`,
+      );
+    }
+  }
+
+  // Token allowlist: this token may only act as one of the listed ids — §5.3.
+  if (input.allowedAgentIds && input.allowedAgentIds.length > 0) {
+    const allowed = new Set(input.allowedAgentIds.map((id) => toCanonicalId(id, aliases)));
+    if (!allowed.has(actorId)) {
+      throw new Error(`caller id "${actorId}" is not in the token allowlist`);
+    }
+  }
+
+  assertRoleMayUseId(actorId, input.role);
+
+  // Build conditionally: under `exactOptionalPropertyTypes` an optional field
+  // must be omitted rather than set to `undefined`.
+  const resolved: ResolvedCaller = { actor_id: actorId, role: input.role };
+  if (input.rawAgentId !== undefined) resolved.raw_id = input.rawAgentId;
+  if (input.injectedAgentId !== undefined) resolved.injected_id = input.injectedAgentId;
+  if (input.authenticatedAgentId !== undefined) {
+    resolved.authenticated_id = input.authenticatedAgentId;
+  }
+  if (aliased.appliedFrom !== undefined) resolved.alias_applied = aliased.appliedFrom;
+  return resolved;
+}

--- a/packages/core/src/caller-identity.ts
+++ b/packages/core/src/caller-identity.ts
@@ -13,6 +13,9 @@
 import { DEFAULT_AGENT_ID } from "./constants.js";
 
 const MAX_ID_LENGTH = 64;
+// Generous slack over MAX_ID_LENGTH: lets legitimately punctuation-heavy raw
+// names through to normalisation while rejecting megabyte-scale junk up front.
+const MAX_RAW_LENGTH = 1024;
 
 /** Caller roles recognised at the trust boundary. */
 export type CallerRole = "agent" | "admin" | "system";
@@ -76,6 +79,12 @@ export interface ResolvedCaller {
  * `claude_code` all collapse to `claude-code`. Throws on empty/overlong output.
  */
 export function normaliseCallerId(raw: string): string {
+  // Reject absurd input cheaply, before the Unicode/regex passes touch it —
+  // the canonical max is 64, so anything past a generous slack is never valid.
+  if (raw.length > MAX_RAW_LENGTH) {
+    throw new Error(`agent_id is too long (>${MAX_RAW_LENGTH} chars before normalisation)`);
+  }
+
   const value = raw
     .normalize("NFKD")
     .replace(/[\u0300-\u036f]/g, "") // drop combining marks
@@ -120,7 +129,10 @@ function applyAlias(id: string, aliases: CallerAliasMap): AliasResult {
   if (target === undefined) return { id };
 
   const canonicalTarget = normaliseCallerId(target);
-  if (canonicalTarget === id) return { id }; // self-alias is a harmless no-op
+  if (canonicalTarget === id) return { id }; // direct self-alias is a harmless no-op
+  // Reject any target that is itself an alias key — this is the single-hop rule
+  // that forbids chains (a→b→c) and loops (a→b→a), and also a second-hop
+  // self-alias (a→b, b→b). We flatten by rejecting, never by recursing (§4.4).
   if (aliases[canonicalTarget] !== undefined) {
     throw new Error(
       `alias chain not allowed: ${id} -> ${canonicalTarget} -> ... (flatten the alias map)`,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,17 @@
 export * from "./constants.js";
 export {
+  type ActorKind,
+  type CallerAliasMap,
+  type CallerRole,
+  type ResolveCallerInput,
+  type ResolvedCaller,
+  SYSTEM_ACTOR_IDS,
+  actorKind,
+  isReservedId,
+  normaliseCallerId,
+  resolveCaller,
+} from "./caller-identity.js";
+export {
   formatRecall,
   renderHandover,
   renderHandoverMarkdown,

--- a/packages/core/tests/caller-identity.test.ts
+++ b/packages/core/tests/caller-identity.test.ts
@@ -1,0 +1,264 @@
+// Agent naming & caller-identity contract — unit coverage.
+//
+// Pins the load-bearing semantics from
+// docs/specs/agent-naming-contract-spec.md:
+//   - normaliseCallerId (§4.2 / §4.3 example table)
+//   - alias resolution after normalisation, with loop/chain rejection (§4.4)
+//   - reserved namespaces system-* / dashboard-* / cli + role gating (§4.4, §6)
+//   - resolveCaller precedence, token-binding mismatch, allowlist, soft mode (§5.3, §7.1)
+//
+// Test list mirrors the spec §11 "Unit tests" bullet points.
+
+import {
+  DEFAULT_AGENT_ID,
+  SYSTEM_ACTOR_IDS,
+  actorKind,
+  normaliseCallerId,
+  resolveCaller,
+} from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+describe("normaliseCallerId (§4.2/§4.3)", () => {
+  it("lowercases and trims", () => {
+    expect(normaliseCallerId("Guybrush")).toBe("guybrush");
+    expect(normaliseCallerId(" guybrush ")).toBe("guybrush");
+    expect(normaliseCallerId("GUYBRUSH")).toBe("guybrush");
+  });
+
+  it("turns punctuation and whitespace into single hyphens", () => {
+    expect(normaliseCallerId("Claude Code")).toBe("claude-code");
+    expect(normaliseCallerId("claude.code")).toBe("claude-code");
+    expect(normaliseCallerId("codex_v2")).toBe("codex-v2");
+    expect(normaliseCallerId("Guybrush (Hermes)")).toBe("guybrush-hermes");
+  });
+
+  it("collapses repeated separators into one hyphen", () => {
+    expect(normaliseCallerId("a   b")).toBe("a-b");
+    expect(normaliseCallerId("a---b")).toBe("a-b");
+    expect(normaliseCallerId("a..__..b")).toBe("a-b");
+  });
+
+  it("strips leading and trailing hyphens", () => {
+    expect(normaliseCallerId("-guybrush-")).toBe("guybrush");
+    expect(normaliseCallerId("!!!guybrush!!!")).toBe("guybrush");
+  });
+
+  it("drops combining marks via NFKD", () => {
+    expect(normaliseCallerId("café")).toBe("cafe");
+  });
+
+  it("rejects input that normalises to empty", () => {
+    expect(() => normaliseCallerId("!!!")).toThrow();
+    expect(() => normaliseCallerId("   ")).toThrow();
+    expect(() => normaliseCallerId("")).toThrow();
+  });
+
+  it("rejects ids longer than 64 chars after normalisation", () => {
+    expect(() => normaliseCallerId("a".repeat(65))).toThrow();
+    expect(normaliseCallerId("a".repeat(64))).toBe("a".repeat(64));
+  });
+
+  it("is idempotent", () => {
+    const once = normaliseCallerId("Guybrush (Hermes)");
+    expect(normaliseCallerId(once)).toBe(once);
+  });
+});
+
+describe("resolveCaller — identity sources & precedence (§7.1)", () => {
+  it("prefers a trusted injected id over a request-body id", () => {
+    const resolved = resolveCaller({
+      role: "agent",
+      injectedAgentId: "guybrush",
+      rawAgentId: "attacker",
+    });
+    expect(resolved.actor_id).toBe("guybrush");
+    expect(resolved.raw_id).toBe("attacker");
+    expect(resolved.injected_id).toBe("guybrush");
+  });
+
+  it("uses the request-body id when no injected id is present", () => {
+    const resolved = resolveCaller({ role: "agent", rawAgentId: "Codex" });
+    expect(resolved.actor_id).toBe("codex");
+  });
+
+  it("falls back to the authenticated (token-bound) id when nothing else is supplied", () => {
+    const resolved = resolveCaller({ role: "agent", authenticatedAgentId: "guybrush" });
+    expect(resolved.actor_id).toBe("guybrush");
+  });
+
+  it("normalises whatever source it resolves", () => {
+    expect(resolveCaller({ role: "agent", rawAgentId: "Claude Code" }).actor_id).toBe(
+      "claude-code",
+    );
+  });
+});
+
+describe("resolveCaller — aliases (§4.4)", () => {
+  const aliases = { "guybrush-hermes": "guybrush", bede: "guybrush" };
+
+  it("applies aliases after normalisation", () => {
+    const resolved = resolveCaller({
+      role: "agent",
+      rawAgentId: "Guybrush (Hermes)",
+      aliases,
+    });
+    expect(resolved.actor_id).toBe("guybrush");
+    expect(resolved.alias_applied).toBe("guybrush-hermes");
+  });
+
+  it("aliases a legacy id (bede → guybrush)", () => {
+    expect(resolveCaller({ role: "agent", rawAgentId: "Bede", aliases }).actor_id).toBe("guybrush");
+  });
+
+  it("leaves non-aliased ids untouched (no alias_applied)", () => {
+    const resolved = resolveCaller({ role: "agent", rawAgentId: "codex", aliases });
+    expect(resolved.actor_id).toBe("codex");
+    expect(resolved.alias_applied).toBeUndefined();
+  });
+
+  it("rejects alias chains (no recursive resolution)", () => {
+    expect(() =>
+      resolveCaller({
+        role: "agent",
+        rawAgentId: "a",
+        aliases: { a: "b", b: "c" },
+      }),
+    ).toThrow(/chain/i);
+  });
+
+  it("rejects alias loops", () => {
+    expect(() =>
+      resolveCaller({
+        role: "agent",
+        rawAgentId: "a",
+        aliases: { a: "b", b: "a" },
+      }),
+    ).toThrow(/chain/i);
+  });
+});
+
+describe("resolveCaller — token binding & allowlist (§5.3)", () => {
+  it("accepts when supplied id matches the token-bound id", () => {
+    const resolved = resolveCaller({
+      role: "agent",
+      rawAgentId: "Guybrush",
+      authenticatedAgentId: "guybrush",
+    });
+    expect(resolved.actor_id).toBe("guybrush");
+  });
+
+  it("rejects when supplied id differs from the token-bound id (impersonation)", () => {
+    expect(() =>
+      resolveCaller({
+        role: "agent",
+        rawAgentId: "codex",
+        authenticatedAgentId: "guybrush",
+      }),
+    ).toThrow(/match|impersonat|mismatch/i);
+  });
+
+  it("compares binding after aliasing", () => {
+    const resolved = resolveCaller({
+      role: "agent",
+      rawAgentId: "Bede",
+      authenticatedAgentId: "guybrush",
+      aliases: { bede: "guybrush" },
+    });
+    expect(resolved.actor_id).toBe("guybrush");
+  });
+
+  it("rejects an id outside the token allowlist", () => {
+    expect(() =>
+      resolveCaller({
+        role: "agent",
+        rawAgentId: "codex",
+        allowedAgentIds: ["guybrush", "claude-code"],
+      }),
+    ).toThrow(/allow/i);
+  });
+
+  it("accepts an id inside the token allowlist", () => {
+    expect(
+      resolveCaller({
+        role: "agent",
+        rawAgentId: "Claude Code",
+        allowedAgentIds: ["guybrush", "claude-code"],
+      }).actor_id,
+    ).toBe("claude-code");
+  });
+});
+
+describe("resolveCaller — missing identity (§5.3, §7.1)", () => {
+  it("rejects a shared-token agent call with no supplied id (hard mode)", () => {
+    expect(() => resolveCaller({ role: "agent" })).toThrow(/identit/i);
+  });
+
+  it("rejects an admin mutation with no audit actor id (hard mode)", () => {
+    expect(() => resolveCaller({ role: "admin" })).toThrow(/identit/i);
+  });
+
+  it("falls back to the legacy sentinel in soft-migration mode", () => {
+    const resolved = resolveCaller({ role: "agent", allowMissingDuringMigration: true });
+    expect(resolved.actor_id).toBe(DEFAULT_AGENT_ID);
+  });
+
+  it("still prefers a real id over the soft-mode fallback", () => {
+    const resolved = resolveCaller({
+      role: "agent",
+      rawAgentId: "codex",
+      allowMissingDuringMigration: true,
+    });
+    expect(resolved.actor_id).toBe("codex");
+  });
+});
+
+describe("reserved namespaces & role gating (§4.4, §6)", () => {
+  it("lets a system actor use the system-* namespace", () => {
+    const resolved = resolveCaller({
+      role: "system",
+      injectedAgentId: SYSTEM_ACTOR_IDS.memoryCurator,
+    });
+    expect(resolved.actor_id).toBe("system-memory-curator");
+  });
+
+  it("blocks an ordinary agent from claiming a system-* id", () => {
+    expect(() => resolveCaller({ role: "agent", rawAgentId: "system-memory-curator" })).toThrow(
+      /reserved|system/i,
+    );
+  });
+
+  it("blocks an ordinary agent from aliasing into a reserved id", () => {
+    expect(() =>
+      resolveCaller({
+        role: "agent",
+        rawAgentId: "sneaky",
+        aliases: { sneaky: "system-scheduler" },
+      }),
+    ).toThrow(/reserved|system/i);
+  });
+
+  it("lets an admin actor use the dashboard-* namespace", () => {
+    expect(resolveCaller({ role: "admin", injectedAgentId: "dashboard-admin" }).actor_id).toBe(
+      "dashboard-admin",
+    );
+  });
+
+  it("blocks an ordinary agent from claiming a dashboard-* id", () => {
+    expect(() => resolveCaller({ role: "agent", rawAgentId: "dashboard-admin" })).toThrow(
+      /reserved|dashboard/i,
+    );
+  });
+
+  it("blocks an ordinary agent from claiming the cli id", () => {
+    expect(() => resolveCaller({ role: "agent", rawAgentId: "cli" })).toThrow(/reserved|cli/i);
+  });
+});
+
+describe("actorKind classifier (§6)", () => {
+  it("classifies by id namespace", () => {
+    expect(actorKind("guybrush")).toBe("agent");
+    expect(actorKind("system-memory-curator")).toBe("system");
+    expect(actorKind("dashboard-admin")).toBe("admin");
+    expect(actorKind("cli")).toBe("cli");
+  });
+});

--- a/packages/core/tests/caller-identity.test.ts
+++ b/packages/core/tests/caller-identity.test.ts
@@ -13,6 +13,7 @@ import {
   DEFAULT_AGENT_ID,
   SYSTEM_ACTOR_IDS,
   actorKind,
+  isReservedId,
   normaliseCallerId,
   resolveCaller,
 } from "@librarian/core";
@@ -56,6 +57,10 @@ describe("normaliseCallerId (§4.2/§4.3)", () => {
   it("rejects ids longer than 64 chars after normalisation", () => {
     expect(() => normaliseCallerId("a".repeat(65))).toThrow();
     expect(normaliseCallerId("a".repeat(64))).toBe("a".repeat(64));
+  });
+
+  it("rejects megabyte-scale raw input cheaply, before normalising", () => {
+    expect(() => normaliseCallerId("x".repeat(10_000))).toThrow(/before normalisation/i);
   });
 
   it("is idempotent", () => {
@@ -155,6 +160,23 @@ describe("resolveCaller — token binding & allowlist (§5.3)", () => {
         authenticatedAgentId: "guybrush",
       }),
     ).toThrow(/match|impersonat|mismatch/i);
+  });
+
+  it("rejects an injected id that differs from the token-bound id", () => {
+    // A compromised wrapper still can't override a bound token.
+    expect(() =>
+      resolveCaller({
+        role: "agent",
+        injectedAgentId: "codex",
+        authenticatedAgentId: "guybrush",
+      }),
+    ).toThrow(/match|impersonat|mismatch/i);
+  });
+
+  it("rejects an invalid token-bound id", () => {
+    expect(() =>
+      resolveCaller({ role: "agent", rawAgentId: "guybrush", authenticatedAgentId: "!!!" }),
+    ).toThrow();
   });
 
   it("compares binding after aliasing", () => {
@@ -260,5 +282,23 @@ describe("actorKind classifier (§6)", () => {
     expect(actorKind("system-memory-curator")).toBe("system");
     expect(actorKind("dashboard-admin")).toBe("admin");
     expect(actorKind("cli")).toBe("cli");
+  });
+
+  it("classifies any dashboard-* id as admin, not just dashboard-admin", () => {
+    expect(actorKind("dashboard-jim")).toBe("admin");
+  });
+});
+
+describe("isReservedId (§4.4)", () => {
+  it("flags every reserved namespace", () => {
+    expect(isReservedId("system-memory-curator")).toBe(true);
+    expect(isReservedId("dashboard-admin")).toBe(true);
+    expect(isReservedId("dashboard-jim")).toBe(true);
+    expect(isReservedId("cli")).toBe(true);
+  });
+
+  it("leaves ordinary agent ids unreserved", () => {
+    expect(isReservedId("guybrush")).toBe(false);
+    expect(isReservedId("claude-code")).toBe(false);
   });
 });


### PR DESCRIPTION
## What

Implements **Stage 1, Workstream 1.2** of [`docs/specs/implementation-plan.md`](docs/specs/implementation-plan.md) — the caller-identity **resolver core** from [`docs/specs/agent-naming-contract-spec.md`](docs/specs/agent-naming-contract-spec.md).

Per the plan's sequencing principle, the naming contract *brackets* the other features and its foundation must land first. This is that foundation: a pure, store-free module in `@librarian/core` that every identity-bearing surface will call at its trust boundary. **Nothing is wired yet**, so no existing behaviour changes.

## Contents

- `normaliseCallerId` — collapse free-form names to `^[a-z0-9]+(-[a-z0-9]+)*$` (§4.2/§4.3), with a cheap pre-normalisation length guard.
- Alias resolution after normalisation, with chain/loop rejection (§4.4).
- Reserved namespaces (`system-*`, `dashboard-*`, `cli`) + role gating applied to the *final* canonical id, so aliasing can't escalate into a reserved namespace (§4.4/§6).
- `SYSTEM_ACTOR_IDS` + `actorKind` / `isReservedId` helpers (§6).
- `resolveCaller` — `injected > request-body > token-bound` precedence, token-binding mismatch + allowlist checks, soft-migration fallback to `unknown-agent` (§5.3/§7.1).
- 39 unit tests mirroring the spec §11 unit-test list.

## Testing

- `pnpm test` — all packages green (core 150, mcp-server 77, cli 45, dashboard 45, root 32).
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` — clean.
- Reviewed by a code-review sub-agent across all five axes (verdict: ship; no Critical/Important; 11+ escalation/bypass vectors probed and blocked).

## Deferred (next increments, see `AUTONOMOUS-BUILD-NOTES-26-05-23.md`)

1.1 baseline audit script · 1.3 store attribution (+`actor_kind` column) · 1.4 surface wiring (MCP/CLI/dashboard, soft mode) · Stages 2–4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)