### PR TITLE
feat(mcp): resolve caller identity at the MCP boundary (naming Stage 1.4)

### DIFF
--- a/AUTONOMOUS-BUILD-NOTES-26-05-23.md
+++ b/AUTONOMOUS-BUILD-NOTES-26-05-23.md
@@ -1,8 +1,43 @@
 # Autonomous Build Notes — 2026-05-23
 
 **Task:** Implement `docs/specs/implementation-plan.md` (autonomous mode).
-**Branch:** `feat/naming-contract-foundation`
 **Driver:** Guybrush (claude-code, autonomous build)
+
+Increments shipped this day, each its own PR:
+
+1. `feat/naming-contract-foundation` — Stage 1.2 resolver core (merged, PR #70).
+2. `feat/naming-contract-mcp-wiring` — Stage 1.4 MCP soft-mode wiring (this PR).
+
+---
+
+## Increment 2 — Stage 1.4 MCP surface wiring (soft mode)
+
+Routes agent identity through `resolveCaller` at the **single MCP chokepoint**
+(`scopeAgentArgs` in `packages/mcp-server/src/mcp/visibility.ts`) — every agent-facing
+tool already funnels through it, matching the spec's "resolve once at dispatch/tool-entry"
+(§7.2). Soft-migration mode, so missing identity is unchanged.
+
+Behaviour now:
+
+- **Normalisation** — a supplied `agent_id` is canonicalised before storage
+  (`Guybrush (Hermes)` → `guybrush-hermes`).
+- **No impersonation** — a mapped token + a *conflicting* request-body `agent_id` is now
+  **rejected** (§5.3/§7.2) instead of silently overwritten. This intentionally changes the
+  old "MCP start_session refuses to honour a caller-supplied agent_id" test, which encoded
+  the silent-overwrite behaviour — it now asserts rejection (a stronger guarantee).
+- **Reserved gating** — an ordinary agent cannot claim `system-*`/`dashboard-*`/`cli`.
+- **Soft fallback** — a shared token with no id still resolves to `unknown-agent`.
+- **Admin** path unchanged (`admin: true`, no `agent_id` pinning).
+
+Also: `ResolveCallerInput`'s three id fields now explicitly accept `| undefined` so trust
+boundaries can pass optional ids without conditional-spread gymnastics under
+`exactOptionalPropertyTypes`.
+
+**Deferred from 1.4 (next increments):** alias-map application (would remap `bede →
+guybrush` and is a Phase-3 backfill concern — applying it live now changes attribution that
+several MCP tests assert literally), CLI `--agent`/`LIBRARIAN_AGENT_ID`, dashboard/tRPC
+dropdowns, and a soft-mode warning log for missing identity. Plus 1.1 audit + 1.3 store
+`actor_kind` column.
 
 ---
 

--- a/packages/core/src/caller-identity.ts
+++ b/packages/core/src/caller-identity.ts
@@ -43,12 +43,15 @@ const CLI_ACTOR_ID = "cli";
 export type CallerAliasMap = Readonly<Record<string, string>>;
 
 export interface ResolveCallerInput {
+  // The three id sources explicitly admit `undefined`: callers at trust
+  // boundaries (MCP/CLI/dashboard) routinely hold an optional id and shouldn't
+  // have to conditionally omit the key under `exactOptionalPropertyTypes`.
   /** Untrusted, model/request-body supplied id. Lowest trust. */
-  rawAgentId?: string;
+  rawAgentId?: string | undefined;
   /** Id bound to the bearer token, when the token maps to one agent. */
-  authenticatedAgentId?: string;
+  authenticatedAgentId?: string | undefined;
   /** Id injected by a trusted wrapper/transport. Highest trust. */
-  injectedAgentId?: string;
+  injectedAgentId?: string | undefined;
   role: CallerRole;
   /** Optional allowlist scoping which ids this token may act as. */
   allowedAgentIds?: string[];

--- a/packages/mcp-server/src/mcp/visibility.ts
+++ b/packages/mcp-server/src/mcp/visibility.ts
@@ -35,6 +35,10 @@ export function scopeAgentArgs(
     scoped.admin = true;
     return scoped;
   }
+  // No alias map yet — applying `bede → guybrush` etc. is a Phase-3 backfill
+  // concern and is wired in a later increment. A non-string `agent_id` is
+  // coerced to "absent" and so resolves to the soft-mode sentinel; once
+  // hard-enforcement lands, a malformed (vs. absent) id should fail loudly.
   const resolved = resolveCaller({
     role: "agent",
     rawAgentId: typeof args.agent_id === "string" ? args.agent_id : undefined,

--- a/packages/mcp-server/src/mcp/visibility.ts
+++ b/packages/mcp-server/src/mcp/visibility.ts
@@ -1,12 +1,15 @@
 // Role + visibility helpers shared across MCP tool handlers.
 //
-// Extracted from the pre-T4.2 dispatch.js. Behaviour is unchanged —
-// the rules are: admin sees everything; an agent sees common rows plus
-// its own private rows. The `scopeAgentArgs` helper drops `admin` from
-// caller input and (for agents) pins `agent_id` to the authenticated
-// identity so a non-admin caller can't impersonate.
+// Extracted from the pre-T4.2 dispatch.js. The rules are: admin sees
+// everything; an agent sees common rows plus its own private rows. The
+// `scopeAgentArgs` helper drops `admin` from caller input and (for agents)
+// resolves `agent_id` to a single canonical actor id via the naming-contract
+// resolver — normalising the supplied id, enforcing a mapped token's bound
+// id (mismatch → reject, never silently overwrite), gating reserved
+// namespaces, and falling back to the legacy sentinel while we run in
+// soft-migration mode (spec §7.2 / §5.3).
 
-import { DEFAULT_AGENT_ID, type LibrarianStore } from "@librarian/core";
+import { DEFAULT_AGENT_ID, resolveCaller, type LibrarianStore } from "@librarian/core";
 import type { ToolContext } from "./tool.js";
 
 interface SessionLike {
@@ -30,9 +33,15 @@ export function scopeAgentArgs(
   delete scoped.admin;
   if (context.role === "admin") {
     scoped.admin = true;
-  } else if (context.role === "agent" && context.agentId) {
-    scoped.agent_id = context.agentId;
+    return scoped;
   }
+  const resolved = resolveCaller({
+    role: "agent",
+    rawAgentId: typeof args.agent_id === "string" ? args.agent_id : undefined,
+    authenticatedAgentId: context.agentId,
+    allowMissingDuringMigration: true,
+  });
+  scoped.agent_id = resolved.actor_id;
   return scoped;
 }
 

--- a/packages/mcp-server/tests/mcp/caller-resolution.mcp.test.ts
+++ b/packages/mcp-server/tests/mcp/caller-resolution.mcp.test.ts
@@ -112,4 +112,22 @@ describe("MCP caller resolution (soft mode)", () => {
       expect(findByTitle(store, "Unattributed")?.agent_id).toBe("unknown-agent");
     });
   });
+
+  it("coerces a non-string agent_id to the soft-mode sentinel (deliberate until hard mode)", async () => {
+    await withStore(async (store) => {
+      // A malformed (non-string) id is treated as absent in soft mode. Once
+      // hard-enforcement lands this should fail loudly instead — see the note
+      // in scopeAgentArgs. Pinned here so the current behaviour is deliberate.
+      const response = await call(store, "remember", {
+        agent_id: 999,
+        title: "Malformed",
+        body: "Body text for the caller-resolution test.",
+        category: "tools",
+        visibility: "common",
+        scope: "global",
+      });
+      expect(response.error).toBeFalsy();
+      expect(findByTitle(store, "Malformed")?.agent_id).toBe("unknown-agent");
+    });
+  });
 });

--- a/packages/mcp-server/tests/mcp/caller-resolution.mcp.test.ts
+++ b/packages/mcp-server/tests/mcp/caller-resolution.mcp.test.ts
@@ -1,0 +1,115 @@
+// MCP caller-identity resolution (naming contract §7.2 / §5.3, soft mode).
+//
+// Pins the behaviour of routing agent identity through `resolveCaller` at the
+// `scopeAgentArgs` chokepoint:
+//   - a supplied agent_id is normalised to its canonical form before storage
+//   - a mapped token + matching request id is accepted (case/variant-folded)
+//   - a mapped token + conflicting request id is rejected (no impersonation)
+//   - an ordinary agent may not claim a reserved (system-*/dashboard-*/cli) id
+//   - a shared token with no id still falls back to the legacy sentinel (soft)
+//   - admin calls are unaffected
+
+import type { LibrarianStore } from "@librarian/core";
+import { handleMcpPayload } from "@librarian/mcp-server";
+import { describe, expect, it } from "vitest";
+import { withStore } from "../../../../test/helpers.js";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyResponse = any;
+
+function call(
+  store: LibrarianStore,
+  name: string,
+  args: Record<string, unknown>,
+  context: { role?: "admin" | "agent"; agentId?: string } = {},
+): Promise<AnyResponse> {
+  return handleMcpPayload(
+    store,
+    { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name, arguments: args } },
+    context,
+  ) as Promise<AnyResponse>;
+}
+
+function rememberArgs(agent_id: string | undefined, title: string) {
+  return {
+    ...(agent_id === undefined ? {} : { agent_id }),
+    title,
+    body: "Body text for the caller-resolution test.",
+    category: "tools",
+    visibility: "common",
+    scope: "global",
+  };
+}
+
+function findByTitle(store: LibrarianStore, title: string) {
+  return store.listAll({}).find((memory) => memory.title === title);
+}
+
+describe("MCP caller resolution (soft mode)", () => {
+  it("normalises a shared-token caller's supplied agent_id before storage", async () => {
+    await withStore(async (store) => {
+      const response = await call(
+        store,
+        "remember",
+        rememberArgs("Guybrush (Hermes)", "Normalised"),
+      );
+      expect(response.error).toBeFalsy();
+      expect(findByTitle(store, "Normalised")?.agent_id).toBe("guybrush-hermes");
+    });
+  });
+
+  it("accepts a mapped token whose request id matches after normalisation", async () => {
+    await withStore(async (store) => {
+      const response = await call(store, "remember", rememberArgs("Codex", "Matched"), {
+        role: "agent",
+        agentId: "codex",
+      });
+      expect(response.error).toBeFalsy();
+      expect(findByTitle(store, "Matched")?.agent_id).toBe("codex");
+    });
+  });
+
+  it("uses the token-bound id when a mapped token supplies no request id", async () => {
+    await withStore(async (store) => {
+      const response = await call(store, "remember", rememberArgs(undefined, "Bound"), {
+        role: "agent",
+        agentId: "codex",
+      });
+      expect(response.error).toBeFalsy();
+      expect(findByTitle(store, "Bound")?.agent_id).toBe("codex");
+    });
+  });
+
+  it("rejects a mapped token whose request id conflicts (impersonation)", async () => {
+    await withStore(async (store) => {
+      const response = await call(store, "remember", rememberArgs("guybrush", "Impersonation"), {
+        role: "agent",
+        agentId: "codex",
+      });
+      expect(response.error).toBeTruthy();
+      expect(response.error.message).toMatch(/match|impersonat|mismatch/i);
+      expect(findByTitle(store, "Impersonation")).toBeUndefined();
+    });
+  });
+
+  it("rejects an ordinary agent claiming a reserved system id", async () => {
+    await withStore(async (store) => {
+      const response = await call(
+        store,
+        "remember",
+        rememberArgs("system-memory-curator", "Reserved"),
+      );
+      expect(response.error).toBeTruthy();
+      expect(response.error.message).toMatch(/reserved|system/i);
+      expect(findByTitle(store, "Reserved")).toBeUndefined();
+    });
+  });
+
+  it("falls back to the legacy sentinel for a shared token with no id (soft mode)", async () => {
+    await withStore(async (store) => {
+      const response = await call(store, "remember", rememberArgs(undefined, "Unattributed"));
+      expect(response.error).toBeFalsy();
+      expect(findByTitle(store, "Unattributed")?.agent_id).toBe("unknown-agent");
+    });
+  });
+});

--- a/packages/mcp-server/tests/mcp/sessions.mcp.test.ts
+++ b/packages/mcp-server/tests/mcp/sessions.mcp.test.ts
@@ -74,9 +74,9 @@ describe("MCP session tools", () => {
     });
   });
 
-  it("MCP start_session refuses to honour a caller-supplied agent_id (no impersonation)", async () => {
+  it("MCP start_session rejects a caller-supplied agent_id that mismatches the token (no impersonation)", async () => {
     await withStore(async (store) => {
-      await callTool(
+      const response = await callTool(
         store,
         "start_session",
         {
@@ -87,10 +87,13 @@ describe("MCP session tools", () => {
         { role: "agent", agentId: "bede" },
       );
 
-      const sessions = store.listSessions({ agent_id: "bede" }).sessions;
-      expect(sessions.length).toBe(1);
-      expect(sessions[0].created_by_agent_id).toBe("bede");
-      expect(sessions[0].created_by_agent_id).not.toBe("imposter");
+      // Spec §7.2 / §5.3: a mapped token may only act as its bound id. A
+      // mismatching request-body id is rejected outright rather than being
+      // silently overwritten, and no session is created under either id.
+      expect(response.error).toBeTruthy();
+      expect(response.error.message).toMatch(/match|impersonat|mismatch/i);
+      expect(store.listSessions({ agent_id: "bede" }).sessions.length).toBe(0);
+      expect(store.listSessions({ agent_id: "imposter" }).sessions.length).toBe(0);
     });
   });
 


### PR DESCRIPTION
## What

**Stage 1, Workstream 1.4 (MCP portion)** of [`docs/specs/implementation-plan.md`](docs/specs/implementation-plan.md) — wires the naming-contract resolver (shipped in #70) into the MCP layer in **soft-migration mode**.

Every agent-facing MCP tool already funnels through `scopeAgentArgs`, so that single chokepoint is exactly where spec §7.2 says to "resolve caller identity once at dispatch/tool-entry." This routes it through `resolveCaller`.

## Behaviour changes (soft mode)

- **Normalisation** — a supplied `agent_id` is canonicalised before storage (`Guybrush (Hermes)` → `guybrush-hermes`).
- **No impersonation** — a mapped token + a *conflicting* request-body `agent_id` is now **rejected** (§5.3/§7.2) rather than silently overwritten. The former `start_session` "refuses to honour a caller-supplied agent_id" test encoded the silent-overwrite behaviour; it's updated to assert rejection + no session created (a stronger guarantee).
- **Reserved gating** — an ordinary agent cannot claim `system-*` / `dashboard-*` / `cli`.
- **Soft fallback preserved** — a shared token with no id still resolves to `unknown-agent` (no regression).
- **Admin** path unchanged.

Also: `ResolveCallerInput`'s three id fields now accept `| undefined` so trust boundaries can pass optional ids without conditional-spread gymnastics under `exactOptionalPropertyTypes`.

## Testing

- `pnpm test` — all green (core 150, mcp-server **84**, cli 45, dashboard 45, root 32).
- `pnpm typecheck` / `lint` / `format:check` — clean.
- New `caller-resolution.mcp.test.ts` (7 cases): normalisation, match-accept, bound-id-when-absent, mismatch-reject, reserved-reject, soft fallback, non-string coercion.
- Code-review sub-agent across 5 axes — **verdict: ship**, no Critical/Important; confirmed the impersonation boundary can't be bypassed (single chokepoint, unconditional overwrite, clean JSON-RPC errors, no partial writes).

## Deferred (next increments, see `AUTONOMOUS-BUILD-NOTES-26-05-23.md`)

Alias-map application (`bede → guybrush`, Phase-3 backfill) · CLI `--agent`/`LIBRARIAN_AGENT_ID` · dashboard/tRPC dropdowns · soft-mode missing-id warning log · 1.1 audit · 1.3 store `actor_kind` column · hard enforcement (incl. failing loudly on malformed ids).

🤖 Generated with [Claude Code](https://claude.com/claude-code)