### PR TITLE
feat(cli): canonicalise the caller agent id (naming Stage 1.4)

### DIFF
--- a/AUTONOMOUS-BUILD-NOTES-26-05-23.md
+++ b/AUTONOMOUS-BUILD-NOTES-26-05-23.md
@@ -6,7 +6,24 @@
 Increments shipped this day, each its own PR:
 
 1. `feat/naming-contract-foundation` — Stage 1.2 resolver core (merged, PR #70).
-2. `feat/naming-contract-mcp-wiring` — Stage 1.4 MCP soft-mode wiring (this PR).
+2. `feat/naming-contract-mcp-wiring` — Stage 1.4 MCP soft-mode wiring (merged, PR #71).
+3. `feat/naming-contract-cli-identity` — Stage 1.4 CLI caller canonicalisation (this PR).
+
+---
+
+## Increment 3 — Stage 1.4 CLI caller canonicalisation
+
+The CLI already had `callerAgent` (`--agent` / `LIBRARIAN_AGENT_ID` / default `cli`), so
+§7.3's flag contract existed; the gap was **canonicalisation** — `--agent "Guybrush"` stored
+`Guybrush`, diverging from the MCP boundary. `callerAgent` now routes through
+`normaliseCallerId`, so all CLI attribution (every command funnels through it) is canonical.
+
+- The CLI is a trusted local boundary (no token), so plain `normaliseCallerId` is used — not
+  the role-gating `resolveCaller`. That keeps `cli` (a reserved id) valid as the default
+  operator actor, per §4.4/§7.3.
+- A malformed `--agent "!!!"` throws → surfaces as a clean `Error: …` (exit 1) via the
+  runtime try/catch.
+- Existing `--agent bede` / `cli` tests are unaffected (they normalise to themselves).
 
 ---
 

--- a/packages/cli/src/parse-flags.ts
+++ b/packages/cli/src/parse-flags.ts
@@ -10,7 +10,7 @@
 // caller-agent fallback, and `--summary` / `--summary-file` resolution.
 
 import fs from "node:fs";
-import { normaliseCallerId } from "@librarian/core";
+import { isReservedId, normaliseCallerId } from "@librarian/core";
 
 export type FlagValue = string | boolean | string[];
 export type FlagMap = Record<string, FlagValue>;
@@ -77,7 +77,14 @@ export function callerAgent(flags: FlagMap): string {
   const agent = flags.agent;
   const raw =
     typeof agent === "string" && agent.length ? agent : process.env.LIBRARIAN_AGENT_ID || "cli";
-  return normaliseCallerId(raw);
+  const id = normaliseCallerId(raw);
+  // `cli` is the only reserved id valid at this boundary (§4.4). Block an
+  // operator from writing attribution as a system/dashboard actor, while still
+  // allowing the `cli` default and ordinary agent ids.
+  if (isReservedId(id) && id !== "cli") {
+    throw new Error(`agent id "${id}" is reserved and cannot be used from the CLI`);
+  }
+  return id;
 }
 
 export function readSummary(flags: FlagMap): string | null {

--- a/packages/cli/src/parse-flags.ts
+++ b/packages/cli/src/parse-flags.ts
@@ -10,6 +10,7 @@
 // caller-agent fallback, and `--summary` / `--summary-file` resolution.
 
 import fs from "node:fs";
+import { normaliseCallerId } from "@librarian/core";
 
 export type FlagValue = string | boolean | string[];
 export type FlagMap = Record<string, FlagValue>;
@@ -68,9 +69,15 @@ export function parseNumber(value: FlagValue | undefined): number | undefined {
 }
 
 export function callerAgent(flags: FlagMap): string {
+  // The CLI is a trusted local boundary (no token), so we only canonicalise
+  // the caller id — `--agent "Guybrush"` → `guybrush` — keeping CLI attribution
+  // consistent with the MCP boundary. A value with no canonical form throws,
+  // surfacing as a clean CLI error via the runtime's try/catch. Manual operator
+  // calls default to the `cli` actor.
   const agent = flags.agent;
-  if (typeof agent === "string" && agent.length) return agent;
-  return process.env.LIBRARIAN_AGENT_ID || "cli";
+  const raw =
+    typeof agent === "string" && agent.length ? agent : process.env.LIBRARIAN_AGENT_ID || "cli";
+  return normaliseCallerId(raw);
 }
 
 export function readSummary(flags: FlagMap): string | null {

--- a/packages/cli/tests/parse-flags.test.ts
+++ b/packages/cli/tests/parse-flags.test.ts
@@ -113,6 +113,27 @@ describe("callerAgent", () => {
       if (previous !== undefined) process.env.LIBRARIAN_AGENT_ID = previous;
     }
   });
+
+  it("canonicalises the --agent flag to naming-contract form", () => {
+    expect(callerAgent({ agent: "Guybrush" })).toBe("guybrush");
+    expect(callerAgent({ agent: "Claude Code" })).toBe("claude-code");
+    expect(callerAgent({ agent: "Guybrush (Hermes)" })).toBe("guybrush-hermes");
+  });
+
+  it("canonicalises $LIBRARIAN_AGENT_ID too", () => {
+    const previous = process.env.LIBRARIAN_AGENT_ID;
+    process.env.LIBRARIAN_AGENT_ID = "Codex";
+    try {
+      expect(callerAgent({ agent: true })).toBe("codex");
+    } finally {
+      if (previous === undefined) delete process.env.LIBRARIAN_AGENT_ID;
+      else process.env.LIBRARIAN_AGENT_ID = previous;
+    }
+  });
+
+  it("throws on a --agent value that has no canonical form", () => {
+    expect(() => callerAgent({ agent: "!!!" })).toThrow();
+  });
 });
 
 describe("flagString", () => {

--- a/packages/cli/tests/parse-flags.test.ts
+++ b/packages/cli/tests/parse-flags.test.ts
@@ -132,7 +132,16 @@ describe("callerAgent", () => {
   });
 
   it("throws on a --agent value that has no canonical form", () => {
-    expect(() => callerAgent({ agent: "!!!" })).toThrow();
+    expect(() => callerAgent({ agent: "!!!" })).toThrow(/empty/i);
+  });
+
+  it("keeps the cli default valid (the one allowed reserved id)", () => {
+    expect(callerAgent({ agent: "CLI" })).toBe("cli");
+  });
+
+  it("rejects an operator claiming a reserved system/dashboard id", () => {
+    expect(() => callerAgent({ agent: "system-memory-curator" })).toThrow(/reserved/i);
+    expect(() => callerAgent({ agent: "dashboard-admin" })).toThrow(/reserved/i);
   });
 });
 


### PR DESCRIPTION
## What

**Stage 1, Workstream 1.4 (CLI portion)** of [`docs/specs/implementation-plan.md`](docs/specs/implementation-plan.md) — spec §7.3.

The CLI already had `callerAgent` (`--agent` / `LIBRARIAN_AGENT_ID` / default `cli`), so the flag contract existed; the gap was **canonicalisation**. `callerAgent` now routes through `normaliseCallerId`, so all CLI attribution (every command funnels through it) matches the MCP boundary.

- `--agent "Guybrush"` → `guybrush`; `--agent "Claude Code"` → `claude-code`.
- The CLI is a trusted local boundary (no token), so plain `normaliseCallerId` is used — not the role-gating `resolveCaller` (which would reject the `cli` default).
- Defence-in-depth: `cli` is the only reserved id valid here (§4.4), so an operator can't write attribution as `system-*`/`dashboard-*`; the `cli` default and ordinary ids still work.
- A malformed `--agent "!!!"` surfaces as a clean `Error: …` (exit 1) via the runtime try/catch.
- Existing `--agent bede` / `cli` tests are unaffected (idempotent — they normalise to themselves).

## Testing

- `pnpm test` — all green (core 150, mcp-server 84, cli **50**, dashboard 45, root 32).
- `pnpm typecheck` / `lint` / `format:check` — clean.
- Code-review sub-agent across 5 axes — **verdict: ship** (no Critical/Important); the reserved-id gating was its main suggestion, now implemented.

## Deferred (next increments)

Dashboard/tRPC dropdowns · alias-map application (`bede → guybrush`) · soft-mode missing-id warning log · 1.1 baseline audit · 1.3 store `actor_kind` column · hard enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)