### PR TITLE
feat(core): baseline caller-id audit dry-run (naming Stage 1.1)

### DIFF
--- a/AUTONOMOUS-BUILD-NOTES-26-05-23.md
+++ b/AUTONOMOUS-BUILD-NOTES-26-05-23.md
@@ -7,7 +7,32 @@ Increments shipped this day, each its own PR:
 
 1. `feat/naming-contract-foundation` — Stage 1.2 resolver core (merged, PR #70).
 2. `feat/naming-contract-mcp-wiring` — Stage 1.4 MCP soft-mode wiring (merged, PR #71).
-3. `feat/naming-contract-cli-identity` — Stage 1.4 CLI caller canonicalisation (this PR).
+3. `feat/naming-contract-cli-identity` — Stage 1.4 CLI caller canonicalisation (merged, PR #72).
+4. `feat/naming-contract-audit` — Stage 1.1 baseline audit dry-run (this PR).
+
+---
+
+## Increment 4 — Stage 1.1 baseline audit (Phase 0 dry-run)
+
+Pure `auditCallerIds(rawIds)` in `@librarian/core` + a read-only
+`scripts/audit-agent-ids.mjs` (`pnpm audit:agent-ids`). Runs `normaliseCallerId` over the
+existing stored ids (memories.agent_id, sessions.created_by_agent_id / current_agent_id),
+groups them by canonical form, flags collapse groups and unnormalisable ids — **changes
+nothing** (no aliases applied; alias decisions wait for human review per §10).
+
+### Audit findings against the repo's `./data` (for the eventual backfill — Workstream 1.3/Phase 3)
+
+Ran `pnpm audit:agent-ids`: **5 distinct ids — `claude`, `codex`, `opencode`, `pi`,
+`system` — all already canonical, no collapse groups, none invalid.** Two points to decide
+before the Phase-3 backfill:
+
+- [ ] **`claude` vs `claude-code`.** Stored data uses `claude`, but spec §8 makes the
+  canonical Claude Code id `claude-code`. Decide whether to alias/rename `claude → claude-code`
+  in the backfill, or accept `claude` as a distinct legacy id.
+- [ ] **`system` as an agent_id.** The CLI `seed` writes memories with `agent_id: "system"`
+  (`packages/cli/src/runtime.ts`). `system` is not a reserved id (only `system-*` is), so it
+  passes — but it's ambiguous against the `system-*` actor namespace. Consider seeding with a
+  real actor id (e.g. `cli` or `system-migration`) or aliasing.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "check:test-count": "node --no-warnings scripts/check-test-count.mjs",
     "check:storage-fixture": "node --no-warnings scripts/check-storage-fixture.mjs",
     "check:schema-version": "node --no-warnings scripts/check-schema-version.mjs",
-    "check:session-state-divergence": "node --no-warnings scripts/check-session-state-divergence.mjs"
+    "check:session-state-divergence": "node --no-warnings scripts/check-session-state-divergence.mjs",
+    "audit:agent-ids": "node --no-warnings scripts/audit-agent-ids.mjs"
   },
   "engines": {
     "node": ">=22.5.0",

--- a/packages/core/src/caller-audit.ts
+++ b/packages/core/src/caller-audit.ts
@@ -1,0 +1,68 @@
+// Baseline caller-id audit — the migration dry-run for the naming contract.
+//
+// `auditCallerIds` runs `normaliseCallerId` over the existing stored ids
+// (memories.agent_id, sessions.created_by_agent_id / current_agent_id) WITHOUT
+// changing anything, so an operator can see — before any backfill — which raw
+// variants would collapse into one canonical id (§9 Phase 0) and which ids have
+// no canonical form. It deliberately applies no aliases: alias decisions come
+// after a human reviews the collapse/collision groups (§10).
+
+import { normaliseCallerId } from "./caller-identity.js";
+
+export interface CallerIdGroup {
+  /** The canonical id all variants normalise to. */
+  canonical: string;
+  /** Distinct raw inputs that map to `canonical`, sorted. */
+  variants: string[];
+}
+
+export interface CallerIdAudit {
+  /** Every canonical group, collapse groups (>1 variant) first, then by name. */
+  groups: CallerIdGroup[];
+  /** The subset of `groups` with more than one raw variant — these merge. */
+  collapses: CallerIdGroup[];
+  /** Raw ids that throw on normalisation (no canonical form). */
+  invalid: string[];
+  /** Count of distinct, non-empty raw ids considered. */
+  total: number;
+}
+
+/**
+ * Dry-run audit of caller ids. Pure: no store access, no mutation. Empty /
+ * whitespace-only ids are skipped entirely; exact duplicates are de-duplicated.
+ */
+export function auditCallerIds(rawIds: Iterable<string>): CallerIdAudit {
+  const seen = new Set<string>();
+  const byCanonical = new Map<string, Set<string>>();
+  const invalid: string[] = [];
+
+  for (const raw of rawIds) {
+    if (typeof raw !== "string" || raw.trim() === "" || seen.has(raw)) continue;
+    seen.add(raw);
+    let canonical: string;
+    try {
+      canonical = normaliseCallerId(raw);
+    } catch {
+      invalid.push(raw);
+      continue;
+    }
+    const variants = byCanonical.get(canonical) ?? new Set<string>();
+    variants.add(raw);
+    byCanonical.set(canonical, variants);
+  }
+
+  const groups: CallerIdGroup[] = [...byCanonical.entries()]
+    .map(([canonical, variants]) => ({ canonical, variants: [...variants].sort() }))
+    .sort((a, b) => {
+      const aIsCollapse = a.variants.length > 1 ? 0 : 1;
+      const bIsCollapse = b.variants.length > 1 ? 0 : 1;
+      return aIsCollapse - bIsCollapse || a.canonical.localeCompare(b.canonical);
+    });
+
+  return {
+    groups,
+    collapses: groups.filter((group) => group.variants.length > 1),
+    invalid,
+    total: seen.size,
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@ export {
   normaliseCallerId,
   resolveCaller,
 } from "./caller-identity.js";
+export { type CallerIdAudit, type CallerIdGroup, auditCallerIds } from "./caller-audit.js";
 export {
   formatRecall,
   renderHandover,

--- a/packages/core/tests/caller-audit.test.ts
+++ b/packages/core/tests/caller-audit.test.ts
@@ -1,0 +1,57 @@
+// Baseline caller-id audit (naming contract §9 Phase 0 / §11 migration dry-run).
+//
+// `auditCallerIds` is the pure dry-run that the migration tooling uses to show
+// how `normaliseCallerId` would collapse the existing stored ids before any
+// backfill — collapse groups (multiple raw variants → one canonical) flag where
+// attribution would merge, and unnormalisable ids are surfaced separately.
+
+import { auditCallerIds } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+describe("auditCallerIds", () => {
+  it("groups raw variants by their canonical form", () => {
+    const audit = auditCallerIds(["Guybrush", "guybrush", " guybrush "]);
+    expect(audit.groups).toHaveLength(1);
+    expect(audit.groups[0]).toEqual({
+      canonical: "guybrush",
+      variants: [" guybrush ", "Guybrush", "guybrush"],
+    });
+  });
+
+  it("flags collapse groups (>1 variant) separately from clean ids", () => {
+    const audit = auditCallerIds(["Codex", "codex", "claude-code"]);
+    expect(audit.collapses.map((g) => g.canonical)).toEqual(["codex"]);
+    expect(audit.collapses[0].variants).toEqual(["Codex", "codex"]);
+    // claude-code is a single clean variant — present in groups, not a collapse.
+    expect(audit.groups.map((g) => g.canonical)).toContain("claude-code");
+  });
+
+  it("sorts collapse groups ahead of single-variant groups", () => {
+    const audit = auditCallerIds(["zeta", "Alpha", "alpha"]);
+    expect(audit.groups[0].canonical).toBe("alpha"); // the collapse group leads
+  });
+
+  it("collects ids with no canonical form as invalid", () => {
+    const audit = auditCallerIds(["guybrush", "!!!", "   "]);
+    expect(audit.invalid).toEqual(["!!!"]);
+    expect(audit.groups.map((g) => g.canonical)).toEqual(["guybrush"]);
+  });
+
+  it("skips empty / whitespace-only ids without counting them", () => {
+    const audit = auditCallerIds(["", "  ", "codex"]);
+    expect(audit.total).toBe(1);
+    expect(audit.groups).toHaveLength(1);
+    expect(audit.invalid).toEqual([]);
+  });
+
+  it("dedupes exact-duplicate raw ids", () => {
+    const audit = auditCallerIds(["codex", "codex"]);
+    expect(audit.groups[0].variants).toEqual(["codex"]);
+    expect(audit.total).toBe(1);
+  });
+
+  it("reports an empty audit for no input", () => {
+    const audit = auditCallerIds([]);
+    expect(audit).toEqual({ groups: [], collapses: [], invalid: [], total: 0 });
+  });
+});

--- a/scripts/audit-agent-ids.mjs
+++ b/scripts/audit-agent-ids.mjs
@@ -16,6 +16,10 @@ import { auditCallerIds, createLibrarianStore } from "@librarian/core";
 const argv = process.argv.slice(2);
 const flagIndex = argv.indexOf("--data-dir");
 const dataDirArg = flagIndex >= 0 ? argv[flagIndex + 1] : undefined;
+if (flagIndex >= 0 && dataDirArg === undefined) {
+  console.error("[audit-agent-ids] --data-dir requires a path argument");
+  process.exit(2);
+}
 const dataDir = path.resolve(dataDirArg ?? process.env.LIBRARIAN_DATA_DIR ?? "./data");
 
 const store = createLibrarianStore({ dataDir });

--- a/scripts/audit-agent-ids.mjs
+++ b/scripts/audit-agent-ids.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+// Baseline caller-id audit (naming contract §9 Phase 0) — read-only dry-run.
+//
+// Reports how `normaliseCallerId` would collapse the existing stored caller ids
+// (memories.agent_id, sessions.created_by_agent_id / current_agent_id) BEFORE
+// any backfill, so collapse groups + collisions can be reviewed and aliases
+// decided deliberately (§10). Changes nothing; always exits 0.
+//
+// Usage: node scripts/audit-agent-ids.mjs [--data-dir <path>]
+//        LIBRARIAN_DATA_DIR=<path> node scripts/audit-agent-ids.mjs
+
+import path from "node:path";
+import process from "node:process";
+import { auditCallerIds, createLibrarianStore } from "@librarian/core";
+
+const argv = process.argv.slice(2);
+const flagIndex = argv.indexOf("--data-dir");
+const dataDirArg = flagIndex >= 0 ? argv[flagIndex + 1] : undefined;
+const dataDir = path.resolve(dataDirArg ?? process.env.LIBRARIAN_DATA_DIR ?? "./data");
+
+const store = createLibrarianStore({ dataDir });
+
+try {
+  const rawIds = [
+    ...store.distinctValues({ field: "agent_id", include_archived: true }),
+    ...store.distinctSessionValues({ field: "created_by_agent_id", include_ended: true }),
+    ...store.distinctSessionValues({ field: "current_agent_id", include_ended: true }),
+  ];
+
+  const audit = auditCallerIds(rawIds);
+
+  console.log(`[audit-agent-ids] data dir: ${dataDir}`);
+  console.log(
+    `[audit-agent-ids] ${audit.total} distinct caller id(s); ${audit.groups.length} canonical, ` +
+      `${audit.collapses.length} collapse group(s), ${audit.invalid.length} invalid.\n`,
+  );
+
+  if (audit.collapses.length) {
+    console.log("Collapse groups (multiple raw variants → one canonical):");
+    for (const group of audit.collapses) {
+      console.log(
+        `  ${group.canonical}  ←  ${group.variants.map((v) => JSON.stringify(v)).join(", ")}`,
+      );
+    }
+    console.log("");
+  }
+
+  const clean = audit.groups.filter((group) => group.variants.length === 1);
+  if (clean.length) {
+    console.log("Already-canonical ids:");
+    console.log(`  ${clean.map((group) => group.canonical).join(", ")}\n`);
+  }
+
+  if (audit.invalid.length) {
+    console.log("Invalid (no canonical form — would be rejected):");
+    for (const raw of audit.invalid) console.log(`  ${JSON.stringify(raw)}`);
+    console.log("");
+  }
+
+  if (audit.groups.some((group) => group.canonical === "unknown-agent")) {
+    console.log("Note: `unknown-agent` is the legacy sentinel — leave it untouched in backfill.");
+  }
+} finally {
+  store.close();
+}


### PR DESCRIPTION
## What

**Stage 1, Workstream 1.1** of [`docs/specs/implementation-plan.md`](docs/specs/implementation-plan.md) — the Phase-0 baseline audit (spec §9 / §10).

A pure `auditCallerIds(rawIds)` in `@librarian/core` plus a read-only `scripts/audit-agent-ids.mjs` (`pnpm audit:agent-ids`). It runs `normaliseCallerId` over the existing stored ids (memories.agent_id, sessions.created_by/current_agent_id) and reports:
- **collapse groups** — multiple raw variants that merge into one canonical id (where attribution would combine);
- already-canonical ids;
- **invalid** ids (no canonical form).

It applies **no aliases and mutates nothing** — alias/backfill decisions wait for human review per §10.

## Audit findings against `./data` (for the eventual Phase-3 backfill)

`pnpm audit:agent-ids` → **5 distinct ids — `claude`, `codex`, `opencode`, `pi`, `system` — all already canonical, 0 collapse groups, 0 invalid.** Two decisions flagged in the build notes:
- `claude` vs spec §8's canonical `claude-code`;
- `system` used as a seed `agent_id` (ambiguous against the `system-*` actor namespace).

## Testing

- `pnpm test` — all green (core **157**, mcp-server 84, cli 50, dashboard 45, root 32); guards pass.
- `pnpm typecheck` / `lint` / `format:check` — clean.
- 7 unit tests (grouping, collapse detection, invalid collection, dedupe, empty-skip, sort order).
- Code-review sub-agent across 5 axes — **verdict: ship** (no Critical/Important); the one actionable suggestion (guard a value-less `--data-dir`) is implemented.

## Deferred (next increments)

Dashboard/tRPC dropdowns · alias-map application + Phase-3 backfill (using this audit) · soft-mode missing-id warning log · 1.3 store `actor_kind` column · Stage 4 hard enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)