### PR TITLE
feat(dashboard): record dashboard-admin actor for admin mutations (naming Stage 1.4)

### DIFF
--- a/AUTONOMOUS-BUILD-NOTES-26-05-23.md
+++ b/AUTONOMOUS-BUILD-NOTES-26-05-23.md
@@ -8,7 +8,22 @@ Increments shipped this day, each its own PR:
 1. `feat/naming-contract-foundation` — Stage 1.2 resolver core (merged, PR #70).
 2. `feat/naming-contract-mcp-wiring` — Stage 1.4 MCP soft-mode wiring (merged, PR #71).
 3. `feat/naming-contract-cli-identity` — Stage 1.4 CLI caller canonicalisation (merged, PR #72).
-4. `feat/naming-contract-audit` — Stage 1.1 baseline audit dry-run (this PR).
+4. `feat/naming-contract-audit` — Stage 1.1 baseline audit dry-run (merged, PR #73).
+5. `feat/naming-contract-dashboard-actor` — Stage 1.4 dashboard-admin actor (this PR).
+
+---
+
+## Increment 5 — Stage 1.4 dashboard admin actor
+
+Both tRPC routers attributed admin mutations to a bare `"dashboard"` actor; spec §6/§7.5
+mandate the reserved `dashboard-admin`. Now sourced from core's
+`SYSTEM_ACTOR_IDS.dashboardAdmin` (single source of truth) in `trpc/memories.ts` and
+`trpc/sessions.ts`. New tRPC test asserts an admin archive with no `agent_id` records the
+`dashboard-admin` actor in the ledger.
+
+Remaining §7.5 (deferred): the dashboard **UI** changes — agent-filter dropdowns showing
+canonical ids only, `unknown-agent` marked legacy, system actors grouped — are a frontend
+task for a later increment.
 
 ---
 

--- a/AUTONOMOUS-BUILD-NOTES-26-05-23.md
+++ b/AUTONOMOUS-BUILD-NOTES-26-05-23.md
@@ -25,6 +25,12 @@ Remaining §7.5 (deferred): the dashboard **UI** changes — agent-filter dropdo
 canonical ids only, `unknown-agent` marked legacy, system actors grouped — are a frontend
 task for a later increment.
 
+- [ ] **Fast-follow:** a mirror test for the sessions router's `dashboard-admin` fallback.
+  The memories router has one; the sessions router uses the identical centralised
+  `?? DASHBOARD_AGENT_ID` pattern through `runAdminAction`, but its actor is recorded as a
+  session **state change** (not a timeline event), so asserting it needs the state-change
+  read surface rather than `sessions.events`. Low risk (shared constant), left untested for now.
+
 ---
 
 ## Increment 4 — Stage 1.1 baseline audit (Phase 0 dry-run)

--- a/packages/mcp-server/src/trpc/memories.ts
+++ b/packages/mcp-server/src/trpc/memories.ts
@@ -13,7 +13,7 @@
 // follow-up; the casts at this boundary are safe because the Zod input
 // schemas validate before the cast runs.
 
-import { DEFAULT_AGENT_ID } from "@librarian/core";
+import { DEFAULT_AGENT_ID, SYSTEM_ACTOR_IDS } from "@librarian/core";
 import {
   CategorySchema,
   MemoryInputSchema,
@@ -26,7 +26,8 @@ import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { adminProcedure, router } from "./trpc.js";
 
-const DASHBOARD_AGENT_ID = "dashboard";
+// Admin dashboard mutations record the reserved `dashboard-admin` actor (§6/§7.5).
+const DASHBOARD_AGENT_ID = SYSTEM_ACTOR_IDS.dashboardAdmin;
 const RECALL_DEFAULT_LIMIT = 12;
 
 const SortFieldSchema = z.enum(["created_at", "updated_at", "title", "priority"]);

--- a/packages/mcp-server/src/trpc/sessions.ts
+++ b/packages/mcp-server/src/trpc/sessions.ts
@@ -15,12 +15,14 @@
 // loose record inputs; the `as Record<string, unknown>` casts at the
 // boundary are safe because Zod validates first.
 
+import { SYSTEM_ACTOR_IDS } from "@librarian/core";
 import { SessionPayloadTypeSchema, SessionStatusSchema } from "@librarian/core/schemas";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { adminProcedure, router } from "./trpc.js";
 
-const DASHBOARD_AGENT_ID = "dashboard";
+// Admin dashboard mutations record the reserved `dashboard-admin` actor (§6/§7.5).
+const DASHBOARD_AGENT_ID = SYSTEM_ACTOR_IDS.dashboardAdmin;
 
 const SessionIdInputSchema = z.object({ session_id: z.string().min(1) });
 

--- a/packages/mcp-server/tests/trpc/memories.test.ts
+++ b/packages/mcp-server/tests/trpc/memories.test.ts
@@ -232,6 +232,27 @@ describe("tRPC memories surface", () => {
     }
   });
 
+  it("attributes an admin mutation (no agent_id) to the dashboard-admin actor", async () => {
+    const dataDir = makeTempDir();
+    const memory = seedMemory(dataDir, { title: "Audited" });
+    const server = await startHttpServer({ dataDir });
+    try {
+      await trpcPost<MemoryRow>(server, "memories.archive", { id: memory.id });
+      const data = await trpcGet<{ events: { event_type: string; agent_id: string }[] }>(
+        server,
+        "memories.events",
+        { memory_id: memory.id, limit: 20 },
+      );
+      const archived = data.events.find((e) => e.event_type === "memory.archived");
+      // Spec §6/§7.5: dashboard admin actions record the `dashboard-admin`
+      // reserved actor, not a bare `dashboard` string.
+      expect(archived?.agent_id).toBe("dashboard-admin");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
   it("memories.approve transitions a proposal to active", async () => {
     const dataDir = makeTempDir();
     const proposal = seedMemory(dataDir, { title: "Who", category: "identity" });


### PR DESCRIPTION
## What

**Stage 1, Workstream 1.4 (dashboard actor)** of [`docs/specs/implementation-plan.md`](docs/specs/implementation-plan.md) — spec §6 / §7.5.

Both tRPC routers attributed admin dashboard mutations to a bare `"dashboard"` actor; the naming contract's system-actor table (§6) and §7.5 mandate the reserved **`dashboard-admin`**. Now sourced from core's `SYSTEM_ACTOR_IDS.dashboardAdmin` (single source of truth) in `trpc/memories.ts` and `trpc/sessions.ts`.

## Testing

- New tRPC test: an admin `archive` with no `agent_id` records `dashboard-admin` in the event ledger (exercises the real fallback through the HTTP server).
- `pnpm test` — all green (core 157, mcp-server **85**, cli 50, dashboard 45, root 32); typecheck/lint/format clean.
- Code-review sub-agent — **verdict: ship**; confirmed full consistency (every admin mutation in both routers) and no regression (no source/frontend depended on the old value).

## Deferred (noted in build notes)

- Sessions-router mirror test for the same fallback (its actor is a session state change, not a timeline event; low risk — shared constant).
- The dashboard **UI** parts of §7.5 (canonical-id dropdowns, `unknown-agent` legacy marking, system-actor grouping) — a frontend increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)