### PR TITLE
feat(core): Phase-3 caller-id backfill (claude→claude-code, system→system-migration)

### DIFF
--- a/AUTONOMOUS-BUILD-NOTES-26-05-23.md
+++ b/AUTONOMOUS-BUILD-NOTES-26-05-23.md
@@ -54,6 +54,15 @@ reintroducing the legacy id (`packages/cli/src/runtime.ts`).
   map (`scripts/backfill-agent-ids.mjs`) is therefore deliberately SEPARATE from the live
   resolver alias map. No spec change required.
 
+### Also added (spec-mandated, surfaced in review)
+
+The backfill alias map also includes `bede → guybrush` and `guybrush-hermes → guybrush` —
+already-approved mappings in spec §8 (Hermes Bede is the same actor as Guybrush) and the §9
+`backfill_aliases` example, not new decisions. They're no-ops on the current `./data` (no such
+ids present) but make the canonical backfill tool spec-complete. The **live** resolver alias
+`bede → guybrush` is still deferred to a separate alias-config increment (the MCP boundary
+passes no alias map today).
+
 ### Note on rewriting `session_state_changes.actor_agent_id`
 
 The backfill also rewrites the historical actor on past state transitions (`claude` →

--- a/AUTONOMOUS-BUILD-NOTES-26-05-23.md
+++ b/AUTONOMOUS-BUILD-NOTES-26-05-23.md
@@ -9,7 +9,57 @@ Increments shipped this day, each its own PR:
 2. `feat/naming-contract-mcp-wiring` — Stage 1.4 MCP soft-mode wiring (merged, PR #71).
 3. `feat/naming-contract-cli-identity` — Stage 1.4 CLI caller canonicalisation (merged, PR #72).
 4. `feat/naming-contract-audit` — Stage 1.1 baseline audit dry-run (merged, PR #73).
-5. `feat/naming-contract-dashboard-actor` — Stage 1.4 dashboard-admin actor (this PR).
+5. `feat/naming-contract-dashboard-actor` — Stage 1.4 dashboard-admin actor (merged, PR #74).
+6. `feat/naming-contract-backfill` — Stage 4.1 Phase-3 caller-id backfill (this PR).
+
+---
+
+## Increment 6 — Stage 4.1 Phase-3 caller-id backfill
+
+The write step that pairs with Increment 4's read-only audit. `backfillCallerIds(store, opts)`
+in `@librarian/core` (+ `scripts/backfill-agent-ids.mjs`, `pnpm backfill:agent-ids`) rewrites
+stored caller ids to canonical form: normalises every non-empty id, applies a **one-time
+backfill alias map**, never touches `unknown-agent`, is a no-op in dry-run, and is idempotent.
+
+Each subsystem is reattributed via its own **durable** path (this is the crux of the design):
+
+- **Memories** are JSONL-canonical (`events.jsonl` is the source; SQLite is a rebuilt
+  projection), so reattribution appends a `memory.bulk_updated` event via `bulkUpdateMemory`.
+  A direct SQL UPDATE would be clobbered on the next projection rebuild.
+- **Sessions** are SQLite-authoritative since R3 (the `sessions` table survives schema bumps;
+  a *warm* rebuild refreshes only the timeline projection — verified in `projection.ts`
+  `rebuildSessionIndex`), so reattribution is a direct, durable UPDATE on `sessions`
+  (`created_by_agent_id` / `current_agent_id`) and `session_state_changes.actor_agent_id`.
+  Caveat: a *cold* rebuild (empty `sessions` table, e.g. after deleting `librarian.sqlite`)
+  replays the legacy JSONL ledger and would reintroduce `claude`; the backfill is idempotent,
+  so re-running after a from-scratch rebuild is the intended recovery (standard for migrations).
+
+Dry-run against the repo's `./data` confirmed: `system → system-migration` (2 memories),
+`claude → claude-code` (8 sessions), `codex`/`opencode`/`pi` left untouched.
+
+Also fixed the CLI `seed` to write `system-migration` instead of a bare `system`, so it stops
+reintroducing the legacy id (`packages/cli/src/runtime.ts`).
+
+### Backfill decisions (RESOLVED with Jim, 2026-05-23)
+
+- [x] **`system` → `system-migration`.** Confirmed. The seed's bootstrap memories are placed by
+  a system process, so `system-migration` (§6's designated backfill actor) is the right id; the
+  seed now writes it directly. No spec conflict.
+- [x] **`claude` → `claude-code`: backfill the rows, but add NO live alias.** This needs care:
+  §8 and §14 (open-question #1) **explicitly resolved against** an alias, keeping `claude`
+  distinct from a *future* `claude` surface. Surfaced that conflict to Jim. Resolution: the
+  existing stored `claude` rows are known *historical Claude Code* data, so the one-time
+  backfill rewrites them to `claude-code`, **but** the resolver's live alias map stays empty
+  for `claude` — honouring the spec's "keep `claude` free going forward". The backfill alias
+  map (`scripts/backfill-agent-ids.mjs`) is therefore deliberately SEPARATE from the live
+  resolver alias map. No spec change required.
+
+### Note on rewriting `session_state_changes.actor_agent_id`
+
+The backfill also rewrites the historical actor on past state transitions (`claude` →
+`claude-code`). This is the *same* actor under its canonical name (not falsifying history), and
+keeps the state-change audit consistent with the reattributed `sessions` rows. Flagged here in
+case you'd prefer audit rows frozen at their original (pre-canonical) spelling.
 
 ---
 
@@ -47,13 +97,10 @@ Ran `pnpm audit:agent-ids`: **5 distinct ids — `claude`, `codex`, `opencode`, 
 `system` — all already canonical, no collapse groups, none invalid.** Two points to decide
 before the Phase-3 backfill:
 
-- [ ] **`claude` vs `claude-code`.** Stored data uses `claude`, but spec §8 makes the
-  canonical Claude Code id `claude-code`. Decide whether to alias/rename `claude → claude-code`
-  in the backfill, or accept `claude` as a distinct legacy id.
-- [ ] **`system` as an agent_id.** The CLI `seed` writes memories with `agent_id: "system"`
-  (`packages/cli/src/runtime.ts`). `system` is not a reserved id (only `system-*` is), so it
-  passes — but it's ambiguous against the `system-*` actor namespace. Consider seeding with a
-  real actor id (e.g. `cli` or `system-migration`) or aliasing.
+- [x] **`claude` vs `claude-code`.** RESOLVED in Increment 6: backfill the stored rows to
+  `claude-code`, but add **no live alias** (the spec keeps `claude` distinct going forward).
+- [x] **`system` as an agent_id.** RESOLVED in Increment 6: backfill to `system-migration` and
+  fix the CLI seed to write it directly. See Increment 6 for the full rationale.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "check:storage-fixture": "node --no-warnings scripts/check-storage-fixture.mjs",
     "check:schema-version": "node --no-warnings scripts/check-schema-version.mjs",
     "check:session-state-divergence": "node --no-warnings scripts/check-session-state-divergence.mjs",
-    "audit:agent-ids": "node --no-warnings scripts/audit-agent-ids.mjs"
+    "audit:agent-ids": "node --no-warnings scripts/audit-agent-ids.mjs",
+    "backfill:agent-ids": "node --no-warnings scripts/backfill-agent-ids.mjs"
   },
   "engines": {
     "node": ">=22.5.0",

--- a/packages/cli/src/runtime.ts
+++ b/packages/cli/src/runtime.ts
@@ -9,7 +9,7 @@
 // map and keeps `rebuild` / `seed` (the two top-level commands)
 // inline. Per-verb logic is now < 100 LOC per file.
 
-import type { LibrarianStore } from "@librarian/core";
+import { SYSTEM_ACTOR_IDS, type LibrarianStore } from "@librarian/core";
 import type { CliResult } from "./commands/_shared.js";
 import { sessionVerbs } from "./commands/index.js";
 import { parseFlags } from "./parse-flags.js";
@@ -62,8 +62,11 @@ function runSessionsCommand(args: string[], store: LibrarianStore): CliResult {
 function seed(store: LibrarianStore): void {
   const existing = store.listAll({});
   if (existing.length) return;
+  // Bootstrap memories are placed by a system process, not an interactive
+  // agent — attribute them to the reserved `system-migration` actor (§6) so
+  // they don't masquerade as a bare `system` id near the system-* namespace.
   store.createMemory({
-    agent_id: "system",
+    agent_id: SYSTEM_ACTOR_IDS.migration,
     title: "The Librarian protects identity memory",
     body: "Identity and relationship memories should be proposed for review rather than written directly by agents.",
     category: "tools",
@@ -74,7 +77,7 @@ function seed(store: LibrarianStore): void {
     tags: ["librarian", "policy"],
   });
   store.createMemory({
-    agent_id: "system",
+    agent_id: SYSTEM_ACTOR_IDS.migration,
     title: "User identity context belongs in proposals first",
     body: "The user wants durable identity and relationship context preserved carefully, without agents silently rewriting it.",
     category: "identity",

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -439,4 +439,14 @@ describe("CLI runtime", () => {
       expect(decisions.stdout).not.toMatch(/npm test/);
     });
   });
+
+  it("seed attributes its bootstrap memories to the system-migration actor", async () => {
+    await withStore(async (store) => {
+      const result = runCli(["seed"], store);
+      expect(result.exitCode).toBe(0);
+      const agents = store.distinctValues({ field: "agent_id" });
+      expect(agents).toContain("system-migration");
+      expect(agents).not.toContain("system");
+    });
+  });
 });

--- a/packages/core/src/caller-backfill.ts
+++ b/packages/core/src/caller-backfill.ts
@@ -1,0 +1,184 @@
+// Phase-3 backfill — rewrite stored caller ids to canonical form (§9 Phase 3).
+//
+// The audit (`auditCallerIds`) is the read-only dry-run that shows which ids
+// would collapse; this is the write step that actually moves them. It applies
+// a one-time backfill alias map (e.g. `claude → claude-code`,
+// `system → system-migration`) AFTER normalisation. That map is deliberately
+// SEPARATE from the live resolver alias map (§4.4): the backfill rewrites
+// stored history once, whereas the resolver's live aliases — intentionally
+// empty for these ids — would remap every future call. Keeping them apart is
+// how we honour "backfill the rows, but keep `claude` distinct going forward".
+//
+// Each subsystem is reattributed via its own DURABLE path:
+//   - Memories are JSONL-canonical (events.jsonl is the source of truth,
+//     SQLite is a rebuilt projection), so reattribution appends a
+//     `memory.bulk_updated` event via `bulkUpdateMemory`. A direct SQL UPDATE
+//     would be clobbered on the next projection rebuild.
+//   - Sessions are SQLite-authoritative since R3 (the `sessions` table
+//     survives schema bumps; a warm rebuild refreshes only the timeline
+//     projection), so reattribution is a direct UPDATE on `sessions` and the
+//     `session_state_changes` audit ledger.
+//
+// Invariants (§9): never guess `unknown-agent`, leave unnormalisable ids
+// untouched, no-op in dry-run, and idempotent on re-run.
+
+import { type CallerAliasMap, SYSTEM_ACTOR_IDS, toCanonicalId } from "./caller-identity.js";
+import { DEFAULT_AGENT_ID } from "./constants.js";
+import type { LibrarianStore } from "./store/librarian-store.js";
+
+export interface BackfillChange {
+  /** The stored id being replaced. */
+  from: string;
+  /** Its canonical replacement. */
+  to: string;
+  /** How many rows carry `from` (memories: matching memories; sessions: matching sessions). */
+  count: number;
+}
+
+export interface BackfillSection {
+  /** Reattributions applied (or, in dry-run, that would be applied). */
+  changes: BackfillChange[];
+  /** Count of distinct, non-empty ids scanned. */
+  scanned: number;
+  /** Ids deliberately left untouched: already canonical, `unknown-agent`, or unnormalisable. */
+  skipped: string[];
+}
+
+export interface CallerBackfillReport {
+  memories: BackfillSection;
+  sessions: BackfillSection;
+  /** Whether the run mutated storage (`true`) or was a dry-run (`false`). */
+  apply: boolean;
+}
+
+export interface BackfillOptions {
+  /**
+   * One-time backfill alias map applied AFTER normalisation. Distinct from the
+   * live resolver alias map — these mappings rewrite stored history but are not
+   * consulted on live calls (§9 Phase 3 vs §4.4).
+   */
+  aliases?: CallerAliasMap;
+  /** Actor recorded against the memory reattribution events. Defaults to `system-migration` (§6). */
+  actorId?: string;
+  /** When false (default), compute the report without mutating anything. */
+  apply?: boolean;
+}
+
+/**
+ * Plan a reattribution for one stored id. Returns the canonical target, or
+ * `null` when the id should be left as-is: empty, the legacy `unknown-agent`
+ * sentinel (§9 forbids guessing it), already canonical, or unnormalisable.
+ */
+function plannedTarget(raw: string, aliases: CallerAliasMap): string | null {
+  if (!raw || raw === DEFAULT_AGENT_ID) return null;
+  let canonical: string;
+  try {
+    canonical = toCanonicalId(raw, aliases);
+  } catch {
+    return null; // no canonical form — leave it rather than dropping/guessing
+  }
+  return canonical === raw ? null : canonical;
+}
+
+function backfillMemories(
+  store: LibrarianStore,
+  aliases: CallerAliasMap,
+  actorId: string,
+  apply: boolean,
+): BackfillSection {
+  const rows = store.db
+    .prepare(
+      "SELECT agent_id AS id, COUNT(*) AS n FROM memories " +
+        "WHERE agent_id IS NOT NULL AND agent_id != '' GROUP BY agent_id",
+    )
+    .all() as Array<{ id: string; n: number }>;
+
+  const changes: BackfillChange[] = [];
+  const skipped: string[] = [];
+  for (const { id, n } of rows) {
+    const target = plannedTarget(id, aliases);
+    if (target === null) {
+      skipped.push(id);
+      continue;
+    }
+    changes.push({ from: id, to: target, count: n });
+    if (apply) {
+      const ids = (
+        store.db.prepare("SELECT id FROM memories WHERE agent_id = ?").all(id) as Array<{
+          id: string;
+        }>
+      ).map((row) => row.id);
+      // Append-event path: durable through the JSONL → SQLite projection rebuild.
+      store.bulkUpdateMemory({ ids, patch: { agent_id: target }, agent_id: actorId });
+    }
+  }
+  return { changes, scanned: rows.length, skipped };
+}
+
+function backfillSessions(
+  store: LibrarianStore,
+  aliases: CallerAliasMap,
+  apply: boolean,
+): BackfillSection {
+  const distinctIds = (
+    store.db
+      .prepare(
+        "SELECT DISTINCT id FROM (" +
+          "SELECT created_by_agent_id AS id FROM sessions " +
+          "UNION SELECT current_agent_id AS id FROM sessions" +
+          ") WHERE id IS NOT NULL AND id != ''",
+      )
+      .all() as Array<{ id: string }>
+  ).map((row) => row.id);
+
+  const changes: BackfillChange[] = [];
+  const skipped: string[] = [];
+  for (const id of distinctIds) {
+    const target = plannedTarget(id, aliases);
+    if (target === null) {
+      skipped.push(id);
+      continue;
+    }
+    const count = (
+      store.db
+        .prepare(
+          "SELECT COUNT(*) AS n FROM sessions WHERE created_by_agent_id = ? OR current_agent_id = ?",
+        )
+        .get(id, id) as { n: number }
+    ).n;
+    changes.push({ from: id, to: target, count });
+    if (apply) {
+      // Direct durable UPDATE: the sessions table is SQLite-authoritative (R3)
+      // and survives schema bumps, so this is not clobbered by a rebuild.
+      store.db
+        .prepare("UPDATE sessions SET created_by_agent_id = ? WHERE created_by_agent_id = ?")
+        .run(target, id);
+      store.db
+        .prepare("UPDATE sessions SET current_agent_id = ? WHERE current_agent_id = ?")
+        .run(target, id);
+      store.db
+        .prepare("UPDATE session_state_changes SET actor_agent_id = ? WHERE actor_agent_id = ?")
+        .run(target, id);
+    }
+  }
+  return { changes, scanned: distinctIds.length, skipped };
+}
+
+/**
+ * Backfill stored caller ids to canonical form across memories and sessions.
+ * Pass `apply: true` to mutate; otherwise returns the planned changes only.
+ */
+export function backfillCallerIds(
+  store: LibrarianStore,
+  options: BackfillOptions = {},
+): CallerBackfillReport {
+  const aliases = options.aliases ?? {};
+  const apply = options.apply === true;
+  const actorId = options.actorId ?? SYSTEM_ACTOR_IDS.migration;
+
+  return {
+    memories: backfillMemories(store, aliases, actorId, apply),
+    sessions: backfillSessions(store, aliases, apply),
+    apply,
+  };
+}

--- a/packages/core/src/caller-backfill.ts
+++ b/packages/core/src/caller-backfill.ts
@@ -31,7 +31,11 @@ export interface BackfillChange {
   from: string;
   /** Its canonical replacement. */
   to: string;
-  /** How many rows carry `from` (memories: matching memories; sessions: matching sessions). */
+  /**
+   * Rows carrying `from`: matching memories, or matching sessions
+   * (`created_by_agent_id`/`current_agent_id`). For sessions the
+   * `session_state_changes` audit rows are rewritten alongside but not counted here.
+   */
   count: number;
 }
 
@@ -149,7 +153,10 @@ function backfillSessions(
     changes.push({ from: id, to: target, count });
     if (apply) {
       // Direct durable UPDATE: the sessions table is SQLite-authoritative (R3)
-      // and survives schema bumps, so this is not clobbered by a rebuild.
+      // and survives schema bumps (a *warm* rebuild refreshes only the timeline
+      // projection), so this is not clobbered. Caveat: a *cold* rebuild (empty
+      // sessions table) replays the legacy JSONL ledger and would reintroduce
+      // pre-canonical ids — re-run this idempotent backfill after any such rebuild.
       store.db
         .prepare("UPDATE sessions SET created_by_agent_id = ? WHERE created_by_agent_id = ?")
         .run(target, id);

--- a/packages/core/src/caller-identity.ts
+++ b/packages/core/src/caller-identity.ts
@@ -172,8 +172,12 @@ function firstSupplied(...values: (string | undefined)[]): string | undefined {
   return values.find(hasValue);
 }
 
-/** Normalise then alias a raw id to its final canonical form (§4.2 + §4.4). */
-function toCanonicalId(raw: string, aliases: CallerAliasMap): string {
+/**
+ * Normalise then alias a raw id to its final canonical form (§4.2 + §4.4).
+ * Exported for the Phase-3 backfill, which computes canonical targets for
+ * stored ids using a one-time backfill alias map (§9).
+ */
+export function toCanonicalId(raw: string, aliases: CallerAliasMap): string {
   return applyAlias(normaliseCallerId(raw), aliases).id;
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,8 +10,16 @@ export {
   isReservedId,
   normaliseCallerId,
   resolveCaller,
+  toCanonicalId,
 } from "./caller-identity.js";
 export { type CallerIdAudit, type CallerIdGroup, auditCallerIds } from "./caller-audit.js";
+export {
+  type BackfillChange,
+  type BackfillOptions,
+  type BackfillSection,
+  type CallerBackfillReport,
+  backfillCallerIds,
+} from "./caller-backfill.js";
 export {
   formatRecall,
   renderHandover,

--- a/packages/core/tests/caller-backfill.test.ts
+++ b/packages/core/tests/caller-backfill.test.ts
@@ -150,6 +150,31 @@ describe("backfillCallerIds (Phase-3 backfill)", () => {
     expect(second.sessions.changes).toEqual([]);
   });
 
+  it("collapses two distinct source ids onto one target, idempotently", () => {
+    const { store } = s!;
+    // `bede` (alias) and `guybrush-hermes` (alias) plus a raw `Guybrush`
+    // (pure normalisation) all resolve to `guybrush` — the §8 collision case.
+    const aliases = { ...BACKFILL_ALIASES, bede: "guybrush", "guybrush-hermes": "guybrush" };
+    seedMemory(store, "bede", "bede note");
+    seedMemory(store, "guybrush-hermes", "hermes note");
+    seedMemory(store, "Guybrush", "raw name");
+
+    const report = backfillCallerIds(store, { aliases, apply: true });
+    const guybrushChanges = report.memories.changes.filter((c) => c.to === "guybrush");
+    expect(guybrushChanges.map((c) => c.from).sort()).toEqual(
+      ["Guybrush", "bede", "guybrush-hermes"].sort(),
+    );
+
+    const mem = memoryAgentIds(store);
+    expect(mem).toContain("guybrush");
+    expect(mem).not.toContain("bede");
+    expect(mem).not.toContain("guybrush-hermes");
+    expect(mem).not.toContain("Guybrush");
+
+    const second = backfillCallerIds(store, { aliases, apply: true });
+    expect(second.memories.changes).toEqual([]);
+  });
+
   it("records system-migration as the actor on the reattribution audit events", () => {
     const { store } = s!;
     backfillCallerIds(store, { aliases: BACKFILL_ALIASES, apply: true });

--- a/packages/core/tests/caller-backfill.test.ts
+++ b/packages/core/tests/caller-backfill.test.ts
@@ -1,0 +1,162 @@
+// Phase-3 backfill (naming contract §9 Phase 3) coverage.
+//
+// `backfillCallerIds` reattributes stored caller ids to their canonical form
+// across both storage subsystems, each via its own durable path:
+//   - memories are JSONL-canonical, so reattribution goes through the
+//     append-event `bulkUpdateMemory` path (survives a projection rebuild);
+//   - sessions are SQLite-authoritative (R3), so reattribution is a direct,
+//     durable UPDATE on the `sessions` table.
+//
+// It applies a one-time backfill alias map (claude → claude-code,
+// system → system-migration) AFTER normalisation. Per §9 it must never guess
+// `unknown-agent`, must be a no-op in dry-run, and must be idempotent.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { type LibrarianStore, backfillCallerIds, createLibrarianStore } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+interface Scope {
+  store: LibrarianStore;
+  dataDir: string;
+}
+
+const BACKFILL_ALIASES = {
+  claude: "claude-code",
+  system: "system-migration",
+} as const;
+
+function scope(): Scope {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-backfill-"));
+  const store = createLibrarianStore({ dataDir });
+  return { store, dataDir };
+}
+
+function teardown(s: Scope | null): void {
+  if (!s) return;
+  try {
+    s.store.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(s.dataDir, { recursive: true, force: true });
+}
+
+function seedMemory(store: LibrarianStore, agent_id: string, title: string): string {
+  const result = store.createMemory({
+    agent_id,
+    title,
+    body: "body text",
+    category: "projects",
+    visibility: "common",
+    scope: "project",
+    project_key: "the-librarian",
+    priority: "normal",
+    confidence: "working",
+  });
+  return result.memory.id;
+}
+
+function memoryAgentIds(store: LibrarianStore): string[] {
+  return [...store.distinctValues({ field: "agent_id", include_archived: true })].sort();
+}
+
+function sessionAgentIds(store: LibrarianStore): { createdBy: string[]; current: string[] } {
+  return {
+    createdBy: [
+      ...store.distinctSessionValues({ field: "created_by_agent_id", include_ended: true }),
+    ].sort(),
+    current: [
+      ...store.distinctSessionValues({ field: "current_agent_id", include_ended: true }),
+    ].sort(),
+  };
+}
+
+describe("backfillCallerIds (Phase-3 backfill)", () => {
+  let s: Scope | null = null;
+  beforeEach(() => {
+    s = scope();
+    const { store } = s;
+    // Memories: a legacy `system` actor (the seed), a non-canonical raw that
+    // collapses by pure normalisation, an already-canonical id, and the
+    // legacy sentinel which must be left alone.
+    seedMemory(store, "system", "seed policy");
+    seedMemory(store, "system", "seed identity");
+    seedMemory(store, "Claude Code", "raw harness name");
+    seedMemory(store, "codex", "already canonical");
+    seedMemory(store, "unknown-agent", "legacy sentinel");
+    // Sessions: a legacy `claude` actor that should alias to `claude-code`,
+    // plus an already-canonical one.
+    store.startSession({ agent_id: "claude", title: "claude work", harness: "claude-code" });
+    store.startSession({ agent_id: "codex", title: "codex work", harness: "codex" });
+  });
+  afterEach(() => {
+    teardown(s);
+    s = null;
+  });
+
+  it("dry-run reports planned changes without mutating anything", () => {
+    const { store } = s!;
+    const report = backfillCallerIds(store, { aliases: BACKFILL_ALIASES });
+
+    expect(report.apply).toBe(false);
+    expect(report.memories.changes).toEqual(
+      expect.arrayContaining([
+        { from: "system", to: "system-migration", count: 2 },
+        { from: "Claude Code", to: "claude-code", count: 1 },
+      ]),
+    );
+    expect(report.sessions.changes).toEqual(
+      expect.arrayContaining([{ from: "claude", to: "claude-code", count: 1 }]),
+    );
+
+    // Nothing changed on disk.
+    expect(memoryAgentIds(store)).toEqual(
+      ["Claude Code", "codex", "system", "unknown-agent"].sort(),
+    );
+    expect(sessionAgentIds(store).createdBy).toEqual(["claude", "codex"]);
+  });
+
+  it("apply reattributes memories and sessions to canonical ids", () => {
+    const { store } = s!;
+    const report = backfillCallerIds(store, { aliases: BACKFILL_ALIASES, apply: true });
+
+    expect(report.apply).toBe(true);
+
+    const mem = memoryAgentIds(store);
+    expect(mem).toContain("system-migration");
+    expect(mem).toContain("claude-code");
+    expect(mem).toContain("codex");
+    expect(mem).not.toContain("system");
+    expect(mem).not.toContain("Claude Code");
+
+    const sess = sessionAgentIds(store);
+    expect(sess.createdBy).toEqual(["claude-code", "codex"]);
+    expect(sess.current).toEqual(["claude-code", "codex"]);
+  });
+
+  it("never guesses the unknown-agent sentinel", () => {
+    const { store } = s!;
+    backfillCallerIds(store, { aliases: BACKFILL_ALIASES, apply: true });
+    expect(memoryAgentIds(store)).toContain("unknown-agent");
+  });
+
+  it("is idempotent — a second apply makes no further changes", () => {
+    const { store } = s!;
+    backfillCallerIds(store, { aliases: BACKFILL_ALIASES, apply: true });
+    const second = backfillCallerIds(store, { aliases: BACKFILL_ALIASES, apply: true });
+    expect(second.memories.changes).toEqual([]);
+    expect(second.sessions.changes).toEqual([]);
+  });
+
+  it("records system-migration as the actor on the reattribution audit events", () => {
+    const { store } = s!;
+    backfillCallerIds(store, { aliases: BACKFILL_ALIASES, apply: true });
+    const { events } = store.listEvents({ type: "memory.bulk_updated", limit: 100 });
+    expect(events.length).toBeGreaterThan(0);
+    for (const event of events) {
+      expect(event.agent_id).toBe("system-migration");
+    }
+  });
+});

--- a/scripts/backfill-agent-ids.mjs
+++ b/scripts/backfill-agent-ids.mjs
@@ -17,15 +17,23 @@
 //   node scripts/backfill-agent-ids.mjs --data-dir ./data --apply
 //   LIBRARIAN_DATA_DIR=./data node scripts/backfill-agent-ids.mjs
 
+import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { backfillCallerIds, createLibrarianStore } from "@librarian/core";
 
-// One-time backfill mappings (decided 2026-05-23). NOT the live resolver alias
-// map — these only rewrite stored history.
+// One-time backfill mappings. NOT the live resolver alias map — these only
+// rewrite stored history. Pure normalisation (e.g. `Bede`/`Guybrush`) is
+// applied first; this map covers the SEMANTIC renames the spec approves.
 const BACKFILL_ALIASES = {
+  // Decided with Jim 2026-05-23 (see AUTONOMOUS-BUILD-NOTES):
   claude: "claude-code", // historical Claude Code sessions predate the canonical id
   system: "system-migration", // the CLI seed wrote a bare `system` actor
+  // Approved in spec §8 (Hermes Bede is the same actor as Guybrush) + the §9
+  // backfill_aliases example. No-op on data dirs without these ids. The LIVE
+  // `bede → guybrush` resolver alias is wired in a separate increment.
+  bede: "guybrush",
+  "guybrush-hermes": "guybrush",
 };
 
 const argv = process.argv.slice(2);
@@ -42,6 +50,13 @@ if (flagIndex >= 0 && (dataDirArg === undefined || dataDirArg.startsWith("--")))
   process.exit(2);
 }
 const dataDir = path.resolve(dataDirArg ?? process.env.LIBRARIAN_DATA_DIR ?? "./data");
+
+// Guard against a typo'd path silently creating (and seeding empty ledgers in)
+// a fresh data dir — there'd be nothing to back-fill, so fail loudly instead.
+if (!fs.existsSync(dataDir)) {
+  console.error(`[backfill-agent-ids] data dir does not exist: ${dataDir}`);
+  process.exit(2);
+}
 
 const store = createLibrarianStore({ dataDir });
 

--- a/scripts/backfill-agent-ids.mjs
+++ b/scripts/backfill-agent-ids.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// Phase-3 caller-id backfill (naming contract §9 Phase 3).
+//
+// Rewrites stored caller ids to their canonical form:
+//   - normalises every non-empty id (§4.2);
+//   - applies the one-time backfill alias map below (§9) — distinct from the
+//     resolver's LIVE alias map, which stays empty for these ids so `claude`
+//     remains available as a future distinct surface (§8/§14);
+//   - leaves `unknown-agent` and unnormalisable ids untouched;
+//   - records before/after counts and is idempotent on re-run.
+//
+// Dry-run by default. Use `--apply` to actually rewrite ids.
+//
+// Usage:
+//   node scripts/backfill-agent-ids.mjs                       # dry-run
+//   node scripts/backfill-agent-ids.mjs --apply
+//   node scripts/backfill-agent-ids.mjs --data-dir ./data --apply
+//   LIBRARIAN_DATA_DIR=./data node scripts/backfill-agent-ids.mjs
+
+import path from "node:path";
+import process from "node:process";
+import { backfillCallerIds, createLibrarianStore } from "@librarian/core";
+
+// One-time backfill mappings (decided 2026-05-23). NOT the live resolver alias
+// map — these only rewrite stored history.
+const BACKFILL_ALIASES = {
+  claude: "claude-code", // historical Claude Code sessions predate the canonical id
+  system: "system-migration", // the CLI seed wrote a bare `system` actor
+};
+
+const argv = process.argv.slice(2);
+if (argv.includes("--help") || argv.includes("-h")) {
+  console.log("Usage: node scripts/backfill-agent-ids.mjs [--data-dir <path>] [--apply]");
+  process.exit(0);
+}
+
+const apply = argv.includes("--apply");
+const flagIndex = argv.indexOf("--data-dir");
+const dataDirArg = flagIndex >= 0 ? argv[flagIndex + 1] : undefined;
+if (flagIndex >= 0 && (dataDirArg === undefined || dataDirArg.startsWith("--"))) {
+  console.error("[backfill-agent-ids] --data-dir requires a path argument");
+  process.exit(2);
+}
+const dataDir = path.resolve(dataDirArg ?? process.env.LIBRARIAN_DATA_DIR ?? "./data");
+
+const store = createLibrarianStore({ dataDir });
+
+try {
+  const report = backfillCallerIds(store, { aliases: BACKFILL_ALIASES, apply });
+
+  const bar = "=".repeat(64);
+  console.log("Caller-id backfill (naming contract §9 Phase 3)");
+  console.log(bar);
+  console.log(`data dir: ${dataDir}`);
+  console.log(`mode:     ${apply ? "APPLY (mutating)" : "dry-run (no changes)"}`);
+  console.log(bar);
+
+  printSection("Memories (append-event reattribution)", report.memories);
+  printSection("Sessions (durable SQLite reattribution)", report.sessions);
+
+  const totalChanges = report.memories.changes.length + report.sessions.changes.length;
+  console.log(bar);
+  if (totalChanges === 0) {
+    console.log("Nothing to backfill — all stored ids are already canonical.");
+  } else if (!apply) {
+    console.log(`${totalChanges} reattribution group(s) planned. Re-run with --apply to write.`);
+  } else {
+    console.log(`Applied ${totalChanges} reattribution group(s).`);
+  }
+} finally {
+  store.close();
+}
+
+function printSection(heading, section) {
+  console.log(`\n${heading}`);
+  console.log(`  scanned ${section.scanned} distinct id(s); ${section.changes.length} to change.`);
+  for (const change of section.changes) {
+    console.log(`    ${change.from}  →  ${change.to}   (${change.count} row(s))`);
+  }
+  if (section.skipped.length) {
+    console.log(`  left untouched: ${section.skipped.join(", ")}`);
+  }
+}


### PR DESCRIPTION
## Summary

Increment 6 of the agent naming-contract build — the **Phase-3 backfill** (spec §9 Phase 3 / plan Workstream 4.1), the write step that pairs with the read-only audit merged in #73.

Adds `backfillCallerIds(store, opts)` in `@librarian/core` plus `scripts/backfill-agent-ids.mjs` (`pnpm backfill:agent-ids`). It rewrites stored caller ids to canonical form: normalises every non-empty id, applies a **one-time backfill alias map**, never guesses `unknown-agent`, is a no-op in dry-run, and is idempotent.

## Two durable reattribution paths (by subsystem canonicality)

- **Memories** are JSONL-canonical (`events.jsonl` is the source; SQLite is a rebuilt projection) → reattribution appends a `memory.bulk_updated` event via `bulkUpdateMemory`. A direct SQL UPDATE would be clobbered on the next projection rebuild.
- **Sessions** are SQLite-authoritative since R3 (the `sessions` table survives schema bumps; a *warm* rebuild refreshes only the timeline projection) → reattribution is a direct, durable `UPDATE` on `sessions` + `session_state_changes`. (A *cold* rebuild from the legacy ledger would reintroduce old ids; the backfill is idempotent, so re-running after a from-scratch rebuild is the intended recovery.)

## Decisions (with Jim, 2026-05-23)

- **`system → system-migration`** — the CLI seed's bootstrap memories; seed now writes it directly. No spec conflict.
- **`claude → claude-code`: backfill the rows, but add NO live alias.** §8/§14 deliberately resolved *against* a live `claude` alias to keep it distinct for a future surface. The existing stored `claude` rows are known *historical Claude Code* data, so the one-time backfill rewrites them — while the resolver's live alias map stays empty. The backfill alias map is therefore **deliberately separate** from the live resolver alias map. No spec change needed.
- Also includes the already-approved `bede → guybrush` / `guybrush-hermes → guybrush` spec mappings (§8/§9) — no-ops on current data, but the canonical tool should be spec-complete. The *live* `bede` alias remains deferred to a later alias-config increment.

Dry-run against `./data`: `system → system-migration` (2 memories), `claude → claude-code` (8 sessions), `codex`/`opencode`/`pi` untouched.

## Tests

- `packages/core/tests/caller-backfill.test.ts` (6): dry-run no-mutation, apply, `unknown-agent` preserved, idempotency, `system-migration` audit actor, and a collision case (two source ids → one target).
- CLI seed test asserting `system-migration` attribution.

## Review

A `code-reviewer` sub-agent reviewed all five axes (no Critical; SQL is fully parameterised). Its two Important findings — the missing `bede`/`guybrush-hermes` spec mappings and a missing collision test — are addressed here, along with the sensible suggestions (typo'd `--data-dir` guard, cold-rebuild + count doc notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)