### PR TITLE
feat(mcp): warn on identity-less agent calls (soft-migration signal)

### DIFF
--- a/AUTONOMOUS-BUILD-NOTES-26-05-23.md
+++ b/AUTONOMOUS-BUILD-NOTES-26-05-23.md
@@ -39,6 +39,12 @@ downstream embedders can reuse the configured pino instance).
 - [ ] **Live `bede → guybrush` alias still deferred.** When Hermes/integration traffic or test
   fixtures are migrated to `guybrush`, wire the live alias map into `scopeAgentArgs` and rename
   the `bede` test fixtures in one dedicated PR. The backfill map already lists it.
+- [ ] **Log volume / gate metric (review note).** The warning is per-call at `warn` level —
+  intentional granularity for the 7-day observation window, but if unattributed traffic is
+  noisy, consider a sampled/aggregated counter as the actual gate metric before Stage 4.
+- [ ] **Predicate drift (review note).** The missing-identity predicate in `dispatch.ts` mirrors
+  the resolver's fallback condition by hand (it's the only layer with the tool name). A cleaner
+  long-term home is the resolver itself returning a `fell_back` flag — fold in when wiring hard mode.
 
 ---
 

--- a/AUTONOMOUS-BUILD-NOTES-26-05-23.md
+++ b/AUTONOMOUS-BUILD-NOTES-26-05-23.md
@@ -10,7 +10,35 @@ Increments shipped this day, each its own PR:
 3. `feat/naming-contract-cli-identity` — Stage 1.4 CLI caller canonicalisation (merged, PR #72).
 4. `feat/naming-contract-audit` — Stage 1.1 baseline audit dry-run (merged, PR #73).
 5. `feat/naming-contract-dashboard-actor` — Stage 1.4 dashboard-admin actor (merged, PR #74).
-6. `feat/naming-contract-backfill` — Stage 4.1 Phase-3 caller-id backfill (this PR).
+6. `feat/naming-contract-backfill` — Stage 4.1 Phase-3 caller-id backfill (merged, PR #75).
+7. `feat/naming-contract-live-aliases` → pivoted to `soft-mode missing-identity warning`
+   (Stage 1.4 observability, this PR).
+
+---
+
+## Increment 7 — Stage 1.4 soft-mode missing-identity warning log
+
+**Pivot note:** this slot was going to be the live `bede → guybrush` alias config, but
+investigation showed that wiring a live alias at the MCP boundary moves ~20+ load-bearing
+`bede` assertions in `sessions.mcp.test.ts` (the churn PR #71 deliberately deferred) for
+**low current value** — there is no live `bede` traffic (data is all `guybrush`/`claude`/…),
+and the Phase-3 backfill already covers stored `bede`. So a live alias would be defensive-only
+dead code today. Pivoted to a higher-value, lower-blast-radius item instead.
+
+The missing-identity warning instruments the exact signal Stage 4 hard-enforcement is gated on
+(§9: "no new `unknown-agent` rows for 7 consecutive days"). `callTool` in `dispatch.ts` — the
+single point that knows the tool name, args, and context — now logs a `logger.warn` whenever an
+**agent** call carries no identity (no token-bound id and no request-body `agent_id`), i.e. when
+the resolver will fall back to `unknown-agent`. Admin calls are exempt (they carry no agent
+identity by design). The warning binds `tool`, `actor_id`, and (when present) `harness` /
+`source_ref`. No change to resolution behaviour — purely additive observability.
+
+`logger` / `createLogger` are now exported from `@librarian/mcp-server` (so tests can spy and
+downstream embedders can reuse the configured pino instance).
+
+- [ ] **Live `bede → guybrush` alias still deferred.** When Hermes/integration traffic or test
+  fixtures are migrated to `guybrush`, wire the live alias map into `scopeAgentArgs` and rename
+  the `bede` test fixtures in one dedicated PR. The backfill map already lists it.
 
 ---
 

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -12,5 +12,6 @@ export {
 } from "./mcp/formatters.js";
 export { dispatchMcp, tools } from "./mcp/dispatch.js";
 export { handleMcpMessage, handleMcpPayload } from "./mcp/rpc.js";
+export { createLogger, logger } from "./logging.js";
 export type { ToolContext, ToolDefinition, McpTextResult } from "./mcp/tool.js";
 export type { AppRouter } from "./trpc/router.js";

--- a/packages/mcp-server/src/mcp/dispatch.ts
+++ b/packages/mcp-server/src/mcp/dispatch.ts
@@ -89,13 +89,18 @@ function callTool(
 // confirm the Stage 4 hard-enforcement gate ("no new unknown-agent rows for
 // 7 consecutive days") before flipping it. Admin calls don't carry an agent
 // identity by design, so they're exempt.
+//
+// The predicate below mirrors the resolver's own fallback condition
+// (`firstSupplied`/`hasValue` in core's caller-identity, fed by `scopeAgentArgs`).
+// It's re-derived here because this is the only layer with the tool name; keep
+// it in sync if `scopeAgentArgs` ever starts feeding the resolver new id sources.
 function warnIfMissingIdentity(
   name: string,
   args: Record<string, unknown>,
   context: ToolContext,
 ): void {
   if (context.role !== "agent") return;
-  if (context.agentId) return;
+  if (context.agentId && context.agentId.trim() !== "") return;
   if (typeof args.agent_id === "string" && args.agent_id.trim() !== "") return;
 
   const bindings: Record<string, unknown> = { tool: name, actor_id: DEFAULT_AGENT_ID };

--- a/packages/mcp-server/src/mcp/dispatch.ts
+++ b/packages/mcp-server/src/mcp/dispatch.ts
@@ -4,7 +4,8 @@
 // and the `initialize` / `tools/list` / `tools/call` / `resources/*`
 // methods. Every callable tool lives in `./tools/<verb>.ts`.
 
-import { formatRecall, type LibrarianStore } from "@librarian/core";
+import { DEFAULT_AGENT_ID, formatRecall, type LibrarianStore } from "@librarian/core";
+import { logger } from "../logging.js";
 import { handleMcpMessage, handleMcpPayload } from "./rpc.js";
 import type { ToolContext, ToolDefinition } from "./tool.js";
 import { tools, toolsByName } from "./tools/index.js";
@@ -78,7 +79,32 @@ function callTool(
   if (tool.adminOnly && context.role !== "admin") {
     throw new Error(`Tool ${name} requires admin authorization.`);
   }
+  warnIfMissingIdentity(name, args, context);
   return tool.handler(store, args, context);
+}
+
+// Soft-migration observability (§9 Phase 1). When an agent call carries no
+// identity — no token-bound id and no request-body `agent_id` — the resolver
+// falls back to the `unknown-agent` sentinel. Log each such call so we can
+// confirm the Stage 4 hard-enforcement gate ("no new unknown-agent rows for
+// 7 consecutive days") before flipping it. Admin calls don't carry an agent
+// identity by design, so they're exempt.
+function warnIfMissingIdentity(
+  name: string,
+  args: Record<string, unknown>,
+  context: ToolContext,
+): void {
+  if (context.role !== "agent") return;
+  if (context.agentId) return;
+  if (typeof args.agent_id === "string" && args.agent_id.trim() !== "") return;
+
+  const bindings: Record<string, unknown> = { tool: name, actor_id: DEFAULT_AGENT_ID };
+  if (typeof args.harness === "string") bindings.harness = args.harness;
+  if (typeof args.source_ref === "string") bindings.source_ref = args.source_ref;
+  logger.warn(
+    bindings,
+    `agent call to "${name}" supplied no identity; falling back to ${DEFAULT_AGENT_ID} (soft-migration)`,
+  );
 }
 
 function toolsForRole(role: ToolContext["role"]): ToolDefinition[] {

--- a/packages/mcp-server/tests/mcp/caller-resolution.mcp.test.ts
+++ b/packages/mcp-server/tests/mcp/caller-resolution.mcp.test.ts
@@ -10,8 +10,8 @@
 //   - admin calls are unaffected
 
 import type { LibrarianStore } from "@librarian/core";
-import { handleMcpPayload } from "@librarian/mcp-server";
-import { describe, expect, it } from "vitest";
+import { handleMcpPayload, logger } from "@librarian/mcp-server";
+import { describe, expect, it, vi } from "vitest";
 import { withStore } from "../../../../test/helpers.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -128,6 +128,44 @@ describe("MCP caller resolution (soft mode)", () => {
       });
       expect(response.error).toBeFalsy();
       expect(findByTitle(store, "Malformed")?.agent_id).toBe("unknown-agent");
+    });
+  });
+
+  it("warns when an agent call supplies no identity (soft-migration signal)", async () => {
+    await withStore(async (store) => {
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+      try {
+        await call(store, "remember", rememberArgs(undefined, "Anon"));
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        const [bindings] = warnSpy.mock.calls[0];
+        expect(bindings).toMatchObject({ tool: "remember", actor_id: "unknown-agent" });
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+  });
+
+  it("does not warn when an agent supplies an identity", async () => {
+    await withStore(async (store) => {
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+      try {
+        await call(store, "remember", rememberArgs("guybrush", "Named"));
+        expect(warnSpy).not.toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+  });
+
+  it("does not warn for admin calls with no agent identity", async () => {
+    await withStore(async (store) => {
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+      try {
+        await call(store, "remember", rememberArgs(undefined, "AdminWrite"), { role: "admin" });
+        expect(warnSpy).not.toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
   });
 });

--- a/packages/mcp-server/tests/mcp/caller-resolution.mcp.test.ts
+++ b/packages/mcp-server/tests/mcp/caller-resolution.mcp.test.ts
@@ -11,7 +11,7 @@
 
 import type { LibrarianStore } from "@librarian/core";
 import { handleMcpPayload, logger } from "@librarian/mcp-server";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { withStore } from "../../../../test/helpers.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -46,6 +46,18 @@ function findByTitle(store: LibrarianStore, title: string) {
 }
 
 describe("MCP caller resolution (soft mode)", () => {
+  // Silence (and capture) the soft-migration missing-identity warning for the
+  // whole suite: several soft-fallback cases here legitimately trigger it, and
+  // `logger` is a module-level singleton, so a shared spy avoids both NDJSON
+  // noise and cross-test bleed.
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
   it("normalises a shared-token caller's supplied agent_id before storage", async () => {
     await withStore(async (store) => {
       const response = await call(
@@ -133,39 +145,44 @@ describe("MCP caller resolution (soft mode)", () => {
 
   it("warns when an agent call supplies no identity (soft-migration signal)", async () => {
     await withStore(async (store) => {
-      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
-      try {
-        await call(store, "remember", rememberArgs(undefined, "Anon"));
-        expect(warnSpy).toHaveBeenCalledTimes(1);
-        const [bindings] = warnSpy.mock.calls[0];
-        expect(bindings).toMatchObject({ tool: "remember", actor_id: "unknown-agent" });
-      } finally {
-        warnSpy.mockRestore();
-      }
+      await call(store, "remember", rememberArgs(undefined, "Anon"));
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const bindings = warnSpy.mock.calls[0][0] as Record<string, unknown>;
+      expect(bindings).toMatchObject({ tool: "remember", actor_id: "unknown-agent" });
+      // Only safe routing metadata is logged — never the memory body/title.
+      expect(JSON.stringify(warnSpy.mock.calls[0])).not.toContain("Body text");
+    });
+  });
+
+  it("binds harness and source_ref when a session call omits identity", async () => {
+    await withStore(async (store) => {
+      await call(store, "start_session", {
+        title: "Anon session",
+        harness: "hermes",
+        source_ref: "cwd:/tmp/anon",
+      });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const bindings = warnSpy.mock.calls[0][0] as Record<string, unknown>;
+      expect(bindings).toMatchObject({
+        tool: "start_session",
+        actor_id: "unknown-agent",
+        harness: "hermes",
+        source_ref: "cwd:/tmp/anon",
+      });
     });
   });
 
   it("does not warn when an agent supplies an identity", async () => {
     await withStore(async (store) => {
-      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
-      try {
-        await call(store, "remember", rememberArgs("guybrush", "Named"));
-        expect(warnSpy).not.toHaveBeenCalled();
-      } finally {
-        warnSpy.mockRestore();
-      }
+      await call(store, "remember", rememberArgs("guybrush", "Named"));
+      expect(warnSpy).not.toHaveBeenCalled();
     });
   });
 
   it("does not warn for admin calls with no agent identity", async () => {
     await withStore(async (store) => {
-      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
-      try {
-        await call(store, "remember", rememberArgs(undefined, "AdminWrite"), { role: "admin" });
-        expect(warnSpy).not.toHaveBeenCalled();
-      } finally {
-        warnSpy.mockRestore();
-      }
+      await call(store, "remember", rememberArgs(undefined, "AdminWrite"), { role: "admin" });
+      expect(warnSpy).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

Increment 7 of the agent naming-contract build — **soft-migration observability** (spec §9 Phase 1 / plan Workstream 1.4).

`callTool` (the single dispatch point that knows the tool name, args, and context) now logs a `logger.warn` whenever an **agent** call carries no caller identity — no token-bound id and no request-body `agent_id` — i.e. when the resolver falls back to the `unknown-agent` sentinel. This instruments the exact signal **Stage 4 hard-enforcement is gated on**: "no new `unknown-agent` rows for 7 consecutive days."

- Admin calls are exempt (they carry no agent identity by design).
- The warning binds only safe routing metadata: `tool`, `actor_id`, and `harness`/`source_ref` when present — **never** the full args (memory bodies/titles).
- Purely additive observability; **no change** to resolution behaviour.
- `logger`/`createLogger` are now exported from `@librarian/mcp-server` (tests spy on it; downstream embedders can reuse the configured pino instance).

## Pivot note

This branch was going to wire the live `bede → guybrush` alias, but that moves ~20 load-bearing `bede` assertions in `sessions.mcp.test.ts` (churn PR #71 deferred) for **low current value** — there's no live `bede` traffic and the Phase-3 backfill already covers stored `bede`. Pivoted to this higher-value, lower-blast-radius item; the live alias remains a documented TODO.

## Tests

`packages/mcp-server/tests/mcp/caller-resolution.mcp.test.ts` (+4): warns on missing identity (asserts bindings + that the body is never logged); binds `harness`/`source_ref` on a session call; no warn when identity supplied; no warn for admin. A shared, silenced spy avoids NDJSON noise and singleton bleed.

## Review

A `code-reviewer` sub-agent reviewed all five axes — verdict **APPROVE**, no Critical/Important; it confirmed the security property (full args never logged) and traced the predicate against the resolver across every edge case. Addressed its suggestions: whitespace-only `agentId` exactness (mirror `hasValue`), the test-noise/singleton-bleed cleanup, and the added positive/negative coverage. Drift + log-volume follow-ups noted in the build notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)