### PR TITLE
feat(core): persist actor_kind on memories + events projections

### DIFF
--- a/AUTONOMOUS-BUILD-NOTES-26-05-23.md
+++ b/AUTONOMOUS-BUILD-NOTES-26-05-23.md
@@ -12,7 +12,31 @@ Increments shipped this day, each its own PR:
 5. `feat/naming-contract-dashboard-actor` — Stage 1.4 dashboard-admin actor (merged, PR #74).
 6. `feat/naming-contract-backfill` — Stage 4.1 Phase-3 caller-id backfill (merged, PR #75).
 7. `feat/naming-contract-live-aliases` → pivoted to `soft-mode missing-identity warning`
-   (Stage 1.4 observability, this PR).
+   (Stage 1.4 observability, merged, PR #76).
+8. `feat/naming-contract-actor-kind` — Stage 1.3 `actor_kind` projection column (this PR).
+
+---
+
+## Increment 8 — Stage 1.3 `actor_kind` projection column
+
+Spec §6 / §14 open-question #3 (resolved): persist an explicit `actor_kind`
+(`agent`/`admin`/`system`/`cli`) so the dashboard can group/filter by actor kind in SQL and
+the audit ledger carries the kind as metadata. Added `actor_kind TEXT` to the **`memories`** and
+**`events`** projection tables, derived from each row's `agent_id` via the resolver's existing
+`actorKind()` during the single `rebuildMemoryIndex` insert path. `PROJECTION_SCHEMA_VERSION`
+bumped 6 → 7; `test/schema-snapshot.json` refreshed. The bump repopulates both tables on next
+boot (memory side is JSONL-canonical, so the rebuild fills the new column for existing installs).
+
+**Scope decision — sessions deferred deliberately.** `sessions.actor_kind` was left out of this
+increment: a session carries *two* agent ids (`created_by_agent_id` / `current_agent_id`) and
+multiple write paths (insert + in-place update), so it needs a modeling decision (which id's
+kind, and keeping it in sync on reassignment) that shouldn't be rushed into a schema migration.
+
+- [ ] **Follow-up: `sessions.actor_kind`.** Decide created_by-vs-current semantics, add the
+  column + populate in `upsertSession`/`updateSessionRow`, keep it in sync on agent reassignment.
+- [ ] **Note:** `actor_kind` is *derivable* from `agent_id` (it's denormalised for SQL
+  grouping/filtering + audit metadata per §6). The dashboard §7.5 grouping work can now
+  `GROUP BY actor_kind` instead of deriving in JS.
 
 ---
 

--- a/packages/core/src/caller-identity.ts
+++ b/packages/core/src/caller-identity.ts
@@ -109,7 +109,11 @@ export function isReservedId(id: string): boolean {
   return id.startsWith(SYSTEM_PREFIX) || id.startsWith(DASHBOARD_PREFIX) || id === CLI_ACTOR_ID;
 }
 
-/** Classify a canonical id into its persisted {@link ActorKind} (§6). */
+/**
+ * Classify a canonical id into its persisted {@link ActorKind} (§6). The legacy
+ * `unknown-agent` sentinel falls through to `"agent"` — it has no kind of its
+ * own; the dashboard surfaces it as legacy/unattributed by id, not by kind (§7.5).
+ */
 export function actorKind(id: string): ActorKind {
   if (id.startsWith(SYSTEM_PREFIX)) return "system";
   if (id.startsWith(DASHBOARD_PREFIX)) return "admin";

--- a/packages/core/src/schemas/memory.ts
+++ b/packages/core/src/schemas/memory.ts
@@ -21,6 +21,10 @@ export const MemorySchema = z.object({
   category: CategorySchema,
   visibility: VisibilitySchema,
   agent_id: z.string().nullable(),
+  // Projection-derived (agent/admin/system/cli) via the resolver's `actorKind`;
+  // never written by callers. Optional because the `payload.memory` snapshots
+  // embedded in JSONL ledger events don't carry it — it lives only on the row.
+  actor_kind: z.string().nullable().optional(),
   scope: ScopeSchema,
   project_key: z.string().nullable(),
   status: MemoryStatusSchema,
@@ -47,6 +51,8 @@ export const MemoryPatchSchema = MemorySchema.partial().omit({
   recall_count: true,
   usefulness_score: true,
   last_recalled_at: true,
+  // Derived from agent_id on every rebuild — never patched directly.
+  actor_kind: true,
 });
 export type MemoryPatch = z.infer<typeof MemoryPatchSchema>;
 

--- a/packages/core/src/store/projection.ts
+++ b/packages/core/src/store/projection.ts
@@ -18,6 +18,7 @@
 
 import fs from "node:fs";
 import type { DatabaseSync } from "node:sqlite";
+import { actorKind } from "../caller-identity.js";
 import {
   MemoryEventType,
   MemoryStatus,
@@ -63,7 +64,11 @@ function asArray(value: unknown): string[] {
 //        transitions live in SQLite only. The DDL is unchanged; the
 //        bump forces a one-time replay from the legacy ledger so any
 //        existing sessions.jsonl rolls into the new shape.
-export const PROJECTION_SCHEMA_VERSION = 6;
+//   - 7: naming contract §6/§14 — explicit `actor_kind` column on the
+//        `memories` and `events` projections, derived from `agent_id`
+//        via `actorKind`. The bump repopulates both on next boot (memory
+//        side is JSONL-canonical, so the rebuild fills the new column).
+export const PROJECTION_SCHEMA_VERSION = 7;
 
 export function getSchemaVersion(db: DatabaseSync): number {
   const row = db.prepare("PRAGMA user_version").get() as { user_version: number };
@@ -169,6 +174,7 @@ export const SCHEMA_DDL = `
       category TEXT NOT NULL,
       visibility TEXT NOT NULL,
       agent_id TEXT,
+      actor_kind TEXT,
       scope TEXT NOT NULL,
       project_key TEXT,
       status TEXT NOT NULL,
@@ -196,6 +202,7 @@ export const SCHEMA_DDL = `
       event_type TEXT NOT NULL,
       memory_id TEXT,
       agent_id TEXT,
+      actor_kind TEXT,
       created_at TEXT NOT NULL,
       payload_json TEXT NOT NULL
     );
@@ -473,17 +480,17 @@ export function rebuildMemoryIndex({
     db.exec("DELETE FROM memories; DELETE FROM memories_fts; DELETE FROM events;");
     const insertMemory = db.prepare(`
       INSERT INTO memories (
-        id, title, body, category, visibility, agent_id, scope, project_key,
+        id, title, body, category, visibility, agent_id, actor_kind, scope, project_key,
         status, priority, confidence, tags_json, applies_to_json, supersedes_json,
         conflicts_with_json, created_at, updated_at, last_recalled_at, recall_count, usefulness_score
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
     const insertFts = db.prepare(
       "INSERT INTO memories_fts (id, title, body, category, tags) VALUES (?, ?, ?, ?, ?)",
     );
     const insertEvent = db.prepare(`
-      INSERT INTO events (event_id, event_type, memory_id, agent_id, created_at, payload_json)
-      VALUES (?, ?, ?, ?, ?, ?)
+      INSERT INTO events (event_id, event_type, memory_id, agent_id, actor_kind, created_at, payload_json)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
     `);
 
     for (const memory of memories) {
@@ -495,6 +502,7 @@ export function rebuildMemoryIndex({
         m.category as string,
         m.visibility as string,
         (m.agent_id as string) || null,
+        m.agent_id ? actorKind(m.agent_id as string) : null,
         m.scope as string,
         (m.project_key as string) || null,
         m.status as string,
@@ -525,6 +533,7 @@ export function rebuildMemoryIndex({
         event.event_type,
         event.memory_id || null,
         event.agent_id || null,
+        event.agent_id ? actorKind(event.agent_id) : null,
         event.created_at,
         JSON.stringify(event.payload || {}),
       );

--- a/packages/core/tests/store/actor-kind.test.ts
+++ b/packages/core/tests/store/actor-kind.test.ts
@@ -1,0 +1,100 @@
+// actor_kind projection column (naming contract §6 / §14 open-question #3).
+//
+// The store persists an explicit `actor_kind` (agent/admin/system/cli) derived
+// from each row's `agent_id` via the resolver's `actorKind`, so the dashboard
+// can group/filter by actor kind in SQL and the audit ledger carries the kind
+// as metadata. This pins that the column is populated on both the `memories`
+// projection and the `events` audit table.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { type LibrarianStore, createLibrarianStore } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+interface Scope {
+  store: LibrarianStore;
+  dataDir: string;
+}
+
+function scope(): Scope {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-actor-kind-"));
+  const store = createLibrarianStore({ dataDir });
+  return { store, dataDir };
+}
+
+function teardown(s: Scope | null): void {
+  if (!s) return;
+  try {
+    s.store.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(s.dataDir, { recursive: true, force: true });
+}
+
+function seedMemory(store: LibrarianStore, agent_id: string, title: string): void {
+  store.createMemory({
+    agent_id,
+    title,
+    body: "body text",
+    category: "projects",
+    visibility: "common",
+    scope: "project",
+    project_key: "the-librarian",
+    priority: "normal",
+    confidence: "working",
+  });
+}
+
+function memoryKindByAgent(store: LibrarianStore): Map<string, string | null> {
+  const rows = store.db.prepare("SELECT agent_id, actor_kind FROM memories").all() as Array<{
+    agent_id: string | null;
+    actor_kind: string | null;
+  }>;
+  return new Map(rows.map((r) => [String(r.agent_id), r.actor_kind]));
+}
+
+describe("actor_kind projection column", () => {
+  let s: Scope | null = null;
+  beforeEach(() => {
+    s = scope();
+  });
+  afterEach(() => {
+    teardown(s);
+    s = null;
+  });
+
+  it("derives actor_kind on memories from each row's agent_id", () => {
+    const { store } = s!;
+    seedMemory(store, "guybrush", "an agent");
+    seedMemory(store, "system-memory-curator", "a system actor");
+    seedMemory(store, "dashboard-admin", "an admin actor");
+    seedMemory(store, "cli", "the cli operator");
+    seedMemory(store, "unknown-agent", "the legacy sentinel");
+
+    const kinds = memoryKindByAgent(store);
+    expect(kinds.get("guybrush")).toBe("agent");
+    expect(kinds.get("system-memory-curator")).toBe("system");
+    expect(kinds.get("dashboard-admin")).toBe("admin");
+    expect(kinds.get("cli")).toBe("cli");
+    expect(kinds.get("unknown-agent")).toBe("agent");
+  });
+
+  it("records actor_kind on the events audit table", () => {
+    const { store } = s!;
+    seedMemory(store, "system-memory-curator", "system write");
+    const rows = store.db
+      .prepare("SELECT agent_id, actor_kind FROM events WHERE agent_id = ?")
+      .all("system-memory-curator") as Array<{ agent_id: string; actor_kind: string | null }>;
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) expect(row.actor_kind).toBe("system");
+  });
+
+  it("survives a projection rebuild", () => {
+    const { store } = s!;
+    seedMemory(store, "dashboard-admin", "persisted");
+    store.rebuildIndex();
+    expect(memoryKindByAgent(store).get("dashboard-admin")).toBe("admin");
+  });
+});

--- a/test/schema-snapshot.json
+++ b/test/schema-snapshot.json
@@ -1,4 +1,4 @@
 {
-  "version": 6,
-  "fingerprint": "bdd2adacb63ef1585c9c5b3f08e50929d3850e183af080641755e9cc45d18868"
+  "version": 7,
+  "fingerprint": "eec6da65bea9e52d33c8f12177a109348733693cf50f53d9d89d37382cb17452"
 }


### PR DESCRIPTION
## Summary

Increment 8 of the agent naming-contract build — **Stage 1.3** (spec §6 / §14 open-question #3, resolved).

Persists an explicit `actor_kind` (`agent`/`admin`/`system`/`cli`) column so the dashboard can group/filter by actor kind in SQL and the audit ledger carries the kind as metadata.

- Added `actor_kind TEXT` to the **`memories`** and **`events`** projection tables in `SCHEMA_DDL`.
- Populated in the single `rebuildMemoryIndex` insert path via the resolver's existing `actorKind(agent_id)`; `agent_id` null → `actor_kind` null. (Confirmed `rebuildMemoryIndex` is the *sole* memory-projection writer — every memory mutation is append-to-JSONL + full rebuild — so no path leaves it stale.)
- Bumped `PROJECTION_SCHEMA_VERSION` 6 → 7 and refreshed `test/schema-snapshot.json`. The bump drops + repopulates `memories`/`events` on next boot (memory side is JSONL-canonical); the SQLite-authoritative `sessions` table is preserved untouched.
- Declared `actor_kind` on `MemorySchema` (optional/nullable, projection-derived) and excluded it from `MemoryPatchSchema` (derived, never patched).

## Scope decision — sessions deferred

`sessions.actor_kind` is intentionally **not** in this increment: a session carries two agent ids (`created_by_agent_id` / `current_agent_id`) and multiple write paths (insert + in-place update), so it needs a deliberate modeling decision (which id's kind, kept in sync on reassignment) rather than being rushed into a schema migration. Captured as a follow-up in the build notes.

## Tests

`packages/core/tests/store/actor-kind.test.ts` (3): per-kind derivation on memories (agent/admin/system/cli + the legacy sentinel), the events audit table, and survival across an explicit rebuild.

## Review

A `code-reviewer` sub-agent reviewed all five axes — verdict **APPROVE**, no Critical/Important. It verified the INSERT column/placeholder/arg alignment (the highest-risk item: 20→21 and 6→7, all aligned), the 6→7 migration mechanics, and that no non-rebuild write path exists. Addressed its suggestions: declared `actor_kind` on the read model (+ patch-omit) and documented the `unknown-agent`→`agent` classification choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)