### PR TITLE
feat(dashboard): group system actors + mark legacy unknown-agent in agent filter (§7.5)

### DIFF
--- a/AUTONOMOUS-BUILD-NOTES-26-05-23.md
+++ b/AUTONOMOUS-BUILD-NOTES-26-05-23.md
@@ -28,13 +28,16 @@ real agents at the top level, reserved/system actors (`system-*`/`dashboard-*`/`
 so filtering is unaffected. Canonical ids were already guaranteed by canonical storage, so no
 backend change was needed.
 
-The reserved-namespace classifier is a small **local** mirror of core's `actorKind` — `filters.tsx`
-is a `"use client"` component, so importing `@librarian/core` would pull its `node:sqlite` store
-into the browser bundle. The duplication is 3 lines and commented as such.
+Reserved classification reuses core's `isReservedId` directly. To avoid pulling core's
+`node:sqlite` store into the client bundle (the barrel `@librarian/core` re-exports it), I added
+a new **client-safe subpath export** `@librarian/core/caller-identity` (the module is pure — no
+I/O) and import from there. Verified with a real `next build`: the client bundle compiles, no
+node builtins leak. (Review caught that an earlier local-mirror copy was avoidable; this is the
+proper drift-free fix.)
 
-Remaining §7.5 (deferred): the same grouping could be applied to the **sessions** dashboard's
-agent filter and the analytics/aggregates views; left for a follow-up to keep this increment
-focused on the memories surface.
+Remaining §7.5 (deferred): the analytics/aggregates views could surface the same grouping. The
+**sessions** dashboard has no agent-filter dropdown (agent shows as a per-row pill), so there's
+nothing to group there. Left as a focused follow-up on the memories surface.
 
 ---
 

--- a/AUTONOMOUS-BUILD-NOTES-26-05-23.md
+++ b/AUTONOMOUS-BUILD-NOTES-26-05-23.md
@@ -13,7 +13,28 @@ Increments shipped this day, each its own PR:
 6. `feat/naming-contract-backfill` — Stage 4.1 Phase-3 caller-id backfill (merged, PR #75).
 7. `feat/naming-contract-live-aliases` → pivoted to `soft-mode missing-identity warning`
    (Stage 1.4 observability, merged, PR #76).
-8. `feat/naming-contract-actor-kind` — Stage 1.3 `actor_kind` projection column (this PR).
+8. `feat/naming-contract-actor-kind` — Stage 1.3 `actor_kind` projection column (merged, PR #77).
+9. `feat/naming-contract-dashboard-grouping` — Stage 1.4 §7.5 agent-filter grouping (this PR).
+
+---
+
+## Increment 9 — Stage 1.4 §7.5 dashboard agent-filter grouping
+
+The user-facing payoff of the canonicalisation/`actor_kind` work. The memories Agent filter
+dropdown (`components/memories/filters.tsx`) now partitions its data-driven options (§7.5):
+real agents at the top level, reserved/system actors (`system-*`/`dashboard-*`/`cli`) under a
+"System actors" `<optgroup>`, and the legacy `unknown-agent` sentinel called out under a
+"Legacy" group as "unknown-agent (legacy)" — while its filter **value** stays `unknown-agent`
+so filtering is unaffected. Canonical ids were already guaranteed by canonical storage, so no
+backend change was needed.
+
+The reserved-namespace classifier is a small **local** mirror of core's `actorKind` — `filters.tsx`
+is a `"use client"` component, so importing `@librarian/core` would pull its `node:sqlite` store
+into the browser bundle. The duplication is 3 lines and commented as such.
+
+Remaining §7.5 (deferred): the same grouping could be applied to the **sessions** dashboard's
+agent filter and the analytics/aggregates views; left for a follow-up to keep this increment
+focused on the memories surface.
 
 ---
 

--- a/apps/dashboard/components/memories/filters.tsx
+++ b/apps/dashboard/components/memories/filters.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { isReservedId } from "@librarian/core/caller-identity";
+import { useMemo } from "react";
 import { CATEGORIES, VISIBILITIES } from "./types";
 import { Input } from "@/components/ui-v2/input";
 import { trpc } from "@/lib/trpc-client";
@@ -17,16 +19,12 @@ export interface FilterState {
 // The legacy sentinel for memories with no resolved caller (naming contract §6).
 const LEGACY_AGENT_ID = "unknown-agent";
 
-// Mirrors core's `actorKind` reserved-namespace check. Kept local on purpose:
-// this is a "use client" component, and importing `@librarian/core` would pull
-// its node:sqlite store into the browser bundle.
-function isReservedActor(id: string): boolean {
-  return id.startsWith("system-") || id.startsWith("dashboard-") || id === "cli";
-}
-
 // Partition the distinct agent ids for the dropdown (§7.5): real agents at the
-// top level, reserved/system actors under their own group, and the legacy
-// `unknown-agent` sentinel called out separately.
+// top level, reserved/system actors (system-*/dashboard-*/cli) under their own
+// group, and the legacy `unknown-agent` sentinel called out separately. Reserved
+// classification reuses core's `isReservedId` — imported from the pure
+// `@librarian/core/caller-identity` subpath, which carries no node:sqlite store,
+// so it's safe in this client bundle.
 function groupAgents(values: readonly string[]): {
   agents: string[];
   systemActors: string[];
@@ -37,7 +35,7 @@ function groupAgents(values: readonly string[]): {
   const legacy: string[] = [];
   for (const id of values) {
     if (id === LEGACY_AGENT_ID) legacy.push(id);
-    else if (isReservedActor(id)) systemActors.push(id);
+    else if (isReservedId(id)) systemActors.push(id);
     else agents.push(id);
   }
   return { agents, systemActors, legacy };
@@ -57,7 +55,7 @@ export function MemoriesFilters({ filters, onChange, onRecall, recalling }: Prop
   // alphabetical sort.
   const agentValues = trpc.memories.distinctValues.useQuery({ field: "agent_id" });
   const projectValues = trpc.memories.distinctValues.useQuery({ field: "project_key" });
-  const agentGroups = groupAgents(agentValues.data ?? []);
+  const agentGroups = useMemo(() => groupAgents(agentValues.data ?? []), [agentValues.data]);
 
   const set = <K extends keyof FilterState>(key: K, value: FilterState[K]) =>
     onChange({ ...filters, [key]: value });

--- a/apps/dashboard/components/memories/filters.tsx
+++ b/apps/dashboard/components/memories/filters.tsx
@@ -14,6 +14,35 @@ export interface FilterState {
   to: string;
 }
 
+// The legacy sentinel for memories with no resolved caller (naming contract §6).
+const LEGACY_AGENT_ID = "unknown-agent";
+
+// Mirrors core's `actorKind` reserved-namespace check. Kept local on purpose:
+// this is a "use client" component, and importing `@librarian/core` would pull
+// its node:sqlite store into the browser bundle.
+function isReservedActor(id: string): boolean {
+  return id.startsWith("system-") || id.startsWith("dashboard-") || id === "cli";
+}
+
+// Partition the distinct agent ids for the dropdown (§7.5): real agents at the
+// top level, reserved/system actors under their own group, and the legacy
+// `unknown-agent` sentinel called out separately.
+function groupAgents(values: readonly string[]): {
+  agents: string[];
+  systemActors: string[];
+  legacy: string[];
+} {
+  const agents: string[] = [];
+  const systemActors: string[] = [];
+  const legacy: string[] = [];
+  for (const id of values) {
+    if (id === LEGACY_AGENT_ID) legacy.push(id);
+    else if (isReservedActor(id)) systemActors.push(id);
+    else agents.push(id);
+  }
+  return { agents, systemActors, legacy };
+}
+
 interface Props {
   filters: FilterState;
   onChange: (next: FilterState) => void;
@@ -28,6 +57,7 @@ export function MemoriesFilters({ filters, onChange, onRecall, recalling }: Prop
   // alphabetical sort.
   const agentValues = trpc.memories.distinctValues.useQuery({ field: "agent_id" });
   const projectValues = trpc.memories.distinctValues.useQuery({ field: "project_key" });
+  const agentGroups = groupAgents(agentValues.data ?? []);
 
   const set = <K extends keyof FilterState>(key: K, value: FilterState[K]) =>
     onChange({ ...filters, [key]: value });
@@ -41,11 +71,29 @@ export function MemoriesFilters({ filters, onChange, onRecall, recalling }: Prop
           onChange={(e) => set("agent_id", e.target.value)}
         >
           <option value="">All agents</option>
-          {(agentValues.data ?? []).map((v) => (
+          {agentGroups.agents.map((v) => (
             <option key={v} value={v}>
               {v}
             </option>
           ))}
+          {agentGroups.systemActors.length > 0 && (
+            <optgroup label="System actors">
+              {agentGroups.systemActors.map((v) => (
+                <option key={v} value={v}>
+                  {v}
+                </option>
+              ))}
+            </optgroup>
+          )}
+          {agentGroups.legacy.length > 0 && (
+            <optgroup label="Legacy">
+              {agentGroups.legacy.map((v) => (
+                <option key={v} value={v}>
+                  {v} (legacy)
+                </option>
+              ))}
+            </optgroup>
+          )}
         </select>
       </label>
       <label className="flex flex-col gap-1">

--- a/apps/dashboard/tests/components/filters.test.tsx
+++ b/apps/dashboard/tests/components/filters.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -9,7 +9,11 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("@/lib/trpc-client", () => ({
   trpc: {
     memories: {
-      distinctValues: { useQuery: () => ({ data: ["a", "claude-code", "codex"] }) },
+      distinctValues: {
+        useQuery: () => ({
+          data: ["claude-code", "codex", "cli", "system-memory-curator", "unknown-agent"],
+        }),
+      },
     },
   },
 }));
@@ -71,5 +75,31 @@ describe("MemoriesFilters", () => {
     // — pick an option populated by the mocked distinctValues hook.
     await userEvent.selectOptions(screen.getByLabelText("Agent"), "claude-code");
     expect(onChange).toHaveBeenLastCalledWith(expect.objectContaining({ agent_id: "claude-code" }));
+  });
+
+  it("groups system/reserved actors under a System actors optgroup (§7.5)", () => {
+    renderFilters();
+    // Scope to the Agent select — the mock feeds the same values to the
+    // Project dropdown too, so global option queries would be ambiguous.
+    const agent = screen.getByLabelText("Agent");
+    const systemGroup = within(agent).getByRole("group", { name: "System actors" });
+    expect(within(systemGroup).getByRole("option", { name: "system-memory-curator" })).toBeTruthy();
+    expect(within(systemGroup).getByRole("option", { name: "cli" })).toBeTruthy();
+    // A real agent must NOT be in the system group.
+    expect(within(systemGroup).queryByRole("option", { name: "claude-code" })).toBeNull();
+  });
+
+  it("marks unknown-agent as legacy while keeping its filter value intact (§7.5)", () => {
+    renderFilters();
+    const agent = screen.getByLabelText("Agent");
+    const legacy = within(agent).getByRole("option", { name: /unknown-agent.*legacy/i });
+    expect(legacy).toHaveValue("unknown-agent");
+  });
+
+  it("keeps regular agents at the top level (outside any optgroup)", () => {
+    renderFilters();
+    const agent = screen.getByLabelText("Agent");
+    const claudeOption = within(agent).getByRole("option", { name: "claude-code" });
+    expect(claudeOption.closest("optgroup")).toBeNull();
   });
 });

--- a/apps/dashboard/tests/components/filters.test.tsx
+++ b/apps/dashboard/tests/components/filters.test.tsx
@@ -11,7 +11,14 @@ vi.mock("@/lib/trpc-client", () => ({
     memories: {
       distinctValues: {
         useQuery: () => ({
-          data: ["claude-code", "codex", "cli", "system-memory-curator", "unknown-agent"],
+          data: [
+            "claude-code",
+            "codex",
+            "cli",
+            "dashboard-admin",
+            "system-memory-curator",
+            "unknown-agent",
+          ],
         }),
       },
     },
@@ -85,6 +92,8 @@ describe("MemoriesFilters", () => {
     const systemGroup = within(agent).getByRole("group", { name: "System actors" });
     expect(within(systemGroup).getByRole("option", { name: "system-memory-curator" })).toBeTruthy();
     expect(within(systemGroup).getByRole("option", { name: "cli" })).toBeTruthy();
+    // dashboard-admin (a reserved actor) groups here too.
+    expect(within(systemGroup).getByRole("option", { name: "dashboard-admin" })).toBeTruthy();
     // A real agent must NOT be in the system group.
     expect(within(systemGroup).queryByRole("option", { name: "claude-code" })).toBeNull();
   });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,6 +15,10 @@
       "types": "./dist/constants.d.ts",
       "import": "./dist/constants.js"
     },
+    "./caller-identity": {
+      "types": "./dist/caller-identity.d.ts",
+      "import": "./dist/caller-identity.js"
+    },
     "./schemas": {
       "types": "./dist/schemas/index.d.ts",
       "import": "./dist/schemas/index.js"


### PR DESCRIPTION
## Summary

Increment 9 of the agent naming-contract build — **§7.5 dashboard agent-filter grouping**, the user-facing payoff of the canonicalisation + `actor_kind` work.

The memories Agent filter dropdown (`components/memories/filters.tsx`) now partitions its data-driven options:
- **real agents** at the top level;
- **reserved/system actors** (`system-*` / `dashboard-*` / `cli`) under a "System actors" `<optgroup>`;
- the legacy **`unknown-agent`** sentinel under a "Legacy" group, shown as "unknown-agent (legacy)" — while its filter **value** stays `unknown-agent` so filtering is unaffected.

Canonical ids were already guaranteed by canonical storage, so no backend change was needed.

Reserved classification reuses core's `isReservedId` via a new **client-safe subpath export** `@librarian/core/caller-identity` (the module is pure — no `node:sqlite`), avoiding a local mirror / drift. Verified the client bundle compiles with a real `next build`.

## Tests

`apps/dashboard/tests/components/filters.test.tsx`: system/reserved actors (incl. `dashboard-admin`) group under "System actors"; real agents stay top-level; `unknown-agent` shows a legacy label while keeping value `unknown-agent`. Queries scoped to the Agent select.

## Scope

The sessions dashboard has no agent-filter dropdown (agent is a per-row pill), so there's nothing to group there; the analytics view is a documented follow-up.

## Review

A `code-reviewer` sub-agent reviewed all five axes — verdict **APPROVE**, no Critical/Important. Its main suggestion (the local classifier mirror was avoidable since `caller-identity` is pure) is addressed here via the subpath export; also memoised the grouping and added the `dashboard-admin` test case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)