### PR TITLE
test(mcp): cover sessions-router dashboard-admin attribution

### DIFF
--- a/AUTONOMOUS-BUILD-NOTES-26-05-23.md
+++ b/AUTONOMOUS-BUILD-NOTES-26-05-23.md
@@ -166,11 +166,10 @@ Remaining §7.5 (deferred): the dashboard **UI** changes — agent-filter dropdo
 canonical ids only, `unknown-agent` marked legacy, system actors grouped — are a frontend
 task for a later increment.
 
-- [ ] **Fast-follow:** a mirror test for the sessions router's `dashboard-admin` fallback.
-  The memories router has one; the sessions router uses the identical centralised
-  `?? DASHBOARD_AGENT_ID` pattern through `runAdminAction`, but its actor is recorded as a
-  session **state change** (not a timeline event), so asserting it needs the state-change
-  read surface rather than `sessions.events`. Low risk (shared constant), left untested for now.
+- [x] **Fast-follow (done, Increment 10):** a mirror test for the sessions router's
+  `dashboard-admin` fallback. Asserts against the `session_state_changes` ledger (read directly
+  from the store, since the actor is recorded as a state change, not a timeline event). It
+  characterises the existing shared-constant behaviour — passed on first write.
 
 ---
 

--- a/packages/mcp-server/tests/trpc/sessions.test.ts
+++ b/packages/mcp-server/tests/trpc/sessions.test.ts
@@ -487,4 +487,37 @@ describe("tRPC sessions surface", () => {
       cleanupTempDir(dataDir);
     }
   });
+
+  it("attributes an admin lifecycle mutation (no agent_id) to the dashboard-admin actor", async () => {
+    // Mirror of the memories-router dashboard-admin test. The sessions router
+    // records the actor on a session *state change* (not a timeline event), so
+    // this asserts against the session_state_changes ledger read directly from
+    // the store — there's no tRPC surface for it. Spec §6/§7.5: dashboard admin
+    // actions record the reserved `dashboard-admin` actor, not a bare string.
+    const dataDir = makeTempDir();
+    try {
+      const session = seedSession(dataDir, { agent_id: "bede", title: "Audited session" });
+      const server = await startHttpServer({ dataDir });
+      try {
+        await trpcPost(server, "sessions.end", { session_id: session.id, summary: "done" });
+      } finally {
+        await server.stop();
+      }
+      const store = createLibrarianStore({ dataDir });
+      try {
+        const rows = store.db
+          .prepare(
+            "SELECT to_status, actor_agent_id FROM session_state_changes WHERE session_id = ? ORDER BY id",
+          )
+          .all(session.id) as Array<{ to_status: string; actor_agent_id: string | null }>;
+        expect(rows.length).toBeGreaterThan(0);
+        // The end transition (the admin mutation) is the most recent change.
+        expect(rows.at(-1)?.actor_agent_id).toBe("dashboard-admin");
+      } finally {
+        store.close();
+      }
+    } finally {
+      cleanupTempDir(dataDir);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Closes the deferred fast-follow from PR #74 — a mirror of the memories-router `dashboard-admin` test, for the **sessions** router.

Asserts that an admin `sessions.end` with no `agent_id` records the reserved `dashboard-admin` actor (spec §6/§7.5). The sessions router records the actor on a session **state change** (not a timeline event), so the test reads `session_state_changes.actor_agent_id` directly from a store opened on the same data dir (after stopping the server) — there's no tRPC surface for the state-change ledger.

Characterises existing behaviour (the routers share the `?? DASHBOARD_AGENT_ID` constant via `runAdminAction`) — passed on first write. **No production code change** (test-only), so the heavyweight sub-agent review was skipped in favour of a self-review.

## Test

`packages/mcp-server/tests/trpc/sessions.test.ts` (+1, now 18): seed a session as `bede`, end it via the admin tRPC route with no `agent_id`, assert the end transition's `actor_agent_id` is `dashboard-admin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)