### PR TITLE
feat(core): add curator_note column to the memory record (curator-only)

### DIFF
--- a/AUTONOMOUS-BUILD-NOTES-26-05-23.md
+++ b/AUTONOMOUS-BUILD-NOTES-26-05-23.md
@@ -14,7 +14,30 @@ Increments shipped this day, each its own PR:
 7. `feat/naming-contract-live-aliases` → pivoted to `soft-mode missing-identity warning`
    (Stage 1.4 observability, merged, PR #76).
 8. `feat/naming-contract-actor-kind` — Stage 1.3 `actor_kind` projection column (merged, PR #77).
-9. `feat/naming-contract-dashboard-grouping` — Stage 1.4 §7.5 agent-filter grouping (this PR).
+9. `feat/naming-contract-dashboard-grouping` — Stage 1.4 §7.5 agent-filter grouping (merged, PR #78).
+10. `feat/naming-contract-sessions-admin-actor-test` — Stage 1.4 sessions-router actor coverage (merged, PR #79).
+11. `feat/curator-note-column` — Stage 2.1 (partial) `curator_note` memory column (this PR).
+
+**Stage 1 is complete** (PRs #70–#79). Stage 2 (memory curator) has begun.
+
+---
+
+## Increment 11 — Stage 2.1 (partial) `curator_note` memory column
+
+First slice of the curator data model (memory-curator spec §8 — explicitly "the **only** change
+to the memory store"). Adds a nullable JSON `curator_note` field to the memory record carrying
+curator provenance + the `supersedes` reference that makes a protected-correction proposal
+actionable. It flows through the event-sourced path like any other memory field: set on input →
+`normalizeMemoryInput` passthrough → memory record → `events.jsonl` → `reduceMemoryLog` →
+projected to a `curator_note TEXT` column (JSON), parsed back in `rowToMemory`. Survives a
+rebuild; defaults to null. `PROJECTION_SCHEMA_VERSION` bumped 7 → 8; snapshot refreshed.
+`CuratorNoteSchema`/`CuratorNote` added to `schemas/memory.ts` and declared on `MemorySchema`.
+
+Deliberately **not** exposed on the MCP-facing `MemoryInputSchema`: only the curator's internal
+apply layer (Stage 2.3) and the proposal path set `curator_note`; ordinary agents can't via MCP.
+
+Remaining Stage 2.1: the `memory_curation_runs` + `memory_curation_operations` tables (a separate
+SQLite-authoritative store with their own accessors) — next increment.
 
 ---
 

--- a/AUTONOMOUS-BUILD-NOTES-26-05-23.md
+++ b/AUTONOMOUS-BUILD-NOTES-26-05-23.md
@@ -27,14 +27,19 @@ Increments shipped this day, each its own PR:
 First slice of the curator data model (memory-curator spec §8 — explicitly "the **only** change
 to the memory store"). Adds a nullable JSON `curator_note` field to the memory record carrying
 curator provenance + the `supersedes` reference that makes a protected-correction proposal
-actionable. It flows through the event-sourced path like any other memory field: set on input →
-`normalizeMemoryInput` passthrough → memory record → `events.jsonl` → `reduceMemoryLog` →
-projected to a `curator_note TEXT` column (JSON), parsed back in `rowToMemory`. Survives a
-rebuild; defaults to null. `PROJECTION_SCHEMA_VERSION` bumped 7 → 8; snapshot refreshed.
+actionable. It flows to a `curator_note TEXT` column via the event-sourced path (memory record →
+`events.jsonl` → `reduceMemoryLog` → projection, parsed back in `rowToMemory`), survives a
+rebuild, and defaults to null. `PROJECTION_SCHEMA_VERSION` bumped 7 → 8; snapshot refreshed.
 `CuratorNoteSchema`/`CuratorNote` added to `schemas/memory.ts` and declared on `MemorySchema`.
 
-Deliberately **not** exposed on the MCP-facing `MemoryInputSchema`: only the curator's internal
-apply layer (Stage 2.3) and the proposal path set `curator_note`; ordinary agents can't via MCP.
+**Security (caught in review — fixed before merge):** `curator_note` is set **only** via
+`createMemory`'s trusted `options` channel (used by the future apply layer / proposal path),
+never from the free-form `input` record. The first cut read it from `normalizeMemoryInput`, which
+would have let an MCP agent smuggle a forged `supersedes` through `remember`/`propose_memory`
+(their `inputSchema` is advertised, not parse-enforced, and `scopeAgentArgs` shallow-copies all
+keys). Now `normalizeMemoryInput` ignores it entirely. Also omitted from `MemoryPatchSchema` so
+the wire contract matches `cleanPatch`'s allowlist (curator_note is not patchable). Two negative
+tests pin it: core (`createMemory` ignores `input.curator_note`) and MCP (`remember` can't set it).
 
 Remaining Stage 2.1: the `memory_curation_runs` + `memory_curation_operations` tables (a separate
 SQLite-authoritative store with their own accessors) — next increment.

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -60,9 +60,6 @@ export interface NormalizedMemoryInput {
   confidence: Confidence;
   tags: string[];
   status: MemoryStatus;
-  // Nullable JSON provenance set by the memory curator's apply layer
-  // (memory-curator spec §8); ordinary callers leave it null.
-  curator_note: Record<string, unknown> | null;
 }
 
 export function normalizeMemoryInput(input: Record<string, unknown> = {}): NormalizedMemoryInput {
@@ -87,11 +84,6 @@ export function normalizeMemoryInput(input: Record<string, unknown> = {}): Norma
     confidence: normalizeEnum(input.confidence, Object.values(Confidence), Confidence.Working),
     tags: asArray(input.tags),
     status: normalizeEnum(input.status, Object.values(MemoryStatus), MemoryStatus.Active),
-    // Structured passthrough — the curator sets a JSON object; everyone else null.
-    curator_note:
-      input.curator_note && typeof input.curator_note === "object"
-        ? (input.curator_note as Record<string, unknown>)
-        : null,
   };
 }
 

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -60,6 +60,9 @@ export interface NormalizedMemoryInput {
   confidence: Confidence;
   tags: string[];
   status: MemoryStatus;
+  // Nullable JSON provenance set by the memory curator's apply layer
+  // (memory-curator spec §8); ordinary callers leave it null.
+  curator_note: Record<string, unknown> | null;
 }
 
 export function normalizeMemoryInput(input: Record<string, unknown> = {}): NormalizedMemoryInput {
@@ -84,6 +87,11 @@ export function normalizeMemoryInput(input: Record<string, unknown> = {}): Norma
     confidence: normalizeEnum(input.confidence, Object.values(Confidence), Confidence.Working),
     tags: asArray(input.tags),
     status: normalizeEnum(input.status, Object.values(MemoryStatus), MemoryStatus.Active),
+    // Structured passthrough — the curator sets a JSON object; everyone else null.
+    curator_note:
+      input.curator_note && typeof input.curator_note === "object"
+        ? (input.curator_note as Record<string, unknown>)
+        : null,
   };
 }
 

--- a/packages/core/src/schemas/memory.ts
+++ b/packages/core/src/schemas/memory.ts
@@ -67,6 +67,9 @@ export const MemoryPatchSchema = MemorySchema.partial().omit({
   last_recalled_at: true,
   // Derived from agent_id on every rebuild — never patched directly.
   actor_kind: true,
+  // Curator-only provenance — set via the trusted create/apply path, not
+  // patchable over the wire (cleanPatch strips it; this keeps the contract honest).
+  curator_note: true,
 });
 export type MemoryPatch = z.infer<typeof MemoryPatchSchema>;
 

--- a/packages/core/src/schemas/memory.ts
+++ b/packages/core/src/schemas/memory.ts
@@ -14,6 +14,17 @@ import {
   VisibilitySchema,
 } from "./common.js";
 
+// Curator provenance attached to a memory (memory-curator spec §8). All fields
+// optional so partial provenance (e.g. just run/operation ids on an auto-applied
+// create) is valid; `supersedes` lists memory ids a correction is meant to replace.
+export const CuratorNoteSchema = z.object({
+  text: z.string().optional(),
+  supersedes: z.array(z.string()).optional(),
+  run_id: z.string().optional(),
+  operation_id: z.string().optional(),
+});
+export type CuratorNote = z.infer<typeof CuratorNoteSchema>;
+
 export const MemorySchema = z.object({
   id: IdSchema,
   title: z.string(),
@@ -39,6 +50,9 @@ export const MemorySchema = z.object({
   last_recalled_at: IsoTimestampSchema.nullable(),
   recall_count: z.number().int().nonnegative(),
   usefulness_score: z.number().int(),
+  // Curator provenance + superseded reference (memory-curator spec §8). Set by
+  // the curator's apply layer; null for agent/user-authored memories.
+  curator_note: CuratorNoteSchema.nullable().optional(),
 });
 export type Memory = z.infer<typeof MemorySchema>;
 

--- a/packages/core/src/store/memory-store.ts
+++ b/packages/core/src/store/memory-store.ts
@@ -482,6 +482,14 @@ export function createMemoryStore(deps: MemoryStoreDeps): MemoryStore {
     const status =
       (options.status as MemoryStatus | undefined) ||
       (protectedWrite ? MemoryStatus.Proposed : normalized.status);
+    // curator_note is curator-only provenance (memory-curator spec §8). It is
+    // accepted ONLY via the trusted `options` channel used by the internal
+    // apply layer / proposal path — never from the free-form `input`, so an
+    // MCP agent can't smuggle a forged `supersedes` through normalizeMemoryInput.
+    const curatorNote =
+      options.curator_note && typeof options.curator_note === "object"
+        ? (options.curator_note as Record<string, unknown>)
+        : null;
     const memory: Memory = {
       id: makeId("mem"),
       ...normalized,
@@ -493,6 +501,7 @@ export function createMemoryStore(deps: MemoryStoreDeps): MemoryStore {
       usefulness_score: 0,
       supersedes: [],
       conflicts_with: [],
+      curator_note: curatorNote,
     };
 
     const related = detectRelated(memory);

--- a/packages/core/src/store/memory-store.ts
+++ b/packages/core/src/store/memory-store.ts
@@ -49,6 +49,7 @@ export type Memory = Record<string, unknown> & {
   confidence: string;
   project_key?: string | null;
   updated_at: string;
+  curator_note?: Record<string, unknown> | null;
 };
 
 export interface AppendMemoryEventOptions {
@@ -773,6 +774,9 @@ function rowToMemory(row: Record<string, unknown>): Memory {
     conflicts_with: JSON.parse((row.conflicts_with_json as string) || "[]"),
     recall_count: Number(row.recall_count || 0),
     usefulness_score: Number(row.usefulness_score || 0),
+    curator_note: row.curator_note
+      ? (JSON.parse(row.curator_note as string) as Record<string, unknown>)
+      : null,
   } as Memory;
 }
 

--- a/packages/core/src/store/projection.ts
+++ b/packages/core/src/store/projection.ts
@@ -68,7 +68,10 @@ function asArray(value: unknown): string[] {
 //        `memories` and `events` projections, derived from `agent_id`
 //        via `actorKind`. The bump repopulates both on next boot (memory
 //        side is JSONL-canonical, so the rebuild fills the new column).
-export const PROJECTION_SCHEMA_VERSION = 7;
+//   - 8: memory-curator §8 — nullable `curator_note` JSON column on
+//        `memories`, carried on the memory record and rebuilt from the
+//        events ledger like the other memory fields.
+export const PROJECTION_SCHEMA_VERSION = 8;
 
 export function getSchemaVersion(db: DatabaseSync): number {
   const row = db.prepare("PRAGMA user_version").get() as { user_version: number };
@@ -188,7 +191,8 @@ export const SCHEMA_DDL = `
       updated_at TEXT NOT NULL,
       last_recalled_at TEXT,
       recall_count INTEGER NOT NULL,
-      usefulness_score INTEGER NOT NULL
+      usefulness_score INTEGER NOT NULL,
+      curator_note TEXT
     );
     CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
       id UNINDEXED,
@@ -482,8 +486,9 @@ export function rebuildMemoryIndex({
       INSERT INTO memories (
         id, title, body, category, visibility, agent_id, actor_kind, scope, project_key,
         status, priority, confidence, tags_json, applies_to_json, supersedes_json,
-        conflicts_with_json, created_at, updated_at, last_recalled_at, recall_count, usefulness_score
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        conflicts_with_json, created_at, updated_at, last_recalled_at, recall_count,
+        usefulness_score, curator_note
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
     const insertFts = db.prepare(
       "INSERT INTO memories_fts (id, title, body, category, tags) VALUES (?, ?, ?, ?, ?)",
@@ -517,6 +522,7 @@ export function rebuildMemoryIndex({
         (m.last_recalled_at as string) || null,
         Number(m.recall_count || 0),
         Number(m.usefulness_score || 0),
+        m.curator_note ? JSON.stringify(m.curator_note) : null,
       );
       insertFts.run(
         m.id as string,

--- a/packages/core/tests/store/curator-note.test.ts
+++ b/packages/core/tests/store/curator-note.test.ts
@@ -1,0 +1,92 @@
+// curator_note column (memory-curator spec §8 — the only memory-store change).
+//
+// A nullable JSON field on the memory record carrying curator provenance and
+// the superseded reference that makes a protected-correction proposal
+// actionable. It must round-trip as structured data through the event-sourced
+// create path AND survive a projection rebuild, and default to null when unset.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { type LibrarianStore, createLibrarianStore } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+interface Scope {
+  store: LibrarianStore;
+  dataDir: string;
+}
+
+function scope(): Scope {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-curator-note-"));
+  const store = createLibrarianStore({ dataDir });
+  return { store, dataDir };
+}
+
+function teardown(s: Scope | null): void {
+  if (!s) return;
+  try {
+    s.store.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(s.dataDir, { recursive: true, force: true });
+}
+
+function baseInput(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    agent_id: "system-memory-curator",
+    title: "curated",
+    body: "body text",
+    category: "projects",
+    visibility: "common",
+    scope: "project",
+    project_key: "the-librarian",
+    priority: "normal",
+    confidence: "working",
+    ...overrides,
+  };
+}
+
+describe("curator_note column", () => {
+  let s: Scope | null = null;
+  beforeEach(() => {
+    s = scope();
+  });
+  afterEach(() => {
+    teardown(s);
+    s = null;
+  });
+
+  it("round-trips structured curator_note through create and rebuild", () => {
+    const { store } = s!;
+    const note = {
+      text: "Supersedes the older note; role changed after the reorg.",
+      supersedes: ["mem_old123"],
+      run_id: "run_1",
+      operation_id: "op_1",
+    };
+    const { memory } = store.createMemory(baseInput({ curator_note: note }));
+
+    expect(store.getMemory(memory.id)?.curator_note).toEqual(note);
+
+    // Survives a full projection rebuild (memories are JSONL-canonical).
+    store.rebuildIndex();
+    expect(store.getMemory(memory.id)?.curator_note).toEqual(note);
+  });
+
+  it("persists curator_note as JSON text in the projection column", () => {
+    const { store } = s!;
+    const note = { text: "note", supersedes: ["mem_x"] };
+    const { memory } = store.createMemory(baseInput({ curator_note: note }));
+    const row = store.db
+      .prepare("SELECT curator_note FROM memories WHERE id = ?")
+      .get(memory.id) as { curator_note: string | null };
+    expect(JSON.parse(row.curator_note as string)).toEqual(note);
+  });
+
+  it("defaults curator_note to null when unset", () => {
+    const { store } = s!;
+    const { memory } = store.createMemory(baseInput());
+    expect(store.getMemory(memory.id)?.curator_note ?? null).toBeNull();
+  });
+});

--- a/packages/core/tests/store/curator-note.test.ts
+++ b/packages/core/tests/store/curator-note.test.ts
@@ -57,7 +57,7 @@ describe("curator_note column", () => {
     s = null;
   });
 
-  it("round-trips structured curator_note through create and rebuild", () => {
+  it("round-trips structured curator_note set via the trusted options channel", () => {
     const { store } = s!;
     const note = {
       text: "Supersedes the older note; role changed after the reorg.",
@@ -65,7 +65,8 @@ describe("curator_note column", () => {
       run_id: "run_1",
       operation_id: "op_1",
     };
-    const { memory } = store.createMemory(baseInput({ curator_note: note }));
+    // curator_note is set via createMemory's trusted `options`, not via input.
+    const { memory } = store.createMemory(baseInput(), { curator_note: note });
 
     expect(store.getMemory(memory.id)?.curator_note).toEqual(note);
 
@@ -77,16 +78,32 @@ describe("curator_note column", () => {
   it("persists curator_note as JSON text in the projection column", () => {
     const { store } = s!;
     const note = { text: "note", supersedes: ["mem_x"] };
-    const { memory } = store.createMemory(baseInput({ curator_note: note }));
+    const { memory } = store.createMemory(baseInput(), { curator_note: note });
     const row = store.db
       .prepare("SELECT curator_note FROM memories WHERE id = ?")
       .get(memory.id) as { curator_note: string | null };
     expect(JSON.parse(row.curator_note as string)).toEqual(note);
   });
 
+  it("ignores curator_note supplied via the untrusted input record (no smuggling)", () => {
+    const { store } = s!;
+    // An agent-facing create passes args as `input`; a forged curator_note
+    // there must be dropped — only the trusted options channel may set it.
+    const { memory } = store.createMemory(
+      baseInput({ curator_note: { supersedes: ["mem_victim"], text: "forged" } }),
+    );
+    const row = store.db
+      .prepare("SELECT curator_note FROM memories WHERE id = ?")
+      .get(memory.id) as { curator_note: string | null };
+    expect(row.curator_note).toBeNull();
+  });
+
   it("defaults curator_note to null when unset", () => {
     const { store } = s!;
     const { memory } = store.createMemory(baseInput());
-    expect(store.getMemory(memory.id)?.curator_note ?? null).toBeNull();
+    const row = store.db
+      .prepare("SELECT curator_note FROM memories WHERE id = ?")
+      .get(memory.id) as { curator_note: string | null };
+    expect(row.curator_note).toBeNull();
   });
 });

--- a/packages/mcp-server/tests/mcp/caller-resolution.mcp.test.ts
+++ b/packages/mcp-server/tests/mcp/caller-resolution.mcp.test.ts
@@ -185,4 +185,18 @@ describe("MCP caller resolution (soft mode)", () => {
       expect(warnSpy).not.toHaveBeenCalled();
     });
   });
+
+  it("ignores a curator_note smuggled through an agent remember call", async () => {
+    await withStore(async (store) => {
+      // curator_note is curator-only provenance; an agent must not be able to
+      // forge a `supersedes` reference through the MCP create path.
+      await call(store, "remember", {
+        ...rememberArgs("guybrush", "Smuggle"),
+        curator_note: { supersedes: ["mem_victim"], text: "forged" },
+      });
+      const memory = findByTitle(store, "Smuggle") as { curator_note?: unknown } | undefined;
+      expect(memory).toBeDefined();
+      expect(memory?.curator_note ?? null).toBeNull();
+    });
+  });
 });

--- a/test/schema-snapshot.json
+++ b/test/schema-snapshot.json
@@ -1,4 +1,4 @@
 {
-  "version": 7,
-  "fingerprint": "eec6da65bea9e52d33c8f12177a109348733693cf50f53d9d89d37382cb17452"
+  "version": 8,
+  "fingerprint": "92eddc6f4daee8a41cbe6f3e246f42906534c0a501e60848c049d842071db5d9"
 }


### PR DESCRIPTION
## Summary

First slice of the **Stage 2 (memory curator)** data model (memory-curator spec §8 — explicitly "the **only** change to the memory store").

Adds a nullable JSON `curator_note` field to the memory record carrying curator provenance + the `supersedes` reference that makes a protected-correction proposal actionable. It flows to a `curator_note TEXT` projection column via the event-sourced path (record → `events.jsonl` → `reduceMemoryLog` → projection, parsed back in `rowToMemory`), survives a rebuild, and defaults to null.

- `PROJECTION_SCHEMA_VERSION` 7 → 8; snapshot refreshed.
- `CuratorNoteSchema` / `CuratorNote` added; declared on `MemorySchema`; omitted from `MemoryPatchSchema` (not patchable — matches `cleanPatch`'s allowlist).

## Security (caught in review, fixed before merge)

`curator_note` is set **only** via `createMemory`'s trusted `options` channel (the future apply layer / proposal path), **never** from the free-form `input` record. The first cut read it from `normalizeMemoryInput`, which would have let an MCP agent smuggle a forged `supersedes` through `remember`/`propose_memory` — their `inputSchema` is advertised, not parse-enforced, and `scopeAgentArgs` shallow-copies all keys. `normalizeMemoryInput` now ignores it entirely. Two negative tests pin the boundary: core (`createMemory` ignores `input.curator_note`) and MCP (`remember` can't set it).

## Tests

`packages/core/tests/store/curator-note.test.ts` (4): trusted-channel round-trip + rebuild, JSON-text persistence, input-ignored (no smuggling), null default. Plus an MCP-boundary negative test in `caller-resolution.mcp.test.ts`.

## Scope

Remaining Stage 2.1: the `memory_curation_runs` + `memory_curation_operations` tables (separate SQLite-authoritative store) — next increment.

## Review

A `code-reviewer` sub-agent reviewed all five axes — verdict **REQUEST CHANGES** for the smuggle vector above (now fixed) plus the patch-schema contract mismatch (fixed). It verified INSERT alignment (21→22, aligned), the JSON round-trip (no double-encoding), and the 7→8 migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)