### PR TITLE
feat(core): add curation runs/operations tables + store (Stage 2.1 data model)

### DIFF
--- a/AUTONOMOUS-BUILD-NOTES-26-05-23.md
+++ b/AUTONOMOUS-BUILD-NOTES-26-05-23.md
@@ -16,9 +16,30 @@ Increments shipped this day, each its own PR:
 8. `feat/naming-contract-actor-kind` — Stage 1.3 `actor_kind` projection column (merged, PR #77).
 9. `feat/naming-contract-dashboard-grouping` — Stage 1.4 §7.5 agent-filter grouping (merged, PR #78).
 10. `feat/naming-contract-sessions-admin-actor-test` — Stage 1.4 sessions-router actor coverage (merged, PR #79).
-11. `feat/curator-note-column` — Stage 2.1 (partial) `curator_note` memory column (this PR).
+11. `feat/curator-note-column` — Stage 2.1 (partial) `curator_note` memory column (merged, PR #80).
+12. `feat/curation-tables` — Stage 2.1 (finish) curation runs/operations tables (this PR).
 
-**Stage 1 is complete** (PRs #70–#79). Stage 2 (memory curator) has begun.
+**Stage 1 is complete** (PRs #70–#79). Stage 2 (memory curator) has begun — **Stage 2.1 data
+model is now complete** (curator_note + curation tables).
+
+---
+
+## Increment 12 — Stage 2.1 (finish) curation runs/operations tables
+
+Completes the curator data model (memory-curator spec §8). Adds `memory_curation_runs` +
+`memory_curation_operations` to the schema and a new `curation-store.ts` create/read data-access
+layer (`createCurationRun`, `getCurationRun`, `listCurationRuns`, `recordCurationOperation`,
+`getCurationOperations`), composed into `LibrarianStore`. JSON array/payload columns round-trip
+via stringify/parse. `PROJECTION_SCHEMA_VERSION` bumped 8 → 9; snapshot refreshed.
+
+Like `sessions`, these tables are **SQLite-authoritative** (they record *why* the curator acted —
+not a projection of the memory ledger), so they are deliberately **absent from
+`dropProjectionTables`** and survive schema-version bumps; the bump just `CREATE`s them on
+existing installs. A rebuild-survival test pins this.
+
+Deferred to the worker (Workstream 2.4), where the transitions are actually exercised:
+`updateCurationRun` (status `pending → running → completed/failed`, usage accounting, timestamps)
+and operation status updates (`applied_at`/`error`). This increment is the create/read foundation.
 
 ---
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,3 +32,11 @@ export {
   type LibrarianStoreOptions,
   createLibrarianStore,
 } from "./store/librarian-store.js";
+export {
+  type CreateCurationRunInput,
+  type CurationOperation,
+  type CurationRun,
+  type CurationStore,
+  type ListCurationRunsInput,
+  type RecordCurationOperationInput,
+} from "./store/curation-store.js";

--- a/packages/core/src/store/curation-store.ts
+++ b/packages/core/src/store/curation-store.ts
@@ -83,6 +83,7 @@ export interface CurationOperation {
 export interface ListCurationRunsInput {
   status?: string;
   trigger?: string;
+  /** Page size, defaulted to 50 and clamped to a 200 ceiling. */
   limit?: number;
 }
 
@@ -133,9 +134,24 @@ interface CurationOperationRow {
   error: string | null;
 }
 
+// Defensive parses: writes always stringify, but the worker (2.4) and any
+// hand-edited row could feed malformed JSON — degrade to empty rather than throw.
 function parseIds(json: string): string[] {
-  const parsed = JSON.parse(json || "[]");
-  return Array.isArray(parsed) ? (parsed as string[]) : [];
+  try {
+    const parsed = JSON.parse(json || "[]");
+    return Array.isArray(parsed) ? (parsed as string[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function parsePayload(json: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(json || "{}");
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
 }
 
 function rowToRun(row: CurationRunRow): CurationRun {
@@ -155,7 +171,7 @@ function rowToOperation(row: CurationOperationRow): CurationOperation {
     source_memory_ids: parseIds(row.source_memory_ids),
     source_session_ids: parseIds(row.source_session_ids),
     target_memory_ids: parseIds(row.target_memory_ids),
-    proposed_payload: JSON.parse(row.proposed_payload || "{}") as Record<string, unknown>,
+    proposed_payload: parsePayload(row.proposed_payload),
   };
 }
 

--- a/packages/core/src/store/curation-store.ts
+++ b/packages/core/src/store/curation-store.ts
@@ -1,0 +1,265 @@
+// Curation data-model store (memory-curator spec §8).
+//
+// `memory_curation_runs` + `memory_curation_operations` record *why* the
+// curator suggested or performed an operation — the existing memory/event
+// store stays authoritative for memory state. These tables are
+// SQLite-authoritative (not ledger projections), so they survive a rebuild.
+//
+// This module is the create/read data-access layer. Run status transitions
+// (pending → running → completed/failed) and usage accounting belong to the
+// scheduler/worker (Workstream 2.4) and are added there, where the transitions
+// are actually exercised.
+
+import type { DatabaseSync } from "node:sqlite";
+import { makeId, nowIso } from "../constants.js";
+
+export interface CreateCurationRunInput {
+  trigger: string; // schedule | manual | maintenance
+  visibility: string; // common | agent_private
+  input_hash: string;
+  status?: string; // defaults to "pending"
+  mode?: string; // defaults to "apply"
+  project_key?: string | null;
+  agent_id?: string | null; // only for agent_private slices
+  input_memory_ids?: string[];
+  input_session_ids?: string[];
+  model_provider?: string | null;
+  model_name?: string | null;
+}
+
+export interface CurationRun {
+  id: string;
+  status: string;
+  trigger: string;
+  mode: string;
+  project_key: string | null;
+  visibility: string;
+  agent_id: string | null;
+  input_hash: string;
+  input_memory_ids: string[];
+  input_session_ids: string[];
+  model_provider: string | null;
+  model_name: string | null;
+  usage_input_tokens: number;
+  usage_output_tokens: number;
+  summary: string | null;
+  error: string | null;
+  created_at: string;
+  started_at: string | null;
+  completed_at: string | null;
+}
+
+export interface RecordCurationOperationInput {
+  run_id: string;
+  operation_type: string; // noop | create | update | archive | merge | split
+  status: string; // proposed | applied | skipped | failed | superseded
+  confidence: number;
+  risk_level: string; // safe | normal | risky | protected
+  rationale: string;
+  proposed_payload: Record<string, unknown>;
+  source_memory_ids?: string[];
+  source_session_ids?: string[];
+  target_memory_ids?: string[];
+  title?: string | null;
+}
+
+export interface CurationOperation {
+  id: string;
+  run_id: string;
+  operation_type: string;
+  status: string;
+  confidence: number;
+  risk_level: string;
+  source_memory_ids: string[];
+  source_session_ids: string[];
+  target_memory_ids: string[];
+  title: string | null;
+  rationale: string;
+  proposed_payload: Record<string, unknown>;
+  applied_at: string | null;
+  error: string | null;
+}
+
+export interface ListCurationRunsInput {
+  status?: string;
+  trigger?: string;
+  limit?: number;
+}
+
+export interface CurationStore {
+  createCurationRun: (input: CreateCurationRunInput) => CurationRun;
+  getCurationRun: (id: string) => CurationRun | null;
+  listCurationRuns: (input?: ListCurationRunsInput) => CurationRun[];
+  recordCurationOperation: (input: RecordCurationOperationInput) => CurationOperation;
+  getCurationOperations: (runId: string) => CurationOperation[];
+}
+
+interface CurationRunRow {
+  id: string;
+  status: string;
+  trigger: string;
+  mode: string;
+  project_key: string | null;
+  visibility: string;
+  agent_id: string | null;
+  input_hash: string;
+  input_memory_ids: string;
+  input_session_ids: string;
+  model_provider: string | null;
+  model_name: string | null;
+  usage_input_tokens: number;
+  usage_output_tokens: number;
+  summary: string | null;
+  error: string | null;
+  created_at: string;
+  started_at: string | null;
+  completed_at: string | null;
+}
+
+interface CurationOperationRow {
+  id: string;
+  run_id: string;
+  operation_type: string;
+  status: string;
+  confidence: number;
+  risk_level: string;
+  source_memory_ids: string;
+  source_session_ids: string;
+  target_memory_ids: string;
+  title: string | null;
+  rationale: string;
+  proposed_payload: string;
+  applied_at: string | null;
+  error: string | null;
+}
+
+function parseIds(json: string): string[] {
+  const parsed = JSON.parse(json || "[]");
+  return Array.isArray(parsed) ? (parsed as string[]) : [];
+}
+
+function rowToRun(row: CurationRunRow): CurationRun {
+  return {
+    ...row,
+    input_memory_ids: parseIds(row.input_memory_ids),
+    input_session_ids: parseIds(row.input_session_ids),
+    usage_input_tokens: Number(row.usage_input_tokens || 0),
+    usage_output_tokens: Number(row.usage_output_tokens || 0),
+  };
+}
+
+function rowToOperation(row: CurationOperationRow): CurationOperation {
+  return {
+    ...row,
+    confidence: Number(row.confidence || 0),
+    source_memory_ids: parseIds(row.source_memory_ids),
+    source_session_ids: parseIds(row.source_session_ids),
+    target_memory_ids: parseIds(row.target_memory_ids),
+    proposed_payload: JSON.parse(row.proposed_payload || "{}") as Record<string, unknown>,
+  };
+}
+
+export function createCurationStore(deps: { db: DatabaseSync }): CurationStore {
+  const { db } = deps;
+
+  function createCurationRun(input: CreateCurationRunInput): CurationRun {
+    const id = makeId("run");
+    db.prepare(
+      `INSERT INTO memory_curation_runs (
+        id, status, trigger, mode, project_key, visibility, agent_id, input_hash,
+        input_memory_ids, input_session_ids, model_provider, model_name,
+        usage_input_tokens, usage_output_tokens, summary, error,
+        created_at, started_at, completed_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, NULL, NULL, ?, NULL, NULL)`,
+    ).run(
+      id,
+      input.status ?? "pending",
+      input.trigger,
+      input.mode ?? "apply",
+      input.project_key ?? null,
+      input.visibility,
+      input.agent_id ?? null,
+      input.input_hash,
+      JSON.stringify(input.input_memory_ids ?? []),
+      JSON.stringify(input.input_session_ids ?? []),
+      input.model_provider ?? null,
+      input.model_name ?? null,
+      nowIso(),
+    );
+    const created = getCurationRun(id);
+    if (!created) throw new Error(`Failed to create curation run ${id}`);
+    return created;
+  }
+
+  function getCurationRun(id: string): CurationRun | null {
+    const row = db.prepare("SELECT * FROM memory_curation_runs WHERE id = ?").get(id) as
+      | CurationRunRow
+      | undefined;
+    return row ? rowToRun(row) : null;
+  }
+
+  function listCurationRuns(input: ListCurationRunsInput = {}): CurationRun[] {
+    const clauses: string[] = [];
+    const params: string[] = [];
+    if (input.status) {
+      clauses.push("status = ?");
+      params.push(input.status);
+    }
+    if (input.trigger) {
+      clauses.push("trigger = ?");
+      params.push(input.trigger);
+    }
+    const where = clauses.length ? `WHERE ${clauses.join(" AND ")}` : "";
+    const limit = Math.min(Math.max(input.limit ?? 50, 1), 200);
+    const rows = db
+      .prepare(
+        `SELECT * FROM memory_curation_runs ${where} ORDER BY created_at DESC, id DESC LIMIT ?`,
+      )
+      .all(...params, limit) as unknown as CurationRunRow[];
+    return rows.map(rowToRun);
+  }
+
+  function recordCurationOperation(input: RecordCurationOperationInput): CurationOperation {
+    const id = makeId("op");
+    db.prepare(
+      `INSERT INTO memory_curation_operations (
+        id, run_id, operation_type, status, confidence, risk_level,
+        source_memory_ids, source_session_ids, target_memory_ids,
+        title, rationale, proposed_payload, applied_at, error
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL)`,
+    ).run(
+      id,
+      input.run_id,
+      input.operation_type,
+      input.status,
+      input.confidence,
+      input.risk_level,
+      JSON.stringify(input.source_memory_ids ?? []),
+      JSON.stringify(input.source_session_ids ?? []),
+      JSON.stringify(input.target_memory_ids ?? []),
+      input.title ?? null,
+      input.rationale,
+      JSON.stringify(input.proposed_payload ?? {}),
+    );
+    const row = db.prepare("SELECT * FROM memory_curation_operations WHERE id = ?").get(id) as
+      | CurationOperationRow
+      | undefined;
+    if (!row) throw new Error(`Failed to record curation operation ${id}`);
+    return rowToOperation(row);
+  }
+
+  function getCurationOperations(runId: string): CurationOperation[] {
+    const rows = db
+      .prepare("SELECT * FROM memory_curation_operations WHERE run_id = ? ORDER BY id")
+      .all(runId) as unknown as CurationOperationRow[];
+    return rows.map(rowToOperation);
+  }
+
+  return {
+    createCurationRun,
+    getCurationRun,
+    listCurationRuns,
+    recordCurationOperation,
+    getCurationOperations,
+  };
+}

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -2,3 +2,4 @@ export * from "./jsonl.js";
 export * from "./projection.js";
 export * from "./memory-store.js";
 export * from "./session-store.js";
+export * from "./curation-store.js";

--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
+import { type CurationStore, createCurationStore } from "./curation-store.js";
 import { readJsonl } from "./jsonl.js";
 import { type MemoryStore, createMemoryStore } from "./memory-store.js";
 import { ensureSchema, rebuildMemoryIndex, rebuildSessionIndex } from "./projection.js";
@@ -12,7 +13,7 @@ export interface LibrarianStoreOptions {
   dataDir?: string;
 }
 
-export interface LibrarianStore extends MemoryStore, SessionStore {
+export interface LibrarianStore extends MemoryStore, SessionStore, CurationStore {
   dataDir: string;
   eventsPath: string;
   // R3 — sessionsPath is the timeline ledger (post-R3, new file).
@@ -84,10 +85,12 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Libra
     sessionsPath,
     createMemory: (input) => memoryStore.createMemory(input),
   });
+  const curationStore = createCurationStore({ db });
 
   return {
     ...memoryStore,
     ...sessionStore,
+    ...curationStore,
     dataDir,
     eventsPath,
     sessionsPath,

--- a/packages/core/src/store/projection.ts
+++ b/packages/core/src/store/projection.ts
@@ -71,7 +71,11 @@ function asArray(value: unknown): string[] {
 //   - 8: memory-curator §8 — nullable `curator_note` JSON column on
 //        `memories`, carried on the memory record and rebuilt from the
 //        events ledger like the other memory fields.
-export const PROJECTION_SCHEMA_VERSION = 8;
+//   - 9: memory-curator §8 — `memory_curation_runs` +
+//        `memory_curation_operations` tables. Like `sessions`, these are
+//        SQLite-authoritative (not ledger projections) and are preserved
+//        across bumps; the bump just CREATEs them on existing installs.
+export const PROJECTION_SCHEMA_VERSION = 9;
 
 export function getSchemaVersion(db: DatabaseSync): number {
   const row = db.prepare("PRAGMA user_version").get() as { user_version: number };
@@ -84,11 +88,12 @@ function stampSchemaVersion(db: DatabaseSync): void {
 
 function dropProjectionTables(db: DatabaseSync): void {
   // R3 — `sessions` and `session_state_changes` are SQLite-authoritative
-  // and must survive schema-version bumps. Future DDL changes to those
-  // tables should use ALTER TABLE rather than the drop-and-rebuild
-  // pattern below. The other tables are projections (memory side stays
-  // JSONL-canonical; session_events is rebuilt from session_events.jsonl
-  // on every bump).
+  // and must survive schema-version bumps. The `memory_curation_*` tables
+  // (memory-curator §8) are likewise authoritative and intentionally absent
+  // here. Future DDL changes to those tables should use ALTER TABLE rather
+  // than the drop-and-rebuild pattern below. The other tables are projections
+  // (memory side stays JSONL-canonical; session_events is rebuilt from
+  // session_events.jsonl on every bump).
   db.exec(`
     DROP TABLE IF EXISTS memories_fts;
     DROP TABLE IF EXISTS memories;
@@ -268,6 +273,46 @@ export const SCHEMA_DDL = `
       summary,
       payload_text
     );
+    CREATE TABLE IF NOT EXISTS memory_curation_runs (
+      id TEXT PRIMARY KEY,
+      status TEXT NOT NULL,
+      trigger TEXT NOT NULL,
+      mode TEXT NOT NULL DEFAULT 'apply',
+      project_key TEXT,
+      visibility TEXT NOT NULL,
+      agent_id TEXT,
+      input_hash TEXT NOT NULL,
+      input_memory_ids TEXT NOT NULL,
+      input_session_ids TEXT NOT NULL,
+      model_provider TEXT,
+      model_name TEXT,
+      usage_input_tokens INTEGER NOT NULL DEFAULT 0,
+      usage_output_tokens INTEGER NOT NULL DEFAULT 0,
+      summary TEXT,
+      error TEXT,
+      created_at TEXT NOT NULL,
+      started_at TEXT,
+      completed_at TEXT
+    );
+    CREATE TABLE IF NOT EXISTS memory_curation_operations (
+      id TEXT PRIMARY KEY,
+      run_id TEXT NOT NULL,
+      operation_type TEXT NOT NULL,
+      status TEXT NOT NULL,
+      confidence REAL NOT NULL,
+      risk_level TEXT NOT NULL,
+      source_memory_ids TEXT NOT NULL,
+      source_session_ids TEXT NOT NULL,
+      target_memory_ids TEXT NOT NULL,
+      title TEXT,
+      rationale TEXT NOT NULL,
+      proposed_payload TEXT NOT NULL,
+      applied_at TEXT,
+      error TEXT,
+      FOREIGN KEY (run_id) REFERENCES memory_curation_runs(id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_memory_curation_operations_run
+      ON memory_curation_operations(run_id, id);
   `;
 
 export function initSchema(db: DatabaseSync): void {

--- a/packages/core/tests/store/curation-store.test.ts
+++ b/packages/core/tests/store/curation-store.test.ts
@@ -1,0 +1,138 @@
+// Curation data-model store (memory-curator spec §8).
+//
+// `memory_curation_runs` + `memory_curation_operations` are a SQLite-authoritative
+// record of *why* the curator suggested or performed an operation. They are not
+// projections of the memory ledger, so they must survive a projection rebuild.
+// This pins create/read round-trips (incl. JSON array/payload fields) and
+// rebuild survival.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { type LibrarianStore, createLibrarianStore } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+interface Scope {
+  store: LibrarianStore;
+  dataDir: string;
+}
+
+function scope(): Scope {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-curation-"));
+  const store = createLibrarianStore({ dataDir });
+  return { store, dataDir };
+}
+
+function teardown(s: Scope | null): void {
+  if (!s) return;
+  try {
+    s.store.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(s.dataDir, { recursive: true, force: true });
+}
+
+describe("curation store (memory_curation_runs + operations)", () => {
+  let s: Scope | null = null;
+  beforeEach(() => {
+    s = scope();
+  });
+  afterEach(() => {
+    teardown(s);
+    s = null;
+  });
+
+  it("creates and reads back a curation run with parsed JSON fields", () => {
+    const { store } = s!;
+    const run = store.createCurationRun({
+      trigger: "manual",
+      visibility: "common",
+      input_hash: "hash-1",
+      input_memory_ids: ["mem_a", "mem_b"],
+      input_session_ids: ["ses_x"],
+      project_key: "the-librarian",
+      model_provider: "anthropic",
+      model_name: "claude-opus-4-7",
+    });
+
+    expect(run.id).toMatch(/^run_/);
+    expect(run.status).toBe("pending");
+    expect(run.mode).toBe("apply");
+    expect(run.input_memory_ids).toEqual(["mem_a", "mem_b"]);
+    expect(run.input_session_ids).toEqual(["ses_x"]);
+
+    const read = store.getCurationRun(run.id);
+    expect(read?.input_memory_ids).toEqual(["mem_a", "mem_b"]);
+    expect(read?.trigger).toBe("manual");
+    expect(read?.model_name).toBe("claude-opus-4-7");
+  });
+
+  it("records and reads operations for a run with parsed payload + id arrays", () => {
+    const { store } = s!;
+    const run = store.createCurationRun({
+      trigger: "schedule",
+      visibility: "common",
+      input_hash: "hash-2",
+    });
+    const op = store.recordCurationOperation({
+      run_id: run.id,
+      operation_type: "create",
+      status: "proposed",
+      confidence: 0.92,
+      risk_level: "safe",
+      source_memory_ids: ["mem_a"],
+      target_memory_ids: ["mem_new"],
+      rationale: "merge two near-duplicate lessons",
+      proposed_payload: { title: "Consolidated lesson", body: "…" },
+    });
+
+    expect(op.id).toMatch(/^op_/);
+    expect(op.run_id).toBe(run.id);
+    expect(op.confidence).toBeCloseTo(0.92);
+
+    const ops = store.getCurationOperations(run.id);
+    expect(ops).toHaveLength(1);
+    expect(ops[0].source_memory_ids).toEqual(["mem_a"]);
+    expect(ops[0].target_memory_ids).toEqual(["mem_new"]);
+    expect(ops[0].proposed_payload).toEqual({ title: "Consolidated lesson", body: "…" });
+  });
+
+  it("lists curation runs most-recent-first", () => {
+    const { store } = s!;
+    const first = store.createCurationRun({
+      trigger: "manual",
+      visibility: "common",
+      input_hash: "h1",
+    });
+    const second = store.createCurationRun({
+      trigger: "manual",
+      visibility: "common",
+      input_hash: "h2",
+    });
+    const ids = store.listCurationRuns().map((r) => r.id);
+    expect(ids).toContain(first.id);
+    expect(ids).toContain(second.id);
+  });
+
+  it("survives a projection rebuild (authoritative, not a ledger projection)", () => {
+    const { store } = s!;
+    const run = store.createCurationRun({
+      trigger: "manual",
+      visibility: "common",
+      input_hash: "h3",
+    });
+    store.recordCurationOperation({
+      run_id: run.id,
+      operation_type: "noop",
+      status: "skipped",
+      confidence: 0,
+      risk_level: "safe",
+      rationale: "nothing to do",
+      proposed_payload: {},
+    });
+    store.rebuildIndex();
+    expect(store.getCurationRun(run.id)?.input_hash).toBe("h3");
+    expect(store.getCurationOperations(run.id)).toHaveLength(1);
+  });
+});

--- a/packages/core/tests/store/curation-store.test.ts
+++ b/packages/core/tests/store/curation-store.test.ts
@@ -115,14 +115,14 @@ describe("curation store (memory_curation_runs + operations)", () => {
     expect(ids).toContain(second.id);
   });
 
-  it("survives a projection rebuild (authoritative, not a ledger projection)", () => {
-    const { store } = s!;
-    const run = store.createCurationRun({
+  it("survives a real schema-version bump (curation tables are not dropped)", () => {
+    const dataDir = s!.dataDir;
+    const run = s!.store.createCurationRun({
       trigger: "manual",
       visibility: "common",
       input_hash: "h3",
     });
-    store.recordCurationOperation({
+    s!.store.recordCurationOperation({
       run_id: run.id,
       operation_type: "noop",
       status: "skipped",
@@ -131,8 +131,15 @@ describe("curation store (memory_curation_runs + operations)", () => {
       rationale: "nothing to do",
       proposed_payload: {},
     });
-    store.rebuildIndex();
-    expect(store.getCurationRun(run.id)?.input_hash).toBe("h3");
-    expect(store.getCurationOperations(run.id)).toHaveLength(1);
+    // Simulate an older install so the next open runs the REAL bump path:
+    // ensureSchema → dropProjectionTables (must NOT include the curation tables)
+    // → initSchema → rebuild. rebuildIndex() alone wouldn't exercise this.
+    s!.store.db.exec("PRAGMA user_version = 8");
+    s!.store.close();
+    const reopened = createLibrarianStore({ dataDir });
+    s!.store = reopened; // hand the live handle to teardown
+
+    expect(reopened.getCurationRun(run.id)?.input_hash).toBe("h3");
+    expect(reopened.getCurationOperations(run.id)).toHaveLength(1);
   });
 });

--- a/test/schema-snapshot.json
+++ b/test/schema-snapshot.json
@@ -1,4 +1,4 @@
 {
-  "version": 8,
-  "fingerprint": "92eddc6f4daee8a41cbe6f3e246f42906534c0a501e60848c049d842071db5d9"
+  "version": 9,
+  "fingerprint": "616de01873ab507ba87303ba42a95625be6cc1be524d149bedfefd3a4fee83c5"
 }


### PR DESCRIPTION
## Summary

Completes the **Stage 2.1 curator data model** (memory-curator spec §8), pairing with the `curator_note` column from #80.

Adds the `memory_curation_runs` + `memory_curation_operations` tables and a new `curation-store.ts` create/read data-access layer (`createCurationRun`, `getCurationRun`, `listCurationRuns`, `recordCurationOperation`, `getCurationOperations`), composed into `LibrarianStore`. JSON array/payload columns round-trip via stringify/parse. `PROJECTION_SCHEMA_VERSION` 8 → 9; snapshot refreshed.

Like `sessions`, these tables are **SQLite-authoritative** (they record *why* the curator acted — not a projection of the memory ledger), so they're deliberately **absent from `dropProjectionTables`** and survive schema bumps; the bump just `CREATE`s them on existing installs.

Run/operation status transitions (`pending → running → completed/failed`, usage accounting, `applied_at`) are deferred to the scheduler/worker (Workstream 2.4), where they're exercised. This is the create/read foundation.

## Tests

`packages/core/tests/store/curation-store.test.ts` (4): run round-trip, operation round-trip (parsed payload + id arrays), list, and a **real schema-bump survival** test (forces `user_version=8` + reopen so `dropProjectionTables` actually runs).

## Review

A `code-reviewer` sub-agent reviewed all five axes — verdict **APPROVE**. It verified both INSERT alignments (19-col runs, 14-col operations), the authoritative-survives-bump production path, JSON round-trips, parameterized SQL, and confirmed FK enforcement is on by default in `node:sqlite`. Its one Important finding — the rebuild-survival test didn't exercise the bump path — is fixed here (now forces a real bump), plus the suggested JSON-read hardening and limit-ceiling doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)