### PR TITLE
feat(core): content fingerprint + resurrection match for the curator (Stage 2.2)

### DIFF
--- a/AUTONOMOUS-BUILD-NOTES-26-05-23.md
+++ b/AUTONOMOUS-BUILD-NOTES-26-05-23.md
@@ -17,10 +17,39 @@ Increments shipped this day, each its own PR:
 9. `feat/naming-contract-dashboard-grouping` — Stage 1.4 §7.5 agent-filter grouping (merged, PR #78).
 10. `feat/naming-contract-sessions-admin-actor-test` — Stage 1.4 sessions-router actor coverage (merged, PR #79).
 11. `feat/curator-note-column` — Stage 2.1 (partial) `curator_note` memory column (merged, PR #80).
-12. `feat/curation-tables` — Stage 2.1 (finish) curation runs/operations tables (this PR).
+12. `feat/curation-tables` — Stage 2.1 (finish) curation runs/operations tables (merged, PR #81).
+13. `feat/curator-fingerprint` — Stage 2.2 (partial) content fingerprint + resurrection match (this PR).
 
-**Stage 1 is complete** (PRs #70–#79). Stage 2 (memory curator) has begun — **Stage 2.1 data
-model is now complete** (curator_note + curation tables).
+**Stage 1 is complete** (PRs #70–#79). **Stage 2.1 (curator data model) is complete** (#80–#81).
+Stage 2.2 in progress.
+
+---
+
+## Increment 13 — Stage 2.2 (partial) content fingerprint + resurrection match
+
+Pure primitives behind the curator's resurrection-prevention pre-pass (memory-curator §9.1 /
+§10.3), in a new `curator-fingerprint.ts`:
+
+- `normalizeForFingerprint(text)` — NFKC, lowercased, punctuation-stripped, whitespace-collapsed.
+- `contentFingerprint(title, body)` — sha256 of the normalised title+body (joined with `\n`, which
+  the normaliser never emits, so the boundary can't collide: `("ab","")` ≠ `("a","b")`).
+- `normalizedTitle(title)` — a tombstone also matches on title alone.
+- `matchesTombstone(candidate, tombstones)` — returns the first tombstone a candidate would
+  resurrect (by fingerprint OR normalised title), else null.
+
+No store/LLM dependency and no schema change — fully unit-tested (10 tests). Server-only, so it
+uses `node:crypto` (not exposed on a client subpath).
+
+Remaining Stage 2.2: **evidence gathering** — slice-scoped (`common_global` / `common_project` /
+per-`agent_private`) bundling from the store, building tombstone refs from archived memories, with
+the **secret/cross-slice redaction** the spec calls a "non-negotiable privacy boundary" (§9). That
+privacy-critical piece is its own focused increment.
+
+### ⛔ Stage 2.3 is a decision gate (needs Jim)
+
+The LLM pass (§10.4) needs operator decisions before it can be built: **provider/endpoint, model,
+and how the API token is supplied** (admin secret-store), plus the `default_auto_apply` posture
+(spec defaults `safe_only`) and confidence threshold. I'll surface these explicitly when 2.2 lands.
 
 ---
 

--- a/packages/core/src/curator-fingerprint.ts
+++ b/packages/core/src/curator-fingerprint.ts
@@ -1,0 +1,70 @@
+// Curator content fingerprints + resurrection detection (memory-curator spec §9.1 / §10.3).
+//
+// Archived memories are passed to the curator's LLM as metadata-only tombstones
+// — never their full body — plus a `content_fingerprint`: a hash of the
+// normalised title+body. The deterministic pre-pass computes the same
+// fingerprint for each create/merge candidate and blocks any whose fingerprint
+// OR normalised title matches a tombstone, so deliberately-deleted content is
+// neither re-exposed to the model nor resurrected. This catches exact and
+// near-exact (normalisation-equivalent) resurrection cheaply; paraphrase-level
+// detection is a v2 concern.
+//
+// Server-only (the curator runs server-side) — safe to depend on node:crypto.
+
+import { createHash } from "node:crypto";
+
+/**
+ * Collapse free-form content to a comparison form: NFKC, lowercased,
+ * punctuation stripped (anything that isn't a letter, number, or whitespace),
+ * whitespace collapsed to single spaces, trimmed.
+ */
+export function normalizeForFingerprint(text: string): string {
+  return text
+    .normalize("NFKC")
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]/gu, "")
+    .replace(/\s+/gu, " ")
+    .trim();
+}
+
+/** The normalised title alone — a tombstone also matches on this (§10.3). */
+export function normalizedTitle(title: string): string {
+  return normalizeForFingerprint(title);
+}
+
+/**
+ * Stable hash of the normalised title+body. Title and body are joined with a
+ * newline, which the normaliser never emits (whitespace is collapsed to single
+ * spaces), so the boundary is unambiguous — `("ab","")` can't collide with
+ * `("a","b")`.
+ */
+export function contentFingerprint(title: string, body: string): string {
+  const normalised = `${normalizeForFingerprint(title)}\n${normalizeForFingerprint(body)}`;
+  return createHash("sha256").update(normalised, "utf8").digest("hex");
+}
+
+/** Metadata-only reference to an archived memory, as carried in evidence (§9.1). */
+export interface TombstoneRef {
+  id: string;
+  content_fingerprint: string;
+  normalized_title: string;
+}
+
+/**
+ * Return the first tombstone a candidate would resurrect — matching either its
+ * content fingerprint or its normalised title — or null if none. The caller
+ * (deterministic pre-pass) suppresses create/merge candidates that match.
+ */
+export function matchesTombstone(
+  candidate: { title: string; body: string },
+  tombstones: Iterable<TombstoneRef>,
+): TombstoneRef | null {
+  const fingerprint = contentFingerprint(candidate.title, candidate.body);
+  const title = normalizedTitle(candidate.title);
+  for (const tombstone of tombstones) {
+    if (tombstone.content_fingerprint === fingerprint || tombstone.normalized_title === title) {
+      return tombstone;
+    }
+  }
+  return null;
+}

--- a/packages/core/src/curator-fingerprint.ts
+++ b/packages/core/src/curator-fingerprint.ts
@@ -17,6 +17,13 @@ import { createHash } from "node:crypto";
  * Collapse free-form content to a comparison form: NFKC, lowercased,
  * punctuation stripped (anything that isn't a letter, number, or whitespace),
  * whitespace collapsed to single spaces, trimmed.
+ *
+ * Deliberately NFKC (not the NFKD + combining-mark strip used by the caller-id
+ * normaliser): diacritics are KEPT, so `café` ≠ `cafe`. Stripping them would
+ * over-merge distinct content and widen resurrection suppression. Note that
+ * empty / punctuation-only input normalises to "" — callers (evidence gathering)
+ * should not build tombstones from empty-normalising memories, or every
+ * empty-normalising candidate would match them.
  */
 export function normalizeForFingerprint(text: string): string {
   return text

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,13 @@ export {
 } from "./caller-identity.js";
 export { type CallerIdAudit, type CallerIdGroup, auditCallerIds } from "./caller-audit.js";
 export {
+  type TombstoneRef,
+  contentFingerprint,
+  matchesTombstone,
+  normalizeForFingerprint,
+  normalizedTitle,
+} from "./curator-fingerprint.js";
+export {
   type BackfillChange,
   type BackfillOptions,
   type BackfillSection,

--- a/packages/core/tests/curator-fingerprint.test.ts
+++ b/packages/core/tests/curator-fingerprint.test.ts
@@ -31,6 +31,16 @@ describe("normalizeForFingerprint", () => {
   it("keeps letters and digits across unicode", () => {
     expect(normalizeForFingerprint("Café 2026 — notes")).toBe("café 2026 notes");
   });
+
+  it("keeps diacritics as distinguishing (NFKC, unlike the caller-id normaliser)", () => {
+    expect(normalizeForFingerprint("café")).not.toBe(normalizeForFingerprint("cafe"));
+  });
+
+  it("normalises empty / whitespace-only / punctuation-only input to empty", () => {
+    expect(normalizeForFingerprint("")).toBe("");
+    expect(normalizeForFingerprint("   \t\n ")).toBe("");
+    expect(normalizeForFingerprint("!!! … ---")).toBe("");
+  });
 });
 
 describe("contentFingerprint", () => {

--- a/packages/core/tests/curator-fingerprint.test.ts
+++ b/packages/core/tests/curator-fingerprint.test.ts
@@ -1,0 +1,86 @@
+// Curator content fingerprint + resurrection match (memory-curator spec §9.1 / §10.3).
+//
+// The deterministic pre-pass blocks resurrection of deliberately-archived
+// memories: it computes a normalised content fingerprint (lowercased,
+// whitespace-collapsed, punctuation-stripped → hashed) for each create/merge
+// candidate and rejects any whose fingerprint OR normalised title matches an
+// archived tombstone. These are the pure primitives behind that check.
+
+import {
+  type TombstoneRef,
+  contentFingerprint,
+  matchesTombstone,
+  normalizeForFingerprint,
+  normalizedTitle,
+} from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+describe("normalizeForFingerprint", () => {
+  it("lowercases, strips punctuation, and collapses whitespace", () => {
+    expect(normalizeForFingerprint("  Hello,   World! ")).toBe("hello world");
+  });
+
+  it("treats case/punctuation/spacing variants as equal", () => {
+    // Punctuation that sits next to a space collapses cleanly; this pins that
+    // case + delimiter punctuation + extra spacing all fold to one form.
+    expect(normalizeForFingerprint("The Plan:  Step 1!")).toBe(
+      normalizeForFingerprint("the plan step 1"),
+    );
+  });
+
+  it("keeps letters and digits across unicode", () => {
+    expect(normalizeForFingerprint("Café 2026 — notes")).toBe("café 2026 notes");
+  });
+});
+
+describe("contentFingerprint", () => {
+  it("is deterministic for the same input", () => {
+    expect(contentFingerprint("Title", "Body")).toBe(contentFingerprint("Title", "Body"));
+  });
+
+  it("collapses normalisation-equivalent title+body to one fingerprint", () => {
+    expect(contentFingerprint("Hello World", "Some body text")).toBe(
+      contentFingerprint("hello,  world!", "some  body   text."),
+    );
+  });
+
+  it("differs for different content", () => {
+    expect(contentFingerprint("Title A", "Body")).not.toBe(contentFingerprint("Title B", "Body"));
+  });
+
+  it("does not collide title/body boundary (AB vs A+B split)", () => {
+    // "ab"+"" must not hash the same as "a"+"b".
+    expect(contentFingerprint("ab", "")).not.toBe(contentFingerprint("a", "b"));
+  });
+});
+
+describe("matchesTombstone", () => {
+  const tombstones: TombstoneRef[] = [
+    {
+      id: "mem_dead",
+      content_fingerprint: contentFingerprint("Deprecated approach", "We tried X, it failed."),
+      normalized_title: normalizedTitle("Deprecated approach"),
+    },
+  ];
+
+  it("matches a resurrection by content fingerprint", () => {
+    const hit = matchesTombstone(
+      { title: "deprecated approach!", body: "we tried x, it failed" },
+      tombstones,
+    );
+    expect(hit?.id).toBe("mem_dead");
+  });
+
+  it("matches a resurrection by normalised title alone (different body)", () => {
+    const hit = matchesTombstone(
+      { title: "Deprecated Approach", body: "totally different wording here" },
+      tombstones,
+    );
+    expect(hit?.id).toBe("mem_dead");
+  });
+
+  it("returns null when neither fingerprint nor title matches", () => {
+    const hit = matchesTombstone({ title: "A fresh idea", body: "new content" }, tombstones);
+    expect(hit).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Stage 2.2 (partial) — pure primitives behind the curator's **resurrection-prevention pre-pass** (memory-curator spec §9.1 / §10.3), in a new `curator-fingerprint.ts`.

Archived memories reach the curator's LLM as metadata-only tombstones (never their body) plus a `content_fingerprint`. The deterministic pre-pass computes the same fingerprint for each create/merge candidate and blocks any whose fingerprint **or** normalised title matches a tombstone — so deliberately-deleted content is neither re-exposed nor resurrected.

- `normalizeForFingerprint(text)` — NFKC, lowercased, punctuation-stripped, whitespace-collapsed.
- `contentFingerprint(title, body)` — sha256 of normalised title+body, newline-joined so the boundary can't collide (`("ab","")` ≠ `("a","b")`).
- `normalizedTitle(title)` — tombstones also match on title alone.
- `matchesTombstone(candidate, tombstones)` — first tombstone a candidate would resurrect, else null.

No store/LLM dependency, no schema change. Server-only (`node:crypto`).

## Tests

`packages/core/tests/curator-fingerprint.test.ts` (10): normalisation (case/punctuation/spacing/unicode), fingerprint determinism + normalisation-equivalence + distinctness + boundary non-collision, and resurrection match by fingerprint, by title-only, and none.

## Scope

Remaining Stage 2.2: **evidence gathering** with secret/cross-slice redaction (the spec's "non-negotiable privacy boundary", §9) — its own focused increment. **Stage 2.3 (LLM pass) is a decision gate** needing operator input on provider/model/token config — I'll surface it when 2.2 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)