### PR TITLE
feat(core): secret redaction for curator evidence (Stage 2.2 privacy boundary)

### DIFF
--- a/AUTONOMOUS-BUILD-NOTES-26-05-23.md
+++ b/AUTONOMOUS-BUILD-NOTES-26-05-23.md
@@ -60,6 +60,15 @@ detection is a v2 concern. Rule order runs the assignment rule first so an assig
 unit and its marker isn't re-matched (no double-count). All regexes linear (no ReDoS). 8 tests
 incl. a negative (git SHA + UUID stay intact). No store/LLM dependency.
 
+**Security review (security-auditor sub-agent) hardened it before merge.** It empirically found a
+**Critical** (the assignment rule failed *fully open* on quoted-with-spaces values — a real leak)
+and Important gaps. Fixes: the assignment value now handles single/double-quoted values in full
+(function replacer reconstructs the quotes); added **Stripe** (`sk_live_`…), **basic-auth URL /
+connection-string passwords** (`scheme://user:pass@host`), and **GitLab/npm/PyPI** rules; markers
+are now skipped by every rule so re-running is a true no-op (`count` = 0); added the `credentials`/
+`account_key` keywords and a bounded Slack rule. Known v1 gap (documented): an *unquoted* secret
+value with spaces is redacted only to the first space. 13 tests.
+
 Remaining Stage 2.2: **evidence gathering** — slice-scoped store bundling that *uses*
 `redactSecrets` + the fingerprint primitives to build the bounded, redacted, tombstone-bearing
 evidence bundle (§9 caps/ordering). That's the integration increment.

--- a/AUTONOMOUS-BUILD-NOTES-26-05-23.md
+++ b/AUTONOMOUS-BUILD-NOTES-26-05-23.md
@@ -18,7 +18,8 @@ Increments shipped this day, each its own PR:
 10. `feat/naming-contract-sessions-admin-actor-test` — Stage 1.4 sessions-router actor coverage (merged, PR #79).
 11. `feat/curator-note-column` — Stage 2.1 (partial) `curator_note` memory column (merged, PR #80).
 12. `feat/curation-tables` — Stage 2.1 (finish) curation runs/operations tables (merged, PR #81).
-13. `feat/curator-fingerprint` — Stage 2.2 (partial) content fingerprint + resurrection match (this PR).
+13. `feat/curator-fingerprint` — Stage 2.2 (partial) content fingerprint + resurrection match (merged, PR #82).
+14. `feat/curator-redaction` — Stage 2.2 (partial) secret redaction (this PR).
 
 **Stage 1 is complete** (PRs #70–#79). **Stage 2.1 (curator data model) is complete** (#80–#81).
 Stage 2.2 in progress.
@@ -44,6 +45,24 @@ Remaining Stage 2.2: **evidence gathering** — slice-scoped (`common_global` / 
 per-`agent_private`) bundling from the store, building tombstone refs from archived memories, with
 the **secret/cross-slice redaction** the spec calls a "non-negotiable privacy boundary" (§9). That
 privacy-critical piece is its own focused increment.
+
+## Increment 14 — Stage 2.2 (partial) secret redaction
+
+The privacy boundary itself (memory-curator §9): `redactSecrets(text)` scrubs secret-looking
+material from evidence **before** prompt construction, in a new `curator-redaction.ts`. A
+conservative **known-format + assignment** redactor — PEM private keys, provider token shapes
+(`sk-`/`sk-ant-`, `ghp_…`, `AKIA…`, `xox…`, `AIza…`), JWTs, `Bearer …`, and `key = secret`
+assignments (value redacted, key kept for context) — returning `{ redacted, count }`.
+
+Deliberate design choices (documented in-module): **no generic high-entropy detection** — it
+would shred git SHAs / UUIDs / content hashes and degrade the curator's evidence; entropy/semantic
+detection is a v2 concern. Rule order runs the assignment rule first so an assigned secret is one
+unit and its marker isn't re-matched (no double-count). All regexes linear (no ReDoS). 8 tests
+incl. a negative (git SHA + UUID stay intact). No store/LLM dependency.
+
+Remaining Stage 2.2: **evidence gathering** — slice-scoped store bundling that *uses*
+`redactSecrets` + the fingerprint primitives to build the bounded, redacted, tombstone-bearing
+evidence bundle (§9 caps/ordering). That's the integration increment.
 
 ### ⛔ Stage 2.3 is a decision gate (needs Jim)
 

--- a/packages/core/src/curator-redaction.ts
+++ b/packages/core/src/curator-redaction.ts
@@ -1,0 +1,106 @@
+// Secret redaction for curator evidence (memory-curator spec §9).
+//
+// Evidence gathered for a curation run (memory bodies, session summaries,
+// commands run, file paths, metadata) is scrubbed of secret-looking material
+// BEFORE prompt construction — the spec is emphatic that catching secrets at
+// output-validation time is too late, since the value would already have been
+// sent to the LLM.
+//
+// This is a conservative, KNOWN-FORMAT redactor: PEM private keys, well-known
+// provider token shapes, JWTs, and `key = secret` assignments. It deliberately
+// does NOT do generic high-entropy detection — that would nuke legitimate
+// content (git SHAs, UUIDs, content hashes) and degrade the curator's evidence.
+// Entropy/semantic detection is a v2 concern. Better to miss an exotic custom
+// secret than to shred every long identifier; the high-signal patterns below
+// cover the overwhelming majority of real leaks.
+//
+// Server-only; no external dependencies (pure string transforms).
+
+interface RedactionRule {
+  name: string;
+  pattern: RegExp;
+  replacement: string;
+}
+
+// Order matters: the assignment rule runs first so an assigned secret is
+// redacted as a single unit; the marker it leaves (`[REDACTED:secret]`) is not
+// matched by any later rule, avoiding double-counting. The provider/JWT/PEM
+// rules then catch bare (un-assigned) secrets.
+const RULES: readonly RedactionRule[] = [
+  {
+    // `api_key = …`, `PASSWORD: …`, `MY_SECRET_KEY="…"`. $1 keeps the key +
+    // separator for context; only the value (6+ non-space, non-quote chars)
+    // is redacted. The keyword must sit immediately before the separator, so
+    // "secretary: Smith" is not mistaken for a secret.
+    name: "secret-assignment",
+    pattern:
+      /\b([\w-]*(?:passwords?|passwd|api[_-]?keys?|access[_-]?keys?|secret[_-]?keys?|client[_-]?secrets?|auth[_-]?tokens?|secrets?|tokens?))(\s*[:=]\s*["']?)([^\s"']{6,})/gi,
+    replacement: "$1$2[REDACTED:secret]",
+  },
+  {
+    name: "private-key",
+    pattern: /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----/g,
+    replacement: "[REDACTED:private-key]",
+  },
+  {
+    name: "jwt",
+    pattern: /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g,
+    replacement: "[REDACTED:jwt]",
+  },
+  {
+    name: "aws-access-key",
+    pattern: /\bAKIA[0-9A-Z]{16}\b/g,
+    replacement: "[REDACTED:aws-key]",
+  },
+  {
+    name: "github-token",
+    pattern: /\bgh[pousr]_[A-Za-z0-9]{36,}\b/g,
+    replacement: "[REDACTED:github-token]",
+  },
+  {
+    name: "google-api-key",
+    pattern: /\bAIza[0-9A-Za-z_-]{35,}\b/g,
+    replacement: "[REDACTED:google-key]",
+  },
+  {
+    name: "slack-token",
+    pattern: /\bxox[baprs]-[0-9A-Za-z-]{10,}/g,
+    replacement: "[REDACTED:slack-token]",
+  },
+  {
+    // OpenAI / Anthropic style: `sk-…` and `sk-ant-…`.
+    name: "api-key",
+    pattern: /\bsk-(?:ant-)?[A-Za-z0-9_-]{20,}\b/g,
+    replacement: "[REDACTED:api-key]",
+  },
+  {
+    name: "bearer-token",
+    pattern: /\bBearer\s+[A-Za-z0-9._~+/-]{8,}=*/g,
+    replacement: "Bearer [REDACTED:bearer]",
+  },
+];
+
+export interface RedactionResult {
+  /** The input with secret-looking material replaced by `[REDACTED:…]` markers. */
+  redacted: string;
+  /** How many secrets were redacted (sum across all rules). */
+  count: number;
+}
+
+/**
+ * Redact secret-looking material from a single string. Pure and idempotent-ish:
+ * re-running over already-redacted text finds nothing new (markers aren't
+ * matched by any rule).
+ */
+export function redactSecrets(text: string): RedactionResult {
+  let redacted = text;
+  let count = 0;
+  for (const rule of RULES) {
+    const matches = redacted.match(rule.pattern);
+    if (matches && matches.length > 0) {
+      count += matches.length;
+      redacted = redacted.replace(rule.pattern, rule.replacement);
+    }
+  }
+  return { redacted, count };
+}

--- a/packages/core/src/curator-redaction.ts
+++ b/packages/core/src/curator-redaction.ts
@@ -7,35 +7,54 @@
 // sent to the LLM.
 //
 // This is a conservative, KNOWN-FORMAT redactor: PEM private keys, well-known
-// provider token shapes, JWTs, and `key = secret` assignments. It deliberately
-// does NOT do generic high-entropy detection — that would nuke legitimate
-// content (git SHAs, UUIDs, content hashes) and degrade the curator's evidence.
-// Entropy/semantic detection is a v2 concern. Better to miss an exotic custom
-// secret than to shred every long identifier; the high-signal patterns below
-// cover the overwhelming majority of real leaks.
+// provider token shapes, JWTs, basic-auth URLs, and `key = secret` assignments.
+// It deliberately does NOT do generic high-entropy detection — that would nuke
+// legitimate content (git SHAs, UUIDs, content hashes) and degrade the curator's
+// evidence. Entropy/semantic detection is a v2 concern. Better to miss an exotic
+// custom secret than to shred every long identifier; the high-signal patterns
+// below cover the overwhelming majority of real leaks.
+//
+// Known v1 limitation: an UNQUOTED secret value containing spaces (e.g. an
+// un-quoted multi-word passphrase) is only redacted up to the first space.
+// Quoted multi-word values are redacted in full. Real secrets in configs / env /
+// JSON are quoted or single-token, so this is an accepted v1 gap.
 //
 // Server-only; no external dependencies (pure string transforms).
+
+type Replacer = string | ((match: string, ...groups: string[]) => string);
 
 interface RedactionRule {
   name: string;
   pattern: RegExp;
-  replacement: string;
+  replacement: Replacer;
 }
 
-// Order matters: the assignment rule runs first so an assigned secret is
-// redacted as a single unit; the marker it leaves (`[REDACTED:secret]`) is not
-// matched by any later rule, avoiding double-counting. The provider/JWT/PEM
-// rules then catch bare (un-assigned) secrets.
+// `[A-Za-z0-9_-]` etc. are spelled out per rule. Order matters: the assignment
+// rule runs first so an assigned secret is redacted as a single unit, and its
+// marker (`[REDACTED:secret]`) is skipped on any later pass via the
+// `(?!\[REDACTED)` guards below — so re-running is a true no-op (count included).
+const ASSIGNMENT_KEYWORDS =
+  "passwords?|passwd|api[_-]?keys?|access[_-]?keys?|secret[_-]?keys?|account[_-]?keys?|" +
+  "client[_-]?secrets?|auth[_-]?tokens?|secrets?|tokens?|credentials?";
+
 const RULES: readonly RedactionRule[] = [
   {
-    // `api_key = …`, `PASSWORD: …`, `MY_SECRET_KEY="…"`. $1 keeps the key +
-    // separator for context; only the value (6+ non-space, non-quote chars)
-    // is redacted. The keyword must sit immediately before the separator, so
-    // "secretary: Smith" is not mistaken for a secret.
+    // `api_key = …`, `PASSWORD: "…"`, `MY_SECRET_KEY='…'`. Keeps the key +
+    // separator for context; redacts only the value. Quoted values (single or
+    // double) are redacted in full (spaces allowed); unquoted values up to the
+    // first space (3+ chars, to avoid nuking tiny prose like "token: no").
     name: "secret-assignment",
-    pattern:
-      /\b([\w-]*(?:passwords?|passwd|api[_-]?keys?|access[_-]?keys?|secret[_-]?keys?|client[_-]?secrets?|auth[_-]?tokens?|secrets?|tokens?))(\s*[:=]\s*["']?)([^\s"']{6,})/gi,
-    replacement: "$1$2[REDACTED:secret]",
+    pattern: new RegExp(
+      `\\b([\\w-]*(?:${ASSIGNMENT_KEYWORDS}))(\\s*[:=]\\s*)` +
+        `(?:"(?!\\[REDACTED)[^"\\n]+"|'(?!\\[REDACTED)[^'\\n]+'|(?!\\[REDACTED)[^\\s"']{3,})`,
+      "gi",
+    ),
+    replacement: (match, key, sep) => {
+      const valueStart = key.length + sep.length;
+      const value = match.slice(valueStart);
+      const quote = value.startsWith('"') ? '"' : value.startsWith("'") ? "'" : "";
+      return `${key}${sep}${quote}[REDACTED:secret]${quote}`;
+    },
   },
   {
     name: "private-key",
@@ -44,8 +63,15 @@ const RULES: readonly RedactionRule[] = [
   },
   {
     name: "jwt",
-    pattern: /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g,
+    pattern: /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}(?![A-Za-z0-9._-])/g,
     replacement: "[REDACTED:jwt]",
+  },
+  {
+    // Basic-auth credentials in URLs / connection strings:
+    // `scheme://user:pass@host`. Keeps scheme + username, redacts the password.
+    name: "url-credential",
+    pattern: /\b([a-z][a-z0-9+.-]*:\/\/[^\s:/@]+):([^\s:/@]+)@/gi,
+    replacement: "$1:[REDACTED:url-credential]@",
   },
   {
     name: "aws-access-key",
@@ -58,14 +84,35 @@ const RULES: readonly RedactionRule[] = [
     replacement: "[REDACTED:github-token]",
   },
   {
+    name: "gitlab-token",
+    pattern: /\bglpat-[A-Za-z0-9_-]{20,}\b/g,
+    replacement: "[REDACTED:gitlab-token]",
+  },
+  {
     name: "google-api-key",
     pattern: /\bAIza[0-9A-Za-z_-]{35,}\b/g,
     replacement: "[REDACTED:google-key]",
   },
   {
     name: "slack-token",
-    pattern: /\bxox[baprs]-[0-9A-Za-z-]{10,}/g,
+    pattern: /\bxox[baprs]-[0-9A-Za-z]+(?:-[0-9A-Za-z]+){1,4}/g,
     replacement: "[REDACTED:slack-token]",
+  },
+  {
+    name: "npm-token",
+    pattern: /\bnpm_[A-Za-z0-9]{36,}\b/g,
+    replacement: "[REDACTED:npm-token]",
+  },
+  {
+    name: "pypi-token",
+    pattern: /\bpypi-[A-Za-z0-9_-]{16,}\b/g,
+    replacement: "[REDACTED:pypi-token]",
+  },
+  {
+    // Stripe live/test keys (underscore-separated; distinct from sk- below).
+    name: "stripe-key",
+    pattern: /\b[rsp]k_(?:live|test)_[A-Za-z0-9]{16,}\b/g,
+    replacement: "[REDACTED:stripe-key]",
   },
   {
     // OpenAI / Anthropic style: `sk-…` and `sk-ant-…`.
@@ -75,7 +122,7 @@ const RULES: readonly RedactionRule[] = [
   },
   {
     name: "bearer-token",
-    pattern: /\bBearer\s+[A-Za-z0-9._~+/-]{8,}=*/g,
+    pattern: /\bBearer\s+(?!\[REDACTED)[A-Za-z0-9._~+/-]{8,}=*/g,
     replacement: "Bearer [REDACTED:bearer]",
   },
 ];
@@ -88,9 +135,9 @@ export interface RedactionResult {
 }
 
 /**
- * Redact secret-looking material from a single string. Pure and idempotent-ish:
- * re-running over already-redacted text finds nothing new (markers aren't
- * matched by any rule).
+ * Redact secret-looking material from a single string. Pure and idempotent:
+ * re-running over already-redacted text finds nothing new and returns count 0
+ * (markers are skipped by every rule).
  */
 export function redactSecrets(text: string): RedactionResult {
   let redacted = text;
@@ -99,7 +146,10 @@ export function redactSecrets(text: string): RedactionResult {
     const matches = redacted.match(rule.pattern);
     if (matches && matches.length > 0) {
       count += matches.length;
-      redacted = redacted.replace(rule.pattern, rule.replacement);
+      redacted =
+        typeof rule.replacement === "function"
+          ? redacted.replace(rule.pattern, rule.replacement)
+          : redacted.replace(rule.pattern, rule.replacement);
     }
   }
   return { redacted, count };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,7 @@ export {
   normalizeForFingerprint,
   normalizedTitle,
 } from "./curator-fingerprint.js";
+export { type RedactionResult, redactSecrets } from "./curator-redaction.js";
 export {
   type BackfillChange,
   type BackfillOptions,

--- a/packages/core/tests/curator-redaction.test.ts
+++ b/packages/core/tests/curator-redaction.test.ts
@@ -62,6 +62,54 @@ describe("redactSecrets", () => {
     expect(redacted).not.toContain("hunter2hunter2");
   });
 
+  it("redacts a quoted assignment value that contains spaces (no fail-open)", () => {
+    const { redacted, count } = redactSecrets('api_key = "  spaced secret value here"');
+    expect(count).toBeGreaterThanOrEqual(1);
+    expect(redacted).not.toContain("spaced secret value here");
+    expect(redacted).toContain("api_key");
+    // single-quoted too
+    expect(redactSecrets("token = 'abc def ghi'").redacted).not.toContain("abc def ghi");
+  });
+
+  it("redacts Stripe keys (underscore-separated)", () => {
+    // Obviously-fake placeholder (low entropy) so secret scanners don't flag the
+    // fixture, while still matching the [rsp]k_(live|test)_ format.
+    const fake = "sk_test_FAKEKEYFAKEKEYFAKEKEY0";
+    const { redacted, count } = redactSecrets(`STRIPE=${fake}`);
+    expect(count).toBeGreaterThanOrEqual(1);
+    expect(redacted).not.toContain(fake);
+  });
+
+  it("redacts basic-auth credentials in URLs, keeping scheme + user", () => {
+    const { redacted } = redactSecrets("git clone https://admin:S3cr3tP4ss@github.com/org/repo");
+    expect(redacted).toContain("https://admin:");
+    expect(redacted).not.toContain("S3cr3tP4ss");
+    const db = redactSecrets("postgres://dbuser:dbpass123@db.host:5432/mydb").redacted;
+    expect(db).not.toContain("dbpass123");
+    expect(db).toContain("postgres://dbuser:");
+  });
+
+  it("redacts GitLab / npm / PyPI tokens", () => {
+    const cases = [
+      "glpat-ABCDEFabcdef0123456789",
+      "npm_ABCDEFabcdef0123456789ABCDEFabcdef0123",
+      "pypi-AgEIcHlwaS5vcmcabcdef0123",
+    ];
+    for (const secret of cases) {
+      expect(redactSecrets(`tok ${secret} end`).redacted, secret).not.toContain(secret);
+    }
+  });
+
+  it("is idempotent — re-redacting already-redacted text finds nothing (count 0)", () => {
+    const first = redactSecrets(
+      'api_key="supersecretvalue" and ghp_ABCDEFabcdef0123456789ABCDEFabcdef0123',
+    );
+    expect(first.count).toBeGreaterThanOrEqual(2);
+    const second = redactSecrets(first.redacted);
+    expect(second.count).toBe(0);
+    expect(second.redacted).toBe(first.redacted);
+  });
+
   it("does not redact ordinary high-length identifiers (git SHA, UUID)", () => {
     // Entropy-based detection is deferred (v2) precisely to avoid nuking these.
     const sha = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08";

--- a/packages/core/tests/curator-redaction.test.ts
+++ b/packages/core/tests/curator-redaction.test.ts
@@ -1,0 +1,81 @@
+// Secret redaction for curator evidence (memory-curator spec §9).
+//
+// Evidence (memory bodies, session summaries, commands run, file paths,
+// metadata) must have secret-looking material redacted BEFORE prompt
+// construction — "do not wait until output validation to catch secrets; by
+// then the sensitive value may already have been sent to an LLM." This is the
+// conservative known-format + assignment redactor behind that boundary.
+
+import { redactSecrets } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+describe("redactSecrets", () => {
+  it("leaves clean text untouched and reports zero redactions", () => {
+    const { redacted, count } = redactSecrets("A normal memory about the deploy process.");
+    expect(redacted).toBe("A normal memory about the deploy process.");
+    expect(count).toBe(0);
+  });
+
+  it("redacts a PEM private key block", () => {
+    const input =
+      "key:\n-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEA...\n-----END RSA PRIVATE KEY-----\ndone";
+    const { redacted, count } = redactSecrets(input);
+    expect(redacted).not.toContain("BEGIN RSA PRIVATE KEY");
+    expect(redacted).not.toContain("MIIEowIBAAKCAQEA");
+    expect(count).toBeGreaterThanOrEqual(1);
+    expect(redacted).toContain("done");
+  });
+
+  it("redacts common provider token formats", () => {
+    const cases = [
+      "sk-abcdef012345678901234567890123456789",
+      "sk-ant-api03-ABCdef0123456789ABCdef0123456789",
+      "ghp_ABCDEFabcdef0123456789ABCDEFabcdef0123",
+      "AKIAIOSFODNN7EXAMPLE",
+      "xoxb-1234567890-ABCDEFabcdef",
+      "AIzaSyA1234567890abcdefghijklmnopqrstuvw",
+    ];
+    for (const secret of cases) {
+      const { redacted, count } = redactSecrets(`token is ${secret} ok`);
+      expect(redacted, secret).not.toContain(secret);
+      expect(count, secret).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("redacts a JWT", () => {
+    const jwt =
+      "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U";
+    const { redacted } = redactSecrets(`auth: ${jwt}`);
+    expect(redacted).not.toContain(jwt);
+  });
+
+  it("redacts a Bearer token but keeps the surrounding label", () => {
+    const { redacted } = redactSecrets("Authorization: Bearer sk-secrettokenvalue1234567890abcd");
+    expect(redacted).toContain("Authorization:");
+    expect(redacted).not.toContain("sk-secrettokenvalue1234567890abcd");
+  });
+
+  it("redacts the value of a secret-like assignment, keeping the key for context", () => {
+    const { redacted } = redactSecrets("API_KEY=supersecretvalue123  PASSWORD: hunter2hunter2");
+    expect(redacted).toContain("API_KEY");
+    expect(redacted).not.toContain("supersecretvalue123");
+    expect(redacted).not.toContain("hunter2hunter2");
+  });
+
+  it("does not redact ordinary high-length identifiers (git SHA, UUID)", () => {
+    // Entropy-based detection is deferred (v2) precisely to avoid nuking these.
+    const sha = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08";
+    const uuid = "550e8400-e29b-41d4-a716-446655440000";
+    const { redacted, count } = redactSecrets(`commit ${sha} for ${uuid}`);
+    expect(redacted).toContain(sha);
+    expect(redacted).toContain(uuid);
+    expect(count).toBe(0);
+  });
+
+  it("counts multiple redactions", () => {
+    const { count } = redactSecrets(
+      "ghp_ABCDEFabcdef0123456789ABCDEFabcdef0123 and AKIAIOSFODNN7EXAMPLE",
+    );
+    expect(count).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Stage 2.2 (partial) — the curator's **privacy boundary** (memory-curator spec §9). `redactSecrets(text)` scrubs secret-looking material from evidence **before** prompt construction; the spec is explicit that catching secrets at output-validation time is too late.

A conservative **known-format + assignment** redactor (`curator-redaction.ts`):
- PEM private-key blocks, JWTs, `Bearer …`
- provider token shapes: `sk-`/`sk-ant-`, `ghp_…`, `AKIA…`, `xox…`, `AIza…`
- `key = secret` assignments — value redacted, key kept for context
- returns `{ redacted, count }`

**Deliberate non-goals** (documented in-module): no generic high-entropy detection — it would shred git SHAs / UUIDs / content hashes and degrade the curator's evidence; entropy/semantic detection is a v2 concern. The assignment rule runs first so an assigned secret is one unit and its marker isn't re-matched (no double-count). All regexes are linear (no ReDoS).

## Tests

`packages/core/tests/curator-redaction.test.ts` (8): PEM, provider formats, JWT, Bearer, assignments (value-only), a **negative** (git SHA + UUID stay intact), and the redaction count.

## Scope

Remaining Stage 2.2: **evidence gathering** — slice-scoped store bundling that *uses* `redactSecrets` + the fingerprint primitives. **Stage 2.3 (LLM pass) remains a decision gate** needing operator input on provider/model/token config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)