### PR TITLE
feat(core): AES-256-GCM encryption primitive for the admin secret-store

### DIFF
--- a/AUTONOMOUS-BUILD-NOTES-26-05-23.md
+++ b/AUTONOMOUS-BUILD-NOTES-26-05-23.md
@@ -19,10 +19,38 @@ Increments shipped this day, each its own PR:
 11. `feat/curator-note-column` — Stage 2.1 (partial) `curator_note` memory column (merged, PR #80).
 12. `feat/curation-tables` — Stage 2.1 (finish) curation runs/operations tables (merged, PR #81).
 13. `feat/curator-fingerprint` — Stage 2.2 (partial) content fingerprint + resurrection match (merged, PR #82).
-14. `feat/curator-redaction` — Stage 2.2 (partial) secret redaction (this PR).
+14. `feat/curator-redaction` — Stage 2.2 (partial) secret redaction (merged, PR #83).
+15. `chore/sanitize-redaction-test-fixtures` — synthetic fixtures + `.gitguardian.yaml` (merged, PR #84).
+16. `feat/admin-secret-crypto` — Stage 2.3-prep AES-256-GCM secret-store crypto (this PR).
 
-**Stage 1 is complete** (PRs #70–#79). **Stage 2.1 (curator data model) is complete** (#80–#81).
-Stage 2.2 in progress.
+**Stage 1 complete** (#70–#79). **Stage 2.1 complete** (#80–#81). **Stage 2.2 primitives**
+(fingerprint #82, redaction #83) complete. Stage 2.3 underway (Jim chose: build the admin
+secret-store; LLM client = OpenAI-compatible).
+
+> **GitGuardian:** the redaction-test fixtures (synthetic, secret-shaped) trip the GitGuardian
+> GitHub App. A scoped `.gitguardian.yaml` was added but the App is dashboard-configured and
+> didn't honour the repo file — **needs a one-time false-positive resolution in the GG dashboard
+> (Jim)**. GG is advisory/non-blocking; all other checks pass.
+
+---
+
+## Increment 16 — Stage 2.3-prep AES-256-GCM secret-store crypto
+
+The encryption-at-rest primitive for the admin secret-store (Jim's decision: build it; spec §7.1
+stores the LLM token via admin secret-storage, never plaintext). New `secret-crypto.ts`:
+`encryptSecret(plaintext, key)` / `decryptSecret(payload, key)` (AES-256-GCM — confidentiality +
+integrity; the auth tag rejects tampering and wrong keys) and `resolveSecretKey(raw)` (parses a
+64-char hex or base64 32-byte master key from the operator). Fresh random 12-byte IV per
+encryption; self-describing versioned payload `gcm1.<iv>.<tag>.<ct>` (base64; no `.` collision).
+Key is injected (read from `LIBRARIAN_SECRET_KEY` by callers), keeping the crypto pure/testable.
+9 tests: round-trip (incl. unicode/empty/5 KB), IV-uniqueness, tamper rejection, wrong-key
+rejection, key parsing (hex/base64/missing/wrong-length).
+
+**Context found:** no admin secret-store or settings table exists today — all config/secrets are
+env vars. So the broader secret-store is: this crypto (done) → a `settings`/secret table + store
+accessors (next) → curator LLM config schema (env `LIBRARIAN_SECRET_KEY` master key + provider/
+endpoint/token/model) → OpenAI-compatible LLM client → prompt/validate/apply (§10.4/§10.5/§11) →
+scheduler/worker (§12/§14) → admin cockpit (§7.1/§13).
 
 ---
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,7 @@ export {
   normalizedTitle,
 } from "./curator-fingerprint.js";
 export { type RedactionResult, redactSecrets } from "./curator-redaction.js";
+export { decryptSecret, encryptSecret, resolveSecretKey } from "./secret-crypto.js";
 export {
   type BackfillChange,
   type BackfillOptions,

--- a/packages/core/src/secret-crypto.ts
+++ b/packages/core/src/secret-crypto.ts
@@ -1,0 +1,79 @@
+// Encryption-at-rest for the admin secret-store (memory-curator spec §7.1).
+//
+// The curator's LLM token (and any future admin secret) is stored encrypted,
+// never in plaintext config or audit records. AES-256-GCM gives both
+// confidentiality and integrity: the authentication tag means a tampered
+// ciphertext or a wrong key fails to decrypt (rather than returning garbage).
+//
+// The master key comes from the operator (env `LIBRARIAN_SECRET_KEY`); it is
+// injected into these functions, never read here, so the crypto stays pure and
+// testable. A fresh random IV per encryption means encrypting the same value
+// twice yields different ciphertexts.
+//
+// Server-only (node:crypto).
+
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+
+const ALGORITHM = "aes-256-gcm";
+const KEY_BYTES = 32;
+const IV_BYTES = 12; // 96-bit nonce, the GCM standard
+const VERSION = "gcm1"; // payload version tag, for future key/algorithm rotation
+
+/**
+ * Parse the operator-supplied master key into a 32-byte buffer. Accepts a
+ * 64-char hex string or a base64-encoded 32-byte value. Throws if missing or
+ * not exactly 32 bytes — callers treat that as "secrets unavailable" (curation
+ * stays off) rather than proceeding with a weak/absent key.
+ */
+export function resolveSecretKey(raw: string | undefined): Buffer {
+  const value = (raw ?? "").trim();
+  if (value === "") {
+    throw new Error("secret key is required (set LIBRARIAN_SECRET_KEY)");
+  }
+  if (/^[0-9a-fA-F]{64}$/.test(value)) {
+    return Buffer.from(value, "hex");
+  }
+  const decoded = Buffer.from(value, "base64");
+  if (decoded.length === KEY_BYTES) {
+    return decoded;
+  }
+  throw new Error("secret key must be 32 bytes (a 64-char hex string or base64)");
+}
+
+/**
+ * Encrypt a UTF-8 string. Returns a self-describing payload
+ * `gcm1.<iv>.<tag>.<ciphertext>` (each segment base64; base64 never contains
+ * `.`, so the segments are unambiguous).
+ */
+export function encryptSecret(plaintext: string, key: Buffer): string {
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return [
+    VERSION,
+    iv.toString("base64"),
+    tag.toString("base64"),
+    ciphertext.toString("base64"),
+  ].join(".");
+}
+
+/**
+ * Decrypt a payload produced by {@link encryptSecret}. Throws on a malformed
+ * payload, a tampered ciphertext/tag, or a wrong key (GCM authentication
+ * failure) — it never returns unauthenticated plaintext.
+ */
+export function decryptSecret(payload: string, key: Buffer): string {
+  const [version, ivB64, tagB64, ctB64] = payload.split(".");
+  // ctB64 may legitimately be "" (empty plaintext), so guard for undefined.
+  if (version !== VERSION || !ivB64 || !tagB64 || ctB64 === undefined) {
+    throw new Error("malformed secret payload");
+  }
+  const iv = Buffer.from(ivB64, "base64");
+  const tag = Buffer.from(tagB64, "base64");
+  const ciphertext = Buffer.from(ctB64, "base64");
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(tag);
+  // `final()` throws if the auth tag doesn't verify (tamper or wrong key).
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString("utf8");
+}

--- a/packages/core/src/secret-crypto.ts
+++ b/packages/core/src/secret-crypto.ts
@@ -17,27 +17,52 @@ import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
 const ALGORITHM = "aes-256-gcm";
 const KEY_BYTES = 32;
 const IV_BYTES = 12; // 96-bit nonce, the GCM standard
-const VERSION = "gcm1"; // payload version tag, for future key/algorithm rotation
+const TAG_BYTES = 16; // 128-bit GCM authentication tag
+// Payload version tag. Decryption dispatches on it, so a future format (e.g. a
+// `gcm2` carrying a key-id for online rotation) can be added without breaking
+// `gcm1` ciphertexts — rotation today means decrypt-all + re-encrypt under the
+// new key. With a fresh random 96-bit IV per call, the same key is safe for far
+// more than this store's handful of secrets (NIST SP 800-38D's ~2^32-message bound).
+const VERSION = "gcm1";
 
 /**
  * Parse the operator-supplied master key into a 32-byte buffer. Accepts a
- * 64-char hex string or a base64-encoded 32-byte value. Throws if missing or
- * not exactly 32 bytes — callers treat that as "secrets unavailable" (curation
- * stays off) rather than proceeding with a weak/absent key.
+ * 64-char hex string or a base64-encoded 32-byte value. Throws if missing,
+ * not exactly 32 bytes, malformed, or a constant-byte placeholder — callers
+ * treat that as "secrets unavailable" (curation stays off) rather than
+ * proceeding with a weak/absent key. The key MUST come from a CSPRNG
+ * (`openssl rand -hex 32` or `crypto.randomBytes(32)`).
  */
 export function resolveSecretKey(raw: string | undefined): Buffer {
   const value = (raw ?? "").trim();
   if (value === "") {
     throw new Error("secret key is required (set LIBRARIAN_SECRET_KEY)");
   }
+
+  let key: Buffer | null = null;
   if (/^[0-9a-fA-F]{64}$/.test(value)) {
-    return Buffer.from(value, "hex");
+    key = Buffer.from(value, "hex");
+  } else {
+    // Base64 decoding is lenient (it silently drops invalid chars), so accept
+    // it only if it round-trips exactly — rejecting truncated/garbled input
+    // that would otherwise decode to a silently-different 32 bytes.
+    const decoded = Buffer.from(value, "base64");
+    const reEncoded = decoded.toString("base64");
+    if (
+      decoded.length === KEY_BYTES &&
+      (value === reEncoded || value === reEncoded.replace(/=+$/, ""))
+    ) {
+      key = decoded;
+    }
   }
-  const decoded = Buffer.from(value, "base64");
-  if (decoded.length === KEY_BYTES) {
-    return decoded;
+
+  if (!key || key.length !== KEY_BYTES) {
+    throw new Error("secret key must be 32 bytes (a 64-char hex string or base64)");
   }
-  throw new Error("secret key must be 32 bytes (a 64-char hex string or base64)");
+  if (key.every((b) => b === key[0])) {
+    throw new Error("secret key has insufficient entropy (constant-byte placeholder)");
+  }
+  return key;
 }
 
 /**
@@ -72,6 +97,11 @@ export function decryptSecret(payload: string, key: Buffer): string {
   const iv = Buffer.from(ivB64, "base64");
   const tag = Buffer.from(tagB64, "base64");
   const ciphertext = Buffer.from(ctB64, "base64");
+  // Strict boundary validation — the GCM tag check would reject these anyway,
+  // but pinning the format gives a precise error and defends in depth.
+  if (iv.length !== IV_BYTES || tag.length !== TAG_BYTES) {
+    throw new Error("malformed secret payload");
+  }
   const decipher = createDecipheriv(ALGORITHM, key, iv);
   decipher.setAuthTag(tag);
   // `final()` throws if the auth tag doesn't verify (tamper or wrong key).

--- a/packages/core/tests/secret-crypto.test.ts
+++ b/packages/core/tests/secret-crypto.test.ts
@@ -1,0 +1,72 @@
+// Encryption-at-rest primitive for the admin secret-store (memory-curator §7.1:
+// the LLM token is stored via admin secret-storage, never in plaintext).
+//
+// AES-256-GCM: confidentiality + integrity (the auth tag detects tampering and
+// wrong keys). Pins round-trip, IV uniqueness, tamper/wrong-key rejection, and
+// key parsing.
+
+import { decryptSecret, encryptSecret, resolveSecretKey } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+// A fixed 32-byte test key (hex).
+const KEY_HEX = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
+const key = resolveSecretKey(KEY_HEX);
+
+describe("encryptSecret / decryptSecret (AES-256-GCM)", () => {
+  it("round-trips a secret", () => {
+    const plaintext = "sk-test-the-actual-llm-token-value";
+    const payload = encryptSecret(plaintext, key);
+    expect(payload).not.toContain(plaintext); // ciphertext, not the value
+    expect(decryptSecret(payload, key)).toBe(plaintext);
+  });
+
+  it("round-trips unicode and empty strings", () => {
+    for (const value of ["", "café — 秘密 — 🔒", "a".repeat(5000)]) {
+      expect(decryptSecret(encryptSecret(value, key), key)).toBe(value);
+    }
+  });
+
+  it("produces a different ciphertext each time (random IV)", () => {
+    const a = encryptSecret("same", key);
+    const b = encryptSecret("same", key);
+    expect(a).not.toBe(b);
+    expect(decryptSecret(a, key)).toBe("same");
+    expect(decryptSecret(b, key)).toBe("same");
+  });
+
+  it("rejects a tampered ciphertext (auth tag)", () => {
+    const payload = encryptSecret("secret", key);
+    // Flip the last base64 char of the ciphertext segment.
+    const tampered = payload.slice(0, -1) + (payload.endsWith("A") ? "B" : "A");
+    expect(() => decryptSecret(tampered, key)).toThrow();
+  });
+
+  it("fails to decrypt with the wrong key", () => {
+    const payload = encryptSecret("secret", key);
+    const otherKey = resolveSecretKey(
+      "ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100",
+    );
+    expect(() => decryptSecret(payload, otherKey)).toThrow();
+  });
+});
+
+describe("resolveSecretKey", () => {
+  it("accepts a 64-char hex key", () => {
+    expect(resolveSecretKey(KEY_HEX)).toHaveLength(32);
+  });
+
+  it("accepts a 32-byte base64 key", () => {
+    const b64 = Buffer.alloc(32, 7).toString("base64");
+    expect(resolveSecretKey(b64)).toHaveLength(32);
+  });
+
+  it("rejects a missing key", () => {
+    expect(() => resolveSecretKey(undefined)).toThrow(/key/i);
+    expect(() => resolveSecretKey("")).toThrow(/key/i);
+  });
+
+  it("rejects a key of the wrong length", () => {
+    expect(() => resolveSecretKey("tooshort")).toThrow(/32 bytes/i);
+    expect(() => resolveSecretKey("aa".repeat(20))).toThrow(/32 bytes/i); // 20 bytes hex
+  });
+});

--- a/packages/core/tests/secret-crypto.test.ts
+++ b/packages/core/tests/secret-crypto.test.ts
@@ -5,6 +5,7 @@
 // wrong keys). Pins round-trip, IV uniqueness, tamper/wrong-key rejection, and
 // key parsing.
 
+import { randomBytes } from "node:crypto";
 import { decryptSecret, encryptSecret, resolveSecretKey } from "@librarian/core";
 import { describe, expect, it } from "vitest";
 
@@ -56,7 +57,7 @@ describe("resolveSecretKey", () => {
   });
 
   it("accepts a 32-byte base64 key", () => {
-    const b64 = Buffer.alloc(32, 7).toString("base64");
+    const b64 = randomBytes(32).toString("base64");
     expect(resolveSecretKey(b64)).toHaveLength(32);
   });
 
@@ -68,5 +69,33 @@ describe("resolveSecretKey", () => {
   it("rejects a key of the wrong length", () => {
     expect(() => resolveSecretKey("tooshort")).toThrow(/32 bytes/i);
     expect(() => resolveSecretKey("aa".repeat(20))).toThrow(/32 bytes/i); // 20 bytes hex
+  });
+
+  it("rejects malformed base64 that doesn't round-trip", () => {
+    const good = randomBytes(32).toString("base64");
+    // Inject characters outside the base64 alphabet; lenient decoding would
+    // otherwise silently accept this as a (different) 32-byte key.
+    expect(() => resolveSecretKey(`!!!!${good}!!!!`)).toThrow(/32 bytes/i);
+  });
+
+  it("rejects a constant-byte (low-entropy) key", () => {
+    expect(() => resolveSecretKey("00".repeat(32))).toThrow(/entropy/i);
+    expect(() => resolveSecretKey(Buffer.alloc(32, 7).toString("base64"))).toThrow(/entropy/i);
+  });
+});
+
+describe("decryptSecret payload validation", () => {
+  it("rejects a wrong-length IV in the payload", () => {
+    const payload = encryptSecret("secret", key);
+    const [version, , tagB64, ctB64] = payload.split(".");
+    const shortIv = Buffer.alloc(8).toString("base64");
+    expect(() => decryptSecret(`${version}.${shortIv}.${tagB64}.${ctB64}`, key)).toThrow(
+      /malformed/i,
+    );
+  });
+
+  it("rejects a malformed payload (wrong segment count / version)", () => {
+    expect(() => decryptSecret("not-a-payload", key)).toThrow(/malformed/i);
+    expect(() => decryptSecret("gcm9.a.b.c", key)).toThrow(/malformed/i);
   });
 });


### PR DESCRIPTION
## Summary

First piece of the **admin secret-store** (your decision; memory-curator spec §7.1 — the curator's LLM token is stored encrypted, never in plaintext config or audit records).

`secret-crypto.ts`:
- `encryptSecret(plaintext, key)` / `decryptSecret(payload, key)` — **AES-256-GCM** (confidentiality + integrity; the auth tag means a tampered ciphertext or wrong key *fails to decrypt* rather than returning garbage).
- `resolveSecretKey(raw)` — parses the operator master key (64-char hex or base64 32-byte); throws if missing/wrong length so callers treat it as "secrets unavailable" (curation stays off).
- Fresh random 12-byte IV per encryption; self-describing versioned payload `gcm1.<iv>.<tag>.<ct>` (base64 segments, no `.` collision).
- Master key is **injected** by callers (from `LIBRARIAN_SECRET_KEY`), keeping the crypto pure and testable.

## Context

There is **no existing admin secret-store or settings table** — all config/secrets are env vars today. This crypto is the foundation; next come a settings/secret table + store, the curator LLM config (env master key + provider/endpoint/token/model), and the OpenAI-compatible client.

## Tests

`packages/core/tests/secret-crypto.test.ts` (9): round-trip (incl. unicode / empty / 5 KB), IV uniqueness, tamper rejection (auth tag), wrong-key rejection, and key parsing (hex / base64 / missing / wrong-length).

## Review

Requested a security-auditor review (key handling, IV/tag, tamper, payload parsing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)