### PR TITLE
feat(core): admin settings/secret store (encrypted at rest)

### DIFF
--- a/AUTONOMOUS-BUILD-NOTES-26-05-23.md
+++ b/AUTONOMOUS-BUILD-NOTES-26-05-23.md
@@ -21,7 +21,23 @@ Increments shipped this day, each its own PR:
 13. `feat/curator-fingerprint` — Stage 2.2 (partial) content fingerprint + resurrection match (merged, PR #82).
 14. `feat/curator-redaction` — Stage 2.2 (partial) secret redaction (merged, PR #83).
 15. `chore/sanitize-redaction-test-fixtures` — synthetic fixtures + `.gitguardian.yaml` (merged, PR #84).
-16. `feat/admin-secret-crypto` — Stage 2.3-prep AES-256-GCM secret-store crypto (this PR).
+16. `feat/admin-secret-crypto` — Stage 2.3-prep AES-256-GCM secret-store crypto (merged, PR #85).
+17. `feat/settings-store` — Stage 2.3 admin settings/secret store (this PR).
+
+## Increment 17 — Stage 2.3 admin settings/secret store
+
+The `settings` table + `settings-store.ts` (memory-curator §7.1), composing the secret-crypto
+primitive. A SQLite-authoritative key-value store: `setSetting`/`getSetting`/`deleteSetting`/
+`listSettings`. Secret values (the curator LLM token) are encrypted at rest via `encryptSecret`
+and require the master key to read/write; plain values don't. `listSettings` returns metadata
+only (`key`/`is_secret`/`updated_at`) — never values, so a secret can't leak through the listing.
+`LibrarianStore` gains an optional `secretKey` (the bin will resolve `LIBRARIAN_SECRET_KEY` and
+pass it; absent key → secret ops throw, plain ops still work). `PROJECTION_SCHEMA_VERSION` 9 → 10;
+the `settings` table is authoritative (preserved across bumps). 6 tests incl. encrypted-at-rest
+(raw row ≠ plaintext), no-key behaviour, list-never-leaks, and bump survival.
+
+Next: curator LLM config (typed getter/setter over settings: provider/endpoint/token[secret]/
+model/enable + addendum + default_auto_apply/confidence) → OpenAI-compatible client → pipeline.
 
 **Stage 1 complete** (#70–#79). **Stage 2.1 complete** (#80–#81). **Stage 2.2 primitives**
 (fingerprint #82, redaction #83) complete. Stage 2.3 underway (Jim chose: build the admin

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -49,3 +49,8 @@ export {
   type ListCurationRunsInput,
   type RecordCurationOperationInput,
 } from "./store/curation-store.js";
+export {
+  type SettingMeta,
+  type SettingsStore,
+  createSettingsStore,
+} from "./store/settings-store.js";

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -3,3 +3,4 @@ export * from "./projection.js";
 export * from "./memory-store.js";
 export * from "./session-store.js";
 export * from "./curation-store.js";
+export * from "./settings-store.js";

--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -6,14 +6,21 @@ import { readJsonl } from "./jsonl.js";
 import { type MemoryStore, createMemoryStore } from "./memory-store.js";
 import { ensureSchema, rebuildMemoryIndex, rebuildSessionIndex } from "./projection.js";
 import { type SessionStore, createSessionStore } from "./session-store.js";
+import { type SettingsStore, createSettingsStore } from "./settings-store.js";
 
 const DEFAULT_DATA_DIR = path.join(process.cwd(), "data");
 
 export interface LibrarianStoreOptions {
   dataDir?: string;
+  /**
+   * Master key for the admin secret-store (memory-curator §7.1). Resolved by
+   * the caller from `LIBRARIAN_SECRET_KEY` via `resolveSecretKey`. When absent,
+   * secret settings throw on access; plain settings still work.
+   */
+  secretKey?: Buffer | null;
 }
 
-export interface LibrarianStore extends MemoryStore, SessionStore, CurationStore {
+export interface LibrarianStore extends MemoryStore, SessionStore, CurationStore, SettingsStore {
   dataDir: string;
   eventsPath: string;
   // R3 — sessionsPath is the timeline ledger (post-R3, new file).
@@ -86,11 +93,13 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Libra
     createMemory: (input) => memoryStore.createMemory(input),
   });
   const curationStore = createCurationStore({ db });
+  const settingsStore = createSettingsStore({ db, secretKey: options.secretKey ?? null });
 
   return {
     ...memoryStore,
     ...sessionStore,
     ...curationStore,
+    ...settingsStore,
     dataDir,
     eventsPath,
     sessionsPath,

--- a/packages/core/src/store/projection.ts
+++ b/packages/core/src/store/projection.ts
@@ -75,7 +75,9 @@ function asArray(value: unknown): string[] {
 //        `memory_curation_operations` tables. Like `sessions`, these are
 //        SQLite-authoritative (not ledger projections) and are preserved
 //        across bumps; the bump just CREATEs them on existing installs.
-export const PROJECTION_SCHEMA_VERSION = 9;
+//   - 10: memory-curator §7.1 — `settings` table (admin secret-store).
+//         Authoritative; preserved across bumps; the bump just CREATEs it.
+export const PROJECTION_SCHEMA_VERSION = 10;
 
 export function getSchemaVersion(db: DatabaseSync): number {
   const row = db.prepare("PRAGMA user_version").get() as { user_version: number };
@@ -89,8 +91,9 @@ function stampSchemaVersion(db: DatabaseSync): void {
 function dropProjectionTables(db: DatabaseSync): void {
   // R3 — `sessions` and `session_state_changes` are SQLite-authoritative
   // and must survive schema-version bumps. The `memory_curation_*` tables
-  // (memory-curator §8) are likewise authoritative and intentionally absent
-  // here. Future DDL changes to those tables should use ALTER TABLE rather
+  // (memory-curator §8) and `settings` (§7.1 admin secret-store) are likewise
+  // authoritative and intentionally absent here. Future DDL changes to those
+  // tables should use ALTER TABLE rather
   // than the drop-and-rebuild pattern below. The other tables are projections
   // (memory side stays JSONL-canonical; session_events is rebuilt from
   // session_events.jsonl on every bump).
@@ -313,6 +316,12 @@ export const SCHEMA_DDL = `
     );
     CREATE INDEX IF NOT EXISTS idx_memory_curation_operations_run
       ON memory_curation_operations(run_id, id);
+    CREATE TABLE IF NOT EXISTS settings (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      is_secret INTEGER NOT NULL DEFAULT 0,
+      updated_at TEXT NOT NULL
+    );
   `;
 
 export function initSchema(db: DatabaseSync): void {

--- a/packages/core/src/store/settings-store.ts
+++ b/packages/core/src/store/settings-store.ts
@@ -60,9 +60,9 @@ export function createSettingsStore(deps: {
   }
 
   function getSetting(key: string): string | null {
-    const row = db.prepare("SELECT * FROM settings WHERE key = ?").get(key) as
-      | SettingRow
-      | undefined;
+    const row = db
+      .prepare("SELECT key, value, is_secret, updated_at FROM settings WHERE key = ?")
+      .get(key) as SettingRow | undefined;
     if (!row) return null;
     return row.is_secret ? decryptSecret(row.value, requireKey()) : row.value;
   }

--- a/packages/core/src/store/settings-store.ts
+++ b/packages/core/src/store/settings-store.ts
@@ -1,0 +1,86 @@
+// Admin settings / secret store (memory-curator spec §7.1).
+//
+// A SQLite-authoritative key-value store for operator-managed admin config —
+// notably the curator's LLM connection. Secret values (the LLM token) are
+// encrypted at rest with AES-256-GCM via secret-crypto and require the master
+// key (env `LIBRARIAN_SECRET_KEY`, injected as `secretKey`) to read or write;
+// plain values do not. `listSettings` returns metadata only, so a secret value
+// can never leak through the listing surface.
+//
+// When no master key is configured, secret operations throw — callers treat
+// that as "secrets unavailable" (e.g. curation stays off) rather than storing
+// a token in plaintext.
+
+import type { DatabaseSync } from "node:sqlite";
+import { nowIso } from "../constants.js";
+import { decryptSecret, encryptSecret } from "../secret-crypto.js";
+
+export interface SettingMeta {
+  key: string;
+  is_secret: boolean;
+  updated_at: string;
+}
+
+export interface SettingsStore {
+  setSetting: (key: string, value: string, options?: { secret?: boolean }) => void;
+  getSetting: (key: string) => string | null;
+  deleteSetting: (key: string) => void;
+  /** Metadata for every setting — never includes values (secret or otherwise). */
+  listSettings: () => SettingMeta[];
+}
+
+interface SettingRow {
+  key: string;
+  value: string;
+  is_secret: number;
+  updated_at: string;
+}
+
+export function createSettingsStore(deps: {
+  db: DatabaseSync;
+  secretKey?: Buffer | null;
+}): SettingsStore {
+  const { db, secretKey } = deps;
+
+  function requireKey(): Buffer {
+    if (!secretKey) {
+      throw new Error("a master key is required for secret settings (set LIBRARIAN_SECRET_KEY)");
+    }
+    return secretKey;
+  }
+
+  function setSetting(key: string, value: string, options: { secret?: boolean } = {}): void {
+    const secret = options.secret === true;
+    const stored = secret ? encryptSecret(value, requireKey()) : value;
+    db.prepare(
+      `INSERT INTO settings (key, value, is_secret, updated_at) VALUES (?, ?, ?, ?)
+       ON CONFLICT(key) DO UPDATE SET value = excluded.value,
+         is_secret = excluded.is_secret, updated_at = excluded.updated_at`,
+    ).run(key, stored, secret ? 1 : 0, nowIso());
+  }
+
+  function getSetting(key: string): string | null {
+    const row = db.prepare("SELECT * FROM settings WHERE key = ?").get(key) as
+      | SettingRow
+      | undefined;
+    if (!row) return null;
+    return row.is_secret ? decryptSecret(row.value, requireKey()) : row.value;
+  }
+
+  function deleteSetting(key: string): void {
+    db.prepare("DELETE FROM settings WHERE key = ?").run(key);
+  }
+
+  function listSettings(): SettingMeta[] {
+    const rows = db
+      .prepare("SELECT key, is_secret, updated_at FROM settings ORDER BY key")
+      .all() as Array<{ key: string; is_secret: number; updated_at: string }>;
+    return rows.map((row) => ({
+      key: row.key,
+      is_secret: row.is_secret === 1,
+      updated_at: row.updated_at,
+    }));
+  }
+
+  return { setSetting, getSetting, deleteSetting, listSettings };
+}

--- a/packages/core/tests/store/settings-store.test.ts
+++ b/packages/core/tests/store/settings-store.test.ts
@@ -104,6 +104,43 @@ describe("settings store", () => {
     expect(store.getSetting("k")).toBeNull();
   });
 
+  it("flips is_secret + encoding atomically when overwriting plain<->secret", () => {
+    const { store } = s!;
+    const rawOf = (key: string) =>
+      store.db.prepare("SELECT value, is_secret FROM settings WHERE key = ?").get(key) as {
+        value: string;
+        is_secret: number;
+      };
+
+    // plain → secret: raw becomes ciphertext, flag set
+    store.setSetting("k", "plainval");
+    store.setSetting("k", "nowsecret-value", { secret: true });
+    let raw = rawOf("k");
+    expect(raw.is_secret).toBe(1);
+    expect(raw.value).not.toContain("nowsecret-value");
+    expect(store.getSetting("k")).toBe("nowsecret-value");
+
+    // secret → plain: raw becomes plaintext, flag cleared
+    store.setSetting("k", "backtoplain");
+    raw = rawOf("k");
+    expect(raw.is_secret).toBe(0);
+    expect(raw.value).toBe("backtoplain");
+    expect(store.getSetting("k")).toBe("backtoplain");
+  });
+
+  it("fails closed when reading a secret with the wrong master key", () => {
+    const { store, dataDir } = s!;
+    store.setSetting("curator.llm_token", "sk-secret", { secret: true });
+    store.close();
+
+    const wrongKey = resolveSecretKey(
+      "ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100",
+    );
+    const reopened = createLibrarianStore({ dataDir, secretKey: wrongKey });
+    s!.store = reopened;
+    expect(() => reopened.getSetting("curator.llm_token")).toThrow();
+  });
+
   it("survives a real schema-version bump (settings are authoritative)", () => {
     const { store, dataDir } = s!;
     store.setSetting("curator.llm_token", "sk-secret", { secret: true });

--- a/packages/core/tests/store/settings-store.test.ts
+++ b/packages/core/tests/store/settings-store.test.ts
@@ -1,0 +1,119 @@
+// Admin settings/secret store (memory-curator spec §7.1).
+//
+// A SQLite-authoritative key-value store for admin config. Secret values (the
+// curator's LLM token) are encrypted at rest via secret-crypto and require the
+// master key to read/write; plain values don't. `listSettings` returns metadata
+// only — it must never leak a secret value.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { type LibrarianStore, createLibrarianStore, resolveSecretKey } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const KEY = resolveSecretKey("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+
+interface Scope {
+  store: LibrarianStore;
+  dataDir: string;
+}
+
+function open(dataDir: string, withKey = true): LibrarianStore {
+  return createLibrarianStore(withKey ? { dataDir, secretKey: KEY } : { dataDir });
+}
+
+function scope(): Scope {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-settings-"));
+  return { store: open(dataDir), dataDir };
+}
+
+function teardown(s: Scope | null): void {
+  if (!s) return;
+  try {
+    s.store.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(s.dataDir, { recursive: true, force: true });
+}
+
+describe("settings store", () => {
+  let s: Scope | null = null;
+  beforeEach(() => {
+    s = scope();
+  });
+  afterEach(() => {
+    teardown(s);
+    s = null;
+  });
+
+  it("round-trips a plain (non-secret) setting", () => {
+    const { store } = s!;
+    store.setSetting("curator.enabled", "true");
+    expect(store.getSetting("curator.enabled")).toBe("true");
+    expect(store.getSetting("missing")).toBeNull();
+  });
+
+  it("stores a secret value encrypted at rest and decrypts it on read", () => {
+    const { store } = s!;
+    const token = "sk-the-real-llm-token-value-1234567890";
+    store.setSetting("curator.llm_token", token, { secret: true });
+
+    // Raw row must not contain the plaintext.
+    const raw = store.db
+      .prepare("SELECT value, is_secret FROM settings WHERE key = ?")
+      .get("curator.llm_token") as { value: string; is_secret: number };
+    expect(raw.is_secret).toBe(1);
+    expect(raw.value).not.toContain(token);
+
+    // Reading with the key decrypts.
+    expect(store.getSetting("curator.llm_token")).toBe(token);
+  });
+
+  it("requires the master key to read or write a secret setting", () => {
+    const { store, dataDir } = s!;
+    store.setSetting("curator.llm_token", "sk-secret", { secret: true });
+    store.close();
+
+    const noKey = open(dataDir, false);
+    s!.store = noKey;
+    expect(() => noKey.getSetting("curator.llm_token")).toThrow(/key/i);
+    expect(() => noKey.setSetting("x", "y", { secret: true })).toThrow(/key/i);
+    // plain settings still work without a key
+    noKey.setSetting("curator.enabled", "false");
+    expect(noKey.getSetting("curator.enabled")).toBe("false");
+  });
+
+  it("listSettings returns metadata only, never secret values", () => {
+    const { store } = s!;
+    store.setSetting("curator.enabled", "true");
+    store.setSetting("curator.llm_token", "sk-secret", { secret: true });
+    const rows = store.listSettings();
+    const tokenRow = rows.find((r) => r.key === "curator.llm_token");
+    expect(tokenRow?.is_secret).toBe(true);
+    // No `value` field on the listing shape at all.
+    expect(JSON.stringify(rows)).not.toContain("sk-secret");
+  });
+
+  it("updates and deletes settings", () => {
+    const { store } = s!;
+    store.setSetting("k", "v1");
+    store.setSetting("k", "v2");
+    expect(store.getSetting("k")).toBe("v2");
+    store.deleteSetting("k");
+    expect(store.getSetting("k")).toBeNull();
+  });
+
+  it("survives a real schema-version bump (settings are authoritative)", () => {
+    const { store, dataDir } = s!;
+    store.setSetting("curator.llm_token", "sk-secret", { secret: true });
+    store.setSetting("curator.enabled", "true");
+    store.db.exec("PRAGMA user_version = 9");
+    store.close();
+
+    const reopened = open(dataDir);
+    s!.store = reopened;
+    expect(reopened.getSetting("curator.enabled")).toBe("true");
+    expect(reopened.getSetting("curator.llm_token")).toBe("sk-secret");
+  });
+});

--- a/test/schema-snapshot.json
+++ b/test/schema-snapshot.json
@@ -1,4 +1,4 @@
 {
-  "version": 9,
-  "fingerprint": "616de01873ab507ba87303ba42a95625be6cc1be524d149bedfefd3a4fee83c5"
+  "version": 10,
+  "fingerprint": "523a7f2c65be271cdaea6b037c74b196a731f9ab3d9fd8c7d1b73249e44cdf3a"
 }


### PR DESCRIPTION
## Summary

Stage 2.3 — the `settings` table + `settings-store.ts` (memory-curator spec §7.1), composing the AES-256-GCM `secret-crypto` primitive from #85 into the admin secret-store.

A SQLite-authoritative key-value store: `setSetting` / `getSetting` / `deleteSetting` / `listSettings`.
- **Secret values** (the curator's LLM token) are encrypted at rest and require the master key to read/write; plain values don't.
- `listSettings` returns **metadata only** (`key` / `is_secret` / `updated_at`) — never values, so a secret can't leak through the listing surface.
- `LibrarianStore` gains an optional `secretKey` (the bin will resolve `LIBRARIAN_SECRET_KEY` and pass it; absent key → secret ops throw, plain ops still work — "secrets unavailable, curation stays off").
- `PROJECTION_SCHEMA_VERSION` 9 → 10; the `settings` table is **authoritative** (preserved across bumps, like `sessions`/curation tables).

## Tests

`packages/core/tests/store/settings-store.test.ts` (6): plain round-trip, **encrypted-at-rest** (raw row ≠ plaintext + decrypt), secret op **requires the key** (plain ops still work without it), `listSettings` **never leaks** secret values, update/delete, and a real **schema-bump survival**.

## Next

Curator LLM config (typed getter/setter over settings: provider/endpoint/token[secret]/model/enable + addendum + `default_auto_apply`/confidence) → OpenAI-compatible client → pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)