### PR TITLE
feat(core): curator LLM config layer over the settings store

### DIFF
--- a/AUTONOMOUS-BUILD-NOTES-26-05-23.md
+++ b/AUTONOMOUS-BUILD-NOTES-26-05-23.md
@@ -22,7 +22,26 @@ Increments shipped this day, each its own PR:
 14. `feat/curator-redaction` — Stage 2.2 (partial) secret redaction (merged, PR #83).
 15. `chore/sanitize-redaction-test-fixtures` — synthetic fixtures + `.gitguardian.yaml` (merged, PR #84).
 16. `feat/admin-secret-crypto` — Stage 2.3-prep AES-256-GCM secret-store crypto (merged, PR #85).
-17. `feat/settings-store` — Stage 2.3 admin settings/secret store (this PR).
+17. `feat/settings-store` — Stage 2.3 admin settings/secret store (merged, PR #86).
+18. `feat/curator-config` — Stage 2.3 curator LLM config layer (this PR).
+
+## Increment 18 — Stage 2.3 curator LLM config layer
+
+Typed config accessors over the settings store (`curator-config.ts`, memory-curator §7.1):
+`readCuratorConfig` / `writeCuratorConfig` / `resolveCuratorToken`. Config keys cover enable,
+LLM connection (provider/endpoint/token/model), prompt addendum, auto-apply posture, and schedule.
+Spec defaults baked in (`safe_only`, confidence `0.90`, every 1 day at `03:00`). Validation:
+addendum ≤ 2 KB, `default_auto_apply` ∈ {off,safe_only,high_confidence}, confidence 0..1, interval
+≥ 1, `HH:MM` time — validated before any write (a bad patch changes nothing).
+
+Security properties: the **token is a secret** (encrypted by the settings store); `readCuratorConfig`
+exposes only `hasToken` and reads token PRESENCE from settings metadata (`listSettings`), so it
+**works without the master key** — the cockpit can render config state without decrypting. Only
+the worker's `resolveCuratorToken` decrypts. `isOperational = enabled && provider+endpoint+model+token`
+is the scheduler gate (§7.1). 7 tests.
+
+Next: OpenAI-compatible LLM client (configurable base URL + model) → prompt assembly → validate →
+risk-classify → apply policy → scheduler/worker → admin cockpit.
 
 ## Increment 17 — Stage 2.3 admin settings/secret store
 

--- a/packages/core/src/curator-config.ts
+++ b/packages/core/src/curator-config.ts
@@ -1,0 +1,163 @@
+// Curator LLM configuration (memory-curator spec §7.1), stored in the admin
+// settings/secret store. Operator-managed: enable flag, LLM connection
+// (provider/endpoint/token/model), prompt addendum, auto-apply posture, and
+// schedule. The token is a secret (encrypted by the settings store); the
+// readable config exposes only `hasToken`, never the value.
+//
+// `readCuratorConfig` deliberately reads token PRESENCE from settings metadata
+// (no decryption), so it works without the master key — the admin cockpit can
+// render the configured state. Only the worker's `resolveCuratorToken` decrypts.
+
+import type { SettingMeta } from "./store/settings-store.js";
+
+const KEYS = {
+  enabled: "curator.enabled",
+  provider: "curator.llm.provider",
+  endpoint: "curator.llm.endpoint",
+  model: "curator.llm.model",
+  token: "curator.llm.token",
+  promptAddendum: "curator.prompt_addendum",
+  defaultAutoApply: "curator.default_auto_apply",
+  autoApplyConfidence: "curator.auto_apply_confidence",
+  scheduleIntervalDays: "curator.schedule.interval_days",
+  scheduleTime: "curator.schedule.time",
+} as const;
+
+export type AutoApplyLevel = "off" | "safe_only" | "high_confidence";
+const AUTO_APPLY_LEVELS: readonly AutoApplyLevel[] = ["off", "safe_only", "high_confidence"];
+const MAX_ADDENDUM_BYTES = 2048; // §7.1: addendum is length-bounded (~2 KB)
+
+// Spec defaults (§7.2 / §12).
+const DEFAULT_AUTO_APPLY: AutoApplyLevel = "safe_only";
+const DEFAULT_CONFIDENCE = 0.9;
+const DEFAULT_INTERVAL_DAYS = 1;
+const DEFAULT_TIME = "03:00";
+
+export interface CuratorConfig {
+  enabled: boolean;
+  llm: { provider: string; endpoint: string; model: string };
+  /** Whether an LLM token is stored — never the value. */
+  hasToken: boolean;
+  promptAddendum: string;
+  defaultAutoApply: AutoApplyLevel;
+  autoApplyConfidence: number;
+  schedule: { intervalDays: number; time: string };
+  /** provider + endpoint + model + token all present. */
+  isLlmComplete: boolean;
+  /** enabled AND the LLM config is complete (§7.1 — the scheduler gate). */
+  isOperational: boolean;
+}
+
+export interface CuratorConfigPatch {
+  enabled?: boolean;
+  llm?: { provider?: string; endpoint?: string; model?: string };
+  /** Plaintext token; stored encrypted. Empty string clears it. */
+  token?: string;
+  promptAddendum?: string;
+  defaultAutoApply?: AutoApplyLevel;
+  autoApplyConfidence?: number;
+  schedule?: { intervalDays?: number; time?: string };
+}
+
+// The slices of the store this module needs.
+interface ConfigReader {
+  getSetting: (key: string) => string | null;
+  listSettings: () => SettingMeta[];
+}
+interface ConfigWriter {
+  setSetting: (key: string, value: string, options?: { secret?: boolean }) => void;
+  deleteSetting: (key: string) => void;
+}
+
+function parseAutoApply(raw: string | null): AutoApplyLevel {
+  return AUTO_APPLY_LEVELS.includes(raw as AutoApplyLevel)
+    ? (raw as AutoApplyLevel)
+    : DEFAULT_AUTO_APPLY;
+}
+
+function parseNumber(raw: string | null, fallback: number): number {
+  const n = Number(raw);
+  return raw !== null && Number.isFinite(n) ? n : fallback;
+}
+
+export function readCuratorConfig(store: ConfigReader): CuratorConfig {
+  const provider = store.getSetting(KEYS.provider) ?? "";
+  const endpoint = store.getSetting(KEYS.endpoint) ?? "";
+  const model = store.getSetting(KEYS.model) ?? "";
+  const hasToken = store.listSettings().some((setting) => setting.key === KEYS.token);
+  const enabled = store.getSetting(KEYS.enabled) === "true";
+
+  const isLlmComplete = Boolean(provider && endpoint && model && hasToken);
+  return {
+    enabled,
+    llm: { provider, endpoint, model },
+    hasToken,
+    promptAddendum: store.getSetting(KEYS.promptAddendum) ?? "",
+    defaultAutoApply: parseAutoApply(store.getSetting(KEYS.defaultAutoApply)),
+    autoApplyConfidence: parseNumber(
+      store.getSetting(KEYS.autoApplyConfidence),
+      DEFAULT_CONFIDENCE,
+    ),
+    schedule: {
+      intervalDays: parseNumber(store.getSetting(KEYS.scheduleIntervalDays), DEFAULT_INTERVAL_DAYS),
+      time: store.getSetting(KEYS.scheduleTime) ?? DEFAULT_TIME,
+    },
+    isLlmComplete,
+    isOperational: enabled && isLlmComplete,
+  };
+}
+
+export function writeCuratorConfig(store: ConfigWriter, patch: CuratorConfigPatch): void {
+  // Validate everything before writing anything (a bad patch makes no change).
+  if (patch.promptAddendum !== undefined) {
+    if (Buffer.byteLength(patch.promptAddendum, "utf8") > MAX_ADDENDUM_BYTES) {
+      throw new Error(`prompt addendum must be ≤ ${MAX_ADDENDUM_BYTES} bytes (~2 KB)`);
+    }
+  }
+  if (patch.defaultAutoApply !== undefined && !AUTO_APPLY_LEVELS.includes(patch.defaultAutoApply)) {
+    throw new Error(`invalid default_auto_apply level: ${patch.defaultAutoApply}`);
+  }
+  if (patch.autoApplyConfidence !== undefined) {
+    const c = patch.autoApplyConfidence;
+    if (!Number.isFinite(c) || c < 0 || c > 1) {
+      throw new Error("auto_apply confidence must be between 0 and 1");
+    }
+  }
+  if (patch.schedule?.intervalDays !== undefined) {
+    const d = patch.schedule.intervalDays;
+    if (!Number.isInteger(d) || d < 1) {
+      throw new Error("schedule interval_days must be a positive integer");
+    }
+  }
+  if (
+    patch.schedule?.time !== undefined &&
+    !/^([01]\d|2[0-3]):[0-5]\d$/.test(patch.schedule.time)
+  ) {
+    throw new Error("schedule time must be HH:MM (24-hour)");
+  }
+
+  if (patch.enabled !== undefined) store.setSetting(KEYS.enabled, patch.enabled ? "true" : "false");
+  if (patch.llm?.provider !== undefined) store.setSetting(KEYS.provider, patch.llm.provider);
+  if (patch.llm?.endpoint !== undefined) store.setSetting(KEYS.endpoint, patch.llm.endpoint);
+  if (patch.llm?.model !== undefined) store.setSetting(KEYS.model, patch.llm.model);
+  if (patch.token !== undefined) {
+    if (patch.token === "") store.deleteSetting(KEYS.token);
+    else store.setSetting(KEYS.token, patch.token, { secret: true });
+  }
+  if (patch.promptAddendum !== undefined)
+    store.setSetting(KEYS.promptAddendum, patch.promptAddendum);
+  if (patch.defaultAutoApply !== undefined)
+    store.setSetting(KEYS.defaultAutoApply, patch.defaultAutoApply);
+  if (patch.autoApplyConfidence !== undefined)
+    store.setSetting(KEYS.autoApplyConfidence, String(patch.autoApplyConfidence));
+  if (patch.schedule?.intervalDays !== undefined)
+    store.setSetting(KEYS.scheduleIntervalDays, String(patch.schedule.intervalDays));
+  if (patch.schedule?.time !== undefined) store.setSetting(KEYS.scheduleTime, patch.schedule.time);
+}
+
+/** Decrypt the stored LLM token for the worker. Returns null when unset. Needs the master key. */
+export function resolveCuratorToken(store: {
+  getSetting: (key: string) => string | null;
+}): string | null {
+  return store.getSetting(KEYS.token);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,14 @@ export {
 export { type RedactionResult, redactSecrets } from "./curator-redaction.js";
 export { decryptSecret, encryptSecret, resolveSecretKey } from "./secret-crypto.js";
 export {
+  type AutoApplyLevel,
+  type CuratorConfig,
+  type CuratorConfigPatch,
+  readCuratorConfig,
+  resolveCuratorToken,
+  writeCuratorConfig,
+} from "./curator-config.js";
+export {
   type BackfillChange,
   type BackfillOptions,
   type BackfillSection,

--- a/packages/core/tests/curator-config.test.ts
+++ b/packages/core/tests/curator-config.test.ts
@@ -1,0 +1,129 @@
+// Curator LLM configuration (memory-curator spec §7.1) over the settings store.
+//
+// Operator-managed config: provider/endpoint/token/model + enable, prompt
+// addendum, auto-apply posture, schedule. The token is a secret (encrypted via
+// the settings store); the readable config never exposes it — only `hasToken`.
+// `readCuratorConfig` works WITHOUT the master key (token presence comes from
+// settings metadata), so the cockpit can render config; only the worker's
+// `resolveCuratorToken` needs the key.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type LibrarianStore,
+  createLibrarianStore,
+  readCuratorConfig,
+  resolveCuratorToken,
+  resolveSecretKey,
+  writeCuratorConfig,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const KEY = resolveSecretKey("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+
+interface Scope {
+  store: LibrarianStore;
+  dataDir: string;
+}
+
+function open(dataDir: string, withKey = true): LibrarianStore {
+  return createLibrarianStore(withKey ? { dataDir, secretKey: KEY } : { dataDir });
+}
+
+function scope(): Scope {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-curator-cfg-"));
+  return { store: open(dataDir), dataDir };
+}
+
+function teardown(s: Scope | null): void {
+  if (!s) return;
+  try {
+    s.store.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(s.dataDir, { recursive: true, force: true });
+}
+
+describe("curator config", () => {
+  let s: Scope | null = null;
+  beforeEach(() => {
+    s = scope();
+  });
+  afterEach(() => {
+    teardown(s);
+    s = null;
+  });
+
+  it("returns safe defaults when nothing is configured", () => {
+    const cfg = readCuratorConfig(s!.store);
+    expect(cfg.enabled).toBe(false);
+    expect(cfg.defaultAutoApply).toBe("safe_only");
+    expect(cfg.autoApplyConfidence).toBeCloseTo(0.9);
+    expect(cfg.hasToken).toBe(false);
+    expect(cfg.isLlmComplete).toBe(false);
+    expect(cfg.isOperational).toBe(false);
+  });
+
+  it("round-trips config and never exposes the token in the readable config", () => {
+    const { store } = s!;
+    writeCuratorConfig(store, {
+      enabled: true,
+      llm: { provider: "openai", endpoint: "https://api.example.com/v1", model: "gpt-x" },
+      token: "sk-the-llm-token",
+      promptAddendum: "prefer merging over archiving",
+    });
+    const cfg = readCuratorConfig(store);
+    expect(cfg.llm.provider).toBe("openai");
+    expect(cfg.llm.endpoint).toBe("https://api.example.com/v1");
+    expect(cfg.llm.model).toBe("gpt-x");
+    expect(cfg.hasToken).toBe(true);
+    expect(cfg.isLlmComplete).toBe(true);
+    expect(cfg.isOperational).toBe(true);
+    expect(cfg.promptAddendum).toBe("prefer merging over archiving");
+    // The readable config object must not carry the token anywhere.
+    expect(JSON.stringify(cfg)).not.toContain("sk-the-llm-token");
+  });
+
+  it("reports hasToken WITHOUT the master key (cockpit render path)", () => {
+    const { store, dataDir } = s!;
+    writeCuratorConfig(store, {
+      enabled: true,
+      llm: { provider: "openai", endpoint: "https://e", model: "m" },
+      token: "sk-secret",
+    });
+    store.close();
+    const noKey = open(dataDir, false);
+    s!.store = noKey;
+    const cfg = readCuratorConfig(noKey); // must not throw despite the secret token
+    expect(cfg.hasToken).toBe(true);
+    expect(cfg.isOperational).toBe(true);
+  });
+
+  it("resolves the decrypted token for the worker", () => {
+    const { store } = s!;
+    writeCuratorConfig(store, { token: "sk-worker-token" });
+    expect(resolveCuratorToken(store)).toBe("sk-worker-token");
+  });
+
+  it("returns null token when none is configured", () => {
+    expect(resolveCuratorToken(s!.store)).toBeNull();
+  });
+
+  it("validates the prompt addendum length (≤ 2 KB)", () => {
+    const { store } = s!;
+    expect(() => writeCuratorConfig(store, { promptAddendum: "x".repeat(2049) })).toThrow(/2/);
+  });
+
+  it("validates default_auto_apply and confidence bounds", () => {
+    const { store } = s!;
+    expect(() =>
+      writeCuratorConfig(store, {
+        defaultAutoApply: "yolo" as unknown as "off",
+      }),
+    ).toThrow(/auto_apply|auto-apply/i);
+    expect(() => writeCuratorConfig(store, { autoApplyConfidence: 1.5 })).toThrow(/confidence/i);
+    expect(() => writeCuratorConfig(store, { autoApplyConfidence: -0.1 })).toThrow(/confidence/i);
+  });
+});


### PR DESCRIPTION
## Summary

Stage 2.3 — typed config accessors over the admin settings store (`curator-config.ts`, memory-curator spec §7.1): `readCuratorConfig` / `writeCuratorConfig` / `resolveCuratorToken`.

Config covers enable, the LLM connection (provider/endpoint/token/model), prompt addendum, auto-apply posture, and schedule. Spec defaults baked in (`safe_only`, confidence `0.90`, every 1 day at `03:00`). Validation (addendum ≤ 2 KB, `default_auto_apply` enum, confidence 0..1, interval ≥ 1, `HH:MM`) runs **before any write** — a bad patch changes nothing.

**Security:** the token is a **secret** (encrypted by the settings store). `readCuratorConfig` exposes only `hasToken` and reads token *presence* from settings metadata (`listSettings`), so it **works without the master key** — the admin cockpit can render config state without decrypting. Only the worker's `resolveCuratorToken` decrypts. `isOperational = enabled && provider+endpoint+model+token` is the scheduler gate (§7.1).

## Tests

`packages/core/tests/curator-config.test.ts` (7): safe defaults; round-trip + token never in the readable config; `hasToken` without the master key; worker token resolution + null when unset; addendum-length, auto-apply-enum, and confidence-bounds validation.

## Next

OpenAI-compatible LLM client (configurable base URL + model) → prompt assembly → validate → risk-classify → apply policy → scheduler/worker → admin cockpit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)