### PR TITLE
chore(core): sanitize cosmetic sk- secret fixtures in tests

### DIFF
--- a/packages/core/tests/curator-config.test.ts
+++ b/packages/core/tests/curator-config.test.ts
@@ -71,7 +71,7 @@ describe("curator config", () => {
     writeCuratorConfig(store, {
       enabled: true,
       llm: { provider: "openai", endpoint: "https://api.example.com/v1", model: "gpt-x" },
-      token: "sk-the-llm-token",
+      token: "dummy-llm-token",
       promptAddendum: "prefer merging over archiving",
     });
     const cfg = readCuratorConfig(store);
@@ -83,7 +83,7 @@ describe("curator config", () => {
     expect(cfg.isOperational).toBe(true);
     expect(cfg.promptAddendum).toBe("prefer merging over archiving");
     // The readable config object must not carry the token anywhere.
-    expect(JSON.stringify(cfg)).not.toContain("sk-the-llm-token");
+    expect(JSON.stringify(cfg)).not.toContain("dummy-llm-token");
   });
 
   it("reports hasToken WITHOUT the master key (cockpit render path)", () => {
@@ -91,7 +91,7 @@ describe("curator config", () => {
     writeCuratorConfig(store, {
       enabled: true,
       llm: { provider: "openai", endpoint: "https://e", model: "m" },
-      token: "sk-secret",
+      token: "dummy-secret",
     });
     store.close();
     const noKey = open(dataDir, false);
@@ -103,8 +103,8 @@ describe("curator config", () => {
 
   it("resolves the decrypted token for the worker", () => {
     const { store } = s!;
-    writeCuratorConfig(store, { token: "sk-worker-token" });
-    expect(resolveCuratorToken(store)).toBe("sk-worker-token");
+    writeCuratorConfig(store, { token: "dummy-worker-token" });
+    expect(resolveCuratorToken(store)).toBe("dummy-worker-token");
   });
 
   it("returns null token when none is configured", () => {

--- a/packages/core/tests/secret-crypto.test.ts
+++ b/packages/core/tests/secret-crypto.test.ts
@@ -15,7 +15,7 @@ const key = resolveSecretKey(KEY_HEX);
 
 describe("encryptSecret / decryptSecret (AES-256-GCM)", () => {
   it("round-trips a secret", () => {
-    const plaintext = "sk-test-the-actual-llm-token-value";
+    const plaintext = "dummy-test-secret-value";
     const payload = encryptSecret(plaintext, key);
     expect(payload).not.toContain(plaintext); // ciphertext, not the value
     expect(decryptSecret(payload, key)).toBe(plaintext);

--- a/packages/core/tests/store/settings-store.test.ts
+++ b/packages/core/tests/store/settings-store.test.ts
@@ -56,7 +56,7 @@ describe("settings store", () => {
 
   it("stores a secret value encrypted at rest and decrypts it on read", () => {
     const { store } = s!;
-    const token = "sk-the-real-llm-token-value-1234567890";
+    const token = "dummy-llm-token-value-1234567890";
     store.setSetting("curator.llm_token", token, { secret: true });
 
     // Raw row must not contain the plaintext.
@@ -72,7 +72,7 @@ describe("settings store", () => {
 
   it("requires the master key to read or write a secret setting", () => {
     const { store, dataDir } = s!;
-    store.setSetting("curator.llm_token", "sk-secret", { secret: true });
+    store.setSetting("curator.llm_token", "dummy-secret", { secret: true });
     store.close();
 
     const noKey = open(dataDir, false);
@@ -87,12 +87,12 @@ describe("settings store", () => {
   it("listSettings returns metadata only, never secret values", () => {
     const { store } = s!;
     store.setSetting("curator.enabled", "true");
-    store.setSetting("curator.llm_token", "sk-secret", { secret: true });
+    store.setSetting("curator.llm_token", "dummy-secret", { secret: true });
     const rows = store.listSettings();
     const tokenRow = rows.find((r) => r.key === "curator.llm_token");
     expect(tokenRow?.is_secret).toBe(true);
     // No `value` field on the listing shape at all.
-    expect(JSON.stringify(rows)).not.toContain("sk-secret");
+    expect(JSON.stringify(rows)).not.toContain("dummy-secret");
   });
 
   it("updates and deletes settings", () => {
@@ -130,7 +130,7 @@ describe("settings store", () => {
 
   it("fails closed when reading a secret with the wrong master key", () => {
     const { store, dataDir } = s!;
-    store.setSetting("curator.llm_token", "sk-secret", { secret: true });
+    store.setSetting("curator.llm_token", "dummy-secret", { secret: true });
     store.close();
 
     const wrongKey = resolveSecretKey(
@@ -143,7 +143,7 @@ describe("settings store", () => {
 
   it("survives a real schema-version bump (settings are authoritative)", () => {
     const { store, dataDir } = s!;
-    store.setSetting("curator.llm_token", "sk-secret", { secret: true });
+    store.setSetting("curator.llm_token", "dummy-secret", { secret: true });
     store.setSetting("curator.enabled", "true");
     store.db.exec("PRAGMA user_version = 9");
     store.close();
@@ -151,6 +151,6 @@ describe("settings store", () => {
     const reopened = open(dataDir);
     s!.store = reopened;
     expect(reopened.getSetting("curator.enabled")).toBe("true");
-    expect(reopened.getSetting("curator.llm_token")).toBe("sk-secret");
+    expect(reopened.getSetting("curator.llm_token")).toBe("dummy-secret");
   });
 });


### PR DESCRIPTION
## What

Renames the `sk-`-prefixed throwaway token fixtures in the curator
config/crypto/settings tests to non-detector strings (`dummy-…`).

## Why

The token *value* is irrelevant to what those tests assert (encryption
at rest, never-leak, round-trip), but the `sk-` shape trips
GitGuardian's generic API-key detector — producing a recurring advisory
GG failure on every curator PR (#83–#87). These are false positives;
removing the detector-matching shape removes the noise at the source.

## Scope / non-goals

- **Behaviour-preserving.** Assertions are repointed at the new values;
  no production code changes; full suite green locally.
- The **redaction tests** (`curator-redaction.test.ts`) are intentionally
  left untouched — their detector-shaped fixtures (`ghp_`, `glpat-`,
  `AKIA`, PEM blocks, …) are load-bearing for what they test and can only
  be resolved dashboard-side (the GG GitHub App does not honour the repo
  `.gitguardian.yaml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)