### PR TITLE
feat(core): OpenAI-compatible LLM client for the memory curator

### DIFF
--- a/packages/core/src/curator-llm-client.ts
+++ b/packages/core/src/curator-llm-client.ts
@@ -1,0 +1,195 @@
+// OpenAI-compatible chat-completions client for the memory curator (spec §10.4:
+// "the LLM produces structured JSON only. No prose parsing."). This is the
+// curator's ONLY network egress.
+//
+// Hard invariant: the bearer token must never appear in a thrown error or any
+// serialisable field — it travels solely in the Authorization header to the
+// configured endpoint. Error messages are built only from the response status
+// or the underlying fetch error's own message, never from the request we sent.
+//
+// The client is intentionally thin: a fetch-injectable POST with an
+// AbortController timeout. Validation of the *content* the LLM returns lives in
+// the pipeline's parse/validate stage (§10.5), not here — this layer only
+// guarantees a well-formed transport result (a string content payload).
+
+export interface LlmClientConfig {
+  /** Base URL, e.g. `https://api.openai.com/v1` (a trailing slash is tolerated). */
+  endpoint: string;
+  /** Bearer token (secret). Never logged or surfaced in errors. */
+  token: string;
+  model: string;
+}
+
+export type LlmRole = "system" | "user" | "assistant";
+
+export interface LlmMessage {
+  role: LlmRole;
+  content: string;
+}
+
+export interface LlmCompletionRequest {
+  messages: LlmMessage[];
+  /** Request a JSON-object response (OpenAI `response_format`). Default `true`. */
+  jsonResponse?: boolean;
+  /** Sampling temperature; omitted from the request when undefined. */
+  temperature?: number;
+  /** Cap on completion tokens; omitted when undefined. */
+  maxTokens?: number;
+  /** Overall request timeout in ms. Default 60_000. */
+  timeoutMs?: number;
+}
+
+export interface LlmUsage {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+}
+
+export interface LlmCompletion {
+  /** Raw assistant message content (a JSON string when `jsonResponse` is set). */
+  content: string;
+  /** Model reported by the provider, falling back to the configured model. */
+  model: string;
+  usage: LlmUsage | null;
+}
+
+/** Discriminates transport failures so the worker can decide what to retry. */
+export type LlmErrorKind = "http" | "timeout" | "network" | "malformed";
+
+export class LlmClientError extends Error {
+  readonly kind: LlmErrorKind;
+  readonly status: number | undefined;
+  constructor(kind: LlmErrorKind, message: string, status?: number) {
+    super(message);
+    this.name = "LlmClientError";
+    this.kind = kind;
+    this.status = status;
+  }
+}
+
+export interface LlmClient {
+  complete(request: LlmCompletionRequest): Promise<LlmCompletion>;
+}
+
+type FetchFn = (url: string, init?: RequestInit) => Promise<Response>;
+
+export interface LlmClientDeps {
+  /** Injectable fetch for testing; defaults to the global. */
+  fetch?: FetchFn;
+}
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+export function createCuratorLlmClient(
+  config: LlmClientConfig,
+  deps: LlmClientDeps = {},
+): LlmClient {
+  const endpoint = config.endpoint.trim();
+  const { token, model: rawModel } = config;
+  const model = rawModel.trim();
+  if (!endpoint) throw new Error("LLM client requires a non-empty endpoint");
+  if (!token) throw new Error("LLM client requires a non-empty token");
+  if (!model) throw new Error("LLM client requires a non-empty model");
+
+  const fetchFn: FetchFn = deps.fetch ?? ((url, init) => fetch(url, init));
+  const url = `${endpoint.replace(/\/+$/, "")}/chat/completions`;
+
+  return {
+    async complete(request) {
+      const {
+        messages,
+        jsonResponse = true,
+        temperature,
+        maxTokens,
+        timeoutMs = DEFAULT_TIMEOUT_MS,
+      } = request;
+
+      const body: Record<string, unknown> = { model, messages };
+      if (jsonResponse) body.response_format = { type: "json_object" };
+      if (temperature !== undefined) body.temperature = temperature;
+      if (maxTokens !== undefined) body.max_tokens = maxTokens;
+
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+      let response: Response;
+      try {
+        response = await fetchFn(url, {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${token}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify(body),
+          signal: controller.signal,
+        });
+      } catch (err) {
+        // Our own timeout aborts the signal; distinguish it from a real failure.
+        if (controller.signal.aborted) {
+          throw new LlmClientError("timeout", `LLM request timed out after ${timeoutMs}ms`);
+        }
+        throw new LlmClientError("network", `LLM request failed: ${networkMessage(err)}`);
+      } finally {
+        clearTimeout(timer);
+      }
+
+      if (!response.ok) {
+        // Status only — the response body may echo provider detail but never our token.
+        throw new LlmClientError(
+          "http",
+          `LLM request failed: HTTP ${response.status}`,
+          response.status,
+        );
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = await response.json();
+      } catch {
+        throw new LlmClientError("malformed", "LLM response was not valid JSON");
+      }
+
+      const content = extractContent(parsed);
+      if (content === null) {
+        throw new LlmClientError("malformed", "LLM response had no message content");
+      }
+      return { content, model: extractModel(parsed) ?? model, usage: extractUsage(parsed) };
+    },
+  };
+}
+
+function networkMessage(err: unknown): string {
+  // The fetch error's own message (e.g. "ECONNREFUSED") — never our request.
+  return err instanceof Error ? err.message : "unknown network error";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function extractContent(parsed: unknown): string | null {
+  if (!isRecord(parsed) || !Array.isArray(parsed.choices)) return null;
+  const first = parsed.choices[0];
+  if (!isRecord(first) || !isRecord(first.message)) return null;
+  const content = first.message.content;
+  return typeof content === "string" ? content : null;
+}
+
+function extractModel(parsed: unknown): string | null {
+  if (isRecord(parsed) && typeof parsed.model === "string" && parsed.model) return parsed.model;
+  return null;
+}
+
+function extractUsage(parsed: unknown): LlmUsage | null {
+  if (!isRecord(parsed) || !isRecord(parsed.usage)) return null;
+  const usage = parsed.usage;
+  return {
+    promptTokens: numberOr(usage.prompt_tokens),
+    completionTokens: numberOr(usage.completion_tokens),
+    totalTokens: numberOr(usage.total_tokens),
+  };
+}
+
+function numberOr(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}

--- a/packages/core/src/curator-llm-client.ts
+++ b/packages/core/src/curator-llm-client.ts
@@ -103,59 +103,84 @@ export function createCuratorLlmClient(
         maxTokens,
         timeoutMs = DEFAULT_TIMEOUT_MS,
       } = request;
+      if (!(timeoutMs > 0)) throw new Error("LLM client timeoutMs must be a positive number");
 
       const body: Record<string, unknown> = { model, messages };
       if (jsonResponse) body.response_format = { type: "json_object" };
       if (temperature !== undefined) body.temperature = temperature;
       if (maxTokens !== undefined) body.max_tokens = maxTokens;
 
+      // One controller guards the whole exchange — connect AND body read. The
+      // timer stays armed until the body is fully parsed (a provider can stall
+      // the body after sending headers), and is always cleared in `finally`.
+      // There is no caller-supplied signal in v1, so any AbortError is ours.
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(), timeoutMs);
-
-      let response: Response;
       try {
-        response = await fetchFn(url, {
-          method: "POST",
-          headers: {
-            authorization: `Bearer ${token}`,
-            "content-type": "application/json",
-          },
-          body: JSON.stringify(body),
-          signal: controller.signal,
-        });
-      } catch (err) {
-        // Our own timeout aborts the signal; distinguish it from a real failure.
-        if (controller.signal.aborted) {
-          throw new LlmClientError("timeout", `LLM request timed out after ${timeoutMs}ms`);
+        let response: Response;
+        try {
+          response = await fetchFn(url, {
+            method: "POST",
+            headers: {
+              authorization: `Bearer ${token}`,
+              "content-type": "application/json",
+            },
+            body: JSON.stringify(body),
+            signal: controller.signal,
+          });
+        } catch (err) {
+          throw fetchFailure(err, timeoutMs);
         }
-        throw new LlmClientError("network", `LLM request failed: ${networkMessage(err)}`);
+
+        if (!response.ok) {
+          // Status only — the response body may echo provider detail but never our token.
+          throw new LlmClientError(
+            "http",
+            `LLM request failed: HTTP ${response.status}`,
+            response.status,
+          );
+        }
+
+        let parsed: unknown;
+        try {
+          parsed = await response.json();
+        } catch (err) {
+          // A stalled body read aborts via the same signal → timeout; bad JSON → malformed.
+          if (isAbortError(err)) {
+            throw new LlmClientError("timeout", `LLM request timed out after ${timeoutMs}ms`);
+          }
+          throw new LlmClientError("malformed", "LLM response was not valid JSON");
+        }
+
+        const content = extractContent(parsed);
+        if (content === null) {
+          throw new LlmClientError("malformed", "LLM response had no message content");
+        }
+        return { content, model: extractModel(parsed) ?? model, usage: extractUsage(parsed) };
       } finally {
         clearTimeout(timer);
       }
-
-      if (!response.ok) {
-        // Status only — the response body may echo provider detail but never our token.
-        throw new LlmClientError(
-          "http",
-          `LLM request failed: HTTP ${response.status}`,
-          response.status,
-        );
-      }
-
-      let parsed: unknown;
-      try {
-        parsed = await response.json();
-      } catch {
-        throw new LlmClientError("malformed", "LLM response was not valid JSON");
-      }
-
-      const content = extractContent(parsed);
-      if (content === null) {
-        throw new LlmClientError("malformed", "LLM response had no message content");
-      }
-      return { content, model: extractModel(parsed) ?? model, usage: extractUsage(parsed) };
     },
   };
+}
+
+/**
+ * Classify a fetch rejection. An AbortError means our timeout fired (no
+ * caller-supplied signal exists in v1); anything else is a transport failure.
+ * Discriminating on the error — not `controller.signal.aborted` — avoids a race
+ * where a real network error settling after the timer would be mislabelled.
+ */
+function fetchFailure(err: unknown, timeoutMs: number): LlmClientError {
+  if (isAbortError(err)) {
+    return new LlmClientError("timeout", `LLM request timed out after ${timeoutMs}ms`);
+  }
+  return new LlmClientError("network", `LLM request failed: ${networkMessage(err)}`);
+}
+
+// Node's `fetch` rejects with a DOMException on abort, which does NOT extend
+// Error — so match on `.name` rather than `instanceof`.
+function isAbortError(err: unknown): boolean {
+  return isRecord(err) && err.name === "AbortError";
 }
 
 function networkMessage(err: unknown): string {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,19 @@ export {
   normalizedTitle,
 } from "./curator-fingerprint.js";
 export { type RedactionResult, redactSecrets } from "./curator-redaction.js";
+export {
+  type LlmClient,
+  type LlmClientConfig,
+  type LlmClientDeps,
+  type LlmCompletion,
+  type LlmCompletionRequest,
+  type LlmErrorKind,
+  type LlmMessage,
+  type LlmRole,
+  type LlmUsage,
+  LlmClientError,
+  createCuratorLlmClient,
+} from "./curator-llm-client.js";
 export { decryptSecret, encryptSecret, resolveSecretKey } from "./secret-crypto.js";
 export {
   type AutoApplyLevel,

--- a/packages/core/tests/curator-llm-client.test.ts
+++ b/packages/core/tests/curator-llm-client.test.ts
@@ -34,6 +34,18 @@ async function failure(run: () => Promise<unknown>): Promise<LlmClientError> {
   throw new Error("expected complete() to reject, but it resolved");
 }
 
+/**
+ * The token must never surface in ANY observable field of a thrown error.
+ * `JSON.stringify` alone is insufficient — it skips the non-enumerable
+ * `message`/`stack`/`cause`, which are exactly where a leak would hide.
+ */
+function expectNoTokenLeak(err: LlmClientError): void {
+  expect(err.message).not.toContain(TOKEN);
+  expect(String(err.stack)).not.toContain(TOKEN);
+  expect(err.cause).toBeUndefined(); // fails loudly if a refactor attaches the raw fetch error
+  expect(JSON.stringify(err)).not.toContain(TOKEN);
+}
+
 describe("createCuratorLlmClient", () => {
   it("POSTs to {endpoint}/chat/completions with bearer auth and a JSON body", async () => {
     const fetchMock = vi.fn(async () => completion(OK_BODY));
@@ -94,8 +106,7 @@ describe("createCuratorLlmClient", () => {
     );
     expect(err.kind).toBe("http");
     expect(err.status).toBe(400);
-    expect(err.message).not.toContain(TOKEN);
-    expect(JSON.stringify(err)).not.toContain(TOKEN);
+    expectNoTokenLeak(err);
   });
 
   it("throws a malformed error when choices/content are missing", async () => {
@@ -106,6 +117,7 @@ describe("createCuratorLlmClient", () => {
       client.complete({ messages: [{ role: "user", content: "x" }] }),
     );
     expect(err.kind).toBe("malformed");
+    expectNoTokenLeak(err);
   });
 
   it("throws a timeout error when the request exceeds timeoutMs", async () => {
@@ -123,6 +135,29 @@ describe("createCuratorLlmClient", () => {
       client.complete({ messages: [{ role: "user", content: "x" }], timeoutMs: 10 }),
     );
     expect(err.kind).toBe("timeout");
+    expectNoTokenLeak(err);
+  });
+
+  it("times out a stalled response-body read, not just the connect", async () => {
+    // Headers arrive immediately, but reading the body hangs until the signal
+    // aborts — the timer must still cover the body read.
+    const stalledBodyFetch = vi.fn((_url: string | URL, init?: RequestInit) =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () =>
+          new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () =>
+              reject(new DOMException("aborted", "AbortError")),
+            );
+          }),
+      } as unknown as Response),
+    );
+    const client = createCuratorLlmClient(CONFIG, { fetch: stalledBodyFetch });
+    const err = await failure(() =>
+      client.complete({ messages: [{ role: "user", content: "x" }], timeoutMs: 10 }),
+    );
+    expect(err.kind).toBe("timeout");
   });
 
   it("wraps a network failure without leaking the token", async () => {
@@ -135,7 +170,14 @@ describe("createCuratorLlmClient", () => {
       client.complete({ messages: [{ role: "user", content: "x" }] }),
     );
     expect(err.kind).toBe("network");
-    expect(JSON.stringify(err)).not.toContain(TOKEN);
+    expectNoTokenLeak(err);
+  });
+
+  it("rejects a non-positive timeoutMs", async () => {
+    const client = createCuratorLlmClient(CONFIG, { fetch: async () => completion(OK_BODY) });
+    await expect(
+      client.complete({ messages: [{ role: "user", content: "x" }], timeoutMs: 0 }),
+    ).rejects.toThrow(/timeout/i);
   });
 
   it("rejects an incomplete configuration at construction", () => {

--- a/packages/core/tests/curator-llm-client.test.ts
+++ b/packages/core/tests/curator-llm-client.test.ts
@@ -1,0 +1,146 @@
+// OpenAI-compatible chat-completions client for the memory curator (spec §10.4:
+// "the LLM produces structured JSON only"). This is the curator's only network
+// egress, so the load-bearing invariant is that the bearer token NEVER appears
+// in a thrown error or anywhere serialisable. The client is otherwise a thin,
+// fetch-injectable POST to {endpoint}/chat/completions.
+
+import { type LlmClientError, createCuratorLlmClient } from "@librarian/core";
+import { describe, expect, it, vi } from "vitest";
+
+const TOKEN = "dummy-llm-token-DO-NOT-LEAK";
+const CONFIG = { endpoint: "https://api.example.com/v1", token: TOKEN, model: "gpt-x" };
+
+/** Build a real Response with an OpenAI-shaped chat-completion body. */
+function completion(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const OK_BODY = {
+  model: "gpt-x-2026",
+  choices: [{ message: { role: "assistant", content: '{"operations":[]}' } }],
+  usage: { prompt_tokens: 12, completion_tokens: 3, total_tokens: 15 },
+};
+
+/** Run `complete` and return whatever it throws (so we can inspect the error). */
+async function failure(run: () => Promise<unknown>): Promise<LlmClientError> {
+  try {
+    await run();
+  } catch (err) {
+    return err as LlmClientError;
+  }
+  throw new Error("expected complete() to reject, but it resolved");
+}
+
+describe("createCuratorLlmClient", () => {
+  it("POSTs to {endpoint}/chat/completions with bearer auth and a JSON body", async () => {
+    const fetchMock = vi.fn(async () => completion(OK_BODY));
+    const client = createCuratorLlmClient(CONFIG, { fetch: fetchMock });
+
+    await client.complete({
+      messages: [
+        { role: "system", content: "curate" },
+        { role: "user", content: "evidence" },
+      ],
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("https://api.example.com/v1/chat/completions");
+    expect(init!.method).toBe("POST");
+    const headers = new Headers(init!.headers);
+    expect(headers.get("authorization")).toBe(`Bearer ${TOKEN}`);
+    expect(headers.get("content-type")).toBe("application/json");
+    const sent = JSON.parse(init!.body as string);
+    expect(sent.model).toBe("gpt-x");
+    expect(sent.messages).toHaveLength(2);
+    expect(sent.response_format).toEqual({ type: "json_object" });
+  });
+
+  it("strips a trailing slash from the endpoint", async () => {
+    const fetchMock = vi.fn(async () => completion(OK_BODY));
+    const client = createCuratorLlmClient(
+      { ...CONFIG, endpoint: "https://api.example.com/v1/" },
+      { fetch: fetchMock },
+    );
+    await client.complete({ messages: [{ role: "user", content: "x" }] });
+    expect(fetchMock.mock.calls[0]![0]).toBe("https://api.example.com/v1/chat/completions");
+  });
+
+  it("returns content, model, and usage from the response", async () => {
+    const client = createCuratorLlmClient(CONFIG, { fetch: async () => completion(OK_BODY) });
+    const result = await client.complete({ messages: [{ role: "user", content: "x" }] });
+    expect(result.content).toBe('{"operations":[]}');
+    expect(result.model).toBe("gpt-x-2026");
+    expect(result.usage).toEqual({ promptTokens: 12, completionTokens: 3, totalTokens: 15 });
+  });
+
+  it("returns null usage when the provider omits it, falling back to the configured model", async () => {
+    const body = { choices: [{ message: { content: "{}" } }] };
+    const client = createCuratorLlmClient(CONFIG, { fetch: async () => completion(body) });
+    const result = await client.complete({ messages: [{ role: "user", content: "x" }] });
+    expect(result.usage).toBeNull();
+    expect(result.model).toBe("gpt-x");
+  });
+
+  it("throws an http error carrying the status — and never the token", async () => {
+    const client = createCuratorLlmClient(CONFIG, {
+      fetch: async () => completion({ error: { message: "bad request" } }, 400),
+    });
+    const err = await failure(() =>
+      client.complete({ messages: [{ role: "user", content: "x" }] }),
+    );
+    expect(err.kind).toBe("http");
+    expect(err.status).toBe(400);
+    expect(err.message).not.toContain(TOKEN);
+    expect(JSON.stringify(err)).not.toContain(TOKEN);
+  });
+
+  it("throws a malformed error when choices/content are missing", async () => {
+    const client = createCuratorLlmClient(CONFIG, {
+      fetch: async () => completion({ choices: [] }),
+    });
+    const err = await failure(() =>
+      client.complete({ messages: [{ role: "user", content: "x" }] }),
+    );
+    expect(err.kind).toBe("malformed");
+  });
+
+  it("throws a timeout error when the request exceeds timeoutMs", async () => {
+    // fetch never resolves on its own; it only rejects when its signal aborts.
+    const hangingFetch = vi.fn(
+      (_url: string | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () =>
+            reject(new DOMException("aborted", "AbortError")),
+          );
+        }),
+    );
+    const client = createCuratorLlmClient(CONFIG, { fetch: hangingFetch });
+    const err = await failure(() =>
+      client.complete({ messages: [{ role: "user", content: "x" }], timeoutMs: 10 }),
+    );
+    expect(err.kind).toBe("timeout");
+  });
+
+  it("wraps a network failure without leaking the token", async () => {
+    const client = createCuratorLlmClient(CONFIG, {
+      fetch: async () => {
+        throw new Error("ECONNREFUSED");
+      },
+    });
+    const err = await failure(() =>
+      client.complete({ messages: [{ role: "user", content: "x" }] }),
+    );
+    expect(err.kind).toBe("network");
+    expect(JSON.stringify(err)).not.toContain(TOKEN);
+  });
+
+  it("rejects an incomplete configuration at construction", () => {
+    expect(() => createCuratorLlmClient({ ...CONFIG, endpoint: "" })).toThrow(/endpoint/i);
+    expect(() => createCuratorLlmClient({ ...CONFIG, token: "" })).toThrow(/token/i);
+    expect(() => createCuratorLlmClient({ ...CONFIG, model: "" })).toThrow(/model/i);
+  });
+});


### PR DESCRIPTION
## What

Adds `createCuratorLlmClient` — the memory curator's only outbound network
call (spec §10.4). A thin, fetch-injectable POST to
`{endpoint}/chat/completions`:

- Bearer auth + JSON body; `response_format: { type: "json_object" }` by default.
- `AbortController` timeout (default 60s) covering **both** the connect and the
  response-body read.
- Typed `LlmClientError` with a `kind` discriminator
  (`http | timeout | network | malformed`) + `status`, so the worker can decide
  what to retry.
- Returns `{ content, model, usage }` from `choices[0].message.content`,
  tolerating a missing `usage` block and falling back to the configured model.

## Security invariant (load-bearing)

The bearer token never appears in any thrown error or serialisable field — error
messages are built only from the response status or the underlying fetch error's
own message, never from the request we sent. Pinned by tests asserting on
`message`, `stack`, `cause`, and `JSON.stringify`.

## Scope boundary

Transport only. Content/operation validation of what the LLM returns is
deliberately deferred to the pipeline's parse/validate stage (§10.5).

## Review

Reviewed by the `code-reviewer` sub-agent across all five axes (verdict:
APPROVE). Three Important findings fixed in the second commit:
- timeout now covers the body read (was: hung forever on a stalled body);
- timeout/network discriminated on the error (`AbortError`) not the racy
  `signal.aborted`;
- token-leak assertions strengthened (`JSON.stringify` alone skipped the
  non-enumerable fields where a leak would hide).

Plus a `timeoutMs > 0` guard. Full suite, lint, typecheck, format all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)