### PR TITLE
feat(core): slice-scoped memory evidence gathering for the curator

### DIFF
--- a/packages/core/src/curator-evidence.ts
+++ b/packages/core/src/curator-evidence.ts
@@ -16,7 +16,7 @@
 // is read-only and never mutates memory. Session evidence is gathered separately.
 
 import type { DatabaseSync } from "node:sqlite";
-import { contentFingerprint, normalizedTitle } from "./curator-fingerprint.js";
+import { curationContentFingerprint, curationNormalizedTitle } from "./curator-fingerprint.js";
 import { redactSecrets } from "./curator-redaction.js";
 
 export type SliceKind = "common_project" | "common_global" | "agent_private";
@@ -158,10 +158,15 @@ function sliceWhere(slice: EvidenceSlice): SliceWhere {
       if (!slice.projectKey) throw new Error("common_project slice requires a projectKey");
       return { clause: "visibility = 'common' AND project_key = ?", params: [slice.projectKey] };
     case "common_global":
-      return {
-        clause: "visibility = 'common' AND (scope = 'global' OR project_key IS NULL)",
-        params: [],
-      };
+      // The true complement of common_project: every common memory with no
+      // owning project. Partitioning on project_key (set → common_project,
+      // null → common_global) guarantees each common memory is curated in
+      // exactly ONE slice — no cross-slice double-exposure. This is a catch-all
+      // for all project-less common scopes (global/environment/tool/session),
+      // not only scope='global'. (Spec §9 says "global scope or null project";
+      // we drop the scope arm because a global-scope memory that still carries a
+      // project_key belongs to that project's slice, not the global run.)
+      return { clause: "visibility = 'common' AND project_key IS NULL", params: [] };
     case "agent_private":
       if (!slice.agentId) throw new Error("agent_private slice requires an agentId");
       return { clause: "visibility = 'agent_private' AND agent_id = ?", params: [slice.agentId] };
@@ -238,10 +243,10 @@ function toItem(
 }
 
 function toTombstone(row: TombstoneRow, stats: GatherStats): TombstoneItem {
-  // Redact before fingerprinting so the key is stable against redacted candidates
-  // in the §10.3 pre-pass; the body is fingerprinted but NEVER emitted.
+  // The body is fingerprinted (via the shared redact-then-fingerprint contract)
+  // but NEVER emitted, so deleted content is not re-exposed (§9.1). Only the
+  // emitted title is redacted here for display + the redaction tally.
   const redactedTitle = redact(row.title, stats);
-  const redactedBody = redact(row.body, stats);
   return {
     id: row.id,
     title: redactedTitle,
@@ -252,8 +257,8 @@ function toTombstone(row: TombstoneRow, stats: GatherStats): TombstoneItem {
     agentId: row.agent_id,
     archivedAt: row.archived_at_event ?? row.updated_at,
     archiveReason: parseArchiveReason(row.archive_payload),
-    contentFingerprint: contentFingerprint(redactedTitle, redactedBody),
-    normalizedTitle: normalizedTitle(redactedTitle),
+    contentFingerprint: curationContentFingerprint(row.title, row.body),
+    normalizedTitle: curationNormalizedTitle(row.title),
   };
 }
 

--- a/packages/core/src/curator-evidence.ts
+++ b/packages/core/src/curator-evidence.ts
@@ -1,0 +1,280 @@
+// Slice-scoped memory evidence gathering for the memory curator (spec §9).
+//
+// A curation run operates on exactly one slice and must never read across a
+// slice boundary (§3). This module turns a slice descriptor into a bounded,
+// redacted, deterministically-ordered bundle of memory evidence:
+//
+//   - active + proposed memories for the slice (bodies redacted, §9/§10.4);
+//   - archived memories as METADATA-ONLY tombstones (id/title/category/slice +
+//     archive metadata + a normalized content fingerprint, NO body) so the
+//     §10.3 pre-pass can block resurrection without re-exposing deleted content
+//     (§9.1);
+//   - caps + truncation so the bundle stays bounded and the prompt knows when
+//     evidence was trimmed (§9 evidence caps).
+//
+// Reads are direct SELECTs against the SQLite projection (the read model) — this
+// is read-only and never mutates memory. Session evidence is gathered separately.
+
+import type { DatabaseSync } from "node:sqlite";
+import { contentFingerprint, normalizedTitle } from "./curator-fingerprint.js";
+import { redactSecrets } from "./curator-redaction.js";
+
+export type SliceKind = "common_project" | "common_global" | "agent_private";
+
+export interface EvidenceSlice {
+  kind: SliceKind;
+  /** Required for `common_project`. */
+  projectKey?: string;
+  /** Required for `agent_private`. */
+  agentId?: string;
+}
+
+export interface MemoryEvidenceCaps {
+  /** Max combined active + proposed + tombstone memories (active prioritised). */
+  maxMemories: number;
+  /** Max chars for a memory body before truncation. Default 4000. */
+  maxBodyChars?: number;
+}
+
+export interface MemoryEvidenceItem {
+  id: string;
+  title: string; // redacted
+  body: string; // redacted, possibly truncated
+  category: string;
+  scope: string;
+  visibility: string;
+  projectKey: string | null;
+  agentId: string | null;
+  status: "active" | "proposed";
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TombstoneItem {
+  id: string;
+  title: string; // redacted
+  category: string;
+  scope: string;
+  visibility: string;
+  projectKey: string | null;
+  agentId: string | null;
+  archivedAt: string;
+  archiveReason: string | null;
+  /** sha256 of the normalized, redacted title+body — the resurrection key (§9.1). */
+  contentFingerprint: string;
+  /** Normalized, redacted title — the secondary resurrection key (§10.3). */
+  normalizedTitle: string;
+}
+
+export interface MemoryEvidenceBundle {
+  slice: EvidenceSlice;
+  activeMemories: MemoryEvidenceItem[];
+  proposedMemories: MemoryEvidenceItem[];
+  tombstones: TombstoneItem[];
+  /** True if the cap dropped any eligible memory or tombstone. */
+  truncatedMemories: boolean;
+  /** True if any body was trimmed to `maxBodyChars`. */
+  truncatedFields: boolean;
+  /** Count of secret occurrences scrubbed while gathering. */
+  redactionCount: number;
+}
+
+const DEFAULT_MAX_BODY_CHARS = 4000;
+const TRUNCATION_MARKER = " …[truncated]";
+const ARCHIVE_EVENT_TYPES = ["memory.archived", "memory.deleted"]; // historical alias
+
+interface MemoryRow {
+  id: string;
+  title: string;
+  body: string;
+  category: string;
+  scope: string;
+  visibility: string;
+  project_key: string | null;
+  agent_id: string | null;
+  status: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface TombstoneRow extends MemoryRow {
+  archive_payload: string | null;
+  archived_at_event: string | null;
+}
+
+/** Running totals threaded through redaction/truncation so the bundle can report them. */
+interface GatherStats {
+  redactionCount: number;
+  truncatedFields: boolean;
+}
+
+export function gatherMemoryEvidence(
+  db: DatabaseSync,
+  slice: EvidenceSlice,
+  caps: MemoryEvidenceCaps,
+): MemoryEvidenceBundle {
+  const where = sliceWhere(slice);
+  const maxBodyChars = caps.maxBodyChars ?? DEFAULT_MAX_BODY_CHARS;
+  const stats: GatherStats = { redactionCount: 0, truncatedFields: false };
+
+  // Fetch one past the budget per status so we can detect (not just apply) the cap.
+  const limit = caps.maxMemories + 1;
+  const activeRows = selectMemories(db, where, "active", limit);
+  const proposedRows = selectMemories(db, where, "proposed", limit);
+  const tombstoneRows = selectTombstones(db, where, limit);
+
+  // Single budget consumed in priority order: active → proposed → tombstones (§9).
+  let remaining = caps.maxMemories;
+  const activeTaken = activeRows.slice(0, remaining);
+  remaining -= activeTaken.length;
+  const proposedTaken = proposedRows.slice(0, remaining);
+  remaining -= proposedTaken.length;
+  const tombstonesTaken = tombstoneRows.slice(0, remaining);
+
+  const truncatedMemories =
+    activeRows.length > activeTaken.length ||
+    proposedRows.length > proposedTaken.length ||
+    tombstoneRows.length > tombstonesTaken.length;
+
+  return {
+    slice,
+    activeMemories: activeTaken.map((row) => toItem(row, "active", maxBodyChars, stats)),
+    proposedMemories: proposedTaken.map((row) => toItem(row, "proposed", maxBodyChars, stats)),
+    tombstones: tombstonesTaken.map((row) => toTombstone(row, stats)),
+    truncatedMemories,
+    truncatedFields: stats.truncatedFields,
+    redactionCount: stats.redactionCount,
+  };
+}
+
+interface SliceWhere {
+  clause: string;
+  params: string[];
+}
+
+function sliceWhere(slice: EvidenceSlice): SliceWhere {
+  switch (slice.kind) {
+    case "common_project":
+      if (!slice.projectKey) throw new Error("common_project slice requires a projectKey");
+      return { clause: "visibility = 'common' AND project_key = ?", params: [slice.projectKey] };
+    case "common_global":
+      return {
+        clause: "visibility = 'common' AND (scope = 'global' OR project_key IS NULL)",
+        params: [],
+      };
+    case "agent_private":
+      if (!slice.agentId) throw new Error("agent_private slice requires an agentId");
+      return { clause: "visibility = 'agent_private' AND agent_id = ?", params: [slice.agentId] };
+  }
+}
+
+function selectMemories(
+  db: DatabaseSync,
+  where: SliceWhere,
+  status: "active" | "proposed",
+  limit: number,
+): MemoryRow[] {
+  return db
+    .prepare(
+      `SELECT id, title, body, category, scope, visibility, project_key, agent_id, status,
+              created_at, updated_at
+       FROM memories
+       WHERE ${where.clause} AND status = ?
+       ORDER BY updated_at DESC
+       LIMIT ?`,
+    )
+    .all(...where.params, status, limit) as unknown as MemoryRow[];
+}
+
+function selectTombstones(db: DatabaseSync, where: SliceWhere, limit: number): TombstoneRow[] {
+  // Archive date + reason live in the events ledger, not on the memory row.
+  const archiveFilter = ARCHIVE_EVENT_TYPES.map(() => "?").join(", ");
+  return (
+    db
+      .prepare(
+        `SELECT m.id, m.title, m.body, m.category, m.scope, m.visibility, m.project_key, m.agent_id,
+              m.status, m.created_at, m.updated_at,
+              (SELECT e.payload_json FROM events e
+                 WHERE e.memory_id = m.id AND e.event_type IN (${archiveFilter})
+                 ORDER BY e.created_at DESC LIMIT 1) AS archive_payload,
+              (SELECT e.created_at FROM events e
+                 WHERE e.memory_id = m.id AND e.event_type IN (${archiveFilter})
+                 ORDER BY e.created_at DESC LIMIT 1) AS archived_at_event
+       FROM memories m
+       WHERE ${where.clause} AND m.status = 'archived'
+       ORDER BY m.updated_at DESC
+       LIMIT ?`,
+      )
+      // Bind in textual placeholder order: the two archive subqueries sit in the
+      // SELECT list (before the WHERE clause), so their event-type params come first.
+      .all(
+        ...ARCHIVE_EVENT_TYPES,
+        ...ARCHIVE_EVENT_TYPES,
+        ...where.params,
+        limit,
+      ) as unknown as TombstoneRow[]
+  );
+}
+
+function toItem(
+  row: MemoryRow,
+  status: "active" | "proposed",
+  maxBodyChars: number,
+  stats: GatherStats,
+): MemoryEvidenceItem {
+  return {
+    id: row.id,
+    title: redact(row.title, stats),
+    body: truncate(redact(row.body, stats), maxBodyChars, stats),
+    category: row.category,
+    scope: row.scope,
+    visibility: row.visibility,
+    projectKey: row.project_key,
+    agentId: row.agent_id,
+    status,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function toTombstone(row: TombstoneRow, stats: GatherStats): TombstoneItem {
+  // Redact before fingerprinting so the key is stable against redacted candidates
+  // in the §10.3 pre-pass; the body is fingerprinted but NEVER emitted.
+  const redactedTitle = redact(row.title, stats);
+  const redactedBody = redact(row.body, stats);
+  return {
+    id: row.id,
+    title: redactedTitle,
+    category: row.category,
+    scope: row.scope,
+    visibility: row.visibility,
+    projectKey: row.project_key,
+    agentId: row.agent_id,
+    archivedAt: row.archived_at_event ?? row.updated_at,
+    archiveReason: parseArchiveReason(row.archive_payload),
+    contentFingerprint: contentFingerprint(redactedTitle, redactedBody),
+    normalizedTitle: normalizedTitle(redactedTitle),
+  };
+}
+
+function redact(value: string, stats: GatherStats): string {
+  const { redacted, count } = redactSecrets(value);
+  stats.redactionCount += count;
+  return redacted;
+}
+
+function truncate(value: string, maxChars: number, stats: GatherStats): string {
+  if (value.length <= maxChars) return value;
+  stats.truncatedFields = true;
+  return value.slice(0, maxChars) + TRUNCATION_MARKER;
+}
+
+function parseArchiveReason(payloadJson: string | null): string | null {
+  if (!payloadJson) return null;
+  try {
+    const payload = JSON.parse(payloadJson) as { reason?: unknown };
+    return typeof payload.reason === "string" ? payload.reason : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/core/src/curator-fingerprint.ts
+++ b/packages/core/src/curator-fingerprint.ts
@@ -12,6 +12,7 @@
 // Server-only (the curator runs server-side) — safe to depend on node:crypto.
 
 import { createHash } from "node:crypto";
+import { redactSecrets } from "./curator-redaction.js";
 
 /**
  * Collapse free-form content to a comparison form: NFKC, lowercased,
@@ -50,6 +51,22 @@ export function contentFingerprint(title: string, body: string): string {
   return createHash("sha256").update(normalised, "utf8").digest("hex");
 }
 
+/**
+ * The curation fingerprint CONTRACT: redact secrets, THEN fingerprint. Both
+ * tombstone gathering (§9.1) and the candidate pre-pass (§10.3) must compute
+ * keys through this pair, so a secret-bearing memory can't slip the resurrection
+ * guard via a raw-vs-redacted fingerprint mismatch. `redactSecrets` is idempotent
+ * (markers are not re-matched), so passing already-redacted text is a safe no-op.
+ */
+export function curationContentFingerprint(title: string, body: string): string {
+  return contentFingerprint(redactSecrets(title).redacted, redactSecrets(body).redacted);
+}
+
+/** Redact-then-normalise the title — the curation-side secondary resurrection key. */
+export function curationNormalizedTitle(title: string): string {
+  return normalizedTitle(redactSecrets(title).redacted);
+}
+
 /** Metadata-only reference to an archived memory, as carried in evidence (§9.1). */
 export interface TombstoneRef {
   id: string;
@@ -61,17 +78,22 @@ export interface TombstoneRef {
  * Return the first tombstone a candidate would resurrect — matching either its
  * content fingerprint or its normalised title — or null if none. The caller
  * (deterministic pre-pass) suppresses create/merge candidates that match.
+ *
+ * Candidate keys are computed through the redact-then-fingerprint contract
+ * (`curationContentFingerprint`/`curationNormalizedTitle`), matching how
+ * tombstone keys are built during evidence gathering — otherwise a secret-bearing
+ * memory would mismatch and escape the guard. An empty normalised title is never
+ * treated as a title hit, so an empty-normalising tombstone can't super-match.
  */
 export function matchesTombstone(
   candidate: { title: string; body: string },
   tombstones: Iterable<TombstoneRef>,
 ): TombstoneRef | null {
-  const fingerprint = contentFingerprint(candidate.title, candidate.body);
-  const title = normalizedTitle(candidate.title);
+  const fingerprint = curationContentFingerprint(candidate.title, candidate.body);
+  const title = curationNormalizedTitle(candidate.title);
   for (const tombstone of tombstones) {
-    if (tombstone.content_fingerprint === fingerprint || tombstone.normalized_title === title) {
-      return tombstone;
-    }
+    if (tombstone.content_fingerprint === fingerprint) return tombstone;
+    if (title !== "" && tombstone.normalized_title === title) return tombstone;
   }
   return null;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,8 @@ export { type CallerIdAudit, type CallerIdGroup, auditCallerIds } from "./caller
 export {
   type TombstoneRef,
   contentFingerprint,
+  curationContentFingerprint,
+  curationNormalizedTitle,
   matchesTombstone,
   normalizeForFingerprint,
   normalizedTitle,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,15 @@ export {
 } from "./curator-fingerprint.js";
 export { type RedactionResult, redactSecrets } from "./curator-redaction.js";
 export {
+  type EvidenceSlice,
+  type MemoryEvidenceBundle,
+  type MemoryEvidenceCaps,
+  type MemoryEvidenceItem,
+  type SliceKind,
+  type TombstoneItem,
+  gatherMemoryEvidence,
+} from "./curator-evidence.js";
+export {
   type LlmClient,
   type LlmClientConfig,
   type LlmClientDeps,

--- a/packages/core/tests/curator-evidence.test.ts
+++ b/packages/core/tests/curator-evidence.test.ts
@@ -1,0 +1,236 @@
+// Slice-scoped memory evidence gathering for the curator (spec §9).
+//
+// The two load-bearing guards here are SECURITY guards and are tested first:
+//   1. Slice isolation — an agent_private run sees only that agent's private
+//      memories; a common_project run sees only that project's common memories.
+//      A curation run must never read across a slice boundary (§3, §9).
+//   2. Redaction-before-return — secret-looking material is scrubbed from
+//      evidence BEFORE it can be handed to the prompt builder (§9, §10.4); by
+//      output-validation time the value would already have left the building.
+//
+// Tombstones carry metadata + a content fingerprint (no body) for the §10.3
+// resurrection pre-pass. Caps + truncation keep the bundle bounded (§9 caps).
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { type LibrarianStore, createLibrarianStore, gatherMemoryEvidence } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+interface Scope {
+  store: LibrarianStore;
+  dataDir: string;
+}
+
+let s: Scope | null = null;
+
+beforeEach(() => {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-evidence-"));
+  s = { store: createLibrarianStore({ dataDir }), dataDir };
+});
+afterEach(() => {
+  if (!s) return;
+  try {
+    s.store.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(s.dataDir, { recursive: true, force: true });
+  s = null;
+});
+
+/** Seed a memory; defaults to a common/project-x active "lessons" memory. */
+function seed(overrides: Record<string, unknown> = {}) {
+  return s!.store.createMemory({
+    agent_id: "agent-a",
+    title: "title",
+    body: "body text",
+    category: "lessons",
+    visibility: "common",
+    scope: "project",
+    project_key: "proj-x",
+    priority: "normal",
+    confidence: "working",
+    ...overrides,
+  });
+}
+
+describe("gatherMemoryEvidence — slice isolation (security)", () => {
+  it("common_project returns only that project's common memories", () => {
+    const here = seed({ title: "here", project_key: "proj-x" }).memory;
+    seed({ title: "other-project", project_key: "proj-y" });
+    seed({
+      title: "private",
+      visibility: "agent_private",
+      scope: "global",
+      project_key: undefined,
+    });
+
+    const bundle = gatherMemoryEvidence(
+      s!.store.db,
+      { kind: "common_project", projectKey: "proj-x" },
+      { maxMemories: 50 },
+    );
+
+    expect(bundle.activeMemories.map((m) => m.id)).toEqual([here.id]);
+    for (const m of bundle.activeMemories) {
+      expect(m.visibility).toBe("common");
+      expect(m.projectKey).toBe("proj-x");
+    }
+  });
+
+  it("agent_private returns only the named agent's private memories — never another agent's, never common", () => {
+    const mine = seed({
+      title: "mine",
+      visibility: "agent_private",
+      agent_id: "agent-a",
+      scope: "global",
+      project_key: undefined,
+    }).memory;
+    seed({
+      title: "theirs",
+      visibility: "agent_private",
+      agent_id: "agent-b",
+      scope: "global",
+      project_key: undefined,
+    });
+    seed({ title: "shared", visibility: "common", project_key: "proj-x" });
+
+    const bundle = gatherMemoryEvidence(
+      s!.store.db,
+      { kind: "agent_private", agentId: "agent-a" },
+      { maxMemories: 50 },
+    );
+
+    expect(bundle.activeMemories.map((m) => m.id)).toEqual([mine.id]);
+    for (const m of bundle.activeMemories) {
+      expect(m.visibility).toBe("agent_private");
+      expect(m.agentId).toBe("agent-a");
+    }
+  });
+
+  it("common_global returns only global/null-project common memories", () => {
+    const global = seed({ title: "global", scope: "global", project_key: undefined }).memory;
+    seed({ title: "project-scoped", scope: "project", project_key: "proj-x" });
+    seed({
+      title: "private",
+      visibility: "agent_private",
+      scope: "global",
+      project_key: undefined,
+    });
+
+    const bundle = gatherMemoryEvidence(
+      s!.store.db,
+      { kind: "common_global" },
+      { maxMemories: 50 },
+    );
+
+    expect(bundle.activeMemories.map((m) => m.id)).toEqual([global.id]);
+  });
+});
+
+describe("gatherMemoryEvidence — redaction (security)", () => {
+  it("redacts secret-looking material from bodies before returning", () => {
+    seed({ title: "with-secret", body: 'deploy notes — token = "FAKETOKENFAKETOKEN" — ok' });
+
+    const bundle = gatherMemoryEvidence(
+      s!.store.db,
+      { kind: "common_project", projectKey: "proj-x" },
+      { maxMemories: 50 },
+    );
+
+    const body = bundle.activeMemories[0]!.body;
+    expect(body).not.toContain("FAKETOKENFAKETOKEN");
+    expect(body).toContain("[REDACTED:secret]");
+    expect(bundle.redactionCount).toBeGreaterThan(0);
+  });
+});
+
+describe("gatherMemoryEvidence — status partition + tombstones", () => {
+  it("splits active and proposed memories", () => {
+    const active = seed({ title: "active-one", category: "lessons" }).memory;
+    // identity is a protected category → routed to a proposal (status proposed).
+    const proposed = seed({ title: "proposed-one", category: "identity" }).memory;
+
+    const bundle = gatherMemoryEvidence(
+      s!.store.db,
+      { kind: "common_project", projectKey: "proj-x" },
+      { maxMemories: 50 },
+    );
+
+    expect(bundle.activeMemories.map((m) => m.id)).toContain(active.id);
+    expect(bundle.activeMemories.every((m) => m.status === "active")).toBe(true);
+    expect(bundle.proposedMemories.map((m) => m.id)).toContain(proposed.id);
+    expect(bundle.proposedMemories.every((m) => m.status === "proposed")).toBe(true);
+  });
+
+  it("returns archived memories as metadata-only tombstones with a fingerprint and no body", () => {
+    const m = seed({ title: "deleted thing", body: "the original body" }).memory;
+    s!.store.archiveMemory(m.id);
+
+    const bundle = gatherMemoryEvidence(
+      s!.store.db,
+      { kind: "common_project", projectKey: "proj-x" },
+      { maxMemories: 50 },
+    );
+
+    expect(bundle.activeMemories.map((x) => x.id)).not.toContain(m.id);
+    const tomb = bundle.tombstones.find((t) => t.id === m.id);
+    expect(tomb).toBeDefined();
+    expect(tomb!.contentFingerprint).toMatch(/^[0-9a-f]{64}$/);
+    expect(tomb!.normalizedTitle).toContain("deleted thing");
+    expect(typeof tomb!.archivedAt).toBe("string");
+    // The deleted body must NOT be re-exposed.
+    expect((tomb as unknown as Record<string, unknown>).body).toBeUndefined();
+    expect(JSON.stringify(tomb)).not.toContain("the original body");
+  });
+});
+
+describe("gatherMemoryEvidence — caps + truncation", () => {
+  it("caps the combined memory budget, prioritising active over proposed", () => {
+    seed({ title: "a1", category: "lessons" });
+    seed({ title: "a2", category: "lessons" });
+    seed({ title: "a3", category: "lessons" });
+    seed({ title: "p1", category: "identity" }); // proposed
+
+    const bundle = gatherMemoryEvidence(
+      s!.store.db,
+      { kind: "common_project", projectKey: "proj-x" },
+      { maxMemories: 2 },
+    );
+
+    expect(bundle.activeMemories).toHaveLength(2);
+    expect(bundle.proposedMemories).toHaveLength(0);
+    expect(bundle.truncatedMemories).toBe(true);
+  });
+
+  it("truncates an oversized body with a marker and flags it", () => {
+    seed({ title: "long", body: "abcdefghijklmnopqrstuvwxyz" });
+
+    const bundle = gatherMemoryEvidence(
+      s!.store.db,
+      { kind: "common_project", projectKey: "proj-x" },
+      { maxMemories: 50, maxBodyChars: 10 },
+    );
+
+    const body = bundle.activeMemories[0]!.body;
+    expect(body.startsWith("abcdefghij")).toBe(true);
+    expect(body).not.toBe("abcdefghijklmnopqrstuvwxyz");
+    expect(body).toMatch(/truncated/i);
+    expect(bundle.truncatedFields).toBe(true);
+  });
+});
+
+describe("gatherMemoryEvidence — slice descriptor validation", () => {
+  it("rejects common_project without a projectKey", () => {
+    expect(() =>
+      gatherMemoryEvidence(s!.store.db, { kind: "common_project" }, { maxMemories: 5 }),
+    ).toThrow(/projectKey/i);
+  });
+
+  it("rejects agent_private without an agentId", () => {
+    expect(() =>
+      gatherMemoryEvidence(s!.store.db, { kind: "agent_private" }, { maxMemories: 5 }),
+    ).toThrow(/agentId/i);
+  });
+});

--- a/packages/core/tests/curator-evidence.test.ts
+++ b/packages/core/tests/curator-evidence.test.ts
@@ -127,6 +127,65 @@ describe("gatherMemoryEvidence — slice isolation (security)", () => {
 
     expect(bundle.activeMemories.map((m) => m.id)).toEqual([global.id]);
   });
+
+  it("partitions on project_key — a global-scope memory with a project_key is NOT double-exposed", () => {
+    const globalNoProject = seed({ title: "g", scope: "global", project_key: undefined }).memory;
+    const globalButKeyed = seed({ title: "gp", scope: "global", project_key: "proj-x" }).memory;
+
+    const inGlobal = gatherMemoryEvidence(
+      s!.store.db,
+      { kind: "common_global" },
+      { maxMemories: 50 },
+    ).activeMemories.map((m) => m.id);
+    const inProject = gatherMemoryEvidence(
+      s!.store.db,
+      { kind: "common_project", projectKey: "proj-x" },
+      { maxMemories: 50 },
+    ).activeMemories.map((m) => m.id);
+
+    // Each common memory lands in exactly one slice.
+    expect(inGlobal).toContain(globalNoProject.id);
+    expect(inGlobal).not.toContain(globalButKeyed.id);
+    expect(inProject).toContain(globalButKeyed.id);
+    expect(inProject).not.toContain(globalNoProject.id);
+  });
+
+  it("keeps a common memory authored by an agent in the common slice (agent_id does not privatise it)", () => {
+    const m = seed({
+      title: "common-by-agent",
+      visibility: "common",
+      agent_id: "agent-z",
+      project_key: "proj-x",
+    }).memory;
+    const bundle = gatherMemoryEvidence(
+      s!.store.db,
+      { kind: "common_project", projectKey: "proj-x" },
+      { maxMemories: 50 },
+    );
+    expect(bundle.activeMemories.map((x) => x.id)).toContain(m.id);
+  });
+
+  it("confines an agent_private memory carrying a project_key to its agent, never a common slice", () => {
+    const m = seed({
+      title: "priv-with-project",
+      visibility: "agent_private",
+      agent_id: "agent-a",
+      scope: "project",
+      project_key: "proj-x",
+    }).memory;
+    const commonProj = gatherMemoryEvidence(
+      s!.store.db,
+      { kind: "common_project", projectKey: "proj-x" },
+      { maxMemories: 50 },
+    );
+    const priv = gatherMemoryEvidence(
+      s!.store.db,
+      { kind: "agent_private", agentId: "agent-a" },
+      { maxMemories: 50 },
+    );
+    expect(commonProj.activeMemories.map((x) => x.id)).not.toContain(m.id);
+    expect(priv.activeMemories.map((x) => x.id)).toContain(m.id);
+  });
 });
 
 describe("gatherMemoryEvidence — redaction (security)", () => {
@@ -183,6 +242,30 @@ describe("gatherMemoryEvidence — status partition + tombstones", () => {
     // The deleted body must NOT be re-exposed.
     expect((tomb as unknown as Record<string, unknown>).body).toBeUndefined();
     expect(JSON.stringify(tomb)).not.toContain("the original body");
+  });
+
+  it("surfaces the archive reason from the events ledger (verify-outdated)", () => {
+    const m = seed({ title: "stale", body: "old" }).memory;
+    s!.store.verifyMemory(m.id, "outdated");
+
+    const bundle = gatherMemoryEvidence(
+      s!.store.db,
+      { kind: "common_project", projectKey: "proj-x" },
+      { maxMemories: 50 },
+    );
+    expect(bundle.tombstones.find((t) => t.id === m.id)?.archiveReason).toBe("verify_outdated");
+  });
+
+  it("reports a null reason for a plain archive (none recorded at source)", () => {
+    const m = seed({ title: "plain-archive", body: "x" }).memory;
+    s!.store.archiveMemory(m.id);
+
+    const bundle = gatherMemoryEvidence(
+      s!.store.db,
+      { kind: "common_project", projectKey: "proj-x" },
+      { maxMemories: 50 },
+    );
+    expect(bundle.tombstones.find((t) => t.id === m.id)?.archiveReason).toBeNull();
   });
 });
 

--- a/packages/core/tests/curator-fingerprint.test.ts
+++ b/packages/core/tests/curator-fingerprint.test.ts
@@ -9,6 +9,8 @@
 import {
   type TombstoneRef,
   contentFingerprint,
+  curationContentFingerprint,
+  curationNormalizedTitle,
   matchesTombstone,
   normalizeForFingerprint,
   normalizedTitle,
@@ -92,5 +94,44 @@ describe("matchesTombstone", () => {
   it("returns null when neither fingerprint nor title matches", () => {
     const hit = matchesTombstone({ title: "A fresh idea", body: "new content" }, tombstones);
     expect(hit).toBeNull();
+  });
+
+  it("does not treat an empty-normalising tombstone title as a super-match", () => {
+    // A tombstone whose title normalises to "" (punctuation-only) must not match
+    // every candidate whose title also normalises to "" — only its fingerprint.
+    const tomb: TombstoneRef = {
+      id: "mem_punct",
+      content_fingerprint: contentFingerprint("---", "specific archived content"),
+      normalized_title: normalizedTitle("---"), // ""
+    };
+    expect(normalizedTitle("---")).toBe("");
+    expect(matchesTombstone({ title: "!!!", body: "completely unrelated" }, [tomb])).toBeNull();
+  });
+});
+
+describe("curation fingerprint contract (redact-then-fingerprint)", () => {
+  it("redacts before fingerprinting, so the same memory matches regardless of the secret VALUE", () => {
+    // Tombstone built from secret-bearing content; a candidate carrying a
+    // different secret of the same shape still resolves to the same key, so
+    // resurrection stays blocked (both redact to the same marker).
+    const tomb: TombstoneRef = {
+      id: "mem_secret",
+      content_fingerprint: curationContentFingerprint("deploy", 'token = "FAKEAAAAAAAA"'),
+      normalized_title: curationNormalizedTitle("deploy"),
+    };
+    const hit = matchesTombstone({ title: "deploy", body: 'token = "FAKEBBBBBBBB"' }, [tomb]);
+    expect(hit?.id).toBe("mem_secret");
+  });
+
+  it("differs from the raw fingerprint for secret content (proving redaction is applied)", () => {
+    const redacted = curationContentFingerprint("t", 'token = "FAKESECRETVALUE"');
+    const raw = contentFingerprint("t", 'token = "FAKESECRETVALUE"');
+    expect(redacted).not.toBe(raw);
+  });
+
+  it("is a no-op for secret-free content (matches the plain fingerprint)", () => {
+    expect(curationContentFingerprint("Title", "ordinary body")).toBe(
+      contentFingerprint("Title", "ordinary body"),
+    );
   });
 });


### PR DESCRIPTION
## What

`gatherMemoryEvidence(db, slice, caps)` — turns a slice descriptor into a
bounded, redacted memory bundle for a curation run (spec §9). Read-only SELECTs
against the SQLite projection; never mutates memory.

- **Slice isolation (security, §3):** `common_project` → only that project's
  common memories; `common_global` → only project-less common memories;
  `agent_private` → only the named agent's private memories, never another
  agent's, never common. Slice params are bound, not interpolated.
- **Redaction-before-return (§9/§10.4):** titles and bodies are scrubbed via
  `redactSecrets` before leaving the gatherer; `redactionCount` reports the total.
- **Tombstones (§9.1):** archived memories return as METADATA-ONLY tombstones —
  id/title/category/slice + archive date/reason + a normalized content
  fingerprint, **no body** — so the §10.3 pre-pass can block resurrection
  without re-exposing deleted content.
- **Caps (§9):** a single memory budget consumed active → proposed → tombstones,
  with `truncatedMemories`/`truncatedFields` flags + a truncation marker.

## Review fixes (second commit)

The `code-reviewer` sub-agent (verdict: REQUEST CHANGES) found:
- **Critical** — `common_global` double-exposed `scope='global' + project_key`
  memories into both the global and the project slice. Now partitions on
  `project_key IS NULL` (true complement of `common_project`).
- **Important** — resurrection keys: tombstones used redacted keys but
  `matchesTombstone` fingerprinted raw candidates, so a secret-bearing memory
  could escape the guard. Introduced the shared `curationContentFingerprint` /
  `curationNormalizedTitle` redact-then-fingerprint contract used by both sides;
  added an empty-title super-match guard.
- **Important** — added isolation-combo + archive-reason test coverage.

All green: core 257, mcp-server 91, cli 51, dashboard 48; lint/typecheck/format clean.

## Scope boundary

Memory evidence only. Session evidence is the next increment; the §10.3
deterministic pre-pass (which consumes these tombstones via `matchesTombstone`)
and the prompt builder follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)