### PR TITLE
feat(core): slice-scoped session evidence gathering for the curator

### DIFF
--- a/packages/core/src/curator-evidence.ts
+++ b/packages/core/src/curator-evidence.ts
@@ -334,6 +334,11 @@ export interface SessionEvidenceBundle {
 
 const DEFAULT_MAX_EVENTS_PER_SESSION = 30;
 
+// The typed evidence-event types worth curating — excludes lifecycle rows
+// (started/paused/checkpointed/…), which share the session_events table.
+const EVIDENCE_EVENT_TYPES: readonly string[] = Object.values(SessionPayloadType);
+const EVIDENCE_EVENT_PLACEHOLDERS = EVIDENCE_EVENT_TYPES.map(() => "?").join(", ");
+
 interface SessionRow {
   id: string;
   title: string;
@@ -394,18 +399,18 @@ function selectSessionEvents(
   sessionId: string,
   limit: number,
 ): SessionEventRow[] {
-  // Only typed evidence events (excludes lifecycle rows like started/paused),
-  // decisions then notes (candidate facts) first, then the rest by recency (§9).
-  const types = Object.values(SessionPayloadType);
-  const placeholders = types.map(() => "?").join(", ");
+  // Only typed evidence events (the IN-clause excludes lifecycle rows), decisions
+  // then notes (candidate facts) first, then the rest by recency (§9 ordering).
+  // The §9 summary-ordering rule concerns the session-row summary COLUMNS
+  // (start/rolling/end), emitted separately — not these event rows.
   return db
     .prepare(
       `SELECT type, summary, created_at FROM session_events
-       WHERE session_id = ? AND type IN (${placeholders})
+       WHERE session_id = ? AND type IN (${EVIDENCE_EVENT_PLACEHOLDERS})
        ORDER BY CASE type WHEN 'decision' THEN 0 WHEN 'note' THEN 1 ELSE 2 END, created_at DESC
        LIMIT ?`,
     )
-    .all(sessionId, ...types, limit) as unknown as SessionEventRow[];
+    .all(sessionId, ...EVIDENCE_EVENT_TYPES, limit) as unknown as SessionEventRow[];
 }
 
 function toSessionItem(

--- a/packages/core/src/curator-evidence.ts
+++ b/packages/core/src/curator-evidence.ts
@@ -18,6 +18,7 @@
 import type { DatabaseSync } from "node:sqlite";
 import { curationContentFingerprint, curationNormalizedTitle } from "./curator-fingerprint.js";
 import { redactSecrets } from "./curator-redaction.js";
+import { SessionPayloadType } from "./schemas/common.js";
 
 export type SliceKind = "common_project" | "common_global" | "agent_private";
 
@@ -152,7 +153,10 @@ interface SliceWhere {
   params: string[];
 }
 
-function sliceWhere(slice: EvidenceSlice): SliceWhere {
+// `agentColumn` is an internal constant ("agent_id" for memories,
+// "created_by_agent_id" for sessions) — never user input, so interpolating it is
+// safe. Slice values (projectKey/agentId) are always bound, never interpolated.
+function sliceWhere(slice: EvidenceSlice, agentColumn = "agent_id"): SliceWhere {
   switch (slice.kind) {
     case "common_project":
       if (!slice.projectKey) throw new Error("common_project slice requires a projectKey");
@@ -169,7 +173,10 @@ function sliceWhere(slice: EvidenceSlice): SliceWhere {
       return { clause: "visibility = 'common' AND project_key IS NULL", params: [] };
     case "agent_private":
       if (!slice.agentId) throw new Error("agent_private slice requires an agentId");
-      return { clause: "visibility = 'agent_private' AND agent_id = ?", params: [slice.agentId] };
+      return {
+        clause: `visibility = 'agent_private' AND ${agentColumn} = ?`,
+        params: [slice.agentId],
+      };
   }
 }
 
@@ -281,5 +288,165 @@ function parseArchiveReason(payloadJson: string | null): string | null {
     return typeof payload.reason === "string" ? payload.reason : null;
   } catch {
     return null;
+  }
+}
+
+// ---------- Session evidence (spec §9) ----------
+
+export interface SessionEvidenceCaps {
+  maxSessions: number;
+  /** Max evidence events per session. Default 30. */
+  maxEventsPerSession?: number;
+  /** Max chars for a summary / event / next-step before truncation. Default 4000. */
+  maxSummaryChars?: number;
+}
+
+export interface SessionEventEvidence {
+  type: string;
+  summary: string; // redacted, possibly truncated
+  createdAt: string;
+}
+
+export interface SessionEvidenceItem {
+  id: string;
+  title: string; // redacted
+  status: string;
+  projectKey: string | null;
+  createdByAgentId: string | null;
+  currentAgentId: string | null;
+  startSummary: string | null; // redacted, truncated
+  rollingSummary: string | null; // redacted, truncated
+  endSummary: string | null; // redacted, truncated
+  nextSteps: string[]; // redacted
+  lastActivityAt: string;
+  events: SessionEventEvidence[];
+  /** True if this session's events were capped. */
+  truncatedEvents: boolean;
+}
+
+export interface SessionEvidenceBundle {
+  slice: EvidenceSlice;
+  sessions: SessionEvidenceItem[];
+  /** True if the session cap dropped any eligible session. */
+  truncatedSessions: boolean;
+  redactionCount: number;
+}
+
+const DEFAULT_MAX_EVENTS_PER_SESSION = 30;
+
+interface SessionRow {
+  id: string;
+  title: string;
+  status: string;
+  project_key: string | null;
+  created_by_agent_id: string | null;
+  current_agent_id: string | null;
+  start_summary: string | null;
+  rolling_summary: string | null;
+  end_summary: string | null;
+  next_steps_json: string;
+  last_activity_at: string;
+}
+
+interface SessionEventRow {
+  type: string;
+  summary: string;
+  created_at: string;
+}
+
+export function gatherSessionEvidence(
+  db: DatabaseSync,
+  slice: EvidenceSlice,
+  caps: SessionEvidenceCaps,
+): SessionEvidenceBundle {
+  // Sessions own their agent attribution under `created_by_agent_id`.
+  const where = sliceWhere(slice, "created_by_agent_id");
+  const maxChars = caps.maxSummaryChars ?? DEFAULT_MAX_BODY_CHARS;
+  const maxEvents = caps.maxEventsPerSession ?? DEFAULT_MAX_EVENTS_PER_SESSION;
+  const stats: GatherStats = { redactionCount: 0, truncatedFields: false };
+
+  const rows = selectSessions(db, where, caps.maxSessions + 1);
+  const taken = rows.slice(0, caps.maxSessions);
+
+  return {
+    slice,
+    sessions: taken.map((row) => toSessionItem(db, row, maxEvents, maxChars, stats)),
+    truncatedSessions: rows.length > taken.length,
+    redactionCount: stats.redactionCount,
+  };
+}
+
+function selectSessions(db: DatabaseSync, where: SliceWhere, limit: number): SessionRow[] {
+  return db
+    .prepare(
+      `SELECT id, title, status, project_key, created_by_agent_id, current_agent_id,
+              start_summary, rolling_summary, end_summary, next_steps_json, last_activity_at
+       FROM sessions
+       WHERE ${where.clause}
+       ORDER BY last_activity_at DESC
+       LIMIT ?`,
+    )
+    .all(...where.params, limit) as unknown as SessionRow[];
+}
+
+function selectSessionEvents(
+  db: DatabaseSync,
+  sessionId: string,
+  limit: number,
+): SessionEventRow[] {
+  // Only typed evidence events (excludes lifecycle rows like started/paused),
+  // decisions then notes (candidate facts) first, then the rest by recency (§9).
+  const types = Object.values(SessionPayloadType);
+  const placeholders = types.map(() => "?").join(", ");
+  return db
+    .prepare(
+      `SELECT type, summary, created_at FROM session_events
+       WHERE session_id = ? AND type IN (${placeholders})
+       ORDER BY CASE type WHEN 'decision' THEN 0 WHEN 'note' THEN 1 ELSE 2 END, created_at DESC
+       LIMIT ?`,
+    )
+    .all(sessionId, ...types, limit) as unknown as SessionEventRow[];
+}
+
+function toSessionItem(
+  db: DatabaseSync,
+  row: SessionRow,
+  maxEvents: number,
+  maxChars: number,
+  stats: GatherStats,
+): SessionEvidenceItem {
+  const eventRows = selectSessionEvents(db, row.id, maxEvents + 1);
+  const eventsTaken = eventRows.slice(0, maxEvents);
+  return {
+    id: row.id,
+    title: redact(row.title, stats),
+    status: row.status,
+    projectKey: row.project_key,
+    createdByAgentId: row.created_by_agent_id,
+    currentAgentId: row.current_agent_id,
+    startSummary: redactNullable(row.start_summary, maxChars, stats),
+    rollingSummary: redactNullable(row.rolling_summary, maxChars, stats),
+    endSummary: redactNullable(row.end_summary, maxChars, stats),
+    nextSteps: parseStringArray(row.next_steps_json).map((step) => redact(step, stats)),
+    lastActivityAt: row.last_activity_at,
+    events: eventsTaken.map((event) => ({
+      type: event.type,
+      summary: truncate(redact(event.summary, stats), maxChars, stats),
+      createdAt: event.created_at,
+    })),
+    truncatedEvents: eventRows.length > eventsTaken.length,
+  };
+}
+
+function redactNullable(value: string | null, maxChars: number, stats: GatherStats): string | null {
+  return value === null ? null : truncate(redact(value, stats), maxChars, stats);
+}
+
+function parseStringArray(json: string): string[] {
+  try {
+    const parsed = JSON.parse(json);
+    return Array.isArray(parsed) ? parsed.filter((x): x is string => typeof x === "string") : [];
+  } catch {
+    return [];
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,9 +28,14 @@ export {
   type MemoryEvidenceBundle,
   type MemoryEvidenceCaps,
   type MemoryEvidenceItem,
+  type SessionEventEvidence,
+  type SessionEvidenceBundle,
+  type SessionEvidenceCaps,
+  type SessionEvidenceItem,
   type SliceKind,
   type TombstoneItem,
   gatherMemoryEvidence,
+  gatherSessionEvidence,
 } from "./curator-evidence.js";
 export {
   type LlmClient,

--- a/packages/core/src/schemas/session.ts
+++ b/packages/core/src/schemas/session.ts
@@ -3,9 +3,12 @@
 // `payload.session` snapshot embedded in `session.*` JSONL ledger events.
 //
 // SessionEventRow is the canonical shape of a row in the `session_events`
-// table — i.e. the per-event projection of `session.event_recorded` ledger
-// entries (lifecycle events like `session.checkpointed` do not produce
-// session_events rows; they update the session row directly).
+// table. BOTH typed evidence events (`session.event_recorded`, projected under
+// their payload type — decision/command/file/…) AND lifecycle events
+// (`session.checkpointed`, `session.paused`, … projected under their short type
+// — checkpointed/paused/…) produce rows here; lifecycle events additionally
+// update the session row. Consumers that want only evidence (e.g. the curator)
+// must filter the `type` column to the SessionPayloadType set.
 
 import { z } from "zod";
 import {

--- a/packages/core/tests/curator-session-evidence.test.ts
+++ b/packages/core/tests/curator-session-evidence.test.ts
@@ -100,6 +100,32 @@ describe("gatherSessionEvidence — slice isolation (security)", () => {
 
     expect(bundle.sessions.map((x) => x.id)).toEqual([global.id]);
   });
+
+  it("keeps a handed-over private session in its CREATOR's slice, not the current holder's", () => {
+    // Created by agent-a, handed over to agent-b. The content originated under
+    // agent-a's privacy boundary, so it must stay in agent-a's run and never
+    // surface in agent-b's — keying on created_by_agent_id fails closed.
+    const sess = startSess({
+      visibility: "agent_private",
+      agent_id: "agent-a",
+      project_key: undefined,
+    });
+    s!.store.attachSession({ session_id: sess.id, agent_id: "agent-b" });
+
+    const owner = gatherSessionEvidence(
+      s!.store.db,
+      { kind: "agent_private", agentId: "agent-a" },
+      { maxSessions: 50 },
+    );
+    const holder = gatherSessionEvidence(
+      s!.store.db,
+      { kind: "agent_private", agentId: "agent-b" },
+      { maxSessions: 50 },
+    );
+
+    expect(owner.sessions.map((x) => x.id)).toContain(sess.id);
+    expect(holder.sessions.map((x) => x.id)).not.toContain(sess.id);
+  });
 });
 
 describe("gatherSessionEvidence — events", () => {
@@ -133,6 +159,22 @@ describe("gatherSessionEvidence — events", () => {
     const item = bundle.sessions.find((x) => x.id === sess.id)!;
     expect(item.startSummary).toBe("kicked off the work");
     expect(item.nextSteps).toContain("do the thing");
+  });
+
+  it("tolerates malformed next_steps_json without throwing", () => {
+    const sess = startSess();
+    // Simulate projection corruption: a non-JSON next_steps_json value.
+    s!.store.db
+      .prepare("UPDATE sessions SET next_steps_json = ? WHERE id = ?")
+      .run("{not valid json", sess.id);
+
+    const bundle = gatherSessionEvidence(
+      s!.store.db,
+      { kind: "common_project", projectKey: "proj-x" },
+      { maxSessions: 50 },
+    );
+
+    expect(bundle.sessions.find((x) => x.id === sess.id)!.nextSteps).toEqual([]);
   });
 });
 

--- a/packages/core/tests/curator-session-evidence.test.ts
+++ b/packages/core/tests/curator-session-evidence.test.ts
@@ -1,0 +1,205 @@
+// Slice-scoped session evidence gathering for the curator (spec §9).
+//
+// Mirrors memory evidence: same slice-isolation guard (a run never reads across
+// a slice boundary, §3) and the same redaction-before-return guard (§9/§10.4),
+// applied to sessions + their typed evidence events. The agent_private slice is
+// keyed on the session's OWNER (created_by_agent_id). Lifecycle noise
+// (started/paused/checkpointed/ended) is excluded — only the typed evidence
+// events (decisions, commands, files, notes, …) are gathered, decisions first.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { type LibrarianStore, createLibrarianStore, gatherSessionEvidence } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+interface Scope {
+  store: LibrarianStore;
+  dataDir: string;
+}
+
+let s: Scope | null = null;
+
+beforeEach(() => {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-sess-evidence-"));
+  s = { store: createLibrarianStore({ dataDir }), dataDir };
+});
+afterEach(() => {
+  if (!s) return;
+  try {
+    s.store.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(s.dataDir, { recursive: true, force: true });
+  s = null;
+});
+
+/** Start a session; defaults to a common/project-x session owned by agent-a. */
+function startSess(overrides: Record<string, unknown> = {}) {
+  const { session } = s!.store.startSession({
+    title: "a session",
+    project_key: "proj-x",
+    agent_id: "agent-a",
+    visibility: "common",
+    ...overrides,
+  });
+  return session!;
+}
+
+function record(sessionId: string, type: string, summary: string) {
+  return s!.store.recordSessionEvent({ session_id: sessionId, type, summary });
+}
+
+describe("gatherSessionEvidence — slice isolation (security)", () => {
+  it("common_project returns only that project's common sessions", () => {
+    const here = startSess({ project_key: "proj-x" });
+    startSess({ project_key: "proj-y" });
+    startSess({ visibility: "agent_private", project_key: undefined });
+
+    const bundle = gatherSessionEvidence(
+      s!.store.db,
+      { kind: "common_project", projectKey: "proj-x" },
+      { maxSessions: 50 },
+    );
+
+    expect(bundle.sessions.map((x) => x.id)).toEqual([here.id]);
+  });
+
+  it("agent_private returns only the owning agent's private sessions", () => {
+    const mine = startSess({
+      visibility: "agent_private",
+      agent_id: "agent-a",
+      project_key: undefined,
+    });
+    startSess({ visibility: "agent_private", agent_id: "agent-b", project_key: undefined });
+    startSess({ visibility: "common", project_key: "proj-x" });
+
+    const bundle = gatherSessionEvidence(
+      s!.store.db,
+      { kind: "agent_private", agentId: "agent-a" },
+      { maxSessions: 50 },
+    );
+
+    expect(bundle.sessions.map((x) => x.id)).toEqual([mine.id]);
+    for (const sess of bundle.sessions) {
+      expect(sess.createdByAgentId).toBe("agent-a");
+    }
+  });
+
+  it("common_global returns only project-less common sessions", () => {
+    const global = startSess({ project_key: undefined });
+    startSess({ project_key: "proj-x" });
+    startSess({ visibility: "agent_private", project_key: undefined });
+
+    const bundle = gatherSessionEvidence(
+      s!.store.db,
+      { kind: "common_global" },
+      { maxSessions: 50 },
+    );
+
+    expect(bundle.sessions.map((x) => x.id)).toEqual([global.id]);
+  });
+});
+
+describe("gatherSessionEvidence — events", () => {
+  it("gathers typed evidence events, prioritising decisions, and excludes lifecycle noise", () => {
+    const sess = startSess();
+    record(sess.id, "message", "just chatting");
+    record(sess.id, "decision", "chose approach X");
+
+    const bundle = gatherSessionEvidence(
+      s!.store.db,
+      { kind: "common_project", projectKey: "proj-x" },
+      { maxSessions: 50 },
+    );
+
+    const events = bundle.sessions[0]!.events;
+    expect(events[0]!.type).toBe("decision"); // decisions first regardless of recency
+    expect(events.map((e) => e.type)).toContain("message");
+    // The session.started lifecycle event must not appear as evidence.
+    expect(events.map((e) => e.type)).not.toContain("started");
+  });
+
+  it("surfaces session summaries and next steps", () => {
+    const sess = startSess({ start_summary: "kicked off the work", next_steps: ["do the thing"] });
+
+    const bundle = gatherSessionEvidence(
+      s!.store.db,
+      { kind: "common_project", projectKey: "proj-x" },
+      { maxSessions: 50 },
+    );
+
+    const item = bundle.sessions.find((x) => x.id === sess.id)!;
+    expect(item.startSummary).toBe("kicked off the work");
+    expect(item.nextSteps).toContain("do the thing");
+  });
+});
+
+describe("gatherSessionEvidence — redaction (security)", () => {
+  it("redacts secrets from summaries and event text before returning", () => {
+    const sess = startSess({ start_summary: 'set token = "FAKESTARTSECRET" in env' });
+    record(sess.id, "command", 'ran with password = "FAKECMDSECRET"');
+
+    const bundle = gatherSessionEvidence(
+      s!.store.db,
+      { kind: "common_project", projectKey: "proj-x" },
+      { maxSessions: 50 },
+    );
+
+    const item = bundle.sessions.find((x) => x.id === sess.id)!;
+    const serialized = JSON.stringify(item);
+    expect(serialized).not.toContain("FAKESTARTSECRET");
+    expect(serialized).not.toContain("FAKECMDSECRET");
+    expect(item.startSummary).toContain("[REDACTED:secret]");
+    expect(bundle.redactionCount).toBeGreaterThan(0);
+  });
+});
+
+describe("gatherSessionEvidence — caps", () => {
+  it("caps the number of sessions and flags truncation", () => {
+    startSess({ title: "s1" });
+    startSess({ title: "s2" });
+    startSess({ title: "s3" });
+
+    const bundle = gatherSessionEvidence(
+      s!.store.db,
+      { kind: "common_project", projectKey: "proj-x" },
+      { maxSessions: 2 },
+    );
+
+    expect(bundle.sessions).toHaveLength(2);
+    expect(bundle.truncatedSessions).toBe(true);
+  });
+
+  it("caps events per session and flags per-session truncation", () => {
+    const sess = startSess();
+    record(sess.id, "note", "n1");
+    record(sess.id, "note", "n2");
+    record(sess.id, "note", "n3");
+
+    const bundle = gatherSessionEvidence(
+      s!.store.db,
+      { kind: "common_project", projectKey: "proj-x" },
+      { maxSessions: 50, maxEventsPerSession: 2 },
+    );
+
+    const item = bundle.sessions.find((x) => x.id === sess.id)!;
+    expect(item.events).toHaveLength(2);
+    expect(item.truncatedEvents).toBe(true);
+  });
+});
+
+describe("gatherSessionEvidence — slice descriptor validation", () => {
+  it("rejects common_project without a projectKey", () => {
+    expect(() =>
+      gatherSessionEvidence(s!.store.db, { kind: "common_project" }, { maxSessions: 5 }),
+    ).toThrow(/projectKey/i);
+  });
+
+  it("rejects agent_private without an agentId", () => {
+    expect(() =>
+      gatherSessionEvidence(s!.store.db, { kind: "agent_private" }, { maxSessions: 5 }),
+    ).toThrow(/agentId/i);
+  });
+});


### PR DESCRIPTION
## What

`gatherSessionEvidence(db, slice, caps)` — the session half of §9 evidence,
mirroring the memory gatherer. Read-only SELECTs against the live SQLite
projection (sessions + session_events are applied on every append).

- **Slice isolation (§3):** common_project / common_global (`project_key IS NULL`)
  / agent_private. Sessions own their attribution, so the private slice keys on
  `created_by_agent_id` (the durable owner).
- **Redaction-before-return (§9/§10.4):** title, start/rolling/end summaries,
  next_steps[], and every event summary are scrubbed; `redactionCount` reports
  the total.
- **Typed evidence events only:** lifecycle rows (started/paused/checkpointed/
  ended) are filtered out via the `SessionPayloadType` set; decisions then notes
  first, then the rest by recency (§9 ordering).
- **Caps:** maxSessions (newest by last_activity) + truncatedSessions; per-session
  maxEventsPerSession + truncatedEvents; summaries trimmed to maxSummaryChars.

`sliceWhere` is parameterised by agent column (`agent_id` for memories,
`created_by_agent_id` for sessions) — an internal constant, never user input;
slice values stay bound.

## Review (code-reviewer sub-agent — verdict: APPROVE)

No Critical/Important findings. Suggestions applied in the second commit:
- hoisted the evidence-type set to a module constant;
- fixed a stale `schemas/session.ts` comment that claimed lifecycle events don't
  produce `session_events` rows (they do — which is why the filter is essential);
- added the **handover privacy test** (a session created by agent-a and handed to
  agent-b stays in agent-a's slice, never agent-b's — fails closed) and a
  malformed-`next_steps_json` robustness test.

A missing-index perf note (events / session_events) is deferred to the
worker/perf phase to avoid a schema bump per evidence increment.

All green: core 269, mcp-server 91, cli 51, dashboard 48; lint/typecheck/format clean.

## Scope boundary

Memory + session evidence now exist independently. The next increment composes
them into the full evidence bundle; the §10.3 deterministic pre-pass and the
prompt builder follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)