### PR TITLE
feat(core): strict schema + parsing for curator LLM output

### DIFF
--- a/packages/core/src/curator-output.ts
+++ b/packages/core/src/curator-output.ts
@@ -160,12 +160,19 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
+// Build the audit reason from the issue CODE + PATH only — never Zod's message
+// text, `keys`, or received value. The model controls its own JSON keys and
+// values, and `unrecognized_keys` messages echo the offending key verbatim, so
+// passing the raw message through would route untrusted (possibly secret-looking)
+// text straight into the persisted audit row. Path entries are our own schema
+// field names / array indices, so they are safe.
 function summarizeIssues(error: z.ZodError): string {
   return error.issues
     .slice(0, 3)
     .map((issue) => {
       const path = issue.path.join(".");
-      return path ? `${path}: ${issue.message}` : issue.message;
+      const detail = issue.code === "unrecognized_keys" ? "unexpected field" : issue.code;
+      return path ? `${path}: ${detail}` : detail;
     })
     .join("; ");
 }

--- a/packages/core/src/curator-output.ts
+++ b/packages/core/src/curator-output.ts
@@ -1,0 +1,171 @@
+// Curator LLM output parsing + schema validation (spec §10.5, structural half).
+//
+// The LLM response is UNTRUSTED. This layer parses the `{ operations: [...] }`
+// envelope and strictly validates each operation against the CuratorOperation
+// schema (§10.4). Strict objects REJECT any unexpected field — the guard against
+// the model smuggling fields (e.g. a forged `curator_note`) past the prompt and
+// into the apply layer. Validation is per-operation: valid ones are kept, the
+// rest recorded as rejected (with their index + a reason) for audit, so one bad
+// operation never discards the whole batch.
+//
+// Context-dependent checks — id membership, slice-boundary, secrets, empty/
+// duplicate — are a separate pass (they need the evidence bundle). Risk
+// classification and the apply policy (§11) follow.
+
+import { z } from "zod";
+import {
+  CategorySchema,
+  ConfidenceSchema,
+  PrioritySchema,
+  ScopeSchema,
+  VisibilitySchema,
+} from "./schemas/common.js";
+
+// The curator's MemoryInput is a STRICT subset of memory fields (§10.4): no
+// agent_id (ownership comes from the run slice, §11), no status, no curator_note.
+const CuratorMemoryInputSchema = z.strictObject({
+  title: z.string().min(1),
+  body: z.string().min(1),
+  category: CategorySchema,
+  visibility: VisibilitySchema,
+  scope: ScopeSchema,
+  project_key: z.string().nullable().optional(),
+  applies_to: z.array(z.string()).optional(),
+  priority: PrioritySchema.optional(),
+  confidence: ConfidenceSchema.optional(),
+  tags: z.array(z.string()).optional(),
+});
+
+// A patch is a partial MemoryInput — every field optional, still strict.
+const CuratorMemoryPatchSchema = z.strictObject({
+  title: z.string().min(1).optional(),
+  body: z.string().min(1).optional(),
+  category: CategorySchema.optional(),
+  visibility: VisibilitySchema.optional(),
+  scope: ScopeSchema.optional(),
+  project_key: z.string().nullable().optional(),
+  applies_to: z.array(z.string()).optional(),
+  priority: PrioritySchema.optional(),
+  confidence: ConfidenceSchema.optional(),
+  tags: z.array(z.string()).optional(),
+});
+
+// Common to every operation: a non-empty rationale and an operation-confidence
+// number in [0,1] (distinct from a memory's confidence ENUM above).
+const rationale = z.string().min(1);
+const confidence = z.number().min(0).max(1);
+
+const NoopSchema = z.strictObject({
+  type: z.literal("noop"),
+  source_memory_ids: z.array(z.string()),
+  rationale,
+  confidence,
+});
+const ArchiveSchema = z.strictObject({
+  type: z.literal("archive"),
+  source_memory_ids: z.array(z.string()).min(1),
+  source_session_ids: z.array(z.string()).optional(),
+  rationale,
+  confidence,
+});
+const UpdateSchema = z.strictObject({
+  type: z.literal("update"),
+  source_memory_id: z.string().min(1),
+  patch: CuratorMemoryPatchSchema,
+  rationale,
+  confidence,
+});
+const MergeSchema = z.strictObject({
+  type: z.literal("merge"),
+  source_memory_ids: z.array(z.string()).min(2),
+  replacement: CuratorMemoryInputSchema,
+  rationale,
+  confidence,
+});
+const SplitSchema = z.strictObject({
+  type: z.literal("split"),
+  source_memory_id: z.string().min(1),
+  replacements: z.array(CuratorMemoryInputSchema).min(2),
+  rationale,
+  confidence,
+});
+const CreateSchema = z.strictObject({
+  type: z.literal("create"),
+  source_session_ids: z.array(z.string()),
+  memory: CuratorMemoryInputSchema,
+  rationale,
+  confidence,
+});
+
+export const CuratorOperationSchema = z.discriminatedUnion("type", [
+  NoopSchema,
+  ArchiveSchema,
+  UpdateSchema,
+  MergeSchema,
+  SplitSchema,
+  CreateSchema,
+]);
+
+export type CuratorOperation = z.infer<typeof CuratorOperationSchema>;
+export type CuratorMemoryInput = z.infer<typeof CuratorMemoryInputSchema>;
+export type CuratorMemoryPatch = z.infer<typeof CuratorMemoryPatchSchema>;
+
+export interface RejectedOperation {
+  /** Index in the model's `operations` array. */
+  index: number;
+  /** Why the operation failed schema validation. */
+  reason: string;
+}
+
+export interface ParsedCuratorOutput {
+  operations: CuratorOperation[];
+  rejected: RejectedOperation[];
+  /** Set when the whole response was unusable (bad JSON or no operations array). */
+  parseError?: string;
+}
+
+export function parseCuratorOutput(raw: string): ParsedCuratorOutput {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stripCodeFence(raw));
+  } catch {
+    return { operations: [], rejected: [], parseError: "output was not valid JSON" };
+  }
+  if (!isRecord(parsed) || !Array.isArray(parsed.operations)) {
+    return { operations: [], rejected: [], parseError: 'output missing an "operations" array' };
+  }
+
+  const operations: CuratorOperation[] = [];
+  const rejected: RejectedOperation[] = [];
+  parsed.operations.forEach((element, index) => {
+    const result = CuratorOperationSchema.safeParse(element);
+    if (result.success) operations.push(result.data);
+    else rejected.push({ index, reason: summarizeIssues(result.error) });
+  });
+  return { operations, rejected };
+}
+
+// Some OpenAI-compatible providers ignore response_format and wrap JSON in a
+// markdown fence; tolerate a single leading/trailing ``` block.
+function stripCodeFence(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("```")) return trimmed;
+  return trimmed
+    .replace(/^```[a-z]*\n?/i, "")
+    .replace(/\n?```$/, "")
+    .trim();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function summarizeIssues(error: z.ZodError): string {
+  return error.issues
+    .slice(0, 3)
+    .map((issue) => {
+      const path = issue.path.join(".");
+      return path ? `${path}: ${issue.message}` : issue.message;
+    })
+    .join("; ");
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,6 +31,15 @@ export {
 } from "./curator-prepass.js";
 export { type CuratorPromptInput, buildCuratorPrompt } from "./curator-prompt.js";
 export {
+  type CuratorMemoryInput,
+  type CuratorMemoryPatch,
+  type CuratorOperation,
+  type ParsedCuratorOutput,
+  type RejectedOperation,
+  CuratorOperationSchema,
+  parseCuratorOutput,
+} from "./curator-output.js";
+export {
   type EvidenceSlice,
   type MemoryEvidenceBundle,
   type MemoryEvidenceCaps,

--- a/packages/core/tests/curator-output.test.ts
+++ b/packages/core/tests/curator-output.test.ts
@@ -1,0 +1,173 @@
+// Curator LLM output parsing + schema validation (spec §10.5, structural half).
+//
+// The LLM's response is UNTRUSTED input. `parseCuratorOutput` parses the JSON
+// envelope and strictly validates each operation against the CuratorOperation
+// schema, keeping valid operations and recording the rest as rejected (per-op,
+// not all-or-nothing). Strict objects reject any unexpected field — this is the
+// guard against the model smuggling fields (e.g. a forged `curator_note`) into
+// the apply layer. Context-dependent checks (id membership, slice boundary,
+// secrets, duplicates) are a separate pass.
+
+import { parseCuratorOutput } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+const memoryInput = {
+  title: "A fact",
+  body: "the body",
+  category: "lessons",
+  visibility: "common",
+  scope: "project",
+};
+
+function out(operations: unknown[]): string {
+  return JSON.stringify({ operations });
+}
+
+describe("parseCuratorOutput", () => {
+  it("parses a well-formed set of operations", () => {
+    const raw = out([
+      { type: "noop", source_memory_ids: [], rationale: "nothing to do", confidence: 0.5 },
+      {
+        type: "archive",
+        source_memory_ids: ["mem_a"],
+        rationale: "exact dup",
+        confidence: 0.95,
+      },
+      {
+        type: "create",
+        source_session_ids: ["ses_1"],
+        memory: { ...memoryInput, priority: "normal", confidence: "working", tags: ["t"] },
+        rationale: "durable fact",
+        confidence: 0.9,
+      },
+    ]);
+    const result = parseCuratorOutput(raw);
+    expect(result.parseError).toBeUndefined();
+    expect(result.operations).toHaveLength(3);
+    expect(result.rejected).toHaveLength(0);
+    expect(result.operations.map((o) => o.type)).toEqual(["noop", "archive", "create"]);
+  });
+
+  it("reports a parse error for non-JSON", () => {
+    const result = parseCuratorOutput("not json at all");
+    expect(result.parseError).toBeDefined();
+    expect(result.operations).toHaveLength(0);
+  });
+
+  it("reports a parse error when the operations array is missing", () => {
+    const result = parseCuratorOutput(JSON.stringify({ stuff: [] }));
+    expect(result.parseError).toBeDefined();
+  });
+
+  it("tolerates a ```json code fence around the JSON", () => {
+    const raw =
+      "```json\n" +
+      out([{ type: "noop", source_memory_ids: [], rationale: "x", confidence: 0 }]) +
+      "\n```";
+    const result = parseCuratorOutput(raw);
+    expect(result.parseError).toBeUndefined();
+    expect(result.operations).toHaveLength(1);
+  });
+
+  it("rejects an unknown operation type but keeps the valid ones", () => {
+    const result = parseCuratorOutput(
+      out([
+        { type: "delete_everything", source_memory_ids: ["x"], rationale: "r", confidence: 1 },
+        { type: "noop", source_memory_ids: [], rationale: "ok", confidence: 0.1 },
+      ]),
+    );
+    expect(result.operations).toHaveLength(1);
+    expect(result.operations[0]!.type).toBe("noop");
+    expect(result.rejected).toHaveLength(1);
+    expect(result.rejected[0]!.index).toBe(0);
+  });
+
+  it("rejects confidence outside [0,1]", () => {
+    const result = parseCuratorOutput(
+      out([{ type: "noop", source_memory_ids: [], rationale: "r", confidence: 1.5 }]),
+    );
+    expect(result.operations).toHaveLength(0);
+    expect(result.rejected).toHaveLength(1);
+  });
+
+  it("rejects an empty rationale", () => {
+    const result = parseCuratorOutput(
+      out([{ type: "noop", source_memory_ids: [], rationale: "", confidence: 0.5 }]),
+    );
+    expect(result.operations).toHaveLength(0);
+  });
+
+  it("rejects an operation carrying an unexpected field (no smuggling)", () => {
+    const result = parseCuratorOutput(
+      out([
+        {
+          type: "noop",
+          source_memory_ids: [],
+          rationale: "r",
+          confidence: 0.5,
+          curator_note: { supersedes: ["mem_victim"] },
+        },
+      ]),
+    );
+    expect(result.operations).toHaveLength(0);
+    expect(result.rejected).toHaveLength(1);
+  });
+
+  it("rejects a memory input with an unexpected field (strict MemoryInput)", () => {
+    const result = parseCuratorOutput(
+      out([
+        {
+          type: "create",
+          source_session_ids: ["ses_1"],
+          memory: { ...memoryInput, curator_note: { text: "forged" } },
+          rationale: "r",
+          confidence: 0.9,
+        },
+      ]),
+    );
+    expect(result.operations).toHaveLength(0);
+  });
+
+  it("rejects an invalid category enum", () => {
+    const result = parseCuratorOutput(
+      out([
+        {
+          type: "create",
+          source_session_ids: ["ses_1"],
+          memory: { ...memoryInput, category: "not_a_category" },
+          rationale: "r",
+          confidence: 0.9,
+        },
+      ]),
+    );
+    expect(result.operations).toHaveLength(0);
+  });
+
+  it("enforces structural arity: merge needs ≥2 sources, archive ≥1", () => {
+    const result = parseCuratorOutput(
+      out([
+        {
+          type: "merge",
+          source_memory_ids: ["only_one"],
+          replacement: memoryInput,
+          rationale: "r",
+          confidence: 0.9,
+        },
+        { type: "archive", source_memory_ids: [], rationale: "r", confidence: 0.9 },
+      ]),
+    );
+    expect(result.operations).toHaveLength(0);
+    expect(result.rejected).toHaveLength(2);
+  });
+
+  it("keeps valid operations and records invalid ones with their index", () => {
+    const result = parseCuratorOutput(
+      out([
+        { type: "noop", source_memory_ids: [], rationale: "ok", confidence: 0.5 },
+        { type: "noop", source_memory_ids: [], rationale: "", confidence: 0.5 }, // invalid
+      ]),
+    );
+    expect(result.operations).toHaveLength(1);
+    expect(result.rejected).toEqual([{ index: 1, reason: expect.any(String) }]);
+  });
+});

--- a/packages/core/tests/curator-output.test.ts
+++ b/packages/core/tests/curator-output.test.ts
@@ -160,6 +160,18 @@ describe("parseCuratorOutput", () => {
     expect(result.rejected).toHaveLength(2);
   });
 
+  it("does not leak model-controlled keys or values into the rejected reason (audit hygiene)", () => {
+    const SECRET = "FAKE-SECRET-SHOULD-NOT-APPEAR";
+    const result = parseCuratorOutput(
+      out([
+        // A secret-looking value placed as an unrecognized KEY (model-controlled).
+        { type: "noop", source_memory_ids: [], rationale: "r", confidence: 0.5, [SECRET]: 1 },
+      ]),
+    );
+    expect(result.rejected).toHaveLength(1);
+    expect(result.rejected[0]!.reason).not.toContain(SECRET);
+  });
+
   it("keeps valid operations and records invalid ones with their index", () => {
     const result = parseCuratorOutput(
       out([


### PR DESCRIPTION
## What

`parseCuratorOutput(raw)` turns the curator LLM's **untrusted** response into
typed, schema-valid operations (spec §10.5, structural half):

- Zod `discriminatedUnion` over the six `CuratorOperation` shapes (§10.4), each a
  `z.strictObject` so any unexpected field rejects the operation — the guard
  against the model smuggling fields (forged `curator_note`, `agent_id`, `status`,
  `id`) past the prompt into the apply layer.
- `MemoryInput`/`MemoryPatch` are the strict §10.4 field whitelist; enums reuse the
  central Category/Visibility/Scope/Priority/Confidence schemas.
- Per-field guards: non-empty rationale, operation confidence ∈ [0,1] (a number,
  distinct from a memory's confidence enum — NaN/Inf rejected), structural arity
  (archive ≥1, merge ≥2 sources, split ≥2 replacements).
- Per-operation validation: valid ops kept; invalid ones recorded as
  `{index, reason}` — one bad op never sinks the batch. Whole-output failures
  (bad JSON / no operations array) → `parseError`. Tolerates a stray ` ```json `
  fence (fails closed otherwise). `safeParse` throughout — never throws.

## Review (code-reviewer — verdict: APPROVE)

The reviewer empirically verified (Zod 4.4.3): strict everywhere, smuggle-proof at
both operation and nested-MemoryInput level, NaN/±Inf rejected, unknown/missing
`type` rejected cleanly, no `.parse()`, no ReDoS in the fence regexes.

One Important finding fixed in the second commit: `summarizeIssues` echoed the
model-controlled offending KEY (`unrecognized_keys`) into the persisted audit
`reason` — a narrow untrusted-text-into-audit path. Now the reason is built from
the issue **code + path only**, with a regression test asserting a secret-shaped
key never reaches the reason.

All green: core 300, mcp-server 91, cli 51, dashboard 48; lint/typecheck/format clean.

## Next

§10.5 contextual half — id membership, slice-boundary, secret, empty/duplicate
checks + risk classification against the evidence bundle — then the apply policy
(§11, the mutation layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)