### PR TITLE
feat(core): curator operation validation + risk classification

### DIFF
--- a/packages/core/src/curator-output.ts
+++ b/packages/core/src/curator-output.ts
@@ -54,17 +54,18 @@ const CuratorMemoryPatchSchema = z.strictObject({
 // number in [0,1] (distinct from a memory's confidence ENUM above).
 const rationale = z.string().min(1);
 const confidence = z.number().min(0).max(1);
+const id = z.string().min(1); // ids are non-empty (an "" id can't match evidence)
 
 const NoopSchema = z.strictObject({
   type: z.literal("noop"),
-  source_memory_ids: z.array(z.string()),
+  source_memory_ids: z.array(id),
   rationale,
   confidence,
 });
 const ArchiveSchema = z.strictObject({
   type: z.literal("archive"),
-  source_memory_ids: z.array(z.string()).min(1),
-  source_session_ids: z.array(z.string()).optional(),
+  source_memory_ids: z.array(id).min(1),
+  source_session_ids: z.array(id).optional(),
   rationale,
   confidence,
 });
@@ -77,7 +78,7 @@ const UpdateSchema = z.strictObject({
 });
 const MergeSchema = z.strictObject({
   type: z.literal("merge"),
-  source_memory_ids: z.array(z.string()).min(2),
+  source_memory_ids: z.array(id).min(2),
   replacement: CuratorMemoryInputSchema,
   rationale,
   confidence,
@@ -91,7 +92,7 @@ const SplitSchema = z.strictObject({
 });
 const CreateSchema = z.strictObject({
   type: z.literal("create"),
-  source_session_ids: z.array(z.string()),
+  source_session_ids: z.array(id),
   memory: CuratorMemoryInputSchema,
   rationale,
   confidence,

--- a/packages/core/src/curator-validate.ts
+++ b/packages/core/src/curator-validate.ts
@@ -1,0 +1,262 @@
+// Curator operation validation + risk classification (spec §10.5 + §11 risk step).
+//
+// The context-dependent gate over already-schema-valid operations (curator-output
+// handled the structural half). These are the HARD GUARDS §11 apply must never
+// relax — they run here, in code, regardless of the model's confidence or the
+// admin addendum:
+//   - referential: every referenced memory/session id is in the evidence bundle;
+//   - slice-boundary: no op may change visibility/project/scope or cross slices;
+//   - secret: an op carrying secret-looking content is rejected (never written);
+//   - empty/duplicate: no empty memory, no duplicate of an existing active one;
+//   - resurrection: no create/merge/split replacement matching a tombstone (§9.1).
+// Accepted ops are tagged `isProtected` + a `risk` level for the §11 decision.
+// Reject reasons are fixed strings — never echo operation content (audit hygiene).
+
+import type {
+  EvidenceSlice,
+  MemoryEvidenceBundle,
+  SessionEvidenceBundle,
+} from "./curator-evidence.js";
+import {
+  type TombstoneRef,
+  curationContentFingerprint,
+  matchesTombstone,
+} from "./curator-fingerprint.js";
+import type { CuratorMemoryInput, CuratorMemoryPatch, CuratorOperation } from "./curator-output.js";
+import type { PrepassResult } from "./curator-prepass.js";
+import { redactSecrets } from "./curator-redaction.js";
+import { PROTECTED_CATEGORIES } from "./schemas/common.js";
+
+export type RiskLevel = "safe" | "normal" | "risky" | "protected";
+
+export interface ValidationContext {
+  slice: EvidenceSlice;
+  memory: MemoryEvidenceBundle;
+  sessions: SessionEvidenceBundle;
+  prepass: PrepassResult;
+}
+
+export type OperationOutcome =
+  | { decision: "accept"; risk: RiskLevel; isProtected: boolean }
+  | { decision: "reject"; reason: string };
+
+export interface ValidatedOperation {
+  operation: CuratorOperation;
+  outcome: OperationOutcome;
+}
+
+export function validateOperations(
+  operations: CuratorOperation[],
+  context: ValidationContext,
+): ValidatedOperation[] {
+  const present = new Map<string, string>(); // memory id -> category, for active + proposed
+  for (const m of [...context.memory.activeMemories, ...context.memory.proposedMemories]) {
+    present.set(m.id, m.category);
+  }
+  const sessionIds = new Set(context.sessions.sessions.map((s) => s.id));
+  const tombstoneRefs: TombstoneRef[] = context.memory.tombstones.map((t) => ({
+    id: t.id,
+    content_fingerprint: t.contentFingerprint,
+    normalized_title: t.normalizedTitle,
+  }));
+  const exactDupIds = new Set(
+    context.prepass.findings
+      .filter((f) => f.kind === "exact_duplicate")
+      .flatMap((f) => f.memoryIds),
+  );
+
+  const gate = { present, sessionIds, tombstoneRefs, exactDupIds, slice: context.slice, context };
+  return operations.map((operation) => ({ operation, outcome: validateOne(operation, gate) }));
+}
+
+interface Gate {
+  present: Map<string, string>;
+  sessionIds: Set<string>;
+  tombstoneRefs: TombstoneRef[];
+  exactDupIds: Set<string>;
+  slice: EvidenceSlice;
+  context: ValidationContext;
+}
+
+function validateOne(op: CuratorOperation, gate: Gate): OperationOutcome {
+  // 1. Referential — every referenced id must be in the evidence bundle.
+  for (const id of referencedMemoryIds(op)) {
+    if (!gate.present.has(id)) return reject("references a memory not in the evidence");
+  }
+  for (const id of referencedSessionIds(op)) {
+    if (!gate.sessionIds.has(id)) return reject("references a session not in the evidence");
+  }
+
+  // 2. Slice-boundary — an op may not change or cross visibility/project/scope.
+  if (op.type === "update" && patchTouchesBoundary(op.patch)) {
+    return reject("would change a slice-boundary field (visibility/project/scope)");
+  }
+  const newMemories = newMemoriesOf(op);
+  if (newMemories.some((m) => crossesBoundary(m, gate.slice))) {
+    return reject("crosses the slice boundary (visibility/project)");
+  }
+
+  // 3. Secret — never write secret-looking content.
+  if (newMemories.some(memoryHasSecret) || (op.type === "update" && patchHasSecret(op.patch))) {
+    return reject("contains secret-looking material");
+  }
+
+  // 4. Empty.
+  if (newMemories.some(isEmptyMemory)) return reject("would create an empty memory");
+
+  // 5. Duplicate of an existing active memory (excluding this op's own sources).
+  const sources = new Set(referencedMemoryIds(op));
+  if (newMemories.some((m) => duplicatesActive(m, sources, gate.context))) {
+    return reject("would duplicate an active memory");
+  }
+
+  // 6. Resurrection of deliberately-archived content (§9.1).
+  if (
+    newMemories.some((m) => matchesTombstone({ title: m.title, body: m.body }, gate.tombstoneRefs))
+  ) {
+    return reject("would resurrect archived content");
+  }
+
+  const isProtected = touchesProtected(op, gate.present);
+  return { decision: "accept", isProtected, risk: classifyRisk(op, isProtected, gate.exactDupIds) };
+}
+
+function reject(reason: string): OperationOutcome {
+  return { decision: "reject", reason };
+}
+
+function referencedMemoryIds(op: CuratorOperation): string[] {
+  switch (op.type) {
+    case "noop":
+    case "archive":
+    case "merge":
+      return op.source_memory_ids;
+    case "update":
+    case "split":
+      return [op.source_memory_id];
+    case "create":
+      return [];
+  }
+}
+
+function referencedSessionIds(op: CuratorOperation): string[] {
+  if (op.type === "create") return op.source_session_ids;
+  if (op.type === "archive") return op.source_session_ids ?? [];
+  return [];
+}
+
+function newMemoriesOf(op: CuratorOperation): CuratorMemoryInput[] {
+  switch (op.type) {
+    case "create":
+      return [op.memory];
+    case "merge":
+      return [op.replacement];
+    case "split":
+      return op.replacements;
+    default:
+      return [];
+  }
+}
+
+function patchTouchesBoundary(patch: CuratorMemoryPatch): boolean {
+  return (
+    patch.visibility !== undefined || patch.project_key !== undefined || patch.scope !== undefined
+  );
+}
+
+// The slice is defined by visibility + project ownership; scope is a within-slice
+// attribute (and patch scope-changes are already rejected above), so it is not a
+// boundary for a freshly-created memory.
+function crossesBoundary(m: CuratorMemoryInput, slice: EvidenceSlice): boolean {
+  const requiredVisibility = slice.kind === "agent_private" ? "agent_private" : "common";
+  if (m.visibility !== requiredVisibility) return true;
+  if (slice.kind === "common_project") {
+    return m.project_key != null && m.project_key !== slice.projectKey;
+  }
+  if (slice.kind === "common_global") {
+    return m.project_key != null && m.project_key !== "";
+  }
+  return false; // agent_private: project_key is unrestricted within the agent's slice
+}
+
+function memoryHasSecret(m: CuratorMemoryInput): boolean {
+  return textHasSecret([m.title, m.body, ...(m.tags ?? []), ...(m.applies_to ?? [])]);
+}
+
+function patchHasSecret(patch: CuratorMemoryPatch): boolean {
+  return textHasSecret([
+    patch.title ?? "",
+    patch.body ?? "",
+    ...(patch.tags ?? []),
+    ...(patch.applies_to ?? []),
+  ]);
+}
+
+function textHasSecret(fields: string[]): boolean {
+  return fields.some((field) => redactSecrets(field).count > 0);
+}
+
+function isEmptyMemory(m: CuratorMemoryInput): boolean {
+  return m.title.trim() === "" || m.body.trim() === "";
+}
+
+function duplicatesActive(
+  m: CuratorMemoryInput,
+  sources: Set<string>,
+  context: ValidationContext,
+): boolean {
+  const fingerprint = curationContentFingerprint(m.title, m.body);
+  return context.memory.activeMemories.some(
+    (a) => !sources.has(a.id) && curationContentFingerprint(a.title, a.body) === fingerprint,
+  );
+}
+
+function isProtectedCategory(category: string | undefined): boolean {
+  return category !== undefined && (PROTECTED_CATEGORIES as ReadonlySet<string>).has(category);
+}
+
+function touchesProtected(op: CuratorOperation, present: Map<string, string>): boolean {
+  switch (op.type) {
+    case "create":
+      return isProtectedCategory(op.memory.category);
+    case "merge":
+      return isProtectedCategory(op.replacement.category);
+    case "split":
+      return op.replacements.some((r) => isProtectedCategory(r.category));
+    case "update":
+      // Protected if the patch sets a protected category OR the existing memory is protected.
+      return (
+        isProtectedCategory(op.patch.category) ||
+        isProtectedCategory(present.get(op.source_memory_id))
+      );
+    case "archive":
+      return op.source_memory_ids.some((id) => isProtectedCategory(present.get(id)));
+    case "noop":
+      return false;
+  }
+}
+
+function classifyRisk(
+  op: CuratorOperation,
+  isProtected: boolean,
+  exactDupIds: Set<string>,
+): RiskLevel {
+  if (isProtected) return "protected";
+  switch (op.type) {
+    case "noop":
+      return "safe";
+    case "archive":
+      return op.source_memory_ids.length > 0 &&
+        op.source_memory_ids.every((id) => exactDupIds.has(id))
+        ? "safe"
+        : "normal";
+    case "merge":
+      return op.source_memory_ids.every((id) => exactDupIds.has(id)) ? "safe" : "normal";
+    case "create":
+      // Session-backed creates are "strong evidence" (§11 safe_only).
+      return op.source_session_ids.length > 0 ? "safe" : "normal";
+    case "update":
+    case "split":
+      return "risky";
+  }
+}

--- a/packages/core/src/curator-validate.ts
+++ b/packages/core/src/curator-validate.ts
@@ -5,16 +5,18 @@
 // relax — they run here, in code, regardless of the model's confidence or the
 // admin addendum:
 //   - referential: every referenced memory/session id is in the evidence bundle;
+//   - proposed-source: a mutating op may not operate on a proposed memory (§11.1);
 //   - slice-boundary: no op may change visibility/project/scope or cross slices;
 //   - secret: an op carrying secret-looking content is rejected (never written);
-//   - empty/duplicate: no empty memory, no duplicate of an existing active one;
-//   - resurrection: no create/merge/split replacement matching a tombstone (§9.1).
+//   - empty/duplicate/resurrection: applied to the RESULTING content of every op
+//     (including an update's patched memory), not just brand-new memories.
 // Accepted ops are tagged `isProtected` + a `risk` level for the §11 decision.
 // Reject reasons are fixed strings — never echo operation content (audit hygiene).
 
 import type {
   EvidenceSlice,
   MemoryEvidenceBundle,
+  MemoryEvidenceItem,
   SessionEvidenceBundle,
 } from "./curator-evidence.js";
 import {
@@ -45,49 +47,82 @@ export interface ValidatedOperation {
   outcome: OperationOutcome;
 }
 
-export function validateOperations(
-  operations: CuratorOperation[],
-  context: ValidationContext,
-): ValidatedOperation[] {
-  const present = new Map<string, string>(); // memory id -> category, for active + proposed
-  for (const m of [...context.memory.activeMemories, ...context.memory.proposedMemories]) {
-    present.set(m.id, m.category);
-  }
-  const sessionIds = new Set(context.sessions.sessions.map((s) => s.id));
-  const tombstoneRefs: TombstoneRef[] = context.memory.tombstones.map((t) => ({
-    id: t.id,
-    content_fingerprint: t.contentFingerprint,
-    normalized_title: t.normalizedTitle,
-  }));
-  const exactDupIds = new Set(
-    context.prepass.findings
-      .filter((f) => f.kind === "exact_duplicate")
-      .flatMap((f) => f.memoryIds),
-  );
-
-  const gate = { present, sessionIds, tombstoneRefs, exactDupIds, slice: context.slice, context };
-  return operations.map((operation) => ({ operation, outcome: validateOne(operation, gate) }));
+// What we need to know about each in-evidence memory to validate an op.
+interface EvidenceItem {
+  category: string;
+  status: "active" | "proposed";
+  title: string;
+  body: string;
 }
 
 interface Gate {
-  present: Map<string, string>;
+  items: Map<string, EvidenceItem>;
   sessionIds: Set<string>;
   tombstoneRefs: TombstoneRef[];
   exactDupIds: Set<string>;
   slice: EvidenceSlice;
-  context: ValidationContext;
+  activeMemories: MemoryEvidenceItem[];
+}
+
+// Operations that consume/mutate their source memories (archive happens for the
+// sources of merge/split too). create/noop don't mutate an existing source.
+const MUTATES_SOURCE: ReadonlySet<CuratorOperation["type"]> = new Set([
+  "archive",
+  "update",
+  "merge",
+  "split",
+]);
+
+export function validateOperations(
+  operations: CuratorOperation[],
+  context: ValidationContext,
+): ValidatedOperation[] {
+  const items = new Map<string, EvidenceItem>();
+  for (const m of context.memory.activeMemories) {
+    items.set(m.id, { category: m.category, status: "active", title: m.title, body: m.body });
+  }
+  for (const m of context.memory.proposedMemories) {
+    items.set(m.id, { category: m.category, status: "proposed", title: m.title, body: m.body });
+  }
+  const gate: Gate = {
+    items,
+    sessionIds: new Set(context.sessions.sessions.map((s) => s.id)),
+    tombstoneRefs: context.memory.tombstones.map((t) => ({
+      id: t.id,
+      content_fingerprint: t.contentFingerprint,
+      normalized_title: t.normalizedTitle,
+    })),
+    exactDupIds: new Set(
+      context.prepass.findings
+        .filter((f) => f.kind === "exact_duplicate")
+        .flatMap((f) => f.memoryIds),
+    ),
+    slice: context.slice,
+    activeMemories: context.memory.activeMemories,
+  };
+  return operations.map((operation) => ({ operation, outcome: validateOne(operation, gate) }));
 }
 
 function validateOne(op: CuratorOperation, gate: Gate): OperationOutcome {
+  const memoryIds = referencedMemoryIds(op);
+
   // 1. Referential — every referenced id must be in the evidence bundle.
-  for (const id of referencedMemoryIds(op)) {
-    if (!gate.present.has(id)) return reject("references a memory not in the evidence");
+  for (const id of memoryIds) {
+    if (!gate.items.has(id)) return reject("references a memory not in the evidence");
   }
   for (const id of referencedSessionIds(op)) {
     if (!gate.sessionIds.has(id)) return reject("references a session not in the evidence");
   }
 
-  // 2. Slice-boundary — an op may not change or cross visibility/project/scope.
+  // 2. Proposed-source — a curator may not archive/update/merge/split a pending
+  //    proposal; that transition isn't supported by the apply layer (§11.1).
+  if (MUTATES_SOURCE.has(op.type)) {
+    for (const id of memoryIds) {
+      if (gate.items.get(id)?.status === "proposed") return reject("operates on a proposed memory");
+    }
+  }
+
+  // 3. Slice-boundary — an op may not change or cross visibility/project/scope.
   if (op.type === "update" && patchTouchesBoundary(op.patch)) {
     return reject("would change a slice-boundary field (visibility/project/scope)");
   }
@@ -96,28 +131,26 @@ function validateOne(op: CuratorOperation, gate: Gate): OperationOutcome {
     return reject("crosses the slice boundary (visibility/project)");
   }
 
-  // 3. Secret — never write secret-looking content.
+  // 4. Secret — never write secret-looking content.
   if (newMemories.some(memoryHasSecret) || (op.type === "update" && patchHasSecret(op.patch))) {
     return reject("contains secret-looking material");
   }
 
-  // 4. Empty.
-  if (newMemories.some(isEmptyMemory)) return reject("would create an empty memory");
-
-  // 5. Duplicate of an existing active memory (excluding this op's own sources).
-  const sources = new Set(referencedMemoryIds(op));
-  if (newMemories.some((m) => duplicatesActive(m, sources, gate.context))) {
+  // 5. Empty / duplicate / resurrection — over the RESULTING content of the op,
+  //    which for an update is the patch merged over the existing memory.
+  const resulting = resultingContent(op, gate);
+  if (resulting.some((c) => c.title.trim() === "" || c.body.trim() === "")) {
+    return reject("would create an empty memory");
+  }
+  const sources = new Set(memoryIds);
+  if (resulting.some((c) => duplicatesActive(c, sources, gate.activeMemories))) {
     return reject("would duplicate an active memory");
   }
-
-  // 6. Resurrection of deliberately-archived content (§9.1).
-  if (
-    newMemories.some((m) => matchesTombstone({ title: m.title, body: m.body }, gate.tombstoneRefs))
-  ) {
+  if (resulting.some((c) => matchesTombstone(c, gate.tombstoneRefs))) {
     return reject("would resurrect archived content");
   }
 
-  const isProtected = touchesProtected(op, gate.present);
+  const isProtected = touchesProtected(op, gate.items);
   return { decision: "accept", isProtected, risk: classifyRisk(op, isProtected, gate.exactDupIds) };
 }
 
@@ -145,6 +178,7 @@ function referencedSessionIds(op: CuratorOperation): string[] {
   return [];
 }
 
+// Brand-new memories an op introduces (for boundary + secret checks).
 function newMemoriesOf(op: CuratorOperation): CuratorMemoryInput[] {
   switch (op.type) {
     case "create":
@@ -153,6 +187,31 @@ function newMemoriesOf(op: CuratorOperation): CuratorMemoryInput[] {
       return [op.replacement];
     case "split":
       return op.replacements;
+    default:
+      return [];
+  }
+}
+
+interface Content {
+  title: string;
+  body: string;
+}
+
+// The content each op would leave in the store — includes an update's patched
+// result, so empty/duplicate/resurrection guards cover updates too.
+function resultingContent(op: CuratorOperation, gate: Gate): Content[] {
+  switch (op.type) {
+    case "create":
+      return [{ title: op.memory.title, body: op.memory.body }];
+    case "merge":
+      return [{ title: op.replacement.title, body: op.replacement.body }];
+    case "split":
+      return op.replacements.map((r) => ({ title: r.title, body: r.body }));
+    case "update": {
+      const existing = gate.items.get(op.source_memory_id);
+      if (!existing) return []; // unreachable: referential guard already passed
+      return [{ title: op.patch.title ?? existing.title, body: op.patch.body ?? existing.body }];
+    }
     default:
       return [];
   }
@@ -171,9 +230,13 @@ function crossesBoundary(m: CuratorMemoryInput, slice: EvidenceSlice): boolean {
   const requiredVisibility = slice.kind === "agent_private" ? "agent_private" : "common";
   if (m.visibility !== requiredVisibility) return true;
   if (slice.kind === "common_project") {
-    return m.project_key != null && m.project_key !== slice.projectKey;
+    // Must carry exactly the slice's project. null/undefined/"" would project to
+    // the GLOBAL slice (partition is project_key set → project, null → global),
+    // so anything other than an exact match crosses the boundary.
+    return m.project_key !== slice.projectKey;
   }
   if (slice.kind === "common_global") {
+    // Must be project-less; a real project key belongs to that project's slice.
     return m.project_key != null && m.project_key !== "";
   }
   return false; // agent_private: project_key is unrestricted within the agent's slice
@@ -196,17 +259,16 @@ function textHasSecret(fields: string[]): boolean {
   return fields.some((field) => redactSecrets(field).count > 0);
 }
 
-function isEmptyMemory(m: CuratorMemoryInput): boolean {
-  return m.title.trim() === "" || m.body.trim() === "";
-}
-
+// Excludes the op's own sources: merge/split archive their sources atomically
+// (§11 — "no window where old and new are both active"), so the replacement
+// matching a source it replaces is expected, not a duplicate collision.
 function duplicatesActive(
-  m: CuratorMemoryInput,
+  content: Content,
   sources: Set<string>,
-  context: ValidationContext,
+  activeMemories: MemoryEvidenceItem[],
 ): boolean {
-  const fingerprint = curationContentFingerprint(m.title, m.body);
-  return context.memory.activeMemories.some(
+  const fingerprint = curationContentFingerprint(content.title, content.body);
+  return activeMemories.some(
     (a) => !sources.has(a.id) && curationContentFingerprint(a.title, a.body) === fingerprint,
   );
 }
@@ -215,22 +277,27 @@ function isProtectedCategory(category: string | undefined): boolean {
   return category !== undefined && (PROTECTED_CATEGORIES as ReadonlySet<string>).has(category);
 }
 
-function touchesProtected(op: CuratorOperation, present: Map<string, string>): boolean {
+// An op is protected if its RESULT is a protected category OR it archives/replaces
+// a protected SOURCE (merge/split/archive all consume their sources, so a protected
+// memory consumed there must route through governance, never auto-apply).
+function touchesProtected(op: CuratorOperation, items: Map<string, EvidenceItem>): boolean {
+  const sourceProtected = (id: string) => isProtectedCategory(items.get(id)?.category);
   switch (op.type) {
     case "create":
       return isProtectedCategory(op.memory.category);
     case "merge":
-      return isProtectedCategory(op.replacement.category);
-    case "split":
-      return op.replacements.some((r) => isProtectedCategory(r.category));
-    case "update":
-      // Protected if the patch sets a protected category OR the existing memory is protected.
       return (
-        isProtectedCategory(op.patch.category) ||
-        isProtectedCategory(present.get(op.source_memory_id))
+        isProtectedCategory(op.replacement.category) || op.source_memory_ids.some(sourceProtected)
       );
+    case "split":
+      return (
+        op.replacements.some((r) => isProtectedCategory(r.category)) ||
+        sourceProtected(op.source_memory_id)
+      );
+    case "update":
+      return isProtectedCategory(op.patch.category) || sourceProtected(op.source_memory_id);
     case "archive":
-      return op.source_memory_ids.some((id) => isProtectedCategory(present.get(id)));
+      return op.source_memory_ids.some(sourceProtected);
     case "noop":
       return false;
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,6 +40,13 @@ export {
   parseCuratorOutput,
 } from "./curator-output.js";
 export {
+  type OperationOutcome,
+  type RiskLevel,
+  type ValidatedOperation,
+  type ValidationContext,
+  validateOperations,
+} from "./curator-validate.js";
+export {
   type EvidenceSlice,
   type MemoryEvidenceBundle,
   type MemoryEvidenceCaps,

--- a/packages/core/tests/curator-validate.test.ts
+++ b/packages/core/tests/curator-validate.test.ts
@@ -343,6 +343,162 @@ describe("validateOperations — protected routing + risk", () => {
   });
 });
 
+describe("validateOperations — security regressions (audit)", () => {
+  it("treats a merge that consumes a protected source as protected", () => {
+    const outcome = only(
+      [
+        {
+          type: "merge",
+          source_memory_ids: ["mem_id", "mem_b"],
+          replacement: { ...newMem, category: "lessons" },
+          rationale: "x",
+          confidence: 0.9,
+        },
+      ],
+      ctx({ active: [memItem("mem_id", { category: "identity" }), memItem("mem_b")] }),
+    );
+    expect(outcome).toMatchObject({ decision: "accept", isProtected: true, risk: "protected" });
+  });
+
+  it("treats a split of a protected source as protected", () => {
+    const outcome = only(
+      [
+        {
+          type: "split",
+          source_memory_id: "mem_id",
+          replacements: [{ ...newMem }, { ...newMem, title: "Two", body: "two" }],
+          rationale: "x",
+          confidence: 0.9,
+        },
+      ],
+      ctx({ active: [memItem("mem_id", { category: "relationship" })] }),
+    );
+    expect(outcome).toMatchObject({ decision: "accept", isProtected: true });
+  });
+
+  it("rejects a common_project create that omits/nulls/empties or mis-targets project_key", () => {
+    const { project_key: _omit, ...memNoProject } = newMem;
+    const omitted = only(
+      [
+        {
+          type: "create",
+          source_session_ids: [],
+          memory: memNoProject,
+          rationale: "x",
+          confidence: 0.9,
+        },
+      ],
+      ctx(),
+    );
+    expect(omitted).toMatchObject({ decision: "reject" });
+
+    for (const project_key of [null, "", "proj-y"] as const) {
+      const outcome = only(
+        [
+          {
+            type: "create",
+            source_session_ids: [],
+            memory: { ...newMem, project_key },
+            rationale: "x",
+            confidence: 0.9,
+          },
+        ],
+        ctx(),
+      );
+      expect(outcome).toMatchObject({ decision: "reject" });
+    }
+  });
+
+  it("accepts a common_project create that carries the exact slice project", () => {
+    const outcome = only(
+      [
+        {
+          type: "create",
+          source_session_ids: [],
+          memory: { ...newMem, project_key: "proj-x" },
+          rationale: "x",
+          confidence: 0.9,
+        },
+      ],
+      ctx(),
+    );
+    expect(outcome.decision).toBe("accept");
+  });
+
+  it("rejects mutating a proposed memory (§11.1)", () => {
+    const archived = only(
+      [{ type: "archive", source_memory_ids: ["mem_p"], rationale: "x", confidence: 0.9 }],
+      ctx({ proposed: [memItem("mem_p", { status: "proposed" })] }),
+    );
+    expect(archived).toMatchObject({ decision: "reject" });
+    expect((archived as { reason: string }).reason).toMatch(/proposed/i);
+
+    const updated = only(
+      [
+        {
+          type: "update",
+          source_memory_id: "mem_p",
+          patch: { body: "tweak" },
+          rationale: "x",
+          confidence: 0.9,
+        },
+      ],
+      ctx({ proposed: [memItem("mem_p", { status: "proposed" })] }),
+    );
+    expect(updated).toMatchObject({ decision: "reject" });
+  });
+
+  it("rejects an update whose patched content resurrects a tombstone", () => {
+    const outcome = only(
+      [
+        {
+          type: "update",
+          source_memory_id: "mem_a",
+          patch: { title: "Gone", body: "deleted content" },
+          rationale: "x",
+          confidence: 0.9,
+        },
+      ],
+      ctx({
+        active: [memItem("mem_a")],
+        tombstones: [tomb("mem_dead", "Gone", "deleted content")],
+      }),
+    );
+    expect(outcome).toMatchObject({ decision: "reject" });
+    expect((outcome as { reason: string }).reason).toMatch(/resurrect|archived/i);
+  });
+
+  it("rejects an update that empties or duplicates via its patched result", () => {
+    const emptied = only(
+      [
+        {
+          type: "update",
+          source_memory_id: "mem_a",
+          patch: { body: "   " },
+          rationale: "x",
+          confidence: 0.9,
+        },
+      ],
+      ctx({ active: [memItem("mem_a")] }),
+    );
+    expect(emptied).toMatchObject({ decision: "reject" });
+
+    const duped = only(
+      [
+        {
+          type: "update",
+          source_memory_id: "mem_a",
+          patch: { title: "Dup", body: "dup body" },
+          rationale: "x",
+          confidence: 0.9,
+        },
+      ],
+      ctx({ active: [memItem("mem_a"), memItem("mem_b", { title: "Dup", body: "dup body" })] }),
+    );
+    expect(duped).toMatchObject({ decision: "reject" });
+  });
+});
+
 describe("validateOperations — batch", () => {
   it("returns one outcome per operation, in order", () => {
     const results = validateOperations(

--- a/packages/core/tests/curator-validate.test.ts
+++ b/packages/core/tests/curator-validate.test.ts
@@ -1,0 +1,359 @@
+// Curator operation validation + risk classification (spec §10.5 + §11 risk).
+//
+// The context-dependent gate over already-schema-valid operations. These are the
+// HARD GUARDS that §11 apply must never relax:
+//   - referential: every referenced memory/session id is in the evidence bundle;
+//   - slice-boundary: an op may not change visibility/project/scope or cross into
+//     another slice;
+//   - secret: an op carrying secret-looking content is rejected (never written);
+//   - empty/duplicate: no empty memory, no duplicate of an active memory;
+//   - resurrection: no create/merge that matches an archived tombstone (§9.1).
+// Accepted ops are tagged protected? + a risk level (safe/normal/risky/protected)
+// for the §11 apply decision. Reject reasons are value-free (audit hygiene).
+
+import {
+  type CuratorOperation,
+  type EvidenceSlice,
+  type MemoryEvidenceBundle,
+  type MemoryEvidenceItem,
+  type PrepassResult,
+  type SessionEvidenceBundle,
+  curationContentFingerprint,
+  curationNormalizedTitle,
+  validateOperations,
+} from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+function memItem(id: string, over: Partial<MemoryEvidenceItem> = {}): MemoryEvidenceItem {
+  return {
+    id,
+    title: `title ${id}`,
+    body: `body ${id}`,
+    category: "lessons",
+    scope: "project",
+    visibility: "common",
+    projectKey: "proj-x",
+    agentId: null,
+    status: "active",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...over,
+  };
+}
+
+function tomb(id: string, title: string, body: string): MemoryEvidenceBundle["tombstones"][number] {
+  return {
+    id,
+    title,
+    category: "lessons",
+    scope: "project",
+    visibility: "common",
+    projectKey: "proj-x",
+    agentId: null,
+    archivedAt: "2026-01-01T00:00:00.000Z",
+    archiveReason: null,
+    contentFingerprint: curationContentFingerprint(title, body),
+    normalizedTitle: curationNormalizedTitle(title),
+  };
+}
+
+interface CtxParts {
+  slice?: EvidenceSlice;
+  active?: MemoryEvidenceItem[];
+  proposed?: MemoryEvidenceItem[];
+  tombstones?: MemoryEvidenceBundle["tombstones"];
+  sessionIds?: string[];
+  prepass?: PrepassResult;
+}
+
+function ctx(parts: CtxParts = {}) {
+  const slice = parts.slice ?? { kind: "common_project", projectKey: "proj-x" };
+  const memory: MemoryEvidenceBundle = {
+    slice,
+    activeMemories: parts.active ?? [],
+    proposedMemories: parts.proposed ?? [],
+    tombstones: parts.tombstones ?? [],
+    truncatedMemories: false,
+    truncatedFields: false,
+    redactionCount: 0,
+  };
+  const sessions: SessionEvidenceBundle = {
+    slice,
+    sessions: (parts.sessionIds ?? []).map((id) => ({
+      id,
+      title: "s",
+      status: "active",
+      projectKey: "proj-x",
+      createdByAgentId: "agent-a",
+      currentAgentId: "agent-a",
+      startSummary: null,
+      rollingSummary: null,
+      endSummary: null,
+      nextSteps: [],
+      lastActivityAt: "2026-01-01T00:00:00.000Z",
+      events: [],
+      truncatedEvents: false,
+    })),
+    truncatedSessions: false,
+    redactionCount: 0,
+  };
+  return { slice, memory, sessions, prepass: parts.prepass ?? { findings: [] } };
+}
+
+const newMem = {
+  title: "Fresh",
+  body: "fresh body",
+  category: "lessons" as const,
+  visibility: "common" as const,
+  scope: "project" as const,
+  project_key: "proj-x",
+};
+
+function only(ops: CuratorOperation[], context: Parameters<typeof validateOperations>[1]) {
+  return validateOperations(ops, context)[0]!.outcome;
+}
+
+describe("validateOperations — referential guard", () => {
+  it("accepts an archive of an in-evidence active memory", () => {
+    const outcome = only(
+      [{ type: "archive", source_memory_ids: ["mem_a"], rationale: "dup", confidence: 0.95 }],
+      ctx({ active: [memItem("mem_a")] }),
+    );
+    expect(outcome.decision).toBe("accept");
+  });
+
+  it("rejects an op referencing an unknown memory id", () => {
+    const outcome = only(
+      [{ type: "archive", source_memory_ids: ["mem_ghost"], rationale: "x", confidence: 0.9 }],
+      ctx({ active: [memItem("mem_a")] }),
+    );
+    expect(outcome).toMatchObject({ decision: "reject" });
+    expect((outcome as { reason: string }).reason).toMatch(/memory/i);
+  });
+
+  it("rejects a create referencing an unknown session id", () => {
+    const outcome = only(
+      [
+        {
+          type: "create",
+          source_session_ids: ["ses_ghost"],
+          memory: newMem,
+          rationale: "x",
+          confidence: 0.9,
+        },
+      ],
+      ctx({ sessionIds: ["ses_real"] }),
+    );
+    expect(outcome).toMatchObject({ decision: "reject" });
+    expect((outcome as { reason: string }).reason).toMatch(/session/i);
+  });
+});
+
+describe("validateOperations — slice-boundary guard", () => {
+  it("rejects an update.patch that changes visibility/project/scope", () => {
+    for (const patch of [
+      { visibility: "agent_private" },
+      { project_key: "proj-y" },
+      { scope: "global" },
+    ]) {
+      const outcome = only(
+        [{ type: "update", source_memory_id: "mem_a", patch, rationale: "x", confidence: 0.9 }],
+        ctx({ active: [memItem("mem_a")] }),
+      );
+      expect(outcome).toMatchObject({ decision: "reject" });
+      expect((outcome as { reason: string }).reason).toMatch(/boundary/i);
+    }
+  });
+
+  it("rejects a create whose memory crosses the slice visibility", () => {
+    const outcome = only(
+      [
+        {
+          type: "create",
+          source_session_ids: [],
+          memory: { ...newMem, visibility: "agent_private" },
+          rationale: "x",
+          confidence: 0.9,
+        },
+      ],
+      ctx(),
+    );
+    expect(outcome).toMatchObject({ decision: "reject" });
+  });
+
+  it("rejects a common_global create that carries a project_key", () => {
+    const outcome = only(
+      [
+        {
+          type: "create",
+          source_session_ids: [],
+          memory: { ...newMem, project_key: "proj-x" },
+          rationale: "x",
+          confidence: 0.9,
+        },
+      ],
+      ctx({ slice: { kind: "common_global" } }),
+    );
+    expect(outcome).toMatchObject({ decision: "reject" });
+  });
+});
+
+describe("validateOperations — secret guard", () => {
+  it("rejects an op carrying secret-looking content, without echoing the secret", () => {
+    const SECRET = "FAKEVALIDATESECRET";
+    const outcome = only(
+      [
+        {
+          type: "create",
+          source_session_ids: [],
+          memory: { ...newMem, body: `token = "${SECRET}"` },
+          rationale: "x",
+          confidence: 0.9,
+        },
+      ],
+      ctx(),
+    );
+    expect(outcome).toMatchObject({ decision: "reject" });
+    expect((outcome as { reason: string }).reason).toMatch(/secret/i);
+    expect((outcome as { reason: string }).reason).not.toContain(SECRET);
+  });
+});
+
+describe("validateOperations — empty + duplicate guards", () => {
+  it("rejects a whitespace-only memory as empty", () => {
+    const outcome = only(
+      [
+        {
+          type: "create",
+          source_session_ids: [],
+          memory: { ...newMem, title: "   ", body: "   " },
+          rationale: "x",
+          confidence: 0.9,
+        },
+      ],
+      ctx(),
+    );
+    expect(outcome).toMatchObject({ decision: "reject" });
+    expect((outcome as { reason: string }).reason).toMatch(/empty/i);
+  });
+
+  it("rejects a create that duplicates an existing active memory", () => {
+    const outcome = only(
+      [
+        {
+          type: "create",
+          source_session_ids: [],
+          memory: { ...newMem, title: "Dup", body: "dup body" },
+          rationale: "x",
+          confidence: 0.9,
+        },
+      ],
+      ctx({ active: [memItem("mem_a", { title: "Dup", body: "dup body" })] }),
+    );
+    expect(outcome).toMatchObject({ decision: "reject" });
+    expect((outcome as { reason: string }).reason).toMatch(/duplicate/i);
+  });
+});
+
+describe("validateOperations — resurrection guard", () => {
+  it("rejects a create whose content matches an archived tombstone", () => {
+    const outcome = only(
+      [
+        {
+          type: "create",
+          source_session_ids: [],
+          memory: { ...newMem, title: "Gone", body: "deleted content" },
+          rationale: "x",
+          confidence: 0.9,
+        },
+      ],
+      ctx({ tombstones: [tomb("mem_dead", "Gone", "deleted content")] }),
+    );
+    expect(outcome).toMatchObject({ decision: "reject" });
+    expect((outcome as { reason: string }).reason).toMatch(/resurrect|archived/i);
+  });
+});
+
+describe("validateOperations — protected routing + risk", () => {
+  it("flags a protected-category create as protected", () => {
+    const outcome = only(
+      [
+        {
+          type: "create",
+          source_session_ids: ["ses_1"],
+          memory: { ...newMem, category: "identity" },
+          rationale: "x",
+          confidence: 0.9,
+        },
+      ],
+      ctx({ sessionIds: ["ses_1"] }),
+    );
+    expect(outcome).toMatchObject({ decision: "accept", isProtected: true, risk: "protected" });
+  });
+
+  it("flags a pure archive of a protected memory as protected", () => {
+    const outcome = only(
+      [{ type: "archive", source_memory_ids: ["mem_id"], rationale: "stale", confidence: 0.9 }],
+      ctx({ active: [memItem("mem_id", { category: "relationship" })] }),
+    );
+    expect(outcome).toMatchObject({ decision: "accept", isProtected: true });
+  });
+
+  it("classifies an exact-duplicate archive as safe (per the pre-pass)", () => {
+    const outcome = only(
+      [{ type: "archive", source_memory_ids: ["mem_a"], rationale: "dup", confidence: 0.95 }],
+      ctx({
+        active: [memItem("mem_a"), memItem("mem_b")],
+        prepass: {
+          findings: [{ kind: "exact_duplicate", memoryIds: ["mem_a", "mem_b"], rationale: "d" }],
+        },
+      }),
+    );
+    expect(outcome).toMatchObject({ decision: "accept", risk: "safe" });
+  });
+
+  it("classifies a session-backed create as safe and an update as risky", () => {
+    const createOutcome = only(
+      [
+        {
+          type: "create",
+          source_session_ids: ["ses_1"],
+          memory: newMem,
+          rationale: "x",
+          confidence: 0.9,
+        },
+      ],
+      ctx({ sessionIds: ["ses_1"] }),
+    );
+    expect(createOutcome).toMatchObject({ decision: "accept", risk: "safe" });
+
+    const updateOutcome = only(
+      [
+        {
+          type: "update",
+          source_memory_id: "mem_a",
+          patch: { body: "tweak" },
+          rationale: "x",
+          confidence: 0.9,
+        },
+      ],
+      ctx({ active: [memItem("mem_a")] }),
+    );
+    expect(updateOutcome).toMatchObject({ decision: "accept", risk: "risky" });
+  });
+});
+
+describe("validateOperations — batch", () => {
+  it("returns one outcome per operation, in order", () => {
+    const results = validateOperations(
+      [
+        { type: "noop", source_memory_ids: [], rationale: "ok", confidence: 0.5 },
+        { type: "archive", source_memory_ids: ["ghost"], rationale: "x", confidence: 0.9 },
+      ],
+      ctx(),
+    );
+    expect(results).toHaveLength(2);
+    expect(results[0]!.outcome.decision).toBe("accept");
+    expect(results[1]!.outcome.decision).toBe("reject");
+  });
+});


### PR DESCRIPTION
## What

`validateOperations(ops, context)` — the context-dependent §10.5 gate over
schema-valid operations, producing per-op `accept{risk, isProtected}` or
`reject{reason}`. These hard guards run in code regardless of the model's
confidence or the admin addendum, and are the gate the §11 mutation layer trusts:

- **referential** — every referenced memory/session id must be in the evidence;
- **proposed-source** — a mutating op may not archive/update/merge/split a pending
  proposal (§11.1);
- **slice-boundary** — `update.patch` may not touch visibility/project/scope, and
  a new/replacement memory may not cross the slice's visibility/project (a
  `common_project` memory must carry exactly the slice project; scope is a
  within-slice attribute);
- **secret** — content carrying secret-looking material is rejected, never written;
- **empty/duplicate/resurrection** — run over each op's RESULTING content,
  including an update's patch merged over the existing memory.

Accepted ops are classified for §11: protected category (looked up from evidence
for archive/update, and for any merge/split source) → `protected`; exact-duplicate
archive/merge (per the pre-pass) and session-backed creates → `safe`; other
creates/archives → `normal`; update/split → `risky`. Reject reasons are fixed
strings — operation content is never echoed into the audit record.

## Security audit (security-auditor sub-agent)

Found a **Critical + 3 Important** bypasses, all fixed in the second commit:
- **Critical** — merge/split consuming a *protected source* was classified
  non-protected → could auto-archive a protected memory without a proposal.
- common_project create with null/absent `project_key` → slice escape into global.
- mutating a *proposed* memory was accepted (violates §11.1).
- `update` patches skipped empty/duplicate/**resurrection** guards (an update could
  resurrect a tombstone).

Plus: non-empty source-id schema; documented the dup-exclusion ↔ §11 atomic-archive
contract. Adversarial regression tests added for each. The auditor confirmed the
agent_private cross-agent deferral, redact-then-fingerprint consistency, audit
hygiene, and crash-safety hold.

All green: core 322, mcp-server 91, cli 51, dashboard 48; lint/typecheck/format clean.

## Next

The apply policy (§11) — the mutation layer that consumes these outcomes:
auto-apply safe ops under `default_auto_apply` + confidence; protected → proposal
with `curator_note.supersedes` / pure-archive → skip+audit; everything else
skip+audit. Atomic source-archive for merge/split. Also gets a security-auditor pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)