### PR TITLE
feat(core): curator apply-decision policy (§11 table)

### DIFF
--- a/packages/core/src/curator-apply-policy.ts
+++ b/packages/core/src/curator-apply-policy.ts
@@ -1,0 +1,51 @@
+// Curator apply-decision policy (spec §11). The PURE rules that map a validated,
+// accepted operation + the admin `default_auto_apply` level + the confidence
+// threshold to one of: auto_apply / propose / skip. Execution (the actual store
+// mutations and proposal creation) is a separate layer; this is just the policy.
+//
+// The protected guard is un-relaxable: identity/relationship operations never
+// auto-apply regardless of level or confidence — create/update/merge/split route
+// to a human proposal, and a protected pure-archive (no replacement) is skipped
+// and audited (§11). Within non-protected discretion, `safe_only` (v1 default)
+// auto-applies only `safe`-risk ops; `high_confidence` auto-applies any
+// non-protected op; both gate on the confidence threshold; `off` applies nothing.
+
+import type { AutoApplyLevel } from "./curator-config.js";
+import type { CuratorOperation } from "./curator-output.js";
+import type { RiskLevel } from "./curator-validate.js";
+
+export type ApplyDecision = "auto_apply" | "propose" | "skip";
+
+export interface ApplyPolicy {
+  level: AutoApplyLevel;
+  confidenceThreshold: number;
+}
+
+/** The accept-branch classification from §10.5 validation. */
+export interface AcceptedClassification {
+  risk: RiskLevel;
+  isProtected: boolean;
+}
+
+export function decideApply(
+  operation: CuratorOperation,
+  accepted: AcceptedClassification,
+  policy: ApplyPolicy,
+): ApplyDecision {
+  // A noop changes nothing.
+  if (operation.type === "noop") return "skip";
+
+  // Protected categories never auto-apply (hard guard, above level + confidence):
+  // create/update/merge/split become human proposals; a pure protected archive
+  // has no replacement to propose, so it is skipped + audited.
+  if (accepted.isProtected) {
+    return operation.type === "archive" ? "skip" : "propose";
+  }
+
+  // Non-protected discretion, gated by level + confidence.
+  if (policy.level === "off") return "skip";
+  if (operation.confidence < policy.confidenceThreshold) return "skip";
+  if (policy.level === "safe_only") return accepted.risk === "safe" ? "auto_apply" : "skip";
+  // high_confidence: any non-protected op at/above the threshold.
+  return "auto_apply";
+}

--- a/packages/core/src/curator-apply-policy.ts
+++ b/packages/core/src/curator-apply-policy.ts
@@ -42,10 +42,14 @@ export function decideApply(
     return operation.type === "archive" ? "skip" : "propose";
   }
 
-  // Non-protected discretion, gated by level + confidence.
+  // Non-protected discretion, gated by level + confidence. The threshold check
+  // sits before the level branches so it applies to safe_only AND high_confidence
+  // uniformly.
   if (policy.level === "off") return "skip";
   if (operation.confidence < policy.confidenceThreshold) return "skip";
-  if (policy.level === "safe_only") return accepted.risk === "safe" ? "auto_apply" : "skip";
-  // high_confidence: any non-protected op at/above the threshold.
-  return "auto_apply";
+  if (policy.level === "high_confidence") return "auto_apply"; // any non-protected op
+  if (policy.level === "safe_only" && accepted.risk === "safe") return "auto_apply";
+  // Fail closed: safe_only below the safe bar, or any unrecognised future level,
+  // is skipped — a new AutoApplyLevel can never silently auto-apply.
+  return "skip";
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -47,6 +47,12 @@ export {
   validateOperations,
 } from "./curator-validate.js";
 export {
+  type AcceptedClassification,
+  type ApplyDecision,
+  type ApplyPolicy,
+  decideApply,
+} from "./curator-apply-policy.js";
+export {
   type EvidenceSlice,
   type MemoryEvidenceBundle,
   type MemoryEvidenceCaps,

--- a/packages/core/tests/curator-apply-policy.test.ts
+++ b/packages/core/tests/curator-apply-policy.test.ts
@@ -1,0 +1,124 @@
+// Curator apply-decision policy (spec §11 table) — the pure rules that map a
+// validated operation + the admin default_auto_apply level + confidence threshold
+// to auto_apply / propose / skip. These are the un-relaxable guards: protected
+// categories NEVER auto-apply (even at high_confidence), and `safe_only` only
+// auto-applies `safe`-risk ops. Execution is a separate layer.
+
+import {
+  type AcceptedClassification,
+  type ApplyPolicy,
+  type CuratorOperation,
+  decideApply,
+} from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+const policy = (level: ApplyPolicy["level"], confidenceThreshold = 0.9): ApplyPolicy => ({
+  level,
+  confidenceThreshold,
+});
+
+const mem = {
+  title: "t",
+  body: "b",
+  category: "lessons" as const,
+  visibility: "common" as const,
+  scope: "project" as const,
+};
+
+function op(type: CuratorOperation["type"], confidence = 0.95): CuratorOperation {
+  switch (type) {
+    case "noop":
+      return { type, source_memory_ids: [], rationale: "r", confidence };
+    case "archive":
+      return { type, source_memory_ids: ["m"], rationale: "r", confidence };
+    case "update":
+      return { type, source_memory_id: "m", patch: { body: "x" }, rationale: "r", confidence };
+    case "merge":
+      return { type, source_memory_ids: ["a", "b"], replacement: mem, rationale: "r", confidence };
+    case "split":
+      return {
+        type,
+        source_memory_id: "m",
+        replacements: [mem, { ...mem, title: "u" }],
+        rationale: "r",
+        confidence,
+      };
+    case "create":
+      return { type, source_session_ids: ["s"], memory: mem, rationale: "r", confidence };
+  }
+}
+
+const accepted = (
+  risk: AcceptedClassification["risk"],
+  isProtected = false,
+): AcceptedClassification => ({
+  risk,
+  isProtected,
+});
+
+describe("decideApply — protected guard (un-relaxable)", () => {
+  it("routes protected create/update/merge/split to a proposal at every level", () => {
+    for (const level of ["off", "safe_only", "high_confidence"] as const) {
+      for (const type of ["create", "update", "merge", "split"] as const) {
+        expect(decideApply(op(type), accepted("protected", true), policy(level))).toBe("propose");
+      }
+    }
+  });
+
+  it("never auto-applies a protected op even at high_confidence with max confidence", () => {
+    expect(
+      decideApply(op("update", 1), accepted("protected", true), policy("high_confidence", 0)),
+    ).toBe("propose");
+  });
+
+  it("skips a protected pure archive (no replacement to propose)", () => {
+    for (const level of ["off", "safe_only", "high_confidence"] as const) {
+      expect(decideApply(op("archive"), accepted("protected", true), policy(level))).toBe("skip");
+    }
+  });
+});
+
+describe("decideApply — noop", () => {
+  it("always skips (nothing to apply)", () => {
+    expect(decideApply(op("noop"), accepted("safe"), policy("high_confidence", 0))).toBe("skip");
+  });
+});
+
+describe("decideApply — off", () => {
+  it("applies nothing, even a high-confidence safe op", () => {
+    expect(decideApply(op("archive", 1), accepted("safe"), policy("off"))).toBe("skip");
+  });
+});
+
+describe("decideApply — safe_only (v1 default)", () => {
+  it("auto-applies a safe op at/above the threshold", () => {
+    expect(decideApply(op("merge", 0.9), accepted("safe"), policy("safe_only", 0.9))).toBe(
+      "auto_apply",
+    );
+  });
+
+  it("skips a safe op below the threshold", () => {
+    expect(decideApply(op("merge", 0.89), accepted("safe"), policy("safe_only", 0.9))).toBe("skip");
+  });
+
+  it("skips non-safe ops (normal/risky) even at high confidence", () => {
+    expect(decideApply(op("create", 1), accepted("normal"), policy("safe_only"))).toBe("skip");
+    expect(decideApply(op("update", 1), accepted("risky"), policy("safe_only"))).toBe("skip");
+  });
+});
+
+describe("decideApply — high_confidence", () => {
+  it("auto-applies any non-protected op at/above the threshold", () => {
+    for (const risk of ["safe", "normal", "risky"] as const) {
+      expect(decideApply(op("update", 0.9), accepted(risk), policy("high_confidence", 0.9))).toBe(
+        "auto_apply",
+      );
+    }
+  });
+
+  it("skips below the threshold", () => {
+    expect(decideApply(op("update", 0.5), accepted("risky"), policy("high_confidence", 0.9))).toBe(
+      "skip",
+    );
+  });
+});


### PR DESCRIPTION
## What

`decideApply(operation, accepted, policy)` — the **pure** rules mapping a
validated, accepted operation + the admin `default_auto_apply` level + the
confidence threshold to `auto_apply` / `propose` / `skip` (spec §11). Execution
(store mutations, proposal creation) is a separate layer.

- **Protected guard (un-relaxable):** identity/relationship ops never auto-apply
  at any level or confidence — create/update/merge/split → `propose`, a protected
  pure-archive → `skip` (no replacement to propose).
- **noop** → skip. **off** → apply nothing.
- **safe_only** (v1 default) → auto-apply only `safe`-risk ops at/above the
  threshold. **high_confidence** → any non-protected op at/above the threshold.
  Below threshold → skip.
- **Fail-closed:** an unrecognised future `AutoApplyLevel` defaults to `skip`,
  never `auto_apply`.

It consumes the §10.5 classification (`{risk, isProtected}`) and trusts it for the
"exact-duplicate / strong-evidence" nuance (already collapsed into `risk`), so its
inputs are sufficient and nothing §11 needs at decision time is missing.

## Review (code-reviewer — verdict: APPROVE)

No Critical/Important. Exhaustive tests over the §11 table, including the
adversarial hard-guard case (protected op, `high_confidence`, confidence 1,
threshold 0 → still `propose`) and the `≥ threshold` boundary on both sides. One
suggestion applied: fail-closed level handling (second commit).

All green: core 332, mcp-server 91, cli 51, dashboard 48; lint/typecheck/format clean.

## Next

The apply **execution** layer (§11 + §11.1): perform the decided mutations via
store methods (archive/create/update; merge/split as atomic create+archive),
create proposals (with `curator_note.supersedes`) for protected ops, and record
every operation outcome. That's the live-memory mutation — it gets a dedicated
security-auditor pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)