### PR TITLE
feat(core): curator apply execution (§11) — the mutation layer

### DIFF
--- a/packages/core/src/curator-apply.ts
+++ b/packages/core/src/curator-apply.ts
@@ -1,0 +1,276 @@
+// Curator apply execution (spec §11 + §11.1). Consumes the §10.5 validated
+// operations, runs each through the §11 decision policy, and EXECUTES the result
+// against the store — the only layer in the curator that mutates live memory.
+//
+// Invariants:
+//   - All memory mutations go through store methods (createMemory / updateMemory /
+//     archiveMemory) — NEVER raw SQL (the projection is rebuilt from the ledger).
+//   - `curator_note` provenance is set only via createMemory's trusted `options`
+//     channel, never via patch (which can't carry it anyway).
+//   - Ownership: agent_private writes are owned by the slice's agent; common
+//     writes by the curator actor. The agent_id is passed explicitly, never taken
+//     from the model.
+//   - Non-protected merge/split archive their superseded sources in the same
+//     operation. Protected ops are NEVER mutated here — they were routed to
+//     "propose" (a new proposal carrying curator_note.supersedes) or "skip".
+//   - Every operation (applied / proposed / skipped / failed) is recorded for the
+//     admin audit; the recorded rationale is redacted as defence-in-depth.
+
+import { type ApplyPolicy, decideApply } from "./curator-apply-policy.js";
+import type { MemoryEvidenceItem } from "./curator-evidence.js";
+import type { CuratorMemoryPatch, CuratorOperation } from "./curator-output.js";
+import { redactSecrets } from "./curator-redaction.js";
+import type { ValidatedOperation, ValidationContext } from "./curator-validate.js";
+import type { RecordCurationOperationInput } from "./store/curation-store.js";
+
+// The store surface the apply layer needs (all mutation flows through these).
+export interface ApplyStore {
+  createMemory: (
+    input: Record<string, unknown>,
+    options?: Record<string, unknown>,
+  ) => { memory: { id: string } };
+  updateMemory: (id: string, patch?: Record<string, unknown>, agent_id?: string) => unknown;
+  archiveMemory: (id: string, agent_id?: string) => unknown;
+  recordCurationOperation: (input: RecordCurationOperationInput) => unknown;
+}
+
+export interface ApplyDeps {
+  store: ApplyStore;
+  runId: string;
+  /** Curator actor id for common-slice writes (e.g. "system-memory-curator"). */
+  actorId: string;
+  policy: ApplyPolicy;
+}
+
+export interface ApplySummary {
+  applied: number;
+  proposed: number;
+  skipped: number;
+  failed: number;
+}
+
+interface ExecContext {
+  store: ApplyStore;
+  runId: string;
+  actorId: string;
+  owner: string;
+  items: Map<string, MemoryEvidenceItem>;
+}
+
+export function applyOperations(
+  validated: ValidatedOperation[],
+  context: ValidationContext,
+  deps: ApplyDeps,
+): ApplySummary {
+  const owner =
+    context.slice.kind === "agent_private" && context.slice.agentId
+      ? context.slice.agentId
+      : deps.actorId;
+  const items = new Map<string, MemoryEvidenceItem>();
+  for (const m of [...context.memory.activeMemories, ...context.memory.proposedMemories]) {
+    items.set(m.id, m);
+  }
+  const exec: ExecContext = {
+    store: deps.store,
+    runId: deps.runId,
+    actorId: deps.actorId,
+    owner,
+    items,
+  };
+
+  const summary: ApplySummary = { applied: 0, proposed: 0, skipped: 0, failed: 0 };
+  for (const { operation, outcome } of validated) {
+    if (outcome.decision === "reject") {
+      // A rejected op may have been rejected FOR its content (e.g. secrets), so
+      // its payload is not persisted — only the value-free reason.
+      record(deps, operation, "skipped", "normal", outcome.reason, [], {});
+      summary.skipped++;
+      continue;
+    }
+    // Accepted ops passed the §10.5 content guards, so their payload is safe to record.
+    const payload = operationPayload(operation);
+    const decision = decideApply(operation, outcome, deps.policy);
+    if (decision === "skip") {
+      record(deps, operation, "skipped", outcome.risk, operation.rationale, [], payload);
+      summary.skipped++;
+      continue;
+    }
+    try {
+      if (decision === "propose") {
+        record(
+          deps,
+          operation,
+          "proposed",
+          outcome.risk,
+          operation.rationale,
+          proposeOp(operation, exec),
+          payload,
+        );
+        summary.proposed++;
+      } else {
+        record(
+          deps,
+          operation,
+          "applied",
+          outcome.risk,
+          operation.rationale,
+          applyOp(operation, exec),
+          payload,
+        );
+        summary.applied++;
+      }
+    } catch {
+      // Never echo the thrown error (could carry store/content detail) into audit.
+      record(deps, operation, "failed", outcome.risk, operation.rationale, [], payload);
+      summary.failed++;
+    }
+  }
+  return summary;
+}
+
+// Auto-apply a non-protected operation; returns the target memory ids.
+function applyOp(op: CuratorOperation, c: ExecContext): string[] {
+  switch (op.type) {
+    case "archive":
+      for (const id of op.source_memory_ids) c.store.archiveMemory(id, c.actorId);
+      return op.source_memory_ids;
+    case "create":
+      return [createMemory(c, op.memory, []).id];
+    case "update":
+      c.store.updateMemory(op.source_memory_id, op.patch, c.actorId);
+      return [op.source_memory_id];
+    case "merge": {
+      // Create-then-archive: on partial failure the duplicate stays active
+      // (recoverable next run) rather than losing the source (data loss).
+      const target = createMemory(c, op.replacement, op.source_memory_ids).id;
+      for (const id of op.source_memory_ids) c.store.archiveMemory(id, c.actorId);
+      return [target];
+    }
+    case "split": {
+      const targets = op.replacements.map((r) => createMemory(c, r, [op.source_memory_id]).id);
+      c.store.archiveMemory(op.source_memory_id, c.actorId);
+      return targets;
+    }
+    case "noop":
+      return [];
+  }
+}
+
+// Route a protected operation to a proposal (createMemory auto-routes a protected
+// category to `proposed`); returns the new proposal ids. Sources are NOT archived
+// — the admin archives the superseded memory after accepting (§11.1).
+function proposeOp(op: CuratorOperation, c: ExecContext): string[] {
+  switch (op.type) {
+    case "create":
+      return [createMemory(c, op.memory, []).id];
+    case "merge":
+      return [createMemory(c, op.replacement, op.source_memory_ids).id];
+    case "split":
+      return op.replacements.map((r) => createMemory(c, r, [op.source_memory_id]).id);
+    case "update": {
+      const existing = c.items.get(op.source_memory_id);
+      if (!existing) throw new Error("update source missing from evidence");
+      return [createMemory(c, correctedMemory(existing, op.patch), [op.source_memory_id]).id];
+    }
+    default:
+      return []; // archive/noop never reach "propose"
+  }
+}
+
+function createMemory(
+  c: ExecContext,
+  memory: Record<string, unknown>,
+  supersedes: string[],
+): { id: string } {
+  const curatorNote: Record<string, unknown> = { run_id: c.runId };
+  if (supersedes.length > 0) curatorNote.supersedes = supersedes;
+  return c.store.createMemory({ ...memory, agent_id: c.owner }, { curator_note: curatorNote })
+    .memory;
+}
+
+// Reconstruct the corrected memory for a protected update proposal: the patch
+// merged over the existing memory. visibility is boundary-immutable (validation
+// rejects a patch that changes it), so it is taken from the existing memory.
+function correctedMemory(
+  existing: MemoryEvidenceItem,
+  patch: CuratorMemoryPatch,
+): Record<string, unknown> {
+  return {
+    title: patch.title ?? existing.title,
+    body: patch.body ?? existing.body,
+    category: patch.category ?? existing.category,
+    visibility: existing.visibility,
+    scope: patch.scope ?? existing.scope,
+    project_key: existing.projectKey ?? undefined,
+    applies_to: patch.applies_to,
+    priority: patch.priority,
+    tags: patch.tags,
+  };
+}
+
+function record(
+  deps: ApplyDeps,
+  op: CuratorOperation,
+  status: RecordCurationOperationInput["status"],
+  risk: string,
+  rationale: string,
+  targets: string[],
+  proposedPayload: Record<string, unknown>,
+): void {
+  deps.store.recordCurationOperation({
+    run_id: deps.runId,
+    operation_type: op.type,
+    status,
+    confidence: op.confidence,
+    risk_level: risk,
+    rationale: redactSecrets(rationale).redacted,
+    proposed_payload: proposedPayload,
+    source_memory_ids: sourceMemoryIds(op),
+    source_session_ids: sourceSessionIds(op),
+    target_memory_ids: targets,
+  });
+}
+
+// The operation's content for the audit record — EXCLUDES the raw rationale
+// (recorded separately, redacted) since an accepted op's rationale prose could
+// still carry a model-hallucinated secret; the content fields here passed the
+// §10.5 secret guard.
+function operationPayload(op: CuratorOperation): Record<string, unknown> {
+  switch (op.type) {
+    case "noop":
+      return { source_memory_ids: op.source_memory_ids };
+    case "archive":
+      return {
+        source_memory_ids: op.source_memory_ids,
+        source_session_ids: op.source_session_ids ?? [],
+      };
+    case "update":
+      return { source_memory_id: op.source_memory_id, patch: op.patch };
+    case "merge":
+      return { source_memory_ids: op.source_memory_ids, replacement: op.replacement };
+    case "split":
+      return { source_memory_id: op.source_memory_id, replacements: op.replacements };
+    case "create":
+      return { source_session_ids: op.source_session_ids, memory: op.memory };
+  }
+}
+
+function sourceMemoryIds(op: CuratorOperation): string[] {
+  switch (op.type) {
+    case "noop":
+    case "archive":
+    case "merge":
+      return op.source_memory_ids;
+    case "update":
+    case "split":
+      return [op.source_memory_id];
+    case "create":
+      return [];
+  }
+}
+
+function sourceSessionIds(op: CuratorOperation): string[] {
+  if (op.type === "create") return op.source_session_ids;
+  if (op.type === "archive") return op.source_session_ids ?? [];
+  return [];
+}

--- a/packages/core/src/curator-apply.ts
+++ b/packages/core/src/curator-apply.ts
@@ -17,11 +17,26 @@
 //     admin audit; the recorded rationale is redacted as defence-in-depth.
 
 import { type ApplyPolicy, decideApply } from "./curator-apply-policy.js";
-import type { MemoryEvidenceItem } from "./curator-evidence.js";
 import type { CuratorMemoryPatch, CuratorOperation } from "./curator-output.js";
 import { redactSecrets } from "./curator-redaction.js";
 import type { ValidatedOperation, ValidationContext } from "./curator-validate.js";
 import type { RecordCurationOperationInput } from "./store/curation-store.js";
+
+// The authoritative stored memory used to reconstruct a protected-update proposal.
+// Must come from the store (getMemory), NOT the evidence projection, which is
+// redacted + truncated.
+interface StoredMemory {
+  title: string;
+  body: string;
+  category: string;
+  visibility: string;
+  scope: string;
+  project_key: string | null;
+  priority: string;
+  confidence: string;
+  tags: string[];
+  applies_to: string[];
+}
 
 // The store surface the apply layer needs (all mutation flows through these).
 export interface ApplyStore {
@@ -31,6 +46,7 @@ export interface ApplyStore {
   ) => { memory: { id: string } };
   updateMemory: (id: string, patch?: Record<string, unknown>, agent_id?: string) => unknown;
   archiveMemory: (id: string, agent_id?: string) => unknown;
+  getMemory: (id: string) => StoredMemory | null;
   recordCurationOperation: (input: RecordCurationOperationInput) => unknown;
 }
 
@@ -40,6 +56,8 @@ export interface ApplyDeps {
   /** Curator actor id for common-slice writes (e.g. "system-memory-curator"). */
   actorId: string;
   policy: ApplyPolicy;
+  /** Optional sink for swallowed execution errors (keeps the audit row content-free). */
+  onError?: (error: unknown, operation: CuratorOperation) => void;
 }
 
 export interface ApplySummary {
@@ -54,7 +72,6 @@ interface ExecContext {
   runId: string;
   actorId: string;
   owner: string;
-  items: Map<string, MemoryEvidenceItem>;
 }
 
 export function applyOperations(
@@ -66,16 +83,11 @@ export function applyOperations(
     context.slice.kind === "agent_private" && context.slice.agentId
       ? context.slice.agentId
       : deps.actorId;
-  const items = new Map<string, MemoryEvidenceItem>();
-  for (const m of [...context.memory.activeMemories, ...context.memory.proposedMemories]) {
-    items.set(m.id, m);
-  }
   const exec: ExecContext = {
     store: deps.store,
     runId: deps.runId,
     actorId: deps.actorId,
     owner,
-    items,
   };
 
   const summary: ApplySummary = { applied: 0, proposed: 0, skipped: 0, failed: 0 };
@@ -119,8 +131,11 @@ export function applyOperations(
         );
         summary.applied++;
       }
-    } catch {
-      // Never echo the thrown error (could carry store/content detail) into audit.
+    } catch (error) {
+      // Never echo the thrown error (could carry store/content detail) into the
+      // audit row; surface it to the optional out-of-band sink so a programming
+      // bug stays observable.
+      deps.onError?.(error, operation);
       record(deps, operation, "failed", outcome.risk, operation.rationale, [], payload);
       summary.failed++;
     }
@@ -152,7 +167,8 @@ function applyOp(op: CuratorOperation, c: ExecContext): string[] {
       return targets;
     }
     case "noop":
-      return [];
+      // decideApply routes noop → skip; reaching here is a mis-route — fail loud.
+      throw new Error("noop is not applicable");
   }
 }
 
@@ -168,12 +184,16 @@ function proposeOp(op: CuratorOperation, c: ExecContext): string[] {
     case "split":
       return op.replacements.map((r) => createMemory(c, r, [op.source_memory_id]).id);
     case "update": {
-      const existing = c.items.get(op.source_memory_id);
-      if (!existing) throw new Error("update source missing from evidence");
+      // Reconstruct from the AUTHORITATIVE store record (not the redacted/truncated
+      // evidence), so a patch that omits a field proposes the real existing value.
+      const existing = c.store.getMemory(op.source_memory_id);
+      if (!existing) throw new Error("update source missing from store");
       return [createMemory(c, correctedMemory(existing, op.patch), [op.source_memory_id]).id];
     }
-    default:
-      return []; // archive/noop never reach "propose"
+    case "archive":
+    case "noop":
+      // decideApply routes these to apply/skip, never propose — fail loud.
+      throw new Error(`${op.type} is not proposable`);
   }
 }
 
@@ -189,10 +209,11 @@ function createMemory(
 }
 
 // Reconstruct the corrected memory for a protected update proposal: the patch
-// merged over the existing memory. visibility is boundary-immutable (validation
-// rejects a patch that changes it), so it is taken from the existing memory.
+// merged over the AUTHORITATIVE stored memory. Every non-boundary field falls
+// back to the existing value so an omitted patch field is preserved, not dropped.
+// visibility is boundary-immutable (validation rejects a patch that changes it).
 function correctedMemory(
-  existing: MemoryEvidenceItem,
+  existing: StoredMemory,
   patch: CuratorMemoryPatch,
 ): Record<string, unknown> {
   return {
@@ -201,10 +222,11 @@ function correctedMemory(
     category: patch.category ?? existing.category,
     visibility: existing.visibility,
     scope: patch.scope ?? existing.scope,
-    project_key: existing.projectKey ?? undefined,
-    applies_to: patch.applies_to,
-    priority: patch.priority,
-    tags: patch.tags,
+    project_key: existing.project_key ?? undefined,
+    applies_to: patch.applies_to ?? existing.applies_to,
+    priority: patch.priority ?? existing.priority,
+    confidence: patch.confidence ?? existing.confidence,
+    tags: patch.tags ?? existing.tags,
   };
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -53,6 +53,12 @@ export {
   decideApply,
 } from "./curator-apply-policy.js";
 export {
+  type ApplyDeps,
+  type ApplyStore,
+  type ApplySummary,
+  applyOperations,
+} from "./curator-apply.js";
+export {
   type EvidenceSlice,
   type MemoryEvidenceBundle,
   type MemoryEvidenceCaps,

--- a/packages/core/tests/curator-apply.test.ts
+++ b/packages/core/tests/curator-apply.test.ts
@@ -8,6 +8,7 @@ import os from "node:os";
 import path from "node:path";
 import {
   type ApplyPolicy,
+  type ApplyStore,
   type LibrarianStore,
   type ValidatedOperation,
   type ValidationContext,
@@ -16,7 +17,7 @@ import {
   gatherMemoryEvidence,
   gatherSessionEvidence,
 } from "@librarian/core";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 interface Scope {
   store: LibrarianStore;
@@ -234,6 +235,118 @@ describe("applyOperations — protected routing", () => {
     expect(summary.skipped).toBe(1);
     expect(s!.store.getMemory(m.id)?.status).toBe("active"); // NOT archived
     expect(recorded()[0]).toMatchObject({ operation_type: "archive", status: "skipped" });
+  });
+});
+
+describe("applyOperations — protected update reconstruction (data integrity)", () => {
+  it("proposes the corrected memory from the authoritative record, preserving untouched fields", () => {
+    // Active protected memory with a body longer than the evidence truncation cap
+    // and a non-default priority — both must survive a title-only patch.
+    const fullBody = "X".repeat(5000);
+    const m = seed(
+      { category: "identity", body: fullBody, priority: "high", tags: ["keep"] },
+      { forceActive: true },
+    );
+
+    const summary = applyOperations(
+      ops({
+        operation: {
+          type: "update",
+          source_memory_id: m.id,
+          patch: { title: "Corrected title" },
+          rationale: "fix",
+          confidence: 0.95,
+        },
+        outcome: accept("protected", true),
+      }),
+      context(),
+      deps(),
+    );
+
+    expect(summary.proposed).toBe(1);
+    const proposalId = recorded().find((o) => o.status === "proposed")!.target_memory_ids[0]!;
+    const proposal = s!.store.getMemory(proposalId)!;
+    expect(proposal.status).toBe("proposed");
+    expect(proposal.title).toBe("Corrected title");
+    expect(proposal.body).toBe(fullBody); // full, untruncated, unredacted
+    expect(proposal.priority).toBe("high"); // preserved, not reset to default
+    expect(proposal.tags).toContain("keep");
+    expect(proposal.curator_note?.supersedes).toEqual([m.id]);
+  });
+});
+
+describe("applyOperations — merge partial failure (no data loss)", () => {
+  it("keeps the created replacement and records failed when a source archive throws", () => {
+    const created: string[] = [];
+    const recordedOps: { status: string }[] = [];
+    let archiveCalls = 0;
+    const onError = vi.fn();
+    const mockStore: ApplyStore = {
+      createMemory: () => {
+        const id = `mem_new_${created.length}`;
+        created.push(id);
+        return { memory: { id } };
+      },
+      updateMemory: () => null,
+      archiveMemory: () => {
+        archiveCalls++;
+        if (archiveCalls === 2) throw new Error("archive boom");
+        return null;
+      },
+      getMemory: () => null,
+      recordCurationOperation: (op) => {
+        recordedOps.push({ status: op.status });
+        return op;
+      },
+    };
+    const slice = { kind: "common_project" as const, projectKey: "proj-x" };
+    const minimalContext: ValidationContext = {
+      slice,
+      memory: {
+        slice,
+        activeMemories: [],
+        proposedMemories: [],
+        tombstones: [],
+        truncatedMemories: false,
+        truncatedFields: false,
+        redactionCount: 0,
+      },
+      sessions: { slice, sessions: [], truncatedSessions: false, redactionCount: 0 },
+      prepass: { findings: [] },
+    };
+
+    const summary = applyOperations(
+      ops({
+        operation: {
+          type: "merge",
+          source_memory_ids: ["a", "b"],
+          replacement: {
+            title: "Merged",
+            body: "merged",
+            category: "lessons",
+            visibility: "common",
+            scope: "project",
+            project_key: "proj-x",
+          },
+          rationale: "merge",
+          confidence: 0.95,
+        },
+        outcome: accept("safe"),
+      }),
+      minimalContext,
+      {
+        store: mockStore,
+        runId: "run_x",
+        actorId: "system-memory-curator",
+        policy: policy("safe_only"),
+        onError,
+      },
+    );
+
+    expect(summary.failed).toBe(1);
+    expect(created).toHaveLength(1); // replacement created → no data loss
+    expect(recordedOps[0]?.status).toBe("failed");
+    expect(onError).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/core/tests/curator-apply.test.ts
+++ b/packages/core/tests/curator-apply.test.ts
@@ -1,0 +1,269 @@
+// Curator apply execution (spec §11 + §11.1) — the live-memory mutation layer.
+// Integration test against a real store: seed memories, open a curation run, run
+// applyOperations over validated operations, and assert both the resulting store
+// state and the recorded audit operations.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type ApplyPolicy,
+  type LibrarianStore,
+  type ValidatedOperation,
+  type ValidationContext,
+  applyOperations,
+  createLibrarianStore,
+  gatherMemoryEvidence,
+  gatherSessionEvidence,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+interface Scope {
+  store: LibrarianStore;
+  dataDir: string;
+  runId: string;
+}
+
+let s: Scope | null = null;
+
+beforeEach(() => {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-apply-"));
+  const store = createLibrarianStore({ dataDir });
+  const run = store.createCurationRun({
+    trigger: "manual",
+    visibility: "common",
+    input_hash: "hash",
+    project_key: "proj-x",
+  });
+  s = { store, dataDir, runId: run.id };
+});
+afterEach(() => {
+  if (!s) return;
+  try {
+    s.store.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(s.dataDir, { recursive: true, force: true });
+  s = null;
+});
+
+function seed(over: Record<string, unknown> = {}, options: Record<string, unknown> = {}) {
+  return s!.store.createMemory(
+    {
+      agent_id: "agent-a",
+      title: "title",
+      body: "body",
+      category: "lessons",
+      visibility: "common",
+      scope: "project",
+      project_key: "proj-x",
+      priority: "normal",
+      confidence: "working",
+      ...over,
+    },
+    options,
+  ).memory;
+}
+
+function context(prepass: ValidationContext["prepass"] = { findings: [] }): ValidationContext {
+  const slice = { kind: "common_project" as const, projectKey: "proj-x" };
+  return {
+    slice,
+    memory: gatherMemoryEvidence(s!.store.db, slice, { maxMemories: 100 }),
+    sessions: gatherSessionEvidence(s!.store.db, slice, { maxSessions: 100 }),
+    prepass,
+  };
+}
+
+const policy = (level: ApplyPolicy["level"], confidenceThreshold = 0.9): ApplyPolicy => ({
+  level,
+  confidenceThreshold,
+});
+
+function deps(level: ApplyPolicy["level"] = "high_confidence") {
+  return {
+    store: s!.store,
+    runId: s!.runId,
+    actorId: "system-memory-curator",
+    policy: policy(level),
+  };
+}
+
+const accept = (risk: string, isProtected = false) =>
+  ({ decision: "accept", risk, isProtected }) as ValidatedOperation["outcome"];
+
+function ops(...validated: ValidatedOperation[]): ValidatedOperation[] {
+  return validated;
+}
+
+function recorded() {
+  return s!.store.getCurationOperations(s!.runId);
+}
+
+describe("applyOperations — auto-apply", () => {
+  it("archives the source memories of an archive op", () => {
+    const m = seed();
+    const summary = applyOperations(
+      ops({
+        operation: {
+          type: "archive",
+          source_memory_ids: [m.id],
+          rationale: "dup",
+          confidence: 0.95,
+        },
+        outcome: accept("safe"),
+      }),
+      context(),
+      deps(),
+    );
+    expect(summary.applied).toBe(1);
+    expect(s!.store.getMemory(m.id)?.status).toBe("archived");
+    expect(recorded()[0]).toMatchObject({ operation_type: "archive", status: "applied" });
+  });
+
+  it("creates a new active memory with curator-note provenance", () => {
+    const summary = applyOperations(
+      ops({
+        operation: {
+          type: "create",
+          source_session_ids: [],
+          memory: {
+            title: "New fact",
+            body: "the body",
+            category: "lessons",
+            visibility: "common",
+            scope: "project",
+            project_key: "proj-x",
+          },
+          rationale: "durable",
+          confidence: 0.95,
+        },
+        outcome: accept("normal"),
+      }),
+      context(),
+      deps(),
+    );
+    expect(summary.applied).toBe(1);
+    const targetId = recorded()[0]!.target_memory_ids[0]!;
+    const created = s!.store.getMemory(targetId)!;
+    expect(created.status).toBe("active");
+    expect(created.title).toBe("New fact");
+    expect(created.curator_note?.run_id).toBe(s!.runId);
+  });
+
+  it("merges: creates the replacement and archives the sources atomically", () => {
+    const a = seed({ title: "A", body: "same" });
+    const b = seed({ title: "B", body: "same" });
+    const summary = applyOperations(
+      ops({
+        operation: {
+          type: "merge",
+          source_memory_ids: [a.id, b.id],
+          replacement: {
+            title: "Merged",
+            body: "merged body",
+            category: "lessons",
+            visibility: "common",
+            scope: "project",
+            project_key: "proj-x",
+          },
+          rationale: "merge dups",
+          confidence: 0.95,
+        },
+        outcome: accept("safe"),
+      }),
+      context(),
+      deps(),
+    );
+    expect(summary.applied).toBe(1);
+    expect(s!.store.getMemory(a.id)?.status).toBe("archived");
+    expect(s!.store.getMemory(b.id)?.status).toBe("archived");
+    const merged = s!.store.getMemory(recorded()[0]!.target_memory_ids[0]!)!;
+    expect(merged.status).toBe("active");
+    expect(merged.curator_note?.supersedes).toEqual([a.id, b.id]);
+  });
+});
+
+describe("applyOperations — protected routing", () => {
+  it("routes a protected create to a proposal, not an active memory", () => {
+    const summary = applyOperations(
+      ops({
+        operation: {
+          type: "create",
+          source_session_ids: [],
+          memory: {
+            title: "Identity fact",
+            body: "who they are",
+            category: "identity",
+            visibility: "common",
+            scope: "project",
+            project_key: "proj-x",
+          },
+          rationale: "identity",
+          confidence: 0.95,
+        },
+        outcome: accept("protected", true),
+      }),
+      context(),
+      deps(),
+    );
+    expect(summary.proposed).toBe(1);
+    expect(summary.applied).toBe(0);
+    const proposedOp = recorded().find((o) => o.status === "proposed")!;
+    expect(s!.store.getMemory(proposedOp.target_memory_ids[0]!)?.status).toBe("proposed");
+  });
+
+  it("skips a protected pure archive (no proposal, source untouched)", () => {
+    // Seed an ACTIVE protected memory (forceActive bypasses protected→proposed).
+    const m = seed({ category: "relationship" }, { forceActive: true });
+    expect(s!.store.getMemory(m.id)?.status).toBe("active");
+    const summary = applyOperations(
+      ops({
+        operation: {
+          type: "archive",
+          source_memory_ids: [m.id],
+          rationale: "stale",
+          confidence: 0.99,
+        },
+        outcome: accept("protected", true),
+      }),
+      context(),
+      deps(),
+    );
+    expect(summary.skipped).toBe(1);
+    expect(s!.store.getMemory(m.id)?.status).toBe("active"); // NOT archived
+    expect(recorded()[0]).toMatchObject({ operation_type: "archive", status: "skipped" });
+  });
+});
+
+describe("applyOperations — skips + rejects mutate nothing", () => {
+  it("records a rejected operation as skipped without mutating", () => {
+    const m = seed();
+    const summary = applyOperations(
+      ops({
+        operation: { type: "archive", source_memory_ids: [m.id], rationale: "x", confidence: 0.9 },
+        outcome: { decision: "reject", reason: "references a memory not in the evidence" },
+      }),
+      context(),
+      deps(),
+    );
+    expect(summary.skipped).toBe(1);
+    expect(s!.store.getMemory(m.id)?.status).toBe("active");
+    expect(recorded()[0]?.status).toBe("skipped");
+  });
+
+  it("skips a below-threshold op under the policy without mutating", () => {
+    const m = seed();
+    const summary = applyOperations(
+      ops({
+        operation: { type: "archive", source_memory_ids: [m.id], rationale: "x", confidence: 0.5 },
+        outcome: accept("safe"),
+      }),
+      context(),
+      deps("safe_only"),
+    );
+    expect(summary.skipped).toBe(1);
+    expect(s!.store.getMemory(m.id)?.status).toBe("active");
+  });
+});


### PR DESCRIPTION
## What

`applyOperations(validated, context, deps)` — the §11 apply execution layer, the
only curator code that mutates live memory. Consumes the §10.5 validated
operations, runs each through the §11 `decideApply` policy, and executes:

- **auto_apply** (non-protected, permitted by level + confidence): archive →
  `archiveMemory`; create → `createMemory` (active); update → `updateMemory`;
  merge → create replacement + archive sources; split → create replacements +
  archive source. Create-first ordering so a partial failure leaves a recoverable
  duplicate, never data loss. All via store methods, never raw SQL.
- **propose** (protected create/update/merge/split): `createMemory` auto-routes
  the protected category to `proposed`, carrying `curator_note.supersedes`; sources
  are NOT archived (admin archives after accepting, §11.1). A protected update is
  reconstructed from the **authoritative store record**.
- **skip**: protected pure-archive, below-threshold/off, and rejected ops —
  recorded, no mutation.

Ownership is explicit (agent_private → slice agent, common → curator actor;
agent_id never taken from the model and applied after the spread). `curator_note`
is set only via the trusted options channel. Every operation is recorded for
audit with a content-only `proposed_payload` (rationale recorded separately,
redacted; rejected ops persist no payload).

## Security audit (security-auditor sub-agent — 0 Critical)

One Medium + suggestions fixed in the second commit:
- **Medium (data integrity):** protected-update proposals rebuilt the body from the
  redacted+truncated **evidence** → now reconstructed from the **store record**
  with consistent field-merge.
- Fail-loud exhaustiveness guards on `applyOp`/`proposeOp`.
- Optional `onError` sink so swallowed execution errors stay observable while the
  audit row stays content-free.

Tests added: protected-update preserves the full untruncated body + untouched
fields; merge partial-failure keeps the replacement and records `failed`. The
auditor confirmed the protected guard, ownership, `curator_note` provenance, and
audit hygiene hold.

All green: core 341, mcp-server 91, cli 51, dashboard 48; lint/typecheck/format clean.

## Next

The §12/§14 scheduler + worker (`enqueueDueMemoryCurationRuns`, input-hash skip,
locking, the `system-memory-curator` actor) that wires gather → prepass → prompt →
LLM client → parse → validate → apply into a run, plus the §7.1/§13 admin cockpit
and wiring `LIBRARIAN_SECRET_KEY` into the server bin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)