### PR TITLE
feat(core): curation run lifecycle transitions (start/complete/fail)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -114,10 +114,12 @@ export {
   createLibrarianStore,
 } from "./store/librarian-store.js";
 export {
+  type CompleteCurationRunInput,
   type CreateCurationRunInput,
   type CurationOperation,
   type CurationRun,
   type CurationStore,
+  type FailCurationRunInput,
   type ListCurationRunsInput,
   type RecordCurationOperationInput,
 } from "./store/curation-store.js";

--- a/packages/core/src/store/curation-store.ts
+++ b/packages/core/src/store/curation-store.ts
@@ -87,12 +87,27 @@ export interface ListCurationRunsInput {
   limit?: number;
 }
 
+export interface CompleteCurationRunInput {
+  summary?: string | null;
+  usage_input_tokens?: number;
+  usage_output_tokens?: number;
+}
+
+export interface FailCurationRunInput {
+  /** A value-free error label (no secrets / untrusted content). */
+  error: string;
+}
+
 export interface CurationStore {
   createCurationRun: (input: CreateCurationRunInput) => CurationRun;
   getCurationRun: (id: string) => CurationRun | null;
   listCurationRuns: (input?: ListCurationRunsInput) => CurationRun[];
   recordCurationOperation: (input: RecordCurationOperationInput) => CurationOperation;
   getCurationOperations: (runId: string) => CurationOperation[];
+  // Lifecycle transitions — direct UPDATEs on the SQLite-authoritative run row.
+  startCurationRun: (id: string) => CurationRun;
+  completeCurationRun: (id: string, input?: CompleteCurationRunInput) => CurationRun;
+  failCurationRun: (id: string, input: FailCurationRunInput) => CurationRun;
 }
 
 interface CurationRunRow {
@@ -271,11 +286,51 @@ export function createCurationStore(deps: { db: DatabaseSync }): CurationStore {
     return rows.map(rowToOperation);
   }
 
+  function requireRun(id: string): CurationRun {
+    const run = getCurationRun(id);
+    if (!run) throw new Error(`No curation run found for id ${id}`);
+    return run;
+  }
+
+  function startCurationRun(id: string): CurationRun {
+    // COALESCE keeps the original started_at if the run is restarted (idempotent).
+    db.prepare(
+      "UPDATE memory_curation_runs SET status = 'running', started_at = COALESCE(started_at, ?) WHERE id = ?",
+    ).run(nowIso(), id);
+    return requireRun(id);
+  }
+
+  function completeCurationRun(id: string, input: CompleteCurationRunInput = {}): CurationRun {
+    db.prepare(
+      `UPDATE memory_curation_runs
+         SET status = 'completed', completed_at = ?, summary = ?,
+             usage_input_tokens = ?, usage_output_tokens = ?
+       WHERE id = ?`,
+    ).run(
+      nowIso(),
+      input.summary ?? null,
+      input.usage_input_tokens ?? 0,
+      input.usage_output_tokens ?? 0,
+      id,
+    );
+    return requireRun(id);
+  }
+
+  function failCurationRun(id: string, input: FailCurationRunInput): CurationRun {
+    db.prepare(
+      "UPDATE memory_curation_runs SET status = 'failed', completed_at = ?, error = ? WHERE id = ?",
+    ).run(nowIso(), input.error, id);
+    return requireRun(id);
+  }
+
   return {
     createCurationRun,
     getCurationRun,
     listCurationRuns,
     recordCurationOperation,
     getCurationOperations,
+    startCurationRun,
+    completeCurationRun,
+    failCurationRun,
   };
 }

--- a/packages/core/tests/store/curation-store.test.ts
+++ b/packages/core/tests/store/curation-store.test.ts
@@ -143,3 +143,62 @@ describe("curation store (memory_curation_runs + operations)", () => {
     expect(reopened.getCurationOperations(run.id)).toHaveLength(1);
   });
 });
+
+describe("curation run lifecycle", () => {
+  let s: Scope | null = null;
+  beforeEach(() => {
+    s = scope();
+  });
+  afterEach(() => {
+    teardown(s);
+    s = null;
+  });
+
+  function newRun() {
+    return s!.store.createCurationRun({
+      trigger: "schedule",
+      visibility: "common",
+      input_hash: "h",
+      project_key: "proj-x",
+    });
+  }
+
+  it("starts a run: running + started_at, idempotent on started_at", () => {
+    const run = newRun();
+    expect(run.status).toBe("pending");
+    const started = s!.store.startCurationRun(run.id);
+    expect(started.status).toBe("running");
+    expect(started.started_at).not.toBeNull();
+    // Starting again keeps the original started_at.
+    const restarted = s!.store.startCurationRun(run.id);
+    expect(restarted.started_at).toBe(started.started_at);
+  });
+
+  it("completes a run with summary + token usage", () => {
+    const run = newRun();
+    s!.store.startCurationRun(run.id);
+    const done = s!.store.completeCurationRun(run.id, {
+      summary: "applied 3, skipped 1",
+      usage_input_tokens: 1200,
+      usage_output_tokens: 300,
+    });
+    expect(done.status).toBe("completed");
+    expect(done.completed_at).not.toBeNull();
+    expect(done.summary).toBe("applied 3, skipped 1");
+    expect(done.usage_input_tokens).toBe(1200);
+    expect(done.usage_output_tokens).toBe(300);
+  });
+
+  it("fails a run with an error + completed_at", () => {
+    const run = newRun();
+    s!.store.startCurationRun(run.id);
+    const failed = s!.store.failCurationRun(run.id, { error: "llm_error: timeout" });
+    expect(failed.status).toBe("failed");
+    expect(failed.error).toBe("llm_error: timeout");
+    expect(failed.completed_at).not.toBeNull();
+  });
+
+  it("throws for an unknown run id", () => {
+    expect(() => s!.store.startCurationRun("run_ghost")).toThrow(/run/i);
+  });
+});


### PR DESCRIPTION
## What

Adds run-lifecycle methods to the curation store so the worker can transition a
run beyond `pending`. Direct-SQL UPDATEs on the SQLite-authoritative
`memory_curation_runs` row — existing columns, **no schema change**:

- `startCurationRun(id)` → `running` + `started_at` (COALESCE, idempotent on restart)
- `completeCurationRun(id, {summary, usage_input_tokens, usage_output_tokens})` →
  `completed` + `completed_at` + run summary + token usage
- `failCurationRun(id, {error})` → `failed` + `completed_at` + a value-free error label

All parameterized; `requireRun` throws on an unknown id.

## Review

Self-reviewed (focused, parameterized CRUD with full test coverage; no schema
change, no injection surface). The worker that composes these with the pipeline
gets the dedicated sub-agent review next.

Tests pin start/complete/fail, the missing-id throw, and start idempotency.
All green: core 345, mcp-server 91, cli 51, dashboard 48; lint/typecheck/format clean.

## Next

The §12/§14 worker: `runCuration(slice)` composing createCurationRun → start →
gather → prepass → prompt → LLM client → parse → validate → apply → complete
(with usage + summary) / fail, as the `system-memory-curator` actor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)