### PR TITLE
feat(core): curator worker — composes the run pipeline (§10 + §12/§14)

### DIFF
--- a/packages/core/src/curator-apply.ts
+++ b/packages/core/src/curator-apply.ts
@@ -31,7 +31,7 @@ interface StoredMemory {
   category: string;
   visibility: string;
   scope: string;
-  project_key: string | null;
+  project_key?: string | null;
   priority: string;
   confidence: string;
   tags: string[];

--- a/packages/core/src/curator-prompt.ts
+++ b/packages/core/src/curator-prompt.ts
@@ -27,6 +27,11 @@ export interface CuratorPromptInput {
   promptAddendum?: string;
 }
 
+// Bump whenever the curator prompt (system instructions or assembly) changes
+// meaningfully. It participates in the run input hash (§10.2) so a prompt change
+// permits a fresh run instead of an idempotency skip.
+export const CURATOR_PROMPT_VERSION = "v1";
+
 const SYSTEM_INSTRUCTIONS = `You are the Memory Curator for The Librarian, a long-term memory store for AI agents.
 
 You operate on ONE slice of memory at a time. Review the EVIDENCE and propose curation operations that improve the store: remove exact duplicates, merge near-duplicates, archive obsolete memories, split overloaded ones, create memories for durable facts evidenced by sessions, and correct stale ones.

--- a/packages/core/src/curator-worker.ts
+++ b/packages/core/src/curator-worker.ts
@@ -17,7 +17,7 @@ import { gatherMemoryEvidence, gatherSessionEvidence } from "./curator-evidence.
 import { LlmClientError, type LlmClient } from "./curator-llm-client.js";
 import { parseCuratorOutput } from "./curator-output.js";
 import { deterministicPrepass } from "./curator-prepass.js";
-import { buildCuratorPrompt } from "./curator-prompt.js";
+import { CURATOR_PROMPT_VERSION, buildCuratorPrompt } from "./curator-prompt.js";
 import { redactSecrets } from "./curator-redaction.js";
 import { validateOperations } from "./curator-validate.js";
 import type { CurationRun } from "./store/curation-store.js";
@@ -81,9 +81,12 @@ export async function runCuration(
     model_provider: options.model.provider,
     model_name: options.model.name,
   });
-  store.startCurationRun(run.id);
 
+  // startCurationRun onward is inside the try so any throw terminalizes the run
+  // (fail) rather than leaving it dangling. createCurationRun is outside: if it
+  // throws there is no run row to fail.
   try {
+    store.startCurationRun(run.id);
     const messages = buildCuratorPrompt({
       memory,
       sessions,
@@ -94,6 +97,8 @@ export async function runCuration(
 
     const parsed = parseCuratorOutput(completion.content);
     if (parsed.parseError) {
+      // Whole-output failure (bad JSON / no operations array) — no usable ops.
+      // Per-operation schema rejects are handled below.
       return store.failCurationRun(run.id, { error: "parse_error" });
     }
     // Schema-rejected operations are recorded as skipped (the reason is value-free).
@@ -145,7 +150,7 @@ function computeInputHash(
 ): string {
   const parts: string[] = [
     `slice:${slice.kind}:${slice.projectKey ?? ""}:${slice.agentId ?? ""}`,
-    "prompt:v1",
+    `prompt:${CURATOR_PROMPT_VERSION}`,
     `addendum:${redactSecrets(addendum).redacted}`,
   ];
   for (const m of [...memory.activeMemories, ...memory.proposedMemories]) {

--- a/packages/core/src/curator-worker.ts
+++ b/packages/core/src/curator-worker.ts
@@ -1,0 +1,161 @@
+// Curator worker (spec §10 pipeline + §12/§14). Composes the curator pieces into
+// a single run over ONE slice:
+//
+//   gather evidence → deterministic pre-pass → build prompt → LLM → parse output
+//   → validate → apply → record run summary.
+//
+// It owns the run lifecycle (create → start → complete/fail) and records token
+// usage. The LLM client is injected (built from the admin config by the caller),
+// so this is fully testable without network. The server-side scheduler that
+// selects due slices, skips by input hash, and locks slices is separate (§12/§14).
+
+import { createHash } from "node:crypto";
+import type { ApplyPolicy } from "./curator-apply-policy.js";
+import { applyOperations } from "./curator-apply.js";
+import type { EvidenceSlice } from "./curator-evidence.js";
+import { gatherMemoryEvidence, gatherSessionEvidence } from "./curator-evidence.js";
+import { LlmClientError, type LlmClient } from "./curator-llm-client.js";
+import { parseCuratorOutput } from "./curator-output.js";
+import { deterministicPrepass } from "./curator-prepass.js";
+import { buildCuratorPrompt } from "./curator-prompt.js";
+import { redactSecrets } from "./curator-redaction.js";
+import { validateOperations } from "./curator-validate.js";
+import type { CurationRun } from "./store/curation-store.js";
+import type { LibrarianStore } from "./store/librarian-store.js";
+
+export interface RunCurationCaps {
+  maxMemories?: number;
+  maxSessions?: number;
+  maxBodyChars?: number;
+  maxEventsPerSession?: number;
+}
+
+export interface RunCurationOptions {
+  store: LibrarianStore;
+  llmClient: LlmClient;
+  /** "schedule" | "manual" | "maintenance" (recorded on the run). */
+  trigger: string;
+  /** Curator actor for common-slice writes (e.g. "system-memory-curator"). */
+  actorId: string;
+  policy: ApplyPolicy;
+  promptAddendum?: string;
+  /** Recorded on the run for observability. */
+  model: { provider: string; name: string };
+  caps?: RunCurationCaps;
+}
+
+const DEFAULT_MAX_MEMORIES = 200;
+const DEFAULT_MAX_SESSIONS = 50;
+
+export async function runCuration(
+  slice: EvidenceSlice,
+  options: RunCurationOptions,
+): Promise<CurationRun> {
+  const { store, caps = {} } = options;
+
+  const memory = gatherMemoryEvidence(store.db, slice, {
+    maxMemories: caps.maxMemories ?? DEFAULT_MAX_MEMORIES,
+    ...(caps.maxBodyChars !== undefined ? { maxBodyChars: caps.maxBodyChars } : {}),
+  });
+  const sessions = gatherSessionEvidence(store.db, slice, {
+    maxSessions: caps.maxSessions ?? DEFAULT_MAX_SESSIONS,
+    ...(caps.maxEventsPerSession !== undefined
+      ? { maxEventsPerSession: caps.maxEventsPerSession }
+      : {}),
+    ...(caps.maxBodyChars !== undefined ? { maxSummaryChars: caps.maxBodyChars } : {}),
+  });
+  const prepass = deterministicPrepass(memory);
+
+  const run = store.createCurationRun({
+    trigger: options.trigger,
+    visibility: slice.kind === "agent_private" ? "agent_private" : "common",
+    project_key: slice.kind === "common_project" ? (slice.projectKey ?? null) : null,
+    agent_id: slice.kind === "agent_private" ? (slice.agentId ?? null) : null,
+    input_hash: computeInputHash(slice, memory, sessions, options.promptAddendum ?? ""),
+    input_memory_ids: [
+      ...memory.activeMemories,
+      ...memory.proposedMemories,
+      ...memory.tombstones,
+    ].map((m) => m.id),
+    input_session_ids: sessions.sessions.map((s) => s.id),
+    model_provider: options.model.provider,
+    model_name: options.model.name,
+  });
+  store.startCurationRun(run.id);
+
+  try {
+    const messages = buildCuratorPrompt({
+      memory,
+      sessions,
+      prepass,
+      ...(options.promptAddendum !== undefined ? { promptAddendum: options.promptAddendum } : {}),
+    });
+    const completion = await options.llmClient.complete({ messages });
+
+    const parsed = parseCuratorOutput(completion.content);
+    if (parsed.parseError) {
+      return store.failCurationRun(run.id, { error: "parse_error" });
+    }
+    // Schema-rejected operations are recorded as skipped (the reason is value-free).
+    for (const rejected of parsed.rejected) {
+      store.recordCurationOperation({
+        run_id: run.id,
+        operation_type: "unknown",
+        status: "skipped",
+        confidence: 0,
+        risk_level: "normal",
+        rationale: `schema: ${rejected.reason}`,
+        proposed_payload: {},
+      });
+    }
+
+    const context = { slice, memory, sessions, prepass };
+    const validated = validateOperations(parsed.operations, context);
+    const summary = applyOperations(validated, context, {
+      store,
+      runId: run.id,
+      actorId: options.actorId,
+      policy: options.policy,
+    });
+
+    return store.completeCurationRun(run.id, {
+      summary: `applied ${summary.applied}, proposed ${summary.proposed}, skipped ${summary.skipped + parsed.rejected.length}, failed ${summary.failed}`,
+      usage_input_tokens: completion.usage?.promptTokens ?? 0,
+      usage_output_tokens: completion.usage?.completionTokens ?? 0,
+    });
+  } catch (error) {
+    return store.failCurationRun(run.id, { error: errorLabel(error) });
+  }
+}
+
+// Value-free error label for the run record — never the error message (which
+// could carry store/content detail).
+function errorLabel(error: unknown): string {
+  return error instanceof LlmClientError ? `llm_${error.kind}` : "error";
+}
+
+// Input hash (§10.2): slice + memory ids/updated/status + tombstone fingerprints
+// + session ids/last-activity + a prompt version + the (redacted) admin addendum,
+// so editing the addendum or any evidence permits a fresh run. Order-independent.
+function computeInputHash(
+  slice: EvidenceSlice,
+  memory: ReturnType<typeof gatherMemoryEvidence>,
+  sessions: ReturnType<typeof gatherSessionEvidence>,
+  addendum: string,
+): string {
+  const parts: string[] = [
+    `slice:${slice.kind}:${slice.projectKey ?? ""}:${slice.agentId ?? ""}`,
+    "prompt:v1",
+    `addendum:${redactSecrets(addendum).redacted}`,
+  ];
+  for (const m of [...memory.activeMemories, ...memory.proposedMemories]) {
+    parts.push(`m:${m.id}:${m.updatedAt}:${m.status}`);
+  }
+  for (const t of memory.tombstones) {
+    parts.push(`t:${t.id}:${t.contentFingerprint}`);
+  }
+  for (const s of sessions.sessions) {
+    parts.push(`s:${s.id}:${s.lastActivityAt}`);
+  }
+  return createHash("sha256").update(parts.sort().join("\n"), "utf8").digest("hex");
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -58,6 +58,7 @@ export {
   type ApplySummary,
   applyOperations,
 } from "./curator-apply.js";
+export { type RunCurationCaps, type RunCurationOptions, runCuration } from "./curator-worker.js";
 export {
   type EvidenceSlice,
   type MemoryEvidenceBundle,

--- a/packages/core/tests/curator-worker.test.ts
+++ b/packages/core/tests/curator-worker.test.ts
@@ -126,6 +126,39 @@ describe("runCuration — happy path", () => {
   });
 });
 
+describe("runCuration — run record + input hash", () => {
+  it("derives the run record fields from the slice (common_project)", async () => {
+    const run = await runCuration(SLICE, options(fakeClient(JSON.stringify({ operations: [] }))));
+    expect(run.visibility).toBe("common");
+    expect(run.project_key).toBe("proj-x");
+    expect(run.agent_id).toBeNull();
+  });
+
+  it("derives the run record fields from the slice (agent_private)", async () => {
+    const slice = { kind: "agent_private" as const, agentId: "agent-a" };
+    const run = await runCuration(slice, {
+      ...options(fakeClient(JSON.stringify({ operations: [] }))),
+    });
+    expect(run.visibility).toBe("agent_private");
+    expect(run.agent_id).toBe("agent-a");
+    expect(run.project_key).toBeNull();
+  });
+
+  it("changes the input hash when the prompt addendum changes, without leaking a secret", async () => {
+    const empty = JSON.stringify({ operations: [] });
+    const base = await runCuration(SLICE, {
+      ...options(fakeClient(empty)),
+      promptAddendum: "prefer merging",
+    });
+    const changed = await runCuration(SLICE, {
+      ...options(fakeClient(empty)),
+      promptAddendum: 'prefer merging; token = "FAKEHASHSECRET"',
+    });
+    expect(changed.input_hash).not.toBe(base.input_hash);
+    expect(changed.input_hash).not.toContain("FAKEHASHSECRET"); // hash is opaque + redacted
+  });
+});
+
 describe("runCuration — failure paths leave memory untouched", () => {
   it("fails the run with a value-free label on an LLM error", async () => {
     const m = seed();

--- a/packages/core/tests/curator-worker.test.ts
+++ b/packages/core/tests/curator-worker.test.ts
@@ -1,0 +1,151 @@
+// Curator worker (spec §10 pipeline + §12/§14) — end-to-end over a real store
+// with an INJECTED fake LLM client (no network). Pins that a run threads
+// gather → prepass → prompt → parse → validate → apply and records its lifecycle.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type ApplyPolicy,
+  type LibrarianStore,
+  type LlmClient,
+  type LlmCompletion,
+  LlmClientError,
+  createLibrarianStore,
+  runCuration,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+interface Scope {
+  store: LibrarianStore;
+  dataDir: string;
+}
+
+let s: Scope | null = null;
+
+beforeEach(() => {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-worker-"));
+  s = { store: createLibrarianStore({ dataDir }), dataDir };
+});
+afterEach(() => {
+  if (!s) return;
+  try {
+    s.store.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(s.dataDir, { recursive: true, force: true });
+  s = null;
+});
+
+function seed(over: Record<string, unknown> = {}) {
+  return s!.store.createMemory({
+    agent_id: "agent-a",
+    title: "title",
+    body: "body",
+    category: "lessons",
+    visibility: "common",
+    scope: "project",
+    project_key: "proj-x",
+    priority: "normal",
+    confidence: "working",
+    ...over,
+  }).memory;
+}
+
+/** A fake LLM client returning a canned completion. */
+function fakeClient(content: string, usage?: LlmCompletion["usage"]): LlmClient {
+  return { complete: async () => ({ content, model: "gpt-x", usage: usage ?? null }) };
+}
+
+const SLICE = { kind: "common_project" as const, projectKey: "proj-x" };
+
+function options(llmClient: LlmClient, level: ApplyPolicy["level"] = "safe_only") {
+  return {
+    store: s!.store,
+    llmClient,
+    trigger: "manual",
+    actorId: "system-memory-curator",
+    policy: { level, confidenceThreshold: 0.9 },
+    model: { provider: "openai", name: "gpt-x" },
+  };
+}
+
+describe("runCuration — happy path", () => {
+  it("threads the pipeline and auto-applies a safe duplicate archive", async () => {
+    const dupA = seed({ title: "Dup", body: "same body" });
+    const dupB = seed({ title: "Dup", body: "same body" });
+    const client = fakeClient(
+      JSON.stringify({
+        operations: [
+          {
+            type: "archive",
+            source_memory_ids: [dupB.id],
+            rationale: "exact duplicate of the other",
+            confidence: 0.95,
+          },
+        ],
+      }),
+      { promptTokens: 100, completionTokens: 20, totalTokens: 120 },
+    );
+
+    const run = await runCuration(SLICE, options(client));
+
+    expect(run.status).toBe("completed");
+    expect(s!.store.getMemory(dupB.id)?.status).toBe("archived");
+    expect(s!.store.getMemory(dupA.id)?.status).toBe("active"); // only the cited dup
+    expect(run.summary).toContain("applied 1");
+    expect(run.usage_input_tokens).toBe(100);
+    expect(run.usage_output_tokens).toBe(20);
+    expect(run.input_hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(run.model_name).toBe("gpt-x");
+
+    const recorded = s!.store.getCurationOperations(run.id);
+    expect(recorded.some((o) => o.operation_type === "archive" && o.status === "applied")).toBe(
+      true,
+    );
+  });
+
+  it("records schema-rejected operations as skipped without aborting the run", async () => {
+    const m = seed();
+    const client = fakeClient(
+      JSON.stringify({
+        operations: [
+          { type: "not_a_real_type", source_memory_ids: [m.id], rationale: "x", confidence: 1 },
+          { type: "noop", source_memory_ids: [], rationale: "nothing", confidence: 0.5 },
+        ],
+      }),
+    );
+
+    const run = await runCuration(SLICE, options(client));
+    expect(run.status).toBe("completed");
+    const recorded = s!.store.getCurationOperations(run.id);
+    expect(recorded.some((o) => o.status === "skipped" && o.rationale.startsWith("schema:"))).toBe(
+      true,
+    );
+  });
+});
+
+describe("runCuration — failure paths leave memory untouched", () => {
+  it("fails the run with a value-free label on an LLM error", async () => {
+    const m = seed();
+    const client: LlmClient = {
+      complete: async () => {
+        throw new LlmClientError("network", "connection refused to 10.0.0.1");
+      },
+    };
+
+    const run = await runCuration(SLICE, options(client));
+    expect(run.status).toBe("failed");
+    expect(run.error).toBe("llm_network"); // value-free, no host/detail
+    expect(s!.store.getMemory(m.id)?.status).toBe("active");
+  });
+
+  it("fails the run on unparseable output", async () => {
+    const m = seed();
+    const run = await runCuration(SLICE, options(fakeClient("this is not json at all")));
+    expect(run.status).toBe("failed");
+    expect(run.error).toBe("parse_error");
+    expect(s!.store.getMemory(m.id)?.status).toBe("active");
+  });
+});


### PR DESCRIPTION
## What

`runCuration(slice, options)` threads the whole curator over one slice and owns
the run lifecycle:

```
createRun → start → gather (memory + session) → pre-pass → build prompt
  → LLM client → parse → validate → apply → complete / fail
```

- Run record derives visibility/project/agent from the **slice** (not caller
  input), records the input id sets + model, and an **input hash** (§10.2: slice +
  memory id/updated/status + tombstone fingerprints + session id/last-activity +
  prompt version + redacted addendum; order-independent) so an addendum/evidence
  change permits a fresh run.
- Schema-rejected ops → recorded skipped (value-free reason); whole-output parse
  failure → run fails `parse_error`; any LLM/unexpected error → run fails with a
  value-free `llm_<kind>` label (never the message) and memory is untouched.
- LLM client is **injected**, so the pipeline is fully testable without network.
  Server-side scheduling/locking/skip is the next, separate increment.

## Review (code-reviewer — verdict: APPROVE)

One Important fixed: `startCurationRun` sat outside the try, so a throw there
could leave a run dangling — moved inside the try so every throw terminalizes the
run as failed (`createCurationRun` stays outside: no row to fail if it throws).
Plus: coupled the hash's prompt version to an exported `CURATOR_PROMPT_VERSION`.
Tests added for slice→run-record derivation (both slice kinds) and the
addendum→input-hash change (no secret leak). The reviewer confirmed value-free
error containment, order-independent hashing, `exactOptionalPropertyTypes`
spreads, null-usage handling, and isolation-by-delegation.

End-to-end tested with an injected fake client. All green: core 352, mcp-server
91, cli 51, dashboard 48; lint/typecheck/format clean.

## Next

The §12/§14 server-side scheduler/worker job: due-slice selection, input-hash
skip (don't re-run an identical completed apply-run), slice locking, and the
`system-memory-curator` actor — wiring `runCuration` into the trusted server
boundary. Then the §7.1/§13 admin cockpit + `LIBRARIAN_SECRET_KEY` in the bin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)