### PR TITLE
feat(core): curator schedule gating (interval + self-gate)

### DIFF
--- a/packages/core/src/curator-schedule.ts
+++ b/packages/core/src/curator-schedule.ts
@@ -1,0 +1,93 @@
+// Curator schedule gating (spec §14 + §7.2). Pure helpers the scheduler uses to
+// decide whether a slice is due to run:
+//
+//   - the INTERVAL — every N days at HH:MM, computed from the last completed run
+//     (default every 1 day at 03:00, §7.1);
+//   - SELF-GATING — even when the interval is due, run only if enough new sessions
+//     accumulated (min_sessions_since_run) OR it has been too long (max_days_since_run,
+//     forces at least weekly). An idle store therefore produces no run and no LLM
+//     cost (§7.2).
+//
+// Times are interpreted in UTC for v1; deployment-timezone handling is a wiring
+// concern for the server-side scheduler (it can pass a tz-adjusted `now`).
+
+export interface ScheduleConfig {
+  /** Whole days between runs (≥ 1). */
+  intervalDays: number;
+  /** Time of day "HH:MM" (24-hour) the run becomes due. */
+  time: string;
+  /** Minimum new sessions since the last run to run at all (self-gate floor). */
+  minSessions: number;
+  /** Maximum days since the last run before a run is forced regardless of sessions. */
+  maxDays: number;
+}
+
+export interface SliceState {
+  /** When the slice's last run completed, or null if it has never run. */
+  lastCompletedAt: Date | null;
+  /** New sessions in the slice since the last completed run. */
+  newSessionCount: number;
+}
+
+export type DueReason =
+  | "interval_not_reached"
+  | "never_run"
+  | "min_sessions"
+  | "max_days"
+  | "self_gated";
+
+export interface DueDecision {
+  due: boolean;
+  reason: DueReason;
+}
+
+const MS_PER_DAY = 86_400_000;
+
+/** The next scheduled run time: last-completed + intervalDays, set to HH:MM (UTC). */
+export function nextScheduledRun(lastCompletedAt: Date, intervalDays: number, time: string): Date {
+  const [hours, minutes] = parseTime(time);
+  const next = new Date(lastCompletedAt.getTime());
+  next.setUTCDate(next.getUTCDate() + intervalDays);
+  next.setUTCHours(hours, minutes, 0, 0);
+  return next;
+}
+
+/** Has the interval elapsed? A slice that has never run is always interval-due. */
+export function isIntervalDue(
+  now: Date,
+  lastCompletedAt: Date | null,
+  config: ScheduleConfig,
+): boolean {
+  if (lastCompletedAt === null) return true;
+  return (
+    now.getTime() >= nextScheduledRun(lastCompletedAt, config.intervalDays, config.time).getTime()
+  );
+}
+
+/**
+ * Decide whether a slice should run now: the interval must be due AND the
+ * self-gate must pass (enough new sessions, or max_days forces it). Returns the
+ * gating reason for observability.
+ */
+export function isSliceDue(now: Date, state: SliceState, config: ScheduleConfig): DueDecision {
+  if (!isIntervalDue(now, state.lastCompletedAt, config)) {
+    return { due: false, reason: "interval_not_reached" };
+  }
+  if (state.lastCompletedAt === null) {
+    return { due: true, reason: "never_run" };
+  }
+  const daysSince = (now.getTime() - state.lastCompletedAt.getTime()) / MS_PER_DAY;
+  if (daysSince >= config.maxDays) return { due: true, reason: "max_days" };
+  if (state.newSessionCount >= config.minSessions) return { due: true, reason: "min_sessions" };
+  return { due: false, reason: "self_gated" };
+}
+
+function parseTime(time: string): [number, number] {
+  const [h, m] = time.split(":");
+  const hours = Number(h);
+  const minutes = Number(m);
+  if (!Number.isInteger(hours) || !Number.isInteger(minutes)) {
+    throw new Error(`invalid schedule time: ${time}`);
+  }
+  return [hours, minutes];
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -60,6 +60,15 @@ export {
 } from "./curator-apply.js";
 export { type RunCurationCaps, type RunCurationOptions, runCuration } from "./curator-worker.js";
 export {
+  type DueDecision,
+  type DueReason,
+  type ScheduleConfig,
+  type SliceState,
+  isIntervalDue,
+  isSliceDue,
+  nextScheduledRun,
+} from "./curator-schedule.js";
+export {
   type EvidenceSlice,
   type MemoryEvidenceBundle,
   type MemoryEvidenceCaps,

--- a/packages/core/tests/curator-schedule.test.ts
+++ b/packages/core/tests/curator-schedule.test.ts
@@ -1,0 +1,94 @@
+// Curator schedule gating (spec §14 + §7.2). Pure logic the scheduler uses to
+// decide whether a slice is due: the interval (every N days at HH:MM, computed
+// from the last completed run) plus self-gating on min_sessions_since_run /
+// max_days_since_run, so an idle store produces no run (and no LLM cost) even
+// when the interval comes due.
+
+import { type ScheduleConfig, isIntervalDue, isSliceDue, nextScheduledRun } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+const d = (iso: string) => new Date(iso);
+const config = (over: Partial<ScheduleConfig> = {}): ScheduleConfig => ({
+  intervalDays: 1,
+  time: "03:00",
+  minSessions: 10,
+  maxDays: 7,
+  ...over,
+});
+
+describe("nextScheduledRun", () => {
+  it("is last-completed + intervalDays at the configured time", () => {
+    expect(nextScheduledRun(d("2026-05-23T03:05:00Z"), 1, "03:00").toISOString()).toBe(
+      "2026-05-24T03:00:00.000Z",
+    );
+    expect(nextScheduledRun(d("2026-05-20T23:00:00Z"), 3, "06:30").toISOString()).toBe(
+      "2026-05-23T06:30:00.000Z",
+    );
+  });
+});
+
+describe("isIntervalDue", () => {
+  it("is due when never run", () => {
+    expect(isIntervalDue(d("2026-05-24T00:00:00Z"), null, config())).toBe(true);
+  });
+  it("is not due before the next scheduled time", () => {
+    expect(isIntervalDue(d("2026-05-24T02:59:00Z"), d("2026-05-23T03:00:00Z"), config())).toBe(
+      false,
+    );
+  });
+  it("is due at/after the next scheduled time", () => {
+    expect(isIntervalDue(d("2026-05-24T03:00:00Z"), d("2026-05-23T03:00:00Z"), config())).toBe(
+      true,
+    );
+    expect(isIntervalDue(d("2026-05-24T09:00:00Z"), d("2026-05-23T03:00:00Z"), config())).toBe(
+      true,
+    );
+  });
+});
+
+describe("isSliceDue", () => {
+  it("not due when the interval has not been reached", () => {
+    const decision = isSliceDue(
+      d("2026-05-24T02:00:00Z"),
+      { lastCompletedAt: d("2026-05-23T03:00:00Z"), newSessionCount: 100 },
+      config(),
+    );
+    expect(decision).toEqual({ due: false, reason: "interval_not_reached" });
+  });
+
+  it("due on first run (never run)", () => {
+    const decision = isSliceDue(
+      d("2026-05-24T03:00:00Z"),
+      { lastCompletedAt: null, newSessionCount: 0 },
+      config(),
+    );
+    expect(decision).toEqual({ due: true, reason: "never_run" });
+  });
+
+  it("due when enough new sessions accumulated", () => {
+    const decision = isSliceDue(
+      d("2026-05-24T03:00:00Z"),
+      { lastCompletedAt: d("2026-05-23T03:00:00Z"), newSessionCount: 12 },
+      config({ minSessions: 10 }),
+    );
+    expect(decision).toEqual({ due: true, reason: "min_sessions" });
+  });
+
+  it("self-gates when the interval is due but too few new sessions", () => {
+    const decision = isSliceDue(
+      d("2026-05-24T03:00:00Z"),
+      { lastCompletedAt: d("2026-05-23T03:00:00Z"), newSessionCount: 2 },
+      config({ minSessions: 10, maxDays: 7 }),
+    );
+    expect(decision).toEqual({ due: false, reason: "self_gated" });
+  });
+
+  it("forces a run past max_days even with too few sessions", () => {
+    const decision = isSliceDue(
+      d("2026-05-31T03:00:00Z"),
+      { lastCompletedAt: d("2026-05-23T03:00:00Z"), newSessionCount: 0 },
+      config({ minSessions: 10, maxDays: 7 }),
+    );
+    expect(decision).toEqual({ due: true, reason: "max_days" });
+  });
+});


### PR DESCRIPTION
## What

Pure scheduling helpers the §14 scheduler will use to decide whether a slice is
due to run:

- `nextScheduledRun(lastCompletedAt, intervalDays, time)` — last-completed +
  intervalDays at `HH:MM` (UTC for v1; deployment-timezone is a server-wiring
  concern).
- `isIntervalDue(now, lastCompletedAt | null, config)` — never-run is always due;
  otherwise `now >= nextScheduledRun`.
- `isSliceDue(now, state, config)` — the interval must be due **and** the self-gate
  must pass: enough new sessions (`min_sessions_since_run`) **or** too long since
  the last run (`max_days_since_run` forces ≥ weekly). An idle store self-gates →
  no run, no LLM cost (§7.2). Returns a `DueReason` for observability
  (`interval_not_reached` / `never_run` / `min_sessions` / `max_days` /
  `self_gated`).

No agent activity can start a run — the clock decides the interval and the gate
keys off completed-run timing + session counts (§12: clock/admin/maintenance only).

## Review

Self-reviewed: pure UTC date math, `parseTime` throws on a malformed time,
interval+self-gate layering matches §7.2/§14. 9 tests cover `nextScheduledRun`,
all `isIntervalDue` branches, and every `isSliceDue` reason. All green: core 361,
mcp-server 91, cli 51, dashboard 48; lint/typecheck/format clean.

## Next

The input-hash skip (a curation-store query for an identical completed apply-run)
+ the server-side `enqueueDueMemoryCurationRuns` / scheduler tick + slice locking
in mcp-server, wiring `runCuration` + this gating behind the trusted boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)