### PR TITLE
feat(core): input-hash idempotency skip for curation runs (§10.2)

### DIFF
--- a/packages/core/src/curator-worker.ts
+++ b/packages/core/src/curator-worker.ts
@@ -42,15 +42,23 @@ export interface RunCurationOptions {
   /** Recorded on the run for observability. */
   model: { provider: string; name: string };
   caps?: RunCurationCaps;
+  /** manual/maintenance runs may bypass the input-hash idempotency skip (§10.2). */
+  bypassSkip?: boolean;
 }
 
 const DEFAULT_MAX_MEMORIES = 200;
 const DEFAULT_MAX_SESSIONS = 50;
 
+/**
+ * Run one curation pass over a slice. Returns the run record, or null when the
+ * run was skipped by input-hash idempotency (an identical completed apply-run
+ * already exists and the trigger didn't bypass it, §10.2) — no run is created
+ * and no LLM call is made.
+ */
 export async function runCuration(
   slice: EvidenceSlice,
   options: RunCurationOptions,
-): Promise<CurationRun> {
+): Promise<CurationRun | null> {
   const { store, caps = {} } = options;
 
   const memory = gatherMemoryEvidence(store.db, slice, {
@@ -66,12 +74,20 @@ export async function runCuration(
   });
   const prepass = deterministicPrepass(memory);
 
+  // §10.2 idempotency: skip if an identical completed apply-run exists, unless a
+  // manual/maintenance trigger explicitly bypasses. Checked BEFORE creating a run
+  // or calling the LLM, so a no-op tick costs nothing.
+  const inputHash = computeInputHash(slice, memory, sessions, options.promptAddendum ?? "");
+  if (!options.bypassSkip && store.findCompletedApplyRun(inputHash)) {
+    return null;
+  }
+
   const run = store.createCurationRun({
     trigger: options.trigger,
     visibility: slice.kind === "agent_private" ? "agent_private" : "common",
     project_key: slice.kind === "common_project" ? (slice.projectKey ?? null) : null,
     agent_id: slice.kind === "agent_private" ? (slice.agentId ?? null) : null,
-    input_hash: computeInputHash(slice, memory, sessions, options.promptAddendum ?? ""),
+    input_hash: inputHash,
     input_memory_ids: [
       ...memory.activeMemories,
       ...memory.proposedMemories,

--- a/packages/core/src/store/curation-store.ts
+++ b/packages/core/src/store/curation-store.ts
@@ -101,6 +101,8 @@ export interface FailCurationRunInput {
 export interface CurationStore {
   createCurationRun: (input: CreateCurationRunInput) => CurationRun;
   getCurationRun: (id: string) => CurationRun | null;
+  /** Latest completed apply-mode run with this input hash, for §10.2 idempotency. */
+  findCompletedApplyRun: (inputHash: string) => CurationRun | null;
   listCurationRuns: (input?: ListCurationRunsInput) => CurationRun[];
   recordCurationOperation: (input: RecordCurationOperationInput) => CurationOperation;
   getCurationOperations: (runId: string) => CurationOperation[];
@@ -229,6 +231,19 @@ export function createCurationStore(deps: { db: DatabaseSync }): CurationStore {
     return row ? rowToRun(row) : null;
   }
 
+  function findCompletedApplyRun(inputHash: string): CurationRun | null {
+    // Only completed APPLY runs satisfy idempotency; dry-runs and in-flight runs
+    // must not suppress a real run (§10.2).
+    const row = db
+      .prepare(
+        `SELECT * FROM memory_curation_runs
+         WHERE input_hash = ? AND mode = 'apply' AND status = 'completed'
+         ORDER BY created_at DESC LIMIT 1`,
+      )
+      .get(inputHash) as CurationRunRow | undefined;
+    return row ? rowToRun(row) : null;
+  }
+
   function listCurationRuns(input: ListCurationRunsInput = {}): CurationRun[] {
     const clauses: string[] = [];
     const params: string[] = [];
@@ -326,6 +341,7 @@ export function createCurationStore(deps: { db: DatabaseSync }): CurationStore {
   return {
     createCurationRun,
     getCurationRun,
+    findCompletedApplyRun,
     listCurationRuns,
     recordCurationOperation,
     getCurationOperations,

--- a/packages/core/tests/curator-worker.test.ts
+++ b/packages/core/tests/curator-worker.test.ts
@@ -60,6 +60,15 @@ function fakeClient(content: string, usage?: LlmCompletion["usage"]): LlmClient 
 
 const SLICE = { kind: "common_project" as const, projectKey: "proj-x" };
 
+/** runCuration, asserting it wasn't skipped (the common case in these tests). */
+async function runOk(
+  ...args: Parameters<typeof runCuration>
+): Promise<NonNullable<Awaited<ReturnType<typeof runCuration>>>> {
+  const run = await runCuration(...args);
+  if (!run) throw new Error("expected a run, got an input-hash skip");
+  return run;
+}
+
 function options(llmClient: LlmClient, level: ApplyPolicy["level"] = "safe_only") {
   return {
     store: s!.store,
@@ -89,7 +98,7 @@ describe("runCuration — happy path", () => {
       { promptTokens: 100, completionTokens: 20, totalTokens: 120 },
     );
 
-    const run = await runCuration(SLICE, options(client));
+    const run = await runOk(SLICE, options(client));
 
     expect(run.status).toBe("completed");
     expect(s!.store.getMemory(dupB.id)?.status).toBe("archived");
@@ -117,7 +126,7 @@ describe("runCuration — happy path", () => {
       }),
     );
 
-    const run = await runCuration(SLICE, options(client));
+    const run = await runOk(SLICE, options(client));
     expect(run.status).toBe("completed");
     const recorded = s!.store.getCurationOperations(run.id);
     expect(recorded.some((o) => o.status === "skipped" && o.rationale.startsWith("schema:"))).toBe(
@@ -128,7 +137,7 @@ describe("runCuration — happy path", () => {
 
 describe("runCuration — run record + input hash", () => {
   it("derives the run record fields from the slice (common_project)", async () => {
-    const run = await runCuration(SLICE, options(fakeClient(JSON.stringify({ operations: [] }))));
+    const run = await runOk(SLICE, options(fakeClient(JSON.stringify({ operations: [] }))));
     expect(run.visibility).toBe("common");
     expect(run.project_key).toBe("proj-x");
     expect(run.agent_id).toBeNull();
@@ -136,7 +145,7 @@ describe("runCuration — run record + input hash", () => {
 
   it("derives the run record fields from the slice (agent_private)", async () => {
     const slice = { kind: "agent_private" as const, agentId: "agent-a" };
-    const run = await runCuration(slice, {
+    const run = await runOk(slice, {
       ...options(fakeClient(JSON.stringify({ operations: [] }))),
     });
     expect(run.visibility).toBe("agent_private");
@@ -146,16 +155,39 @@ describe("runCuration — run record + input hash", () => {
 
   it("changes the input hash when the prompt addendum changes, without leaking a secret", async () => {
     const empty = JSON.stringify({ operations: [] });
-    const base = await runCuration(SLICE, {
+    const base = await runOk(SLICE, {
       ...options(fakeClient(empty)),
       promptAddendum: "prefer merging",
     });
-    const changed = await runCuration(SLICE, {
+    const changed = await runOk(SLICE, {
       ...options(fakeClient(empty)),
       promptAddendum: 'prefer merging; token = "FAKEHASHSECRET"',
     });
     expect(changed.input_hash).not.toBe(base.input_hash);
     expect(changed.input_hash).not.toContain("FAKEHASHSECRET"); // hash is opaque + redacted
+  });
+});
+
+describe("runCuration — input-hash idempotency (§10.2)", () => {
+  it("skips a scheduled re-run with an identical input hash, but a bypass runs again", async () => {
+    seed(); // some evidence; the LLM does nothing so the evidence (and hash) is stable
+    const noOp = () => fakeClient(JSON.stringify({ operations: [] }));
+
+    const first = await runOk(SLICE, { ...options(noOp()), trigger: "schedule" });
+    expect(first.status).toBe("completed");
+
+    // Same evidence → same input hash → a scheduled re-run is skipped (null, no run).
+    const skipped = await runCuration(SLICE, { ...options(noOp()), trigger: "schedule" });
+    expect(skipped).toBeNull();
+
+    // A manual/maintenance trigger may bypass the skip.
+    const bypassed = await runCuration(SLICE, {
+      ...options(noOp()),
+      trigger: "manual",
+      bypassSkip: true,
+    });
+    expect(bypassed).not.toBeNull();
+    expect(bypassed!.id).not.toBe(first.id);
   });
 });
 
@@ -168,7 +200,7 @@ describe("runCuration — failure paths leave memory untouched", () => {
       },
     };
 
-    const run = await runCuration(SLICE, options(client));
+    const run = await runOk(SLICE, options(client));
     expect(run.status).toBe("failed");
     expect(run.error).toBe("llm_network"); // value-free, no host/detail
     expect(s!.store.getMemory(m.id)?.status).toBe("active");
@@ -176,7 +208,7 @@ describe("runCuration — failure paths leave memory untouched", () => {
 
   it("fails the run on unparseable output", async () => {
     const m = seed();
-    const run = await runCuration(SLICE, options(fakeClient("this is not json at all")));
+    const run = await runOk(SLICE, options(fakeClient("this is not json at all")));
     expect(run.status).toBe("failed");
     expect(run.error).toBe("parse_error");
     expect(s!.store.getMemory(m.id)?.status).toBe("active");

--- a/packages/core/tests/store/curation-store.test.ts
+++ b/packages/core/tests/store/curation-store.test.ts
@@ -201,4 +201,30 @@ describe("curation run lifecycle", () => {
   it("throws for an unknown run id", () => {
     expect(() => s!.store.startCurationRun("run_ghost")).toThrow(/run/i);
   });
+
+  it("findCompletedApplyRun matches only completed apply-mode runs", () => {
+    const { store } = s!;
+    // pending apply run → not a match
+    store.createCurationRun({ trigger: "schedule", visibility: "common", input_hash: "h1" });
+    expect(store.findCompletedApplyRun("h1")).toBeNull();
+
+    // completed DRY-RUN → not a match (dry-runs don't satisfy idempotency)
+    const dry = store.createCurationRun({
+      trigger: "manual",
+      visibility: "common",
+      input_hash: "h2",
+      mode: "dry_run",
+    });
+    store.completeCurationRun(dry.id);
+    expect(store.findCompletedApplyRun("h2")).toBeNull();
+
+    // completed apply run → a match
+    const run = store.createCurationRun({
+      trigger: "schedule",
+      visibility: "common",
+      input_hash: "h3",
+    });
+    store.completeCurationRun(run.id);
+    expect(store.findCompletedApplyRun("h3")?.id).toBe(run.id);
+  });
 });


### PR DESCRIPTION
## What

- **curation-store** `findCompletedApplyRun(inputHash)` — the latest **completed,
  apply-mode** run with a given input hash. Dry-runs and in-flight runs never
  satisfy idempotency.
- **worker** — `runCuration` computes the input hash up front and, unless the
  trigger bypasses (manual/maintenance via `bypassSkip`), returns **null** —
  creating no run and making **no LLM call** — when an identical completed
  apply-run already exists (§10.2). A scheduled tick over unchanged evidence is
  free.

`runCuration`'s return type widens to `CurationRun | null` (null = skipped).

## Review

Self-reviewed: the query filters `mode='apply' AND status='completed'`; the worker
checks before any run creation or LLM cost; manual/maintenance bypass. Tests cover
the scheduled-skip (null) + bypass (new run) path end-to-end and the
`findCompletedApplyRun` filter edges (pending and dry-run excluded).

All green: core 363, mcp-server 91, cli 51, dashboard 48; lint/typecheck/format clean.

## Next

The mcp-server internal job: `enqueueDueMemoryCurationRuns` / scheduler tick that
selects due slices (using `isSliceDue`), runs them via `runCuration` as the
`system-memory-curator` actor behind the trusted boundary, with slice locking.
Then the §7.1/§13 admin cockpit + `LIBRARIAN_SECRET_KEY` bin wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)