### PR TITLE
feat(core): candidate-slice enumeration for the curator scheduler

### DIFF
--- a/packages/core/src/curator-evidence.ts
+++ b/packages/core/src/curator-evidence.ts
@@ -22,6 +22,55 @@ import { SessionPayloadType } from "./schemas/common.js";
 
 export type SliceKind = "common_project" | "common_global" | "agent_private";
 
+/**
+ * Enumerate the candidate slices that have curatable content (§9): the common
+ * global slice (project-less common), one common_project per distinct project,
+ * and one agent_private per distinct owning agent. Drawn from BOTH memories
+ * (active/proposed — archived-only slices have nothing to curate) and sessions
+ * (so a slice with sessions but no memories yet can still have memories created).
+ * The scheduler then applies due-gating (§14) to this set.
+ */
+export function listCuratorSlices(db: DatabaseSync): EvidenceSlice[] {
+  const slices: EvidenceSlice[] = [];
+
+  const hasGlobal =
+    db
+      .prepare(
+        "SELECT 1 FROM memories WHERE visibility = 'common' AND status != 'archived' AND project_key IS NULL LIMIT 1",
+      )
+      .get() ??
+    db
+      .prepare("SELECT 1 FROM sessions WHERE visibility = 'common' AND project_key IS NULL LIMIT 1")
+      .get();
+  if (hasGlobal) slices.push({ kind: "common_global" });
+
+  for (const projectKey of distinctValues(db, [
+    "SELECT DISTINCT project_key AS v FROM memories WHERE visibility = 'common' AND status != 'archived' AND project_key IS NOT NULL",
+    "SELECT DISTINCT project_key AS v FROM sessions WHERE visibility = 'common' AND project_key IS NOT NULL",
+  ])) {
+    slices.push({ kind: "common_project", projectKey });
+  }
+
+  for (const agentId of distinctValues(db, [
+    "SELECT DISTINCT agent_id AS v FROM memories WHERE visibility = 'agent_private' AND status != 'archived' AND agent_id IS NOT NULL",
+    "SELECT DISTINCT created_by_agent_id AS v FROM sessions WHERE visibility = 'agent_private' AND created_by_agent_id IS NOT NULL",
+  ])) {
+    slices.push({ kind: "agent_private", agentId });
+  }
+
+  return slices;
+}
+
+function distinctValues(db: DatabaseSync, queries: string[]): string[] {
+  const values = new Set<string>();
+  for (const query of queries) {
+    for (const row of db.prepare(query).all() as unknown as { v: string | null }[]) {
+      if (row.v) values.add(row.v);
+    }
+  }
+  return [...values].sort();
+}
+
 export interface EvidenceSlice {
   kind: SliceKind;
   /** Required for `common_project`. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -81,6 +81,7 @@ export {
   type TombstoneItem,
   gatherMemoryEvidence,
   gatherSessionEvidence,
+  listCuratorSlices,
 } from "./curator-evidence.js";
 export {
   type LlmClient,

--- a/packages/core/tests/curator-slices.test.ts
+++ b/packages/core/tests/curator-slices.test.ts
@@ -1,0 +1,106 @@
+// Candidate-slice enumeration for the curator scheduler (spec §9 + §14): which
+// slices have curatable content, drawn from memories (active/proposed) and
+// sessions, before due-gating is applied.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { type LibrarianStore, createLibrarianStore, listCuratorSlices } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let store: LibrarianStore | null = null;
+let dataDir = "";
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-slices-"));
+  store = createLibrarianStore({ dataDir });
+});
+afterEach(() => {
+  try {
+    store?.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  store = null;
+});
+
+function mem(over: Record<string, unknown>, options: Record<string, unknown> = {}) {
+  return store!.createMemory(
+    {
+      agent_id: "agent-a",
+      title: "t",
+      body: "b",
+      category: "lessons",
+      visibility: "common",
+      scope: "project",
+      priority: "normal",
+      confidence: "working",
+      ...over,
+    },
+    options,
+  ).memory;
+}
+
+describe("listCuratorSlices", () => {
+  it("returns nothing for an empty store", () => {
+    expect(listCuratorSlices(store!.db)).toEqual([]);
+  });
+
+  it("enumerates the global slice, common projects, and private agents", () => {
+    mem({ scope: "global", project_key: undefined }); // common global
+    mem({ project_key: "proj-x" }); // common project x
+    mem({ project_key: "proj-y" }); // common project y
+    mem({
+      visibility: "agent_private",
+      agent_id: "agent-a",
+      scope: "global",
+      project_key: undefined,
+    });
+    mem({
+      visibility: "agent_private",
+      agent_id: "agent-b",
+      scope: "global",
+      project_key: undefined,
+    });
+
+    const slices = listCuratorSlices(store!.db);
+    expect(slices).toContainEqual({ kind: "common_global" });
+    expect(slices).toContainEqual({ kind: "common_project", projectKey: "proj-x" });
+    expect(slices).toContainEqual({ kind: "common_project", projectKey: "proj-y" });
+    expect(slices).toContainEqual({ kind: "agent_private", agentId: "agent-a" });
+    expect(slices).toContainEqual({ kind: "agent_private", agentId: "agent-b" });
+  });
+
+  it("excludes a project whose only memory is archived", () => {
+    const m = mem({ project_key: "proj-dead" });
+    store!.archiveMemory(m.id);
+    const projects = listCuratorSlices(store!.db).filter((s) => s.kind === "common_project");
+    expect(projects).not.toContainEqual({ kind: "common_project", projectKey: "proj-dead" });
+  });
+
+  it("enumerates a project that has only a session (no memories yet)", () => {
+    store!.startSession({ title: "s", project_key: "proj-sessiononly", visibility: "common" });
+    expect(listCuratorSlices(store!.db)).toContainEqual({
+      kind: "common_project",
+      projectKey: "proj-sessiononly",
+    });
+  });
+
+  it("enumerates an agent_private slice from a private session owner", () => {
+    store!.startSession({ title: "s", visibility: "agent_private", agent_id: "agent-priv" });
+    expect(listCuratorSlices(store!.db)).toContainEqual({
+      kind: "agent_private",
+      agentId: "agent-priv",
+    });
+  });
+
+  it("is deterministically ordered", () => {
+    mem({ project_key: "proj-b" });
+    mem({ project_key: "proj-a" });
+    const projectKeys = listCuratorSlices(store!.db)
+      .filter((s) => s.kind === "common_project")
+      .map((s) => (s.kind === "common_project" ? s.projectKey : ""));
+    expect(projectKeys).toEqual(["proj-a", "proj-b"]);
+  });
+});


### PR DESCRIPTION
## What

`listCuratorSlices(db)` returns the slices that have curatable content (§9/§14):
the common global slice (project-less common), one `common_project` per distinct
project, and one `agent_private` per distinct owning agent.

- Drawn from **both** memories (active/proposed — an archived-only slice has
  nothing to curate, so it's excluded) and sessions (so a slice with sessions but
  no memories yet can still have memories created from them).
- agent_private agents come from memory `agent_id` + session `created_by_agent_id`.
- Read-only SELECTs over literal queries (no interpolated input); deterministically
  sorted. The scheduler applies due-gating (`isSliceDue`) to this set.

## Review

Self-reviewed: no injection surface (literal queries, no params), archived-only
slices excluded, sessions included, sorted. 6 tests cover empty store,
global/project/agent enumeration, archived-only exclusion, session-only inclusion
(common + private), and ordering. All green: core 369, mcp-server 91, cli 51,
dashboard 48; lint/typecheck/format clean.

## Next

The mcp-server scheduler tick: `enumerate (listCuratorSlices) → due-gate
(isSliceDue, with session-since counts) → runCuration as system-memory-curator`
behind the trusted boundary, with slice locking. Then the §7.1/§13 admin cockpit
+ `LIBRARIAN_SECRET_KEY` bin wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)