### PR TITLE
feat(core): due-slice selection for the curator scheduler (§14)

### DIFF
--- a/packages/core/src/curator-scheduler.ts
+++ b/packages/core/src/curator-scheduler.ts
@@ -1,0 +1,94 @@
+// Curator due-slice selection (spec §14). Composes candidate-slice enumeration
+// (§9), the last-completed-run lookup, and the new-session count into the set of
+// slices that should run now under the schedule + self-gate (§7.2). Read-only;
+// the server-side scheduler wraps this with a timer + slice locking, and runs
+// each due slice via runCuration as the system-memory-curator actor.
+
+import type { DatabaseSync } from "node:sqlite";
+import type { EvidenceSlice } from "./curator-evidence.js";
+import { listCuratorSlices } from "./curator-evidence.js";
+import { type DueReason, type ScheduleConfig, isSliceDue } from "./curator-schedule.js";
+
+export interface DueSlice {
+  slice: EvidenceSlice;
+  reason: DueReason;
+  lastCompletedAt: Date | null;
+  newSessionCount: number;
+}
+
+export function selectDueSlices(db: DatabaseSync, config: ScheduleConfig, now: Date): DueSlice[] {
+  const due: DueSlice[] = [];
+  for (const slice of listCuratorSlices(db)) {
+    const lastCompletedAt = lastCompletedRunAt(db, slice);
+    const newSessionCount = countSessionsSince(db, slice, lastCompletedAt);
+    const decision = isSliceDue(now, { lastCompletedAt, newSessionCount }, config);
+    if (decision.due)
+      due.push({ slice, reason: decision.reason, lastCompletedAt, newSessionCount });
+  }
+  return due;
+}
+
+interface Filter {
+  clause: string;
+  params: string[];
+}
+
+// Slice → run-row filter (runs key the owning agent on agent_id).
+function runFilter(slice: EvidenceSlice): Filter {
+  switch (slice.kind) {
+    case "common_global":
+      return { clause: "visibility = 'common' AND project_key IS NULL", params: [] };
+    case "common_project":
+      return {
+        clause: "visibility = 'common' AND project_key = ?",
+        params: [slice.projectKey ?? ""],
+      };
+    case "agent_private":
+      return {
+        clause: "visibility = 'agent_private' AND agent_id = ?",
+        params: [slice.agentId ?? ""],
+      };
+  }
+}
+
+// Slice → session-row filter (sessions key the owning agent on created_by_agent_id).
+function sessionFilter(slice: EvidenceSlice): Filter {
+  switch (slice.kind) {
+    case "common_global":
+      return { clause: "visibility = 'common' AND project_key IS NULL", params: [] };
+    case "common_project":
+      return {
+        clause: "visibility = 'common' AND project_key = ?",
+        params: [slice.projectKey ?? ""],
+      };
+    case "agent_private":
+      return {
+        clause: "visibility = 'agent_private' AND created_by_agent_id = ?",
+        params: [slice.agentId ?? ""],
+      };
+  }
+}
+
+function lastCompletedRunAt(db: DatabaseSync, slice: EvidenceSlice): Date | null {
+  const { clause, params } = runFilter(slice);
+  const row = db
+    .prepare(
+      `SELECT completed_at FROM memory_curation_runs
+       WHERE ${clause} AND status = 'completed' AND completed_at IS NOT NULL
+       ORDER BY completed_at DESC LIMIT 1`,
+    )
+    .get(...params) as { completed_at: string } | undefined;
+  return row?.completed_at ? new Date(row.completed_at) : null;
+}
+
+function countSessionsSince(db: DatabaseSync, slice: EvidenceSlice, since: Date | null): number {
+  const { clause, params } = sessionFilter(slice);
+  const args: string[] = [...params];
+  let sql = `SELECT COUNT(*) AS n FROM sessions WHERE ${clause}`;
+  if (since) {
+    sql += " AND last_activity_at > ?"; // ISO-8601 strings sort chronologically
+    args.push(since.toISOString());
+  }
+  const row = db.prepare(sql).get(...args) as { n: number | bigint };
+  return Number(row.n);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -68,6 +68,7 @@ export {
   isSliceDue,
   nextScheduledRun,
 } from "./curator-schedule.js";
+export { type DueSlice, selectDueSlices } from "./curator-scheduler.js";
 export {
   type EvidenceSlice,
   type MemoryEvidenceBundle,

--- a/packages/core/tests/curator-scheduler.test.ts
+++ b/packages/core/tests/curator-scheduler.test.ts
@@ -1,0 +1,121 @@
+// Curator due-slice selection (spec §14 + §7.2) over a real store: which slices
+// the scheduler would run now, given last-completed runs + new-session counts.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type ScheduleConfig,
+  createLibrarianStore,
+  selectDueSlices,
+  type LibrarianStore,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let store: LibrarianStore | null = null;
+let dataDir = "";
+const NOW = new Date();
+const daysAgo = (n: number) => new Date(NOW.getTime() - n * 86_400_000);
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-sched-"));
+  store = createLibrarianStore({ dataDir });
+});
+afterEach(() => {
+  try {
+    store?.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  store = null;
+});
+
+const config = (over: Partial<ScheduleConfig> = {}): ScheduleConfig => ({
+  intervalDays: 1,
+  time: "03:00",
+  minSessions: 10,
+  maxDays: 7,
+  ...over,
+});
+
+function seedCommonMemory(projectKey: string) {
+  store!.createMemory({
+    agent_id: "agent-a",
+    title: "t",
+    body: "b",
+    category: "lessons",
+    visibility: "common",
+    scope: "project",
+    project_key: projectKey,
+    priority: "normal",
+    confidence: "working",
+  });
+}
+
+/** A completed apply run for a common project, with completed_at set in the past. */
+function completedRun(projectKey: string, completedAt: Date) {
+  const run = store!.createCurationRun({
+    trigger: "schedule",
+    visibility: "common",
+    input_hash: `h-${projectKey}-${completedAt.toISOString()}`,
+    project_key: projectKey,
+  });
+  store!.completeCurationRun(run.id);
+  store!.db
+    .prepare("UPDATE memory_curation_runs SET completed_at = ? WHERE id = ?")
+    .run(completedAt.toISOString(), run.id);
+}
+
+function dueProjectKeys() {
+  return selectDueSlices(store!.db, config(), NOW)
+    .filter((d) => d.slice.kind === "common_project")
+    .map((d) => (d.slice.kind === "common_project" ? d.slice.projectKey : ""));
+}
+
+describe("selectDueSlices", () => {
+  it("returns nothing for an empty store", () => {
+    expect(selectDueSlices(store!.db, config(), NOW)).toEqual([]);
+  });
+
+  it("a never-run slice with content is due (never_run)", () => {
+    seedCommonMemory("proj-new");
+    const due = selectDueSlices(store!.db, config(), NOW);
+    const hit = due.find((d) => d.slice.kind === "common_project");
+    expect(hit?.reason).toBe("never_run");
+  });
+
+  it("not due before the interval elapses", () => {
+    seedCommonMemory("proj-recent");
+    completedRun("proj-recent", new Date(NOW.getTime() - 3_600_000)); // 1h ago
+    expect(dueProjectKeys()).not.toContain("proj-recent");
+  });
+
+  it("self-gates when the interval is due but too few new sessions", () => {
+    seedCommonMemory("proj-idle");
+    completedRun("proj-idle", daysAgo(2)); // interval elapsed, no new sessions
+    expect(dueProjectKeys()).not.toContain("proj-idle");
+  });
+
+  it("is due once enough new sessions accumulate", () => {
+    seedCommonMemory("proj-busy");
+    completedRun("proj-busy", daysAgo(2));
+    for (let i = 0; i < 12; i++) {
+      store!.startSession({ title: `s${i}`, project_key: "proj-busy", visibility: "common" });
+    }
+    const hit = selectDueSlices(store!.db, config(), NOW).find(
+      (d) => d.slice.kind === "common_project" && d.slice.projectKey === "proj-busy",
+    );
+    expect(hit?.reason).toBe("min_sessions");
+    expect(hit?.newSessionCount).toBe(12);
+  });
+
+  it("forces a run past max_days even with no new sessions", () => {
+    seedCommonMemory("proj-stale");
+    completedRun("proj-stale", daysAgo(8));
+    const hit = selectDueSlices(store!.db, config(), NOW).find(
+      (d) => d.slice.kind === "common_project" && d.slice.projectKey === "proj-stale",
+    );
+    expect(hit?.reason).toBe("max_days");
+  });
+});


### PR DESCRIPTION
## What

`selectDueSlices(db, config, now)` composes the scheduling pieces into the set of
slices that should run now:

1. enumerate candidate slices (`listCuratorSlices`, §9);
2. for each, look up the last **completed** run (slice-matched) and count new
   sessions since then (`last_activity_at > completed_at`);
3. apply the pure due-gate (`isSliceDue`) — interval elapsed **and** the self-gate
   passes (`min_sessions_since_run`, or `max_days_since_run` forces it).

Returns each due slice with its gating reason + inputs (`lastCompletedAt`,
`newSessionCount`) for observability. Read-only, parameterized slice values.

## Review

Self-reviewed: parameterized slice values, literal clauses (no injection),
ISO-string chronological comparison, gating delegated to the pure `isSliceDue`.
6 tests (real store, timestamps relative to now): empty → none; never-run → due;
within-interval → not due; interval-due-but-idle → self-gated; ≥ min_sessions →
due (count pinned); past max_days with no sessions → forced. All green: core 375,
mcp-server 91, cli 51, dashboard 48; lint/typecheck/format clean.

## Next

The mcp-server internal job wraps `selectDueSlices` with a timer + slice locking
and runs each due slice via `runCuration` (built from `readCuratorConfig` +
`resolveCuratorToken` + `createCuratorLlmClient`) as `system-memory-curator`;
run-now shares the enqueue path. Then the §7.1/§13 admin cockpit +
`LIBRARIAN_SECRET_KEY` bin wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)