### PR TITLE
feat: wire LIBRARIAN_SECRET_KEY into the server bins

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -97,7 +97,12 @@ export {
   LlmClientError,
   createCuratorLlmClient,
 } from "./curator-llm-client.js";
-export { decryptSecret, encryptSecret, resolveSecretKey } from "./secret-crypto.js";
+export {
+  decryptSecret,
+  encryptSecret,
+  resolveOptionalSecretKey,
+  resolveSecretKey,
+} from "./secret-crypto.js";
 export {
   type AutoApplyLevel,
   type CuratorConfig,

--- a/packages/core/src/secret-crypto.ts
+++ b/packages/core/src/secret-crypto.ts
@@ -66,6 +66,17 @@ export function resolveSecretKey(raw: string | undefined): Buffer {
 }
 
 /**
+ * Resolve an OPTIONAL master key for store construction: returns null when the
+ * env var is absent/blank (the store runs without secret support — plain admin
+ * settings still work, secrets cannot be read/written), and a 32-byte key when
+ * present. A present-but-malformed key still throws, so a typo'd key fails loudly
+ * at boot rather than silently disabling secrets.
+ */
+export function resolveOptionalSecretKey(raw: string | undefined): Buffer | null {
+  return (raw ?? "").trim() === "" ? null : resolveSecretKey(raw);
+}
+
+/**
  * Encrypt a UTF-8 string. Returns a self-describing payload
  * `gcm1.<iv>.<tag>.<ciphertext>` (each segment base64; base64 never contains
  * `.`, so the segments are unambiguous).

--- a/packages/core/tests/secret-crypto.test.ts
+++ b/packages/core/tests/secret-crypto.test.ts
@@ -6,7 +6,12 @@
 // key parsing.
 
 import { randomBytes } from "node:crypto";
-import { decryptSecret, encryptSecret, resolveSecretKey } from "@librarian/core";
+import {
+  decryptSecret,
+  encryptSecret,
+  resolveOptionalSecretKey,
+  resolveSecretKey,
+} from "@librarian/core";
 import { describe, expect, it } from "vitest";
 
 // A fixed 32-byte test key (hex).
@@ -81,6 +86,23 @@ describe("resolveSecretKey", () => {
   it("rejects a constant-byte (low-entropy) key", () => {
     expect(() => resolveSecretKey("00".repeat(32))).toThrow(/entropy/i);
     expect(() => resolveSecretKey(Buffer.alloc(32, 7).toString("base64"))).toThrow(/entropy/i);
+  });
+});
+
+describe("resolveOptionalSecretKey", () => {
+  it("returns null when the key is absent or blank (secrets disabled)", () => {
+    expect(resolveOptionalSecretKey(undefined)).toBeNull();
+    expect(resolveOptionalSecretKey("")).toBeNull();
+    expect(resolveOptionalSecretKey("   ")).toBeNull();
+  });
+
+  it("returns the resolved key when present", () => {
+    expect(resolveOptionalSecretKey(KEY_HEX)).toHaveLength(32);
+  });
+
+  it("still throws on a present-but-malformed key (fail loud at boot)", () => {
+    expect(() => resolveOptionalSecretKey("tooshort")).toThrow(/32 bytes/i);
+    expect(() => resolveOptionalSecretKey("00".repeat(32))).toThrow(/entropy/i);
   });
 });
 

--- a/packages/mcp-server/src/bin/http.ts
+++ b/packages/mcp-server/src/bin/http.ts
@@ -5,12 +5,21 @@
 // server from `../http/server.ts`. All env parsing + boot-time
 // validation lives here so the server module itself stays pure.
 
-import { createLibrarianStore } from "@librarian/core";
+import { createLibrarianStore, resolveOptionalSecretKey } from "@librarian/core";
 import { type AuthConfig, AgentTokensError, parseAgentTokenMap, parseCsv } from "../http/auth.js";
 import { createHttpServer } from "../http/server.js";
 import { logger } from "../logging.js";
 
-const store = createLibrarianStore();
+// LIBRARIAN_SECRET_KEY (optional) unlocks encrypted admin settings (the curator's
+// LLM token). Absent → store runs without secret support; present-but-bad → fail loud.
+let secretKey: Buffer | null;
+try {
+  secretKey = resolveOptionalSecretKey(process.env.LIBRARIAN_SECRET_KEY);
+} catch (error) {
+  logger.fatal(`Invalid LIBRARIAN_SECRET_KEY: ${(error as Error).message}`);
+  process.exit(1);
+}
+const store = createLibrarianStore({ secretKey });
 const host = process.env.LIBRARIAN_HOST || process.env.LIBRARIAN_DASHBOARD_HOST || "127.0.0.1";
 const port = Number(process.env.LIBRARIAN_PORT || process.env.LIBRARIAN_DASHBOARD_PORT || 3838);
 const adminToken = process.env.LIBRARIAN_ADMIN_TOKEN || process.env.LIBRARIAN_AUTH_TOKEN || "";

--- a/packages/mcp-server/src/bin/stdio.ts
+++ b/packages/mcp-server/src/bin/stdio.ts
@@ -5,10 +5,19 @@
 // through `handleMcpMessage`, and writes responses to stdout. Roles
 // come from `LIBRARIAN_STDIO_ROLE` / `LIBRARIAN_STDIO_AGENT_ID`.
 
-import { createLibrarianStore } from "@librarian/core";
+import { createLibrarianStore, resolveOptionalSecretKey } from "@librarian/core";
 import { handleMcpMessage } from "../mcp/rpc.js";
 
-const store = createLibrarianStore();
+// LIBRARIAN_SECRET_KEY (optional) unlocks encrypted admin settings. Absent → no
+// secret support; present-but-bad → fail loud (to stderr; stdout is the RPC channel).
+let secretKey: Buffer | null;
+try {
+  secretKey = resolveOptionalSecretKey(process.env.LIBRARIAN_SECRET_KEY);
+} catch (error) {
+  process.stderr.write(`Invalid LIBRARIAN_SECRET_KEY: ${(error as Error).message}\n`);
+  process.exit(1);
+}
+const store = createLibrarianStore({ secretKey });
 
 process.stdin.setEncoding("utf8");
 


### PR DESCRIPTION
## What

The curator's LLM token is stored encrypted and needs the master key to read —
but both bins created the store with no key, so secret settings couldn't resolve
in prod. This wires it:

- **core** `resolveOptionalSecretKey(raw)` — null for an absent/blank key (store
  runs without secret support; plain settings still work), the resolved 32-byte
  key when present, and **throws on a present-but-malformed key** so a typo fails
  loudly at boot rather than silently disabling secrets.
- **http + stdio bins** — resolve `LIBRARIAN_SECRET_KEY` and pass it to
  `createLibrarianStore`, fatal-exiting on an invalid key (http via the logger,
  stdio via stderr since stdout is the JSON-RPC channel).

## Review

Self-reviewed; the testable logic lives in core. Tests: null for
absent/blank/whitespace, resolves a present key, throws on malformed/low-entropy.
The bin wiring is covered by the existing integration smokes (which spawn the
bins with no key → null → store boots). All green: core 378, mcp-server 91, cli
51, dashboard 48; lint/typecheck/format clean.

## Next

The mcp-server scheduler tick (timer + slice locking around `selectDueSlices` +
`runCuration`, building the LLM client from `readCuratorConfig` +
`resolveCuratorToken` + `createCuratorLlmClient` as `system-memory-curator`), the
admin run-now endpoint, and the §7.1/§13 dashboard cockpit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)