### PR TITLE
feat(core): curator enqueue + run loop with slice locking (§12 + §10.1)

### DIFF
--- a/packages/core/src/curator-enqueue.ts
+++ b/packages/core/src/curator-enqueue.ts
@@ -1,0 +1,98 @@
+// Curator enqueue + run loop (spec §12 enqueueDueMemoryCurationRuns + §10.1
+// locking). Composes due-slice selection with per-slice locking and runCuration:
+//
+//   for each due slice:
+//     - if a run is already in progress and not stale → skip (locked);
+//     - if the in-progress run is older than the lock TTL → reclaim it (a crashed
+//       worker must not block a slice forever, §10.1) then run;
+//     - otherwise run it (which creates+starts the run = takes the lock, and
+//       completes/fails it = releases).
+//
+// The "running" run row IS the lock. This is safe for the v1 single-process
+// scheduler; true multi-process atomic locking (conditional insert / advisory
+// lock) is a documented hardening follow-up. The LLM client is injected, so the
+// loop is testable without network. The server-side tick calls this on a timer;
+// admin run-now calls it with a manual trigger that bypasses the input-hash skip.
+
+import { type ApplyPolicy } from "./curator-apply-policy.js";
+import type { LlmClient } from "./curator-llm-client.js";
+import type { ScheduleConfig } from "./curator-schedule.js";
+import { findRunningRun, selectDueSlices } from "./curator-scheduler.js";
+import type { RunCurationCaps } from "./curator-worker.js";
+import { runCuration } from "./curator-worker.js";
+import type { LibrarianStore } from "./store/librarian-store.js";
+
+const DEFAULT_LOCK_TTL_MS = 30 * 60_000; // 30 minutes
+
+export interface RunDueCurationOptions {
+  store: LibrarianStore;
+  now: Date;
+  schedule: ScheduleConfig;
+  llmClient: LlmClient;
+  /** Curator actor for common-slice writes (e.g. "system-memory-curator"). */
+  actorId: string;
+  policy: ApplyPolicy;
+  promptAddendum?: string;
+  model: { provider: string; name: string };
+  caps?: RunCurationCaps;
+  /** "schedule" | "manual" | "maintenance". Default "schedule". */
+  trigger?: string;
+  /** manual/maintenance may bypass the input-hash idempotency skip (§10.2). */
+  bypassSkip?: boolean;
+  /** A run still "running" past this age is treated as stale and reclaimed. */
+  lockTtlMs?: number;
+}
+
+export interface RunDueCurationSummary {
+  due: number;
+  ran: number;
+  skippedLocked: number;
+  skippedIdempotent: number;
+  reclaimedStaleLocks: number;
+}
+
+export async function runDueCuration(
+  options: RunDueCurationOptions,
+): Promise<RunDueCurationSummary> {
+  const { store, now } = options;
+  const lockTtlMs = options.lockTtlMs ?? DEFAULT_LOCK_TTL_MS;
+  const summary: RunDueCurationSummary = {
+    due: 0,
+    ran: 0,
+    skippedLocked: 0,
+    skippedIdempotent: 0,
+    reclaimedStaleLocks: 0,
+  };
+
+  const due = selectDueSlices(store.db, options.schedule, now);
+  summary.due = due.length;
+
+  for (const { slice } of due) {
+    const lock = findRunningRun(store.db, slice);
+    if (lock) {
+      if (now.getTime() - lock.startedAt.getTime() < lockTtlMs) {
+        summary.skippedLocked++;
+        continue; // an active run holds the slice lock
+      }
+      // Stale lock (crashed worker): reclaim it, then proceed.
+      store.failCurationRun(lock.id, { error: "stale_lock_reclaimed" });
+      summary.reclaimedStaleLocks++;
+    }
+
+    const run = await runCuration(slice, {
+      store,
+      llmClient: options.llmClient,
+      trigger: options.trigger ?? "schedule",
+      actorId: options.actorId,
+      policy: options.policy,
+      model: options.model,
+      ...(options.promptAddendum !== undefined ? { promptAddendum: options.promptAddendum } : {}),
+      ...(options.caps !== undefined ? { caps: options.caps } : {}),
+      ...(options.bypassSkip !== undefined ? { bypassSkip: options.bypassSkip } : {}),
+    });
+    if (run === null) summary.skippedIdempotent++;
+    else summary.ran++;
+  }
+
+  return summary;
+}

--- a/packages/core/src/curator-enqueue.ts
+++ b/packages/core/src/curator-enqueue.ts
@@ -8,11 +8,19 @@
 //     - otherwise run it (which creates+starts the run = takes the lock, and
 //       completes/fails it = releases).
 //
-// The "running" run row IS the lock. This is safe for the v1 single-process
-// scheduler; true multi-process atomic locking (conditional insert / advisory
-// lock) is a documented hardening follow-up. The LLM client is injected, so the
-// loop is testable without network. The server-side tick calls this on a timer;
-// admin run-now calls it with a manual trigger that bypasses the input-hash skip.
+// The "running" run row IS the lock. This is correct for the v1 PREFERRED
+// single-process scheduler (§14): the server-side tick must run SERIALLY (await
+// this before the next tick), so a live run is never reclaimed mid-flight — the
+// TTL reclaim only fires for a run left "running" by a CRASHED worker. Lifecycle
+// transitions are status-guarded (curation-store), so a reclaim can never be
+// undone by a late completion. FOLLOW-UP (tracked): true multi-process atomic
+// mutual exclusion (a partial-unique index on the running row) + a worker
+// heartbeat, for running the scheduler in more than one process.
+//
+// The LLM client is injected, so the loop is testable without network. The
+// server-side tick calls this on a timer; admin run-now calls it with a manual
+// trigger that bypasses the input-hash skip. One slice's failure never aborts the
+// rest of the batch.
 
 import { type ApplyPolicy } from "./curator-apply-policy.js";
 import type { LlmClient } from "./curator-llm-client.js";
@@ -22,7 +30,14 @@ import type { RunCurationCaps } from "./curator-worker.js";
 import { runCuration } from "./curator-worker.js";
 import type { LibrarianStore } from "./store/librarian-store.js";
 
-const DEFAULT_LOCK_TTL_MS = 30 * 60_000; // 30 minutes
+// The only valid run triggers (§12). schedule = the clock; manual = admin run-now;
+// maintenance = trusted internal code. No agent-reachable trigger exists.
+export type CuratorTrigger = "schedule" | "manual" | "maintenance";
+
+// A run still "running" past this age is treated as a crashed-worker lock and
+// reclaimed. Set well above the worst-case run time so a live run is never
+// reclaimed; with a serial single-process tick, reclaim only fires after a crash.
+const DEFAULT_LOCK_TTL_MS = 60 * 60_000; // 60 minutes
 
 export interface RunDueCurationOptions {
   store: LibrarianStore;
@@ -35,8 +50,8 @@ export interface RunDueCurationOptions {
   promptAddendum?: string;
   model: { provider: string; name: string };
   caps?: RunCurationCaps;
-  /** "schedule" | "manual" | "maintenance". Default "schedule". */
-  trigger?: string;
+  /** Default "schedule". */
+  trigger?: CuratorTrigger;
   /** manual/maintenance may bypass the input-hash idempotency skip (§10.2). */
   bypassSkip?: boolean;
   /** A run still "running" past this age is treated as stale and reclaimed. */
@@ -49,6 +64,8 @@ export interface RunDueCurationSummary {
   skippedLocked: number;
   skippedIdempotent: number;
   reclaimedStaleLocks: number;
+  /** Slices whose run-loop body threw (store error etc.); the rest still ran. */
+  errored: number;
 }
 
 export async function runDueCuration(
@@ -62,36 +79,42 @@ export async function runDueCuration(
     skippedLocked: 0,
     skippedIdempotent: 0,
     reclaimedStaleLocks: 0,
+    errored: 0,
   };
 
   const due = selectDueSlices(store.db, options.schedule, now);
   summary.due = due.length;
 
   for (const { slice } of due) {
-    const lock = findRunningRun(store.db, slice);
-    if (lock) {
-      if (now.getTime() - lock.startedAt.getTime() < lockTtlMs) {
-        summary.skippedLocked++;
-        continue; // an active run holds the slice lock
+    // One slice's failure (store error etc.) must not abort the whole batch.
+    try {
+      const lock = findRunningRun(store.db, slice);
+      if (lock) {
+        if (now.getTime() - lock.startedAt.getTime() < lockTtlMs) {
+          summary.skippedLocked++;
+          continue; // an active run holds the slice lock
+        }
+        // Stale lock (crashed worker): reclaim it, then proceed.
+        store.failCurationRun(lock.id, { error: "stale_lock_reclaimed" });
+        summary.reclaimedStaleLocks++;
       }
-      // Stale lock (crashed worker): reclaim it, then proceed.
-      store.failCurationRun(lock.id, { error: "stale_lock_reclaimed" });
-      summary.reclaimedStaleLocks++;
-    }
 
-    const run = await runCuration(slice, {
-      store,
-      llmClient: options.llmClient,
-      trigger: options.trigger ?? "schedule",
-      actorId: options.actorId,
-      policy: options.policy,
-      model: options.model,
-      ...(options.promptAddendum !== undefined ? { promptAddendum: options.promptAddendum } : {}),
-      ...(options.caps !== undefined ? { caps: options.caps } : {}),
-      ...(options.bypassSkip !== undefined ? { bypassSkip: options.bypassSkip } : {}),
-    });
-    if (run === null) summary.skippedIdempotent++;
-    else summary.ran++;
+      const run = await runCuration(slice, {
+        store,
+        llmClient: options.llmClient,
+        trigger: options.trigger ?? "schedule",
+        actorId: options.actorId,
+        policy: options.policy,
+        model: options.model,
+        ...(options.promptAddendum !== undefined ? { promptAddendum: options.promptAddendum } : {}),
+        ...(options.caps !== undefined ? { caps: options.caps } : {}),
+        ...(options.bypassSkip !== undefined ? { bypassSkip: options.bypassSkip } : {}),
+      });
+      if (run === null) summary.skippedIdempotent++;
+      else summary.ran++;
+    } catch {
+      summary.errored++;
+    }
   }
 
   return summary;

--- a/packages/core/src/curator-scheduler.ts
+++ b/packages/core/src/curator-scheduler.ts
@@ -69,6 +69,26 @@ function sessionFilter(slice: EvidenceSlice): Filter {
   }
 }
 
+/**
+ * The latest in-progress (running) run for a slice — the §10.1 lock. A non-null
+ * result means the slice is being worked; the caller compares startedAt against a
+ * TTL to distinguish an active lock from a stale (crashed-worker) one to reclaim.
+ */
+export function findRunningRun(
+  db: DatabaseSync,
+  slice: EvidenceSlice,
+): { id: string; startedAt: Date } | null {
+  const { clause, params } = runFilter(slice);
+  const row = db
+    .prepare(
+      `SELECT id, started_at FROM memory_curation_runs
+       WHERE ${clause} AND status = 'running' AND started_at IS NOT NULL
+       ORDER BY started_at DESC LIMIT 1`,
+    )
+    .get(...params) as { id: string; started_at: string } | undefined;
+  return row ? { id: row.id, startedAt: new Date(row.started_at) } : null;
+}
+
 function lastCompletedRunAt(db: DatabaseSync, slice: EvidenceSlice): Date | null {
   const { clause, params } = runFilter(slice);
   const row = db

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -68,7 +68,12 @@ export {
   isSliceDue,
   nextScheduledRun,
 } from "./curator-schedule.js";
-export { type DueSlice, selectDueSlices } from "./curator-scheduler.js";
+export { type DueSlice, findRunningRun, selectDueSlices } from "./curator-scheduler.js";
+export {
+  type RunDueCurationOptions,
+  type RunDueCurationSummary,
+  runDueCuration,
+} from "./curator-enqueue.js";
 export {
   type EvidenceSlice,
   type MemoryEvidenceBundle,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -70,6 +70,7 @@ export {
 } from "./curator-schedule.js";
 export { type DueSlice, findRunningRun, selectDueSlices } from "./curator-scheduler.js";
 export {
+  type CuratorTrigger,
   type RunDueCurationOptions,
   type RunDueCurationSummary,
   runDueCuration,

--- a/packages/core/src/store/curation-store.ts
+++ b/packages/core/src/store/curation-store.ts
@@ -315,12 +315,15 @@ export function createCurationStore(deps: { db: DatabaseSync }): CurationStore {
     return requireRun(id);
   }
 
+  // complete/fail only transition a NON-terminal run, so a run already moved to a
+  // terminal state (e.g. reclaimed → failed by a stale-lock sweep) cannot be
+  // resurrected by a late completion from the original worker (§10.1).
   function completeCurationRun(id: string, input: CompleteCurationRunInput = {}): CurationRun {
     db.prepare(
       `UPDATE memory_curation_runs
          SET status = 'completed', completed_at = ?, summary = ?,
              usage_input_tokens = ?, usage_output_tokens = ?
-       WHERE id = ?`,
+       WHERE id = ? AND status NOT IN ('completed', 'failed')`,
     ).run(
       nowIso(),
       input.summary ?? null,
@@ -333,7 +336,8 @@ export function createCurationStore(deps: { db: DatabaseSync }): CurationStore {
 
   function failCurationRun(id: string, input: FailCurationRunInput): CurationRun {
     db.prepare(
-      "UPDATE memory_curation_runs SET status = 'failed', completed_at = ?, error = ? WHERE id = ?",
+      `UPDATE memory_curation_runs SET status = 'failed', completed_at = ?, error = ?
+       WHERE id = ? AND status NOT IN ('completed', 'failed')`,
     ).run(nowIso(), input.error, id);
     return requireRun(id);
   }

--- a/packages/core/tests/curator-enqueue.test.ts
+++ b/packages/core/tests/curator-enqueue.test.ts
@@ -1,0 +1,123 @@
+// Curator enqueue + run loop (spec §12 + §10.1 locking) over a real store with an
+// injected fake LLM client. Pins that due slices run, an active lock is honoured,
+// and a stale lock is reclaimed.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type ApplyPolicy,
+  type LibrarianStore,
+  type LlmClient,
+  type ScheduleConfig,
+  createLibrarianStore,
+  runDueCuration,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let store: LibrarianStore | null = null;
+let dataDir = "";
+const NOW = new Date();
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-enqueue-"));
+  store = createLibrarianStore({ dataDir });
+});
+afterEach(() => {
+  try {
+    store?.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  store = null;
+});
+
+const schedule = (): ScheduleConfig => ({
+  intervalDays: 1,
+  time: "03:00",
+  minSessions: 10,
+  maxDays: 7,
+});
+const policy: ApplyPolicy = { level: "safe_only", confidenceThreshold: 0.9 };
+const noOpClient: LlmClient = {
+  complete: async () => ({
+    content: JSON.stringify({ operations: [] }),
+    model: "gpt-x",
+    usage: null,
+  }),
+};
+
+function seedCommonMemory(projectKey: string) {
+  store!.createMemory({
+    agent_id: "agent-a",
+    title: "t",
+    body: "b",
+    category: "lessons",
+    visibility: "common",
+    scope: "project",
+    project_key: projectKey,
+    priority: "normal",
+    confidence: "working",
+  });
+}
+
+function options(over: Partial<Parameters<typeof runDueCuration>[0]> = {}) {
+  return {
+    store: store!,
+    now: NOW,
+    schedule: schedule(),
+    llmClient: noOpClient,
+    actorId: "system-memory-curator",
+    policy,
+    model: { provider: "openai", name: "gpt-x" },
+    trigger: "schedule",
+    ...over,
+  };
+}
+
+/** Create a RUNNING run for a common project, with started_at set to the past. */
+function runningRun(projectKey: string, startedAt: Date) {
+  const run = store!.createCurationRun({
+    trigger: "schedule",
+    visibility: "common",
+    input_hash: `h-${projectKey}`,
+    project_key: projectKey,
+  });
+  store!.startCurationRun(run.id);
+  store!.db
+    .prepare("UPDATE memory_curation_runs SET started_at = ? WHERE id = ?")
+    .run(startedAt.toISOString(), run.id);
+  return run.id;
+}
+
+describe("runDueCuration", () => {
+  it("runs every due slice", async () => {
+    seedCommonMemory("proj-x");
+    seedCommonMemory("proj-y");
+
+    const summary = await runDueCuration(options());
+    expect(summary.due).toBeGreaterThanOrEqual(2);
+    expect(summary.ran).toBeGreaterThanOrEqual(2);
+    expect(summary.skippedLocked).toBe(0);
+  });
+
+  it("skips a slice that is already locked by an active run", async () => {
+    seedCommonMemory("proj-locked");
+    runningRun("proj-locked", NOW); // active lock
+
+    const summary = await runDueCuration(options());
+    expect(summary.skippedLocked).toBe(1);
+    expect(summary.ran).toBe(0);
+  });
+
+  it("reclaims a stale lock and runs the slice", async () => {
+    seedCommonMemory("proj-stalelock");
+    const staleId = runningRun("proj-stalelock", new Date(NOW.getTime() - 3_600_000)); // 1h ago
+
+    const summary = await runDueCuration(options({ lockTtlMs: 30 * 60_000 }));
+    expect(summary.reclaimedStaleLocks).toBe(1);
+    expect(summary.ran).toBe(1);
+    expect(store!.getCurationRun(staleId)?.status).toBe("failed"); // reclaimed
+  });
+});

--- a/packages/core/tests/curator-enqueue.test.ts
+++ b/packages/core/tests/curator-enqueue.test.ts
@@ -120,4 +120,21 @@ describe("runDueCuration", () => {
     expect(summary.ran).toBe(1);
     expect(store!.getCurationRun(staleId)?.status).toBe("failed"); // reclaimed
   });
+
+  it("one slice's failure does not abort the rest of the batch", async () => {
+    seedCommonMemory("proj-boom");
+    seedCommonMemory("proj-ok");
+    // Wrap the store so creating a run for proj-boom throws (a store error mid-loop).
+    const wrapped = {
+      ...store!,
+      createCurationRun: (input: Parameters<LibrarianStore["createCurationRun"]>[0]) => {
+        if (input.project_key === "proj-boom") throw new Error("boom");
+        return store!.createCurationRun(input);
+      },
+    } as LibrarianStore;
+
+    const summary = await runDueCuration(options({ store: wrapped }));
+    expect(summary.errored).toBe(1); // proj-boom threw
+    expect(summary.ran).toBe(1); // proj-ok still ran
+  });
 });

--- a/packages/core/tests/store/curation-store.test.ts
+++ b/packages/core/tests/store/curation-store.test.ts
@@ -198,6 +198,17 @@ describe("curation run lifecycle", () => {
     expect(failed.completed_at).not.toBeNull();
   });
 
+  it("a terminal run cannot be resurrected by a late completion (§10.1 reclaim safety)", () => {
+    const run = newRun();
+    s!.store.startCurationRun(run.id);
+    s!.store.failCurationRun(run.id, { error: "stale_lock_reclaimed" }); // e.g. reclaimed
+    // The original worker's late completion must be a no-op, not a resurrection.
+    const after = s!.store.completeCurationRun(run.id, { summary: "done", usage_input_tokens: 9 });
+    expect(after.status).toBe("failed");
+    expect(after.summary).toBeNull();
+    expect(after.usage_input_tokens).toBe(0);
+  });
+
   it("throws for an unknown run id", () => {
     expect(() => s!.store.startCurationRun("run_ghost")).toThrow(/run/i);
   });


### PR DESCRIPTION
## What

`runDueCuration(options)` — the §12 enqueue path the scheduler tick and admin
run-now both call. It selects due slices and, per slice: skips if an in-progress
run holds the lock (within TTL), reclaims a stale (crashed-worker) run then runs,
or runs it via `runCuration`. Returns a counted summary
(`due/ran/skippedLocked/skippedIdempotent/reclaimedStaleLocks/errored`). LLM
client injected → testable without network.

## Review (code-reviewer — REQUEST CHANGES → addressed)

- **Loop resilience** — per-slice try/catch + `errored` counter, so one slice's
  store error can't abort the batch.
- **Reclaim safety** — `completeCurationRun`/`failCurationRun` are status-guarded
  (only transition a non-terminal run), so a reclaimed run can't be resurrected by
  a late completion (prevents the record corruption the reviewer flagged).
- **TTL** — raised to 60 min, documented as the crashed-worker recovery threshold;
  with the required serial single-process tick, a live run is never reclaimed
  mid-flight.
- **trigger** is now the `CuratorTrigger` union.

### Scope (documented, tracked follow-up)
The run-row-as-lock is correct for the spec's **preferred single-process** v1
scheduler (§14). **True multi-process atomic mutual exclusion** (a partial-unique
index on the running row) **+ a worker heartbeat** is the remaining hardening for
running the scheduler in multiple processes — flagged for Jim. The status guards
already prevent record corruption under any overlap. I shipped single-process-correct
+ documented rather than rushing a schema-touching concurrency change.

Tests: all due run; active lock honoured; stale lock reclaimed (→ failed);
one-slice-failure resilience; terminal-run resurrection guard. All green: core 383,
mcp-server 91, cli 51, dashboard 48; lint/typecheck/format clean.

## Next

The mcp-server internal job: a serial timer tick + admin run-now endpoint that call
`runDueCuration` (LLM client built from `readCuratorConfig` + `resolveCuratorToken`
+ `createCuratorLlmClient`) as `system-memory-curator`. Then the §7.1/§13 dashboard cockpit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)