### PR TITLE
feat(core): curator tick — config-driven run entrypoint (§12/§14)

### DIFF
--- a/packages/core/src/curator-tick.ts
+++ b/packages/core/src/curator-tick.ts
@@ -1,0 +1,88 @@
+// Curator tick (spec §12 + §14) — the config-driven entrypoint the server-side
+// scheduler calls on a (serial) timer, and the admin run-now action calls with a
+// manual trigger. Reads the admin config, gates on it, builds the LLM client from
+// it, and runs all due slices via runDueCuration as the system-memory-curator
+// actor. It never runs unless curation is enabled AND the LLM config is complete
+// AND the token can be decrypted (the scheduler must never run on an incomplete
+// config, §7.1).
+//
+// The LLM client builder is injectable for testing; in production it defaults to
+// the OpenAI-compatible client.
+
+import { SYSTEM_ACTOR_IDS } from "./caller-identity.js";
+import { type CuratorConfig, readCuratorConfig, resolveCuratorToken } from "./curator-config.js";
+import {
+  type CuratorTrigger,
+  type RunDueCurationSummary,
+  runDueCuration,
+} from "./curator-enqueue.js";
+import { type LlmClient, createCuratorLlmClient } from "./curator-llm-client.js";
+import type { RunCurationCaps } from "./curator-worker.js";
+import type { LibrarianStore } from "./store/librarian-store.js";
+
+// §7.2 operational gates (not part of the admin LLM config).
+const DEFAULT_MIN_SESSIONS = 10;
+const DEFAULT_MAX_DAYS = 7;
+
+export type CuratorTickSkipReason = "disabled" | "incomplete_config" | "no_token";
+
+export type CuratorTickResult =
+  | { ran: true; summary: RunDueCurationSummary }
+  | { ran: false; reason: CuratorTickSkipReason };
+
+export interface CuratorTickOptions {
+  store: LibrarianStore;
+  now?: Date;
+  /** Default "schedule"; admin run-now passes "manual". */
+  trigger?: CuratorTrigger;
+  /** manual/maintenance may bypass the input-hash idempotency skip. */
+  bypassSkip?: boolean;
+  minSessions?: number;
+  maxDays?: number;
+  caps?: RunCurationCaps;
+  /** Injectable LLM client builder (defaults to the OpenAI-compatible client). */
+  buildClient?: (llm: CuratorConfig["llm"], token: string) => LlmClient;
+}
+
+export async function runCuratorTick(options: CuratorTickOptions): Promise<CuratorTickResult> {
+  const { store } = options;
+  const config = readCuratorConfig(store);
+
+  if (!config.enabled) return { ran: false, reason: "disabled" };
+  if (!config.isLlmComplete) return { ran: false, reason: "incomplete_config" };
+
+  // The token is configured (isLlmComplete ⇒ hasToken); decryption can still fail
+  // if the server is missing the master key — treat that as "not runnable".
+  let token: string | null;
+  try {
+    token = resolveCuratorToken(store);
+  } catch {
+    return { ran: false, reason: "no_token" };
+  }
+  if (!token) return { ran: false, reason: "no_token" };
+
+  const buildClient =
+    options.buildClient ??
+    ((llm, secret) =>
+      createCuratorLlmClient({ endpoint: llm.endpoint, token: secret, model: llm.model }));
+
+  const summary = await runDueCuration({
+    store,
+    now: options.now ?? new Date(),
+    schedule: {
+      intervalDays: config.schedule.intervalDays,
+      time: config.schedule.time,
+      minSessions: options.minSessions ?? DEFAULT_MIN_SESSIONS,
+      maxDays: options.maxDays ?? DEFAULT_MAX_DAYS,
+    },
+    llmClient: buildClient(config.llm, token),
+    actorId: SYSTEM_ACTOR_IDS.memoryCurator,
+    policy: { level: config.defaultAutoApply, confidenceThreshold: config.autoApplyConfidence },
+    promptAddendum: config.promptAddendum,
+    model: { provider: config.llm.provider, name: config.llm.model },
+    trigger: options.trigger ?? "schedule",
+    ...(options.bypassSkip !== undefined ? { bypassSkip: options.bypassSkip } : {}),
+    ...(options.caps !== undefined ? { caps: options.caps } : {}),
+  });
+  return { ran: true, summary };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -76,6 +76,12 @@ export {
   runDueCuration,
 } from "./curator-enqueue.js";
 export {
+  type CuratorTickOptions,
+  type CuratorTickResult,
+  type CuratorTickSkipReason,
+  runCuratorTick,
+} from "./curator-tick.js";
+export {
   type EvidenceSlice,
   type MemoryEvidenceBundle,
   type MemoryEvidenceCaps,

--- a/packages/core/tests/curator-tick.test.ts
+++ b/packages/core/tests/curator-tick.test.ts
@@ -1,0 +1,110 @@
+// Curator tick (spec §12/§14) — the config-driven entrypoint. Verifies gating
+// (disabled / incomplete / undecryptable token) and that an operational config
+// builds the client from config and runs due slices. Network-free via an injected
+// client builder.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type LibrarianStore,
+  type LlmClient,
+  createLibrarianStore,
+  resolveSecretKey,
+  runCuratorTick,
+  writeCuratorConfig,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const KEY = resolveSecretKey("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+
+let store: LibrarianStore | null = null;
+let dataDir = "";
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-tick-"));
+  store = createLibrarianStore({ dataDir, secretKey: KEY });
+});
+afterEach(() => {
+  try {
+    store?.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  store = null;
+});
+
+const noOpClient: LlmClient = {
+  complete: async () => ({ content: JSON.stringify({ operations: [] }), model: "m", usage: null }),
+};
+
+function seedMemory() {
+  store!.createMemory({
+    agent_id: "agent-a",
+    title: "t",
+    body: "b",
+    category: "lessons",
+    visibility: "common",
+    scope: "project",
+    project_key: "proj-x",
+    priority: "normal",
+    confidence: "working",
+  });
+}
+
+describe("runCuratorTick — gating", () => {
+  it("does nothing when curation is disabled (the default)", async () => {
+    const result = await runCuratorTick({ store: store! });
+    expect(result).toEqual({ ran: false, reason: "disabled" });
+  });
+
+  it("does nothing when the LLM config is incomplete (no token)", async () => {
+    writeCuratorConfig(store!, {
+      enabled: true,
+      llm: { provider: "openai", endpoint: "https://e/v1", model: "gpt-x" },
+    });
+    const result = await runCuratorTick({ store: store! });
+    expect(result).toEqual({ ran: false, reason: "incomplete_config" });
+  });
+});
+
+describe("runCuratorTick — operational", () => {
+  it("builds the client from config (with the decrypted token) and runs due slices", async () => {
+    seedMemory();
+    writeCuratorConfig(store!, {
+      enabled: true,
+      llm: { provider: "openai", endpoint: "https://api.example.com/v1", model: "gpt-x" },
+      token: "dummy-decrypted-token",
+    });
+    const buildClient = vi.fn(() => noOpClient);
+
+    const result = await runCuratorTick({ store: store!, buildClient });
+
+    expect(result.ran).toBe(true);
+    expect(buildClient).toHaveBeenCalledTimes(1);
+    // The decrypted token + the configured connection flow into the builder.
+    expect(buildClient).toHaveBeenCalledWith(
+      { provider: "openai", endpoint: "https://api.example.com/v1", model: "gpt-x" },
+      "dummy-decrypted-token",
+    );
+    if (result.ran) expect(result.summary.ran).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("runCuratorTick — token undecryptable without the master key", () => {
+  it("does not run when the configured token can't be decrypted", async () => {
+    writeCuratorConfig(store!, {
+      enabled: true,
+      llm: { provider: "openai", endpoint: "https://e/v1", model: "gpt-x" },
+      token: "dummy-secret",
+    });
+    store!.close();
+
+    // Reopen WITHOUT the master key: config still reads as complete (token presence
+    // is metadata), but the token can't be decrypted → not runnable.
+    store = createLibrarianStore({ dataDir });
+    const result = await runCuratorTick({ store: store!, buildClient: () => noOpClient });
+    expect(result).toEqual({ ran: false, reason: "no_token" });
+  });
+});


### PR DESCRIPTION
## What

`runCuratorTick(options)` — the config-driven entrypoint the server-side scheduler
timer and admin run-now both call. It reads the admin curator config and:

- **gates**: returns `{ran:false, reason}` when disabled / LLM config incomplete /
  the configured token can't be decrypted (server missing the master key) — the
  scheduler never runs on an incomplete config (§7.1);
- otherwise builds the OpenAI-compatible LLM client from config (endpoint/model +
  the **decrypted** token) and runs all due slices via `runDueCuration` as the
  `system-memory-curator` actor, with policy (`default_auto_apply` + confidence)
  and schedule (interval/time + min_sessions/max_days) drawn from config.

The client builder is injectable → testable without network. `trigger` defaults
to `"schedule"`; admin run-now passes `"manual"` (with `bypassSkip`).

## Review

Self-reviewed (config→run composition over audited pieces): gating order
(disabled → incomplete → no_token); `resolveCuratorToken` wrapped so a decrypt
failure → `no_token`; token flows to the builder, never logged; reserved
`SYSTEM_ACTOR_IDS.memoryCurator` actor. 4 tests cover all gates, the token-flow
into the builder, and the undecryptable-token case. All green: core 387,
mcp-server 91, cli 51, dashboard 48; lint/typecheck/format clean.

## Next

The mcp-server wiring: a serial timer that calls `runCuratorTick` on the
configured interval (started from the server process) + an admin-authenticated
run-now endpoint that calls it with `trigger:"manual"`. Then the §7.1/§13
dashboard cockpit (config / observability / run-now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)