### PR TITLE
feat(mcp-server): curator admin API (config + observability + run-now)

### DIFF
--- a/packages/core/src/curator-config.ts
+++ b/packages/core/src/curator-config.ts
@@ -8,6 +8,7 @@
 // (no decryption), so it works without the master key — the admin cockpit can
 // render the configured state. Only the worker's `resolveCuratorToken` decrypts.
 
+import { z } from "zod";
 import type { SettingMeta } from "./store/settings-store.js";
 
 const KEYS = {
@@ -58,6 +59,27 @@ export interface CuratorConfigPatch {
   autoApplyConfidence?: number;
   schedule?: { intervalDays?: number; time?: string };
 }
+
+// Input validation for the admin API. Permissive shape (all optional); the deeper
+// invariants — addendum ≤ 2 KB, confidence 0..1, interval ≥ 1, HH:MM — are
+// enforced by writeCuratorConfig, which is the single source of truth.
+export const CuratorConfigPatchSchema = z.strictObject({
+  enabled: z.boolean().optional(),
+  llm: z
+    .strictObject({
+      provider: z.string().optional(),
+      endpoint: z.string().optional(),
+      model: z.string().optional(),
+    })
+    .optional(),
+  token: z.string().optional(),
+  promptAddendum: z.string().optional(),
+  defaultAutoApply: z.enum(["off", "safe_only", "high_confidence"]).optional(),
+  autoApplyConfidence: z.number().optional(),
+  schedule: z
+    .strictObject({ intervalDays: z.number().optional(), time: z.string().optional() })
+    .optional(),
+});
 
 // The slices of the store this module needs.
 interface ConfigReader {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -119,6 +119,7 @@ export {
   type AutoApplyLevel,
   type CuratorConfig,
   type CuratorConfigPatch,
+  CuratorConfigPatchSchema,
   readCuratorConfig,
   resolveCuratorToken,
   writeCuratorConfig,

--- a/packages/mcp-server/src/trpc/curator.ts
+++ b/packages/mcp-server/src/trpc/curator.ts
@@ -1,0 +1,53 @@
+// Memory-curator admin tRPC procedures (memory-curator spec §7.1 / §13).
+//
+// The admin cockpit's typed surface: read/update the curator config, read-only
+// run + operation observability, and the run-now control. All admin-gated — there
+// is deliberately NO consumer-agent surface for curation (§12). The config read
+// never exposes the token (only `hasToken`); writes go through core's
+// writeCuratorConfig, which validates and stores the token encrypted.
+
+import type { CuratorConfigPatch, ListCurationRunsInput } from "@librarian/core";
+import {
+  CuratorConfigPatchSchema,
+  readCuratorConfig,
+  runCuratorTick,
+  writeCuratorConfig,
+} from "@librarian/core";
+import { z } from "zod";
+import { adminProcedure, router } from "./trpc.js";
+
+const ListRunsInputSchema = z.strictObject({
+  status: z.string().optional(),
+  trigger: z.string().optional(),
+  limit: z.number().int().positive().max(200).optional(),
+});
+
+export const curatorRouter = router({
+  // Current config (never includes the token — only hasToken).
+  config: adminProcedure.query(({ ctx }) => readCuratorConfig(ctx.store)),
+
+  // Update config; returns the fresh readable config. writeCuratorConfig validates
+  // (addendum size, confidence range, interval, HH:MM) and encrypts the token.
+  setConfig: adminProcedure.input(CuratorConfigPatchSchema).mutation(({ ctx, input }) => {
+    // Cast at the validated boundary: Zod `.optional()` infers `T | undefined`,
+    // which the patch type (optional-key, not undefined-value) rejects under
+    // exactOptionalPropertyTypes. The schema already validated the shape.
+    writeCuratorConfig(ctx.store, input as CuratorConfigPatch);
+    return readCuratorConfig(ctx.store);
+  }),
+
+  // Observability: run history (most recent first) + per-run operations.
+  runs: adminProcedure
+    .input(ListRunsInputSchema.optional())
+    .query(({ ctx, input }) => ctx.store.listCurationRuns((input ?? {}) as ListCurationRunsInput)),
+
+  runOperations: adminProcedure
+    .input(z.strictObject({ runId: z.string().min(1) }))
+    .query(({ ctx, input }) => ctx.store.getCurationOperations(input.runId)),
+
+  // Admin run-now: shares the scheduler enqueue path (manual trigger, bypasses the
+  // input-hash skip). Synchronous — the admin awaits the result summary.
+  runNow: adminProcedure.mutation(({ ctx }) =>
+    runCuratorTick({ store: ctx.store, trigger: "manual", bypassSkip: true }),
+  ),
+});

--- a/packages/mcp-server/src/trpc/router.ts
+++ b/packages/mcp-server/src/trpc/router.ts
@@ -5,12 +5,14 @@
 // intentionally empty and get populated in T4.4 and T4.5. The
 // `AppRouter` type is the public contract the dashboard imports.
 
+import { curatorRouter } from "./curator.js";
 import { healthRouter } from "./health.js";
 import { memoriesRouter } from "./memories.js";
 import { sessionsRouter } from "./sessions.js";
 import { router } from "./trpc.js";
 
 export const appRouter = router({
+  curator: curatorRouter,
   health: healthRouter,
   memories: memoriesRouter,
   sessions: sessionsRouter,

--- a/packages/mcp-server/tests/trpc/curator.test.ts
+++ b/packages/mcp-server/tests/trpc/curator.test.ts
@@ -1,0 +1,105 @@
+// Memory-curator admin tRPC procedure tests (§7.1/§13). Spawns the real HTTP bin
+// and exercises the cockpit surface end to end: admin gating, config read/update
+// round-trip (no token — the encrypted-token path is covered by core), run
+// observability, and run-now (disabled config → no run).
+
+import { describe, expect, it } from "vitest";
+import { cleanupTempDir, makeTempDir, startHttpServer } from "../../../../test/helpers.js";
+
+interface TrpcOk<T> {
+  result: { data: T };
+}
+interface TrpcErr {
+  error: unknown;
+}
+interface ServerHandle {
+  url: string;
+  token: string;
+  stop: () => Promise<void>;
+}
+
+async function trpcGet<T>(server: ServerHandle, path: string, input?: unknown): Promise<T> {
+  const url = new URL(`${server.url}/trpc/${path}`);
+  if (input !== undefined) url.searchParams.set("input", JSON.stringify(input));
+  const response = await fetch(url, { headers: { authorization: `Bearer ${server.token}` } });
+  const json = (await response.json()) as TrpcOk<T> | TrpcErr;
+  if (response.status >= 400 || "error" in json) {
+    throw new Error(`trpc GET ${path} failed: ${JSON.stringify(json)}`);
+  }
+  return (json as TrpcOk<T>).result.data;
+}
+
+async function trpcPost<T>(server: ServerHandle, path: string, input?: unknown): Promise<T> {
+  const response = await fetch(`${server.url}/trpc/${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${server.token}` },
+    body: input === undefined ? undefined : JSON.stringify(input),
+  });
+  const json = (await response.json()) as TrpcOk<T> | TrpcErr;
+  if (response.status >= 400 || "error" in json) {
+    throw new Error(`trpc POST ${path} failed: ${JSON.stringify(json)}`);
+  }
+  return (json as TrpcOk<T>).result.data;
+}
+
+interface CuratorConfig {
+  enabled: boolean;
+  llm: { provider: string; endpoint: string; model: string };
+  hasToken: boolean;
+  defaultAutoApply: string;
+  isOperational: boolean;
+}
+
+describe("tRPC curator surface", () => {
+  it("requires admin auth", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const response = await fetch(`${server.url}/trpc/curator.config`); // no Authorization
+      expect(response.status).toBeGreaterThanOrEqual(400);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("reads safe defaults and round-trips a config update (no token)", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const before = await trpcGet<CuratorConfig>(server, "curator.config");
+      expect(before.enabled).toBe(false);
+      expect(before.defaultAutoApply).toBe("safe_only");
+      expect(before.isOperational).toBe(false);
+
+      const after = await trpcPost<CuratorConfig>(server, "curator.setConfig", {
+        enabled: true,
+        llm: { provider: "openai", endpoint: "https://api.example.com/v1", model: "gpt-x" },
+        defaultAutoApply: "high_confidence",
+        promptAddendum: "prefer merging",
+      });
+      expect(after.enabled).toBe(true);
+      expect(after.llm.model).toBe("gpt-x");
+      expect(after.defaultAutoApply).toBe("high_confidence");
+      expect(after.hasToken).toBe(false); // no token set, no secret leak
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("lists runs (empty initially) and run-now no-ops on a disabled config", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const runs = await trpcGet<unknown[]>(server, "curator.runs");
+      expect(runs).toEqual([]);
+
+      const result = await trpcPost<{ ran: boolean; reason?: string }>(server, "curator.runNow");
+      expect(result).toEqual({ ran: false, reason: "disabled" });
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+});

--- a/packages/mcp-server/tests/trpc/curator.test.ts
+++ b/packages/mcp-server/tests/trpc/curator.test.ts
@@ -63,6 +63,21 @@ describe("tRPC curator surface", () => {
     }
   });
 
+  it("rejects an agent-role token on run-now (§12 — no consumer-reachable trigger)", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir }); // agentToken defaults to "agent-token"
+    try {
+      const response = await fetch(`${server.url}/trpc/curator.runNow`, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: "Bearer agent-token" },
+      });
+      expect(response.status).toBeGreaterThanOrEqual(400); // agent role is not admin
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
   it("reads safe defaults and round-trips a config update (no token)", async () => {
     const dataDir = makeTempDir();
     const server = await startHttpServer({ dataDir });


### PR DESCRIPTION
## What

The admin cockpit's typed tRPC surface (§7.1/§13), all `adminProcedure`-gated —
no consumer-agent surface for curation (§12):

- **curator.config** — read the config; never includes the token (only `hasToken`).
- **curator.setConfig** — update via core's `writeCuratorConfig` (validates
  addendum size / confidence / interval / HH:MM; stores the token encrypted);
  returns the fresh token-free config.
- **curator.runs / curator.runOperations** — read-only run + operation observability.
- **curator.runNow** — admin run-now, sharing the scheduler enqueue path (manual
  trigger, bypasses the input-hash skip) via `runCuratorTick`.

Adds `CuratorConfigPatchSchema` to core (permissive `z.strictObject`; deep
invariants stay enforced by `writeCuratorConfig`). Registered under
`appRouter.curator` (the dashboard's typed contract).

## Security audit (security-auditor — 0 Critical/High/Medium)

Confirmed clean: every procedure admin-gated; token never exposed (config derives
`hasToken` from metadata, no code path returns the value); strict-object input +
authoritative core validation; run-now bypasses the skip only for the manual
trigger and still gates on enabled+complete+decryptable; observability reads back
already-redacted records. One Low (defense-in-depth) applied: an **agent-role**
negative test now pins that an agent token is rejected on run-now.

Tests (real spawned server): admin-auth required; agent-role rejected on run-now;
config defaults + update round-trip (no token leaked); runs empty; run-now no-ops
on a disabled config. All green: core 387, mcp-server 95, cli 51, dashboard 48;
lint/typecheck/format clean.

## Next

A serial scheduler timer started from the server bin (calls `runCuratorTick` on
the configured interval), then the §7.1/§13 dashboard cockpit UI consuming this
router.

🤖 Generated with [Claude Code](https://claude.com/claude-code)