### PR TITLE
feat: serial curator scheduler timer wired into the server bin (§14)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -82,6 +82,11 @@ export {
   runCuratorTick,
 } from "./curator-tick.js";
 export {
+  type SerialScheduler,
+  type SerialSchedulerOptions,
+  createSerialScheduler,
+} from "./serial-scheduler.js";
+export {
   type EvidenceSlice,
   type MemoryEvidenceBundle,
   type MemoryEvidenceCaps,

--- a/packages/core/src/serial-scheduler.ts
+++ b/packages/core/src/serial-scheduler.ts
@@ -1,0 +1,51 @@
+// A minimal serial interval runner (spec §14: the curator scheduler "must run
+// serially" so a live run is never reclaimed mid-flight). Fires `task` every
+// `intervalMs`, but NEVER overlaps — if a tick is still in flight when the timer
+// fires, that tick is skipped. Errors are routed to `onError` (never thrown out
+// of the timer). The internal timer is unref'd so it doesn't keep the process
+// alive on its own.
+
+export interface SerialScheduler {
+  start(): void;
+  stop(): void;
+  /** True while a tick is in flight (exposed for tests/observability). */
+  isRunning(): boolean;
+}
+
+export interface SerialSchedulerOptions {
+  task: () => Promise<unknown>;
+  intervalMs: number;
+  onError?: (error: unknown) => void;
+}
+
+export function createSerialScheduler(options: SerialSchedulerOptions): SerialScheduler {
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let running = false;
+
+  async function tick(): Promise<void> {
+    if (running) return; // previous tick still in flight — skip, no overlap
+    running = true;
+    try {
+      await options.task();
+    } catch (error) {
+      options.onError?.(error);
+    } finally {
+      running = false;
+    }
+  }
+
+  return {
+    start() {
+      if (timer) return; // idempotent
+      timer = setInterval(() => void tick(), options.intervalMs);
+      timer.unref?.();
+    },
+    stop() {
+      if (timer) {
+        clearInterval(timer);
+        timer = null;
+      }
+    },
+    isRunning: () => running,
+  };
+}

--- a/packages/core/tests/serial-scheduler.test.ts
+++ b/packages/core/tests/serial-scheduler.test.ts
@@ -1,0 +1,93 @@
+// Serial interval runner (spec §14). Verifies the non-overlap guarantee, error
+// routing, and start/stop idempotency using fake timers.
+
+import { createSerialScheduler } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+/** A task whose promise resolves only when `release()` is called. */
+function deferredTask() {
+  let release: () => void = () => {};
+  let calls = 0;
+  const task = vi.fn(() => {
+    calls++;
+    return new Promise<void>((resolve) => {
+      release = resolve;
+    });
+  });
+  return {
+    task,
+    release: () => release(),
+    get calls() {
+      return calls;
+    },
+  };
+}
+
+describe("createSerialScheduler", () => {
+  it("fires the task on each interval", async () => {
+    const task = vi.fn(async () => {});
+    const scheduler = createSerialScheduler({ task, intervalMs: 1000 });
+    scheduler.start();
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(task).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(task).toHaveBeenCalledTimes(2);
+
+    scheduler.stop();
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(task).toHaveBeenCalledTimes(2); // no more after stop
+  });
+
+  it("never overlaps — a tick is skipped while the previous is still running", async () => {
+    const { task, release } = deferredTask();
+    const scheduler = createSerialScheduler({ task, intervalMs: 1000 });
+    scheduler.start();
+
+    await vi.advanceTimersByTimeAsync(1000); // tick 1 starts, stays pending
+    expect(task).toHaveBeenCalledTimes(1);
+    expect(scheduler.isRunning()).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(2000); // two more intervals — both skipped
+    expect(task).toHaveBeenCalledTimes(1);
+
+    release(); // tick 1 finishes
+    await vi.advanceTimersByTimeAsync(0);
+    expect(scheduler.isRunning()).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1000); // next interval now runs
+    expect(task).toHaveBeenCalledTimes(2);
+    scheduler.stop();
+  });
+
+  it("routes a task error to onError without stopping the schedule", async () => {
+    const onError = vi.fn();
+    let attempt = 0;
+    const task = vi.fn(async () => {
+      attempt++;
+      if (attempt === 1) throw new Error("boom");
+    });
+    const scheduler = createSerialScheduler({ task, intervalMs: 1000, onError });
+    scheduler.start();
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(onError).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1000); // schedule survives the error
+    expect(task).toHaveBeenCalledTimes(2);
+    scheduler.stop();
+  });
+
+  it("start is idempotent (a second start does not double-schedule)", async () => {
+    const task = vi.fn(async () => {});
+    const scheduler = createSerialScheduler({ task, intervalMs: 1000 });
+    scheduler.start();
+    scheduler.start();
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(task).toHaveBeenCalledTimes(1); // not 2
+    scheduler.stop();
+  });
+});

--- a/packages/mcp-server/src/bin/http.ts
+++ b/packages/mcp-server/src/bin/http.ts
@@ -5,7 +5,12 @@
 // server from `../http/server.ts`. All env parsing + boot-time
 // validation lives here so the server module itself stays pure.
 
-import { createLibrarianStore, resolveOptionalSecretKey } from "@librarian/core";
+import {
+  createLibrarianStore,
+  createSerialScheduler,
+  resolveOptionalSecretKey,
+  runCuratorTick,
+} from "@librarian/core";
 import { type AuthConfig, AgentTokensError, parseAgentTokenMap, parseCsv } from "../http/auth.js";
 import { createHttpServer } from "../http/server.js";
 import { logger } from "../logging.js";
@@ -85,19 +90,34 @@ const auth: AuthConfig = {
 
 const server = createHttpServer({ store, auth, maxBodyBytes });
 
+// Memory-curator scheduler (§14): a serial tick that runs due slices on a cadence.
+// The tick self-gates on the admin config (disabled/incomplete → cheap no-op), so
+// it's safe to always start. Set LIBRARIAN_CURATOR_TICK_MS=0 to disable (e.g. when
+// a separate worker process owns curation). Default hourly; the per-slice schedule
+// (every N days at HH:MM) is enforced inside the tick.
+const curatorTickMs = Number(process.env.LIBRARIAN_CURATOR_TICK_MS ?? 60 * 60_000);
+const curatorScheduler =
+  curatorTickMs > 0
+    ? createSerialScheduler({
+        task: () => runCuratorTick({ store }),
+        intervalMs: curatorTickMs,
+        onError: (error) => logger.error({ err: error }, "curator tick failed"),
+      })
+    : null;
+
 server.listen(port, host, () => {
+  curatorScheduler?.start();
   logger.info(
     { host, port, mcp: `http://${host}:${port}/mcp`, trpc: `http://${host}:${port}/trpc` },
     "The Librarian MCP service is running",
   );
 });
 
-process.on("SIGINT", () => {
+function shutdown(): void {
+  curatorScheduler?.stop();
   store.close();
   server.close(() => process.exit(0));
-});
+}
 
-process.on("SIGTERM", () => {
-  store.close();
-  server.close(() => process.exit(0));
-});
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);


### PR DESCRIPTION
## What

Completes the unattended-curation path.

- **core** `createSerialScheduler({task, intervalMs, onError})` — a minimal interval
  runner that **never overlaps** (a tick is skipped while the previous is still in
  flight — §14's serial requirement, which keeps a live run from being reclaimed
  mid-flight), routes task errors to `onError` without stopping the schedule, and
  unref's its timer so it can't keep the process alive on its own.
- **http bin** — starts a curator scheduler on `listen` that calls `runCuratorTick`
  on a cadence (default hourly; `LIBRARIAN_CURATOR_TICK_MS`, set `0` to disable when
  a separate worker owns curation) and stops it on shutdown. The tick self-gates on
  the admin config (disabled/incomplete → cheap no-op); the per-slice schedule
  (every N days at HH:MM) is enforced inside the tick.

The server now runs due slices on a schedule, serially, as `system-memory-curator`.

## Review

Self-reviewed: the runner is unit-tested with fake timers (interval firing,
**non-overlap**, error-routing, idempotent start); the bin wiring is covered by the
integration smokes (server boots + scheduler starts; default 1h tick won't fire
during the smoke). All green: core 391, mcp-server 95, cli 51, dashboard 48;
lint/typecheck/format clean.

## Next

The §7.1/§13 dashboard cockpit UI consuming `appRouter.curator` — config form,
read-only observability, and the run-now control. That completes the curator
deliverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)