### PR TITLE
feat(dashboard): memory-curator cockpit — read-only config + run history

### DIFF
--- a/apps/dashboard/app/curator/page.tsx
+++ b/apps/dashboard/app/curator/page.tsx
@@ -1,0 +1,34 @@
+// Memory-curator admin cockpit (spec §7.1 / §13) — read-only v1 view: current
+// config + recent run history. Config editing and run-now land as follow-ups.
+
+import { CuratorConfigSummary } from "@/components/curator/config-summary";
+import { CuratorRunsTable } from "@/components/curator/runs-table";
+import { serverTRPC } from "@/lib/trpc-server";
+
+export const dynamic = "force-dynamic";
+
+export default async function CuratorPage() {
+  let config: Awaited<ReturnType<typeof serverTRPC.curator.config.query>> | null = null;
+  let runs: Awaited<ReturnType<typeof serverTRPC.curator.runs.query>> = [];
+  let error: string | null = null;
+  try {
+    [config, runs] = await Promise.all([
+      serverTRPC.curator.config.query(),
+      serverTRPC.curator.runs.query({ limit: 50 }),
+    ]);
+  } catch (err) {
+    error = err instanceof Error ? err.message : String(err);
+  }
+
+  return (
+    <main className="flex flex-col gap-6 p-6">
+      <h1 className="text-2xl font-semibold tracking-tight">Memory Curator</h1>
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+      {config ? <CuratorConfigSummary config={config} /> : null}
+      <section className="rounded-md border bg-card p-4" aria-label="Run history">
+        <h2 className="mb-3 font-semibold">Recent runs</h2>
+        <CuratorRunsTable runs={runs} />
+      </section>
+    </main>
+  );
+}

--- a/apps/dashboard/components/curator/config-summary.tsx
+++ b/apps/dashboard/components/curator/config-summary.tsx
@@ -1,0 +1,42 @@
+// Read-only summary of the memory-curator config (spec §7.1 / §13). The token is
+// never shown — only whether one is configured (config.hasToken).
+
+import type { CuratorConfig } from "@librarian/core";
+
+function statusOf(config: CuratorConfig): { label: string; tone: string } {
+  if (config.isOperational) return { label: "Operational", tone: "text-green-600" };
+  if (config.enabled) return { label: "Enabled — config incomplete", tone: "text-amber-600" };
+  return { label: "Disabled", tone: "text-muted-foreground" };
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-4 py-1">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      <span className="font-mono text-sm">{value}</span>
+    </div>
+  );
+}
+
+export function CuratorConfigSummary({ config }: { config: CuratorConfig }) {
+  const status = statusOf(config);
+  return (
+    <section className="rounded-md border bg-card p-4" aria-label="Curator configuration">
+      <header className="mb-3 flex items-baseline justify-between">
+        <h2 className="font-semibold">Configuration</h2>
+        <span className={`text-sm font-medium ${status.tone}`}>{status.label}</span>
+      </header>
+      <Row
+        label="Schedule"
+        value={`every ${config.schedule.intervalDays}d at ${config.schedule.time}`}
+      />
+      <Row label="Provider" value={config.llm.provider || "—"} />
+      <Row label="Endpoint" value={config.llm.endpoint || "—"} />
+      <Row label="Model" value={config.llm.model || "—"} />
+      <Row label="API token" value={config.hasToken ? "configured" : "not set"} />
+      <Row label="Auto-apply" value={config.defaultAutoApply} />
+      <Row label="Confidence threshold" value={String(config.autoApplyConfidence)} />
+      <Row label="Prompt addendum" value={config.promptAddendum ? "set" : "—"} />
+    </section>
+  );
+}

--- a/apps/dashboard/components/curator/runs-table.tsx
+++ b/apps/dashboard/components/curator/runs-table.tsx
@@ -1,0 +1,42 @@
+// Read-only curation run history (spec §13 observability): trigger, status, when,
+// summary (per-action counts), token usage, model.
+
+import type { CurationRun } from "@librarian/core";
+
+function fmt(ts: string | null): string {
+  return ts ? new Date(ts).toLocaleString() : "—";
+}
+
+export function CuratorRunsTable({ runs }: { runs: CurationRun[] }) {
+  if (runs.length === 0) {
+    return <p className="text-sm text-muted-foreground">No curation runs yet.</p>;
+  }
+  return (
+    <table className="w-full text-left text-sm" aria-label="Curation runs">
+      <thead className="text-xs text-muted-foreground">
+        <tr>
+          <th className="py-2 pr-4 font-medium">Trigger</th>
+          <th className="py-2 pr-4 font-medium">Status</th>
+          <th className="py-2 pr-4 font-medium">Started</th>
+          <th className="py-2 pr-4 font-medium">Summary</th>
+          <th className="py-2 pr-4 font-medium">Tokens (in/out)</th>
+          <th className="py-2 font-medium">Model</th>
+        </tr>
+      </thead>
+      <tbody>
+        {runs.map((run) => (
+          <tr key={run.id} className="border-t align-top">
+            <td className="py-2 pr-4">{run.trigger}</td>
+            <td className="py-2 pr-4">{run.status}</td>
+            <td className="py-2 pr-4 font-mono text-xs">{fmt(run.started_at)}</td>
+            <td className="py-2 pr-4">{run.summary ?? run.error ?? "—"}</td>
+            <td className="py-2 pr-4 font-mono text-xs">
+              {run.usage_input_tokens}/{run.usage_output_tokens}
+            </td>
+            <td className="py-2 font-mono text-xs">{run.model_name ?? "—"}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/apps/dashboard/components/keyboard-host.tsx
+++ b/apps/dashboard/components/keyboard-host.tsx
@@ -19,6 +19,7 @@ const NAV_ITEMS = [
   { id: "nav-proposals", label: "Go to Proposals", href: "/proposals", hint: "" },
   { id: "nav-archive", label: "Go to Archive", href: "/archive", hint: "" },
   { id: "nav-logs", label: "Go to Logs", href: "/logs", hint: "" },
+  { id: "nav-curator", label: "Go to Curator", href: "/curator", hint: "" },
 ];
 
 const SHORTCUTS: Array<{ keys: string; description: string }> = [

--- a/apps/dashboard/tests/components/curator/cockpit.test.tsx
+++ b/apps/dashboard/tests/components/curator/cockpit.test.tsx
@@ -1,0 +1,83 @@
+import type { CuratorConfig, CurationRun } from "@librarian/core";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { CuratorConfigSummary } from "@/components/curator/config-summary";
+import { CuratorRunsTable } from "@/components/curator/runs-table";
+
+function config(over: Partial<CuratorConfig> = {}): CuratorConfig {
+  return {
+    enabled: false,
+    llm: { provider: "", endpoint: "", model: "" },
+    hasToken: false,
+    promptAddendum: "",
+    defaultAutoApply: "safe_only",
+    autoApplyConfidence: 0.9,
+    schedule: { intervalDays: 1, time: "03:00" },
+    isLlmComplete: false,
+    isOperational: false,
+    ...over,
+  };
+}
+
+function run(over: Partial<CurationRun> = {}): CurationRun {
+  return {
+    id: "run_1",
+    status: "completed",
+    trigger: "schedule",
+    mode: "apply",
+    project_key: "proj-x",
+    visibility: "common",
+    agent_id: null,
+    input_hash: "h",
+    input_memory_ids: [],
+    input_session_ids: [],
+    model_provider: "openai",
+    model_name: "gpt-x",
+    usage_input_tokens: 10,
+    usage_output_tokens: 5,
+    summary: "applied 2, skipped 1",
+    error: null,
+    created_at: "2026-05-24T00:00:00.000Z",
+    started_at: "2026-05-24T00:00:00.000Z",
+    completed_at: "2026-05-24T00:01:00.000Z",
+    ...over,
+  };
+}
+
+describe("CuratorConfigSummary", () => {
+  it("shows Disabled by default and never reveals the token", () => {
+    render(<CuratorConfigSummary config={config()} />);
+    expect(screen.getByText("Disabled")).toBeTruthy();
+    expect(screen.getByText("not set")).toBeTruthy(); // token presence only, never a value
+  });
+
+  it("shows Operational when enabled and the LLM config is complete", () => {
+    render(
+      <CuratorConfigSummary
+        config={config({
+          enabled: true,
+          hasToken: true,
+          isLlmComplete: true,
+          isOperational: true,
+          llm: { provider: "openai", endpoint: "https://e/v1", model: "gpt-x" },
+        })}
+      />,
+    );
+    expect(screen.getByText("Operational")).toBeTruthy();
+    expect(screen.getByText("configured")).toBeTruthy();
+  });
+});
+
+describe("CuratorRunsTable", () => {
+  it("renders an empty state with no runs", () => {
+    render(<CuratorRunsTable runs={[]} />);
+    expect(screen.getByText(/no curation runs/i)).toBeTruthy();
+  });
+
+  it("renders a run row with its summary, tokens, and model", () => {
+    render(<CuratorRunsTable runs={[run()]} />);
+    expect(screen.getByText("applied 2, skipped 1")).toBeTruthy();
+    expect(screen.getByText("10/5")).toBeTruthy();
+    expect(screen.getByText("gpt-x")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## What

The admin cockpit's read-only v1 view (spec §7.1/§13) at **/curator** (+ a
command-palette nav entry "Go to Curator"):

- **CuratorConfigSummary** — status (Operational / Enabled-incomplete / Disabled),
  schedule, LLM provider/endpoint/model, auto-apply level + confidence, prompt-
  addendum presence. The **token is never shown** — only whether one is configured.
- **CuratorRunsTable** — recent run history: trigger, status, started, summary
  (per-action counts) or error, token usage, model.
- **/curator** server page fetches `curator.config` + `curator.runs` via the
  admin-authed `serverTRPC` (mirrors the analytics page; `force-dynamic` + error
  handling).

## Review

Self-reviewed (read-only display mirroring the existing analytics page; presentational
components are pure/testable). Component tests: config Disabled→Operational and the
token is never revealed (only "configured"/"not set"); runs empty state + a populated
row. All green: core 391, mcp-server 95, cli 51, dashboard 52; lint/typecheck/format
clean.

## Next

Config editing (a client form → `curator.setConfig`) and the **run-now** control
(→ `curator.runNow`), completing the §7.1/§13 cockpit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)