### PR TITLE
feat(dashboard): curator cockpit interactivity — config edit + run-now

### DIFF
--- a/apps/dashboard/app/curator/actions.ts
+++ b/apps/dashboard/app/curator/actions.ts
@@ -1,0 +1,38 @@
+"use server";
+
+import type { CuratorConfigPatch, CuratorTickResult } from "@librarian/core";
+import { revalidatePath } from "next/cache";
+import { serverTRPC } from "@/lib/trpc-server";
+
+export type RunNowResult = { ok: true; result: CuratorTickResult } | { ok: false; error: string };
+
+export type SaveConfigResult = { ok: true } | { ok: false; error: string };
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+// Admin run-now (§12) — shares the scheduler enqueue path via the curator router.
+export async function runCuratorNowAction(): Promise<RunNowResult> {
+  try {
+    const result = await serverTRPC.curator.runNow.mutate();
+    revalidatePath("/curator");
+    return { ok: true, result };
+  } catch (error) {
+    return { ok: false, error: message(error) };
+  }
+}
+
+// Save the curator config (§7.1). An empty token field leaves the stored token
+// unchanged (the form never round-trips the secret); send "" explicitly to clear.
+export async function saveCuratorConfigAction(
+  patch: CuratorConfigPatch,
+): Promise<SaveConfigResult> {
+  try {
+    await serverTRPC.curator.setConfig.mutate(patch);
+    revalidatePath("/curator");
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: message(error) };
+  }
+}

--- a/apps/dashboard/app/curator/page.tsx
+++ b/apps/dashboard/app/curator/page.tsx
@@ -1,7 +1,10 @@
 // Memory-curator admin cockpit (spec §7.1 / §13) — read-only v1 view: current
 // config + recent run history. Config editing and run-now land as follow-ups.
 
+import { runCuratorNowAction, saveCuratorConfigAction } from "@/app/curator/actions";
+import { CuratorConfigForm } from "@/components/curator/config-form";
 import { CuratorConfigSummary } from "@/components/curator/config-summary";
+import { RunNowButton } from "@/components/curator/run-now-button";
 import { CuratorRunsTable } from "@/components/curator/runs-table";
 import { serverTRPC } from "@/lib/trpc-server";
 
@@ -22,9 +25,13 @@ export default async function CuratorPage() {
 
   return (
     <main className="flex flex-col gap-6 p-6">
-      <h1 className="text-2xl font-semibold tracking-tight">Memory Curator</h1>
+      <header className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold tracking-tight">Memory Curator</h1>
+        <RunNowButton onRun={runCuratorNowAction} />
+      </header>
       {error ? <p className="text-sm text-destructive">{error}</p> : null}
       {config ? <CuratorConfigSummary config={config} /> : null}
+      {config ? <CuratorConfigForm initial={config} onSave={saveCuratorConfigAction} /> : null}
       <section className="rounded-md border bg-card p-4" aria-label="Run history">
         <h2 className="mb-3 font-semibold">Recent runs</h2>
         <CuratorRunsTable runs={runs} />

--- a/apps/dashboard/components/curator/config-form.tsx
+++ b/apps/dashboard/components/curator/config-form.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import type { AutoApplyLevel, CuratorConfig, CuratorConfigPatch } from "@librarian/core";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import type { SaveConfigResult } from "@/app/curator/actions";
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="flex flex-col gap-1 text-sm">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      {children}
+    </label>
+  );
+}
+
+const inputClass = "rounded-md border bg-background px-2 py-1 font-mono text-sm";
+
+export function CuratorConfigForm({
+  initial,
+  onSave,
+}: {
+  initial: CuratorConfig;
+  onSave: (patch: CuratorConfigPatch) => Promise<SaveConfigResult>;
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [status, setStatus] = useState<string | null>(null);
+
+  const [enabled, setEnabled] = useState(initial.enabled);
+  const [provider, setProvider] = useState(initial.llm.provider);
+  const [endpoint, setEndpoint] = useState(initial.llm.endpoint);
+  const [model, setModel] = useState(initial.llm.model);
+  const [token, setToken] = useState("");
+  const [level, setLevel] = useState<AutoApplyLevel>(initial.defaultAutoApply);
+  const [confidence, setConfidence] = useState(String(initial.autoApplyConfidence));
+  const [intervalDays, setIntervalDays] = useState(String(initial.schedule.intervalDays));
+  const [time, setTime] = useState(initial.schedule.time);
+  const [addendum, setAddendum] = useState(initial.promptAddendum);
+
+  const submit = (event: React.FormEvent) => {
+    event.preventDefault();
+    startTransition(async () => {
+      const patch: CuratorConfigPatch = {
+        enabled,
+        llm: { provider, endpoint, model },
+        defaultAutoApply: level,
+        autoApplyConfidence: Number(confidence),
+        schedule: { intervalDays: Number(intervalDays), time },
+        promptAddendum: addendum,
+      };
+      // An empty token field leaves the stored token unchanged (never round-tripped).
+      if (token.length > 0) patch.token = token;
+      const result = await onSave(patch);
+      setStatus(result.ok ? "Saved." : `Error: ${result.error}`);
+      if (result.ok) {
+        setToken("");
+        router.refresh();
+      }
+    });
+  };
+
+  return (
+    <form
+      onSubmit={submit}
+      className="flex flex-col gap-4 rounded-md border bg-card p-4"
+      aria-label="Curator configuration form"
+    >
+      <h2 className="font-semibold">Edit configuration</h2>
+      <label className="flex items-center gap-2 text-sm">
+        <input type="checkbox" checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />
+        Enable scheduled curation
+      </label>
+      <div className="grid gap-3 sm:grid-cols-3">
+        <Field label="Provider">
+          <input
+            className={inputClass}
+            value={provider}
+            onChange={(e) => setProvider(e.target.value)}
+          />
+        </Field>
+        <Field label="Endpoint">
+          <input
+            className={inputClass}
+            value={endpoint}
+            onChange={(e) => setEndpoint(e.target.value)}
+          />
+        </Field>
+        <Field label="Model">
+          <input className={inputClass} value={model} onChange={(e) => setModel(e.target.value)} />
+        </Field>
+      </div>
+      <Field label="API token (blank = keep current)">
+        <input
+          className={inputClass}
+          type="password"
+          value={token}
+          placeholder={initial.hasToken ? "•••••• (configured)" : "not set"}
+          onChange={(e) => setToken(e.target.value)}
+        />
+      </Field>
+      <div className="grid gap-3 sm:grid-cols-3">
+        <Field label="Auto-apply">
+          <select
+            className={inputClass}
+            value={level}
+            onChange={(e) => setLevel(e.target.value as AutoApplyLevel)}
+          >
+            <option value="off">off</option>
+            <option value="safe_only">safe_only</option>
+            <option value="high_confidence">high_confidence</option>
+          </select>
+        </Field>
+        <Field label="Confidence (0–1)">
+          <input
+            className={inputClass}
+            type="number"
+            min="0"
+            max="1"
+            step="0.05"
+            value={confidence}
+            onChange={(e) => setConfidence(e.target.value)}
+          />
+        </Field>
+        <Field label="Run time (HH:MM)">
+          <input
+            className={inputClass}
+            type="time"
+            value={time}
+            onChange={(e) => setTime(e.target.value)}
+          />
+        </Field>
+      </div>
+      <Field label="Run every N days">
+        <input
+          className={inputClass}
+          type="number"
+          min="1"
+          value={intervalDays}
+          onChange={(e) => setIntervalDays(e.target.value)}
+        />
+      </Field>
+      <Field label="Prompt addendum (advisory, ≤ 2 KB)">
+        <textarea
+          className={inputClass}
+          rows={3}
+          value={addendum}
+          onChange={(e) => setAddendum(e.target.value)}
+        />
+      </Field>
+      <div className="flex items-center gap-3">
+        <button
+          type="submit"
+          disabled={pending}
+          className="rounded-md border bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground disabled:opacity-50"
+        >
+          {pending ? "Saving…" : "Save"}
+        </button>
+        {status ? <span className="text-sm text-muted-foreground">{status}</span> : null}
+      </div>
+    </form>
+  );
+}

--- a/apps/dashboard/components/curator/run-now-button.tsx
+++ b/apps/dashboard/components/curator/run-now-button.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import type { RunNowResult } from "@/app/curator/actions";
+
+export function RunNowButton({ onRun }: { onRun: () => Promise<RunNowResult> }) {
+  const [pending, startTransition] = useTransition();
+  const [message, setMessage] = useState<string | null>(null);
+  const router = useRouter();
+
+  const run = () =>
+    startTransition(async () => {
+      const res = await onRun();
+      if (!res.ok) {
+        setMessage(`Error: ${res.error}`);
+        return;
+      }
+      const r = res.result;
+      setMessage(
+        r.ran
+          ? `Ran — ${r.summary.ran} of ${r.summary.due} due slice(s) curated.`
+          : `Skipped — ${r.reason.replace(/_/g, " ")}.`,
+      );
+      router.refresh();
+    });
+
+  return (
+    <div className="flex items-center gap-3">
+      <button
+        type="button"
+        onClick={run}
+        disabled={pending}
+        className="rounded-md border bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground disabled:opacity-50"
+      >
+        {pending ? "Running…" : "Run now"}
+      </button>
+      {message ? <span className="text-sm text-muted-foreground">{message}</span> : null}
+    </div>
+  );
+}

--- a/apps/dashboard/tests/components/curator/cockpit-actions.test.tsx
+++ b/apps/dashboard/tests/components/curator/cockpit-actions.test.tsx
@@ -1,0 +1,90 @@
+import type { CuratorConfig, CuratorConfigPatch } from "@librarian/core";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { CuratorConfigForm } from "@/components/curator/config-form";
+import { RunNowButton } from "@/components/curator/run-now-button";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
+
+const summary = {
+  due: 2,
+  ran: 2,
+  skippedLocked: 0,
+  skippedIdempotent: 0,
+  reclaimedStaleLocks: 0,
+  errored: 0,
+};
+
+describe("RunNowButton", () => {
+  it("reports the run summary on success", async () => {
+    const onRun = vi.fn(async () => ({
+      ok: true as const,
+      result: { ran: true as const, summary },
+    }));
+    render(<RunNowButton onRun={onRun} />);
+    await userEvent.click(screen.getByRole("button", { name: /run now/i }));
+    expect(onRun).toHaveBeenCalledTimes(1);
+    expect(screen.getByText(/Ran — 2 of 2 due/)).toBeTruthy();
+  });
+
+  it("reports a skip reason when nothing ran", async () => {
+    const onRun = vi.fn(async () => ({
+      ok: true as const,
+      result: { ran: false as const, reason: "disabled" as const },
+    }));
+    render(<RunNowButton onRun={onRun} />);
+    await userEvent.click(screen.getByRole("button", { name: /run now/i }));
+    expect(screen.getByText(/Skipped — disabled/)).toBeTruthy();
+  });
+
+  it("surfaces an error", async () => {
+    const onRun = vi.fn(async () => ({ ok: false as const, error: "nope" }));
+    render(<RunNowButton onRun={onRun} />);
+    await userEvent.click(screen.getByRole("button", { name: /run now/i }));
+    expect(screen.getByText(/Error: nope/)).toBeTruthy();
+  });
+});
+
+const config: CuratorConfig = {
+  enabled: false,
+  llm: { provider: "openai", endpoint: "https://e/v1", model: "gpt-x" },
+  hasToken: true,
+  promptAddendum: "",
+  defaultAutoApply: "safe_only",
+  autoApplyConfidence: 0.9,
+  schedule: { intervalDays: 1, time: "03:00" },
+  isLlmComplete: true,
+  isOperational: false,
+};
+
+describe("CuratorConfigForm", () => {
+  it("pre-fills from the current config and saves a patch without the token when left blank", async () => {
+    const onSave = vi.fn(async (_patch: CuratorConfigPatch) => ({ ok: true as const }));
+    render(<CuratorConfigForm initial={config} onSave={onSave} />);
+
+    expect((screen.getByLabelText("Provider") as HTMLInputElement).value).toBe("openai");
+    expect((screen.getByLabelText("Model") as HTMLInputElement).value).toBe("gpt-x");
+
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+    expect(onSave).toHaveBeenCalledTimes(1);
+    const patch = onSave.mock.calls[0]![0];
+    expect(patch).toMatchObject({
+      enabled: false,
+      llm: { provider: "openai", endpoint: "https://e/v1", model: "gpt-x" },
+      defaultAutoApply: "safe_only",
+      autoApplyConfidence: 0.9,
+      schedule: { intervalDays: 1, time: "03:00" },
+    });
+    expect("token" in patch).toBe(false); // blank token field → unchanged
+    expect(screen.getByText("Saved.")).toBeTruthy();
+  });
+
+  it("includes the token only when the field is filled", async () => {
+    const onSave = vi.fn(async (_patch: CuratorConfigPatch) => ({ ok: true as const }));
+    render(<CuratorConfigForm initial={config} onSave={onSave} />);
+    await userEvent.type(screen.getByLabelText(/API token/), "new-token-value");
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+    expect(onSave.mock.calls[0]![0].token).toBe("new-token-value");
+  });
+});


### PR DESCRIPTION
## What

Completes the §7.1/§13 admin cockpit with controls, following the dashboard's
server-action mutation pattern (`serverTRPC` + `revalidatePath`):

- **app/curator/actions.ts** — `runCuratorNowAction` (→ `curator.runNow`) and
  `saveCuratorConfigAction` (→ `curator.setConfig`), admin-authed server-side.
- **RunNowButton** — triggers a manual run and reports the result (ran N of M due
  slices, the skip reason, or an error).
- **CuratorConfigForm** — edits enable / provider·endpoint·model / token /
  auto-apply level + confidence / schedule (every N days at HH:MM) / prompt
  addendum. The **token field is blank by default and only sent when filled**, so
  the stored secret is never round-tripped to the browser; `writeCuratorConfig`
  validates server-side.

Both are client components taking the server action as a prop (unit-testable).

## Review

Self-reviewed: mirrors the existing session server-action pattern; admin auth is
enforced by `serverTRPC`'s admin token (the curator router is admin-gated +
audited); the secret token is never sent to the browser and only written when the
admin types a new one. Tests: run-now summary/skip/error rendering; config-form
prefill, save **without** the token when blank, and token included only when typed.
All green: core 391, mcp-server 95, cli 51, dashboard 57; lint/typecheck/format clean.

This completes the Memory Curator deliverable end-to-end: pipeline → scheduling →
locking → config-driven tick → serial timer → admin API → cockpit (observability +
config + run-now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)