### PR TITLE
feat(lifecycle): shared package scaffold + privacy-marker detection (§3.3)

### DIFF
--- a/integrations/shared/librarian-lifecycle/README.md
+++ b/integrations/shared/librarian-lifecycle/README.md
@@ -1,0 +1,33 @@
+# @librarian/lifecycle
+
+Shared harness lifecycle helper used by every Librarian integration (Claude
+Code, Codex, Hermes, OpenCode, Pi). It is the single place where the rules from
+[`docs/specs/harness-commands-and-lifecycle-spec.md`](../../../docs/specs/harness-commands-and-lifecycle-spec.md)
+live, so each harness hook stays a thin adapter.
+
+Dependency-light by design (§6) — it runs in several harness environments and
+must not drag heavy deps into hook scripts.
+
+## Modules
+
+| Module       | Responsibility (spec)                                                            |
+| ------------ | ------------------------------------------------------------------------------- |
+| `privacy.ts` | Detect privacy markers and the toggle command (§3.1, §3.3). Pure, no I/O.        |
+| `state.ts`   | Load/save local harness state; atomic writes, `0700`/`0600`, fail-closed (§4).   |
+| `cli.ts`     | Call `the-librarian` with consistent flags (§8).                                 |
+| `session.ts` | Idempotent start/resume/pause, checkpoint gating, private-transition end (§5/§9). |
+
+## Privacy detection
+
+```ts
+import { detectPrivacySignal } from "@librarian/lifecycle";
+
+detectPrivacySignal("off the record, here's a secret");
+// → { signal: "enter-private", matched: "off the record", hasSubstantiveContent: true }
+```
+
+Detection is exact / near-exact phrase matching only (§3.3) — never a semantic
+classifier. The bias is deliberate: a missed marker leaks nothing on its own,
+but a false positive on ordinary prose ("refactor the **private** fields")
+would silently stop recording legitimate work. Private markers take precedence
+over exit markers in the same prompt (fail toward privacy).

--- a/integrations/shared/librarian-lifecycle/package.json
+++ b/integrations/shared/librarian-lifecycle/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@librarian/lifecycle",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Shared harness lifecycle helper: privacy detection, local state, and idempotent session automation.",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "prepare": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.json",
+    "test:vitest": "vitest run",
+    "test": "pnpm run build && pnpm run test:vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.5",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "license": "Apache-2.0"
+}

--- a/integrations/shared/librarian-lifecycle/src/index.ts
+++ b/integrations/shared/librarian-lifecycle/src/index.ts
@@ -1,0 +1,8 @@
+// @librarian/lifecycle — shared harness lifecycle helper.
+//
+// Privacy detection, local state, CLI wiring, and idempotent session
+// automation used by every harness integration (Claude Code, Codex,
+// Hermes, OpenCode, Pi). Dependency-light by design: it runs in several
+// harness environments (§6).
+
+export * from "./privacy.js";

--- a/integrations/shared/librarian-lifecycle/src/privacy.ts
+++ b/integrations/shared/librarian-lifecycle/src/privacy.ts
@@ -1,0 +1,113 @@
+// Privacy-marker detection (spec §3.1, §3.3).
+//
+// Pure, dependency-free phrase matching — no I/O, no remote calls. The
+// shared helper and every harness hook run this *before* any Librarian
+// call to decide whether the current prompt is off-record. Per §3.3 we
+// use exact / near-exact phrase matching, never an aggressive semantic
+// classifier: a false negative leaks nothing, but a false positive that
+// trips on ordinary prose ("refactor the private fields") would silently
+// stop recording legitimate work.
+
+/** Default enter-private phrases (§3.3). */
+export const DEFAULT_PRIVATE_MARKERS: readonly string[] = [
+  "this is a private session",
+  "don't remember this",
+  "do not remember this",
+  "don't save this",
+  "do not save this",
+  "don't store this",
+  "off the record",
+  "keep this between us",
+  "private from here",
+];
+
+/** Default exit-private phrases (§3.3). */
+export const DEFAULT_PUBLIC_MARKERS: readonly string[] = [
+  "you can remember again",
+  "end private mode",
+  "back on the record",
+  "this can be remembered",
+];
+
+/** The pure toggle command, in both the colon and hyphen renderings (§3.1). */
+const TOGGLE_COMMANDS: readonly string[] = ["/lib-toggle-private", "/lib:toggle-private"];
+
+export type PrivacySignal = "enter-private" | "exit-private" | "toggle" | "none";
+
+export interface PrivacyMarkers {
+  privateMarkers?: readonly string[];
+  publicMarkers?: readonly string[];
+}
+
+export interface PrivacyDetection {
+  signal: PrivacySignal;
+  /** The marker/command phrase that matched, if any (for neutral logging). */
+  matched?: string;
+  /** Whether the prompt carries substantive content beyond the marker (§3.3). */
+  hasSubstantiveContent: boolean;
+}
+
+// Lowercase and fold smart apostrophes to ASCII so "don’t remember this"
+// matches the straight-quoted marker list.
+function normalise(text: string): string {
+  return text.normalize("NFKC").replace(/[‘’]/g, "'").toLowerCase();
+}
+
+// Count alphanumeric characters left after the marker phrase is removed.
+// Trailing punctuation ("off the record.") is not substantive; real
+// content ("off the record, my key is …") is.
+const SUBSTANTIVE_MIN_CHARS = 3;
+
+function hasSubstantiveRemainder(normalisedPrompt: string, normalisedMarker: string): boolean {
+  const idx = normalisedPrompt.indexOf(normalisedMarker);
+  const without =
+    idx === -1
+      ? normalisedPrompt
+      : `${normalisedPrompt.slice(0, idx)} ${normalisedPrompt.slice(idx + normalisedMarker.length)}`;
+  const alnum = without.replace(/[^a-z0-9]+/g, "");
+  return alnum.length >= SUBSTANTIVE_MIN_CHARS;
+}
+
+function firstMatch(normalisedPrompt: string, markers: readonly string[]): string | undefined {
+  return markers.find((marker) => normalisedPrompt.includes(normalise(marker)));
+}
+
+/**
+ * Classify a prompt's privacy intent. Private markers take precedence over
+ * exit markers in the same prompt (fail toward privacy, §3.3). A pure
+ * `/lib-toggle-private` command is reported as `toggle`; the same string
+ * embedded in prose is not.
+ */
+export function detectPrivacySignal(
+  prompt: string,
+  markers: PrivacyMarkers = {},
+): PrivacyDetection {
+  const normalised = normalise(prompt);
+  const trimmed = normalised.trim();
+
+  if (TOGGLE_COMMANDS.includes(trimmed)) {
+    return { signal: "toggle", matched: trimmed, hasSubstantiveContent: false };
+  }
+
+  const privateMarkers = markers.privateMarkers ?? DEFAULT_PRIVATE_MARKERS;
+  const enter = firstMatch(normalised, privateMarkers);
+  if (enter !== undefined) {
+    return {
+      signal: "enter-private",
+      matched: enter,
+      hasSubstantiveContent: hasSubstantiveRemainder(normalised, normalise(enter)),
+    };
+  }
+
+  const publicMarkers = markers.publicMarkers ?? DEFAULT_PUBLIC_MARKERS;
+  const exit = firstMatch(normalised, publicMarkers);
+  if (exit !== undefined) {
+    return {
+      signal: "exit-private",
+      matched: exit,
+      hasSubstantiveContent: hasSubstantiveRemainder(normalised, normalise(exit)),
+    };
+  }
+
+  return { signal: "none", hasSubstantiveContent: false };
+}

--- a/integrations/shared/librarian-lifecycle/src/privacy.ts
+++ b/integrations/shared/librarian-lifecycle/src/privacy.ts
@@ -55,10 +55,18 @@ function normalise(text: string): string {
 
 // Count alphanumeric characters left after the marker phrase is removed.
 // Trailing punctuation ("off the record.") is not substantive; real
-// content ("off the record, my key is …") is.
+// content ("off the record, my key is …") is. The 3-char floor lets short
+// punctuation/filler ("ok", ".") read as a bare marker while any genuine
+// instruction trips it. Note both directions of error fail safe: an
+// over-report means we decline to record the current turn (the private-
+// biased choice for both enter and exit per §3.3).
 const SUBSTANTIVE_MIN_CHARS = 3;
 
 function hasSubstantiveRemainder(normalisedPrompt: string, normalisedMarker: string): boolean {
+  // Removing only the first occurrence is deliberate: if a marker repeats,
+  // the leftover copies inflate the count toward "substantive" — i.e.
+  // toward not recording the turn, the safe direction. Do not "fix" this
+  // into stripping all occurrences without re-checking that bias.
   const idx = normalisedPrompt.indexOf(normalisedMarker);
   const without =
     idx === -1
@@ -68,6 +76,9 @@ function hasSubstantiveRemainder(normalisedPrompt: string, normalisedMarker: str
   return alnum.length >= SUBSTANTIVE_MIN_CHARS;
 }
 
+// Returns a matching marker (the first in list order, not necessarily the
+// first by position in the prompt). Only `signal` drives behaviour; `matched`
+// is for neutral logging, so list-order is sufficient.
 function firstMatch(normalisedPrompt: string, markers: readonly string[]): string | undefined {
   return markers.find((marker) => normalisedPrompt.includes(normalise(marker)));
 }

--- a/integrations/shared/librarian-lifecycle/tests/privacy.test.ts
+++ b/integrations/shared/librarian-lifecycle/tests/privacy.test.ts
@@ -45,6 +45,12 @@ describe("detectPrivacySignal — exit-private markers (§3.3)", () => {
     expect(d.signal).toBe("exit-private");
     expect(d.hasSubstantiveContent).toBe(true);
   });
+
+  it("treats a bare exit marker (sub-threshold trailing punctuation) as no content", () => {
+    const d = detectPrivacySignal("end private mode!");
+    expect(d.signal).toBe("exit-private");
+    expect(d.hasSubstantiveContent).toBe(false);
+  });
 });
 
 describe("detectPrivacySignal — toggle command (§3.1)", () => {

--- a/integrations/shared/librarian-lifecycle/tests/privacy.test.ts
+++ b/integrations/shared/librarian-lifecycle/tests/privacy.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_PRIVATE_MARKERS,
+  DEFAULT_PUBLIC_MARKERS,
+  detectPrivacySignal,
+} from "../src/privacy.js";
+
+describe("detectPrivacySignal — enter-private markers (§3.3)", () => {
+  it("catches each explicit private phrase on its own", () => {
+    for (const marker of DEFAULT_PRIVATE_MARKERS) {
+      const d = detectPrivacySignal(marker);
+      expect(d.signal, marker).toBe("enter-private");
+      expect(d.matched, marker).toBe(marker);
+    }
+  });
+
+  it("treats a private marker mixed with substantive content as fully private", () => {
+    const d = detectPrivacySignal("off the record, my api key is abc123 — what do you think?");
+    expect(d.signal).toBe("enter-private");
+    expect(d.hasSubstantiveContent).toBe(true);
+  });
+
+  it("flags a bare marker as having no substantive content", () => {
+    const d = detectPrivacySignal("  Off The Record.  ");
+    expect(d.signal).toBe("enter-private");
+    expect(d.hasSubstantiveContent).toBe(false);
+  });
+
+  it("normalises curly apostrophes so smart-quoted contractions still match", () => {
+    const d = detectPrivacySignal("don’t remember this");
+    expect(d.signal).toBe("enter-private");
+  });
+});
+
+describe("detectPrivacySignal — exit-private markers (§3.3)", () => {
+  it("catches each explicit exit phrase on its own", () => {
+    for (const marker of DEFAULT_PUBLIC_MARKERS) {
+      const d = detectPrivacySignal(marker);
+      expect(d.signal, marker).toBe("exit-private");
+    }
+  });
+
+  it("applies the exit signal even with trailing substantive content (resumes next prompt)", () => {
+    const d = detectPrivacySignal("you can remember again — let's get back to the refactor");
+    expect(d.signal).toBe("exit-private");
+    expect(d.hasSubstantiveContent).toBe(true);
+  });
+});
+
+describe("detectPrivacySignal — toggle command (§3.1)", () => {
+  it("recognises the hyphen and colon forms as a pure toggle", () => {
+    expect(detectPrivacySignal("/lib-toggle-private").signal).toBe("toggle");
+    expect(detectPrivacySignal("  /lib:toggle-private  ").signal).toBe("toggle");
+  });
+
+  it("does not treat the command embedded in prose as a toggle", () => {
+    expect(detectPrivacySignal("run /lib-toggle-private to flip mode").signal).toBe("none");
+  });
+});
+
+describe("detectPrivacySignal — no false positives (§11.1)", () => {
+  it("returns none for unrelated prose", () => {
+    const d = detectPrivacySignal(
+      "Please refactor the private fields in this class to be readonly.",
+    );
+    expect(d.signal).toBe("none");
+  });
+
+  it("returns none for an empty prompt", () => {
+    expect(detectPrivacySignal("").signal).toBe("none");
+  });
+
+  it("private markers take precedence over exit markers in the same prompt", () => {
+    const d = detectPrivacySignal("you can remember again but actually keep this between us");
+    expect(d.signal).toBe("enter-private");
+  });
+});
+
+describe("detectPrivacySignal — custom marker lists", () => {
+  it("honours caller-supplied markers", () => {
+    const d = detectPrivacySignal("zip it", {
+      privateMarkers: ["zip it"],
+      publicMarkers: ["unzip"],
+    });
+    expect(d.signal).toBe("enter-private");
+  });
+});

--- a/integrations/shared/librarian-lifecycle/tsconfig.json
+++ b/integrations/shared/librarian-lifecycle/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules", "tests"]
+}

--- a/integrations/shared/librarian-lifecycle/vitest.config.ts
+++ b/integrations/shared/librarian-lifecycle/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+    passWithNoTests: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,18 @@ importers:
         specifier: 'catalog:'
         version: 2.1.9(@types/node@22.19.19)(jsdom@25.0.1)(lightningcss@1.32.0)
 
+  integrations/shared/librarian-lifecycle:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.5
+        version: 22.19.19
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@22.19.19)(jsdom@25.0.1)(lightningcss@1.32.0)
+
   packages/cli:
     dependencies:
       '@librarian/core':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - "packages/*"
   - "apps/*"
+  - "integrations/shared/*"
 
 catalog:
   typescript: ^5.7.2


### PR DESCRIPTION
## What

First slice of **Stage 3 — Harness commands & lifecycle** (`docs/specs/implementation-plan.md` Workstream 3.1). Introduces the shared lifecycle helper package `@librarian/lifecycle` at `integrations/shared/librarian-lifecycle/` and its first module: pure, dependency-light **privacy-marker detection** (spec §3.1, §3.3).

Every harness hook (Claude Code, Codex, Hermes, OpenCode, Pi) will run this *before* any Librarian call to decide whether the current prompt is off-record. Keeping it in one shared, pure module means each per-harness adapter stays thin and the privacy rules live in exactly one place.

## API

```ts
detectPrivacySignal("off the record, here's a secret")
// → { signal: "enter-private", matched: "off the record", hasSubstantiveContent: true }
```

`signal`: `enter-private` | `exit-private` | `toggle` | `none`.

- Exact / near-exact phrase matching only — **no** semantic classifier (§3.3). The bias is deliberate: a missed marker leaks nothing on its own, but a false positive on ordinary prose ("refactor the **private** fields") would silently stop recording legitimate work.
- **Private markers take precedence** over exit markers in the same prompt (fail toward privacy).
- `hasSubstantiveContent` distinguishes a bare marker from marker+content so the §3.3 "exit-private resumes from the *next* prompt" rule can be honoured.
- Smart apostrophes folded to ASCII; pure `/lib-toggle-private` (colon + hyphen forms) recognised, embedded-in-prose is not.
- Marker lists are caller-overridable; defaults are a verbatim match to spec §3.3.

## Scope / not in this PR

State persistence (`state.ts`), CLI wiring (`cli.ts`), and session orchestration (`session.ts`) are the next slices of Workstream 3.1. This PR is the pure detector + package scaffold only.

## Tests

13 tests mapping onto the privacy items of §11.1: enter/exit/toggle/none, mixed content, bare-marker boundaries (incl. the exit-path sub-threshold case), smart-quote folding, no-false-positive prose, empty prompt, precedence, custom markers. Reviewed by a code-reviewer sub-agent (APPROVE, no Critical/Important; doc + coverage suggestions applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)