### PR TITLE
feat(lifecycle): local harness state — atomic, permissioned, locked (§4/§9)

### DIFF
--- a/integrations/shared/librarian-lifecycle/src/index.ts
+++ b/integrations/shared/librarian-lifecycle/src/index.ts
@@ -6,3 +6,4 @@
 // harness environments (§6).
 
 export * from "./privacy.js";
+export * from "./state.js";

--- a/integrations/shared/librarian-lifecycle/src/state.ts
+++ b/integrations/shared/librarian-lifecycle/src/state.ts
@@ -109,6 +109,10 @@ function ensureDir(dir: string): void {
   fs.chmodSync(dir, DIR_MODE);
 }
 
+function optionalString(v: unknown): boolean {
+  return v === undefined || typeof v === "string";
+}
+
 function isState(value: unknown): value is HarnessLibrarianState {
   if (typeof value !== "object" || value === null) return false;
   const v = value as Record<string, unknown>;
@@ -117,7 +121,16 @@ function isState(value: unknown): value is HarnessLibrarianState {
     typeof v.harness === "string" &&
     (HARNESSES as readonly string[]).includes(v.harness) &&
     typeof v.harness_session_key === "string" &&
-    (v.privacy === "public" || v.privacy === "private")
+    (v.privacy === "public" || v.privacy === "private") &&
+    // Optional fields, when present, must be strings — a malformed one
+    // fails closed rather than loading partially-typed state.
+    optionalString(v.source_ref) &&
+    optionalString(v.cwd) &&
+    optionalString(v.project_key) &&
+    optionalString(v.librarian_session_id) &&
+    optionalString(v.entered_private_at) &&
+    optionalString(v.last_activity_at) &&
+    optionalString(v.last_checkpoint_at)
   );
 }
 
@@ -155,7 +168,15 @@ export function saveState(state: HarnessLibrarianState, opts: StateOptions = {})
   const tmp = path.join(dir, `.${path.basename(file)}.${process.pid}.${crypto.randomUUID()}.tmp`);
   try {
     ensureDir(dir);
-    fs.writeFileSync(tmp, JSON.stringify(state, null, 2), { mode: FILE_MODE });
+    // Exclusive create (wx) refuses to follow a pre-planted symlink at the
+    // temp path and makes the name-collision impossible rather than merely
+    // improbable. chmod after still guards against umask masking the mode.
+    const fd = fs.openSync(tmp, "wx", FILE_MODE);
+    try {
+      fs.writeFileSync(fd, JSON.stringify(state, null, 2));
+    } finally {
+      fs.closeSync(fd);
+    }
     fs.chmodSync(tmp, FILE_MODE);
     fs.renameSync(tmp, file);
   } catch (err) {
@@ -183,23 +204,43 @@ function lockAge(lockPath: string): number {
   }
 }
 
-function acquireLock(lockPath: string, opts: StateOptions): void {
+// Reclaim an abandoned lock without an unconditional delete. Racing
+// reclaimers must NOT both `rm` the path — that lets a loser stomp the
+// fresh lock a winner just created. Instead we atomically rename the
+// stale file out of the way: exactly one process's rename succeeds; the
+// others get ENOENT and simply loop back to let O_EXCL arbitrate. The
+// exclusive create remains the single serialization point.
+function reclaimStaleLock(lockPath: string): void {
+  const claim = `${lockPath}.reclaim.${process.pid}.${crypto.randomUUID()}`;
+  try {
+    fs.renameSync(lockPath, claim);
+    fs.rmSync(claim, { force: true });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return; // another reclaimer won
+    throw new StateIoError(`cannot reclaim stale lock ${lockPath}: ${(err as Error).message}`);
+  }
+}
+
+function acquireLock(lockPath: string, opts: StateOptions): string {
   const timeoutMs = opts.lockTimeoutMs ?? DEFAULT_LOCK_TIMEOUT_MS;
   const staleMs = opts.lockStaleMs ?? DEFAULT_LOCK_STALE_MS;
   const deadline = Date.now() + timeoutMs;
+  // A unique token identifies *our* hold, so release only removes our own
+  // lock and never one a later holder placed after reclaiming ours.
+  const token = `${process.pid}:${crypto.randomUUID()}`;
   ensureDir(path.dirname(lockPath));
   for (;;) {
     try {
       const fd = fs.openSync(lockPath, "wx", FILE_MODE); // exclusive create
-      fs.writeSync(fd, String(process.pid));
+      fs.writeSync(fd, token);
       fs.closeSync(fd);
-      return;
+      return token;
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
         throw new StateIoError(`cannot acquire lock ${lockPath}: ${(err as Error).message}`);
       }
       if (lockAge(lockPath) > staleMs) {
-        fs.rmSync(lockPath, { force: true }); // reclaim an abandoned lock
+        reclaimStaleLock(lockPath);
         continue;
       }
       if (Date.now() >= deadline) {
@@ -210,14 +251,28 @@ function acquireLock(lockPath: string, opts: StateOptions): void {
   }
 }
 
+// Release only if the lock still carries our token. If it was reclaimed
+// (we outran staleMs) and another holder now owns it, leave it alone.
+function releaseLock(lockPath: string, token: string): void {
+  let current: string;
+  try {
+    current = fs.readFileSync(lockPath, "utf8");
+  } catch {
+    return; // already gone or unreadable — nothing safe to do
+  }
+  if (current === token) {
+    fs.rmSync(lockPath, { force: true });
+  }
+}
+
 /** Run `fn` while holding the per-state lock; the lock is always released. */
 export function withStateLock<T>(loc: StateLocation, fn: () => T, opts: StateOptions = {}): T {
   const lockPath = `${stateFilePath(loc, opts)}.lock`;
-  acquireLock(lockPath, opts);
+  const token = acquireLock(lockPath, opts);
   try {
     return fn();
   } finally {
-    fs.rmSync(lockPath, { force: true });
+    releaseLock(lockPath, token);
   }
 }
 

--- a/integrations/shared/librarian-lifecycle/src/state.ts
+++ b/integrations/shared/librarian-lifecycle/src/state.ts
@@ -1,0 +1,239 @@
+// Local harness state (spec §4, §9).
+//
+// Every harness integration needs durable local state — we cannot rely on
+// LIBRARIAN_SESSION_ID alone because hooks generally cannot export env vars
+// back into an already-running parent process (§4). This module owns that
+// state: where it lives, how it is read/written, and the locking that lets
+// concurrent hooks mutate it safely.
+//
+// Two non-negotiables from the spec drive the design:
+//   - the state may identify sessions but must never hold private prompt
+//     text or summaries (§4.1); callers are responsible for that.
+//   - if state cannot be read or written, the integration must FAIL CLOSED
+//     (do not call The Librarian automatically, §4.2/§9). We surface that
+//     by throwing StateIoError rather than returning a usable value — a
+//     corrupt or unreadable file is never silently treated as "no state".
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export const HARNESSES = ["claude-code", "codex", "hermes", "opencode", "pi"] as const;
+export type Harness = (typeof HARNESSES)[number];
+
+export const STATE_VERSION = 1 as const;
+
+export interface HarnessLibrarianState {
+  version: typeof STATE_VERSION;
+  harness: Harness;
+  harness_session_key: string;
+  source_ref?: string;
+  cwd?: string;
+  project_key?: string;
+  librarian_session_id?: string;
+  privacy: "public" | "private";
+  entered_private_at?: string;
+  last_activity_at?: string;
+  last_checkpoint_at?: string;
+}
+
+/** The non-secret identifiers that locate a state file (§4.2). */
+export interface StateLocation {
+  harness: Harness;
+  harnessSessionKey: string;
+  sourceRef?: string;
+  cwd?: string;
+  projectKey?: string;
+}
+
+export interface StateOptions {
+  /** Override the state root; defaults to ~/.librarian/harness-state. */
+  baseDir?: string;
+  /** Max time to wait for the lock before throwing StateLockError. */
+  lockTimeoutMs?: number;
+  /** A lock older than this is considered abandoned and reclaimed. */
+  lockStaleMs?: number;
+}
+
+/** Read/write/parse failure — the signal to fail closed (§4.2/§9). */
+export class StateIoError extends Error {
+  override readonly name = "StateIoError";
+}
+
+/** Could not acquire the per-state lock within the timeout (§9). */
+export class StateLockError extends Error {
+  override readonly name = "StateLockError";
+}
+
+const DIR_MODE = 0o700;
+const FILE_MODE = 0o600;
+const DEFAULT_LOCK_TIMEOUT_MS = 5_000;
+const DEFAULT_LOCK_STALE_MS = 30_000;
+const LOCK_RETRY_MS = 50;
+
+export function defaultStateBaseDir(): string {
+  return path.join(os.homedir(), ".librarian", "harness-state");
+}
+
+function baseDirOf(opts: StateOptions): string {
+  return opts.baseDir ?? defaultStateBaseDir();
+}
+
+// Hash the non-secret location identifiers into a stable filename. Order is
+// fixed and fields are NUL-joined so distinct locations cannot collide by
+// concatenation (e.g. "ab"+"c" vs "a"+"bc").
+function locationHash(loc: StateLocation): string {
+  const parts = [loc.harnessSessionKey, loc.cwd ?? "", loc.sourceRef ?? "", loc.projectKey ?? ""];
+  return crypto.createHash("sha256").update(parts.join("\0")).digest("hex").slice(0, 40);
+}
+
+export function stateFilePath(loc: StateLocation, opts: StateOptions = {}): string {
+  return path.join(baseDirOf(opts), loc.harness, `${locationHash(loc)}.json`);
+}
+
+function locationOf(state: HarnessLibrarianState): StateLocation {
+  const loc: StateLocation = {
+    harness: state.harness,
+    harnessSessionKey: state.harness_session_key,
+  };
+  if (state.source_ref !== undefined) loc.sourceRef = state.source_ref;
+  if (state.cwd !== undefined) loc.cwd = state.cwd;
+  if (state.project_key !== undefined) loc.projectKey = state.project_key;
+  return loc;
+}
+
+function ensureDir(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true, mode: DIR_MODE });
+  // mkdir's mode is umask-masked; chmod the leaf to guarantee 0700 (§4.2).
+  fs.chmodSync(dir, DIR_MODE);
+}
+
+function isState(value: unknown): value is HarnessLibrarianState {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    v.version === STATE_VERSION &&
+    typeof v.harness === "string" &&
+    (HARNESSES as readonly string[]).includes(v.harness) &&
+    typeof v.harness_session_key === "string" &&
+    (v.privacy === "public" || v.privacy === "private")
+  );
+}
+
+/** Load state, or null if none exists. Throws StateIoError if present but unreadable/invalid. */
+export function loadState(
+  loc: StateLocation,
+  opts: StateOptions = {},
+): HarnessLibrarianState | null {
+  const file = stateFilePath(loc, opts);
+  let raw: string;
+  try {
+    raw = fs.readFileSync(file, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw new StateIoError(`cannot read harness state at ${file}: ${(err as Error).message}`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new StateIoError(`harness state at ${file} is not valid JSON: ${(err as Error).message}`);
+  }
+  if (!isState(parsed)) {
+    throw new StateIoError(`harness state at ${file} is structurally invalid`);
+  }
+  return parsed;
+}
+
+/** Persist state atomically with 0700/0600 permissions. Throws StateIoError on failure. */
+export function saveState(state: HarnessLibrarianState, opts: StateOptions = {}): void {
+  const file = stateFilePath(locationOf(state), opts);
+  const dir = path.dirname(file);
+  // A unique temp name in the same directory keeps the final rename atomic
+  // (same filesystem) and collision-free under concurrent writers (§9).
+  const tmp = path.join(dir, `.${path.basename(file)}.${process.pid}.${crypto.randomUUID()}.tmp`);
+  try {
+    ensureDir(dir);
+    fs.writeFileSync(tmp, JSON.stringify(state, null, 2), { mode: FILE_MODE });
+    fs.chmodSync(tmp, FILE_MODE);
+    fs.renameSync(tmp, file);
+  } catch (err) {
+    try {
+      fs.rmSync(tmp, { force: true });
+    } catch {
+      // best-effort temp cleanup
+    }
+    throw new StateIoError(`cannot write harness state at ${file}: ${(err as Error).message}`);
+  }
+}
+
+function sleepMs(ms: number): void {
+  if (ms <= 0) return;
+  // Synchronous sleep without a busy loop — hooks run in short-lived sync
+  // processes, so blocking here is correct and cheaper than spinning.
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function lockAge(lockPath: string): number {
+  try {
+    return Date.now() - fs.statSync(lockPath).mtimeMs;
+  } catch {
+    return Number.POSITIVE_INFINITY; // vanished → treat as reclaimable
+  }
+}
+
+function acquireLock(lockPath: string, opts: StateOptions): void {
+  const timeoutMs = opts.lockTimeoutMs ?? DEFAULT_LOCK_TIMEOUT_MS;
+  const staleMs = opts.lockStaleMs ?? DEFAULT_LOCK_STALE_MS;
+  const deadline = Date.now() + timeoutMs;
+  ensureDir(path.dirname(lockPath));
+  for (;;) {
+    try {
+      const fd = fs.openSync(lockPath, "wx", FILE_MODE); // exclusive create
+      fs.writeSync(fd, String(process.pid));
+      fs.closeSync(fd);
+      return;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
+        throw new StateIoError(`cannot acquire lock ${lockPath}: ${(err as Error).message}`);
+      }
+      if (lockAge(lockPath) > staleMs) {
+        fs.rmSync(lockPath, { force: true }); // reclaim an abandoned lock
+        continue;
+      }
+      if (Date.now() >= deadline) {
+        throw new StateLockError(`lock ${lockPath} is held; gave up after ${timeoutMs}ms`);
+      }
+      sleepMs(Math.min(LOCK_RETRY_MS, Math.max(0, deadline - Date.now())));
+    }
+  }
+}
+
+/** Run `fn` while holding the per-state lock; the lock is always released. */
+export function withStateLock<T>(loc: StateLocation, fn: () => T, opts: StateOptions = {}): T {
+  const lockPath = `${stateFilePath(loc, opts)}.lock`;
+  acquireLock(lockPath, opts);
+  try {
+    return fn();
+  } finally {
+    fs.rmSync(lockPath, { force: true });
+  }
+}
+
+/** Lock + load + mutate + save, the read-modify-write path hooks should use. */
+export function updateState(
+  loc: StateLocation,
+  mutate: (current: HarnessLibrarianState | null) => HarnessLibrarianState,
+  opts: StateOptions = {},
+): HarnessLibrarianState {
+  return withStateLock(
+    loc,
+    () => {
+      const next = mutate(loadState(loc, opts));
+      saveState(next, opts);
+      return next;
+    },
+    opts,
+  );
+}

--- a/integrations/shared/librarian-lifecycle/tests/state.test.ts
+++ b/integrations/shared/librarian-lifecycle/tests/state.test.ts
@@ -1,0 +1,183 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  type HarnessLibrarianState,
+  type StateLocation,
+  loadState,
+  saveState,
+  StateIoError,
+  StateLockError,
+  stateFilePath,
+  updateState,
+  withStateLock,
+} from "../src/state.js";
+
+let baseDir: string;
+
+beforeEach(() => {
+  baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "lib-state-"));
+});
+
+afterEach(() => {
+  fs.rmSync(baseDir, { recursive: true, force: true });
+});
+
+const loc: StateLocation = {
+  harness: "claude-code",
+  harnessSessionKey: "sess-1",
+  cwd: "/home/jim/code/the-librarian",
+  projectKey: "the-librarian",
+};
+
+function sample(over: Partial<HarnessLibrarianState> = {}): HarnessLibrarianState {
+  return {
+    version: 1,
+    harness: "claude-code",
+    harness_session_key: "sess-1",
+    cwd: "/home/jim/code/the-librarian",
+    project_key: "the-librarian",
+    privacy: "public",
+    ...over,
+  };
+}
+
+describe("stateFilePath", () => {
+  it("places files under baseDir/<harness>/<hash>.json", () => {
+    const p = stateFilePath(loc, { baseDir });
+    expect(p.startsWith(path.join(baseDir, "claude-code"))).toBe(true);
+    expect(p.endsWith(".json")).toBe(true);
+  });
+
+  it("is stable for the same location and differs across locations", () => {
+    expect(stateFilePath(loc, { baseDir })).toBe(stateFilePath(loc, { baseDir }));
+    const other = stateFilePath({ ...loc, harnessSessionKey: "sess-2" }, { baseDir });
+    expect(other).not.toBe(stateFilePath(loc, { baseDir }));
+  });
+});
+
+describe("loadState / saveState", () => {
+  it("round-trips state", () => {
+    const state = sample({
+      librarian_session_id: "ses_abc",
+      last_activity_at: "2026-05-24T00:00:00.000Z",
+    });
+    saveState(state, { baseDir });
+    expect(loadState(loc, { baseDir })).toEqual(state);
+  });
+
+  it("returns null when no state file exists", () => {
+    expect(loadState(loc, { baseDir })).toBeNull();
+  });
+
+  it("throws StateIoError on corrupt JSON (fail closed, not silent)", () => {
+    const p = stateFilePath(loc, { baseDir });
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, "{ not json");
+    expect(() => loadState(loc, { baseDir })).toThrow(StateIoError);
+  });
+
+  it("throws StateIoError on a structurally invalid state object", () => {
+    const p = stateFilePath(loc, { baseDir });
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, JSON.stringify({ version: 99, harness: "claude-code" }));
+    expect(() => loadState(loc, { baseDir })).toThrow(StateIoError);
+  });
+});
+
+describe("permissions (§4.2)", () => {
+  it("writes the state file 0600 and its directory 0700", () => {
+    saveState(sample(), { baseDir });
+    const p = stateFilePath(loc, { baseDir });
+    expect(fs.statSync(p).mode & 0o777).toBe(0o600);
+    expect(fs.statSync(path.dirname(p)).mode & 0o777).toBe(0o700);
+  });
+});
+
+describe("atomic writes (§9)", () => {
+  it("leaves no temp files behind", () => {
+    saveState(sample(), { baseDir });
+    const dir = path.dirname(stateFilePath(loc, { baseDir }));
+    const leftovers = fs.readdirSync(dir).filter((f) => f.includes(".tmp"));
+    expect(leftovers).toEqual([]);
+  });
+
+  it("replaces existing state wholesale", () => {
+    saveState(sample({ privacy: "public" }), { baseDir });
+    saveState(sample({ privacy: "private", entered_private_at: "2026-05-24T01:00:00.000Z" }), {
+      baseDir,
+    });
+    const loaded = loadState(loc, { baseDir });
+    expect(loaded?.privacy).toBe("private");
+    expect(loaded?.entered_private_at).toBe("2026-05-24T01:00:00.000Z");
+  });
+});
+
+describe("withStateLock / updateState", () => {
+  it("runs the mutator and persists the result", () => {
+    const result = updateState(
+      loc,
+      (current) => {
+        expect(current).toBeNull();
+        return sample({ librarian_session_id: "ses_new" });
+      },
+      { baseDir },
+    );
+    expect(result.librarian_session_id).toBe("ses_new");
+    expect(loadState(loc, { baseDir })?.librarian_session_id).toBe("ses_new");
+  });
+
+  it("read-modify-writes existing state under the lock", () => {
+    saveState(sample({ privacy: "public" }), { baseDir });
+    updateState(
+      loc,
+      (current) => ({
+        ...current!,
+        privacy: "private",
+        entered_private_at: "2026-05-24T02:00:00.000Z",
+      }),
+      { baseDir },
+    );
+    expect(loadState(loc, { baseDir })?.privacy).toBe("private");
+  });
+
+  it("throws StateLockError when the lock is already held", () => {
+    const lockPath = `${stateFilePath(loc, { baseDir })}.lock`;
+    fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+    fs.writeFileSync(lockPath, String(process.pid));
+    expect(() =>
+      withStateLock(loc, () => "x", { baseDir, lockTimeoutMs: 0, lockStaleMs: 60_000 }),
+    ).toThrow(StateLockError);
+  });
+
+  it("reclaims a stale lock", () => {
+    const lockPath = `${stateFilePath(loc, { baseDir })}.lock`;
+    fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+    fs.writeFileSync(lockPath, "999999");
+    const old = Date.now() / 1000 - 3600;
+    fs.utimesSync(lockPath, old, old);
+    const ran = withStateLock(loc, () => "ran", { baseDir, lockTimeoutMs: 0, lockStaleMs: 1000 });
+    expect(ran).toBe("ran");
+  });
+
+  it("releases the lock after the function returns", () => {
+    withStateLock(loc, () => "ok", { baseDir });
+    const lockPath = `${stateFilePath(loc, { baseDir })}.lock`;
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+
+  it("releases the lock even when the function throws", () => {
+    expect(() =>
+      withStateLock(
+        loc,
+        () => {
+          throw new Error("boom");
+        },
+        { baseDir },
+      ),
+    ).toThrow("boom");
+    const lockPath = `${stateFilePath(loc, { baseDir })}.lock`;
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+});

--- a/integrations/shared/librarian-lifecycle/tests/state.test.ts
+++ b/integrations/shared/librarian-lifecycle/tests/state.test.ts
@@ -180,4 +180,20 @@ describe("withStateLock / updateState", () => {
     const lockPath = `${stateFilePath(loc, { baseDir })}.lock`;
     expect(fs.existsSync(lockPath)).toBe(false);
   });
+
+  it("does not stomp a lock reclaimed by another holder on release (token check)", () => {
+    // Simulate: while we hold the lock we outran staleMs, another process
+    // reclaimed it and now holds it with its own token. Our release must
+    // leave that new lock intact.
+    const lockPath = `${stateFilePath(loc, { baseDir })}.lock`;
+    withStateLock(
+      loc,
+      () => {
+        fs.writeFileSync(lockPath, "other-holder-token");
+      },
+      { baseDir },
+    );
+    expect(fs.existsSync(lockPath)).toBe(true);
+    expect(fs.readFileSync(lockPath, "utf8")).toBe("other-holder-token");
+  });
 });


### PR DESCRIPTION
## What

Second slice of **Stage 3 / Workstream 3.1** (shared lifecycle helper). The durable local-state layer every harness hook relies on, because hooks generally can't export `LIBRARIAN_SESSION_ID` back into the parent process (§4).

- `HarnessLibrarianState` shape (§4.1) — identifies sessions/privacy, never holds prompt text or summaries.
- Hash-derived path `~/.librarian/harness-state/<harness>/<hash>.json` (§4.2). The hash NUL-joins the non-secret location identifiers so distinct locations can't collide by concatenation; sha256-hex so no path traversal via inputs.
- `saveState`: atomic temp-write + rename, dir `0700` / file `0600` (umask-safe via explicit chmod; temp opened `wx` so it won't follow a planted symlink).
- `loadState`: `null` when absent, but **throws `StateIoError`** on unreadable / invalid-JSON / structurally-invalid files — the **fail-closed** signal (§4.2/§9). A corrupt file is never silently treated as "no state".
- `withStateLock` / `updateState`: cross-process lockfile for the read-modify-write path concurrent hooks share.

## Security review

A security-auditor sub-agent reviewed this (fail-closed integrity, permissions/TOCTOU, lock races, path/hash, atomicity). It confirmed the fail-closed core, permissions, atomic replace, and hash collision-resistance all hold, and found one **Important** concurrency defect — a stale-lock reclaim race that broke mutual exclusion in the multi-hook case. Fixed in the second commit:

- Lock now carries a unique `pid:uuid` **token**; stale reclaim **atomically renames** the lock out of the way (only one racer wins; O_EXCL stays the sole arbiter); **release** removes the lock only if it still carries our token (won't stomp a later holder's lock).
- Temp write hardened to exclusive-create; optional state fields validated as strings (malformed → fail closed).

## Scope

CLI wiring (`cli.ts`) and session orchestration (`session.ts`) are the next slices.

## Tests

16 state tests + 13 privacy = 29: round-trip, absent/corrupt/invalid, `0700`/`0600`, no temp leftovers, wholesale replace, lock held/stale-reclaim/release-on-throw, and token-checked release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)