### PR TITLE
feat(lifecycle): the-librarian CLI wrapper for hook scripts (§8)

### DIFF
--- a/integrations/shared/librarian-lifecycle/src/cli.ts
+++ b/integrations/shared/librarian-lifecycle/src/cli.ts
@@ -114,6 +114,9 @@ function defaultRunner(config: LibrarianCliConfig): CliRunner {
     const res = spawnSync(bin, args, {
       encoding: "utf8",
       timeout: config.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      // Full env passthrough is deliberate: the CLI needs LIBRARIAN_SECRET_KEY
+      // and the DB path from the environment. No failure path surfaces env
+      // contents — LibrarianCliError carries only stderr/exitCode/verb.
       env: config.env ?? process.env,
       cwd: config.cwd,
       maxBuffer: MAX_BUFFER,
@@ -164,28 +167,26 @@ export function createLibrarianCli(
 
   // Run a JSON command and return the parsed object, mapping every failure
   // mode onto a typed LibrarianCliError the caller can log and fail-soft on.
-  function runJson(args: string[]): unknown {
+  // The verb is passed explicitly rather than read from argv[1] so the error
+  // text stays correct regardless of argv shape.
+  function runJson(verb: string, args: string[]): unknown {
     const res = run([...args, "--json"]);
     if (res.error) {
-      throw new LibrarianCliError(
-        "spawn",
-        `the-librarian ${args[1]} failed to spawn: ${res.error.message}`,
-        {
-          stderr: res.stderr,
-        },
-      );
+      // spawnSync reports a timeout via error.code === "ETIMEDOUT" *and*
+      // status === null, so the timeout must be distinguished here, before
+      // the generic spawn-failure branch, or every timeout reads as "spawn".
+      const code = (res.error as NodeJS.ErrnoException).code;
+      const kind: CliErrorKind = code === "ETIMEDOUT" ? "timeout" : "spawn";
+      const what = kind === "timeout" ? "timed out" : `failed to spawn: ${res.error.message}`;
+      throw new LibrarianCliError(kind, `the-librarian ${verb} ${what}`, { stderr: res.stderr });
     }
     if (res.status === null) {
-      throw new LibrarianCliError(
-        "timeout",
-        `the-librarian ${args[1]} was killed (timeout/signal)`,
-        {
-          stderr: res.stderr,
-        },
-      );
+      throw new LibrarianCliError("timeout", `the-librarian ${verb} was killed (signal)`, {
+        stderr: res.stderr,
+      });
     }
     if (res.status !== 0) {
-      throw new LibrarianCliError("exit", `the-librarian ${args[1]} exited ${res.status}`, {
+      throw new LibrarianCliError("exit", `the-librarian ${verb} exited ${res.status}`, {
         exitCode: res.status,
         stderr: res.stderr,
       });
@@ -195,7 +196,7 @@ export function createLibrarianCli(
     } catch (err) {
       throw new LibrarianCliError(
         "parse",
-        `the-librarian ${args[1]} returned invalid JSON: ${(err as Error).message}`,
+        `the-librarian ${verb} returned invalid JSON: ${(err as Error).message}`,
       );
     }
   }
@@ -206,6 +207,10 @@ export function createLibrarianCli(
   function withSummaryFile<T>(summary: string, fn: (file: string) => T): T {
     const file = path.join(tmpDir, `librarian-summary-${process.pid}-${crypto.randomUUID()}.txt`);
     fs.writeFileSync(file, summary, { mode: 0o600 });
+    // writeFileSync's mode is umask-masked at create time; chmod guarantees
+    // 0600 so a summary (which can carry sensitive work context) is never
+    // left world-readable under a permissive umask. Mirrors state.ts.
+    fs.chmodSync(file, 0o600);
     try {
       return fn(file);
     } finally {
@@ -221,7 +226,7 @@ export function createLibrarianCli(
       pushFlag(argv, "--project", args.projectKey);
       pushFlag(argv, "--start-summary", args.summary);
       pushFlag(argv, "--title", args.title);
-      const parsed = runJson(argv) as { session?: unknown };
+      const parsed = runJson("start", argv) as { session?: unknown };
       return toCliSession(parsed.session, "start");
     },
 
@@ -234,13 +239,16 @@ export function createLibrarianCli(
       for (const status of args.statuses ?? ["active", "paused"]) {
         argv.push("--status", status);
       }
-      const parsed = runJson(argv) as { sessions?: unknown };
+      const parsed = runJson("list", argv) as { sessions?: unknown };
       const sessions = Array.isArray(parsed.sessions) ? parsed.sessions : [];
       return sessions.map((s) => toCliSession(s, "list"));
     },
 
+    // The continue payload also carries handover/text/format, but the
+    // lifecycle helper only needs the attached session here; callers that
+    // want the handover prose use MCP continue_session / the slash command.
     continueSession(sessionId) {
-      const parsed = runJson(["sessions", "continue", sessionId, ...agentFlags]) as {
+      const parsed = runJson("continue", ["sessions", "continue", sessionId, ...agentFlags]) as {
         session?: unknown;
       };
       return toCliSession(parsed.session, "continue");
@@ -248,13 +256,20 @@ export function createLibrarianCli(
 
     checkpointSession(sessionId, summary) {
       withSummaryFile(summary, (file) => {
-        runJson(["sessions", "checkpoint", sessionId, ...agentFlags, "--summary-file", file]);
+        runJson("checkpoint", [
+          "sessions",
+          "checkpoint",
+          sessionId,
+          ...agentFlags,
+          "--summary-file",
+          file,
+        ]);
       });
     },
 
     pauseSession(sessionId, summary) {
       withSummaryFile(summary, (file) => {
-        runJson(["sessions", "pause", sessionId, ...agentFlags, "--summary-file", file]);
+        runJson("pause", ["sessions", "pause", sessionId, ...agentFlags, "--summary-file", file]);
       });
     },
   };

--- a/integrations/shared/librarian-lifecycle/src/cli.ts
+++ b/integrations/shared/librarian-lifecycle/src/cli.ts
@@ -1,0 +1,261 @@
+// The Librarian CLI wrapper (spec §8).
+//
+// Hook scripts prefer the CLI over MCP, especially on shutdown paths where
+// MCP may be slow or unavailable during process teardown (§8). This module
+// is the single place that knows the `the-librarian sessions …` flag
+// contract, so every harness adapter spawns it the same way and parses the
+// same JSON.
+//
+// The runner is injectable so the orchestration tests never spawn a real
+// binary; the default uses spawnSync because hooks run as short-lived,
+// synchronous processes.
+
+import { spawnSync } from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { Harness } from "./state.js";
+
+export interface CliRunResult {
+  stdout: string;
+  stderr: string;
+  /** Process exit code, or null when killed by signal/timeout. */
+  status: number | null;
+  /** Spawn failure (e.g. binary not found), if any. */
+  error?: Error;
+}
+
+export type CliRunner = (args: string[]) => CliRunResult;
+
+export interface LibrarianCliConfig {
+  /** Canonical agent id for attribution (--agent). */
+  agent: string;
+  /** CLI binary; defaults to $LIBRARIAN_CLI_BIN or "the-librarian". */
+  bin?: string;
+  /** Per-call timeout for the default runner. */
+  timeoutMs?: number;
+  /** Environment for the spawned process (defaults to process.env). */
+  env?: NodeJS.ProcessEnv;
+  /** Working directory for the spawned process. */
+  cwd?: string;
+}
+
+export interface LibrarianCliDeps {
+  run?: CliRunner;
+  /** Directory for transient --summary-file payloads (test override). */
+  tmpDir?: string;
+}
+
+export type CliErrorKind = "spawn" | "timeout" | "exit" | "parse";
+
+export class LibrarianCliError extends Error {
+  override readonly name = "LibrarianCliError";
+  readonly kind: CliErrorKind;
+  readonly exitCode?: number | undefined;
+  readonly stderr?: string | undefined;
+
+  constructor(
+    kind: CliErrorKind,
+    message: string,
+    extra: { exitCode?: number | null; stderr?: string } = {},
+  ) {
+    super(message);
+    this.kind = kind;
+    this.exitCode = extra.exitCode ?? undefined;
+    this.stderr = extra.stderr;
+  }
+}
+
+/** A session as the lifecycle helper needs it — a thin view over the CLI JSON. */
+export interface CliSession {
+  id: string;
+  status: string;
+  title: string | null;
+  project_key: string | null;
+  source_ref: string | null;
+  cwd: string | null;
+}
+
+export type SessionStatus = "active" | "paused" | "ended";
+
+export interface StartSessionArgs {
+  harness: Harness;
+  sourceRef?: string;
+  cwd?: string;
+  projectKey?: string;
+  summary?: string;
+  title?: string;
+}
+
+export interface ListSessionsArgs {
+  harness?: Harness;
+  sourceRef?: string;
+  cwd?: string;
+  projectKey?: string;
+  /** Defaults to active + paused — automation never attaches ended sessions (§5.2). */
+  statuses?: SessionStatus[];
+}
+
+export interface LibrarianCli {
+  startSession(args: StartSessionArgs): CliSession;
+  listSessions(args: ListSessionsArgs): CliSession[];
+  continueSession(sessionId: string): CliSession;
+  checkpointSession(sessionId: string, summary: string): void;
+  pauseSession(sessionId: string, summary: string): void;
+}
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const MAX_BUFFER = 10 * 1024 * 1024;
+
+function defaultRunner(config: LibrarianCliConfig): CliRunner {
+  const bin = config.bin ?? process.env.LIBRARIAN_CLI_BIN ?? "the-librarian";
+  return (args) => {
+    const res = spawnSync(bin, args, {
+      encoding: "utf8",
+      timeout: config.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      env: config.env ?? process.env,
+      cwd: config.cwd,
+      maxBuffer: MAX_BUFFER,
+    });
+    const result: CliRunResult = {
+      stdout: res.stdout ?? "",
+      stderr: res.stderr ?? "",
+      status: res.status,
+    };
+    if (res.error) result.error = res.error;
+    return result;
+  };
+}
+
+function pushFlag(args: string[], flag: string, value: string | undefined): void {
+  if (value !== undefined && value !== "") args.push(flag, value);
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function toCliSession(raw: unknown, context: string): CliSession {
+  if (typeof raw !== "object" || raw === null) {
+    throw new LibrarianCliError("parse", `${context}: response had no session`);
+  }
+  const s = raw as Record<string, unknown>;
+  if (typeof s.id !== "string" || typeof s.status !== "string") {
+    throw new LibrarianCliError("parse", `${context}: session is missing id/status`);
+  }
+  return {
+    id: s.id,
+    status: s.status,
+    title: asString(s.title),
+    project_key: asString(s.project_key),
+    source_ref: asString(s.source_ref),
+    cwd: asString(s.cwd),
+  };
+}
+
+export function createLibrarianCli(
+  config: LibrarianCliConfig,
+  deps: LibrarianCliDeps = {},
+): LibrarianCli {
+  const run = deps.run ?? defaultRunner(config);
+  const tmpDir = deps.tmpDir ?? os.tmpdir();
+  const agentFlags = ["--agent", config.agent];
+
+  // Run a JSON command and return the parsed object, mapping every failure
+  // mode onto a typed LibrarianCliError the caller can log and fail-soft on.
+  function runJson(args: string[]): unknown {
+    const res = run([...args, "--json"]);
+    if (res.error) {
+      throw new LibrarianCliError(
+        "spawn",
+        `the-librarian ${args[1]} failed to spawn: ${res.error.message}`,
+        {
+          stderr: res.stderr,
+        },
+      );
+    }
+    if (res.status === null) {
+      throw new LibrarianCliError(
+        "timeout",
+        `the-librarian ${args[1]} was killed (timeout/signal)`,
+        {
+          stderr: res.stderr,
+        },
+      );
+    }
+    if (res.status !== 0) {
+      throw new LibrarianCliError("exit", `the-librarian ${args[1]} exited ${res.status}`, {
+        exitCode: res.status,
+        stderr: res.stderr,
+      });
+    }
+    try {
+      return JSON.parse(res.stdout);
+    } catch (err) {
+      throw new LibrarianCliError(
+        "parse",
+        `the-librarian ${args[1]} returned invalid JSON: ${(err as Error).message}`,
+      );
+    }
+  }
+
+  // checkpoint/pause take their summary via a temp file (§8) so a long
+  // summary never bloats argv. The file is 0600 and removed after the call,
+  // even if it throws.
+  function withSummaryFile<T>(summary: string, fn: (file: string) => T): T {
+    const file = path.join(tmpDir, `librarian-summary-${process.pid}-${crypto.randomUUID()}.txt`);
+    fs.writeFileSync(file, summary, { mode: 0o600 });
+    try {
+      return fn(file);
+    } finally {
+      fs.rmSync(file, { force: true });
+    }
+  }
+
+  return {
+    startSession(args) {
+      const argv = ["sessions", "start", ...agentFlags, "--harness", args.harness];
+      pushFlag(argv, "--source-ref", args.sourceRef);
+      pushFlag(argv, "--cwd", args.cwd);
+      pushFlag(argv, "--project", args.projectKey);
+      pushFlag(argv, "--start-summary", args.summary);
+      pushFlag(argv, "--title", args.title);
+      const parsed = runJson(argv) as { session?: unknown };
+      return toCliSession(parsed.session, "start");
+    },
+
+    listSessions(args) {
+      const argv = ["sessions", "list", ...agentFlags];
+      pushFlag(argv, "--harness", args.harness);
+      pushFlag(argv, "--source-ref", args.sourceRef);
+      pushFlag(argv, "--cwd", args.cwd);
+      pushFlag(argv, "--project", args.projectKey);
+      for (const status of args.statuses ?? ["active", "paused"]) {
+        argv.push("--status", status);
+      }
+      const parsed = runJson(argv) as { sessions?: unknown };
+      const sessions = Array.isArray(parsed.sessions) ? parsed.sessions : [];
+      return sessions.map((s) => toCliSession(s, "list"));
+    },
+
+    continueSession(sessionId) {
+      const parsed = runJson(["sessions", "continue", sessionId, ...agentFlags]) as {
+        session?: unknown;
+      };
+      return toCliSession(parsed.session, "continue");
+    },
+
+    checkpointSession(sessionId, summary) {
+      withSummaryFile(summary, (file) => {
+        runJson(["sessions", "checkpoint", sessionId, ...agentFlags, "--summary-file", file]);
+      });
+    },
+
+    pauseSession(sessionId, summary) {
+      withSummaryFile(summary, (file) => {
+        runJson(["sessions", "pause", sessionId, ...agentFlags, "--summary-file", file]);
+      });
+    },
+  };
+}

--- a/integrations/shared/librarian-lifecycle/src/index.ts
+++ b/integrations/shared/librarian-lifecycle/src/index.ts
@@ -5,5 +5,6 @@
 // Hermes, OpenCode, Pi). Dependency-light by design: it runs in several
 // harness environments (§6).
 
+export * from "./cli.js";
 export * from "./privacy.js";
 export * from "./state.js";

--- a/integrations/shared/librarian-lifecycle/tests/cli.test.ts
+++ b/integrations/shared/librarian-lifecycle/tests/cli.test.ts
@@ -115,6 +115,16 @@ describe("createLibrarianCli — checkpoint/pause use --summary-file", () => {
     cli.pauseSession("ses_abc", "switching off");
     expect(seen).toBe("switching off");
   });
+
+  it("removes the summary temp file even when the call fails", () => {
+    let seenPath: string | undefined;
+    const { cli } = cliWith((args) => {
+      seenPath = args[args.indexOf("--summary-file") + 1];
+      return { stdout: "", stderr: "nope", status: 1 };
+    });
+    expect(() => cli.checkpointSession("ses_abc", "x")).toThrow(LibrarianCliError);
+    expect(fs.existsSync(seenPath!)).toBe(false);
+  });
 });
 
 describe("createLibrarianCli — error mapping", () => {
@@ -140,7 +150,17 @@ describe("createLibrarianCli — error mapping", () => {
     expect(() => cli.listSessions({})).toThrow(expect.objectContaining({ kind: "spawn" }));
   });
 
-  it("maps a null status (timeout/signal) to kind=timeout", () => {
+  it("maps a spawnSync timeout (ETIMEDOUT + null status) to kind=timeout", () => {
+    const { cli } = cliWith(() => ({
+      stdout: "",
+      stderr: "",
+      status: null,
+      error: Object.assign(new Error("timed out"), { code: "ETIMEDOUT" }),
+    }));
+    expect(() => cli.listSessions({})).toThrow(expect.objectContaining({ kind: "timeout" }));
+  });
+
+  it("maps a bare null status (signal kill, no error) to kind=timeout", () => {
     const { cli } = cliWith(() => ({ stdout: "", stderr: "", status: null }));
     expect(() => cli.listSessions({})).toThrow(expect.objectContaining({ kind: "timeout" }));
   });

--- a/integrations/shared/librarian-lifecycle/tests/cli.test.ts
+++ b/integrations/shared/librarian-lifecycle/tests/cli.test.ts
@@ -1,0 +1,152 @@
+import fs from "node:fs";
+import { describe, expect, it } from "vitest";
+import { type CliRunResult, createLibrarianCli, LibrarianCliError } from "../src/cli.js";
+
+function ok(json: unknown): CliRunResult {
+  return { stdout: JSON.stringify(json), stderr: "", status: 0 };
+}
+
+const session = {
+  id: "ses_abc",
+  status: "active",
+  title: "Work",
+  project_key: "the-librarian",
+  source_ref: null,
+  cwd: "/home/jim/code/the-librarian",
+};
+
+function cliWith(run: (args: string[]) => CliRunResult, overrides = {}) {
+  const calls: string[][] = [];
+  const wrapped = (args: string[]) => {
+    calls.push(args);
+    return run(args);
+  };
+  const cli = createLibrarianCli({ agent: "guybrush", ...overrides }, { run: wrapped });
+  return { cli, calls };
+}
+
+describe("createLibrarianCli — startSession", () => {
+  it("builds the start argv with --agent, --harness, and --json and parses the session", () => {
+    const { cli, calls } = cliWith(() => ok({ session }));
+    const result = cli.startSession({
+      harness: "claude-code",
+      cwd: "/home/jim/code/the-librarian",
+      projectKey: "the-librarian",
+      summary: "starting work",
+    });
+    expect(result.id).toBe("ses_abc");
+    const args = calls[0]!;
+    expect(args.slice(0, 2)).toEqual(["sessions", "start"]);
+    expect(args).toContain("--agent");
+    expect(args).toContain("guybrush");
+    expect(args).toEqual(expect.arrayContaining(["--harness", "claude-code"]));
+    expect(args).toEqual(expect.arrayContaining(["--project", "the-librarian"]));
+    expect(args).toEqual(expect.arrayContaining(["--start-summary", "starting work"]));
+    expect(args).toContain("--json");
+  });
+
+  it("omits optional flags that were not provided", () => {
+    const { cli, calls } = cliWith(() => ok({ session }));
+    cli.startSession({ harness: "codex" });
+    const args = calls[0]!;
+    expect(args).not.toContain("--source-ref");
+    expect(args).not.toContain("--project");
+    expect(args).not.toContain("--start-summary");
+  });
+
+  it("throws a parse error when the store returns no session", () => {
+    const { cli } = cliWith(() => ok({ session: null }));
+    expect(() => cli.startSession({ harness: "pi" })).toThrow(LibrarianCliError);
+  });
+});
+
+describe("createLibrarianCli — listSessions", () => {
+  it("defaults to active+paused status and parses the sessions array", () => {
+    const { cli, calls } = cliWith(() => ok({ sessions: [session], total: 1, limit: 20 }));
+    const result = cli.listSessions({ cwd: "/home/jim/code/the-librarian" });
+    expect(result.map((s) => s.id)).toEqual(["ses_abc"]);
+    const args = calls[0]!;
+    const statusFlags = args.filter((_, i) => args[i - 1] === "--status");
+    expect(statusFlags).toEqual(["active", "paused"]);
+  });
+
+  it("honours explicit statuses", () => {
+    const { cli, calls } = cliWith(() => ok({ sessions: [], total: 0, limit: 20 }));
+    cli.listSessions({ statuses: ["paused"] });
+    const args = calls[0]!;
+    expect(args.filter((_, i) => args[i - 1] === "--status")).toEqual(["paused"]);
+  });
+});
+
+describe("createLibrarianCli — continueSession", () => {
+  it("passes the id, agent, and --json", () => {
+    const { cli, calls } = cliWith(() => ok({ session, handover: {}, text: "", format: "prose" }));
+    const result = cli.continueSession("ses_abc");
+    expect(result.id).toBe("ses_abc");
+    const args = calls[0]!;
+    expect(args.slice(0, 3)).toEqual(["sessions", "continue", "ses_abc"]);
+    expect(args).toContain("--json");
+  });
+});
+
+describe("createLibrarianCli — checkpoint/pause use --summary-file", () => {
+  it("writes the summary to a temp file, passes --summary-file, and cleans it up", () => {
+    let seenPath: string | undefined;
+    let seenContent: string | undefined;
+    const { cli, calls } = cliWith((args) => {
+      const i = args.indexOf("--summary-file");
+      seenPath = args[i + 1];
+      seenContent = fs.readFileSync(seenPath!, "utf8");
+      return ok({ session });
+    });
+    cli.checkpointSession("ses_abc", "did the thing");
+    expect(seenContent).toBe("did the thing");
+    expect(calls[0]!.slice(0, 3)).toEqual(["sessions", "checkpoint", "ses_abc"]);
+    expect(fs.existsSync(seenPath!)).toBe(false); // cleaned up
+  });
+
+  it("pause writes its summary file too", () => {
+    let seen: string | undefined;
+    const { cli } = cliWith((args) => {
+      const i = args.indexOf("--summary-file");
+      seen = fs.readFileSync(args[i + 1]!, "utf8");
+      return ok({ session: { ...session, status: "paused" } });
+    });
+    cli.pauseSession("ses_abc", "switching off");
+    expect(seen).toBe("switching off");
+  });
+});
+
+describe("createLibrarianCli — error mapping", () => {
+  it("maps a non-zero exit to a LibrarianCliError with stderr", () => {
+    const { cli } = cliWith(() => ({ stdout: "", stderr: "boom", status: 1 }));
+    try {
+      cli.listSessions({});
+      expect.unreachable();
+    } catch (err) {
+      expect(err).toBeInstanceOf(LibrarianCliError);
+      expect((err as LibrarianCliError).kind).toBe("exit");
+      expect((err as LibrarianCliError).stderr).toBe("boom");
+    }
+  });
+
+  it("maps a spawn failure to kind=spawn", () => {
+    const { cli } = cliWith(() => ({
+      stdout: "",
+      stderr: "",
+      status: null,
+      error: Object.assign(new Error("ENOENT"), { code: "ENOENT" }),
+    }));
+    expect(() => cli.listSessions({})).toThrow(expect.objectContaining({ kind: "spawn" }));
+  });
+
+  it("maps a null status (timeout/signal) to kind=timeout", () => {
+    const { cli } = cliWith(() => ({ stdout: "", stderr: "", status: null }));
+    expect(() => cli.listSessions({})).toThrow(expect.objectContaining({ kind: "timeout" }));
+  });
+
+  it("maps malformed JSON to kind=parse", () => {
+    const { cli } = cliWith(() => ({ stdout: "not json", stderr: "", status: 0 }));
+    expect(() => cli.listSessions({})).toThrow(expect.objectContaining({ kind: "parse" }));
+  });
+});


### PR DESCRIPTION
## What

Third slice of **Stage 3 / Workstream 3.1**. The single place that knows the `the-librarian sessions …` flag contract, so every harness adapter spawns the CLI identically and parses the same JSON. Hooks prefer the CLI over MCP on shutdown paths where MCP may be slow/unavailable (§8).

`createLibrarianCli({ agent, bin?, timeoutMs?, env?, cwd? }, { run? })` →
- `startSession` / `listSessions` / `continueSession` / `checkpointSession` / `pauseSession`, each returning a thin `CliSession` view over the store JSON.
- `list` defaults to `--status active --status paused` (never attach ended sessions, §5.2); `continue` attaches; `checkpoint`/`pause` pass the summary via a **0600 temp `--summary-file`** (removed even on throw) so a long summary never bloats argv.
- Every failure maps to a typed `LibrarianCliError` (`spawn` / `timeout` / `exit` / `parse`) the orchestration layer can log and fail-soft on.
- Runner injectable; default uses `spawnSync` (hooks are short-lived sync processes), `shell` unset so values can't be shell-interpreted. Start summary uses the real `--start-summary` flag (see notes; §8's literal `--summary` is loose).

## Review

A code-reviewer sub-agent cross-checked the argv contract against the real `packages/cli`, the JSON shapes against `SessionStore`, and the security boundary. It returned REQUEST CHANGES on two real issues, both fixed in the second commit:

- **Critical** — `withSummaryFile` relied on `writeFileSync`'s umask-masked mode; now `chmod 0600` after write (mirrors `state.ts`), so a summary is never left world-readable.
- **Important** — `spawnSync` reports a timeout as `error.code === "ETIMEDOUT"` with `status: null`, so timeouts were misclassified as `kind: "spawn"`. Now detected as `timeout` before the generic branch; tests updated to the real shape.
- Suggestions applied: explicit verb param to `runJson`, doc comments (continue drops handover; env passthrough deliberate + non-leaking), and a cleanup-on-throw test.

## Tests

14 cli tests (43 package total) via an injected fake runner: argv shape, optional-flag omission, status defaulting/override, summary-file round-trip + cleanup (success and throw), and all error kinds (spawn / ETIMEDOUT-timeout / signal-kill / exit / parse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)