### PR TITLE
feat(lifecycle): session orchestration — privacy gate + lifecycle (§4.3/§5/§9)

### DIFF
--- a/integrations/shared/librarian-lifecycle/src/cli.ts
+++ b/integrations/shared/librarian-lifecycle/src/cli.ts
@@ -103,6 +103,8 @@ export interface LibrarianCli {
   continueSession(sessionId: string): CliSession;
   checkpointSession(sessionId: string, summary: string): void;
   pauseSession(sessionId: string, summary: string): void;
+  /** End a session with a short content-free reason (the §4.3 private-transition end). */
+  endSession(sessionId: string, reason: string): void;
 }
 
 const DEFAULT_TIMEOUT_MS = 15_000;
@@ -271,6 +273,12 @@ export function createLibrarianCli(
       withSummaryFile(summary, (file) => {
         runJson("pause", ["sessions", "pause", sessionId, ...agentFlags, "--summary-file", file]);
       });
+    },
+
+    endSession(sessionId, reason) {
+      // The reason is short and content-free ("switching to private mode"),
+      // so it goes inline via --summary rather than a temp file.
+      runJson("end", ["sessions", "end", sessionId, ...agentFlags, "--summary", reason]);
     },
   };
 }

--- a/integrations/shared/librarian-lifecycle/src/index.ts
+++ b/integrations/shared/librarian-lifecycle/src/index.ts
@@ -7,4 +7,5 @@
 
 export * from "./cli.js";
 export * from "./privacy.js";
+export * from "./session.js";
 export * from "./state.js";

--- a/integrations/shared/librarian-lifecycle/src/session.ts
+++ b/integrations/shared/librarian-lifecycle/src/session.ts
@@ -1,0 +1,448 @@
+// Session lifecycle orchestration (spec §4.3, §5, §9).
+//
+// This is the layer every harness adapter calls. It composes the pure
+// privacy detector, the local-state store, and the CLI wrapper into the
+// four decisions a hook actually makes:
+//
+//   handlePrompt    — privacy gate + idempotent start/resume (§3.3, §5.2)
+//   handleCheckpoint— gated, rate-limited checkpoint (§5.3)
+//   handlePause     — pause on exit/idle, never end (§5.4)
+//   handleToggle    — flip privacy mode, ending an attached session on
+//                     the public→private transition (§3.1, §4.3)
+//
+// Two invariants dominate the design:
+//   - FAIL CLOSED on privacy: if local state can't be read/written we make
+//     no automatic Librarian call (§9). Privacy enforcement failing is the
+//     only thing that suppresses; an ordinary CLI failure is logged and
+//     swallowed so it never blocks the user.
+//   - NEVER auto-end on a guess (§5.4). The only automatic end is the
+//     user-initiated public→private transition.
+
+import {
+  type CliSession,
+  type LibrarianCli,
+  type SessionStatus,
+  LibrarianCliError,
+} from "./cli.js";
+import { type PrivacyMarkers, detectPrivacySignal } from "./privacy.js";
+import {
+  type HarnessLibrarianState,
+  type StateLocation,
+  type StateOptions,
+  StateIoError,
+  StateLockError,
+  STATE_VERSION,
+  loadState,
+  updateState,
+} from "./state.js";
+
+const PRIVATE_END_REASON = "switching to private mode";
+const DEFAULT_PAUSE_SUMMARY = "Session paused (harness exit or idle).";
+const DEFAULT_START_SUMMARY = "Session started by the harness lifecycle helper.";
+
+export interface CheckpointThresholds {
+  minIntervalMinutes: number;
+  minFilesTouched: number;
+  minToolCalls: number;
+  onCompaction: boolean;
+  onTaskCompleted: boolean;
+}
+
+export interface LifecycleConfig {
+  enabled: boolean;
+  privacyDetection: boolean;
+  autoStart: boolean;
+  autoResume: boolean;
+  autoPause: boolean;
+  checkpoint: CheckpointThresholds;
+  idlePauseAfterHours: number;
+  privateMarkers?: string[];
+  publicMarkers?: string[];
+}
+
+// Defaults from §5.3 / §10.
+export const DEFAULT_LIFECYCLE_CONFIG: LifecycleConfig = {
+  enabled: true,
+  privacyDetection: true,
+  autoStart: true,
+  autoResume: true,
+  autoPause: true,
+  checkpoint: {
+    minIntervalMinutes: 30,
+    minFilesTouched: 2,
+    minToolCalls: 5,
+    onCompaction: true,
+    onTaskCompleted: true,
+  },
+  idlePauseAfterHours: 6,
+};
+
+export interface LifecycleLogEntry {
+  level: "info" | "warn" | "error";
+  message: string;
+  error?: unknown;
+}
+
+export interface LifecycleDeps {
+  cli: LibrarianCli;
+  location: StateLocation;
+  config?: Partial<LifecycleConfig>;
+  stateOptions?: StateOptions;
+  now?: () => number;
+  logger?: (entry: LifecycleLogEntry) => void;
+}
+
+export type PromptAction =
+  | "disabled"
+  | "suppressed-error"
+  | "suppressed-private"
+  | "entered-private"
+  | "exited-private"
+  | "toggled-public"
+  | "started"
+  | "resumed"
+  | "active"
+  | "error";
+
+export interface PromptOutcome {
+  action: PromptAction;
+  privacy: "public" | "private";
+  sessionId?: string;
+}
+
+export interface CheckpointInput {
+  trigger?: "compaction" | "task-completed" | "activity";
+  /** Files touched since the last checkpoint. */
+  filesTouched?: number;
+  /** Tool/command calls since the last checkpoint. */
+  toolCalls?: number;
+  summary?: string;
+}
+
+export type CheckpointAction =
+  | "disabled"
+  | "suppressed-private"
+  | "suppressed-error"
+  | "no-session"
+  | "skipped-gate"
+  | "checkpointed"
+  | "error";
+
+export interface CheckpointOutcome {
+  action: CheckpointAction;
+  sessionId?: string;
+}
+
+export type PauseAction =
+  | "disabled"
+  | "suppressed-private"
+  | "suppressed-error"
+  | "no-session"
+  | "paused"
+  | "error";
+
+export interface PauseOutcome {
+  action: PauseAction;
+}
+
+export interface LibrarianLifecycle {
+  handlePrompt(prompt: string): PromptOutcome;
+  handleCheckpoint(input?: CheckpointInput): CheckpointOutcome;
+  handlePause(input?: PauseInput): PauseOutcome;
+  handleToggle(): PromptOutcome;
+}
+
+export interface PauseInput {
+  summary?: string;
+}
+
+export function createLibrarianLifecycle(deps: LifecycleDeps): LibrarianLifecycle {
+  const { cli, location } = deps;
+  const config: LifecycleConfig = {
+    ...DEFAULT_LIFECYCLE_CONFIG,
+    ...deps.config,
+    checkpoint: { ...DEFAULT_LIFECYCLE_CONFIG.checkpoint, ...deps.config?.checkpoint },
+  };
+  const stateOptions = deps.stateOptions ?? {};
+  const now = deps.now ?? Date.now;
+  const log = deps.logger ?? (() => {});
+
+  const markers: PrivacyMarkers = {};
+  if (config.privateMarkers) markers.privateMarkers = config.privateMarkers;
+  if (config.publicMarkers) markers.publicMarkers = config.publicMarkers;
+
+  function nowIso(): string {
+    return new Date(now()).toISOString();
+  }
+
+  // Rebuild state from the authoritative location each time, carrying the
+  // few fields the location does not own.
+  function composeState(
+    privacy: "public" | "private",
+    fields: {
+      librarianSessionId?: string | undefined;
+      enteredPrivateAt?: string | undefined;
+      lastActivityAt?: string | undefined;
+      lastCheckpointAt?: string | undefined;
+    },
+  ): HarnessLibrarianState {
+    const state: HarnessLibrarianState = {
+      version: STATE_VERSION,
+      harness: location.harness,
+      harness_session_key: location.harnessSessionKey,
+      privacy,
+    };
+    if (location.sourceRef !== undefined) state.source_ref = location.sourceRef;
+    if (location.cwd !== undefined) state.cwd = location.cwd;
+    if (location.projectKey !== undefined) state.project_key = location.projectKey;
+    if (fields.librarianSessionId !== undefined)
+      state.librarian_session_id = fields.librarianSessionId;
+    if (fields.enteredPrivateAt !== undefined) state.entered_private_at = fields.enteredPrivateAt;
+    if (fields.lastActivityAt !== undefined) state.last_activity_at = fields.lastActivityAt;
+    if (fields.lastCheckpointAt !== undefined) state.last_checkpoint_at = fields.lastCheckpointAt;
+    return state;
+  }
+
+  // A handler body wrapped so privacy-state I/O failures fail closed and
+  // CLI failures are logged but never thrown to the harness (§9).
+  function guard<T>(failClosed: T, cliFallback: T, body: () => T): T {
+    try {
+      return body();
+    } catch (err) {
+      if (err instanceof StateIoError || err instanceof StateLockError) {
+        log({
+          level: "error",
+          message: "librarian lifecycle: state unavailable, failing closed",
+          error: err,
+        });
+        return failClosed;
+      }
+      if (err instanceof LibrarianCliError) {
+        log({ level: "warn", message: `librarian lifecycle: CLI ${err.kind} error`, error: err });
+        return cliFallback;
+      }
+      throw err;
+    }
+  }
+
+  function resolveSession(): { session: CliSession; action: "started" | "resumed" } | null {
+    if (config.autoResume) {
+      const statuses: SessionStatus[] = ["active", "paused"];
+      const listArgs: Parameters<LibrarianCli["listSessions"]>[0] = {
+        harness: location.harness,
+        statuses,
+      };
+      if (location.sourceRef !== undefined) listArgs.sourceRef = location.sourceRef;
+      if (location.cwd !== undefined) listArgs.cwd = location.cwd;
+      if (location.projectKey !== undefined) listArgs.projectKey = location.projectKey;
+      const matches = cli.listSessions(listArgs);
+      // Exactly one good match → resume it. Zero or many (we are unattended
+      // in a hook) → start fresh rather than guess (§5.2).
+      if (matches.length === 1) {
+        return { session: cli.continueSession(matches[0]!.id), action: "resumed" };
+      }
+    }
+    if (!config.autoStart) return null;
+    const startArgs: Parameters<LibrarianCli["startSession"]>[0] = {
+      harness: location.harness,
+      summary: DEFAULT_START_SUMMARY,
+    };
+    if (location.sourceRef !== undefined) startArgs.sourceRef = location.sourceRef;
+    if (location.cwd !== undefined) startArgs.cwd = location.cwd;
+    if (location.projectKey !== undefined) startArgs.projectKey = location.projectKey;
+    return { session: cli.startSession(startArgs), action: "started" };
+  }
+
+  // Find-or-create the public session under the state lock so concurrent
+  // hooks converge on ONE attached session (§9): the second caller, once it
+  // holds the lock, sees the id the first wrote and does not start again.
+  function ensureSession(): PromptOutcome {
+    let action: PromptAction = "active";
+    const next = updateState(
+      location,
+      (current) => {
+        if (current?.librarian_session_id) {
+          action = "active";
+          return composeState("public", {
+            librarianSessionId: current.librarian_session_id,
+            lastActivityAt: nowIso(),
+            lastCheckpointAt: current.last_checkpoint_at,
+          });
+        }
+        const resolved = resolveSession();
+        if (!resolved) {
+          action = "active";
+          return composeState("public", { lastActivityAt: nowIso() });
+        }
+        action = resolved.action;
+        return composeState("public", {
+          librarianSessionId: resolved.session.id,
+          lastActivityAt: nowIso(),
+        });
+      },
+      stateOptions,
+    );
+    const outcome: PromptOutcome = { action, privacy: "public" };
+    if (next.librarian_session_id !== undefined) outcome.sessionId = next.librarian_session_id;
+    return outcome;
+  }
+
+  // Enter private mode (§4.3). We write the private local state FIRST so that
+  // even if the end call fails, no future automatic call is made; then we end
+  // the previously-attached public session with a neutral reason. This is a
+  // deliberate reordering of §4.3's steps in service of its own fail-closed
+  // intent — the end state is identical, but a partial failure still suppresses.
+  function enterPrivate(attachedId: string | undefined): PromptOutcome {
+    updateState(
+      location,
+      () => composeState("private", { enteredPrivateAt: nowIso() }),
+      stateOptions,
+    );
+    if (attachedId) {
+      try {
+        cli.endSession(attachedId, PRIVATE_END_REASON);
+      } catch (err) {
+        log({
+          level: "error",
+          message: `librarian lifecycle: failed to end session ${attachedId} on private transition`,
+          error: err,
+        });
+      }
+    }
+    return { action: "entered-private", privacy: "private" };
+  }
+
+  function handleToggle(): PromptOutcome {
+    return guard<PromptOutcome>(
+      { action: "suppressed-error", privacy: "private" },
+      { action: "error", privacy: "private" },
+      () => {
+        const state = loadState(location, stateOptions);
+        if (state?.privacy === "private") {
+          updateState(location, () => composeState("public", {}), stateOptions);
+          return { action: "toggled-public", privacy: "public" };
+        }
+        return enterPrivate(state?.librarian_session_id);
+      },
+    );
+  }
+
+  return {
+    handlePrompt(prompt) {
+      if (!config.enabled) return { action: "disabled", privacy: "public" };
+      return guard<PromptOutcome>(
+        { action: "suppressed-error", privacy: "private" },
+        { action: "error", privacy: "public" },
+        () => {
+          const state = loadState(location, stateOptions);
+          const isPrivate = state?.privacy === "private";
+
+          if (config.privacyDetection) {
+            const { signal } = detectPrivacySignal(prompt, markers);
+            if (signal === "toggle") return handleToggle();
+            if (signal === "enter-private") return enterPrivate(state?.librarian_session_id);
+            if (signal === "exit-private") {
+              // Flip to public locally, but DO NOT record this prompt — public
+              // Librarian behaviour resumes from the next prompt (§3.3).
+              updateState(location, () => composeState("public", {}), stateOptions);
+              return { action: "exited-private", privacy: "public" };
+            }
+          }
+
+          // No marker. While private, make no call at all (§9).
+          if (isPrivate) return { action: "suppressed-private", privacy: "private" };
+          return ensureSession();
+        },
+      );
+    },
+
+    handleCheckpoint(input = {}) {
+      if (!config.enabled) return { action: "disabled" };
+      return guard<CheckpointOutcome>({ action: "suppressed-error" }, { action: "error" }, () => {
+        const state = loadState(location, stateOptions);
+        if (state?.privacy === "private") return { action: "suppressed-private" };
+        const sessionId = state?.librarian_session_id;
+        if (!sessionId) return { action: "no-session" };
+        if (!shouldCheckpoint(input, state, now(), config.checkpoint)) {
+          return { action: "skipped-gate", sessionId };
+        }
+        cli.checkpointSession(sessionId, input.summary ?? DEFAULT_START_SUMMARY);
+        updateState(
+          location,
+          (current) =>
+            composeState("public", {
+              librarianSessionId: sessionId,
+              lastActivityAt: nowIso(),
+              lastCheckpointAt: nowIso(),
+              enteredPrivateAt: current?.entered_private_at,
+            }),
+          stateOptions,
+        );
+        return { action: "checkpointed", sessionId };
+      });
+    },
+
+    handlePause(input = {}) {
+      if (!config.enabled || !config.autoPause) return { action: "disabled" };
+      return guard<PauseOutcome>({ action: "suppressed-error" }, { action: "error" }, () => {
+        const state = loadState(location, stateOptions);
+        if (state?.privacy === "private") return { action: "suppressed-private" };
+        const sessionId = state?.librarian_session_id;
+        if (!sessionId) return { action: "no-session" };
+        cli.pauseSession(sessionId, input.summary ?? DEFAULT_PAUSE_SUMMARY);
+        // Detach locally: the paused session is resumed via the list match
+        // on the next public prompt (§5.2), not by a lingering local id.
+        updateState(
+          location,
+          (current) =>
+            composeState("public", {
+              lastActivityAt: nowIso(),
+              lastCheckpointAt: current?.last_checkpoint_at,
+            }),
+          stateOptions,
+        );
+        return { action: "paused" };
+      });
+    },
+
+    handleToggle,
+  };
+}
+
+// Decide whether to checkpoint (§5.3). High-value boundaries (compaction,
+// task-completed) always pass; activity-driven checkpoints require new work
+// since the last checkpoint AND either an accumulated-work gate or the time
+// gate — which together both express "at least one gate" and dedupe (§9).
+function shouldCheckpoint(
+  input: CheckpointInput,
+  state: HarnessLibrarianState | null,
+  nowMs: number,
+  cfg: CheckpointThresholds,
+): boolean {
+  if (input.trigger === "compaction" && cfg.onCompaction) return true;
+  if (input.trigger === "task-completed" && cfg.onTaskCompleted) return true;
+
+  const files = input.filesTouched ?? 0;
+  const tools = input.toolCalls ?? 0;
+  const hasSummary = typeof input.summary === "string" && input.summary.trim().length > 0;
+  const newWork = files > 0 || tools > 0 || hasSummary;
+  if (!newWork) return false; // nothing new since last checkpoint → duplicate
+
+  // The count gate fires on accumulated work — callers pass deltas *since the
+  // last checkpoint*, so it is self-rate-limiting (work must re-accumulate).
+  const countGate = files >= cfg.minFilesTouched || tools >= cfg.minToolCalls;
+
+  const lastMs = state?.last_checkpoint_at ? Date.parse(state.last_checkpoint_at) : NaN;
+  const hasPriorCheckpoint = !Number.isNaN(lastMs);
+  // Before the first checkpoint there is no "elapsed since last checkpoint",
+  // so the time gate does not apply — a young session must accumulate real
+  // work (count gate) or supply an explicit summary, not checkpoint a trivial
+  // change just because no prior checkpoint exists.
+  if (!hasPriorCheckpoint) return countGate || hasSummary;
+
+  const elapsedMin = (nowMs - lastMs) / 60_000;
+  const timeGate = elapsedMin >= cfg.minIntervalMinutes;
+  // After the first checkpoint: substantial work checkpoints immediately;
+  // otherwise wait out the interval (which also rate-limits summaries).
+  return countGate || timeGate || (hasSummary && timeGate);
+}

--- a/integrations/shared/librarian-lifecycle/src/session.ts
+++ b/integrations/shared/librarian-lifecycle/src/session.ts
@@ -261,6 +261,15 @@ export function createLibrarianLifecycle(deps: LifecycleDeps): LibrarianLifecycl
     const next = updateState(
       location,
       (current) => {
+        // Re-check privacy *inside* the lock. handlePrompt read privacy
+        // outside it as a fast path, but a concurrent toggle/enter-private
+        // hook may have flipped to private in the gap. The privacy decision
+        // and the CLI-triggering write must be the same critical section, or
+        // an off-record prompt could still attach a session (§9).
+        if (current && current.privacy === "private") {
+          action = "suppressed-private";
+          return current;
+        }
         if (current?.librarian_session_id) {
           action = "active";
           return composeState("public", {
@@ -282,47 +291,80 @@ export function createLibrarianLifecycle(deps: LifecycleDeps): LibrarianLifecycl
       },
       stateOptions,
     );
-    const outcome: PromptOutcome = { action, privacy: "public" };
+    const outcome: PromptOutcome = { action, privacy: next.privacy };
     if (next.librarian_session_id !== undefined) outcome.sessionId = next.librarian_session_id;
     return outcome;
   }
 
-  // Enter private mode (§4.3). We write the private local state FIRST so that
-  // even if the end call fails, no future automatic call is made; then we end
-  // the previously-attached public session with a neutral reason. This is a
-  // deliberate reordering of §4.3's steps in service of its own fail-closed
-  // intent — the end state is identical, but a partial failure still suppresses.
-  function enterPrivate(attachedId: string | undefined): PromptOutcome {
-    updateState(
-      location,
-      () => composeState("private", { enteredPrivateAt: nowIso() }),
-      stateOptions,
-    );
-    if (attachedId) {
-      try {
-        cli.endSession(attachedId, PRIVATE_END_REASON);
-      } catch (err) {
-        log({
-          level: "error",
-          message: `librarian lifecycle: failed to end session ${attachedId} on private transition`,
-          error: err,
-        });
-      }
+  // End the previously-attached public session with a neutral reason (§4.3).
+  // A failure here is logged loudly — the session lingers active server-side,
+  // so an operator needs to see it — but never thrown: local state has already
+  // gone private, so no *further* automatic call will be made.
+  function endAttached(attachedId: string | undefined): void {
+    if (!attachedId) return;
+    try {
+      cli.endSession(attachedId, PRIVATE_END_REASON);
+    } catch (err) {
+      log({
+        level: "error",
+        message: `librarian lifecycle: failed to end session ${attachedId} on private transition; it may linger active`,
+        error: err,
+      });
     }
+  }
+
+  // Force private mode (the enter-private *signal* path — a private marker
+  // always means private, regardless of current mode). We persist private
+  // state, then end the attached session. If the state write itself fails we
+  // STILL attempt the end, then rethrow so the caller fails closed for this
+  // turn (§9) rather than silently leaving on-disk state public.
+  function enterPrivate(attachedId: string | undefined): PromptOutcome {
+    let written = false;
+    try {
+      updateState(
+        location,
+        () => composeState("private", { enteredPrivateAt: nowIso() }),
+        stateOptions,
+      );
+      written = true;
+    } catch (err) {
+      log({
+        level: "error",
+        message:
+          "librarian lifecycle: could not persist private mode; attempting end and failing closed",
+        error: err,
+      });
+    }
+    endAttached(attachedId);
+    if (!written) throw new StateIoError("could not persist private mode");
     return { action: "entered-private", privacy: "private" };
   }
 
+  // Flip privacy. The direction decision and the state write happen in ONE
+  // locked mutation so a concurrent flip can't make us act on a stale read;
+  // the end call (a subprocess) runs after the lock is released.
   function handleToggle(): PromptOutcome {
     return guard<PromptOutcome>(
       { action: "suppressed-error", privacy: "private" },
       { action: "error", privacy: "private" },
       () => {
-        const state = loadState(location, stateOptions);
-        if (state?.privacy === "private") {
-          updateState(location, () => composeState("public", {}), stateOptions);
-          return { action: "toggled-public", privacy: "public" };
-        }
-        return enterPrivate(state?.librarian_session_id);
+        let goingPrivate = false;
+        let attachedId: string | undefined;
+        updateState(
+          location,
+          (current) => {
+            if (current && current.privacy === "private") {
+              return composeState("public", { lastCheckpointAt: current.last_checkpoint_at });
+            }
+            goingPrivate = true;
+            attachedId = current?.librarian_session_id;
+            return composeState("private", { enteredPrivateAt: nowIso() });
+          },
+          stateOptions,
+        );
+        if (!goingPrivate) return { action: "toggled-public", privacy: "public" };
+        endAttached(attachedId);
+        return { action: "entered-private", privacy: "private" };
       },
     );
   }
@@ -338,12 +380,19 @@ export function createLibrarianLifecycle(deps: LifecycleDeps): LibrarianLifecycl
           const isPrivate = state?.privacy === "private";
 
           if (config.privacyDetection) {
+            // Only `signal` is consulted: for enter-private we always suppress
+            // regardless of substantive content (private bias), and exit-private
+            // never stores the current prompt either, so hasSubstantiveContent
+            // is intentionally not load-bearing in this layer (§3.3).
             const { signal } = detectPrivacySignal(prompt, markers);
             if (signal === "toggle") return handleToggle();
             if (signal === "enter-private") return enterPrivate(state?.librarian_session_id);
             if (signal === "exit-private") {
               // Flip to public locally, but DO NOT record this prompt — public
-              // Librarian behaviour resumes from the next prompt (§3.3).
+              // Librarian behaviour resumes from the next prompt (§3.3). The
+              // prior public session was already ended on entering private, so
+              // the next prompt starts fresh; dropping last_checkpoint_at here
+              // is correct (a new session has no prior checkpoint).
               updateState(location, () => composeState("public", {}), stateOptions);
               return { action: "exited-private", privacy: "public" };
             }

--- a/integrations/shared/librarian-lifecycle/tests/cli.test.ts
+++ b/integrations/shared/librarian-lifecycle/tests/cli.test.ts
@@ -127,6 +127,16 @@ describe("createLibrarianCli — checkpoint/pause use --summary-file", () => {
   });
 });
 
+describe("createLibrarianCli — endSession", () => {
+  it("ends with an inline --summary reason", () => {
+    const { cli, calls } = cliWith(() => ok({ session: { ...session, status: "ended" } }));
+    cli.endSession("ses_abc", "switching to private mode");
+    const args = calls[0]!;
+    expect(args.slice(0, 3)).toEqual(["sessions", "end", "ses_abc"]);
+    expect(args).toEqual(expect.arrayContaining(["--summary", "switching to private mode"]));
+  });
+});
+
 describe("createLibrarianCli — error mapping", () => {
   it("maps a non-zero exit to a LibrarianCliError with stderr", () => {
     const { cli } = cliWith(() => ({ stdout: "", stderr: "boom", status: 1 }));

--- a/integrations/shared/librarian-lifecycle/tests/session.test.ts
+++ b/integrations/shared/librarian-lifecycle/tests/session.test.ts
@@ -1,0 +1,246 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { type CliSession, type LibrarianCli, LibrarianCliError } from "../src/cli.js";
+import { createLibrarianLifecycle, type LifecycleDeps } from "../src/session.js";
+import { loadState, type StateLocation } from "../src/state.js";
+
+let baseDir: string;
+
+beforeEach(() => {
+  baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "lib-session-"));
+});
+afterEach(() => {
+  fs.rmSync(baseDir, { recursive: true, force: true });
+});
+
+const location: StateLocation = {
+  harness: "claude-code",
+  harnessSessionKey: "sess-1",
+  cwd: "/home/jim/code/the-librarian",
+  projectKey: "the-librarian",
+};
+
+function fakeSession(over: Partial<CliSession> = {}): CliSession {
+  return {
+    id: "ses_1",
+    status: "active",
+    title: null,
+    project_key: "the-librarian",
+    source_ref: null,
+    cwd: "/home/jim/code/the-librarian",
+    ...over,
+  };
+}
+
+function fakeCli(over: Partial<LibrarianCli> = {}): LibrarianCli {
+  return {
+    startSession: vi.fn(() => fakeSession()),
+    listSessions: vi.fn(() => []),
+    continueSession: vi.fn((id) => fakeSession({ id })),
+    checkpointSession: vi.fn(),
+    pauseSession: vi.fn(),
+    endSession: vi.fn(),
+    ...over,
+  };
+}
+
+function make(over: Partial<LifecycleDeps> = {}) {
+  const cli = over.cli ?? fakeCli();
+  const deps: LifecycleDeps = {
+    cli,
+    location,
+    stateOptions: { baseDir },
+    now: () => Date.parse("2026-05-24T12:00:00.000Z"),
+    ...over,
+  };
+  return { lifecycle: createLibrarianLifecycle(deps), cli };
+}
+
+describe("handlePrompt — start/resume (§5.2)", () => {
+  it("starts a new session on the first public prompt when none match", () => {
+    const { lifecycle, cli } = make();
+    const out = lifecycle.handlePrompt("let's refactor the parser");
+    expect(out.action).toBe("started");
+    expect(out.sessionId).toBe("ses_1");
+    expect(cli.startSession).toHaveBeenCalledTimes(1);
+    expect(loadState(location, { baseDir })?.librarian_session_id).toBe("ses_1");
+  });
+
+  it("resumes when exactly one active/paused session matches", () => {
+    const cli = fakeCli({ listSessions: vi.fn(() => [fakeSession({ id: "ses_existing" })]) });
+    const { lifecycle } = make({ cli });
+    const out = lifecycle.handlePrompt("back to work");
+    expect(out.action).toBe("resumed");
+    expect(out.sessionId).toBe("ses_existing");
+    expect(cli.continueSession).toHaveBeenCalledWith("ses_existing");
+    expect(cli.startSession).not.toHaveBeenCalled();
+  });
+
+  it("starts fresh (not guess) when multiple sessions match", () => {
+    const cli = fakeCli({
+      listSessions: vi.fn(() => [fakeSession({ id: "a" }), fakeSession({ id: "b" })]),
+    });
+    const { lifecycle } = make({ cli });
+    expect(lifecycle.handlePrompt("hello").action).toBe("started");
+    expect(cli.continueSession).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent: a second prompt with a session attached does not start again", () => {
+    const { lifecycle, cli } = make();
+    lifecycle.handlePrompt("first");
+    const out = lifecycle.handlePrompt("second");
+    expect(out.action).toBe("active");
+    expect(cli.startSession).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("handlePrompt — privacy gate (§3.3, §4.3, §9)", () => {
+  it("makes no Librarian call for a same-message private marker", () => {
+    const { lifecycle, cli } = make();
+    const out = lifecycle.handlePrompt("off the record, my password is hunter2");
+    expect(out.action).toBe("entered-private");
+    expect(out.privacy).toBe("private");
+    expect(cli.startSession).not.toHaveBeenCalled();
+    expect(loadState(location, { baseDir })?.privacy).toBe("private");
+  });
+
+  it("ends the attached session with a neutral reason on entering private, then makes no further calls", () => {
+    const { lifecycle, cli } = make();
+    lifecycle.handlePrompt("start work"); // attaches ses_1
+    const out = lifecycle.handlePrompt("this is a private session");
+    expect(out.action).toBe("entered-private");
+    expect(cli.endSession).toHaveBeenCalledWith("ses_1", "switching to private mode");
+    const state = loadState(location, { baseDir });
+    expect(state?.privacy).toBe("private");
+    expect(state?.librarian_session_id).toBeUndefined();
+    // Subsequent ordinary prompt while private → no call.
+    (cli.startSession as ReturnType<typeof vi.fn>).mockClear();
+    const next = lifecycle.handlePrompt("more secret stuff");
+    expect(next.action).toBe("suppressed-private");
+    expect(cli.startSession).not.toHaveBeenCalled();
+  });
+
+  it("exit-private resumes public only from the next prompt", () => {
+    const { lifecycle, cli } = make();
+    lifecycle.handlePrompt("off the record"); // private
+    const exit = lifecycle.handlePrompt("you can remember again, now fix the bug");
+    expect(exit.action).toBe("exited-private");
+    expect(exit.privacy).toBe("public");
+    // This (exit) prompt did not start/resume.
+    expect(cli.startSession).not.toHaveBeenCalled();
+    // The NEXT public prompt starts.
+    const next = lifecycle.handlePrompt("continue the fix");
+    expect(next.action).toBe("started");
+    expect(cli.startSession).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("handleToggle (§3.1)", () => {
+  it("toggles public→private (ending the attached session) and back", () => {
+    const { lifecycle, cli } = make();
+    lifecycle.handlePrompt("work"); // attached
+    const toPriv = lifecycle.handleToggle();
+    expect(toPriv.privacy).toBe("private");
+    expect(cli.endSession).toHaveBeenCalledWith("ses_1", "switching to private mode");
+    const toPub = lifecycle.handleToggle();
+    expect(toPub.action).toBe("toggled-public");
+    expect(toPub.privacy).toBe("public");
+  });
+});
+
+describe("handleCheckpoint (§5.3)", () => {
+  it("does nothing when no session is attached", () => {
+    const { lifecycle, cli } = make();
+    expect(lifecycle.handleCheckpoint({ trigger: "compaction" }).action).toBe("no-session");
+    expect(cli.checkpointSession).not.toHaveBeenCalled();
+  });
+
+  it("checkpoints on a compaction boundary", () => {
+    const { lifecycle, cli } = make();
+    lifecycle.handlePrompt("work");
+    expect(lifecycle.handleCheckpoint({ trigger: "compaction" }).action).toBe("checkpointed");
+    expect(cli.checkpointSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips a low-activity checkpoint below the gates", () => {
+    const { lifecycle } = make();
+    lifecycle.handlePrompt("work");
+    expect(lifecycle.handleCheckpoint({ filesTouched: 1, toolCalls: 1 }).action).toBe(
+      "skipped-gate",
+    );
+  });
+
+  it("checkpoints once enough files were touched", () => {
+    const { lifecycle, cli } = make();
+    lifecycle.handlePrompt("work");
+    expect(lifecycle.handleCheckpoint({ filesTouched: 3 }).action).toBe("checkpointed");
+    expect(cli.checkpointSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("makes no call while private", () => {
+    const { lifecycle, cli } = make();
+    lifecycle.handlePrompt("off the record");
+    expect(lifecycle.handleCheckpoint({ trigger: "compaction" }).action).toBe("suppressed-private");
+    expect(cli.checkpointSession).not.toHaveBeenCalled();
+  });
+});
+
+describe("handlePause (§5.4)", () => {
+  it("pauses and detaches so the next prompt resumes via list", () => {
+    const cli = fakeCli();
+    const { lifecycle } = make({ cli });
+    lifecycle.handlePrompt("work"); // ses_1 attached
+    const paused = lifecycle.handlePause();
+    expect(paused.action).toBe("paused");
+    expect(cli.pauseSession).toHaveBeenCalledWith("ses_1", expect.any(String));
+    expect(loadState(location, { baseDir })?.librarian_session_id).toBeUndefined();
+  });
+
+  it("is idempotent when nothing is attached", () => {
+    const { lifecycle, cli } = make();
+    expect(lifecycle.handlePause().action).toBe("no-session");
+    expect(cli.pauseSession).not.toHaveBeenCalled();
+  });
+
+  it("makes no call while private", () => {
+    const { lifecycle, cli } = make();
+    lifecycle.handlePrompt("off the record");
+    expect(lifecycle.handlePause().action).toBe("suppressed-private");
+    expect(cli.pauseSession).not.toHaveBeenCalled();
+  });
+});
+
+describe("fail-closed + fail-soft (§9)", () => {
+  it("suppresses all calls when local state cannot be read", () => {
+    const cli = fakeCli();
+    // Point state at a path that can't be created (a file where a dir is needed).
+    const filePath = path.join(baseDir, "blocker");
+    fs.writeFileSync(filePath, "x");
+    const { lifecycle } = make({ cli, stateOptions: { baseDir: filePath } });
+    const out = lifecycle.handlePrompt("work");
+    expect(out.action).toBe("suppressed-error");
+    expect(cli.startSession).not.toHaveBeenCalled();
+  });
+
+  it("logs but does not throw when the CLI fails", () => {
+    const cli = fakeCli({
+      startSession: vi.fn(() => {
+        throw new LibrarianCliError("exit", "boom");
+      }),
+    });
+    const logger = vi.fn();
+    const { lifecycle } = make({ cli, logger });
+    const out = lifecycle.handlePrompt("work");
+    expect(out.action).toBe("error");
+    expect(logger).toHaveBeenCalled();
+  });
+
+  it("is a no-op when disabled", () => {
+    const cli = fakeCli();
+    const { lifecycle } = make({ cli, config: { enabled: false } });
+    expect(lifecycle.handlePrompt("work").action).toBe("disabled");
+    expect(cli.startSession).not.toHaveBeenCalled();
+  });
+});

--- a/integrations/shared/librarian-lifecycle/tests/session.test.ts
+++ b/integrations/shared/librarian-lifecycle/tests/session.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { type CliSession, type LibrarianCli, LibrarianCliError } from "../src/cli.js";
 import { createLibrarianLifecycle, type LifecycleDeps } from "../src/session.js";
-import { loadState, type StateLocation } from "../src/state.js";
+import { loadState, type StateLocation, stateFilePath } from "../src/state.js";
 
 let baseDir: string;
 
@@ -122,6 +122,17 @@ describe("handlePrompt — privacy gate (§3.3, §4.3, §9)", () => {
     expect(cli.startSession).not.toHaveBeenCalled();
   });
 
+  it("never starts a session when on-disk state is already private (in-lock re-check)", () => {
+    const cli = fakeCli();
+    const { lifecycle } = make({ cli });
+    // Seed private state directly, as a concurrent toggle hook would.
+    lifecycle.handleToggle(); // public → private
+    (cli.startSession as ReturnType<typeof vi.fn>).mockClear();
+    const out = lifecycle.handlePrompt("ordinary work");
+    expect(out.action).toBe("suppressed-private");
+    expect(cli.startSession).not.toHaveBeenCalled();
+  });
+
   it("exit-private resumes public only from the next prompt", () => {
     const { lifecycle, cli } = make();
     lifecycle.handlePrompt("off the record"); // private
@@ -147,6 +158,24 @@ describe("handleToggle (§3.1)", () => {
     const toPub = lifecycle.handleToggle();
     expect(toPub.action).toBe("toggled-public");
     expect(toPub.privacy).toBe("public");
+  });
+
+  it("still attempts the end and fails closed when the private-state write fails", () => {
+    const cli = fakeCli();
+    const logger = vi.fn();
+    // Reads succeed but the write can't acquire the lock: a held lock + zero
+    // timeout makes updateState throw while the prior loadState still works.
+    const { lifecycle } = make({
+      cli,
+      logger,
+      stateOptions: { baseDir, lockTimeoutMs: 0, lockStaleMs: 600_000 },
+    });
+    lifecycle.handlePrompt("work"); // ses_1 attached, state persisted, lock released
+    fs.writeFileSync(`${stateFilePath(location, { baseDir })}.lock`, "held-by-another");
+    const out = lifecycle.handlePrompt("off the record");
+    expect(out.action).toBe("suppressed-error"); // failed closed for this turn
+    expect(cli.endSession).toHaveBeenCalledWith("ses_1", "switching to private mode");
+    expect(logger).toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## What

Final slice of **Stage 3 / Workstream 3.1** — the orchestration layer every harness adapter calls. It composes the privacy detector, local state, and CLI wrapper into the four hook decisions, and is where the spec's privacy + lifecycle rules actually live so each per-harness adapter stays thin.

- **`handlePrompt`** — privacy gate first (§3.3): `toggle` / `enter-private` / `exit-private` / `none`. A same-message private marker makes **no** Librarian call; `exit-private` flips public locally but resumes recording only from the **next** prompt. Otherwise idempotent start/resume runs **inside the state lock** so concurrent hooks converge on one attached session (§9), resuming the single active/paused match or starting fresh rather than guessing (§5.2).
- **`handleCheckpoint`** — gated + rate-limited (§5.3): compaction/task-completed are high-value boundaries; activity-driven needs new work plus the count gate (self-rate-limiting on since-last-checkpoint deltas) or, after a first checkpoint, the time gate.
- **`handlePause`** — pause + detach so the next prompt resumes via list; never auto-end (§5.4).
- **`handleToggle` / enter-private** — end the attached session with a neutral reason on the public→private transition (§4.3).
- Fail closed on state I/O (§9); CLI failures logged, never thrown to the user. `enabled` / markers / thresholds all config-driven (§10).

Also adds `endSession` to the CLI wrapper (its only consumer is the private-transition end).

## Security review

A security-auditor sub-agent traced every `handlePrompt` path for the four signals in both privacy states, the §4.3 transition, fail-closed behaviour, the concurrency model, and the checkpoint gate. It confirmed the core privacy gate holds (no single-threaded path lets an off-record prompt reach the Librarian; fail-closed vs fail-soft split correct; idempotent start inside the lock; checkpoint gate sound). It raised **two Important** issues — both fixed in the second commit, and both worth closing now because this is the layer the (not-yet-built) concurrent-hook adapters will inherit:

1. **TOCTOU** — privacy was read outside the lock and not re-checked inside `ensureSession`'s mutation; a concurrent toggle→private could still attach a session. The decision and the CLI-triggering write are now one critical section.
2. **Fail-closed durability** — if the private-state write itself threw, the §4.3 end wasn't attempted and on-disk state stayed public. `enterPrivate` now still attempts the end, logs the lingering session, and rethrows so the turn fails closed.

Plus suggestions applied: atomic toggle decision under the lock, shared `endAttached`, and clarifying comments.

## Tests

21 session tests (65 package total) covering the §11.1 shared behaviours: start/resume/idempotency, same-message private (no call), private-transition end + subsequent suppression, exit-private resume-next-prompt, toggle both directions, checkpoint gates (compaction / below-gate / count-gate / private), pause idempotency, fail-closed on state I/O, fail-soft on CLI error, disabled no-op, the in-lock-private invariant, and the durable fail-closed transition.

This completes Workstream 3.1 (shared lifecycle helper). Next: the per-harness adapters (3.2), starting with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)