### PR TITLE
feat(lifecycle): Claude Code harness adapter — hook dispatch + bin (§7.1)

### DIFF
--- a/integrations/shared/librarian-lifecycle/package.json
+++ b/integrations/shared/librarian-lifecycle/package.json
@@ -6,6 +6,9 @@
   "description": "Shared harness lifecycle helper: privacy detection, local state, and idempotent session automation.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "librarian-claude-hook": "./dist/bin/claude-code-hook.js"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/integrations/shared/librarian-lifecycle/src/bin/claude-code-hook.ts
+++ b/integrations/shared/librarian-lifecycle/src/bin/claude-code-hook.ts
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+// Claude Code hook entrypoint. The thin shell hook scripts in
+// integrations/claude-code/hooks/librarian/ pipe the hook event JSON to this
+// bin on stdin. It builds the lifecycle from the event + environment and
+// dispatches. It ALWAYS exits 0 and never blocks the prompt: the privacy
+// guarantee is "no Librarian call", not "stop the model".
+
+import {
+  type ClaudeHookEvent,
+  createClaudeCodeLifecycle,
+  dispatchClaudeHook,
+} from "../harness/claude-code.js";
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function main(): Promise<void> {
+  let event: ClaudeHookEvent = {};
+  try {
+    const raw = (await readStdin()).trim();
+    if (raw) event = JSON.parse(raw) as ClaudeHookEvent;
+  } catch {
+    // Unparseable hook input → do nothing. No state read, no Librarian call:
+    // fail closed for the turn.
+    process.exit(0);
+  }
+
+  try {
+    const lifecycle = createClaudeCodeLifecycle(event);
+    dispatchClaudeHook(event, lifecycle);
+  } catch (err) {
+    // The lifecycle handlers already swallow their own state/CLI errors; this
+    // catches only unexpected failures. Never block the user (§9) — log to
+    // stderr (transcript-only) and exit 0.
+    process.stderr.write(`librarian lifecycle hook error: ${(err as Error).message}\n`);
+  }
+  process.exit(0);
+}
+
+void main();

--- a/integrations/shared/librarian-lifecycle/src/harness/claude-code.ts
+++ b/integrations/shared/librarian-lifecycle/src/harness/claude-code.ts
@@ -56,6 +56,10 @@ export function claudeLocationFromEvent(
 ): StateLocation {
   const location: StateLocation = {
     harness: "claude-code",
+    // session_id is present on every event that drives a CLI call
+    // (UserPromptSubmit/PostCompact/TaskCompleted/SessionEnd); cwd and the
+    // final literal are should-never-happen sentinels for degenerate events
+    // that never reach the Librarian anyway.
     harnessSessionKey: event.session_id ?? event.cwd ?? "claude-code",
   };
   if (event.cwd) location.cwd = event.cwd;
@@ -97,6 +101,8 @@ export function createClaudeCodeLifecycle(
   const env = options.env ?? process.env;
   const location = claudeLocationFromEvent(event, env);
   const agent = env.LIBRARIAN_AGENT_ID || "claude-code";
+  // The spawn cwd is deliberately the same value as the location's match cwd
+  // (§5.2) — keep them in lockstep if either is ever changed.
   const cli =
     options.cli ?? createLibrarianCli({ agent, ...(event.cwd ? { cwd: event.cwd } : {}) });
   const deps: LifecycleDeps = { cli, location };

--- a/integrations/shared/librarian-lifecycle/src/harness/claude-code.ts
+++ b/integrations/shared/librarian-lifecycle/src/harness/claude-code.ts
@@ -1,0 +1,107 @@
+// Claude Code harness adapter (spec §7.1).
+//
+// Translates Claude Code hook events into shared-lifecycle calls. The mapping
+// is verified against the real Claude Code hook surface:
+//
+//   UserPromptSubmit → handlePrompt   (privacy gate + start/resume)
+//   PostCompact      → checkpoint(compaction)   — high-value boundary
+//   TaskCompleted    → checkpoint(task-completed)
+//   SessionEnd       → pause           (never end, §5.4)
+//   SessionStart     → no-op           (state is lazily created on the first
+//                                        meaningful prompt — opening a tool
+//                                        should not create a session, §5.1)
+//   Stop / anything  → no-op           (optional heartbeat, skipped for v1)
+//
+// The privacy gate does NOT block the prompt from reaching the model — it only
+// suppresses the Librarian call. Because this adapter is the only thing that
+// calls the Librarian on a prompt, a hook crash is inherently fail-closed:
+// nothing is recorded for that turn.
+
+import { type LibrarianCli, createLibrarianCli } from "../cli.js";
+import {
+  type CheckpointOutcome,
+  type LibrarianLifecycle,
+  type LifecycleConfig,
+  type LifecycleDeps,
+  type LifecycleLogEntry,
+  type PauseOutcome,
+  type PromptOutcome,
+  createLibrarianLifecycle,
+} from "../session.js";
+import type { StateLocation } from "../state.js";
+
+export interface ClaudeHookEvent {
+  hook_event_name?: string;
+  session_id?: string;
+  cwd?: string;
+  prompt?: string;
+  source?: string;
+  reason?: string;
+  trigger?: string;
+}
+
+export type ClaudeHookResult =
+  | PromptOutcome
+  | CheckpointOutcome
+  | PauseOutcome
+  | { action: "ignored" };
+
+// Build the state location. Local state is keyed per Claude session_id, but the
+// Librarian session is matched by cwd (+project) — a coding harness resumes by
+// directory, not by a per-session source_ref that would never match across
+// Claude sessions (§5.2). So sourceRef is intentionally left unset.
+export function claudeLocationFromEvent(
+  event: ClaudeHookEvent,
+  env: NodeJS.ProcessEnv,
+): StateLocation {
+  const location: StateLocation = {
+    harness: "claude-code",
+    harnessSessionKey: event.session_id ?? event.cwd ?? "claude-code",
+  };
+  if (event.cwd) location.cwd = event.cwd;
+  if (env.LIBRARIAN_PROJECT_KEY) location.projectKey = env.LIBRARIAN_PROJECT_KEY;
+  return location;
+}
+
+export function dispatchClaudeHook(
+  event: ClaudeHookEvent,
+  lifecycle: LibrarianLifecycle,
+): ClaudeHookResult {
+  switch (event.hook_event_name) {
+    case "UserPromptSubmit":
+      return lifecycle.handlePrompt(event.prompt ?? "");
+    case "PostCompact":
+      return lifecycle.handleCheckpoint({ trigger: "compaction" });
+    case "TaskCompleted":
+      return lifecycle.handleCheckpoint({ trigger: "task-completed" });
+    case "SessionEnd":
+      return lifecycle.handlePause();
+    default:
+      return { action: "ignored" };
+  }
+}
+
+export interface ClaudeCodeAdapterOptions {
+  env?: NodeJS.ProcessEnv;
+  config?: Partial<LifecycleConfig>;
+  /** Injectable for tests; defaults to a real spawnSync-backed CLI. */
+  cli?: LibrarianCli;
+  logger?: (entry: LifecycleLogEntry) => void;
+  now?: () => number;
+}
+
+export function createClaudeCodeLifecycle(
+  event: ClaudeHookEvent,
+  options: ClaudeCodeAdapterOptions = {},
+): LibrarianLifecycle {
+  const env = options.env ?? process.env;
+  const location = claudeLocationFromEvent(event, env);
+  const agent = env.LIBRARIAN_AGENT_ID || "claude-code";
+  const cli =
+    options.cli ?? createLibrarianCli({ agent, ...(event.cwd ? { cwd: event.cwd } : {}) });
+  const deps: LifecycleDeps = { cli, location };
+  if (options.config) deps.config = options.config;
+  if (options.logger) deps.logger = options.logger;
+  if (options.now) deps.now = options.now;
+  return createLibrarianLifecycle(deps);
+}

--- a/integrations/shared/librarian-lifecycle/src/index.ts
+++ b/integrations/shared/librarian-lifecycle/src/index.ts
@@ -6,6 +6,7 @@
 // harness environments (§6).
 
 export * from "./cli.js";
+export * from "./harness/claude-code.js";
 export * from "./privacy.js";
 export * from "./session.js";
 export * from "./state.js";

--- a/integrations/shared/librarian-lifecycle/tests/harness-claude-code.test.ts
+++ b/integrations/shared/librarian-lifecycle/tests/harness-claude-code.test.ts
@@ -1,3 +1,8 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import {
   type ClaudeHookEvent,
@@ -87,5 +92,57 @@ describe("claudeLocationFromEvent", () => {
   it("falls back to the session_id when cwd is absent", () => {
     const loc = claudeLocationFromEvent({ hook_event_name: "Stop", session_id: "x" }, {});
     expect(loc.harnessSessionKey).toBe("x");
+  });
+});
+
+// The bin's contract is privacy-critical: it must ALWAYS exit 0 and emit no
+// stdout (UserPromptSubmit stdout would be injected into the model's context),
+// so a lifecycle failure can never block or pollute a user's prompt. These run
+// the built dist bin (the package `test` script builds before vitest).
+const binPath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "dist",
+  "bin",
+  "claude-code-hook.js",
+);
+
+function runBin(input: string) {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "lib-bin-home-"));
+  try {
+    return spawnSync(process.execPath, [binPath], {
+      input,
+      encoding: "utf8",
+      env: { ...process.env, HOME: home, LIBRARIAN_CLI_BIN: "definitely-not-a-real-binary-xyz" },
+    });
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+}
+
+describe("claude-code-hook bin contract", () => {
+  it("exits 0 with no stdout for an ignored event", () => {
+    const r = runBin(JSON.stringify({ hook_event_name: "Stop", session_id: "b" }));
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe("");
+  });
+
+  it("exits 0 with no stdout on unparseable input", () => {
+    const r = runBin("{ not json");
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe("");
+  });
+
+  it("exits 0 with no stdout for a prompt even when the CLI is unreachable", () => {
+    const r = runBin(
+      JSON.stringify({
+        hook_event_name: "UserPromptSubmit",
+        session_id: "b",
+        cwd: "/tmp/lib-bin-x",
+        prompt: "hi",
+      }),
+    );
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe("");
   });
 });

--- a/integrations/shared/librarian-lifecycle/tests/harness-claude-code.test.ts
+++ b/integrations/shared/librarian-lifecycle/tests/harness-claude-code.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  type ClaudeHookEvent,
+  claudeLocationFromEvent,
+  dispatchClaudeHook,
+} from "../src/harness/claude-code.js";
+import type { LibrarianLifecycle } from "../src/session.js";
+
+function fakeLifecycle(): LibrarianLifecycle {
+  return {
+    handlePrompt: vi.fn(() => ({ action: "started" as const, privacy: "public" as const })),
+    handleCheckpoint: vi.fn(() => ({ action: "checkpointed" as const })),
+    handlePause: vi.fn(() => ({ action: "paused" as const })),
+    handleToggle: vi.fn(() => ({ action: "toggled-public" as const, privacy: "public" as const })),
+  };
+}
+
+describe("dispatchClaudeHook (§7.1 mapping)", () => {
+  it("routes UserPromptSubmit to handlePrompt with the prompt text", () => {
+    const lc = fakeLifecycle();
+    dispatchClaudeHook({ hook_event_name: "UserPromptSubmit", prompt: "fix the bug" }, lc);
+    expect(lc.handlePrompt).toHaveBeenCalledWith("fix the bug");
+  });
+
+  it("routes PostCompact to a compaction checkpoint", () => {
+    const lc = fakeLifecycle();
+    dispatchClaudeHook({ hook_event_name: "PostCompact" }, lc);
+    expect(lc.handleCheckpoint).toHaveBeenCalledWith({ trigger: "compaction" });
+  });
+
+  it("routes TaskCompleted to a task-completed checkpoint", () => {
+    const lc = fakeLifecycle();
+    dispatchClaudeHook({ hook_event_name: "TaskCompleted" }, lc);
+    expect(lc.handleCheckpoint).toHaveBeenCalledWith({ trigger: "task-completed" });
+  });
+
+  it("routes SessionEnd to handlePause", () => {
+    const lc = fakeLifecycle();
+    dispatchClaudeHook({ hook_event_name: "SessionEnd", reason: "other" }, lc);
+    expect(lc.handlePause).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores SessionStart and Stop (no lifecycle mutation)", () => {
+    const lc = fakeLifecycle();
+    expect(
+      dispatchClaudeHook({ hook_event_name: "SessionStart", source: "startup" }, lc).action,
+    ).toBe("ignored");
+    expect(dispatchClaudeHook({ hook_event_name: "Stop" }, lc).action).toBe("ignored");
+    expect(lc.handlePrompt).not.toHaveBeenCalled();
+    expect(lc.handleCheckpoint).not.toHaveBeenCalled();
+    expect(lc.handlePause).not.toHaveBeenCalled();
+  });
+
+  it("ignores an unknown event rather than throwing", () => {
+    const lc = fakeLifecycle();
+    expect(dispatchClaudeHook({ hook_event_name: "PreToolUse" }, lc).action).toBe("ignored");
+  });
+
+  it("treats a missing prompt as empty string", () => {
+    const lc = fakeLifecycle();
+    dispatchClaudeHook({ hook_event_name: "UserPromptSubmit" }, lc);
+    expect(lc.handlePrompt).toHaveBeenCalledWith("");
+  });
+});
+
+describe("claudeLocationFromEvent", () => {
+  const event: ClaudeHookEvent = {
+    hook_event_name: "UserPromptSubmit",
+    session_id: "claude-abc",
+    cwd: "/home/jim/code/the-librarian",
+  };
+
+  it("keys local state per Claude session and matches the Librarian session by cwd", () => {
+    const loc = claudeLocationFromEvent(event, {});
+    expect(loc.harness).toBe("claude-code");
+    expect(loc.harnessSessionKey).toBe("claude-abc");
+    expect(loc.cwd).toBe("/home/jim/code/the-librarian");
+    // No per-session source_ref — that would block cross-session resume (§5.2).
+    expect(loc.sourceRef).toBeUndefined();
+  });
+
+  it("takes the project key from the environment when provided", () => {
+    const loc = claudeLocationFromEvent(event, { LIBRARIAN_PROJECT_KEY: "the-librarian" });
+    expect(loc.projectKey).toBe("the-librarian");
+  });
+
+  it("falls back to the session_id when cwd is absent", () => {
+    const loc = claudeLocationFromEvent({ hook_event_name: "Stop", session_id: "x" }, {});
+    expect(loc.harnessSessionKey).toBe("x");
+  });
+});


### PR DESCRIPTION
## What

First per-harness adapter of **Workstream 3.2**. Maps Claude Code hook events onto the merged shared lifecycle (`src/session.ts`), verified against the **real** Claude Code hook API:

| Claude event | Lifecycle call |
|---|---|
| `UserPromptSubmit` | `handlePrompt` (privacy gate + start/resume) |
| `PostCompact` | `handleCheckpoint({ trigger: "compaction" })` |
| `TaskCompleted` | `handleCheckpoint({ trigger: "task-completed" })` |
| `SessionEnd` | `handlePause` |
| `SessionStart` / `Stop` / other | no-op (lazy state init on first prompt; opening a tool must not create a session, §5.1) |

- **`claudeLocationFromEvent`** — local state keyed per Claude `session_id`, but the Librarian session matched by **cwd** (+ `LIBRARIAN_PROJECT_KEY`), **not** a per-session `source_ref` that could never match across Claude sessions (§5.2). So a paused session from a prior Claude session in the same directory resumes correctly.
- **`createClaudeCodeLifecycle`** — builds location + CLI (agent from `LIBRARIAN_AGENT_ID`, default `claude-code`) + lifecycle; `cli` injectable for tests.
- **`bin/claude-code-hook.ts`** — reads the hook event JSON on stdin, dispatches, and **always exits 0, never emits stdout, never blocks the prompt**. The privacy guarantee is "no Librarian call", not "stop the model" — and since this hook is the only thing that calls the Librarian on a prompt, a crash is inherently fail-closed (nothing recorded that turn).

## Review

A code-reviewer sub-agent reviewed the mapping, the location decision, and the bin's fail-safe posture: **APPROVE, no Critical/Important**. It confirmed the fail-safe posture is airtight (three cooperating layers; no path emits stdout or exits non-zero), the location decision matches §5.2, and SessionStart/Stop-as-no-op matches §5.1. Suggestions applied: sentinel-fallback + spawn-cwd comments, and **bin integration tests** that run the built dist bin to lock the "always exit 0, never stdout" contract (ignored event, unparseable input, prompt with unreachable CLI).

## Scope / next

This is the adapter **core**. The integration wiring — the `lib-toggle-private` command file, the thin hook shell scripts under `integrations/claude-code/hooks/librarian/`, and the settings that point Claude's hooks at this bin — is the next slice. (The toggle path is reached via `UserPromptSubmit` detecting `/lib-toggle-private`, wired in that slice.)

## Tests

78 package tests: 10 dispatch/location + 3 bin-contract added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)