### PR TITLE
feat(claude-code): wire lifecycle hooks + lib-toggle-private (§7.1)

### DIFF
--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -102,6 +102,16 @@ On a long-running Discord thread (or similar surface), this command defines the 
 3. Return numbered matches.
 4. Allow follow-up `/lib:session resume <number>`.
 
+## `/lib:toggle-private` (privacy — outside the `/lib:session` family)
+
+A separate, **local** command that toggles off-record mode. It is *not* an MCP tool — calling The Librarian to say "be private" would already touch The Librarian. Per-harness rendering follows the same convention as the session verbs: `/lib:toggle-private` where `:` is safe, `/lib-toggle-private` for flat-file command systems (Claude Code, OpenCode, Pi).
+
+- The flip is enforced by a synchronous local path that runs **before** the prompt reaches the model and before any automatic Librarian call — a `UserPromptSubmit` hook (Claude Code, Codex), gateway middleware (Hermes), the `input` gate (Pi). A prompt-only command file is a discoverability aid, never the enforcement mechanism.
+- The single Librarian call it may make is ending the attached public session (neutral reason `switching to private mode`) on the **public → private** transition. Going **private → public** resumes normal behaviour from the *next* prompt.
+- The natural-language markers (`off the record`, `don't remember this`, …) are the primary directional path into private mode; the toggle is the explicit control.
+
+Full behaviour: `specs/harness-commands-and-lifecycle-spec.md` §3 (triggers) and §4.3 (private transition).
+
 ## Boundaries
 
 - Session history is **evidence**, not durable memory. Promote selectively via `/lib:session end` candidates or `promote_session_fact`.

--- a/integrations/claude-code/CLAUDE.md
+++ b/integrations/claude-code/CLAUDE.md
@@ -22,6 +22,7 @@ This package ships **native Claude Code slash commands** — one per verb — un
 - `/lib-session-resume [<number|session_id>]` — fetch handover and attach in one call (default `attach: true`). With no argument, the command does an inline list-and-select flow. Works on `ended` sessions (flips them to `paused`).
 - `/lib-session-checkpoint` / `/lib-session-pause` / `/lib-session-end` — explicit lifecycle. Process exit should generally pause, not end. `end`'s summary is optional — the bare call is the "I'm done with this session" abandonment path.
 - `/lib-session-search <query>` — full-text search across session events.
+- `/lib-toggle-private` — toggle off-record mode (outside the session family). Local privacy control enforced by the `UserPromptSubmit` hook; going private ends the attached session with a neutral reason and stops automatic recording until you toggle back. Natural-language markers ("off the record", "don't remember this") do the same directionally.
 
 Sessions are always in one of three states: `active`, `paused`, or `ended`. The legacy `archived`, `deleted`, and `status` verbs were removed when the three-state model landed — `end` covers archive/delete, `resume` covers restore, and `list` scoped to the current harness covers status.
 

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -8,19 +8,42 @@ Wires Claude Code (Anthropic's CLI / IDE extensions / web app) into The Libraria
 
 2. **Drop `CLAUDE.md` into the project root** (or merge with an existing `CLAUDE.md`). This is a *standalone* file — Claude Code reads it on session start and gets the session-command contract and Claude-specific guidance.
 
-3. **Install the per-verb slash commands.** Copy the markdown files in [`commands/`](./commands/) into your `.claude/commands/` directory (project-local) or `~/.claude/commands/` (user-global). Seven files land 7 native Claude Code slash commands (`/lib-session-start`, `/lib-session-list`, `/lib-session-resume`, `/lib-session-checkpoint`, `/lib-session-pause`, `/lib-session-end`, `/lib-session-search`). Each command is a thin prompt that tells the agent which MCP tool to call with which scoping.
+3. **Install the per-verb slash commands.** Copy the markdown files in [`commands/`](./commands/) into your `.claude/commands/` directory (project-local) or `~/.claude/commands/` (user-global). The session verbs land as native slash commands (`/lib-session-start`, `/lib-session-list`, `/lib-session-resume`, `/lib-session-checkpoint`, `/lib-session-pause`, `/lib-session-end`, `/lib-session-search`), plus the privacy toggle `/lib-toggle-private`. Each command is a thin prompt that tells the agent which MCP tool to call with which scoping.
    ```sh
    mkdir -p .claude/commands
    cp integrations/claude-code/commands/*.md .claude/commands/
    ```
 
-4. **Optionally use [`wrapper.sh`](./wrapper.sh)** to bracket `claude` invocations with `the-librarian sessions start` (on launch) and `pause` (on exit). The wrapper exports `LIBRARIAN_SESSION_ID` so child processes can record events against the right session.
+4. **Install the automatic lifecycle hooks (recommended).** These start/resume a session on your first meaningful prompt, checkpoint on compaction and task completion, pause on session end, and enforce the privacy gate (`/lib-toggle-private` and off-record markers like "off the record"). Copy the hook script and merge the hook config into your settings:
+   ```sh
+   mkdir -p .claude/hooks/librarian
+   cp integrations/claude-code/hooks/librarian/dispatch.sh .claude/hooks/librarian/
+   chmod +x .claude/hooks/librarian/dispatch.sh
+   # then merge integrations/claude-code/hooks/settings.example.json into .claude/settings.json
+   ```
+   The hooks require `the-librarian` and `librarian-claude-hook` (from `@librarian/lifecycle`) on `PATH`. Set `LIBRARIAN_AGENT_ID` (canonical agent id) and optionally `LIBRARIAN_PROJECT_KEY`. The privacy gate **never blocks your prompt** — it only suppresses the Librarian call when off-record — and if the helper isn't installed the hook is a silent no-op.
+
+5. **Optionally use [`wrapper.sh`](./wrapper.sh)** to bracket `claude` invocations with `the-librarian sessions start` (on launch) and `pause` (on exit). The wrapper exports `LIBRARIAN_SESSION_ID` so child processes can record events against the right session. Use the wrapper *or* the hooks — the hooks are the richer, privacy-aware path.
    ```sh
    chmod +x integrations/claude-code/wrapper.sh
    integrations/claude-code/wrapper.sh --project the-librarian -- claude
    ```
 
-5. **Run the healthcheck.** See [`healthcheck.md`](./healthcheck.md).
+6. **Run the healthcheck.** See [`healthcheck.md`](./healthcheck.md).
+
+## Automatic lifecycle & privacy
+
+The hooks installed in step 4 are thin shells around the `librarian-claude-hook` bin, which maps Claude Code hook events onto the shared lifecycle helper ([`integrations/shared/librarian-lifecycle`](../shared/librarian-lifecycle)):
+
+| Claude event | Action |
+|---|---|
+| `UserPromptSubmit` | Privacy gate + start/resume a session (idempotent). |
+| `PostCompact` | Checkpoint (high-value boundary). |
+| `TaskCompleted` | Gated checkpoint. |
+| `SessionEnd` | Pause (never end — process exit is rarely a coherent stop). |
+| `SessionStart` / `Stop` | No-op (a session is created lazily on the first prompt). |
+
+Privacy is local and fails closed: if the hook can't read/write its local state it makes no automatic Librarian call. Going private ends the attached public session with a neutral reason and suppresses further calls until you go public again. See [`docs/specs/harness-commands-and-lifecycle-spec.md`](../../docs/specs/harness-commands-and-lifecycle-spec.md).
 
 ## Native resume interaction
 

--- a/integrations/claude-code/commands/lib-toggle-private.md
+++ b/integrations/claude-code/commands/lib-toggle-private.md
@@ -1,0 +1,27 @@
+---
+description: Toggle off-record (private) mode — the Librarian stops recording until you toggle back
+---
+
+Flip The Librarian's local **off-record mode** for this harness.
+
+This is a **local** privacy control. It is enforced by the Librarian
+`UserPromptSubmit` hook, not by this command file or any MCP/CLI call — typing
+`/lib-toggle-private` is detected by the hook synchronously, *before* the prompt
+reaches the model, and it:
+
+- flips local mode between **public** and **private**;
+- when going **public → private** with a session attached, ends that session
+  with a neutral reason (`switching to private mode`) and makes no further
+  automatic Librarian calls until you go public again;
+- when going **private → public**, resumes normal behaviour from your *next*
+  prompt (this prompt is not recorded).
+
+You do not need to call any tool. Just tell the user which way they toggled:
+confirm "**now private** — recording paused" or "**now public** — recording
+resumed", based on what they asked for. If the lifecycle hook is not installed,
+this command is a no-op and you should say so.
+
+The natural-language markers (`off the record`, `don't remember this`, …) are the
+primary, unambiguous way to go private; this command is the explicit toggle.
+
+Canonical contract: [`docs/slash-commands.md`](../../../docs/slash-commands.md).

--- a/integrations/claude-code/hooks/librarian/dispatch.sh
+++ b/integrations/claude-code/hooks/librarian/dispatch.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# integrations/claude-code/hooks/librarian/dispatch.sh
+#
+# Single Claude Code hook entrypoint for The Librarian lifecycle. Every hook
+# event (UserPromptSubmit, PostCompact, TaskCompleted, SessionEnd, SessionStart,
+# Stop) routes here — the `librarian-claude-hook` bin reads the hook_event_name
+# from the JSON on stdin and dispatches (see
+# integrations/shared/librarian-lifecycle/src/harness/claude-code.ts).
+#
+# This is the privacy gate: it MUST run before the prompt reaches the model and
+# before any other Librarian hook. It NEVER blocks the prompt — the privacy
+# guarantee is "no Librarian call", not "stop the model" — so it always exits 0.
+#
+# Environment (set by the wrapper / your shell):
+#   LIBRARIAN_AGENT_ID     canonical agent id for attribution (default claude-code)
+#   LIBRARIAN_PROJECT_KEY  optional project key for session matching
+#   LIBRARIAN_SECRET_KEY   forwarded to the CLI if your store needs it
+# Requires `the-librarian` and `librarian-claude-hook` on PATH.
+
+set -uo pipefail
+
+BIN="${LIBRARIAN_CLAUDE_HOOK_BIN:-librarian-claude-hook}"
+
+if ! command -v "$BIN" >/dev/null 2>&1; then
+  # Lifecycle helper not installed: do nothing, never block the prompt.
+  exit 0
+fi
+
+# The bin reads the event JSON from this script's stdin and always exits 0.
+# Guard anyway so a helper failure can never surface as a blocking hook error.
+"$BIN" || true
+exit 0

--- a/integrations/claude-code/hooks/settings.example.json
+++ b/integrations/claude-code/hooks/settings.example.json
@@ -1,0 +1,58 @@
+{
+  "_comment": "Librarian lifecycle hooks for Claude Code. Merge into your .claude/settings.json (project) or ~/.claude/settings.json (user). Every event routes to the one dispatch.sh; the librarian-claude-hook bin dispatches by hook_event_name. The privacy gate (UserPromptSubmit) never blocks the prompt — it only suppresses the Librarian call when off-record. Adjust the command path to where you installed dispatch.sh.",
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/librarian/dispatch.sh",
+            "timeout": 10,
+            "statusMessage": "Librarian privacy gate…"
+          }
+        ]
+      }
+    ],
+    "PostCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/librarian/dispatch.sh"
+          }
+        ]
+      }
+    ],
+    "TaskCompleted": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/librarian/dispatch.sh"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/librarian/dispatch.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/librarian/dispatch.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## What

The integration wiring that makes the merged Claude Code adapter (`librarian-claude-hook`) usable inside Claude Code. Completes the Claude Code piece of **Workstream 3.2**.

- **`hooks/librarian/dispatch.sh`** — one thin entrypoint for every hook event. The `librarian-claude-hook` bin reads `hook_event_name` from the stdin JSON and dispatches, so a single script serves UserPromptSubmit / PostCompact / TaskCompleted / SessionEnd / SessionStart. It **never blocks the prompt** (always exits 0) and is a **silent no-op** if the helper isn't on `PATH`.
- **`hooks/settings.example.json`** — the `hooks` config to merge into `.claude/settings.json`, wiring all five events to `dispatch.sh`.
- **`commands/lib-toggle-private.md`** — the discoverability command. The actual privacy transition is enforced synchronously by the `UserPromptSubmit` hook (the command file is an aid, not the mechanism — §3.1/§7.1).
- **README** — install steps for the hooks, an event→action table, and the privacy / fail-closed behaviour. **`docs/slash-commands.md`** — documents `/lib:toggle-private` (outside the `/lib:session` family) as the canonical contract. **`CLAUDE.md`** — adds the toggle to the command list.

## Verification

This slice is shell + markdown + JSON (no unit-testable TS — the adapter/bin it drives were tested in the previous PR). Manually verified:
- `dispatch.sh` pipes stdin to the bin and exits 0 when the bin is present (proved with a marker shim capturing stdin).
- `dispatch.sh` no-ops and exits 0 when the bin is missing.
- `settings.example.json` is valid JSON; all touched files pass prettier; the exec bit on `dispatch.sh` is recorded in git (100755).

## Notes

The `librarian-claude-hook` bin lands on `PATH` when `@librarian/lifecycle` is installed as a dependency / globally — packaging it into the Claude Code plugin is the §7.6 distribution slice (later). Until then the hook degrades gracefully (no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)