### PR TITLE
feat(codex): harness adapter + lifecycle hook wiring (§7.3)

### DIFF
--- a/docs/specs/harness-commands-and-lifecycle-spec.md
+++ b/docs/specs/harness-commands-and-lifecycle-spec.md
@@ -366,7 +366,9 @@ Long Discord threads can contain multiple Librarian sessions over time. Automati
 
 ### 7.3 Codex
 
-Codex is **first-class** when hooks are enabled: it ships a real synchronous `UserPromptSubmit` hook that runs *before user input is processed* and can return `{"decision": "block"}` to stop a prompt reaching the model — a genuine pre-agent privacy gate, equivalent to Claude Code's. Codex hooks are gated behind `codex_hooks = true` and configured in `hooks.json` or inline in `config.toml`; they are synchronous/blocking and receive JSON on `stdin`.
+Codex is **first-class** when hooks are enabled: it ships a real synchronous `UserPromptSubmit` hook that runs *before user input is processed* and can return `{"decision": "block"}` to stop a prompt reaching the model — a genuine pre-agent privacy gate, equivalent to Claude Code's. Codex hooks are gated behind the feature flag (referred to as `codex_hooks` in this spec; the **real Codex config flag is `[features] hooks = true`**, default true) and configured in `hooks.json` or inline in `config.toml`; they are synchronous/blocking and receive JSON on `stdin`.
+
+> **Implementation note (verified against the Codex hooks docs).** Codex's actual event set is `SessionStart`, `PreToolUse`, `PermissionRequest`, `PostToolUse`, `PreCompact`, `PostCompact`, `UserPromptSubmit`, `SubagentStart`, `SubagentStop`, `Stop` — there is **no `SessionEnd` and no `TaskCompleted`** event. Consequently the integration maps `UserPromptSubmit → handlePrompt`, `PostCompact → checkpoint`, and treats `PreCompact` as a no-op (checkpointing on both would double-fire around one compaction, since the lifecycle treats `compaction` as an always-pass boundary). Pause-on-exit is the wrapper's job, not a hook.
 
 #### Hooks (primary path)
 

--- a/integrations/codex/AGENTS.md
+++ b/integrations/codex/AGENTS.md
@@ -43,6 +43,12 @@ Codex is cwd-oriented. Use the most specific form available:
 
 The wrapper script in this package will populate `LIBRARIAN_SESSION_ID` for child processes; respect it when recording events.
 
+## Privacy / off-record (`/lib-toggle-private` and markers)
+
+When the lifecycle hooks are enabled (`[features] hooks = true`), the `UserPromptSubmit` hook is the real privacy gate: typing `/lib-toggle-private` or an off-record marker ("off the record", "don't remember this", …) flips local off-record mode synchronously, before you act, and ends the attached session with a neutral reason. You don't need to do anything.
+
+**When hooks are off, this is best-effort and on you:** if the user types `/lib-toggle-private` or says they're going off the record, treat the rest of that turn as private — make **no** Librarian session/memory calls and do not start a session — until they say recording can resume. Without the hook there is no synchronous enforcement, so err toward not recording. See `docs/slash-commands.md` (`/lib:toggle-private`).
+
 ## Capture mode
 
 Default to `summary`. Never enable raw `log` capture by default.

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -8,13 +8,36 @@ Wires Codex (cwd-oriented coding agent) into The Librarian's session layer.
 
 2. **Drop [`AGENTS.md`](./AGENTS.md) into the project root** (or merge with an existing `AGENTS.md`). Codex reads it on session start and learns the `/lib:session` contract and Codex-specific guidance.
 
-3. **Optionally use [`wrapper.sh`](./wrapper.sh)** to bracket `codex` invocations with `the-librarian sessions start` (on launch) and `pause` (on exit):
+3. **Enable the automatic lifecycle hooks (recommended — Codex is first-class with hooks on).** With `[features] hooks = true`, Codex's synchronous `UserPromptSubmit` hook is a genuine pre-agent privacy gate. Install the hook script and merge the config:
+   ```sh
+   mkdir -p ~/.codex/hooks/librarian
+   cp integrations/codex/hooks/librarian/dispatch.sh ~/.codex/hooks/librarian/
+   chmod +x ~/.codex/hooks/librarian/dispatch.sh
+   # merge integrations/codex/hooks/config.example.toml into ~/.codex/config.toml,
+   # replacing the command path. (Codex restricts hooks/notify in project-local
+   # config.toml — use the user-level file.)
+   ```
+   Requires `the-librarian` and `librarian-codex-hook` (from `@librarian/lifecycle`) on `PATH`. Set `LIBRARIAN_AGENT_ID` and optionally `LIBRARIAN_PROJECT_KEY`. The gate **never blocks your prompt** — it only suppresses the Librarian call when off-record — and is a silent no-op if the helper isn't installed.
+
+4. **Optionally use [`wrapper.sh`](./wrapper.sh)** to bracket `codex` invocations with `the-librarian sessions start` (on launch) and `pause` (on exit). The wrapper also covers pause-on-exit, which the hooks can't (Codex has no `SessionEnd` event):
    ```sh
    chmod +x integrations/codex/wrapper.sh
    integrations/codex/wrapper.sh --project the-librarian -- codex
    ```
 
-4. **Run the healthcheck.** See [`healthcheck.md`](./healthcheck.md).
+5. **Run the healthcheck.** See [`healthcheck.md`](./healthcheck.md).
+
+## Automatic lifecycle & privacy
+
+The hooks (step 3) are a thin shell around the `librarian-codex-hook` bin, which maps Codex hook events onto the shared lifecycle helper ([`integrations/shared/librarian-lifecycle`](../shared/librarian-lifecycle)):
+
+| Codex event | Action |
+|---|---|
+| `UserPromptSubmit` | Privacy gate + start/resume (idempotent). |
+| `PostCompact` | Checkpoint (high-value boundary). |
+| `SessionStart` / `PreCompact` / `Stop` | No-op (state is created lazily on the first prompt). |
+
+Codex has no `SessionEnd` or `TaskCompleted` event, so pause-on-exit is the wrapper's job. **When hooks are off** (`[features] hooks = false`), there is no synchronous pre-agent gate: privacy detection is best-effort instruction-following per `AGENTS.md`, and automatic start should stay disabled. Privacy fails closed: if the hook can't read/write its local state it makes no automatic Librarian call. See [`docs/specs/harness-commands-and-lifecycle-spec.md`](../../docs/specs/harness-commands-and-lifecycle-spec.md) §7.3.
 
 ## Source ref shape
 

--- a/integrations/codex/hooks/config.example.toml
+++ b/integrations/codex/hooks/config.example.toml
@@ -1,0 +1,31 @@
+# Librarian lifecycle hooks for Codex.
+#
+# Merge into your USER-level ~/.codex/config.toml (Codex restricts hooks/notify
+# in project-local config.toml). Replace the command path with where you
+# installed dispatch.sh. The librarian-codex-hook bin (from @librarian/lifecycle)
+# must be on PATH; it dispatches by hook_event_name, so one script serves every
+# event. The UserPromptSubmit gate never blocks the prompt — it only suppresses
+# the Librarian call when off-record.
+#
+# Pause-on-exit is handled by integrations/codex/wrapper.sh's exit trap; Codex
+# has no SessionEnd hook event.
+
+[features]
+hooks = true
+
+[[hooks.UserPromptSubmit]]
+[[hooks.UserPromptSubmit.hooks]]
+type = "command"
+command = "/absolute/path/to/.codex/hooks/librarian/dispatch.sh"
+timeout = 10
+statusMessage = "Librarian privacy gate…"
+
+[[hooks.PostCompact]]
+[[hooks.PostCompact.hooks]]
+type = "command"
+command = "/absolute/path/to/.codex/hooks/librarian/dispatch.sh"
+
+[[hooks.SessionStart]]
+[[hooks.SessionStart.hooks]]
+type = "command"
+command = "/absolute/path/to/.codex/hooks/librarian/dispatch.sh"

--- a/integrations/codex/hooks/librarian/dispatch.sh
+++ b/integrations/codex/hooks/librarian/dispatch.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# integrations/codex/hooks/librarian/dispatch.sh
+#
+# Single Codex hook entrypoint for The Librarian lifecycle. Every hook event
+# (UserPromptSubmit, PostCompact, SessionStart, …) routes here — the
+# `librarian-codex-hook` bin reads the hook_event_name from the JSON on stdin
+# and dispatches (see integrations/shared/librarian-lifecycle/src/harness/codex.ts).
+#
+# This is the privacy gate. Codex CAN block a prompt (exit 2 / {"decision":"block"}),
+# but this hook deliberately does NOT: the privacy guarantee is "no Librarian
+# call", not "stop the model". It always exits 0 and never blocks the prompt.
+#
+# Requires `the-librarian` and `librarian-codex-hook` (from @librarian/lifecycle)
+# on PATH. Set LIBRARIAN_AGENT_ID (default codex) and optionally
+# LIBRARIAN_PROJECT_KEY. Pause-on-exit is handled by wrapper.sh, not a hook
+# (Codex has no SessionEnd event).
+
+set -uo pipefail
+
+BIN="${LIBRARIAN_CODEX_HOOK_BIN:-librarian-codex-hook}"
+
+if ! command -v "$BIN" >/dev/null 2>&1; then
+  exit 0 # lifecycle helper not installed: do nothing, never block the prompt
+fi
+
+"$BIN" || true
+exit 0

--- a/integrations/shared/librarian-lifecycle/package.json
+++ b/integrations/shared/librarian-lifecycle/package.json
@@ -7,7 +7,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "librarian-claude-hook": "./dist/bin/claude-code-hook.js"
+    "librarian-claude-hook": "./dist/bin/claude-code-hook.js",
+    "librarian-codex-hook": "./dist/bin/codex-hook.js"
   },
   "exports": {
     ".": {

--- a/integrations/shared/librarian-lifecycle/src/bin/codex-hook.ts
+++ b/integrations/shared/librarian-lifecycle/src/bin/codex-hook.ts
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+// Codex hook entrypoint. The thin hook scripts in integrations/codex/hooks/
+// librarian/ pipe the hook event JSON to this bin on stdin. It builds the
+// lifecycle from the event + environment and dispatches. It ALWAYS exits 0 and
+// never blocks the prompt: the privacy guarantee is "no Librarian call", not
+// "stop the model". (Codex CAN block via {"decision":"block"} / exit 2, but we
+// deliberately don't.)
+
+import { type CodexHookEvent, createCodexLifecycle, dispatchCodexHook } from "../harness/codex.js";
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function main(): Promise<void> {
+  let event: CodexHookEvent = {};
+  try {
+    const raw = (await readStdin()).trim();
+    if (raw) event = JSON.parse(raw) as CodexHookEvent;
+  } catch {
+    process.exit(0); // unparseable input → no state read, no call, fail closed
+  }
+
+  try {
+    const lifecycle = createCodexLifecycle(event);
+    dispatchCodexHook(event, lifecycle);
+  } catch (err) {
+    process.stderr.write(`librarian lifecycle hook error: ${(err as Error).message}\n`);
+  }
+  process.exit(0);
+}
+
+void main();

--- a/integrations/shared/librarian-lifecycle/src/harness/codex.ts
+++ b/integrations/shared/librarian-lifecycle/src/harness/codex.ts
@@ -1,0 +1,103 @@
+// Codex harness adapter (spec §7.3).
+//
+// Codex is first-class when hooks are enabled (`[features] hooks = true`): it
+// ships a real synchronous UserPromptSubmit hook that runs before the prompt is
+// processed — a genuine pre-agent privacy gate. Its hook stdin JSON mirrors
+// Claude Code's (session_id, cwd, hook_event_name, prompt), so the mapping is
+// the same shape with two differences:
+//
+//   - Codex has NO SessionEnd and NO TaskCompleted event. Pause-on-exit is
+//     handled by integrations/codex/wrapper.sh's exit trap, not a hook.
+//   - Compaction checkpointing uses PostCompact (PreCompact is left a no-op to
+//     avoid double-checkpointing).
+//
+// Mapping:
+//   UserPromptSubmit → handlePrompt   (privacy gate + start/resume)
+//   PostCompact      → checkpoint(compaction)
+//   SessionStart / PreCompact / Stop / other → no-op
+//
+// Like Claude Code, the gate does NOT block the prompt — privacy means "no
+// Librarian call", not "stop the model".
+
+import { type LibrarianCli, createLibrarianCli } from "../cli.js";
+import {
+  type CheckpointOutcome,
+  type LibrarianLifecycle,
+  type LifecycleConfig,
+  type LifecycleDeps,
+  type LifecycleLogEntry,
+  type PauseOutcome,
+  type PromptOutcome,
+  createLibrarianLifecycle,
+} from "../session.js";
+import type { StateLocation } from "../state.js";
+
+export interface CodexHookEvent {
+  hook_event_name?: string;
+  session_id?: string;
+  cwd?: string;
+  prompt?: string;
+  source?: string;
+  trigger?: string;
+}
+
+export type CodexHookResult =
+  | PromptOutcome
+  | CheckpointOutcome
+  | PauseOutcome
+  | { action: "ignored" };
+
+// Local state keyed per Codex session_id; the Librarian session is matched by
+// cwd (+project), not a per-session source_ref that could never match across
+// Codex sessions (§5.2). Kept consistent with the Claude Code adapter.
+export function codexLocationFromEvent(
+  event: CodexHookEvent,
+  env: NodeJS.ProcessEnv,
+): StateLocation {
+  const location: StateLocation = {
+    harness: "codex",
+    harnessSessionKey: event.session_id ?? event.cwd ?? "codex",
+  };
+  if (event.cwd) location.cwd = event.cwd;
+  if (env.LIBRARIAN_PROJECT_KEY) location.projectKey = env.LIBRARIAN_PROJECT_KEY;
+  return location;
+}
+
+export function dispatchCodexHook(
+  event: CodexHookEvent,
+  lifecycle: LibrarianLifecycle,
+): CodexHookResult {
+  switch (event.hook_event_name) {
+    case "UserPromptSubmit":
+      return lifecycle.handlePrompt(event.prompt ?? "");
+    case "PostCompact":
+      return lifecycle.handleCheckpoint({ trigger: "compaction" });
+    default:
+      return { action: "ignored" };
+  }
+}
+
+export interface CodexAdapterOptions {
+  env?: NodeJS.ProcessEnv;
+  config?: Partial<LifecycleConfig>;
+  /** Injectable for tests; defaults to a real spawnSync-backed CLI. */
+  cli?: LibrarianCli;
+  logger?: (entry: LifecycleLogEntry) => void;
+  now?: () => number;
+}
+
+export function createCodexLifecycle(
+  event: CodexHookEvent,
+  options: CodexAdapterOptions = {},
+): LibrarianLifecycle {
+  const env = options.env ?? process.env;
+  const location = codexLocationFromEvent(event, env);
+  const agent = env.LIBRARIAN_AGENT_ID || "codex";
+  const cli =
+    options.cli ?? createLibrarianCli({ agent, ...(event.cwd ? { cwd: event.cwd } : {}) });
+  const deps: LifecycleDeps = { cli, location };
+  if (options.config) deps.config = options.config;
+  if (options.logger) deps.logger = options.logger;
+  if (options.now) deps.now = options.now;
+  return createLibrarianLifecycle(deps);
+}

--- a/integrations/shared/librarian-lifecycle/src/index.ts
+++ b/integrations/shared/librarian-lifecycle/src/index.ts
@@ -7,6 +7,7 @@
 
 export * from "./cli.js";
 export * from "./harness/claude-code.js";
+export * from "./harness/codex.js";
 export * from "./privacy.js";
 export * from "./session.js";
 export * from "./state.js";

--- a/integrations/shared/librarian-lifecycle/tests/harness-codex.test.ts
+++ b/integrations/shared/librarian-lifecycle/tests/harness-codex.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  type CodexHookEvent,
+  codexLocationFromEvent,
+  dispatchCodexHook,
+} from "../src/harness/codex.js";
+import type { LibrarianLifecycle } from "../src/session.js";
+
+function fakeLifecycle(): LibrarianLifecycle {
+  return {
+    handlePrompt: vi.fn(() => ({ action: "started" as const, privacy: "public" as const })),
+    handleCheckpoint: vi.fn(() => ({ action: "checkpointed" as const })),
+    handlePause: vi.fn(() => ({ action: "paused" as const })),
+    handleToggle: vi.fn(() => ({ action: "toggled-public" as const, privacy: "public" as const })),
+  };
+}
+
+describe("dispatchCodexHook (§7.3 mapping)", () => {
+  it("routes UserPromptSubmit to handlePrompt with the prompt text", () => {
+    const lc = fakeLifecycle();
+    dispatchCodexHook({ hook_event_name: "UserPromptSubmit", prompt: "ship it" }, lc);
+    expect(lc.handlePrompt).toHaveBeenCalledWith("ship it");
+  });
+
+  it("routes PostCompact to a compaction checkpoint", () => {
+    const lc = fakeLifecycle();
+    dispatchCodexHook({ hook_event_name: "PostCompact", trigger: "auto" }, lc);
+    expect(lc.handleCheckpoint).toHaveBeenCalledWith({ trigger: "compaction" });
+  });
+
+  it("ignores events Codex does not provide for lifecycle (no SessionEnd / TaskCompleted)", () => {
+    const lc = fakeLifecycle();
+    // Codex has no SessionEnd; pause is handled by the wrapper exit trap.
+    expect(
+      dispatchCodexHook({ hook_event_name: "SessionStart", source: "startup" }, lc).action,
+    ).toBe("ignored");
+    expect(dispatchCodexHook({ hook_event_name: "PreCompact", trigger: "manual" }, lc).action).toBe(
+      "ignored",
+    );
+    expect(dispatchCodexHook({ hook_event_name: "Stop" }, lc).action).toBe("ignored");
+    expect(lc.handlePause).not.toHaveBeenCalled();
+    expect(lc.handleCheckpoint).not.toHaveBeenCalled();
+  });
+
+  it("treats a missing prompt as empty string", () => {
+    const lc = fakeLifecycle();
+    dispatchCodexHook({ hook_event_name: "UserPromptSubmit" }, lc);
+    expect(lc.handlePrompt).toHaveBeenCalledWith("");
+  });
+});
+
+describe("codexLocationFromEvent", () => {
+  const event: CodexHookEvent = {
+    hook_event_name: "UserPromptSubmit",
+    session_id: "codex-abc",
+    cwd: "/home/jim/code/the-librarian",
+  };
+
+  it("uses the codex harness, keys state per session, matches by cwd", () => {
+    const loc = codexLocationFromEvent(event, {});
+    expect(loc.harness).toBe("codex");
+    expect(loc.harnessSessionKey).toBe("codex-abc");
+    expect(loc.cwd).toBe("/home/jim/code/the-librarian");
+    expect(loc.sourceRef).toBeUndefined();
+  });
+
+  it("takes the project key from the environment", () => {
+    const loc = codexLocationFromEvent(event, { LIBRARIAN_PROJECT_KEY: "the-librarian" });
+    expect(loc.projectKey).toBe("the-librarian");
+  });
+});


### PR DESCRIPTION
## What

Second per-harness adapter of **Workstream 3.2**. Codex hooks mirror Claude Code's stdin JSON shape, so the adapter is the same mapping with Codex's real event set (verified against the Codex hooks docs):

| Codex event | Action |
|---|---|
| `UserPromptSubmit` | `handlePrompt` (privacy gate + start/resume) |
| `PostCompact` | `handleCheckpoint({ trigger: "compaction" })` |
| `SessionStart` / `PreCompact` / `Stop` / other | no-op |

Codex has **no `SessionEnd` and no `TaskCompleted`** event, so pause-on-exit stays the `wrapper.sh` exit-trap's job. `PreCompact` is intentionally a no-op (checkpointing on both pre+post would double-fire around one compaction). Local state keyed per Codex `session_id`; the Librarian session matched by cwd (+project), no per-session `source_ref` (§5.2) — kept consistent with the Claude Code adapter.

- `src/harness/codex.ts` + `src/bin/codex-hook.ts` (new `librarian-codex-hook` bin). The bin always exits 0 and never emits stdout — Codex *can* block (exit 2 / `decision:block`), but privacy = "no Librarian call", not "stop the model".
- Wiring: `hooks/librarian/dispatch.sh`, `hooks/config.example.toml` (`[features] hooks = true` + `[[hooks.*]]`), an `AGENTS.md` privacy section with the **hooks-off best-effort** instruction fallback (§7.3), and README install steps.
- Spec reconciliation: §7.3 said `codex_hooks` and listed PreCompact/PostCompact together; updated to the real `[features] hooks` flag and the actual event set.

## Review

A code-reviewer sub-agent reviewed it: **APPROVE, no Critical/Important**. Confirmed the mapping is correct against Codex's real events, the fail-safe bin posture is airtight (never stdout, never non-zero, fails closed on bad input), it's exactly consistent with the merged Claude adapter where it should be, and `dispatch.sh`/`config.toml` are correct. On duplication: the reviewer agreed **not** to extract a shared helper yet (only two Claude-shaped harnesses; pi/opencode/hermes differ). Its main suggestion — the spec flag-name mismatch — is fixed in the second commit.

## Tests

6 codex adapter tests (84 package total). Smoke-verified `dispatch.sh` pipes stdin to the bin and exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)