### PR TITLE
docs(research): mark the two research docs superseded by their specs

### DIFF
--- a/docs/research/harness-commands-and-lifecycle-research.md
+++ b/docs/research/harness-commands-and-lifecycle-research.md
@@ -1,8 +1,10 @@
 # Harness Commands, Private Mode, and Session Lifecycle — Research
 
+> **Superseded by the spec.** This is the original research/exploration doc. The implemented design lives in [`docs/specs/harness-commands-and-lifecycle-spec.md`](../specs/harness-commands-and-lifecycle-spec.md); the build followed [`docs/specs/implementation-plan.md`](../specs/implementation-plan.md). Where this doc and the spec disagree, the spec wins. Kept for provenance — read the spec for current behaviour.
+
 **Author:** Guybrush, with Jim
 **Date:** 2026-05-23
-**Status:** Research — revised after stronger-model review
+**Status:** Research — superseded by `docs/specs/harness-commands-and-lifecycle-spec.md`
 
 ---
 

--- a/docs/research/memory-curator-research.md
+++ b/docs/research/memory-curator-research.md
@@ -1,8 +1,10 @@
 # Memory Curator — Research
 
+> **Superseded by the spec.** This is the original research/exploration doc. The implemented design lives in [`docs/specs/memory-curator-spec.md`](../specs/memory-curator-spec.md); the build followed [`docs/specs/implementation-plan.md`](../specs/implementation-plan.md). Where this doc and the spec disagree, the spec wins. Kept for provenance — read the spec for current behaviour.
+
 **Author:** Guybrush, with Jim
 **Date:** 2026-05-23
-**Status:** Research — revised after stronger-model review
+**Status:** Research — superseded by `docs/specs/memory-curator-spec.md`
 
 ---
 


### PR DESCRIPTION
## What

Housekeeping from `docs/specs/implementation-plan.md` §6: add a "superseded by the spec" banner to the two original research/exploration docs so future readers go to the implemented specs rather than the pre-implementation exploration.

- `docs/research/memory-curator-research.md` → points to `docs/specs/memory-curator-spec.md`
- `docs/research/harness-commands-and-lifecycle-research.md` → points to `docs/specs/harness-commands-and-lifecycle-spec.md`

Both note the spec wins on any disagreement; the research docs are kept for provenance. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)