### PR TITLE
feat(core): curator evidence-query indexes (schema v11)

### DIFF
--- a/packages/core/src/store/projection.ts
+++ b/packages/core/src/store/projection.ts
@@ -79,9 +79,13 @@ function asArray(value: unknown): string[] {
 //         Authoritative; preserved across bumps; the bump just CREATEs it.
 //   - 11: curator evidence-query indexes — idx_events_memory and
 //         idx_session_events_session back the offline-batch evidence
-//         queries (tombstone archive-reason subqueries + per-session
-//         evidence). Index-only change; the bump recreates them on next
-//         boot (both indexed tables are dropped+rebuilt on a bump anyway).
+//         queries (tombstone archive-reason subqueries on `events`;
+//         per-session evidence on `session_events`). They serve the
+//         equality + IN(...) filter (the scan→search win); the trailing
+//         created_at is a small covering tail (the queries' IN / CASE
+//         ORDER BY still uses a tiny temp sort over the filtered rows).
+//         Index-only change; the bump recreates them on next boot (both
+//         indexed tables are dropped+rebuilt on a bump anyway).
 export const PROJECTION_SCHEMA_VERSION = 11;
 
 export function getSchemaVersion(db: DatabaseSync): number {
@@ -223,8 +227,6 @@ export const SCHEMA_DDL = `
       created_at TEXT NOT NULL,
       payload_json TEXT NOT NULL
     );
-    -- Backs the curator tombstone archive-reason subqueries (curator-evidence.ts):
-    -- WHERE memory_id = ? AND event_type IN (...) ORDER BY created_at DESC.
     CREATE INDEX IF NOT EXISTS idx_events_memory
       ON events(memory_id, event_type, created_at);
     CREATE TABLE IF NOT EXISTS sessions (
@@ -279,8 +281,6 @@ export const SCHEMA_DDL = `
       payload_json TEXT NOT NULL,
       created_at TEXT NOT NULL
     );
-    -- Backs the curator per-session evidence query (curator-evidence.ts):
-    -- WHERE session_id = ? AND type IN (...) ORDER BY ... created_at DESC.
     CREATE INDEX IF NOT EXISTS idx_session_events_session
       ON session_events(session_id, type, created_at);
     CREATE VIRTUAL TABLE IF NOT EXISTS session_events_fts USING fts5(

--- a/packages/core/src/store/projection.ts
+++ b/packages/core/src/store/projection.ts
@@ -77,7 +77,12 @@ function asArray(value: unknown): string[] {
 //        across bumps; the bump just CREATEs them on existing installs.
 //   - 10: memory-curator §7.1 — `settings` table (admin secret-store).
 //         Authoritative; preserved across bumps; the bump just CREATEs it.
-export const PROJECTION_SCHEMA_VERSION = 10;
+//   - 11: curator evidence-query indexes — idx_events_memory and
+//         idx_session_events_session back the offline-batch evidence
+//         queries (tombstone archive-reason subqueries + per-session
+//         evidence). Index-only change; the bump recreates them on next
+//         boot (both indexed tables are dropped+rebuilt on a bump anyway).
+export const PROJECTION_SCHEMA_VERSION = 11;
 
 export function getSchemaVersion(db: DatabaseSync): number {
   const row = db.prepare("PRAGMA user_version").get() as { user_version: number };
@@ -218,6 +223,10 @@ export const SCHEMA_DDL = `
       created_at TEXT NOT NULL,
       payload_json TEXT NOT NULL
     );
+    -- Backs the curator tombstone archive-reason subqueries (curator-evidence.ts):
+    -- WHERE memory_id = ? AND event_type IN (...) ORDER BY created_at DESC.
+    CREATE INDEX IF NOT EXISTS idx_events_memory
+      ON events(memory_id, event_type, created_at);
     CREATE TABLE IF NOT EXISTS sessions (
       id TEXT PRIMARY KEY,
       title TEXT NOT NULL,
@@ -270,6 +279,10 @@ export const SCHEMA_DDL = `
       payload_json TEXT NOT NULL,
       created_at TEXT NOT NULL
     );
+    -- Backs the curator per-session evidence query (curator-evidence.ts):
+    -- WHERE session_id = ? AND type IN (...) ORDER BY ... created_at DESC.
+    CREATE INDEX IF NOT EXISTS idx_session_events_session
+      ON session_events(session_id, type, created_at);
     CREATE VIRTUAL TABLE IF NOT EXISTS session_events_fts USING fts5(
       event_id UNINDEXED,
       session_id,

--- a/packages/core/tests/store/curator-evidence-indexes.test.ts
+++ b/packages/core/tests/store/curator-evidence-indexes.test.ts
@@ -43,21 +43,31 @@ describe("curator evidence-query indexes", () => {
     expect(indexNames()).toContain("idx_session_events_session");
   });
 
-  it("the events index actually backs the tombstone archive-reason subquery", () => {
+  function queryPlan(sql: string): string {
     const store = createLibrarianStore({ dataDir });
     try {
-      const plan = store.db
-        .prepare(
-          `EXPLAIN QUERY PLAN
-             SELECT e.payload_json FROM events e
-              WHERE e.memory_id = ? AND e.event_type IN ('memory.archived', 'memory.deleted')
-              ORDER BY e.created_at DESC LIMIT 1`,
-        )
-        .all() as Array<{ detail: string }>;
-      const detail = plan.map((r) => r.detail).join(" | ");
-      expect(detail).toContain("idx_events_memory");
+      const plan = store.db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all() as Array<{ detail: string }>;
+      return plan.map((r) => r.detail).join(" | ");
     } finally {
       store.close();
     }
+  }
+
+  it("the events index actually backs the tombstone archive-reason subquery", () => {
+    const detail = queryPlan(
+      `SELECT e.payload_json FROM events e
+        WHERE e.memory_id = ? AND e.event_type IN ('memory.archived', 'memory.deleted')
+        ORDER BY e.created_at DESC LIMIT 1`,
+    );
+    expect(detail).toContain("idx_events_memory");
+  });
+
+  it("the session_events index actually backs the per-session evidence query", () => {
+    const detail = queryPlan(
+      `SELECT type, summary, created_at FROM session_events
+        WHERE session_id = ? AND type IN ('decision', 'note')
+        ORDER BY CASE type WHEN 'decision' THEN 0 WHEN 'note' THEN 1 ELSE 2 END, created_at DESC`,
+    );
+    expect(detail).toContain("idx_session_events_session");
   });
 });

--- a/packages/core/tests/store/curator-evidence-indexes.test.ts
+++ b/packages/core/tests/store/curator-evidence-indexes.test.ts
@@ -1,0 +1,63 @@
+// Indexes that back the curator evidence queries (curator-evidence.ts):
+//   - the tombstone archive-reason correlated subqueries over `events`
+//     (WHERE memory_id = ? AND event_type IN (...) ORDER BY created_at DESC)
+//   - the per-session evidence query over `session_events`
+//     (WHERE session_id = ? AND type IN (...) ORDER BY ... created_at DESC)
+// Both run in the offline curator batch; the indexes keep them off full scans
+// once a real store grows.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createLibrarianStore } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+describe("curator evidence-query indexes", () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-idx-"));
+  });
+  afterEach(() => {
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  function indexNames(): string[] {
+    const store = createLibrarianStore({ dataDir });
+    try {
+      return (
+        store.db.prepare("SELECT name FROM sqlite_master WHERE type = 'index'").all() as Array<{
+          name: string;
+        }>
+      ).map((r) => r.name);
+    } finally {
+      store.close();
+    }
+  }
+
+  it("creates an events(memory_id, event_type, created_at) index", () => {
+    expect(indexNames()).toContain("idx_events_memory");
+  });
+
+  it("creates a session_events(session_id, type, created_at) index", () => {
+    expect(indexNames()).toContain("idx_session_events_session");
+  });
+
+  it("the events index actually backs the tombstone archive-reason subquery", () => {
+    const store = createLibrarianStore({ dataDir });
+    try {
+      const plan = store.db
+        .prepare(
+          `EXPLAIN QUERY PLAN
+             SELECT e.payload_json FROM events e
+              WHERE e.memory_id = ? AND e.event_type IN ('memory.archived', 'memory.deleted')
+              ORDER BY e.created_at DESC LIMIT 1`,
+        )
+        .all() as Array<{ detail: string }>;
+      const detail = plan.map((r) => r.detail).join(" | ");
+      expect(detail).toContain("idx_events_memory");
+    } finally {
+      store.close();
+    }
+  });
+});

--- a/test/schema-snapshot.json
+++ b/test/schema-snapshot.json
@@ -1,4 +1,4 @@
 {
-  "version": 10,
-  "fingerprint": "523a7f2c65be271cdaea6b037c74b196a731f9ab3d9fd8c7d1b73249e44cdf3a"
+  "version": 11,
+  "fingerprint": "2b3923509d55a317de04c58feae2e969bd50c7a102260c58fea2ab9b5020b9c9"
 }

--- a/test/schema-snapshot.json
+++ b/test/schema-snapshot.json
@@ -1,4 +1,4 @@
 {
   "version": 11,
-  "fingerprint": "2b3923509d55a317de04c58feae2e969bd50c7a102260c58fea2ab9b5020b9c9"
+  "fingerprint": "211c74c3ed97a3b356e463414898c73f61c9125ec380d45353e4cfef7920bd4c"
 }


### PR DESCRIPTION
## What

You asked me to land this now (deferred follow-up from the curator build). The two curator evidence queries did capped-but-unindexed scans; this adds the backing indexes so the offline curator batch stays off full scans on a large store.

- `idx_events_memory ON events(memory_id, event_type, created_at)` — backs the tombstone archive-reason correlated subqueries (`WHERE memory_id = ? AND event_type IN (...) ORDER BY created_at DESC`).
- `idx_session_events_session ON session_events(session_id, type, created_at)` — backs the per-session evidence query (`WHERE session_id = ? AND type IN (...) ORDER BY ... created_at DESC`).

Index-only change. `PROJECTION_SCHEMA_VERSION` 10 → 11 with a bump-history note; schema snapshot refreshed. Both indexed tables are dropped+rebuilt on a version bump, so the indexes are recreated on next boot, and they live in `SCHEMA_DDL` with `IF NOT EXISTS` so the already-at-version path creates them too — no install misses them.

The indexes serve the equality + `IN(...)` filter (the scan→search win); the trailing `created_at` is a small covering tail (the `IN`/`CASE` `ORDER BY` still uses a tiny temp sort over the already-filtered rows). The v11 history note states this precisely.

## Review

A code-reviewer sub-agent verified the schema-version protocol is complete (snapshot refreshed; `check-storage-fixture` correctly untouched since it's count-only), simulated the v10→v11 upgrade (both indexes present after rebuild), and confirmed the planner uses the indexes via `EXPLAIN QUERY PLAN`. **APPROVE, no Critical/Important.** Its two suggestions are applied: removed inline DDL comments that overstated the ordering benefit, and added the symmetric EXPLAIN assertion for the session index.

## Tests

395 core tests (4 new): both indexes exist (`sqlite_master`), and `EXPLAIN QUERY PLAN` shows each is actually used by its real query shape. All CI guards (schema-version, storage-fixture, session-state-divergence) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)