### PR TITLE
feat(lifecycle): secure HTTP MCP client for the remote transport

### DIFF
--- a/integrations/shared/librarian-lifecycle/package.json
+++ b/integrations/shared/librarian-lifecycle/package.json
@@ -24,6 +24,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
+    "@librarian/mcp-server": "workspace:*",
     "@types/node": "^22.10.5",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/integrations/shared/librarian-lifecycle/src/index.ts
+++ b/integrations/shared/librarian-lifecycle/src/index.ts
@@ -8,6 +8,7 @@
 export * from "./cli.js";
 export * from "./harness/claude-code.js";
 export * from "./harness/codex.js";
+export * from "./mcp-client.js";
 export * from "./privacy.js";
 export * from "./session.js";
 export * from "./state.js";

--- a/integrations/shared/librarian-lifecycle/src/mcp-client.ts
+++ b/integrations/shared/librarian-lifecycle/src/mcp-client.ts
@@ -1,0 +1,286 @@
+// Minimal MCP client for the Librarian HTTP server (remote lifecycle transport).
+//
+// The Librarian's `/mcp` is a STATELESS JSON-RPC 2.0 endpoint: no `initialize`
+// handshake and no session id — a `tools/call` is POSTed directly with a Bearer
+// token. So this is a single-request client: build the envelope, POST it, map
+// every failure onto a typed `McpClientError`, and return the tool's text.
+//
+// Mirrors the security posture of the Hermes plugin's `client.py` (which a
+// security review hardened): the bearer token lives ONLY in the Authorization
+// header and is never put into an error message; 3xx redirects are refused so a
+// redirect can't carry the token cross-origin; the endpoint scheme is
+// allowlisted to http(s); and the response body is capped so a runaway endpoint
+// cannot exhaust memory. The transport is injectable so tests never touch the
+// network.
+//
+// MCP session tools return human-readable PROSE (see `@librarian/mcp-server`
+// formatters), not JSON, so this module also parses the two shapes the lifecycle
+// needs (a single session block, and a session list). The parsers are pinned to
+// the real formatters by round-trip tests in the same monorepo.
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_MAX_RESPONSE_BYTES = 8 * 1024 * 1024;
+const MAX_RPC_MESSAGE_CHARS = 200;
+
+export type McpClientErrorKind = "config" | "network" | "timeout" | "http" | "rpc" | "malformed";
+
+export class McpClientError extends Error {
+  override readonly name = "McpClientError";
+  readonly kind: McpClientErrorKind;
+  readonly status?: number | undefined;
+
+  constructor(kind: McpClientErrorKind, message: string, extra: { status?: number } = {}) {
+    super(message);
+    this.kind = kind;
+    this.status = extra.status;
+  }
+}
+
+export interface McpRequest {
+  url: string;
+  body: string;
+  headers: Record<string, string>;
+  timeoutMs: number;
+}
+
+export interface McpResponse {
+  status: number;
+  body: string;
+}
+
+/** POST and return `(status, body)`. Throw a TimeoutError-named error on timeout. */
+export type McpTransport = (req: McpRequest) => Promise<McpResponse>;
+
+export interface McpClientConfig {
+  endpoint: string;
+  token: string;
+  timeoutMs?: number;
+  /** Cap on the buffered response body (default 8 MiB). */
+  maxResponseBytes?: number;
+}
+
+export interface McpClient {
+  callTool(name: string, args: Record<string, unknown>): Promise<string>;
+}
+
+export function createMcpClient(config: McpClientConfig, transport?: McpTransport): McpClient {
+  // Allowlist the scheme so a mistemplated endpoint can't reach a file:/data:
+  // handler (config-driven SSRF / local file read).
+  const scheme = safeScheme(config.endpoint);
+  if (scheme !== "http" && scheme !== "https") {
+    throw new McpClientError(
+      "config",
+      `Librarian endpoint must be http(s), got ${scheme ?? "(none)"}`,
+    );
+  }
+  const endpoint = config.endpoint;
+  const token = config.token;
+  const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxResponseBytes = config.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES;
+  const send = transport ?? defaultTransport(maxResponseBytes);
+
+  return {
+    async callTool(name, args) {
+      const body = JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name, arguments: args },
+      });
+      // The token lives ONLY here — never in args, the URL, or any error text.
+      const headers = {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        Authorization: `Bearer ${token}`,
+      };
+
+      let response: McpResponse;
+      try {
+        response = await send({ url: endpoint, body, headers, timeoutMs });
+      } catch (err) {
+        if (err instanceof McpClientError) throw err;
+        if (isTimeoutError(err)) {
+          throw new McpClientError("timeout", `${name} timed out after ${timeoutMs}ms`);
+        }
+        // Don't interpolate the underlying error (it may echo the request) —
+        // keep the token-bearing call strictly out of anything we render.
+        throw new McpClientError("network", `${name} could not reach the Librarian at ${endpoint}`);
+      }
+
+      if (response.status !== 200) {
+        throw new McpClientError("http", `${name} returned HTTP ${response.status}`, {
+          status: response.status,
+        });
+      }
+
+      let payload: unknown;
+      try {
+        payload = JSON.parse(response.body);
+      } catch {
+        throw new McpClientError("malformed", `${name} returned non-JSON`);
+      }
+
+      if (isRecord(payload) && "error" in payload) {
+        const rpc = payload.error;
+        const code = isRecord(rpc) ? rpc.code : undefined;
+        // Truncate the server-controlled message so it can't bloat logs.
+        const msg = isRecord(rpc) ? String(rpc.message ?? "").slice(0, MAX_RPC_MESSAGE_CHARS) : "";
+        throw new McpClientError("rpc", `${name} failed: ${msg} (code ${String(code)})`);
+      }
+
+      const text = extractText(payload);
+      if (text === null) {
+        throw new McpClientError("malformed", `${name} response had no text content`);
+      }
+      return text;
+    },
+  };
+}
+
+function safeScheme(endpoint: string): string | null {
+  try {
+    return new URL(endpoint).protocol.replace(/:$/, "");
+  } catch {
+    return null;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isTimeoutError(err: unknown): boolean {
+  const name = (err as { name?: string } | null)?.name;
+  const code = (err as { code?: string } | null)?.code;
+  return name === "AbortError" || name === "TimeoutError" || code === "ETIMEDOUT";
+}
+
+/** Pull `result.content[0].text` from an MCP tool response, or null. */
+function extractText(payload: unknown): string | null {
+  if (!isRecord(payload)) return null;
+  const result = payload.result;
+  if (!isRecord(result)) return null;
+  const content = result.content;
+  if (!Array.isArray(content) || content.length === 0) return null;
+  const first: unknown = content[0];
+  if (!isRecord(first)) return null;
+  return typeof first.text === "string" ? first.text : null;
+}
+
+function defaultTransport(maxResponseBytes: number): McpTransport {
+  return async ({ url, body, headers, timeoutMs }) => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        body,
+        headers,
+        // A 3xx must NEVER be followed: fetch would carry the Authorization
+        // header to the redirect target and leak the bearer token cross-origin.
+        // The Librarian /mcp is a single stateless POST with no legitimate 3xx.
+        redirect: "error",
+        signal: controller.signal,
+      });
+      return { status: response.status, body: await readCapped(response, maxResponseBytes) };
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+}
+
+async function readCapped(response: Response, cap: number): Promise<string> {
+  const reader = response.body?.getReader();
+  if (!reader) return (await response.text()).slice(0, cap);
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    total += value.byteLength;
+    if (total > cap) {
+      await reader.cancel();
+      throw new McpClientError("malformed", "Librarian response exceeded the size cap");
+    }
+    chunks.push(value);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+// --- Prose parsers (pinned to @librarian/mcp-server formatters by round-trip
+// tests). The lifecycle only needs `id` + `status`; other fields are best-effort.
+
+export interface ParsedSession {
+  id: string;
+  status: string;
+  title: string | null;
+  project_key: string | null;
+  source_ref: string | null;
+  cwd: string | null;
+}
+
+function firstMatch(text: string, re: RegExp): string | null {
+  const m = text.match(re);
+  return m?.[1] ? m[1].trim() : null;
+}
+
+function projectOrNull(value: string | null): string | null {
+  return value === null || value === "(none)" || value === "no project" ? null : value;
+}
+
+/**
+ * Parse a single-session block (`formatSessionStart` / `formatSessionLifecycle`
+ * / `formatSessionDetail`). Returns null when there is no `ID:`/`Status:` pair.
+ */
+export function parseSessionFromProse(text: string): ParsedSession | null {
+  const id = firstMatch(text, /^ID:\s*(.+)$/m);
+  const status = firstMatch(text, /^Status:\s*(.+)$/m);
+  if (!id || !status) return null;
+  const title = firstMatch(text, /^Title:\s*(.+)$/m) ?? firstMatch(text, /^Session:\s*(.+)$/m);
+  return {
+    id,
+    status,
+    title,
+    project_key: projectOrNull(firstMatch(text, /^Project:\s*(.+)$/m)),
+    source_ref: firstMatch(text, /^Source:\s*(.+)$/m),
+    cwd: firstMatch(text, /^Cwd:\s*(.+)$/m),
+  };
+}
+
+/**
+ * Parse a session list (`formatSessionList`). Each entry is a numbered headline
+ * `N. [status] title — project — harness — last: …` followed (possibly after a
+ * `next:` line) by an `id: …` line.
+ */
+export function parseSessionListFromProse(text: string): ParsedSession[] {
+  const sessions: ParsedSession[] = [];
+  let status: string | null = null;
+  let title: string | null = null;
+  let project: string | null = null;
+  for (const line of text.split("\n")) {
+    const head = line.match(/^\d+\.\s*\[([^\]]+)\]\s*(.*)$/);
+    if (head) {
+      status = head[1]!.trim();
+      const segments = (head[2] ?? "").split(" — ");
+      title = segments[0]?.trim() || null;
+      project = projectOrNull(segments[1]?.trim() ?? null);
+      continue;
+    }
+    const idLine = line.match(/^\s*id:\s*(\S+)/);
+    if (idLine && status) {
+      sessions.push({
+        id: idLine[1]!,
+        status,
+        title,
+        project_key: project,
+        source_ref: null,
+        cwd: null,
+      });
+      status = null;
+      title = null;
+      project = null;
+    }
+  }
+  return sessions;
+}

--- a/integrations/shared/librarian-lifecycle/src/mcp-client.ts
+++ b/integrations/shared/librarian-lifecycle/src/mcp-client.ts
@@ -64,16 +64,33 @@ export interface McpClient {
 }
 
 export function createMcpClient(config: McpClientConfig, transport?: McpTransport): McpClient {
+  let url: URL;
+  try {
+    url = new URL(config.endpoint);
+  } catch {
+    throw new McpClientError("config", "Librarian endpoint is not a valid URL");
+  }
   // Allowlist the scheme so a mistemplated endpoint can't reach a file:/data:
   // handler (config-driven SSRF / local file read).
-  const scheme = safeScheme(config.endpoint);
-  if (scheme !== "http" && scheme !== "https") {
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
     throw new McpClientError(
       "config",
-      `Librarian endpoint must be http(s), got ${scheme ?? "(none)"}`,
+      `Librarian endpoint must be http(s), got ${url.protocol.replace(/:$/, "") || "(none)"}`,
+    );
+  }
+  // Reject HTTP basic-auth userinfo in the URL: the token is the auth mechanism,
+  // and an embedded password is a second secret that would otherwise leak into
+  // the network error message below (same leak class as the bearer token).
+  if (url.username || url.password) {
+    throw new McpClientError(
+      "config",
+      "Librarian endpoint must not embed credentials; authenticate with the token instead",
     );
   }
   const endpoint = config.endpoint;
+  // A credential-free, query-free rendering used in error messages so nothing
+  // secret-bearing in the endpoint can leak into logs.
+  const safeEndpoint = `${url.protocol}//${url.host}${url.pathname}`;
   const token = config.token;
   const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const maxResponseBytes = config.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES;
@@ -104,7 +121,10 @@ export function createMcpClient(config: McpClientConfig, transport?: McpTranspor
         }
         // Don't interpolate the underlying error (it may echo the request) —
         // keep the token-bearing call strictly out of anything we render.
-        throw new McpClientError("network", `${name} could not reach the Librarian at ${endpoint}`);
+        throw new McpClientError(
+          "network",
+          `${name} could not reach the Librarian at ${safeEndpoint}`,
+        );
       }
 
       if (response.status !== 200) {
@@ -120,7 +140,9 @@ export function createMcpClient(config: McpClientConfig, transport?: McpTranspor
         throw new McpClientError("malformed", `${name} returned non-JSON`);
       }
 
-      if (isRecord(payload) && "error" in payload) {
+      // `!= null` (not `"error" in payload`) so a spec-tolerant `error: null`
+      // alongside a result is treated as success, not a phantom rpc failure.
+      if (isRecord(payload) && payload.error != null) {
         const rpc = payload.error;
         const code = isRecord(rpc) ? rpc.code : undefined;
         // Truncate the server-controlled message so it can't bloat logs.
@@ -135,14 +157,6 @@ export function createMcpClient(config: McpClientConfig, transport?: McpTranspor
       return text;
     },
   };
-}
-
-function safeScheme(endpoint: string): string | null {
-  try {
-    return new URL(endpoint).protocol.replace(/:$/, "");
-  } catch {
-    return null;
-  }
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -191,7 +205,15 @@ function defaultTransport(maxResponseBytes: number): McpTransport {
 
 async function readCapped(response: Response, cap: number): Promise<string> {
   const reader = response.body?.getReader();
-  if (!reader) return (await response.text()).slice(0, cap);
+  if (!reader) {
+    // No readable stream (e.g. an empty body). arrayBuffer buffers fully, but
+    // we still enforce the BYTE cap before decoding so the protection holds.
+    const buffer = Buffer.from(await response.arrayBuffer());
+    if (buffer.byteLength > cap) {
+      throw new McpClientError("malformed", "Librarian response exceeded the size cap");
+    }
+    return buffer.toString("utf8");
+  }
   const chunks: Uint8Array[] = [];
   let total = 0;
   for (;;) {
@@ -262,9 +284,22 @@ export function parseSessionListFromProse(text: string): ParsedSession[] {
     const head = line.match(/^\d+\.\s*\[([^\]]+)\]\s*(.*)$/);
     if (head) {
       status = head[1]!.trim();
+      // The headline tail is `title — project — harness — last: <ts>`. project,
+      // harness, and last never contain the " — " separator, but a TITLE can, so
+      // parse from the RIGHT: the last three segments are fixed, the rest is the
+      // title. (title/project are best-effort; only id+status are load-bearing.)
       const segments = (head[2] ?? "").split(" — ");
-      title = segments[0]?.trim() || null;
-      project = projectOrNull(segments[1]?.trim() ?? null);
+      if (segments.length >= 4) {
+        project = projectOrNull(segments[segments.length - 3]!.trim());
+        title =
+          segments
+            .slice(0, segments.length - 3)
+            .join(" — ")
+            .trim() || null;
+      } else {
+        title = segments[0]?.trim() || null;
+        project = projectOrNull(segments[1]?.trim() ?? null);
+      }
       continue;
     }
     const idLine = line.match(/^\s*id:\s*(\S+)/);

--- a/integrations/shared/librarian-lifecycle/tests/mcp-client.test.ts
+++ b/integrations/shared/librarian-lifecycle/tests/mcp-client.test.ts
@@ -1,0 +1,302 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import {
+  formatSessionLifecycle,
+  formatSessionList,
+  formatSessionStart,
+} from "@librarian/mcp-server/formatters";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  type McpTransport,
+  McpClientError,
+  createMcpClient,
+  parseSessionFromProse,
+  parseSessionListFromProse,
+} from "../src/mcp-client.js";
+
+const ENDPOINT = "https://librarian.example/mcp";
+const TOKEN = "tok_super_secret_value";
+
+function rpcResult(text: string): string {
+  return JSON.stringify({ jsonrpc: "2.0", id: 1, result: { content: [{ type: "text", text }] } });
+}
+
+function transportReturning(
+  status: number,
+  body: string,
+): { transport: McpTransport; reqs: Parameters<McpTransport>[0][] } {
+  const reqs: Parameters<McpTransport>[0][] = [];
+  const transport: McpTransport = async (req) => {
+    reqs.push(req);
+    return { status, body };
+  };
+  return { transport, reqs };
+}
+
+// A bare Session shape — the formatters only read these fields, so a cast keeps
+// the test independent of @librarian/core's full Session type.
+function session(overrides: Record<string, unknown> = {}): never {
+  return {
+    id: "ses_round_trip",
+    status: "active",
+    title: "Round trip",
+    visibility: "common",
+    project_key: "the-librarian",
+    current_harness: "claude-code",
+    start_summary: "do the work",
+    last_activity_at: "2026-05-24T10:00:00.000Z",
+    next_steps: [],
+    tags: [],
+    ...overrides,
+  } as never;
+}
+
+describe("createMcpClient — request envelope", () => {
+  it("POSTs a tools/call envelope with a bearer token and returns the text content", async () => {
+    const { transport, reqs } = transportReturning(200, rpcResult("recalled"));
+    const client = createMcpClient({ endpoint: ENDPOINT, token: TOKEN }, transport);
+
+    const text = await client.callTool("recall", { query: "x" });
+
+    expect(text).toBe("recalled");
+    const req = reqs[0]!;
+    expect(req.url).toBe(ENDPOINT);
+    expect(req.headers.Authorization).toBe(`Bearer ${TOKEN}`);
+    expect(req.headers["Content-Type"]).toBe("application/json");
+    const parsed = JSON.parse(req.body);
+    expect(parsed.method).toBe("tools/call");
+    expect(parsed.jsonrpc).toBe("2.0");
+    expect(parsed.params).toEqual({ name: "recall", arguments: { query: "x" } });
+  });
+});
+
+describe("createMcpClient — error mapping", () => {
+  it("maps a non-200 status to a typed http error carrying the status", async () => {
+    const { transport } = transportReturning(503, "upstream down");
+    const client = createMcpClient({ endpoint: ENDPOINT, token: TOKEN }, transport);
+    await expect(client.callTool("recall", {})).rejects.toMatchObject({
+      name: "McpClientError",
+      kind: "http",
+      status: 503,
+    });
+  });
+
+  it("maps a JSON-RPC error payload to a typed rpc error with the (truncated) message", async () => {
+    const body = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      error: { code: -32000, message: "boom" },
+    });
+    const { transport } = transportReturning(200, body);
+    const client = createMcpClient({ endpoint: ENDPOINT, token: TOKEN }, transport);
+    const err = await client.callTool("recall", {}).catch((e) => e);
+    expect(err).toBeInstanceOf(McpClientError);
+    expect(err.kind).toBe("rpc");
+    expect(err.message).toContain("boom");
+  });
+
+  it("maps non-JSON to a malformed error", async () => {
+    const { transport } = transportReturning(200, "<html>not json</html>");
+    const client = createMcpClient({ endpoint: ENDPOINT, token: TOKEN }, transport);
+    await expect(client.callTool("recall", {})).rejects.toMatchObject({ kind: "malformed" });
+  });
+
+  it("maps a result with no text content to a malformed error", async () => {
+    const body = JSON.stringify({ jsonrpc: "2.0", id: 1, result: { content: [] } });
+    const { transport } = transportReturning(200, body);
+    const client = createMcpClient({ endpoint: ENDPOINT, token: TOKEN }, transport);
+    await expect(client.callTool("recall", {})).rejects.toMatchObject({ kind: "malformed" });
+  });
+
+  it("maps a transport TimeoutError to a typed timeout error", async () => {
+    const transport: McpTransport = async () => {
+      throw Object.assign(new Error("aborted"), { name: "TimeoutError" });
+    };
+    const client = createMcpClient({ endpoint: ENDPOINT, token: TOKEN }, transport);
+    await expect(client.callTool("recall", {})).rejects.toMatchObject({ kind: "timeout" });
+  });
+
+  it("maps an arbitrary transport failure to a typed network error", async () => {
+    const transport: McpTransport = async () => {
+      throw new Error("ECONNREFUSED 127.0.0.1:3838");
+    };
+    const client = createMcpClient({ endpoint: ENDPOINT, token: TOKEN }, transport);
+    await expect(client.callTool("recall", {})).rejects.toMatchObject({ kind: "network" });
+  });
+
+  it("never leaks the token in any error message", async () => {
+    const cases: McpTransport[] = [
+      async () => ({ status: 500, body: TOKEN }), // even if the server echoes it
+      async () => ({ status: 200, body: "not json" }),
+      async () => {
+        throw new Error(`failed talking to host with ${TOKEN}`);
+      },
+    ];
+    for (const transport of cases) {
+      const client = createMcpClient({ endpoint: ENDPOINT, token: TOKEN }, transport);
+      const err = await client.callTool("recall", {}).catch((e: Error) => e);
+      expect(err).toBeInstanceOf(McpClientError);
+      expect(err.message).not.toContain(TOKEN);
+    }
+  });
+});
+
+describe("createMcpClient — scheme allowlist", () => {
+  it("rejects a non-http(s) endpoint scheme at construction", () => {
+    expect(() => createMcpClient({ endpoint: "file:///etc/passwd", token: TOKEN })).toThrow(
+      McpClientError,
+    );
+    expect(() => createMcpClient({ endpoint: "ftp://host/x", token: TOKEN })).toThrow(
+      McpClientError,
+    );
+  });
+
+  it("accepts http and https endpoints", () => {
+    expect(() =>
+      createMcpClient({ endpoint: "http://127.0.0.1:3838/mcp", token: TOKEN }),
+    ).not.toThrow();
+    expect(() =>
+      createMcpClient({ endpoint: "https://lib.example/mcp", token: TOKEN }),
+    ).not.toThrow();
+  });
+});
+
+describe("parseSessionFromProse — round-trips the real formatters", () => {
+  it("parses a start-session block", () => {
+    const parsed = parseSessionFromProse(formatSessionStart(session()));
+    expect(parsed).toMatchObject({
+      id: "ses_round_trip",
+      status: "active",
+      title: "Round trip",
+      project_key: "the-librarian",
+    });
+  });
+
+  it("parses a lifecycle (checkpoint/pause/end) block", () => {
+    const text = formatSessionLifecycle(session({ status: "paused" }), "Session paused.");
+    expect(parseSessionFromProse(text)).toMatchObject({ id: "ses_round_trip", status: "paused" });
+  });
+
+  it("treats a (none) project as null", () => {
+    const parsed = parseSessionFromProse(formatSessionStart(session({ project_key: null })));
+    expect(parsed?.project_key).toBeNull();
+  });
+
+  it("returns null for prose with no session id", () => {
+    expect(parseSessionFromProse("No session found for id ses_x.")).toBeNull();
+  });
+});
+
+describe("parseSessionListFromProse — round-trips the real formatter", () => {
+  it("parses every entry's id and status in order", () => {
+    const list = {
+      total: 2,
+      sessions: [
+        session({ id: "ses_a", status: "paused", title: "A", next_steps: ["next a"] }),
+        session({
+          id: "ses_b",
+          status: "active",
+          title: "B",
+          project_key: null,
+          current_harness: null,
+        }),
+      ],
+    } as never;
+    const parsed = parseSessionListFromProse(formatSessionList(list));
+    expect(parsed.map((s) => s.id)).toEqual(["ses_a", "ses_b"]);
+    expect(parsed.map((s) => s.status)).toEqual(["paused", "active"]);
+  });
+
+  it("returns [] for an empty list", () => {
+    const parsed = parseSessionListFromProse(
+      formatSessionList({ total: 0, sessions: [] } as never),
+    );
+    expect(parsed).toEqual([]);
+  });
+});
+
+// --- Default transport: real-server security behaviour (the bearer-leak class
+// of bug from the Hermes client review). These exercise the built-in fetch
+// transport rather than an injected one. ---
+
+describe("default transport — security", () => {
+  const servers: http.Server[] = [];
+
+  function listen(server: http.Server): Promise<number> {
+    servers.push(server);
+    return new Promise((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve((server.address() as AddressInfo).port));
+    });
+  }
+
+  afterEach(async () => {
+    await Promise.all(
+      servers.splice(0).map((s) => new Promise<void>((resolve) => s.close(() => resolve()))),
+    );
+  });
+
+  it("sends the bearer token and returns the text on the happy path", async () => {
+    let authSeen: string | undefined;
+    const port = await listen(
+      http.createServer((req, res) => {
+        authSeen = req.headers.authorization;
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(rpcResult("live"));
+      }),
+    );
+    const client = createMcpClient({ endpoint: `http://127.0.0.1:${port}/mcp`, token: TOKEN });
+    await expect(client.callTool("recall", {})).resolves.toBe("live");
+    expect(authSeen).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it("refuses to follow a 3xx redirect (no cross-origin token leak)", async () => {
+    const targetHits: (string | undefined)[] = [];
+    const targetPort = await listen(
+      http.createServer((req, res) => {
+        targetHits.push(req.headers.authorization);
+        res.end(rpcResult("leaked"));
+      }),
+    );
+    const redirectorPort = await listen(
+      http.createServer((_req, res) => {
+        res.writeHead(302, { Location: `http://127.0.0.1:${targetPort}/mcp` });
+        res.end();
+      }),
+    );
+    const client = createMcpClient({
+      endpoint: `http://127.0.0.1:${redirectorPort}/mcp`,
+      token: TOKEN,
+    });
+    await expect(client.callTool("recall", {})).rejects.toBeInstanceOf(McpClientError);
+    expect(targetHits).toEqual([]); // the redirect target was never contacted
+  });
+
+  it("caps the response body so a runaway endpoint cannot exhaust memory", async () => {
+    const port = await listen(
+      http.createServer((_req, res) => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end("x".repeat(2048));
+      }),
+    );
+    const client = createMcpClient({
+      endpoint: `http://127.0.0.1:${port}/mcp`,
+      token: TOKEN,
+      maxResponseBytes: 256,
+    });
+    await expect(client.callTool("recall", {})).rejects.toBeInstanceOf(McpClientError);
+  });
+
+  it("times out a slow endpoint", async () => {
+    const port = await listen(
+      http.createServer(() => {
+        /* never responds */
+      }),
+    );
+    const client = createMcpClient({
+      endpoint: `http://127.0.0.1:${port}/mcp`,
+      token: TOKEN,
+      timeoutMs: 120,
+    });
+    await expect(client.callTool("recall", {})).rejects.toMatchObject({ kind: "timeout" });
+  });
+});

--- a/integrations/shared/librarian-lifecycle/tests/mcp-client.test.ts
+++ b/integrations/shared/librarian-lifecycle/tests/mcp-client.test.ts
@@ -124,6 +124,18 @@ describe("createMcpClient — error mapping", () => {
     await expect(client.callTool("recall", {})).rejects.toMatchObject({ kind: "network" });
   });
 
+  it("treats a spec-tolerant `error: null` alongside a result as success", async () => {
+    const body = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      error: null,
+      result: { content: [{ type: "text", text: "ok" }] },
+    });
+    const { transport } = transportReturning(200, body);
+    const client = createMcpClient({ endpoint: ENDPOINT, token: TOKEN }, transport);
+    await expect(client.callTool("recall", {})).resolves.toBe("ok");
+  });
+
   it("never leaks the token in any error message", async () => {
     const cases: McpTransport[] = [
       async () => ({ status: 500, body: TOKEN }), // even if the server echoes it
@@ -158,6 +170,20 @@ describe("createMcpClient — scheme allowlist", () => {
     expect(() =>
       createMcpClient({ endpoint: "https://lib.example/mcp", token: TOKEN }),
     ).not.toThrow();
+  });
+
+  it("rejects an endpoint that embeds basic-auth credentials (a second secret)", () => {
+    const err = (() => {
+      try {
+        createMcpClient({ endpoint: "https://user:s3cr3t@lib.example/mcp", token: TOKEN });
+        return null;
+      } catch (e) {
+        return e as McpClientError;
+      }
+    })();
+    expect(err).toBeInstanceOf(McpClientError);
+    expect(err?.kind).toBe("config");
+    expect(err?.message).not.toContain("s3cr3t");
   });
 });
 
@@ -205,6 +231,21 @@ describe("parseSessionListFromProse — round-trips the real formatter", () => {
     const parsed = parseSessionListFromProse(formatSessionList(list));
     expect(parsed.map((s) => s.id)).toEqual(["ses_a", "ses_b"]);
     expect(parsed.map((s) => s.status)).toEqual(["paused", "active"]);
+  });
+
+  it("preserves a title that itself contains the ' — ' separator", () => {
+    const list = {
+      total: 1,
+      sessions: [session({ id: "ses_dash", status: "active", title: "Fix bug — urgent" })],
+    } as never;
+    const parsed = parseSessionListFromProse(formatSessionList(list));
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]).toMatchObject({
+      id: "ses_dash",
+      status: "active",
+      title: "Fix bug — urgent",
+      project_key: "the-librarian",
+    });
   });
 
   it("returns [] for an empty list", () => {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -10,6 +10,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./formatters": {
+      "types": "./dist/mcp/formatters.d.ts",
+      "import": "./dist/mcp/formatters.js"
     }
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
 
   integrations/shared/librarian-lifecycle:
     devDependencies:
+      '@librarian/mcp-server':
+        specifier: workspace:*
+        version: link:../../../packages/mcp-server
       '@types/node':
         specifier: ^22.10.5
         version: 22.19.19


### PR DESCRIPTION
## What & why

First piece of the **remote lifecycle transport**: a stateless JSON-RPC client for the Librarian `/mcp` HTTP endpoint, so the harness lifecycle hooks can drive a **remote** Librarian (today they only know the local `the-librarian` CLI). This unblocks a marketplace-distributable Claude Code plugin that records sessions + enforces the off-record gate against the *same* remote Librarian the agent's MCP tools use.

The lifecycle is deliberately synchronous (cross-process lockfile + `Atomics.wait`, with the session-resolving call inside the locked section), so rather than an async rewrite we keep that shape and bridge to async HTTP over a subprocess in later PRs. This PR adds the network client that subprocess will use.

## What's here

- `mcp-client.ts` — `createMcpClient({ endpoint, token })` → `callTool(name, args)`. Stateless `tools/call` POST, typed `McpClientError(kind)` for fail-soft callers.
- Prose parsers (`parseSessionFromProse`, `parseSessionListFromProse`) — the MCP session tools return human-readable prose, so these extract the `id`/`status` the lifecycle needs. **Pinned to the real `@librarian/mcp-server` formatters by round-trip tests** (new `./formatters` subpath export keeps that import free of the store / `node:sqlite` runtime).

## Security posture (mirrors the security-reviewed Hermes `client.py`)

- bearer token only ever in the `Authorization` header — never in an error message; endpoints embedding basic-auth userinfo are rejected at construction
- `redirect: "error"` so a 3xx can't carry the token cross-origin (the CRITICAL bug class from the Hermes review)
- http(s) scheme allowlist (no `file:`/`data:` SSRF / local read)
- capped response read (streaming + no-stream paths) so a runaway endpoint can't exhaust memory
- `AbortController` timeout

Real-server tests (node:http) exercise redirect-refusal, the size cap, and timeout; injected-transport tests cover the envelope + every error-kind mapping + token non-leak.

## Status

Unused until the remote `LibrarianCli` + adapter wiring lands (next PRs). A code-review sub-agent reviewed this; its Critical (endpoint-credential leak) + Important (list-parser em-dash, capped-read fallback) findings are fixed in the second commit.

107 lifecycle tests green; typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)