### PR TITLE
feat(lifecycle): synchronous remote LibrarianCli transport (mcp-call bin)

### DIFF
--- a/integrations/shared/librarian-lifecycle/package.json
+++ b/integrations/shared/librarian-lifecycle/package.json
@@ -8,7 +8,8 @@
   "types": "./dist/index.d.ts",
   "bin": {
     "librarian-claude-hook": "./dist/bin/claude-code-hook.js",
-    "librarian-codex-hook": "./dist/bin/codex-hook.js"
+    "librarian-codex-hook": "./dist/bin/codex-hook.js",
+    "librarian-mcp-call": "./dist/bin/mcp-call.js"
   },
   "exports": {
     ".": {

--- a/integrations/shared/librarian-lifecycle/src/bin/mcp-call.ts
+++ b/integrations/shared/librarian-lifecycle/src/bin/mcp-call.ts
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+// The `mcp-call` helper bin — the sync↔async bridge for the remote transport.
+//
+// `remote-cli.ts` spawns this per verb (`spawnSync`), so the synchronous
+// lifecycle can drive an async HTTP MCP client. It reads the endpoint + token
+// from the environment, the verb from argv, and the verb's arguments as JSON on
+// stdin; it performs ONE `tools/call`, parses the (prose) response into the
+// CliSession-shaped JSON the remote CLI expects, prints it to stdout, and exits
+// 0. Any failure prints to stderr and exits non-zero so the remote CLI raises a
+// LibrarianCliError and the lifecycle fails soft.
+
+import {
+  type McpClient,
+  createMcpClient,
+  parseSessionFromProse,
+  parseSessionListFromProse,
+} from "../mcp-client.js";
+
+function fail(message: string): never {
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function firstLine(text: string): string {
+  return text.split("\n", 1)[0] ?? text;
+}
+
+function ensureFound(text: string, verb: string): void {
+  if (/^No session found/.test(text.trim())) fail(`${verb}: ${firstLine(text)}`);
+}
+
+// Drop undefined values so optional args aren't sent as JSON nulls.
+function compact(obj: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (value !== undefined) out[key] = value;
+  }
+  return out;
+}
+
+async function dispatch(
+  client: McpClient,
+  verb: string,
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  switch (verb) {
+    case "start": {
+      const text = await client.callTool(
+        "start_session",
+        compact({
+          harness: args.harness,
+          source_ref: args.sourceRef,
+          cwd: args.cwd,
+          project_key: args.projectKey,
+          start_summary: args.summary,
+          title: args.title,
+        }),
+      );
+      const session = parseSessionFromProse(text);
+      if (!session) fail(`start: ${firstLine(text)}`);
+      return { session };
+    }
+    case "list": {
+      const text = await client.callTool(
+        "list_sessions",
+        compact({
+          harness: args.harness,
+          source_ref: args.sourceRef,
+          cwd: args.cwd,
+          project_key: args.projectKey,
+          status: args.statuses,
+        }),
+      );
+      return { sessions: parseSessionListFromProse(text) };
+    }
+    case "continue": {
+      const text = await client.callTool(
+        "continue_session",
+        compact({
+          session_id: args.sessionId,
+          target_harness: args.harness,
+          target_cwd: args.cwd,
+          target_source_ref: args.sourceRef,
+          attach: true,
+        }),
+      );
+      ensureFound(text, "continue");
+      // continue_session returns a handover package, not a session block; the id
+      // is the one we passed in (the lifecycle only reads .id from the result).
+      return {
+        session: {
+          id: String(args.sessionId),
+          status: "active",
+          title: null,
+          project_key: null,
+          source_ref: null,
+          cwd: null,
+        },
+      };
+    }
+    case "checkpoint": {
+      const text = await client.callTool("checkpoint_session", {
+        session_id: args.sessionId,
+        summary: args.summary,
+      });
+      ensureFound(text, "checkpoint");
+      return { ok: true };
+    }
+    case "pause": {
+      const text = await client.callTool("pause_session", {
+        session_id: args.sessionId,
+        summary: args.summary,
+      });
+      ensureFound(text, "pause");
+      return { ok: true };
+    }
+    case "end": {
+      const text = await client.callTool(
+        "end_session",
+        compact({ session_id: args.sessionId, summary: args.reason }),
+      );
+      ensureFound(text, "end");
+      return { ok: true };
+    }
+    default:
+      fail(`unknown verb: ${verb}`);
+  }
+}
+
+async function main(): Promise<void> {
+  const verb = process.argv[2];
+  if (!verb) fail("usage: mcp-call <verb> (args on stdin)");
+
+  const endpoint = process.env.LIBRARIAN_MCP_URL;
+  const token = process.env.LIBRARIAN_AGENT_TOKEN;
+  if (!endpoint || !token) {
+    fail("LIBRARIAN_MCP_URL and LIBRARIAN_AGENT_TOKEN must be set");
+  }
+  const timeoutEnv = Number(process.env.LIBRARIAN_TIMEOUT_MS);
+
+  let args: Record<string, unknown> = {};
+  try {
+    const raw = (await readStdin()).trim();
+    if (raw) args = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    fail("invalid JSON on stdin");
+  }
+
+  let client: McpClient;
+  try {
+    client = createMcpClient({
+      endpoint,
+      token,
+      ...(Number.isFinite(timeoutEnv) && timeoutEnv > 0 ? { timeoutMs: timeoutEnv } : {}),
+    });
+  } catch (err) {
+    fail((err as Error).message);
+  }
+
+  try {
+    const out = await dispatch(client, verb, args);
+    process.stdout.write(JSON.stringify(out));
+    process.exit(0);
+  } catch (err) {
+    // McpClientError (and anything else) → stderr + non-zero. The token is never
+    // in McpClientError messages (the client guarantees that).
+    fail((err as Error).message);
+  }
+}
+
+void main();

--- a/integrations/shared/librarian-lifecycle/src/bin/mcp-call.ts
+++ b/integrations/shared/librarian-lifecycle/src/bin/mcp-call.ts
@@ -91,8 +91,11 @@ async function dispatch(
         }),
       );
       ensureFound(text, "continue");
-      // continue_session returns a handover package, not a session block; the id
-      // is the one we passed in (the lifecycle only reads .id from the result).
+      // continue_session returns a handover package, not a session block. Only
+      // the id is real (the one we passed in); the lifecycle reads ONLY .id from
+      // a continued session. Every other field here is a placeholder — in
+      // particular `status` is NOT authoritative (the server may resume an ended
+      // session to `paused`), so do not read it.
       return {
         session: {
           id: String(args.sessionId),
@@ -105,18 +108,18 @@ async function dispatch(
       };
     }
     case "checkpoint": {
-      const text = await client.callTool("checkpoint_session", {
-        session_id: args.sessionId,
-        summary: args.summary,
-      });
+      const text = await client.callTool(
+        "checkpoint_session",
+        compact({ session_id: args.sessionId, summary: args.summary }),
+      );
       ensureFound(text, "checkpoint");
       return { ok: true };
     }
     case "pause": {
-      const text = await client.callTool("pause_session", {
-        session_id: args.sessionId,
-        summary: args.summary,
-      });
+      const text = await client.callTool(
+        "pause_session",
+        compact({ session_id: args.sessionId, summary: args.summary }),
+      );
       ensureFound(text, "pause");
       return { ok: true };
     }
@@ -144,9 +147,14 @@ async function main(): Promise<void> {
   }
   const timeoutEnv = Number(process.env.LIBRARIAN_TIMEOUT_MS);
 
+  let raw: string;
+  try {
+    raw = (await readStdin()).trim();
+  } catch {
+    fail("could not read stdin");
+  }
   let args: Record<string, unknown> = {};
   try {
-    const raw = (await readStdin()).trim();
     if (raw) args = JSON.parse(raw) as Record<string, unknown>;
   } catch {
     fail("invalid JSON on stdin");
@@ -174,4 +182,4 @@ async function main(): Promise<void> {
   }
 }
 
-void main();
+void main().catch((err) => fail((err as Error).message));

--- a/integrations/shared/librarian-lifecycle/src/cli.ts
+++ b/integrations/shared/librarian-lifecycle/src/cli.ts
@@ -141,7 +141,7 @@ function asString(value: unknown): string | null {
   return typeof value === "string" ? value : null;
 }
 
-function toCliSession(raw: unknown, context: string): CliSession {
+export function toCliSession(raw: unknown, context: string): CliSession {
   if (typeof raw !== "object" || raw === null) {
     throw new LibrarianCliError("parse", `${context}: response had no session`);
   }

--- a/integrations/shared/librarian-lifecycle/src/index.ts
+++ b/integrations/shared/librarian-lifecycle/src/index.ts
@@ -10,5 +10,6 @@ export * from "./harness/claude-code.js";
 export * from "./harness/codex.js";
 export * from "./mcp-client.js";
 export * from "./privacy.js";
+export * from "./remote-cli.js";
 export * from "./session.js";
 export * from "./state.js";

--- a/integrations/shared/librarian-lifecycle/src/remote-cli.ts
+++ b/integrations/shared/librarian-lifecycle/src/remote-cli.ts
@@ -1,0 +1,187 @@
+// Remote LibrarianCli transport (spec §8, remote deployment).
+//
+// A drop-in `LibrarianCli` that talks to a REMOTE Librarian over HTTP instead of
+// the local `the-librarian` CLI. The lifecycle is deliberately synchronous (the
+// state lock is a cross-process lockfile held across the session-resolving call),
+// so this keeps the synchronous `LibrarianCli` shape and bridges to the async
+// HTTP client over a subprocess — exactly as the local CLI transport bridges to
+// the local store via `spawnSync`. Each verb spawns the `mcp-call` helper bin,
+// which performs ONE MCP `tools/call` and prints CliSession-shaped JSON.
+//
+// Failures surface as `LibrarianCliError` (the same type the local CLI throws)
+// so the orchestration's fail-soft `guard()` treats both transports identically.
+
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import {
+  type CliRunResult,
+  type CliSession,
+  type LibrarianCli,
+  type SessionStatus,
+  LibrarianCliError,
+  toCliSession,
+} from "./cli.js";
+import type { Harness } from "./state.js";
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const MAX_BUFFER = 10 * 1024 * 1024;
+
+/** Run the helper for `verb` with a JSON `input` payload on stdin. */
+export type RemoteRunner = (verb: string, input: string) => CliRunResult;
+
+export interface RemoteLibrarianCliConfig {
+  /** Attach-target harness for `continueSession` (the interface passes only an id). */
+  harness?: Harness;
+  /** Attach-target cwd for `continueSession`. */
+  cwd?: string;
+  /** Attach-target source_ref for `continueSession`. */
+  sourceRef?: string;
+  /**
+   * Path to the bundled `mcp-call` helper. Defaults to `$LIBRARIAN_MCP_CALL_BIN`
+   * (set by the plugin to its bundled artifact), else this package's own dist bin.
+   */
+  mcpCallBin?: string;
+  /** Node executable used to run the helper (default `process.execPath`). */
+  nodeBin?: string;
+  timeoutMs?: number;
+  /** Environment for the spawned helper (defaults to process.env). */
+  env?: NodeJS.ProcessEnv;
+  /** Working directory for the spawned helper. */
+  spawnCwd?: string;
+}
+
+export interface RemoteLibrarianCliDeps {
+  run?: RemoteRunner;
+}
+
+function resolveHelperBin(config: RemoteLibrarianCliConfig): string {
+  return (
+    config.mcpCallBin ??
+    process.env.LIBRARIAN_MCP_CALL_BIN ??
+    fileURLToPath(new URL("./bin/mcp-call.js", import.meta.url))
+  );
+}
+
+function defaultRunner(config: RemoteLibrarianCliConfig): RemoteRunner {
+  const nodeBin = config.nodeBin ?? process.execPath;
+  const helperBin = resolveHelperBin(config);
+  return (verb, input) => {
+    const res = spawnSync(nodeBin, [helperBin, verb], {
+      input,
+      encoding: "utf8",
+      timeout: config.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      // The helper reads LIBRARIAN_MCP_URL / LIBRARIAN_AGENT_TOKEN from this env.
+      // No failure path surfaces env contents — LibrarianCliError carries only
+      // stderr/exitCode/verb.
+      env: config.env ?? process.env,
+      cwd: config.spawnCwd,
+      maxBuffer: MAX_BUFFER,
+    });
+    const result: CliRunResult = {
+      stdout: res.stdout ?? "",
+      stderr: res.stderr ?? "",
+      status: res.status,
+    };
+    if (res.error) result.error = res.error;
+    return result;
+  };
+}
+
+// Drop keys whose value is undefined so optional flags aren't sent as JSON nulls.
+function compact(obj: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (value !== undefined) out[key] = value;
+  }
+  return out;
+}
+
+export function createRemoteLibrarianCli(
+  config: RemoteLibrarianCliConfig = {},
+  deps: RemoteLibrarianCliDeps = {},
+): LibrarianCli {
+  const run = deps.run ?? defaultRunner(config);
+
+  // Run a helper verb and parse its JSON, mapping every failure mode onto a
+  // typed LibrarianCliError — identical contract to cli.ts's runJson so the
+  // orchestration's guard() handles local and remote transports the same way.
+  function runJson(verb: string, args: Record<string, unknown>): unknown {
+    const res = run(verb, JSON.stringify(compact(args)));
+    if (res.error) {
+      const code = (res.error as NodeJS.ErrnoException).code;
+      const kind = code === "ETIMEDOUT" ? "timeout" : "spawn";
+      const what = kind === "timeout" ? "timed out" : `failed to spawn: ${res.error.message}`;
+      throw new LibrarianCliError(kind, `librarian-mcp-call ${verb} ${what}`, {
+        stderr: res.stderr,
+      });
+    }
+    if (res.status === null) {
+      throw new LibrarianCliError("timeout", `librarian-mcp-call ${verb} was killed (signal)`, {
+        stderr: res.stderr,
+      });
+    }
+    if (res.status !== 0) {
+      throw new LibrarianCliError("exit", `librarian-mcp-call ${verb} exited ${res.status}`, {
+        exitCode: res.status,
+        stderr: res.stderr,
+      });
+    }
+    try {
+      return JSON.parse(res.stdout);
+    } catch (err) {
+      throw new LibrarianCliError(
+        "parse",
+        `librarian-mcp-call ${verb} returned invalid JSON: ${(err as Error).message}`,
+      );
+    }
+  }
+
+  return {
+    startSession(args) {
+      const parsed = runJson("start", {
+        harness: args.harness,
+        sourceRef: args.sourceRef,
+        cwd: args.cwd,
+        projectKey: args.projectKey,
+        summary: args.summary,
+        title: args.title,
+      }) as { session?: unknown };
+      return toCliSession(parsed.session, "start");
+    },
+
+    listSessions(args) {
+      const statuses: SessionStatus[] = args.statuses ?? ["active", "paused"];
+      const parsed = runJson("list", {
+        harness: args.harness,
+        sourceRef: args.sourceRef,
+        cwd: args.cwd,
+        projectKey: args.projectKey,
+        statuses,
+      }) as { sessions?: unknown };
+      const sessions = Array.isArray(parsed.sessions) ? parsed.sessions : [];
+      return sessions.map((s) => toCliSession(s, "list"));
+    },
+
+    continueSession(sessionId): CliSession {
+      const parsed = runJson("continue", {
+        sessionId,
+        harness: config.harness,
+        cwd: config.cwd,
+        sourceRef: config.sourceRef,
+      }) as { session?: unknown };
+      return toCliSession(parsed.session, "continue");
+    },
+
+    checkpointSession(sessionId, summary) {
+      runJson("checkpoint", { sessionId, summary });
+    },
+
+    pauseSession(sessionId, summary) {
+      runJson("pause", { sessionId, summary });
+    },
+
+    endSession(sessionId, reason) {
+      runJson("end", { sessionId, reason });
+    },
+  };
+}

--- a/integrations/shared/librarian-lifecycle/src/remote-cli.ts
+++ b/integrations/shared/librarian-lifecycle/src/remote-cli.ts
@@ -25,6 +25,10 @@ import type { Harness } from "./state.js";
 
 const DEFAULT_TIMEOUT_MS = 15_000;
 const MAX_BUFFER = 10 * 1024 * 1024;
+// Give the child's own fetch timeout this much head start over the spawn timeout,
+// so the child times out FIRST with a clean McpClientError("timeout") message
+// rather than being SIGKILLed mid-fetch ("was killed (signal)").
+const SPAWN_GRACE_MS = 2_000;
 
 /** Run the helper for `verb` with a JSON `input` payload on stdin. */
 export type RemoteRunner = (verb: string, input: string) => CliRunResult;
@@ -65,15 +69,22 @@ function resolveHelperBin(config: RemoteLibrarianCliConfig): string {
 function defaultRunner(config: RemoteLibrarianCliConfig): RemoteRunner {
   const nodeBin = config.nodeBin ?? process.execPath;
   const helperBin = resolveHelperBin(config);
+  const childTimeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  // Propagate the budget to the child's fetch (unless the caller pinned it) so the
+  // two timeouts are coordinated rather than racing at independent defaults.
+  const baseEnv = config.env ?? process.env;
+  const env = baseEnv.LIBRARIAN_TIMEOUT_MS
+    ? baseEnv
+    : { ...baseEnv, LIBRARIAN_TIMEOUT_MS: String(childTimeoutMs) };
   return (verb, input) => {
     const res = spawnSync(nodeBin, [helperBin, verb], {
       input,
       encoding: "utf8",
-      timeout: config.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      timeout: childTimeoutMs + SPAWN_GRACE_MS,
       // The helper reads LIBRARIAN_MCP_URL / LIBRARIAN_AGENT_TOKEN from this env.
       // No failure path surfaces env contents — LibrarianCliError carries only
       // stderr/exitCode/verb.
-      env: config.env ?? process.env,
+      env,
       cwd: config.spawnCwd,
       maxBuffer: MAX_BUFFER,
     });

--- a/integrations/shared/librarian-lifecycle/tests/mcp-call-bin.test.ts
+++ b/integrations/shared/librarian-lifecycle/tests/mcp-call-bin.test.ts
@@ -1,0 +1,178 @@
+import { spawn } from "node:child_process";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  formatSessionLifecycle,
+  formatSessionList,
+  formatSessionStart,
+} from "@librarian/mcp-server/formatters";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+// Exercises the BUILT helper bin end-to-end against a fake Librarian /mcp that
+// returns the REAL formatter prose, so the verb→tool mapping, prose parsing, and
+// stdout/exit-code contract are all covered. The package `test` script builds
+// before vitest runs.
+const binPath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "dist",
+  "bin",
+  "mcp-call.js",
+);
+
+const TOKEN = "tok_bin_test";
+
+function session(overrides: Record<string, unknown> = {}): never {
+  return {
+    id: "ses_bin",
+    status: "active",
+    title: "Bin test",
+    visibility: "common",
+    project_key: "the-librarian",
+    current_harness: "claude-code",
+    start_summary: "go",
+    last_activity_at: "2026-05-24T10:00:00.000Z",
+    next_steps: [],
+    tags: [],
+    ...overrides,
+  } as never;
+}
+
+function rpc(text: string): string {
+  return JSON.stringify({ jsonrpc: "2.0", id: 1, result: { content: [{ type: "text", text }] } });
+}
+
+let server: http.Server;
+let url: string;
+let lastAuth: string | undefined;
+
+beforeAll(async () => {
+  server = http.createServer((req, res) => {
+    lastAuth = req.headers.authorization;
+    const chunks: Buffer[] = [];
+    req.on("data", (c) => chunks.push(c as Buffer));
+    req.on("end", () => {
+      const payload = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+      const name = payload.params?.name as string;
+      const args = (payload.params?.arguments ?? {}) as Record<string, unknown>;
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(rpc(responseFor(name, args)));
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+  url = `http://127.0.0.1:${(server.address() as AddressInfo).port}/mcp`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+function responseFor(name: string, args: Record<string, unknown>): string {
+  switch (name) {
+    case "start_session":
+      return formatSessionStart(session({ id: "ses_started", title: args.title ?? "Bin test" }));
+    case "list_sessions":
+      return formatSessionList({
+        total: 2,
+        sessions: [session({ id: "ses_one" }), session({ id: "ses_two", status: "paused" })],
+      } as never);
+    case "continue_session":
+      return args.session_id === "ses_missing"
+        ? "No session found for id ses_missing."
+        : `Handover for ${String(args.session_id)} — pick up where you left off.`;
+    case "checkpoint_session":
+      return formatSessionLifecycle(session(), "Checkpoint recorded.");
+    case "pause_session":
+      return formatSessionLifecycle(session({ status: "paused" }), "Session paused.");
+    case "end_session":
+      return formatSessionLifecycle(session({ status: "ended" }), "Session ended.");
+    default:
+      return `Unknown tool ${name}`;
+  }
+}
+
+interface BinResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+// Invoke the built bin with ASYNC spawn (not spawnSync): the fake server runs in
+// THIS process, so a synchronous spawn would block the event loop and deadlock
+// the server it's waiting on. In production the server is remote, so the remote
+// CLI's spawnSync is fine — and is unit-tested separately with an injected runner.
+function runBin(
+  verb: string,
+  args: Record<string, unknown>,
+  env: Record<string, string> = {},
+): Promise<BinResult> {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [binPath, verb], {
+      env: { ...process.env, LIBRARIAN_MCP_URL: url, LIBRARIAN_AGENT_TOKEN: TOKEN, ...env },
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => (stdout += d));
+    child.stderr.on("data", (d) => (stderr += d));
+    child.on("close", (status) => resolve({ status, stdout, stderr }));
+    child.stdin.write(JSON.stringify(args));
+    child.stdin.end();
+  });
+}
+
+describe("mcp-call bin", () => {
+  it("start: returns the parsed session and sends the bearer token", async () => {
+    const r = await runBin("start", { harness: "claude-code", cwd: "/x", summary: "go" });
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout).session).toMatchObject({ id: "ses_started", status: "active" });
+    expect(lastAuth).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it("list: returns every session id+status", async () => {
+    const r = await runBin("list", { harness: "claude-code" });
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout);
+    expect(out.sessions.map((s: { id: string }) => s.id)).toEqual(["ses_one", "ses_two"]);
+    expect(out.sessions.map((s: { status: string }) => s.status)).toEqual(["active", "paused"]);
+  });
+
+  it("continue: synthesizes the session from the passed id", async () => {
+    const r = await runBin("continue", {
+      sessionId: "ses_keep",
+      harness: "claude-code",
+      cwd: "/x",
+    });
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout).session).toMatchObject({ id: "ses_keep", status: "active" });
+  });
+
+  it("continue: fails when the server reports no such session", async () => {
+    const r = await runBin("continue", { sessionId: "ses_missing" });
+    expect(r.status).not.toBe(0);
+    expect(r.stdout).toBe("");
+  });
+
+  it("checkpoint: succeeds with ok", async () => {
+    const r = await runBin("checkpoint", { sessionId: "ses_bin", summary: "did work" });
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout)).toMatchObject({ ok: true });
+  });
+
+  it("end: succeeds with ok", async () => {
+    const r = await runBin("end", { sessionId: "ses_bin", reason: "switching to private mode" });
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout)).toMatchObject({ ok: true });
+  });
+
+  it("fails (exit 1) when the endpoint env is missing", async () => {
+    const r = await runBin("start", {}, { LIBRARIAN_MCP_URL: "", LIBRARIAN_AGENT_TOKEN: "" });
+    expect(r.status).not.toBe(0);
+  });
+
+  it("fails (exit 1) on an unknown verb", async () => {
+    const r = await runBin("frobnicate", {});
+    expect(r.status).not.toBe(0);
+  });
+});

--- a/integrations/shared/librarian-lifecycle/tests/remote-cli-integration.test.ts
+++ b/integrations/shared/librarian-lifecycle/tests/remote-cli-integration.test.ts
@@ -1,0 +1,120 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { LibrarianCliError } from "../src/cli.js";
+import { createRemoteLibrarianCli } from "../src/remote-cli.js";
+
+// Exercises the REAL default runner end-to-end: createRemoteLibrarianCli with NO
+// injected runner → real spawnSync of the built mcp-call bin → a fake /mcp.
+//
+// The fake server runs OUT OF PROCESS (a separate node), which is essential here:
+// the remote CLI uses spawnSync, which blocks this thread, so an in-process server
+// would deadlock. In production the Librarian is remote, so this is the real shape.
+const here = path.dirname(fileURLToPath(import.meta.url));
+const binPath = path.join(here, "..", "dist", "bin", "mcp-call.js");
+
+const SERVER_SOURCE = `
+import http from "node:http";
+const server = http.createServer((req, res) => {
+  let body = "";
+  req.on("data", (c) => (body += c));
+  req.on("end", () => {
+    let name = "";
+    try { name = JSON.parse(body).params?.name ?? ""; } catch {}
+    const text =
+      name === "start_session"
+        ? "Session started.\\nID: ses_int\\nStatus: active\\nTitle: T\\nProject: (none)"
+        : name === "list_sessions"
+        ? "Resumable sessions (1 of 1):\\n\\n1. [active] T — no project — claude-code — last: x\\n   id: ses_int\\n"
+        : "ok";
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ jsonrpc: "2.0", id: 1, result: { content: [{ type: "text", text }] } }));
+  });
+});
+server.listen(0, "127.0.0.1", () => process.stdout.write("PORT:" + server.address().port + "\\n"));
+`;
+
+let serverProc: ChildProcess;
+let serverFile: string;
+let url: string;
+
+beforeAll(async () => {
+  serverFile = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "lib-int-")), "server.mjs");
+  fs.writeFileSync(serverFile, SERVER_SOURCE);
+  serverProc = spawn(process.execPath, [serverFile], { stdio: ["ignore", "pipe", "inherit"] });
+  const port = await new Promise<string>((resolve, reject) => {
+    let buf = "";
+    serverProc.stdout!.on("data", (d) => {
+      buf += d;
+      const m = buf.match(/PORT:(\d+)/);
+      if (m) resolve(m[1]!);
+    });
+    serverProc.on("error", reject);
+    setTimeout(() => reject(new Error("server did not report a port")), 5000);
+  });
+  url = `http://127.0.0.1:${port}/mcp`;
+});
+
+afterAll(() => {
+  serverProc?.kill();
+  if (serverFile) fs.rmSync(path.dirname(serverFile), { recursive: true, force: true });
+});
+
+function realCli(overrides: Record<string, unknown> = {}) {
+  return createRemoteLibrarianCli({
+    mcpCallBin: binPath,
+    env: { ...process.env, LIBRARIAN_MCP_URL: url, LIBRARIAN_AGENT_TOKEN: "tok_int" },
+    ...overrides,
+  });
+}
+
+describe("createRemoteLibrarianCli — real spawnSync path", () => {
+  it("starts a session through the real bin + default runner", () => {
+    const session = realCli().startSession({ harness: "claude-code", cwd: "/x", summary: "go" });
+    expect(session.id).toBe("ses_int");
+    expect(session.status).toBe("active");
+  });
+
+  it("lists sessions through the real bin", () => {
+    const sessions = realCli().listSessions({ harness: "claude-code", cwd: "/x" });
+    expect(sessions.map((s) => s.id)).toEqual(["ses_int"]);
+  });
+
+  it("maps a missing node binary to a spawn error (fail-soft)", () => {
+    const cli = createRemoteLibrarianCli({
+      nodeBin: "definitely-not-a-real-node-xyz",
+      mcpCallBin: binPath,
+      env: { ...process.env, LIBRARIAN_MCP_URL: url, LIBRARIAN_AGENT_TOKEN: "tok_int" },
+    });
+    const err = (() => {
+      try {
+        cli.startSession({ harness: "pi" });
+        return null;
+      } catch (e) {
+        return e as LibrarianCliError;
+      }
+    })();
+    expect(err).toBeInstanceOf(LibrarianCliError);
+    expect(err?.kind).toBe("spawn");
+  });
+
+  it("maps a non-zero helper exit to an exit error (fail-soft)", () => {
+    const cli = createRemoteLibrarianCli({
+      mcpCallBin: path.join(here, "no-such-helper-xyz.js"),
+      env: { ...process.env, LIBRARIAN_MCP_URL: url, LIBRARIAN_AGENT_TOKEN: "tok_int" },
+    });
+    const err = (() => {
+      try {
+        cli.startSession({ harness: "pi" });
+        return null;
+      } catch (e) {
+        return e as LibrarianCliError;
+      }
+    })();
+    expect(err).toBeInstanceOf(LibrarianCliError);
+    expect(err?.kind).toBe("exit");
+  });
+});

--- a/integrations/shared/librarian-lifecycle/tests/remote-cli.test.ts
+++ b/integrations/shared/librarian-lifecycle/tests/remote-cli.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import { type CliRunResult, LibrarianCliError } from "../src/cli.js";
+import { type RemoteRunner, createRemoteLibrarianCli } from "../src/remote-cli.js";
+
+function ok(json: unknown): CliRunResult {
+  return { stdout: JSON.stringify(json), stderr: "", status: 0 };
+}
+
+const session = {
+  id: "ses_abc",
+  status: "active",
+  title: "Work",
+  project_key: "the-librarian",
+  source_ref: null,
+  cwd: "/home/jim/code/the-librarian",
+};
+
+function remoteWith(run: RemoteRunner, config = {}) {
+  const calls: { verb: string; args: Record<string, unknown> }[] = [];
+  const wrapped: RemoteRunner = (verb, input) => {
+    calls.push({ verb, args: JSON.parse(input) });
+    return run(verb, input);
+  };
+  const cli = createRemoteLibrarianCli(config, { run: wrapped });
+  return { cli, calls };
+}
+
+describe("createRemoteLibrarianCli — startSession", () => {
+  it("invokes the start verb with the mapped args and parses the session", () => {
+    const { cli, calls } = remoteWith(() => ok({ session }));
+    const result = cli.startSession({
+      harness: "claude-code",
+      cwd: "/home/jim/code/the-librarian",
+      projectKey: "the-librarian",
+      summary: "starting work",
+      title: "Work",
+    });
+    expect(result.id).toBe("ses_abc");
+    expect(calls[0]!.verb).toBe("start");
+    expect(calls[0]!.args).toMatchObject({
+      harness: "claude-code",
+      cwd: "/home/jim/code/the-librarian",
+      projectKey: "the-librarian",
+      summary: "starting work",
+      title: "Work",
+    });
+  });
+
+  it("throws a parse error when the helper returns no session", () => {
+    const { cli } = remoteWith(() => ok({ session: null }));
+    expect(() => cli.startSession({ harness: "pi" })).toThrow(LibrarianCliError);
+  });
+});
+
+describe("createRemoteLibrarianCli — listSessions", () => {
+  it("invokes the list verb with default statuses and maps the array", () => {
+    const { cli, calls } = remoteWith(() =>
+      ok({ sessions: [session, { ...session, id: "ses_two" }] }),
+    );
+    const result = cli.listSessions({ harness: "claude-code", cwd: "/x" });
+    expect(result.map((s) => s.id)).toEqual(["ses_abc", "ses_two"]);
+    expect(calls[0]!.verb).toBe("list");
+    expect(calls[0]!.args.statuses).toEqual(["active", "paused"]);
+  });
+
+  it("returns [] when the helper reports no sessions", () => {
+    const { cli } = remoteWith(() => ok({ sessions: [] }));
+    expect(cli.listSessions({ harness: "codex" })).toEqual([]);
+  });
+
+  it("passes through explicit statuses", () => {
+    const { cli, calls } = remoteWith(() => ok({ sessions: [] }));
+    cli.listSessions({ harness: "codex", statuses: ["active"] });
+    expect(calls[0]!.args.statuses).toEqual(["active"]);
+  });
+});
+
+describe("createRemoteLibrarianCli — continueSession", () => {
+  it("invokes the continue verb with the session id and config attach targets", () => {
+    const { cli, calls } = remoteWith(() => ok({ session }), {
+      harness: "claude-code",
+      cwd: "/home/jim/code/the-librarian",
+    });
+    const result = cli.continueSession("ses_abc");
+    expect(result.id).toBe("ses_abc");
+    expect(calls[0]!.verb).toBe("continue");
+    expect(calls[0]!.args).toMatchObject({
+      sessionId: "ses_abc",
+      harness: "claude-code",
+      cwd: "/home/jim/code/the-librarian",
+    });
+  });
+});
+
+describe("createRemoteLibrarianCli — checkpoint/pause/end", () => {
+  it("invokes checkpoint with the summary", () => {
+    const { cli, calls } = remoteWith(() => ok({ ok: true }));
+    cli.checkpointSession("ses_abc", "did things");
+    expect(calls[0]!).toMatchObject({
+      verb: "checkpoint",
+      args: { sessionId: "ses_abc", summary: "did things" },
+    });
+  });
+
+  it("invokes pause with the summary", () => {
+    const { cli, calls } = remoteWith(() => ok({ ok: true }));
+    cli.pauseSession("ses_abc", "paused");
+    expect(calls[0]!).toMatchObject({
+      verb: "pause",
+      args: { sessionId: "ses_abc", summary: "paused" },
+    });
+  });
+
+  it("invokes end with the reason", () => {
+    const { cli, calls } = remoteWith(() => ok({ ok: true }));
+    cli.endSession("ses_abc", "switching to private mode");
+    expect(calls[0]!).toMatchObject({
+      verb: "end",
+      args: { sessionId: "ses_abc", reason: "switching to private mode" },
+    });
+  });
+});
+
+describe("createRemoteLibrarianCli — error mapping", () => {
+  it("maps a spawn failure to a typed spawn error", () => {
+    const { cli } = remoteWith(() => ({
+      stdout: "",
+      stderr: "",
+      status: null,
+      error: Object.assign(new Error("nope"), { code: "ENOENT" }),
+    }));
+    const err = (() => {
+      try {
+        cli.startSession({ harness: "pi" });
+        return null;
+      } catch (e) {
+        return e as LibrarianCliError;
+      }
+    })();
+    expect(err).toBeInstanceOf(LibrarianCliError);
+    expect(err?.kind).toBe("spawn");
+  });
+
+  it("maps a timeout (status null, ETIMEDOUT) to a timeout error", () => {
+    const { cli } = remoteWith(() => ({
+      stdout: "",
+      stderr: "",
+      status: null,
+      error: Object.assign(new Error("t"), { code: "ETIMEDOUT" }),
+    }));
+    expect(() => cli.startSession({ harness: "pi" })).toThrow(
+      expect.objectContaining({ kind: "timeout" }),
+    );
+  });
+
+  it("maps a non-zero exit to an exit error carrying the code", () => {
+    const { cli } = remoteWith(() => ({ stdout: "", stderr: "boom", status: 2 }));
+    const err = (() => {
+      try {
+        cli.startSession({ harness: "pi" });
+        return null;
+      } catch (e) {
+        return e as LibrarianCliError;
+      }
+    })();
+    expect(err?.kind).toBe("exit");
+    expect(err?.exitCode).toBe(2);
+  });
+
+  it("maps invalid JSON to a parse error", () => {
+    const { cli } = remoteWith(() => ({ stdout: "not json", stderr: "", status: 0 }));
+    expect(() => cli.startSession({ harness: "pi" })).toThrow(
+      expect.objectContaining({ kind: "parse" }),
+    );
+  });
+});


### PR DESCRIPTION
## What & why

Second piece of the **remote lifecycle transport** (builds on #121). A drop-in `LibrarianCli` that drives a **remote** Librarian instead of the local `the-librarian` CLI — so the harness lifecycle hooks can record sessions + enforce the off-record gate against the same remote Librarian the agent's MCP tools use.

The lifecycle is deliberately synchronous (the state lock is held across the session-resolving call), so this keeps the synchronous `LibrarianCli` shape and bridges to the async HTTP client **over a subprocess** — exactly as the local CLI transport bridges to the local store via `spawnSync`.

## What's here

- **`bin/mcp-call.ts`** — the sync↔async bridge. Reads `LIBRARIAN_MCP_URL` + `LIBRARIAN_AGENT_TOKEN` from env, a verb from argv, args as JSON on stdin; performs ONE MCP `tools/call` (via the #121 client); parses the prose response into CliSession-shaped JSON; prints it and exits 0. Failures → stderr + non-zero. (start/list/continue/checkpoint/pause/end → the matching MCP session tools; agent attribution is token-bound server-side, so no agent flag is sent.)
- **`remote-cli.ts`** — `createRemoteLibrarianCli()` returns a **synchronous** `LibrarianCli` that `spawnSync`s the helper per verb and reuses `cli.ts`'s `toCliSession`. Every failure surfaces as the same `LibrarianCliError` the local CLI throws, so the orchestration's fail-soft `guard()` treats both transports identically. The helper path resolves from `$LIBRARIAN_MCP_CALL_BIN` (set by the plugin to its bundled artifact) or this package's own dist bin.

## Tests

- `remote-cli` with an injected runner: verb/arg mapping + every error kind.
- the built bin end-to-end against a fake `/mcp` returning the **real** formatter prose.
- **the real `spawnSync` default-runner path** end-to-end against an out-of-process fake server (in-process would deadlock the sync spawn), covering helper-path resolution + spawn-error + exit-error fail-soft branches.

A code-review sub-agent approved this; its two Important items (real-runner coverage, timeout coordination) are addressed in the second commit. 132 lifecycle tests green; typecheck + build clean. Unused until the adapter transport-selection PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)