### PR TITLE
feat(lifecycle): env-driven transport selection (local CLI vs remote MCP)

### DIFF
--- a/integrations/shared/librarian-lifecycle/src/harness/claude-code.ts
+++ b/integrations/shared/librarian-lifecycle/src/harness/claude-code.ts
@@ -17,7 +17,7 @@
 // calls the Librarian on a prompt, a hook crash is inherently fail-closed:
 // nothing is recorded for that turn.
 
-import { type LibrarianCli, createLibrarianCli } from "../cli.js";
+import type { LibrarianCli } from "../cli.js";
 import {
   type CheckpointOutcome,
   type LibrarianLifecycle,
@@ -29,6 +29,7 @@ import {
   createLibrarianLifecycle,
 } from "../session.js";
 import type { StateLocation } from "../state.js";
+import { createLibrarianCliForEnv } from "../transport.js";
 
 export interface ClaudeHookEvent {
   hook_event_name?: string;
@@ -101,10 +102,17 @@ export function createClaudeCodeLifecycle(
   const env = options.env ?? process.env;
   const location = claudeLocationFromEvent(event, env);
   const agent = env.LIBRARIAN_AGENT_ID || "claude-code";
-  // The spawn cwd is deliberately the same value as the location's match cwd
-  // (§5.2) — keep them in lockstep if either is ever changed.
+  // The cwd is deliberately the same value as the location's match cwd (§5.2) —
+  // keep them in lockstep if either is ever changed. Transport (local CLI vs
+  // remote HTTP MCP) is selected from the environment.
   const cli =
-    options.cli ?? createLibrarianCli({ agent, ...(event.cwd ? { cwd: event.cwd } : {}) });
+    options.cli ??
+    createLibrarianCliForEnv({
+      harness: "claude-code",
+      agent,
+      env,
+      ...(event.cwd ? { cwd: event.cwd } : {}),
+    });
   const deps: LifecycleDeps = { cli, location };
   if (options.config) deps.config = options.config;
   if (options.logger) deps.logger = options.logger;

--- a/integrations/shared/librarian-lifecycle/src/harness/codex.ts
+++ b/integrations/shared/librarian-lifecycle/src/harness/codex.ts
@@ -19,7 +19,7 @@
 // Like Claude Code, the gate does NOT block the prompt — privacy means "no
 // Librarian call", not "stop the model".
 
-import { type LibrarianCli, createLibrarianCli } from "../cli.js";
+import type { LibrarianCli } from "../cli.js";
 import {
   type CheckpointOutcome,
   type LibrarianLifecycle,
@@ -31,6 +31,7 @@ import {
   createLibrarianLifecycle,
 } from "../session.js";
 import type { StateLocation } from "../state.js";
+import { createLibrarianCliForEnv } from "../transport.js";
 
 export interface CodexHookEvent {
   hook_event_name?: string;
@@ -93,8 +94,15 @@ export function createCodexLifecycle(
   const env = options.env ?? process.env;
   const location = codexLocationFromEvent(event, env);
   const agent = env.LIBRARIAN_AGENT_ID || "codex";
+  // Transport (local CLI vs remote HTTP MCP) is selected from the environment.
   const cli =
-    options.cli ?? createLibrarianCli({ agent, ...(event.cwd ? { cwd: event.cwd } : {}) });
+    options.cli ??
+    createLibrarianCliForEnv({
+      harness: "codex",
+      agent,
+      env,
+      ...(event.cwd ? { cwd: event.cwd } : {}),
+    });
   const deps: LifecycleDeps = { cli, location };
   if (options.config) deps.config = options.config;
   if (options.logger) deps.logger = options.logger;

--- a/integrations/shared/librarian-lifecycle/src/index.ts
+++ b/integrations/shared/librarian-lifecycle/src/index.ts
@@ -13,3 +13,4 @@ export * from "./privacy.js";
 export * from "./remote-cli.js";
 export * from "./session.js";
 export * from "./state.js";
+export * from "./transport.js";

--- a/integrations/shared/librarian-lifecycle/src/transport.ts
+++ b/integrations/shared/librarian-lifecycle/src/transport.ts
@@ -21,6 +21,11 @@ export interface TransportOptions {
   agent: string;
   /** Working directory — the cwd match key (§5.2) and the continue attach target. */
   cwd?: string;
+  /**
+   * Reserved. Coding harnesses resume by directory and intentionally leave this
+   * unset (§5.2) — wiring it would change the cwd-match contract. Present for
+   * symmetry with RemoteLibrarianCliConfig.
+   */
   sourceRef?: string;
   env: NodeJS.ProcessEnv;
 }
@@ -37,8 +42,8 @@ export function createLibrarianCliForEnv(options: TransportOptions): LibrarianCl
       harness: options.harness,
       env: options.env,
     };
-    if (options.cwd !== undefined) config.cwd = options.cwd;
-    if (options.sourceRef !== undefined) config.sourceRef = options.sourceRef;
+    if (options.cwd) config.cwd = options.cwd;
+    if (options.sourceRef) config.sourceRef = options.sourceRef;
     return createRemoteLibrarianCli(config);
   }
   return createLibrarianCli({

--- a/integrations/shared/librarian-lifecycle/src/transport.ts
+++ b/integrations/shared/librarian-lifecycle/src/transport.ts
@@ -1,0 +1,48 @@
+// Transport selection: local CLI vs remote HTTP MCP.
+//
+// The lifecycle's `LibrarianCli` is the same synchronous interface either way.
+// When `LIBRARIAN_MCP_URL` is set the harness talks to a REMOTE Librarian (the
+// marketplace plugin's deployment — see remote-cli.ts); otherwise it spawns the
+// local `the-librarian` CLI against a local store. The orchestration is
+// transport-agnostic, so every adapter selects here and is otherwise unchanged.
+
+import { type LibrarianCli, createLibrarianCli } from "./cli.js";
+import { createRemoteLibrarianCli } from "./remote-cli.js";
+import type { Harness } from "./state.js";
+
+/** Remote transport is chosen when an MCP endpoint is configured. */
+export function shouldUseRemote(env: NodeJS.ProcessEnv): boolean {
+  return Boolean(env.LIBRARIAN_MCP_URL && env.LIBRARIAN_MCP_URL.trim());
+}
+
+export interface TransportOptions {
+  harness: Harness;
+  /** Agent id for local-CLI attribution (remote attribution is token-bound). */
+  agent: string;
+  /** Working directory — the cwd match key (§5.2) and the continue attach target. */
+  cwd?: string;
+  sourceRef?: string;
+  env: NodeJS.ProcessEnv;
+}
+
+/**
+ * Build the `LibrarianCli` for the current environment: the remote HTTP transport
+ * when `LIBRARIAN_MCP_URL` is set, else the local `the-librarian` CLI. The remote
+ * transport reads the endpoint + token from `env`; a missing token surfaces as a
+ * clean fail-soft error from the helper, not here.
+ */
+export function createLibrarianCliForEnv(options: TransportOptions): LibrarianCli {
+  if (shouldUseRemote(options.env)) {
+    const config: Parameters<typeof createRemoteLibrarianCli>[0] = {
+      harness: options.harness,
+      env: options.env,
+    };
+    if (options.cwd !== undefined) config.cwd = options.cwd;
+    if (options.sourceRef !== undefined) config.sourceRef = options.sourceRef;
+    return createRemoteLibrarianCli(config);
+  }
+  return createLibrarianCli({
+    agent: options.agent,
+    ...(options.cwd ? { cwd: options.cwd } : {}),
+  });
+}

--- a/integrations/shared/librarian-lifecycle/tests/harness-codex.test.ts
+++ b/integrations/shared/librarian-lifecycle/tests/harness-codex.test.ts
@@ -1,3 +1,8 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import {
   type CodexHookEvent,
@@ -67,5 +72,51 @@ describe("codexLocationFromEvent", () => {
   it("takes the project key from the environment", () => {
     const loc = codexLocationFromEvent(event, { LIBRARIAN_PROJECT_KEY: "the-librarian" });
     expect(loc.projectKey).toBe("the-librarian");
+  });
+});
+
+// Mirrors the claude-code bin contract: the codex hook must ALWAYS exit 0 and
+// emit no stdout, and the LOCAL transport (default — no LIBRARIAN_MCP_URL) is
+// selected and degrades cleanly when the CLI is unreachable. Runs the built bin.
+const codexBinPath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "dist",
+  "bin",
+  "codex-hook.js",
+);
+
+function runCodexBin(input: string) {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "lib-codex-bin-home-"));
+  try {
+    return spawnSync(process.execPath, [codexBinPath], {
+      input,
+      encoding: "utf8",
+      // No LIBRARIAN_MCP_URL → local transport; the fake bin makes it unreachable.
+      env: { ...process.env, HOME: home, LIBRARIAN_CLI_BIN: "definitely-not-a-real-binary-xyz" },
+    });
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+}
+
+describe("codex-hook bin contract", () => {
+  it("exits 0 with no stdout for an ignored event", () => {
+    const r = runCodexBin(JSON.stringify({ hook_event_name: "SessionStart", session_id: "c" }));
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe("");
+  });
+
+  it("exits 0 with no stdout for a prompt even when the local CLI is unreachable", () => {
+    const r = runCodexBin(
+      JSON.stringify({
+        hook_event_name: "UserPromptSubmit",
+        session_id: "c",
+        cwd: "/tmp/lib-codex-x",
+        prompt: "hi",
+      }),
+    );
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe("");
   });
 });

--- a/integrations/shared/librarian-lifecycle/tests/remote-wiring-e2e.test.ts
+++ b/integrations/shared/librarian-lifecycle/tests/remote-wiring-e2e.test.ts
@@ -1,0 +1,104 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { formatSessionStart } from "@librarian/mcp-server/formatters";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+// End-to-end proof that the Claude Code adapter SELECTS THE REMOTE TRANSPORT when
+// LIBRARIAN_MCP_URL is set: drive the built claude-code-hook bin with a remote
+// env and assert the fake /mcp receives the session calls.
+//
+// The hook bin is launched with ASYNC spawn so this process's event loop stays
+// free to service the in-process server. The bin internally spawnSyncs the
+// mcp-call helper (a grandchild) which connects here — no deadlock, because the
+// blocked spawnSync is in the bin's process, not ours.
+const binPath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "dist",
+  "bin",
+  "claude-code-hook.js",
+);
+
+function rpc(text: string): string {
+  return JSON.stringify({ jsonrpc: "2.0", id: 1, result: { content: [{ type: "text", text }] } });
+}
+
+let server: http.Server;
+let url: string;
+let toolNames: string[];
+
+beforeAll(async () => {
+  toolNames = [];
+  server = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c) => chunks.push(c as Buffer));
+    req.on("end", () => {
+      const name = JSON.parse(Buffer.concat(chunks).toString("utf8")).params?.name as string;
+      toolNames.push(name);
+      const text =
+        name === "list_sessions"
+          ? "No resumable sessions found."
+          : name === "start_session"
+            ? formatSessionStart({
+                id: "ses_e2e",
+                status: "active",
+                title: "T",
+                visibility: "common",
+                project_key: null,
+                current_harness: "claude-code",
+              } as never)
+            : "ok";
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(rpc(text));
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+  url = `http://127.0.0.1:${(server.address() as AddressInfo).port}/mcp`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+function runHook(event: object): Promise<{ status: number | null; stdout: string }> {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "lib-e2e-home-"));
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [binPath], {
+      env: {
+        ...process.env,
+        HOME: home,
+        LIBRARIAN_MCP_URL: url,
+        LIBRARIAN_AGENT_TOKEN: "tok_e2e",
+      },
+    });
+    let stdout = "";
+    child.stdout.on("data", (d) => (stdout += d));
+    child.on("close", (status) => {
+      fs.rmSync(home, { recursive: true, force: true });
+      resolve({ status, stdout });
+    });
+    child.stdin.write(JSON.stringify(event));
+    child.stdin.end();
+  });
+}
+
+describe("claude-code adapter — remote transport selection (e2e)", () => {
+  it("drives the remote Librarian on a prompt and keeps the hook contract (exit 0, no stdout)", async () => {
+    const r = await runHook({
+      hook_event_name: "UserPromptSubmit",
+      session_id: "s-e2e",
+      cwd: "/tmp/lib-e2e-proj",
+      prompt: "hello there",
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toBe(""); // UserPromptSubmit stdout would pollute the model's context
+    // Fresh state → list (no matches) then start, both against the remote /mcp.
+    expect(toolNames).toContain("list_sessions");
+    expect(toolNames).toContain("start_session");
+  });
+});

--- a/integrations/shared/librarian-lifecycle/tests/remote-wiring-e2e.test.ts
+++ b/integrations/shared/librarian-lifecycle/tests/remote-wiring-e2e.test.ts
@@ -8,21 +8,15 @@ import { fileURLToPath } from "node:url";
 import { formatSessionStart } from "@librarian/mcp-server/formatters";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-// End-to-end proof that the Claude Code adapter SELECTS THE REMOTE TRANSPORT when
-// LIBRARIAN_MCP_URL is set: drive the built claude-code-hook bin with a remote
-// env and assert the fake /mcp receives the session calls.
+// End-to-end proof that the harness adapters SELECT THE REMOTE TRANSPORT when
+// LIBRARIAN_MCP_URL is set: drive each built hook bin with a remote env and
+// assert the fake /mcp receives the session calls.
 //
 // The hook bin is launched with ASYNC spawn so this process's event loop stays
 // free to service the in-process server. The bin internally spawnSyncs the
 // mcp-call helper (a grandchild) which connects here — no deadlock, because the
 // blocked spawnSync is in the bin's process, not ours.
-const binPath = path.join(
-  path.dirname(fileURLToPath(import.meta.url)),
-  "..",
-  "dist",
-  "bin",
-  "claude-code-hook.js",
-);
+const binDir = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "dist", "bin");
 
 function rpc(text: string): string {
   return JSON.stringify({ jsonrpc: "2.0", id: 1, result: { content: [{ type: "text", text }] } });
@@ -65,10 +59,13 @@ afterAll(async () => {
   await new Promise<void>((resolve) => server.close(() => resolve()));
 });
 
-function runHook(event: object): Promise<{ status: number | null; stdout: string }> {
+function runHook(
+  binName: string,
+  event: object,
+): Promise<{ status: number | null; stdout: string }> {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "lib-e2e-home-"));
   return new Promise((resolve) => {
-    const child = spawn(process.execPath, [binPath], {
+    const child = spawn(process.execPath, [path.join(binDir, binName)], {
       env: {
         ...process.env,
         HOME: home,
@@ -87,18 +84,22 @@ function runHook(event: object): Promise<{ status: number | null; stdout: string
   });
 }
 
-describe("claude-code adapter — remote transport selection (e2e)", () => {
-  it("drives the remote Librarian on a prompt and keeps the hook contract (exit 0, no stdout)", async () => {
-    const r = await runHook({
-      hook_event_name: "UserPromptSubmit",
-      session_id: "s-e2e",
-      cwd: "/tmp/lib-e2e-proj",
-      prompt: "hello there",
+describe.each([["claude-code-hook.js"], ["codex-hook.js"]])(
+  "%s — remote transport selection (e2e)",
+  (binName) => {
+    it("drives the remote Librarian on a prompt and keeps the hook contract (exit 0, no stdout)", async () => {
+      toolNames.length = 0;
+      const r = await runHook(binName, {
+        hook_event_name: "UserPromptSubmit",
+        session_id: "s-e2e",
+        cwd: "/tmp/lib-e2e-proj",
+        prompt: "hello there",
+      });
+      expect(r.status).toBe(0);
+      expect(r.stdout).toBe(""); // UserPromptSubmit stdout would pollute the model's context
+      // Fresh state → list (no matches) then start, both against the remote /mcp.
+      expect(toolNames).toContain("list_sessions");
+      expect(toolNames).toContain("start_session");
     });
-    expect(r.status).toBe(0);
-    expect(r.stdout).toBe(""); // UserPromptSubmit stdout would pollute the model's context
-    // Fresh state → list (no matches) then start, both against the remote /mcp.
-    expect(toolNames).toContain("list_sessions");
-    expect(toolNames).toContain("start_session");
-  });
-});
+  },
+);

--- a/integrations/shared/librarian-lifecycle/tests/transport.test.ts
+++ b/integrations/shared/librarian-lifecycle/tests/transport.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { createLibrarianCliForEnv, shouldUseRemote } from "../src/transport.js";
+
+describe("shouldUseRemote", () => {
+  it("is true when LIBRARIAN_MCP_URL is set", () => {
+    expect(shouldUseRemote({ LIBRARIAN_MCP_URL: "https://lib.example/mcp" })).toBe(true);
+  });
+
+  it("is false when LIBRARIAN_MCP_URL is unset", () => {
+    expect(shouldUseRemote({})).toBe(false);
+  });
+
+  it("is false for an empty or whitespace-only value", () => {
+    expect(shouldUseRemote({ LIBRARIAN_MCP_URL: "" })).toBe(false);
+    expect(shouldUseRemote({ LIBRARIAN_MCP_URL: "   " })).toBe(false);
+  });
+});
+
+describe("createLibrarianCliForEnv", () => {
+  it("returns a full LibrarianCli for the local transport", () => {
+    const cli = createLibrarianCliForEnv({ harness: "claude-code", agent: "a", env: {} });
+    expect(typeof cli.startSession).toBe("function");
+    expect(typeof cli.listSessions).toBe("function");
+    expect(typeof cli.continueSession).toBe("function");
+    expect(typeof cli.checkpointSession).toBe("function");
+    expect(typeof cli.pauseSession).toBe("function");
+    expect(typeof cli.endSession).toBe("function");
+  });
+
+  it("returns a full LibrarianCli for the remote transport", () => {
+    const cli = createLibrarianCliForEnv({
+      harness: "claude-code",
+      agent: "a",
+      env: { LIBRARIAN_MCP_URL: "https://lib.example/mcp", LIBRARIAN_AGENT_TOKEN: "t" },
+    });
+    expect(typeof cli.startSession).toBe("function");
+    expect(typeof cli.endSession).toBe("function");
+  });
+});


### PR DESCRIPTION
## What & why

Final wiring PR for the **remote lifecycle transport** (builds on #121, #122). Routes both harness adapters through a single environment-driven selection point so the lifecycle hooks talk to a **remote** Librarian when configured, else the local `the-librarian` CLI.

This completes the chain: hook → adapter → transport selection → remote CLI → `mcp-call` bin → HTTP `/mcp`.

## What's here

- **`transport.ts`** — `shouldUseRemote(env)` (true when `LIBRARIAN_MCP_URL` is set) + `createLibrarianCliForEnv()`. Remote → `createRemoteLibrarianCli` (reads endpoint+token from env; threads `harness`/`cwd` as the continue attach target, leaves `sourceRef` unset per §5.2). Local → unchanged `createLibrarianCli`.
- Claude Code **and** Codex adapters now select via `createLibrarianCliForEnv` — Codex gets remote support for free. The local default path is behavior-preserving.

A missing token (URL set, token absent) fails **soft** via the helper (clean error → `guard()` logs + degrades) rather than silently falling back to the local store — the privacy/fail-soft invariants hold.

## Tests

- `shouldUseRemote` decision (set/unset/blank); `createLibrarianCliForEnv` shape for both branches.
- **End-to-end** (`describe.each` over both bins): drives the built `claude-code-hook` **and** `codex-hook` with a remote env against a fake `/mcp`, asserting each issues `list_sessions` + `start_session` while keeping the hook contract (exit 0, no stdout).
- Codex local bin-contract test (exit 0 / no stdout when the CLI is unreachable).

A code-review sub-agent approved this; its Important item (codex coverage gap) + tidy suggestions are in the second commit. 141 lifecycle tests green; typecheck + build clean.

This finishes the `the-librarian`-side work; the marketplace Claude plugin (separate repo) will bundle `librarian-claude-hook.js` + `librarian-mcp-call.js` and set the two env vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)