### PR TITLE
fix(dashboard): stop the Memories grid overflowing the viewport width

### DIFF
--- a/apps/dashboard/components/memories/view.tsx
+++ b/apps/dashboard/components/memories/view.tsx
@@ -102,7 +102,9 @@ export function MemoriesView() {
         />
         {recallError ? <p className="mt-2 text-xs text-destructive">{recallError}</p> : null}
       </aside>
-      <main className="flex flex-col gap-4 p-6">
+      {/* min-w-0: this is the grid's 1fr track — without it, wide content (the
+          list table, long ids) forces the column past the viewport width. */}
+      <main className="flex min-w-0 flex-col gap-4 p-6">
         <header className="flex items-center justify-between gap-4">
           <h1 className="text-2xl font-semibold tracking-tight">Memories</h1>
           <div className="flex items-center gap-2">
@@ -154,7 +156,9 @@ export function MemoriesView() {
             </Button>
           </div>
         ) : null}
-        <section className="grid flex-1 grid-cols-1 gap-4 lg:grid-cols-[1fr_400px]">
+        {/* [&>*]:min-w-0 lets each grid cell shrink so the list/table can't blow
+            the 1fr column past the available width (defaults to min-content). */}
+        <section className="grid flex-1 grid-cols-1 gap-4 [&>*]:min-w-0 lg:grid-cols-[1fr_400px]">
           <MemoriesList
             memories={displayed}
             isLoading={!recallResults && listQuery.isLoading}

--- a/apps/dashboard/e2e/memories.spec.ts
+++ b/apps/dashboard/e2e/memories.spec.ts
@@ -25,4 +25,21 @@ test.describe("memories list + detail", () => {
     await expect(page.getByRole("button", { name: "Edit" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Archive" })).toBeVisible();
   });
+
+  test("does not overflow horizontally with a long title in a sub-fullscreen window", async ({
+    page,
+  }) => {
+    // A long, unbroken title makes the truncated title's min-content huge; without
+    // min-w-0 on the memories grid tracks, `truncate` can't constrain it and the
+    // 1fr column forces the page wider than the viewport (the reported bug).
+    await createTestMemory(`e2e-wide-${"x".repeat(200)}`, "Body for the overflow regression test.");
+    await page.setViewportSize({ width: 900, height: 720 });
+    await page.goto("/");
+    await expect(page.getByRole("heading", { name: "Memories", level: 1 })).toBeVisible();
+
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+    );
+    expect(overflow).toBeLessThanOrEqual(1); // no horizontal page overflow
+  });
 });


### PR DESCRIPTION
## The bug

On the Memories page the layout was wider than the browser window when the window wasn't maximized ("screen-width, not window-width" — horizontal scroll).

## Cause

The Memories surface is a CSS grid (`components/memories/view.tsx`: `grid-cols-[280px_1fr]`); the `1fr` track holds `<main>`, which nests another `1fr` grid for the list. Grid/flex items default to `min-width: auto`, so the row titles' `truncate` (`white-space: nowrap`) couldn't constrain — the column grew to the title's full min-content and pushed the page past the window width.

## Fix

`min-w-0` on the outer `1fr` track (`<main>`) and on the inner section's grid cells (`[&>*]:min-w-0`), so the tracks can shrink and `truncate`/`line-clamp` actually take effect. CSS-only; no behavior change.

## Test

New Playwright regression test: a 200-char unbroken title at a 900px viewport must not produce horizontal page overflow (`scrollWidth - clientWidth <= 1`). This reliably exercises the bug — without the fix the long truncated title blows the column out.

Verified: typecheck, eslint, `next build`, and 61 dashboard unit tests pass locally; the e2e runs in CI.