### PR TITLE
docs(.env): document LIBRARIAN_SECRET_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,15 @@ LIBRARIAN_AGENT_TOKEN=replace-with-a-different-long-random-agent-token
 # the shared LIBRARIAN_AGENT_TOKEN above must be set.
 LIBRARIAN_AGENT_TOKENS=
 
+# ----- Optional: encryption key for secret settings at rest -----
+# An AES-256 key (NOT a bearer token) that encrypts secret settings stored in
+# the DB — today, the memory curator's LLM API token. The server runs without
+# it, but SAVING any secret setting (e.g. curator config in the dashboard) fails
+# until it's set. Must be a 32-byte CSPRNG value as 64 hex chars — generate with
+# `openssl rand -hex 32` (NOT the base64-48 above). Once set, keep it STABLE:
+# changing it makes previously-encrypted settings unreadable.
+LIBRARIAN_SECRET_KEY=
+
 # ----- Optional: published host bindings -----
 # By default both services bind to 127.0.0.1 on the host so they only
 # accept local connections. Set these to a Tailnet IP (e.g. 100.x.y.z)


### PR DESCRIPTION
`.env.example` documented `LIBRARIAN_ADMIN_TOKEN` / `AGENT_TOKEN[S]` but not `LIBRARIAN_SECRET_KEY`, so saving curator config (whose LLM token is a *secret setting* encrypted at rest) failed with no hint of what to set or how.

Adds the var with the **correct** generation command — `openssl rand -hex 32` (a 32-byte key, not the `base64 48` used for bearer tokens) — and the "keep it stable" caveat. Pairs with the README's new Configuration & secrets section.

Docs-only.