### PR TITLE
feat(deploy): single-container process supervisor (C1)

### DIFF
--- a/docker/supervisor.mjs
+++ b/docker/supervisor.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// Process supervisor for the single-container image (spec: deploy-single-container, C1).
+//
+// Runs as PID 1 and starts both services as children (the MCP HTTP server and the
+// Next.js dashboard). Its only jobs are the two things a container's init must get
+// right:
+//
+//   1. Signal forwarding — relay SIGTERM/SIGINT to both children so each runs its
+//      own graceful shutdown, then exit 0 once both are down.
+//   2. Crash-fast — if either child exits while we are NOT shutting down, kill the
+//      sibling and exit non-zero, so the orchestrator restarts the whole pair
+//      rather than leaving the container half-up.
+//
+// Zero dependencies (shipped verbatim in the image; no build step). The two child
+// commands come from LIBRARIAN_SUPERVISOR_CHILDREN (JSON `[{name,cmd,args}]`) so the
+// Dockerfile owns the real image paths and tests can inject fakes.
+
+import { spawn } from "node:child_process";
+
+function loadChildren() {
+  const raw = process.env.LIBRARIAN_SUPERVISOR_CHILDREN;
+  if (raw) {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed) || parsed.length === 0) {
+      throw new Error("LIBRARIAN_SUPERVISOR_CHILDREN must be a non-empty JSON array");
+    }
+    return parsed;
+  }
+  // Fallback for the all-in-one image (the Dockerfile sets the env explicitly).
+  return [
+    { name: "mcp-server", cmd: process.execPath, args: ["mcp-server/dist/bin/http.js"] },
+    { name: "dashboard", cmd: process.execPath, args: ["dashboard/server.js"] },
+  ];
+}
+
+const children = loadChildren();
+
+// "running" → all up; "signal" → graceful shutdown from a received signal (exit 0);
+// "crash" → a child died unexpectedly (exit non-zero).
+let mode = "running";
+let crashCode = 1;
+
+const procs = children.map((child) =>
+  spawn(child.cmd, child.args ?? [], { stdio: "inherit", env: process.env }),
+);
+
+function alive(proc) {
+  return proc.exitCode === null && proc.signalCode === null;
+}
+
+function stopAll(signal) {
+  for (const proc of procs) {
+    if (alive(proc)) proc.kill(signal);
+  }
+}
+
+function finishIfAllDown() {
+  if (procs.some(alive)) return;
+  process.exit(mode === "crash" ? crashCode : 0);
+}
+
+for (const proc of procs) {
+  proc.on("error", () => {
+    // Failed to spawn (e.g. bad path) is an unexpected death → crash-fast.
+    if (mode === "running") {
+      mode = "crash";
+      crashCode = 1;
+      stopAll("SIGTERM");
+    }
+    finishIfAllDown();
+  });
+  proc.on("exit", (code) => {
+    if (mode === "running") {
+      // A child exiting on its own — even with code 0 — means the container can no
+      // longer do its job. Take everything down and report failure.
+      mode = "crash";
+      crashCode = code && code !== 0 ? code : 1;
+      stopAll("SIGTERM");
+    }
+    finishIfAllDown();
+  });
+}
+
+for (const signal of ["SIGTERM", "SIGINT"]) {
+  process.on(signal, () => {
+    if (mode === "running") mode = "signal";
+    stopAll(signal);
+  });
+}

--- a/docker/supervisor.mjs
+++ b/docker/supervisor.mjs
@@ -14,13 +14,22 @@
 // Zero dependencies (shipped verbatim in the image; no build step). The two child
 // commands come from LIBRARIAN_SUPERVISOR_CHILDREN (JSON `[{name,cmd,args}]`) so the
 // Dockerfile owns the real image paths and tests can inject fakes.
+//
+// MUST run under an init that reaps re-parented orphans — Node as PID 1 does not
+// reap grandchildren (e.g. workers forked by the children). The C2 image runs this
+// under `tini` as the real PID 1 (equivalently, `docker run --init`).
 
 import { spawn } from "node:child_process";
 
 function loadChildren() {
   const raw = process.env.LIBRARIAN_SUPERVISOR_CHILDREN;
   if (raw) {
-    const parsed = JSON.parse(raw);
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      throw new Error(`LIBRARIAN_SUPERVISOR_CHILDREN is not valid JSON: ${err.message}`);
+    }
     if (!Array.isArray(parsed) || parsed.length === 0) {
       throw new Error("LIBRARIAN_SUPERVISOR_CHILDREN must be a non-empty JSON array");
     }
@@ -74,7 +83,7 @@ for (const proc of procs) {
       // A child exiting on its own — even with code 0 — means the container can no
       // longer do its job. Take everything down and report failure.
       mode = "crash";
-      crashCode = code && code !== 0 ? code : 1;
+      crashCode = typeof code === "number" && code > 0 ? code : 1;
       stopAll("SIGTERM");
     }
     finishIfAllDown();

--- a/test/supervisor.test.ts
+++ b/test/supervisor.test.ts
@@ -38,6 +38,7 @@ function crashChild(name: string, code: number): Child {
 function runSupervisor(children: Child[]): {
   done: Promise<{ code: number | null; signal: NodeJS.Signals | null; stdout: string }>;
   kill: (signal: NodeJS.Signals) => void;
+  waitForStdout: (needle: string, timeoutMs?: number) => Promise<void>;
 } {
   const proc = spawn(process.execPath, [supervisor], {
     env: { ...process.env, LIBRARIAN_SUPERVISOR_CHILDREN: JSON.stringify(children) },
@@ -50,19 +51,39 @@ function runSupervisor(children: Child[]): {
       proc.on("close", (code, signal) => resolve({ code, signal, stdout }));
     },
   );
-  return { done, kill: (signal) => proc.kill(signal) };
+  // Resolve as soon as `needle` appears in stdout — deterministic, no fixed sleep.
+  function waitForStdout(needle: string, timeoutMs = 5000): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const deadline = Date.now() + timeoutMs;
+      const tick = setInterval(() => {
+        if (stdout.includes(needle)) {
+          clearInterval(tick);
+          resolve();
+        } else if (Date.now() > deadline) {
+          clearInterval(tick);
+          reject(new Error(`timed out waiting for "${needle}"; saw: ${JSON.stringify(stdout)}`));
+        }
+      }, 20);
+    });
+  }
+  return { done, kill: (signal) => proc.kill(signal), waitForStdout };
 }
-
-const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 describe("docker/supervisor.mjs", () => {
   it("starts both children and exits 0 when sent SIGTERM", async () => {
     const sup = runSupervisor([longChild("a"), longChild("b")]);
-    await wait(600); // let both children start
+    await sup.waitForStdout("STARTED:a");
+    await sup.waitForStdout("STARTED:b");
     sup.kill("SIGTERM");
     const result = await sup.done;
-    expect(result.stdout).toContain("STARTED:a");
-    expect(result.stdout).toContain("STARTED:b");
+    expect(result.code).toBe(0);
+  });
+
+  it("exits 0 on SIGINT too", async () => {
+    const sup = runSupervisor([longChild("a"), longChild("b")]);
+    await sup.waitForStdout("STARTED:b");
+    sup.kill("SIGINT");
+    const result = await sup.done;
     expect(result.code).toBe(0);
   });
 
@@ -74,10 +95,15 @@ describe("docker/supervisor.mjs", () => {
     expect(result.code).not.toBe(0);
   }, 10_000);
 
+  it("treats a child exiting 0 on its own as a failure (all-or-nothing container)", async () => {
+    const sup = runSupervisor([crashChild("quitter", 0), longChild("sibling")]);
+    const result = await sup.done;
+    expect(result.code).not.toBe(0);
+  }, 10_000);
+
   it("never writes to its own stdout beyond child output (no banner noise)", async () => {
-    // The supervisor itself should be quiet; only child output (STARTED:*) appears.
     const sup = runSupervisor([longChild("only")]);
-    await wait(400);
+    await sup.waitForStdout("STARTED:only");
     sup.kill("SIGTERM");
     const result = await sup.done;
     const nonChildLines = result.stdout

--- a/test/supervisor.test.ts
+++ b/test/supervisor.test.ts
@@ -1,0 +1,88 @@
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// The single-container image runs both services under docker/supervisor.mjs as
+// PID 1. These spawn the real supervisor with FAKE children (via the
+// LIBRARIAN_SUPERVISOR_CHILDREN override) and assert the two invariants that make
+// it safe as PID 1: clean signal forwarding (SIGTERM → both stop → exit 0) and
+// crash-fast (a child dying takes the whole container down non-zero, so the
+// orchestrator restarts the pair rather than limping on half-up).
+const supervisor = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "docker",
+  "supervisor.mjs",
+);
+
+interface Child {
+  name: string;
+  cmd: string;
+  args: string[];
+}
+
+function longChild(name: string): Child {
+  // Print a start marker, then run until killed.
+  return {
+    name,
+    cmd: process.execPath,
+    args: ["-e", `console.log("STARTED:${name}");setInterval(() => {}, 1e9);`],
+  };
+}
+
+function crashChild(name: string, code: number): Child {
+  return { name, cmd: process.execPath, args: ["-e", `process.exit(${code});`] };
+}
+
+function runSupervisor(children: Child[]): {
+  done: Promise<{ code: number | null; signal: NodeJS.Signals | null; stdout: string }>;
+  kill: (signal: NodeJS.Signals) => void;
+} {
+  const proc = spawn(process.execPath, [supervisor], {
+    env: { ...process.env, LIBRARIAN_SUPERVISOR_CHILDREN: JSON.stringify(children) },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stdout = "";
+  proc.stdout.on("data", (d) => (stdout += d));
+  const done = new Promise<{ code: number | null; signal: NodeJS.Signals | null; stdout: string }>(
+    (resolve) => {
+      proc.on("close", (code, signal) => resolve({ code, signal, stdout }));
+    },
+  );
+  return { done, kill: (signal) => proc.kill(signal) };
+}
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("docker/supervisor.mjs", () => {
+  it("starts both children and exits 0 when sent SIGTERM", async () => {
+    const sup = runSupervisor([longChild("a"), longChild("b")]);
+    await wait(600); // let both children start
+    sup.kill("SIGTERM");
+    const result = await sup.done;
+    expect(result.stdout).toContain("STARTED:a");
+    expect(result.stdout).toContain("STARTED:b");
+    expect(result.code).toBe(0);
+  });
+
+  it("crash-fasts (non-zero) and kills the sibling when one child exits unexpectedly", async () => {
+    // The crasher exits 1 immediately; if the supervisor did NOT kill the
+    // long-running sibling, this promise would hang until the test timeout.
+    const sup = runSupervisor([crashChild("crasher", 1), longChild("sibling")]);
+    const result = await sup.done;
+    expect(result.code).not.toBe(0);
+  }, 10_000);
+
+  it("never writes to its own stdout beyond child output (no banner noise)", async () => {
+    // The supervisor itself should be quiet; only child output (STARTED:*) appears.
+    const sup = runSupervisor([longChild("only")]);
+    await wait(400);
+    sup.kill("SIGTERM");
+    const result = await sup.done;
+    const nonChildLines = result.stdout
+      .split("\n")
+      .filter((line) => line.trim() && !line.startsWith("STARTED:"));
+    expect(nonChildLines).toEqual([]);
+  });
+});


### PR DESCRIPTION
First PR of the **single-container deploy** spec ([`docs/specs/deploy-single-container.md`](https://github.com/JimJafar/the-librarian/blob/main/docs/specs/deploy-single-container.md)).

`docker/supervisor.mjs` — a zero-dep PID-1-style init for the upcoming all-in-one image. It starts both services (MCP server + dashboard) as children and:
- forwards `SIGTERM`/`SIGINT` to both, then exits 0 once both are down
- **crash-fasts** (kills the sibling, exits non-zero) if either child exits while not shutting down — even on a voluntary `exit(0)` — so the orchestrator restarts the pair rather than limping half-up

Child commands come from `LIBRARIAN_SUPERVISOR_CHILDREN` (JSON) so C2's Dockerfile owns the real paths and the test injects fakes. Per review, it documents that it must run under an init that reaps orphans (C2 runs it under `tini`).

`test/supervisor.test.ts` spawns the real supervisor with fake children and pins: start-both → SIGTERM → exit 0; SIGINT → exit 0; crash → non-zero (without hanging, proving the sibling is killed); exit-0-child → failure; and no stdout banner noise. Reviewed by a sub-agent (one Important — reaping — addressed via the init contract + C2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)