### PR TITLE
feat(deploy): dashboard liveness route + healthcheck fix (C3)

### DIFF
--- a/apps/dashboard/app/api/health/route.ts
+++ b/apps/dashboard/app/api/health/route.ts
@@ -1,0 +1,10 @@
+// Pure liveness probe for the dashboard. Unlike the `/health` SSR page (which
+// calls the MCP server and is really a readiness view), this returns 200 without
+// any downstream dependency, so a container HEALTHCHECK reflects "the dashboard
+// process is up" rather than "the MCP server is reachable".
+
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  return Response.json({ status: "ok" });
+}

--- a/apps/dashboard/tests/health-route.test.ts
+++ b/apps/dashboard/tests/health-route.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { GET } from "@/app/api/health/route";
+
+describe("GET /api/health", () => {
+  it("returns 200 ok as a pure liveness probe (no MCP call)", async () => {
+    const res = GET();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: "ok" });
+  });
+});

--- a/docker/dashboard.Dockerfile
+++ b/docker/dashboard.Dockerfile
@@ -49,6 +49,6 @@ USER node
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=15s --retries=3 \
-  CMD node -e "fetch('http://127.0.0.1:3000/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
+  CMD node -e "fetch('http://127.0.0.1:3000/api/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
 
 CMD ["node", "apps/dashboard/server.js"]


### PR DESCRIPTION
Part of the single-container deploy spec. Adds `app/api/health` — a pure liveness probe (`{status:"ok"}`, 200, no MCP call), unlike the existing `/health` SSR page which calls the MCP server and returns 200 even when MCP is down (a weak probe). Points the dashboard Dockerfile's `HEALTHCHECK` at `/api/health`; the all-in-one image (C2) uses it too.

Test asserts the handler returns 200 + JSON. 62 dashboard tests pass; `/api/health` compiles in the Next build.