### PR TITLE
feat(deploy): single-container image + Fly template + docs (C2, C4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,14 @@ jobs:
       - name: Run it and smoke both health endpoints
         run: |
           set -euo pipefail
-          docker run -d --name librarian-ci -p 3000:3000 -p 3838:3838 librarian-all-in-one:ci
+          # Tokens are required: the image binds 0.0.0.0, so the MCP boot guard
+          # refuses to start without an admin token (the production contract).
+          # /healthz + /api/health are both public, so the smoke still works.
+          docker run -d --name librarian-ci -p 3000:3000 -p 3838:3838 \
+            -e LIBRARIAN_ADMIN_TOKEN=ci-admin-token \
+            -e LIBRARIAN_AGENT_TOKEN=ci-agent-token \
+            -e LIBRARIAN_SECRET_KEY="$(openssl rand -hex 32)" \
+            librarian-all-in-one:ci
           ok=0
           for _ in $(seq 1 45); do
             if curl -fsS http://127.0.0.1:3000/api/health >/dev/null \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,36 @@ jobs:
           LIBRARIAN_AGENT_TOKEN: ci-agent-token
         run: docker compose -f docker/docker-compose.yml config
 
+  docker-image:
+    name: Single-container image build + smoke
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Build the all-in-one image
+        run: docker build -f docker/all-in-one.Dockerfile -t librarian-all-in-one:ci .
+
+      - name: Run it and smoke both health endpoints
+        run: |
+          set -euo pipefail
+          docker run -d --name librarian-ci -p 3000:3000 -p 3838:3838 librarian-all-in-one:ci
+          ok=0
+          for _ in $(seq 1 45); do
+            if curl -fsS http://127.0.0.1:3000/api/health >/dev/null \
+               && curl -fsS http://127.0.0.1:3838/healthz >/dev/null; then
+              ok=1; break
+            fi
+            sleep 2
+          done
+          echo "--- container logs ---"; docker logs librarian-ci || true
+          docker rm -f librarian-ci >/dev/null 2>&1 || true
+          if [ "$ok" != "1" ]; then echo "image did not become healthy"; exit 1; fi
+          echo "both endpoints healthy"
+
   e2e:
     name: Dashboard e2e (Playwright)
     needs: build

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,8 +1,40 @@
 # Deploying The Librarian
 
-This deployment is designed for a low-traffic personal VPS in a Tailnet.
+This deployment is designed for a low-traffic personal VPS or a remote host.
 
-## Shape
+## Single container (recommended)
+
+One image runs both services under `tini` (PID 1) → a small supervisor → the MCP
+server + the dashboard. The lowest-friction way to self-host:
+
+```sh
+docker build -f docker/all-in-one.Dockerfile -t the-librarian .
+docker run -d --name the-librarian \
+  -p 3000:3000 -p 3838:3838 \
+  -v librarian_data:/data \
+  -e LIBRARIAN_ADMIN_TOKEN="$(openssl rand -base64 48)" \
+  -e LIBRARIAN_AGENT_TOKEN="$(openssl rand -base64 48)" \
+  -e LIBRARIAN_SECRET_KEY="$(openssl rand -hex 32)" \
+  the-librarian
+```
+
+- Dashboard → `http://<host>:3000`; MCP endpoint → `http://<host>:3838/mcp`.
+- `/data` is a named volume (your memories + sessions) — back it up (see the README's Backup section).
+- `LIBRARIAN_SECRET_KEY` is optional but **required to save curator config** (it encrypts the curator's LLM token at rest); generate with `openssl rand -hex 32` — a 32-byte key, not the base64-48 used for tokens.
+- The MCP port is exposed for remote agents; it requires a bearer token and should sit behind TLS (a reverse proxy) for anything beyond a private network.
+- The image runs `tini` as PID 1 (orphan reaping) and **crash-fasts** if either service dies, so your orchestrator restarts the pair.
+
+### Fly.io
+
+A starter [`fly.toml`](./fly.toml) is included. Edit `app` / `primary_region`, then:
+
+```sh
+fly volumes create librarian_data --size 1
+fly secrets set LIBRARIAN_ADMIN_TOKEN=… LIBRARIAN_AGENT_TOKEN=… LIBRARIAN_SECRET_KEY=…
+fly deploy
+```
+
+## Shape (two-container compose — advanced)
 
 - Two Node services in a Docker Compose stack:
   - `mcp-server` — JSON-RPC at `/mcp`, admin tRPC at `/trpc/*`, liveness at `/healthz`. Port 3838.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -19,9 +19,9 @@ docker run -d --name the-librarian \
 ```
 
 - Dashboard → `http://<host>:3000`; MCP endpoint → `http://<host>:3838/mcp`.
-- `/data` is a named volume (your memories + sessions) — back it up (see the README's Backup section).
+- `/data` is a named volume (your memories + sessions) — back it up (see the README's Backup section). It must be **writable by UID 1000** (the image's `node` user); on platforms that mount volumes root-owned, `chown` it.
 - `LIBRARIAN_SECRET_KEY` is optional but **required to save curator config** (it encrypts the curator's LLM token at rest); generate with `openssl rand -hex 32` — a 32-byte key, not the base64-48 used for tokens.
-- The MCP port is exposed for remote agents; it requires a bearer token and should sit behind TLS (a reverse proxy) for anything beyond a private network.
+- **Port 3838 carries the admin tRPC API (`/trpc/*`) as well as `/mcp`.** `LIBRARIAN_ADMIN_TOKEN` is therefore **mandatory** — the server refuses to start when bound beyond localhost without it — and 3838 should sit behind **TLS** (a reverse proxy). Do **not** set `LIBRARIAN_ALLOW_NO_AUTH=true` on a publicly-reachable host.
 - The image runs `tini` as PID 1 (orphan reaping) and **crash-fasts** if either service dies, so your orchestrator restarts the pair.
 
 ### Fly.io

--- a/docker/all-in-one.Dockerfile
+++ b/docker/all-in-one.Dockerfile
@@ -1,0 +1,87 @@
+# syntax=docker/dockerfile:1.7
+
+# Single-container image: runs BOTH the MCP server and the Next.js dashboard in
+# one container, under `tini` (PID 1, reaps orphans) → docker/supervisor.mjs →
+# the two services. See docs/specs/deploy-single-container.md.
+#
+# The two services live in separate subtrees (/app/mcp-server, /app/dashboard) so
+# their node_modules don't collide; the supervisor runs each by absolute path, so
+# Node resolves each one's modules from its own subtree regardless of cwd.
+
+# ---------- builder ----------
+FROM node:22.17.1-bookworm-slim AS builder
+WORKDIR /app
+RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
+
+# Manifests first for a cacheable install layer.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY packages/core/package.json ./packages/core/package.json
+COPY packages/mcp-server/package.json ./packages/mcp-server/package.json
+COPY packages/cli/package.json ./packages/cli/package.json
+COPY apps/dashboard/package.json ./apps/dashboard/package.json
+
+RUN pnpm install --frozen-lockfile --ignore-scripts
+
+COPY tsconfig.base.json ./
+COPY packages/core ./packages/core
+COPY packages/mcp-server ./packages/mcp-server
+COPY apps/dashboard ./apps/dashboard
+
+# core + mcp-server first (the dashboard imports mcp-server types), then dashboard.
+RUN pnpm --filter @librarian/core --filter @librarian/mcp-server run build \
+  && pnpm --filter @librarian/dashboard run build
+
+# Prune the workspace to prod deps for the mcp-server runtime tree. The dashboard's
+# .next/standalone output already bundles its own pruned node_modules, so this
+# doesn't affect it.
+RUN pnpm install --prod --frozen-lockfile --ignore-scripts && pnpm store prune
+
+# ---------- runtime ----------
+FROM node:22.17.1-bookworm-slim AS runtime
+WORKDIR /app
+
+# tini as PID 1 reaps re-parented orphans (Node won't); the supervisor runs as
+# its child. Equivalent to `docker run --init`.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends tini \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV NODE_ENV=production \
+    LIBRARIAN_DATA_DIR=/data \
+    LIBRARIAN_HOST=0.0.0.0 \
+    LIBRARIAN_PORT=3838 \
+    LIBRARIAN_SERVER_URL=http://127.0.0.1:3838 \
+    PORT=3000 \
+    HOSTNAME=0.0.0.0 \
+    NEXT_TELEMETRY_DISABLED=1 \
+    LIBRARIAN_SUPERVISOR_CHILDREN="[{\"name\":\"mcp-server\",\"cmd\":\"node\",\"args\":[\"--no-warnings\",\"/app/mcp-server/packages/mcp-server/dist/bin/http.js\"]},{\"name\":\"dashboard\",\"cmd\":\"node\",\"args\":[\"/app/dashboard/apps/dashboard/server.js\"]}]"
+
+# --- mcp-server runtime tree under /app/mcp-server (mirrors mcp-server.Dockerfile) ---
+COPY --from=builder /app/package.json /app/pnpm-workspace.yaml /app/mcp-server/
+COPY --from=builder /app/node_modules /app/mcp-server/node_modules
+COPY --from=builder /app/packages/core/package.json /app/mcp-server/packages/core/package.json
+COPY --from=builder /app/packages/core/dist /app/mcp-server/packages/core/dist
+COPY --from=builder /app/packages/core/node_modules /app/mcp-server/packages/core/node_modules
+COPY --from=builder /app/packages/mcp-server/package.json /app/mcp-server/packages/mcp-server/package.json
+COPY --from=builder /app/packages/mcp-server/dist /app/mcp-server/packages/mcp-server/dist
+COPY --from=builder /app/packages/mcp-server/node_modules /app/mcp-server/packages/mcp-server/node_modules
+
+# --- dashboard standalone tree under /app/dashboard (mirrors dashboard.Dockerfile) ---
+COPY --from=builder /app/apps/dashboard/.next/standalone /app/dashboard/
+COPY --from=builder /app/apps/dashboard/.next/static /app/dashboard/apps/dashboard/.next/static
+COPY --from=builder /app/apps/dashboard/public /app/dashboard/apps/dashboard/public
+
+# --- supervisor ---
+COPY docker/supervisor.mjs /app/supervisor.mjs
+
+RUN mkdir -p /data && chown -R node:node /app /data
+USER node
+
+EXPOSE 3000 3838
+
+# Healthy only when BOTH the dashboard liveness route and the MCP server respond.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD node -e "Promise.all([fetch('http://127.0.0.1:3000/api/health'),fetch('http://127.0.0.1:3838/healthz')]).then(rs=>process.exit(rs.every(r=>r.ok)?0:1)).catch(()=>process.exit(1))"
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["node", "/app/supervisor.mjs"]

--- a/fly.toml
+++ b/fly.toml
@@ -18,15 +18,19 @@ primary_region = "lhr"
   source = "librarian_data"
   destination = "/data"
 
-# Dashboard (HTTP, TLS-terminated by Fly).
+# Dashboard (HTTP, TLS-terminated by Fly). For an always-on personal memory
+# server, prefer `auto_stop_machines = false` so an idle dashboard never stops the
+# machine and drops MCP connectivity on 3838.
 [http_service]
   internal_port = 3000
   force_https = true
-  auto_stop_machines = "stop"
+  auto_stop_machines = false
   auto_start_machines = true
   min_machines_running = 1
 
-# MCP endpoint for remote agents (POST /mcp with a bearer token, over TLS).
+# MCP endpoint for remote agents over TLS. NOTE: 3838 also serves the admin tRPC
+# API (/trpc/*), so LIBRARIAN_ADMIN_TOKEN MUST be set (via `fly secrets set`) — the
+# server refuses to start without it when bound beyond localhost.
 [[services]]
   internal_port = 3838
   protocol = "tcp"

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,36 @@
+# Fly.io deploy for the single-container Librarian image.
+# A starter template — edit `app` and `primary_region`, and verify the schema
+# against current Fly docs (https://fly.io/docs/reference/configuration/).
+
+app = "the-librarian"
+primary_region = "lhr"
+
+[build]
+  dockerfile = "docker/all-in-one.Dockerfile"
+
+[env]
+  LIBRARIAN_DATA_DIR = "/data"
+  # Tokens + LIBRARIAN_SECRET_KEY come from `fly secrets set …`, not here.
+
+# Persistent volume for memories + sessions. Create once:
+#   fly volumes create librarian_data --size 1
+[mounts]
+  source = "librarian_data"
+  destination = "/data"
+
+# Dashboard (HTTP, TLS-terminated by Fly).
+[http_service]
+  internal_port = 3000
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 1
+
+# MCP endpoint for remote agents (POST /mcp with a bearer token, over TLS).
+[[services]]
+  internal_port = 3838
+  protocol = "tcp"
+
+  [[services.ports]]
+    port = 3838
+    handlers = ["tls"]


### PR DESCRIPTION
Completes the single-container deploy ([`docs/specs/deploy-single-container.md`](https://github.com/JimJafar/the-librarian/blob/main/docs/specs/deploy-single-container.md)).

**`docker/all-in-one.Dockerfile`** — one image, both services under `tini` (PID 1, reaps orphans) → `supervisor.mjs` (C1) → MCP server + dashboard. Each service lives in its own subtree (`/app/mcp-server`, `/app/dashboard`) so their `node_modules` don't collide; the supervisor runs each by absolute path. The dashboard reaches MCP over loopback (`LIBRARIAN_SERVER_URL`); MCP binds `0.0.0.0` so remote agents can POST `/mcp` (token-gated). Both ports exposed; HEALTHCHECK requires **both** `/api/health` and `/healthz`.

**CI** gains a `docker-image` job that builds the image, runs it, and smoke-tests both endpoints — the real verification (no local Docker in dev).

**C4** — `fly.toml` starter + a "Single container (recommended)" section in `DEPLOYMENT.md` with the `docker run` one-liner (incl. `LIBRARIAN_SECRET_KEY`) and the Fly flow; the two-container compose stays as the advanced option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)