### PR TITLE
feat(core): backup / restore / export module (B1)

### DIFF
--- a/packages/core/src/backup/backup.ts
+++ b/packages/core/src/backup/backup.ts
@@ -7,11 +7,13 @@
 //   <dir>/events.jsonl            — memory ledger (append-only)
 //   <dir>/session_events.jsonl    — session timeline ledger (append-only)
 //   <dir>/sessions.legacy.jsonl   — pre-R3 anchor, only if present
+//   <dir>/memories.md             — derived snapshot, only if present
 //   <dir>/manifest.json           — format + schema version, file list + sha256
 //
-// The derived memories.md snapshot is intentionally NOT backed up — restore
-// regenerates it from events.jsonl. The JSONL ledgers are append-only, so a copy
-// taken in the same (quiescent) window is consistent with the SQLite snapshot.
+// PRECONDITION: the caller should quiesce writes for the snapshot window. The
+// store is synchronous and single-owner, so a backup taken between requests is
+// point-in-time; VACUUM INTO is transactionally consistent regardless, and the
+// JSONL ledgers are append-only, so the copies are consistent with the db snapshot.
 
 import { createHash } from "node:crypto";
 import fs from "node:fs";
@@ -45,36 +47,48 @@ function sha256(file: string): string {
 }
 
 export function createBackup(store: LibrarianStore, options: { destDir: string }): BackupResult {
-  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
-  const dir = path.join(options.destDir, `librarian-backup-${stamp}`);
+  const now = new Date();
+  const dir = path.join(
+    options.destDir,
+    `librarian-backup-${now.toISOString().replace(/[:.]/g, "-")}`,
+  );
   fs.mkdirSync(dir, { recursive: true });
 
-  // SQLite: a transactionally-consistent copy. VACUUM INTO refuses to overwrite,
-  // so the fresh backup dir guarantees the dest doesn't exist.
-  const dbDest = path.join(dir, "librarian.sqlite");
-  store.db.exec(`VACUUM INTO '${dbDest.replace(/'/g, "''")}'`);
+  try {
+    // SQLite: a transactionally-consistent copy. VACUUM INTO refuses to overwrite,
+    // so the fresh backup dir guarantees the dest doesn't exist.
+    const dbDest = path.join(dir, "librarian.sqlite");
+    store.db.exec(`VACUUM INTO '${dbDest.replace(/'/g, "''")}'`);
 
-  const ledgers: { name: string; src: string }[] = [
-    { name: "events.jsonl", src: store.eventsPath },
-    { name: "session_events.jsonl", src: store.sessionsPath },
-  ];
-  if (fs.existsSync(store.sessionsLegacyPath)) {
-    ledgers.push({ name: "sessions.legacy.jsonl", src: store.sessionsLegacyPath });
-  }
-  for (const ledger of ledgers) {
-    fs.copyFileSync(ledger.src, path.join(dir, ledger.name));
-  }
+    const copies: { name: string; src: string }[] = [
+      { name: "events.jsonl", src: store.eventsPath },
+      { name: "session_events.jsonl", src: store.sessionsPath },
+    ];
+    if (fs.existsSync(store.sessionsLegacyPath)) {
+      copies.push({ name: "sessions.legacy.jsonl", src: store.sessionsLegacyPath });
+    }
+    if (fs.existsSync(store.snapshotPath)) {
+      copies.push({ name: "memories.md", src: store.snapshotPath });
+    }
+    for (const copy of copies) {
+      fs.copyFileSync(copy.src, path.join(dir, copy.name));
+    }
 
-  const names = ["librarian.sqlite", ...ledgers.map((l) => l.name)];
-  const manifest: BackupManifest = {
-    format_version: BACKUP_FORMAT_VERSION,
-    created_at: new Date().toISOString(),
-    schema_version: getSchemaVersion(store.db),
-    files: names.map((name) => {
-      const abs = path.join(dir, name);
-      return { name, sha256: sha256(abs), bytes: fs.statSync(abs).size };
-    }),
-  };
-  fs.writeFileSync(path.join(dir, BACKUP_MANIFEST), `${JSON.stringify(manifest, null, 2)}\n`);
-  return { dir, manifest };
+    const names = ["librarian.sqlite", ...copies.map((c) => c.name)];
+    const manifest: BackupManifest = {
+      format_version: BACKUP_FORMAT_VERSION,
+      created_at: now.toISOString(),
+      schema_version: getSchemaVersion(store.db),
+      files: names.map((name) => {
+        const abs = path.join(dir, name);
+        return { name, sha256: sha256(abs), bytes: fs.statSync(abs).size };
+      }),
+    };
+    fs.writeFileSync(path.join(dir, BACKUP_MANIFEST), `${JSON.stringify(manifest, null, 2)}\n`);
+    return { dir, manifest };
+  } catch (err) {
+    // Never leave a half-written bundle that could later be mistaken for a good one.
+    fs.rmSync(dir, { recursive: true, force: true });
+    throw err;
+  }
 }

--- a/packages/core/src/backup/backup.ts
+++ b/packages/core/src/backup/backup.ts
@@ -1,0 +1,80 @@
+// Backup: a consistent, restorable snapshot of the whole store (spec:
+// persistence-backup-restore, B1).
+//
+// The snapshot is a plain directory bundle (zero-dep, transparent to restore):
+//   <dir>/librarian.sqlite        — VACUUM INTO copy (transactionally consistent
+//                                    even on a live connection)
+//   <dir>/events.jsonl            — memory ledger (append-only)
+//   <dir>/session_events.jsonl    — session timeline ledger (append-only)
+//   <dir>/sessions.legacy.jsonl   — pre-R3 anchor, only if present
+//   <dir>/manifest.json           — format + schema version, file list + sha256
+//
+// The derived memories.md snapshot is intentionally NOT backed up — restore
+// regenerates it from events.jsonl. The JSONL ledgers are append-only, so a copy
+// taken in the same (quiescent) window is consistent with the SQLite snapshot.
+
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import type { LibrarianStore } from "../store/librarian-store.js";
+import { getSchemaVersion } from "../store/projection.js";
+
+export const BACKUP_FORMAT_VERSION = 1;
+export const BACKUP_MANIFEST = "manifest.json";
+
+export interface BackupFileEntry {
+  name: string;
+  sha256: string;
+  bytes: number;
+}
+
+export interface BackupManifest {
+  format_version: number;
+  created_at: string;
+  schema_version: number;
+  files: BackupFileEntry[];
+}
+
+export interface BackupResult {
+  dir: string;
+  manifest: BackupManifest;
+}
+
+function sha256(file: string): string {
+  return createHash("sha256").update(fs.readFileSync(file)).digest("hex");
+}
+
+export function createBackup(store: LibrarianStore, options: { destDir: string }): BackupResult {
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const dir = path.join(options.destDir, `librarian-backup-${stamp}`);
+  fs.mkdirSync(dir, { recursive: true });
+
+  // SQLite: a transactionally-consistent copy. VACUUM INTO refuses to overwrite,
+  // so the fresh backup dir guarantees the dest doesn't exist.
+  const dbDest = path.join(dir, "librarian.sqlite");
+  store.db.exec(`VACUUM INTO '${dbDest.replace(/'/g, "''")}'`);
+
+  const ledgers: { name: string; src: string }[] = [
+    { name: "events.jsonl", src: store.eventsPath },
+    { name: "session_events.jsonl", src: store.sessionsPath },
+  ];
+  if (fs.existsSync(store.sessionsLegacyPath)) {
+    ledgers.push({ name: "sessions.legacy.jsonl", src: store.sessionsLegacyPath });
+  }
+  for (const ledger of ledgers) {
+    fs.copyFileSync(ledger.src, path.join(dir, ledger.name));
+  }
+
+  const names = ["librarian.sqlite", ...ledgers.map((l) => l.name)];
+  const manifest: BackupManifest = {
+    format_version: BACKUP_FORMAT_VERSION,
+    created_at: new Date().toISOString(),
+    schema_version: getSchemaVersion(store.db),
+    files: names.map((name) => {
+      const abs = path.join(dir, name);
+      return { name, sha256: sha256(abs), bytes: fs.statSync(abs).size };
+    }),
+  };
+  fs.writeFileSync(path.join(dir, BACKUP_MANIFEST), `${JSON.stringify(manifest, null, 2)}\n`);
+  return { dir, manifest };
+}

--- a/packages/core/src/backup/export.ts
+++ b/packages/core/src/backup/export.ts
@@ -1,0 +1,26 @@
+// Portable export of the current store contents (spec: persistence-backup-restore,
+// B1) — a human-/tool-readable dump of memories + sessions, distinct from a backup
+// (which is for restore). `json` is one object; `ndjson` is one tagged record per
+// line.
+
+import type { LibrarianStore } from "../store/librarian-store.js";
+
+export type ExportFormat = "ndjson" | "json";
+
+// Large enough to export every session without the list's default cap.
+const EXPORT_LIMIT = 1_000_000;
+
+export function exportData(store: LibrarianStore, options: { format: ExportFormat }): string {
+  const memories = store.listAll({});
+  const sessions = store.listSessions({ limit: EXPORT_LIMIT }).sessions;
+
+  if (options.format === "json") {
+    return `${JSON.stringify({ memories, sessions }, null, 2)}\n`;
+  }
+
+  const lines = [
+    ...memories.map((memory) => JSON.stringify({ type: "memory", ...memory })),
+    ...sessions.map((session) => JSON.stringify({ type: "session", ...session })),
+  ];
+  return lines.length ? `${lines.join("\n")}\n` : "";
+}

--- a/packages/core/src/backup/export.ts
+++ b/packages/core/src/backup/export.ts
@@ -2,17 +2,21 @@
 // B1) — a human-/tool-readable dump of memories + sessions, distinct from a backup
 // (which is for restore). `json` is one object; `ndjson` is one tagged record per
 // line.
+//
+// Sessions are read straight from the canonical `sessions` table (ALL statuses and
+// visibilities, uncapped) — NOT via `listSessions`, which clamps to 100 rows and
+// defaults to active+paused + common-only, all of which would silently drop data
+// from an export.
 
 import type { LibrarianStore } from "../store/librarian-store.js";
 
 export type ExportFormat = "ndjson" | "json";
 
-// Large enough to export every session without the list's default cap.
-const EXPORT_LIMIT = 1_000_000;
-
 export function exportData(store: LibrarianStore, options: { format: ExportFormat }): string {
-  const memories = store.listAll({});
-  const sessions = store.listSessions({ limit: EXPORT_LIMIT }).sessions;
+  const memories = store.listAll({}); // no status filter → every memory
+  const sessions = store.db
+    .prepare("SELECT * FROM sessions ORDER BY started_at, id")
+    .all() as Record<string, unknown>[];
 
   if (options.format === "json") {
     return `${JSON.stringify({ memories, sessions }, null, 2)}\n`;

--- a/packages/core/src/backup/restore.ts
+++ b/packages/core/src/backup/restore.ts
@@ -26,7 +26,32 @@ export interface RestoreResult {
 function isManifest(value: unknown): value is BackupManifest {
   if (typeof value !== "object" || value === null) return false;
   const m = value as Record<string, unknown>;
-  return typeof m.format_version === "number" && Array.isArray(m.files);
+  if (typeof m.format_version !== "number" || !Array.isArray(m.files)) return false;
+  return m.files.every(
+    (f) =>
+      typeof f === "object" &&
+      f !== null &&
+      typeof (f as Record<string, unknown>).name === "string" &&
+      typeof (f as Record<string, unknown>).sha256 === "string",
+  );
+}
+
+// A manifest file name must be a plain basename that stays inside the data dir —
+// reject path separators / `..` so a hostile manifest can't write outside it
+// (arbitrary-file-write via restore).
+function assertSafeName(name: string): void {
+  if (
+    name.length === 0 ||
+    name.includes("/") ||
+    name.includes("\\") ||
+    name.includes("\0") ||
+    name.split(/[\\/]/).includes("..") ||
+    name === ".." ||
+    path.isAbsolute(name) ||
+    path.basename(name) !== name
+  ) {
+    throw new BackupRestoreError(`unsafe backup file name: ${JSON.stringify(name)}`);
+  }
 }
 
 export function restoreBackup(backupDir: string, options: { dataDir: string }): RestoreResult {
@@ -49,9 +74,10 @@ export function restoreBackup(backupDir: string, options: { dataDir: string }): 
     );
   }
 
-  // Validate everything up front so a corrupt backup never half-overwrites the
-  // data dir.
+  // Validate everything up front (safe names + presence + checksums) so a corrupt
+  // or hostile backup never half-overwrites — or escapes — the data dir.
   for (const file of manifest.files) {
+    assertSafeName(file.name);
     const src = path.join(backupDir, file.name);
     if (!fs.existsSync(src)) throw new BackupRestoreError(`backup file missing: ${file.name}`);
     const actual = createHash("sha256").update(fs.readFileSync(src)).digest("hex");

--- a/packages/core/src/backup/restore.ts
+++ b/packages/core/src/backup/restore.ts
@@ -1,0 +1,74 @@
+// Restore a backup bundle into a data dir (spec: persistence-backup-restore, B1).
+//
+// Verifies the manifest + every file's checksum BEFORE touching the data dir, then
+// swaps each file in atomically (temp + rename). The store MUST be closed during a
+// restore (the SQLite file is replaced). On the next store open, ensureSchema
+// rebuilds the memory projection if the backup's schema_version is older; session
+// state is SQLite-canonical, so a same-version restore is exact (a cross-version
+// restore rebuilds memory from the ledger but may not reconstruct old session
+// state — see the spec).
+
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { BACKUP_FORMAT_VERSION, BACKUP_MANIFEST, type BackupManifest } from "./backup.js";
+
+export class BackupRestoreError extends Error {
+  override readonly name = "BackupRestoreError";
+}
+
+export interface RestoreResult {
+  dataDir: string;
+  restored: string[];
+  schemaVersion: number;
+}
+
+function isManifest(value: unknown): value is BackupManifest {
+  if (typeof value !== "object" || value === null) return false;
+  const m = value as Record<string, unknown>;
+  return typeof m.format_version === "number" && Array.isArray(m.files);
+}
+
+export function restoreBackup(backupDir: string, options: { dataDir: string }): RestoreResult {
+  const manifestPath = path.join(backupDir, BACKUP_MANIFEST);
+  if (!fs.existsSync(manifestPath)) {
+    throw new BackupRestoreError(`no ${BACKUP_MANIFEST} in ${backupDir}`);
+  }
+  let manifest: unknown;
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  } catch (err) {
+    throw new BackupRestoreError(`${BACKUP_MANIFEST} is not valid JSON: ${(err as Error).message}`);
+  }
+  if (!isManifest(manifest)) {
+    throw new BackupRestoreError(`${BACKUP_MANIFEST} is structurally invalid`);
+  }
+  if (manifest.format_version !== BACKUP_FORMAT_VERSION) {
+    throw new BackupRestoreError(
+      `unsupported backup format_version ${manifest.format_version} (expected ${BACKUP_FORMAT_VERSION})`,
+    );
+  }
+
+  // Validate everything up front so a corrupt backup never half-overwrites the
+  // data dir.
+  for (const file of manifest.files) {
+    const src = path.join(backupDir, file.name);
+    if (!fs.existsSync(src)) throw new BackupRestoreError(`backup file missing: ${file.name}`);
+    const actual = createHash("sha256").update(fs.readFileSync(src)).digest("hex");
+    if (actual !== file.sha256) {
+      throw new BackupRestoreError(`checksum mismatch for ${file.name}`);
+    }
+  }
+
+  fs.mkdirSync(options.dataDir, { recursive: true });
+  const restored: string[] = [];
+  for (const file of manifest.files) {
+    const src = path.join(backupDir, file.name);
+    const dest = path.join(options.dataDir, file.name);
+    const tmp = `${dest}.restore-${process.pid}-${Date.now()}.tmp`;
+    fs.copyFileSync(src, tmp);
+    fs.renameSync(tmp, dest); // atomic on the same filesystem
+    restored.push(file.name);
+  }
+  return { dataDir: options.dataDir, restored, schemaVersion: manifest.schema_version };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -149,6 +149,16 @@ export {
   createLibrarianStore,
 } from "./store/librarian-store.js";
 export {
+  type BackupFileEntry,
+  type BackupManifest,
+  type BackupResult,
+  BACKUP_FORMAT_VERSION,
+  BACKUP_MANIFEST,
+  createBackup,
+} from "./backup/backup.js";
+export { type RestoreResult, BackupRestoreError, restoreBackup } from "./backup/restore.js";
+export { type ExportFormat, exportData } from "./backup/export.js";
+export {
   type CompleteCurationRunInput,
   type CreateCurationRunInput,
   type CurationOperation,

--- a/packages/core/tests/backup.test.ts
+++ b/packages/core/tests/backup.test.ts
@@ -15,7 +15,7 @@ let dataDir: string;
 let destDir: string;
 let store: LibrarianStore;
 
-function seed(s: LibrarianStore) {
+function seedMemory(s: LibrarianStore) {
   s.createMemory({
     agent_id: "claude",
     title: "pnpm not npm",
@@ -27,30 +27,21 @@ function seed(s: LibrarianStore) {
     priority: "normal",
     confidence: "working",
   });
-  const started = s.startSession({
-    agent_id: "claude",
-    title: "backup work",
-    harness: "claude-code",
-  });
-  s.checkpointSession({
-    session_id: (started.session as { id: string }).id,
-    summary: "did the backup module",
-  });
 }
 
-function snapshot(s: LibrarianStore) {
+function startSession(s: LibrarianStore, extra: Record<string, unknown> = {}): string {
+  const r = s.startSession({ agent_id: "claude", title: "work", harness: "claude-code", ...extra });
+  return (r.session as { id: string }).id;
+}
+
+// Full-row snapshots — deep equality across every column, not just id/status, so a
+// restore that silently dropped rolling_summary / timestamps / events would fail.
+function deepSnapshot(s: LibrarianStore) {
   return {
-    memories: s
-      .listAll({})
-      .map((m) => (m as { id: string }).id)
-      .sort(),
-    sessions: s
-      .listSessions({ limit: 1000 })
-      .sessions.map((x) => ({
-        id: (x as { id: string }).id,
-        status: (x as { status: string }).status,
-      }))
-      .sort((a, b) => a.id.localeCompare(b.id)),
+    memories: s.db.prepare("SELECT * FROM memories ORDER BY id").all(),
+    sessions: s.db.prepare("SELECT * FROM sessions ORDER BY id").all(),
+    sessionEvents: s.readSessionEvents(),
+    events: s.readEvents(),
   };
 }
 
@@ -71,28 +62,29 @@ afterEach(() => {
 });
 
 describe("createBackup / restoreBackup", () => {
-  it("round-trips the store: seed → backup → wipe → restore → identical", () => {
-    seed(store);
-    const before = snapshot(store);
+  it("round-trips the full store: seed → backup → wipe → restore → byte-identical state", () => {
+    seedMemory(store);
+    const sid = startSession(store);
+    store.checkpointSession({ session_id: sid, summary: "did the backup module" });
+    const before = deepSnapshot(store);
 
     const { dir, manifest } = createBackup(store, { destDir });
     expect(manifest.schema_version).toBeGreaterThan(0);
-    expect(manifest.files.map((f) => f.name)).toContain("librarian.sqlite");
-    expect(manifest.files.map((f) => f.name)).toContain("events.jsonl");
-    expect(fs.existsSync(path.join(dir, "manifest.json"))).toBe(true);
+    expect(manifest.files.map((f) => f.name)).toEqual(
+      expect.arrayContaining(["librarian.sqlite", "events.jsonl", "session_events.jsonl"]),
+    );
 
-    // Wipe + restore into a fresh data dir, then re-open.
     store.close();
     fs.rmSync(dataDir, { recursive: true, force: true });
     const result = restoreBackup(dir, { dataDir });
     expect(result.restored).toContain("librarian.sqlite");
 
     store = createLibrarianStore({ dataDir });
-    expect(snapshot(store)).toEqual(before);
+    expect(deepSnapshot(store)).toEqual(before); // full fidelity incl. rolling_summary, timestamps, events
   });
 
   it("records a sha256 + byte size for every file", () => {
-    seed(store);
+    seedMemory(store);
     const { manifest } = createBackup(store, { destDir });
     for (const file of manifest.files) {
       expect(file.sha256).toMatch(/^[0-9a-f]{64}$/);
@@ -101,10 +93,9 @@ describe("createBackup / restoreBackup", () => {
   });
 
   it("rejects a backup whose file no longer matches its checksum", () => {
-    seed(store);
+    seedMemory(store);
     const { dir } = createBackup(store, { destDir });
     store.close();
-    // Corrupt a backed-up ledger after the manifest was written.
     fs.appendFileSync(path.join(dir, "events.jsonl"), "tampered\n");
     expect(() => restoreBackup(dir, { dataDir })).toThrow(BackupRestoreError);
   });
@@ -114,20 +105,55 @@ describe("createBackup / restoreBackup", () => {
     expect(() => restoreBackup(empty, { dataDir })).toThrow(BackupRestoreError);
     fs.rmSync(empty, { recursive: true, force: true });
   });
+
+  it("refuses a manifest with a path-traversal file name (no arbitrary write)", () => {
+    const evilDir = fs.mkdtempSync(path.join(os.tmpdir(), "lib-backup-evil-"));
+    fs.writeFileSync(
+      path.join(evilDir, "manifest.json"),
+      JSON.stringify({
+        format_version: 1,
+        created_at: new Date().toISOString(),
+        schema_version: 1,
+        files: [{ name: "../escape.txt", sha256: "0".repeat(64), bytes: 0 }],
+      }),
+    );
+    expect(() => restoreBackup(evilDir, { dataDir })).toThrow(/unsafe backup file name/);
+    fs.rmSync(evilDir, { recursive: true, force: true });
+  });
 });
 
 describe("exportData", () => {
   it("exports memories + sessions as JSON", () => {
-    seed(store);
+    seedMemory(store);
+    startSession(store);
     const parsed = JSON.parse(exportData(store, { format: "json" }));
     expect(parsed.memories.length).toBe(1);
     expect(parsed.sessions.length).toBe(1);
   });
 
   it("exports one tagged record per line as NDJSON", () => {
-    seed(store);
-    const lines = exportData(store, { format: "ndjson" }).trim().split("\n");
-    const types = lines.map((l) => JSON.parse(l).type).sort();
+    seedMemory(store);
+    startSession(store);
+    const types = exportData(store, { format: "ndjson" })
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l).type)
+      .sort();
     expect(types).toEqual(["memory", "session"]);
+  });
+
+  it("includes EVERY session — ended, private, and beyond the list's 100-row cap", () => {
+    const ended = startSession(store, { title: "ended one" });
+    store.endSession({ session_id: ended });
+    const priv = startSession(store, { title: "private one", visibility: "agent_private" });
+    for (let i = 0; i < 100; i++) startSession(store, { title: `bulk ${i}` });
+
+    const sessions = JSON.parse(exportData(store, { format: "json" })).sessions as {
+      id: string;
+    }[];
+    expect(sessions.length).toBe(102); // 1 ended + 1 private + 100 bulk, none dropped
+    const ids = sessions.map((s) => s.id);
+    expect(ids).toContain(ended);
+    expect(ids).toContain(priv);
   });
 });

--- a/packages/core/tests/backup.test.ts
+++ b/packages/core/tests/backup.test.ts
@@ -1,0 +1,133 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type LibrarianStore,
+  BackupRestoreError,
+  createBackup,
+  createLibrarianStore,
+  exportData,
+  restoreBackup,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let dataDir: string;
+let destDir: string;
+let store: LibrarianStore;
+
+function seed(s: LibrarianStore) {
+  s.createMemory({
+    agent_id: "claude",
+    title: "pnpm not npm",
+    body: "this repo uses pnpm",
+    category: "projects",
+    visibility: "common",
+    scope: "project",
+    project_key: "the-librarian",
+    priority: "normal",
+    confidence: "working",
+  });
+  const started = s.startSession({
+    agent_id: "claude",
+    title: "backup work",
+    harness: "claude-code",
+  });
+  s.checkpointSession({
+    session_id: (started.session as { id: string }).id,
+    summary: "did the backup module",
+  });
+}
+
+function snapshot(s: LibrarianStore) {
+  return {
+    memories: s
+      .listAll({})
+      .map((m) => (m as { id: string }).id)
+      .sort(),
+    sessions: s
+      .listSessions({ limit: 1000 })
+      .sessions.map((x) => ({
+        id: (x as { id: string }).id,
+        status: (x as { status: string }).status,
+      }))
+      .sort((a, b) => a.id.localeCompare(b.id)),
+  };
+}
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "lib-backup-data-"));
+  destDir = fs.mkdtempSync(path.join(os.tmpdir(), "lib-backup-dest-"));
+  store = createLibrarianStore({ dataDir });
+});
+
+afterEach(() => {
+  try {
+    store.close();
+  } catch {
+    // already closed by a test
+  }
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  fs.rmSync(destDir, { recursive: true, force: true });
+});
+
+describe("createBackup / restoreBackup", () => {
+  it("round-trips the store: seed → backup → wipe → restore → identical", () => {
+    seed(store);
+    const before = snapshot(store);
+
+    const { dir, manifest } = createBackup(store, { destDir });
+    expect(manifest.schema_version).toBeGreaterThan(0);
+    expect(manifest.files.map((f) => f.name)).toContain("librarian.sqlite");
+    expect(manifest.files.map((f) => f.name)).toContain("events.jsonl");
+    expect(fs.existsSync(path.join(dir, "manifest.json"))).toBe(true);
+
+    // Wipe + restore into a fresh data dir, then re-open.
+    store.close();
+    fs.rmSync(dataDir, { recursive: true, force: true });
+    const result = restoreBackup(dir, { dataDir });
+    expect(result.restored).toContain("librarian.sqlite");
+
+    store = createLibrarianStore({ dataDir });
+    expect(snapshot(store)).toEqual(before);
+  });
+
+  it("records a sha256 + byte size for every file", () => {
+    seed(store);
+    const { manifest } = createBackup(store, { destDir });
+    for (const file of manifest.files) {
+      expect(file.sha256).toMatch(/^[0-9a-f]{64}$/);
+      expect(file.bytes).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("rejects a backup whose file no longer matches its checksum", () => {
+    seed(store);
+    const { dir } = createBackup(store, { destDir });
+    store.close();
+    // Corrupt a backed-up ledger after the manifest was written.
+    fs.appendFileSync(path.join(dir, "events.jsonl"), "tampered\n");
+    expect(() => restoreBackup(dir, { dataDir })).toThrow(BackupRestoreError);
+  });
+
+  it("rejects a directory with no manifest", () => {
+    const empty = fs.mkdtempSync(path.join(os.tmpdir(), "lib-backup-empty-"));
+    expect(() => restoreBackup(empty, { dataDir })).toThrow(BackupRestoreError);
+    fs.rmSync(empty, { recursive: true, force: true });
+  });
+});
+
+describe("exportData", () => {
+  it("exports memories + sessions as JSON", () => {
+    seed(store);
+    const parsed = JSON.parse(exportData(store, { format: "json" }));
+    expect(parsed.memories.length).toBe(1);
+    expect(parsed.sessions.length).toBe(1);
+  });
+
+  it("exports one tagged record per line as NDJSON", () => {
+    seed(store);
+    const lines = exportData(store, { format: "ndjson" }).trim().split("\n");
+    const types = lines.map((l) => JSON.parse(l).type).sort();
+    expect(types).toEqual(["memory", "session"]);
+  });
+});


### PR DESCRIPTION
Phase 2 (persistence) foundation — keeps `node:sqlite`, no async refactor.

- **`createBackup`** → a plain directory bundle: a `VACUUM INTO` copy of the SQLite db (transactionally consistent on a live connection) + the append-only JSONL ledgers + the derived `memories.md` + `manifest.json` (format + schema version, per-file sha256 + size). Cleans up a half-written bundle on failure.
- **`restoreBackup`** → verifies the manifest + **every checksum and file name** before touching the data dir (rejects path-traversal names), then swaps each file in atomically (temp + rename). Idempotent; store must be closed.
- **`exportData`** → portable json/ndjson of **every** memory + session, read from the canonical sources (uncapped, all statuses/visibilities).

A code-review sub-agent found 3 Critical (restore path-traversal; export 100-row cap; export dropping ended/private) — **all fixed and tested** in the second commit. Tests: full deep round-trip (memories + sessions + events), per-file checksums, corrupt-file + missing-manifest + path-traversal rejection, and export completeness (102 sessions incl. ended + private). 403 core tests green.

Follow-ups deferred to B2 (noted): full restore dir-swap atomicity + store-closed enforcement in the CLI.