### PR TITLE
feat(cli): backup / restore / export commands (B2)

### DIFF
--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -14,5 +14,11 @@ try {
   if (result.stdout) console.log(result.stdout);
   process.exitCode = result.exitCode || 0;
 } finally {
-  store.close();
+  // `restore` closes the store itself before replacing the SQLite file, so guard
+  // against a double close here.
+  try {
+    store.close();
+  } catch {
+    // already closed
+  }
 }

--- a/packages/cli/src/commands/backup.ts
+++ b/packages/cli/src/commands/backup.ts
@@ -1,0 +1,18 @@
+// `the-librarian backup [--out <dir>]` — write a restorable snapshot bundle.
+
+import { type LibrarianStore, createBackup } from "@librarian/core";
+import type { FlagMap } from "../parse-flags.js";
+import type { CliResult } from "./_shared.js";
+
+export function backupCommand(
+  store: LibrarianStore,
+  _positionals: string[],
+  flags: FlagMap,
+): CliResult {
+  const destDir = typeof flags.out === "string" && flags.out ? flags.out : process.cwd();
+  const { dir, manifest } = createBackup(store, { destDir });
+  return {
+    stdout: `Backup written to ${dir} (${manifest.files.length} files, schema v${manifest.schema_version}).`,
+    exitCode: 0,
+  };
+}

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -1,0 +1,15 @@
+// `the-librarian export [--format ndjson|json]` — portable dump of memories +
+// sessions (every status/visibility). Defaults to ndjson.
+
+import { type LibrarianStore, exportData } from "@librarian/core";
+import type { FlagMap } from "../parse-flags.js";
+import type { CliResult } from "./_shared.js";
+
+export function exportCommand(
+  store: LibrarianStore,
+  _positionals: string[],
+  flags: FlagMap,
+): CliResult {
+  const format = flags.format === "json" ? "json" : "ndjson";
+  return { stdout: exportData(store, { format }), exitCode: 0 };
+}

--- a/packages/cli/src/commands/restore.ts
+++ b/packages/cli/src/commands/restore.ts
@@ -1,0 +1,40 @@
+// `the-librarian restore --from <backup-dir> --force` — restore a snapshot bundle.
+//
+// Destructive: it overwrites the data dir, so it requires --force. It closes the
+// store first (the SQLite file is replaced) — restore is terminal, so the handle
+// stays closed; the bin's own close is idempotent.
+
+import { BackupRestoreError, type LibrarianStore, restoreBackup } from "@librarian/core";
+import type { FlagMap } from "../parse-flags.js";
+import type { CliResult } from "./_shared.js";
+
+export function restoreCommand(
+  store: LibrarianStore,
+  _positionals: string[],
+  flags: FlagMap,
+): CliResult {
+  const from = typeof flags.from === "string" ? flags.from : "";
+  if (!from) {
+    return { stdout: "restore requires --from <backup-dir>.", exitCode: 1 };
+  }
+  if (flags.force !== true) {
+    return {
+      stdout: `restore OVERWRITES the data dir (${store.dataDir}). Re-run with --force once you're sure.`,
+      exitCode: 1,
+    };
+  }
+
+  store.close(); // release the SQLite handle before the file is replaced
+  try {
+    const result = restoreBackup(from, { dataDir: store.dataDir });
+    return {
+      stdout: `Restored ${result.restored.length} files to ${result.dataDir} (schema v${result.schemaVersion}). Restart the server.`,
+      exitCode: 0,
+    };
+  } catch (err) {
+    if (err instanceof BackupRestoreError) {
+      return { stdout: `Restore failed: ${err.message}`, exitCode: 1 };
+    }
+    throw err;
+  }
+}

--- a/packages/cli/src/runtime.ts
+++ b/packages/cli/src/runtime.ts
@@ -10,11 +10,21 @@
 // inline. Per-verb logic is now < 100 LOC per file.
 
 import { SYSTEM_ACTOR_IDS, type LibrarianStore } from "@librarian/core";
-import type { CliResult } from "./commands/_shared.js";
+import type { CliResult, Command } from "./commands/_shared.js";
+import { backupCommand } from "./commands/backup.js";
+import { exportCommand } from "./commands/export.js";
 import { sessionVerbs } from "./commands/index.js";
+import { restoreCommand } from "./commands/restore.js";
 import { parseFlags } from "./parse-flags.js";
 
 export type { CliResult } from "./commands/_shared.js";
+
+// Top-level commands that take flags (unlike the bare rebuild/seed).
+const topLevelCommands: Record<string, Command> = {
+  backup: backupCommand,
+  restore: restoreCommand,
+  export: exportCommand,
+};
 
 export function runCli(argv: string[], store: LibrarianStore): CliResult {
   const [command, ...rest] = argv;
@@ -36,6 +46,11 @@ export function runCli(argv: string[], store: LibrarianStore): CliResult {
       stdout: `Seeded sample proposal and operating memory in ${store.dataDir}`,
       exitCode: 0,
     };
+  }
+  const topLevel = topLevelCommands[command];
+  if (topLevel) {
+    const { positionals, flags } = parseFlags(rest);
+    return topLevel(store, positionals, flags);
   }
   if (command === "sessions") return runSessionsCommand(rest, store);
   return { stdout: `Unknown command: ${command}\n\n${usage()}`, exitCode: 1 };
@@ -96,6 +111,9 @@ export function usage(): string {
     "Commands:",
     "  rebuild                       Replay events.jsonl and sessions.jsonl into the SQLite projection",
     "  seed                          Seed sample memories (no-op if any exist)",
+    "  backup [--out <dir>]          Write a restorable snapshot bundle",
+    "  restore --from <dir> --force  Restore a snapshot bundle into the data dir (destructive)",
+    "  export [--format ndjson|json] Dump memories + sessions to stdout",
     "  sessions <verb>               Manage Librarian sessions (see 'sessions help')",
   ].join("\n");
 }

--- a/packages/cli/tests/backup-commands.test.ts
+++ b/packages/cli/tests/backup-commands.test.ts
@@ -1,0 +1,80 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { type LibrarianStore, createLibrarianStore } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+import { withStore } from "../../../test/helpers.js";
+import { runCli } from "../src/runtime.js";
+
+function seed(store: LibrarianStore, title: string) {
+  store.createMemory({
+    agent_id: "claude",
+    title,
+    body: "body",
+    category: "projects",
+    visibility: "common",
+    scope: "project",
+    project_key: "the-librarian",
+    priority: "normal",
+    confidence: "working",
+  });
+}
+
+function backupDirIn(out: string): string {
+  const name = fs.readdirSync(out).find((d) => d.startsWith("librarian-backup-"));
+  if (!name) throw new Error(`no backup dir in ${out}`);
+  return path.join(out, name);
+}
+
+describe("the-librarian backup / export / restore", () => {
+  it("backup writes a bundle with a manifest", async () => {
+    await withStore(async (store: LibrarianStore) => {
+      seed(store, "one");
+      const out = fs.mkdtempSync(path.join(os.tmpdir(), "lib-cli-bk-"));
+      const r = runCli(["backup", "--out", out], store);
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toContain("Backup written");
+      expect(fs.existsSync(path.join(backupDirIn(out), "manifest.json"))).toBe(true);
+      fs.rmSync(out, { recursive: true, force: true });
+    });
+  });
+
+  it("export --format json dumps memories + sessions", async () => {
+    await withStore(async (store: LibrarianStore) => {
+      seed(store, "one");
+      const r = runCli(["export", "--format", "json"], store);
+      expect(r.exitCode).toBe(0);
+      expect(JSON.parse(r.stdout).memories.length).toBe(1);
+    });
+  });
+
+  it("restore refuses without --force", async () => {
+    await withStore(async (store: LibrarianStore) => {
+      const r = runCli(["restore", "--from", "/nonexistent"], store);
+      expect(r.exitCode).toBe(1);
+      expect(r.stdout).toContain("--force");
+    });
+  });
+
+  it("restore --force reverts the data dir to the backed-up state", async () => {
+    await withStore(async (store: LibrarianStore, dataDir: string) => {
+      seed(store, "one"); // 1 memory
+      const out = fs.mkdtempSync(path.join(os.tmpdir(), "lib-cli-bk-"));
+      runCli(["backup", "--out", out], store);
+      const bdir = backupDirIn(out);
+
+      seed(store, "two"); // 2 memories, AFTER the backup
+
+      const r = runCli(["restore", "--from", bdir, "--force"], store); // closes the store
+      expect(r.exitCode).toBe(0);
+
+      const reopened = createLibrarianStore({ dataDir });
+      try {
+        expect(reopened.listAll({}).length).toBe(1); // reverted to the backup state
+      } finally {
+        reopened.close();
+      }
+      fs.rmSync(out, { recursive: true, force: true });
+    });
+  });
+});

--- a/packages/cli/tests/snapshots.test.ts
+++ b/packages/cli/tests/snapshots.test.ts
@@ -21,6 +21,9 @@ describe("CLI snapshots", () => {
       Commands:
         rebuild                       Replay events.jsonl and sessions.jsonl into the SQLite projection
         seed                          Seed sample memories (no-op if any exist)
+        backup [--out <dir>]          Write a restorable snapshot bundle
+        restore --from <dir> --force  Restore a snapshot bundle into the data dir (destructive)
+        export [--format ndjson|json] Dump memories + sessions to stdout
         sessions <verb>               Manage Librarian sessions (see 'sessions help')"
     `);
   });


### PR DESCRIPTION
Thin CLI wrappers over the B1 core backup module:

- `the-librarian backup [--out <dir>]` — write a snapshot bundle.
- `the-librarian restore --from <dir> --force` — destructive; requires `--force`; **closes the store before the SQLite file is replaced** (enforces the store-closed contract the B1 review flagged) and surfaces `BackupRestoreError` as a clean exit 1.
- `the-librarian export [--format ndjson|json]` — dump memories + sessions to stdout.

`bin.ts` close made idempotent (so restore's own close doesn't double-close); `usage()` snapshot refreshed. Test covers backup-writes-manifest, export-json, restore-refuses-without-force, and a real round-trip (seed → backup → add → restore → reopen → reverted). 55 CLI tests green.