### PR TITLE
feat(core): pluggable cloud backup sync (B3)

### DIFF
--- a/packages/core/src/backup/sync/bundle.ts
+++ b/packages/core/src/backup/sync/bundle.ts
@@ -1,0 +1,40 @@
+// Push/pull a local backup bundle (a directory of files) to/from a BackupTarget.
+// Objects are keyed `<bundleName>/<file>`, so one target can hold many bundles.
+
+import fs from "node:fs";
+import path from "node:path";
+import type { BackupTarget } from "./types.js";
+
+/** Upload every file in `backupDir` under `<basename(backupDir)>/`. Returns the keys. */
+export async function syncBundle(target: BackupTarget, backupDir: string): Promise<string[]> {
+  const bundleName = path.basename(backupDir);
+  const keys: string[] = [];
+  for (const file of fs.readdirSync(backupDir)) {
+    const key = `${bundleName}/${file}`;
+    await target.put(key, fs.readFileSync(path.join(backupDir, file)));
+    keys.push(key);
+  }
+  return keys;
+}
+
+/** Download the `<bundleName>/` objects into `<destDir>/<bundleName>/`; returns that path. */
+export async function fetchBundle(
+  target: BackupTarget,
+  bundleName: string,
+  destDir: string,
+): Promise<string> {
+  const prefix = `${bundleName}/`;
+  const keys = await target.list(prefix);
+  if (keys.length === 0) throw new Error(`no backup objects under ${prefix}`);
+  const dir = path.join(destDir, bundleName);
+  fs.mkdirSync(dir, { recursive: true });
+  for (const key of keys) {
+    const file = key.slice(prefix.length);
+    // A target must never write outside the bundle dir.
+    if (!file || file.includes("/") || file.includes("\\") || file.includes("..")) {
+      throw new Error(`unsafe object key: ${key}`);
+    }
+    fs.writeFileSync(path.join(dir, file), await target.get(key));
+  }
+  return dir;
+}

--- a/packages/core/src/backup/sync/config.ts
+++ b/packages/core/src/backup/sync/config.ts
@@ -1,0 +1,48 @@
+// Resolve S3-compatible sync config from the settings store (dashboard-configured,
+// B4) with an env fallback (headless). Returns null when not configured.
+//
+// Credentials are secret settings (encrypted at rest); reading them needs
+// LIBRARIAN_SECRET_KEY, so getSetting may throw — we fall back to env in that case.
+
+import type { LibrarianStore } from "../../store/librarian-store.js";
+
+export interface S3SyncConfig {
+  bucket: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  region?: string;
+  endpoint?: string;
+  prefix?: string;
+}
+
+type SettingsReader = Pick<LibrarianStore, "getSetting">;
+
+function readSetting(store: SettingsReader, key: string): string {
+  try {
+    return store.getSetting(key) ?? "";
+  } catch {
+    return ""; // secret setting without a master key, or store error → fall back to env
+  }
+}
+
+export function resolveS3SyncConfig(
+  store: SettingsReader,
+  env: NodeJS.ProcessEnv = process.env,
+): S3SyncConfig | null {
+  const pick = (settingKey: string, envKey: string): string =>
+    readSetting(store, settingKey) || env[envKey] || "";
+
+  const bucket = pick("backup.s3.bucket", "LIBRARIAN_BACKUP_S3_BUCKET");
+  const accessKeyId = pick("backup.s3.access_key", "LIBRARIAN_BACKUP_S3_ACCESS_KEY");
+  const secretAccessKey = pick("backup.s3.secret_key", "LIBRARIAN_BACKUP_S3_SECRET_KEY");
+  if (!bucket || !accessKeyId || !secretAccessKey) return null;
+
+  const config: S3SyncConfig = { bucket, accessKeyId, secretAccessKey };
+  const region = pick("backup.s3.region", "LIBRARIAN_BACKUP_S3_REGION");
+  const endpoint = pick("backup.s3.endpoint", "LIBRARIAN_BACKUP_S3_ENDPOINT");
+  const prefix = pick("backup.s3.prefix", "LIBRARIAN_BACKUP_S3_PREFIX");
+  if (region) config.region = region;
+  if (endpoint) config.endpoint = endpoint;
+  if (prefix) config.prefix = prefix;
+  return config;
+}

--- a/packages/core/src/backup/sync/memory.ts
+++ b/packages/core/src/backup/sync/memory.ts
@@ -1,0 +1,26 @@
+// In-memory BackupTarget — the reference implementation and the test double for
+// the target contract (so the bundle round-trip can be tested without a network).
+
+import type { BackupTarget } from "./types.js";
+
+export interface MemoryBackupTarget extends BackupTarget {
+  readonly objects: Map<string, Buffer>;
+}
+
+export function createMemoryBackupTarget(): MemoryBackupTarget {
+  const objects = new Map<string, Buffer>();
+  return {
+    objects,
+    async put(name, data) {
+      objects.set(name, Buffer.from(data));
+    },
+    async get(name) {
+      const data = objects.get(name);
+      if (!data) throw new Error(`object not found: ${name}`);
+      return data;
+    },
+    async list(prefix = "") {
+      return [...objects.keys()].filter((key) => key.startsWith(prefix)).sort();
+    },
+  };
+}

--- a/packages/core/src/backup/sync/s3.ts
+++ b/packages/core/src/backup/sync/s3.ts
@@ -1,0 +1,61 @@
+// S3-compatible BackupTarget. `@aws-sdk/client-s3` is an OPTIONAL, lazy-loaded
+// dependency — it is NOT required to build or install @librarian/core; it's only
+// needed at runtime when S3 sync is actually used (works with AWS, Cloudflare R2,
+// MinIO, Backblaze via the `endpoint` override + path-style addressing).
+
+import type { S3SyncConfig } from "./config.js";
+import type { BackupTarget } from "./types.js";
+
+// A variable specifier so TypeScript does not resolve the module at build time
+// (keeps the package optional). The module is typed as `any` at the call site.
+const S3_PACKAGE = "@aws-sdk/client-s3";
+
+interface AwsS3Module {
+  S3Client: new (cfg: unknown) => { send(command: unknown): Promise<unknown> };
+  PutObjectCommand: new (input: unknown) => unknown;
+  GetObjectCommand: new (input: unknown) => unknown;
+  ListObjectsV2Command: new (input: unknown) => unknown;
+}
+
+export async function createS3Target(config: S3SyncConfig): Promise<BackupTarget> {
+  let aws: AwsS3Module;
+  try {
+    aws = (await import(S3_PACKAGE)) as unknown as AwsS3Module;
+  } catch {
+    throw new Error(
+      "@aws-sdk/client-s3 is not installed — run `npm i @aws-sdk/client-s3` to enable S3 backup sync",
+    );
+  }
+  const { S3Client, PutObjectCommand, GetObjectCommand, ListObjectsV2Command } = aws;
+
+  const client = new S3Client({
+    region: config.region ?? "us-east-1",
+    ...(config.endpoint ? { endpoint: config.endpoint, forcePathStyle: true } : {}),
+    credentials: { accessKeyId: config.accessKeyId, secretAccessKey: config.secretAccessKey },
+  });
+  const prefix = config.prefix ? `${config.prefix.replace(/\/+$/, "")}/` : "";
+
+  return {
+    async put(name, data) {
+      await client.send(
+        new PutObjectCommand({ Bucket: config.bucket, Key: prefix + name, Body: data }),
+      );
+    },
+    async get(name) {
+      const res = (await client.send(
+        new GetObjectCommand({ Bucket: config.bucket, Key: prefix + name }),
+      )) as { Body?: { transformToByteArray(): Promise<Uint8Array> } };
+      if (!res.Body) throw new Error(`empty object: ${name}`);
+      return Buffer.from(await res.Body.transformToByteArray());
+    },
+    async list(p = "") {
+      const res = (await client.send(
+        new ListObjectsV2Command({ Bucket: config.bucket, Prefix: prefix + p }),
+      )) as { Contents?: { Key?: string }[] };
+      return (res.Contents ?? [])
+        .map((o) => o.Key ?? "")
+        .filter((k) => k.startsWith(prefix))
+        .map((k) => k.slice(prefix.length));
+    },
+  };
+}

--- a/packages/core/src/backup/sync/types.ts
+++ b/packages/core/src/backup/sync/types.ts
@@ -1,0 +1,13 @@
+// Object-storage abstraction for backup sync (spec: persistence-backup-restore,
+// B3). Pluggable so S3-compatible is the first impl and GCS/others can drop in.
+// Cloud sync is async, so it runs from the async server/dashboard (B4), not the
+// synchronous CLI.
+
+export interface BackupTarget {
+  /** Store `data` at `name` (overwriting). */
+  put(name: string, data: Buffer): Promise<void>;
+  /** Fetch the bytes at `name`. Rejects if absent. */
+  get(name: string): Promise<Buffer>;
+  /** List object names, optionally filtered by a `prefix`. */
+  list(prefix?: string): Promise<string[]>;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -158,6 +158,11 @@ export {
 } from "./backup/backup.js";
 export { type RestoreResult, BackupRestoreError, restoreBackup } from "./backup/restore.js";
 export { type ExportFormat, exportData } from "./backup/export.js";
+export { type BackupTarget } from "./backup/sync/types.js";
+export { type MemoryBackupTarget, createMemoryBackupTarget } from "./backup/sync/memory.js";
+export { fetchBundle, syncBundle } from "./backup/sync/bundle.js";
+export { type S3SyncConfig, resolveS3SyncConfig } from "./backup/sync/config.js";
+export { createS3Target } from "./backup/sync/s3.js";
 export {
   type CompleteCurationRunInput,
   type CreateCurationRunInput,

--- a/packages/core/tests/backup-sync.test.ts
+++ b/packages/core/tests/backup-sync.test.ts
@@ -1,0 +1,115 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type BackupTarget,
+  createMemoryBackupTarget,
+  createS3Target,
+  fetchBundle,
+  resolveS3SyncConfig,
+  syncBundle,
+} from "@librarian/core";
+import { afterEach, describe, expect, it } from "vitest";
+
+const tmpDirs: string[] = [];
+function tmp(prefix: string): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tmpDirs.push(d);
+  return d;
+}
+afterEach(() => {
+  for (const d of tmpDirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+});
+
+describe("BackupTarget contract (memory)", () => {
+  it("put / get / list round-trips", async () => {
+    const t = createMemoryBackupTarget();
+    await t.put("a/x.txt", Buffer.from("hello"));
+    await t.put("a/y.txt", Buffer.from("world"));
+    expect((await t.get("a/x.txt")).toString()).toBe("hello");
+    expect(await t.list("a/")).toEqual(["a/x.txt", "a/y.txt"]);
+    await expect(t.get("missing")).rejects.toThrow();
+  });
+});
+
+describe("syncBundle / fetchBundle", () => {
+  it("uploads a bundle dir and pulls it back identically", async () => {
+    const src = tmp("lib-bundle-src-");
+    const bundleDir = path.join(src, "librarian-backup-2026");
+    fs.mkdirSync(bundleDir);
+    fs.writeFileSync(path.join(bundleDir, "manifest.json"), "{}");
+    fs.writeFileSync(path.join(bundleDir, "events.jsonl"), "line\n");
+
+    const target = createMemoryBackupTarget();
+    const keys = await syncBundle(target, bundleDir);
+    expect(keys.sort()).toEqual([
+      "librarian-backup-2026/events.jsonl",
+      "librarian-backup-2026/manifest.json",
+    ]);
+
+    const dest = tmp("lib-bundle-dest-");
+    const out = await fetchBundle(target, "librarian-backup-2026", dest);
+    expect(fs.readFileSync(path.join(out, "events.jsonl"), "utf8")).toBe("line\n");
+    expect(fs.readFileSync(path.join(out, "manifest.json"), "utf8")).toBe("{}");
+  });
+
+  it("fetchBundle rejects an object key that escapes the bundle dir", async () => {
+    const target = createMemoryBackupTarget();
+    await target.put("b/../escape", Buffer.from("x"));
+    const dest = tmp("lib-bundle-evil-");
+    await expect(fetchBundle(target, "b", dest)).rejects.toThrow(/unsafe object key/);
+  });
+});
+
+describe("resolveS3SyncConfig", () => {
+  const noSettings = { getSetting: () => null };
+
+  it("returns null when not configured", () => {
+    expect(resolveS3SyncConfig(noSettings, {})).toBeNull();
+  });
+
+  it("resolves from env", () => {
+    const config = resolveS3SyncConfig(noSettings, {
+      LIBRARIAN_BACKUP_S3_BUCKET: "b",
+      LIBRARIAN_BACKUP_S3_ACCESS_KEY: "ak",
+      LIBRARIAN_BACKUP_S3_SECRET_KEY: "sk",
+      LIBRARIAN_BACKUP_S3_ENDPOINT: "https://r2.example",
+    });
+    expect(config).toEqual({
+      bucket: "b",
+      accessKeyId: "ak",
+      secretAccessKey: "sk",
+      endpoint: "https://r2.example",
+    });
+  });
+
+  it("prefers settings over env and tolerates a secret read that throws", () => {
+    const store = {
+      getSetting: (key: string) => {
+        if (key === "backup.s3.secret_key") throw new Error("no master key");
+        if (key === "backup.s3.bucket") return "from-settings";
+        return null;
+      },
+    };
+    const config = resolveS3SyncConfig(store, {
+      LIBRARIAN_BACKUP_S3_BUCKET: "from-env",
+      LIBRARIAN_BACKUP_S3_ACCESS_KEY: "ak",
+      LIBRARIAN_BACKUP_S3_SECRET_KEY: "sk", // settings read threw → env used
+    });
+    expect(config?.bucket).toBe("from-settings");
+    expect(config?.secretAccessKey).toBe("sk");
+  });
+});
+
+describe("createS3Target", () => {
+  it("fails with a clear message when @aws-sdk/client-s3 is not installed", async () => {
+    // The package is intentionally NOT a dependency, so the lazy import fails here.
+    await expect(
+      createS3Target({
+        bucket: "b",
+        accessKeyId: "ak",
+        secretAccessKey: "sk",
+      }) as Promise<BackupTarget>,
+    ).rejects.toThrow(/@aws-sdk\/client-s3 is not installed/);
+  });
+});


### PR DESCRIPTION
Async object-storage layer for backup bundles. Cloud sync is async, so it runs from the async server/dashboard (B4), not the synchronous CLI.

- **`BackupTarget`** interface + an in-memory reference/test target.
- **`syncBundle`/`fetchBundle`** — push/pull a backup directory as `<bundle>/<file>` objects; fetch guards against keys escaping the bundle dir.
- **`resolveS3SyncConfig`** — settings-store (dashboard-configured, encrypted) with env fallback (`LIBRARIAN_BACKUP_S3_*`); tolerates a secret read throwing when no master key is set.
- **`createS3Target`** — S3-compatible (AWS/R2/MinIO/Backblaze via `endpoint` + path-style). `@aws-sdk/client-s3` is an **optional, lazy-imported** dep (not required to build/install core); a clear error if absent at runtime.

Tested: target contract, bundle round-trip + unsafe-key rejection, config (env + settings-override + throwing-secret tolerance), and the missing-dep error. 410 core tests green. The S3 wire calls need MinIO to test live (noted); the contract is covered via the in-memory target.