### PR TITLE
feat(server): backup tRPC router + scheduled backups + docs (B4a)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -145,30 +145,50 @@ docker compose --env-file .env -f docker/docker-compose.yml up -d
 
 ## Backups
 
-Back up `events.jsonl` and `sessions.jsonl` first. They are the canonical source of truth. `librarian.sqlite` and `memories.md` can be rebuilt.
+**Back up all three load-bearing files**: `events.jsonl` (memory canonical),
+`session_events.jsonl` (timeline), and `librarian.sqlite` (**session-canonical** post-R3 —
+NOT rebuildable for sessions). `memories.md` is derived. (See the README's Backup section for the
+full rationale.)
 
-The volume is named `librarian_data`. Inspect its mount path with `docker volume inspect librarian_data` (typically `/var/lib/docker/volumes/librarian_data/_data` on Linux hosts).
+### Built-in backup / restore (recommended)
 
-Simple daily backup example:
+Consistent (VACUUM INTO) snapshot of the whole store, with a checksummed manifest:
 
 ```sh
-mkdir -p ~/librarian-backups
+the-librarian backup --out /var/backups/librarian        # write a bundle
+the-librarian restore --from /var/backups/librarian/librarian-backup-… --force   # restore (server stopped)
+the-librarian export --format ndjson > dump.ndjson       # portable dump
+```
+
+Inside the single-container image, run via `docker exec <container> the-librarian backup --out /data/backups`.
+
+### Scheduled backups + cloud sync
+
+- **Schedule**: set `LIBRARIAN_BACKUP_INTERVAL_MS` (>0) to have the server write a bundle on a
+  cadence (to `LIBRARIAN_BACKUP_DIR`, default `<data>/backups`). Trigger one anytime from the
+  dashboard's **Backups** page (admin).
+- **Cloud sync** (optional): configure S3-compatible storage (AWS / Cloudflare R2 / MinIO /
+  Backblaze) via the dashboard, or env: `LIBRARIAN_BACKUP_S3_BUCKET`, `…_ACCESS_KEY`,
+  `…_SECRET_KEY`, and optionally `…_REGION` / `…_ENDPOINT` / `…_PREFIX`. Each scheduled or
+  dashboard backup is then uploaded after it's written locally. (Requires `@aws-sdk/client-s3`
+  installed in the runtime; the credentials are encrypted at rest with `LIBRARIAN_SECRET_KEY`.)
+
+### Volume snapshot (alternative)
+
+A crash-consistent tarball of the three files (or use your platform's volume snapshots, e.g. Fly):
+
+```sh
 docker run --rm -v librarian_data:/data -v ~/librarian-backups:/backup busybox \
   tar -czf /backup/librarian-$(date +%Y-%m-%d).tar.gz \
-  /data/events.jsonl /data/sessions.jsonl /data/memories.md
+  /data/events.jsonl /data/session_events.jsonl /data/librarian.sqlite
 ```
 
-### Rebuild from JSONL after a SQLite wipe
+### Rebuild the memory projection after a SQLite wipe
 
-The SQLite file is a projection; deleting it is recoverable. The mcp-server rebuilds the projection automatically on startup if `librarian.sqlite` is missing. So the recovery sequence is:
-
-```sh
-docker compose --env-file .env -f docker/docker-compose.yml down
-docker run --rm -v librarian_data:/data busybox rm -f /data/librarian.sqlite
-docker compose --env-file .env -f docker/docker-compose.yml up -d
-```
-
-The next boot replays `events.jsonl` and `sessions.jsonl` into a fresh `librarian.sqlite`. Check the logs (`docker compose ... logs mcp-server`) for the projection-rebuild line.
+The memory side of `librarian.sqlite` is a projection of `events.jsonl`; **session state is not**
+(it lives only in SQLite post-R3). If only the memory projection is suspect, `the-librarian rebuild`
+replays the ledgers — but do not delete `librarian.sqlite` to "fix" sessions; restore it from a
+backup instead.
 
 ## Operations
 

--- a/README.md
+++ b/README.md
@@ -297,4 +297,6 @@ Restore: stop the server, copy the three files back, optionally `pnpm run rebuil
 `memories.md` + the memory projection), restart. Back up **daily** under active use and **before**
 risky operations (migrations, `purge_session`). `librarian.sqlite` is a SQLite DB — copy it stopped,
 or use SQLite's online-backup API for live snapshots; the JSONL ledgers are append-only and safe to
-`rsync` at any time. Built-in backup/restore tooling is on the [Roadmap](#roadmap).
+`rsync` at any time. Built-in `the-librarian backup` / `restore` / `export`, scheduled backups
+(`LIBRARIAN_BACKUP_INTERVAL_MS`), and optional S3-compatible cloud sync are available — see
+[DEPLOYMENT.md](./DEPLOYMENT.md#backups).

--- a/packages/core/src/backup/run.ts
+++ b/packages/core/src/backup/run.ts
@@ -1,0 +1,32 @@
+// Orchestrate a backup: create the local bundle, then (if cloud sync is
+// configured) upload it. Async, so it runs from the server scheduler + the admin
+// tRPC surface (not the synchronous CLI). Sync failures do not lose the local
+// backup — the bundle is already on disk before the upload is attempted.
+
+import type { LibrarianStore } from "../store/librarian-store.js";
+import { type BackupManifest, createBackup } from "./backup.js";
+import { syncBundle } from "./sync/bundle.js";
+import { resolveS3SyncConfig } from "./sync/config.js";
+import { createS3Target } from "./sync/s3.js";
+
+export interface RunBackupResult {
+  dir: string;
+  manifest: BackupManifest;
+  synced: boolean;
+  syncedKeys?: string[];
+}
+
+export async function runBackup(
+  store: LibrarianStore,
+  options: { destDir: string; sync?: boolean },
+): Promise<RunBackupResult> {
+  const { dir, manifest } = createBackup(store, { destDir: options.destDir });
+
+  if (options.sync === false) return { dir, manifest, synced: false };
+  const config = resolveS3SyncConfig(store);
+  if (!config) return { dir, manifest, synced: false };
+
+  const target = await createS3Target(config);
+  const syncedKeys = await syncBundle(target, dir);
+  return { dir, manifest, synced: true, syncedKeys };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -163,6 +163,7 @@ export { type MemoryBackupTarget, createMemoryBackupTarget } from "./backup/sync
 export { fetchBundle, syncBundle } from "./backup/sync/bundle.js";
 export { type S3SyncConfig, resolveS3SyncConfig } from "./backup/sync/config.js";
 export { createS3Target } from "./backup/sync/s3.js";
+export { type RunBackupResult, runBackup } from "./backup/run.js";
 export {
   type CompleteCurationRunInput,
   type CreateCurationRunInput,

--- a/packages/mcp-server/src/bin/http.ts
+++ b/packages/mcp-server/src/bin/http.ts
@@ -5,10 +5,12 @@
 // server from `../http/server.ts`. All env parsing + boot-time
 // validation lives here so the server module itself stays pure.
 
+import path from "node:path";
 import {
   createLibrarianStore,
   createSerialScheduler,
   resolveOptionalSecretKey,
+  runBackup,
   runCuratorTick,
 } from "@librarian/core";
 import { type AuthConfig, AgentTokensError, parseAgentTokenMap, parseCsv } from "../http/auth.js";
@@ -105,8 +107,22 @@ const curatorScheduler =
       })
     : null;
 
+// Scheduled backups (opt-in): set LIBRARIAN_BACKUP_INTERVAL_MS > 0 to enable. Each
+// tick writes a local bundle and, if cloud sync is configured, uploads it.
+const backupIntervalMs = Number(process.env.LIBRARIAN_BACKUP_INTERVAL_MS ?? 0);
+const backupDir = process.env.LIBRARIAN_BACKUP_DIR || path.join(store.dataDir, "backups");
+const backupScheduler =
+  backupIntervalMs > 0
+    ? createSerialScheduler({
+        task: () => runBackup(store, { destDir: backupDir }),
+        intervalMs: backupIntervalMs,
+        onError: (error) => logger.error({ err: error }, "scheduled backup failed"),
+      })
+    : null;
+
 server.listen(port, host, () => {
   curatorScheduler?.start();
+  backupScheduler?.start();
   logger.info(
     { host, port, mcp: `http://${host}:${port}/mcp`, trpc: `http://${host}:${port}/trpc` },
     "The Librarian MCP service is running",
@@ -115,6 +131,7 @@ server.listen(port, host, () => {
 
 function shutdown(): void {
   curatorScheduler?.stop();
+  backupScheduler?.stop();
   store.close();
   server.close(() => process.exit(0));
 }

--- a/packages/mcp-server/src/trpc/backup.ts
+++ b/packages/mcp-server/src/trpc/backup.ts
@@ -1,0 +1,76 @@
+// Backup admin tRPC procedures: trigger a backup now, list recent backups, and
+// read/update the cloud-sync config. All admin-gated. The config read never
+// returns the secret credentials — only whether they are set.
+
+import fs from "node:fs";
+import path from "node:path";
+import type { LibrarianStore } from "@librarian/core";
+import { runBackup } from "@librarian/core";
+import { z } from "zod";
+import { adminProcedure, router } from "./trpc.js";
+
+function backupDestDir(store: LibrarianStore): string {
+  return process.env.LIBRARIAN_BACKUP_DIR || path.join(store.dataDir, "backups");
+}
+
+const SetConfigSchema = z.strictObject({
+  bucket: z.string().optional(),
+  region: z.string().optional(),
+  endpoint: z.string().optional(),
+  prefix: z.string().optional(),
+  accessKey: z.string().optional(),
+  secretKey: z.string().optional(),
+});
+
+export const backupRouter = router({
+  createNow: adminProcedure.mutation(async ({ ctx }) => {
+    const result = await runBackup(ctx.store, { destDir: backupDestDir(ctx.store) });
+    return {
+      dir: result.dir,
+      files: result.manifest.files.length,
+      schema_version: result.manifest.schema_version,
+      synced: result.synced,
+    };
+  }),
+
+  list: adminProcedure.query(({ ctx }) => {
+    const dir = backupDestDir(ctx.store);
+    if (!fs.existsSync(dir)) return [];
+    return fs
+      .readdirSync(dir)
+      .filter((name) => name.startsWith("librarian-backup-"))
+      .map((name) => ({ name, created_at: fs.statSync(path.join(dir, name)).mtime.toISOString() }))
+      .sort((a, b) => b.created_at.localeCompare(a.created_at));
+  }),
+
+  // Non-secret view + whether credentials are configured (never the values).
+  config: adminProcedure.query(({ ctx }) => {
+    const settingKeys = new Set(ctx.store.listSettings().map((s) => s.key));
+    return {
+      bucket: ctx.store.getSetting("backup.s3.bucket") ?? "",
+      region: ctx.store.getSetting("backup.s3.region") ?? "",
+      endpoint: ctx.store.getSetting("backup.s3.endpoint") ?? "",
+      prefix: ctx.store.getSetting("backup.s3.prefix") ?? "",
+      hasAccessKey: settingKeys.has("backup.s3.access_key"),
+      hasSecretKey: settingKeys.has("backup.s3.secret_key"),
+    };
+  }),
+
+  setConfig: adminProcedure.input(SetConfigSchema).mutation(({ ctx, input }) => {
+    const plain: Record<string, string | undefined> = {
+      "backup.s3.bucket": input.bucket,
+      "backup.s3.region": input.region,
+      "backup.s3.endpoint": input.endpoint,
+      "backup.s3.prefix": input.prefix,
+    };
+    for (const [key, value] of Object.entries(plain)) {
+      if (value !== undefined) ctx.store.setSetting(key, value);
+    }
+    // Empty string leaves a secret unchanged (the form never round-trips it).
+    if (input.accessKey)
+      ctx.store.setSetting("backup.s3.access_key", input.accessKey, { secret: true });
+    if (input.secretKey)
+      ctx.store.setSetting("backup.s3.secret_key", input.secretKey, { secret: true });
+    return { ok: true };
+  }),
+});

--- a/packages/mcp-server/src/trpc/router.ts
+++ b/packages/mcp-server/src/trpc/router.ts
@@ -5,6 +5,7 @@
 // intentionally empty and get populated in T4.4 and T4.5. The
 // `AppRouter` type is the public contract the dashboard imports.
 
+import { backupRouter } from "./backup.js";
 import { curatorRouter } from "./curator.js";
 import { healthRouter } from "./health.js";
 import { memoriesRouter } from "./memories.js";
@@ -12,6 +13,7 @@ import { sessionsRouter } from "./sessions.js";
 import { router } from "./trpc.js";
 
 export const appRouter = router({
+  backup: backupRouter,
   curator: curatorRouter,
   health: healthRouter,
   memories: memoriesRouter,

--- a/packages/mcp-server/tests/trpc/backup.test.ts
+++ b/packages/mcp-server/tests/trpc/backup.test.ts
@@ -1,0 +1,94 @@
+// Backup admin tRPC tests — spawns the real HTTP bin and exercises admin gating,
+// createNow → list, and a plain config round-trip. (The secret-credential path is
+// covered by core's settings-store; it needs LIBRARIAN_SECRET_KEY in the server env.)
+
+import { describe, expect, it } from "vitest";
+import { cleanupTempDir, makeTempDir, startHttpServer } from "../../../../test/helpers.js";
+
+interface TrpcOk<T> {
+  result: { data: T };
+}
+interface TrpcErr {
+  error: unknown;
+}
+interface ServerHandle {
+  url: string;
+  token: string;
+  stop: () => Promise<void>;
+}
+
+async function trpcGet<T>(server: ServerHandle, p: string, input?: unknown): Promise<T> {
+  const url = new URL(`${server.url}/trpc/${p}`);
+  if (input !== undefined) url.searchParams.set("input", JSON.stringify(input));
+  const res = await fetch(url, { headers: { authorization: `Bearer ${server.token}` } });
+  const json = (await res.json()) as TrpcOk<T> | TrpcErr;
+  if (res.status >= 400 || "error" in json) throw new Error(`GET ${p}: ${JSON.stringify(json)}`);
+  return (json as TrpcOk<T>).result.data;
+}
+
+async function trpcPost<T>(server: ServerHandle, p: string, input?: unknown): Promise<T> {
+  const res = await fetch(`${server.url}/trpc/${p}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${server.token}` },
+    body: input === undefined ? undefined : JSON.stringify(input),
+  });
+  const json = (await res.json()) as TrpcOk<T> | TrpcErr;
+  if (res.status >= 400 || "error" in json) throw new Error(`POST ${p}: ${JSON.stringify(json)}`);
+  return (json as TrpcOk<T>).result.data;
+}
+
+describe("tRPC backup surface", () => {
+  it("requires admin auth", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const res = await fetch(`${server.url}/trpc/backup.list`); // no Authorization
+      expect(res.status).toBeGreaterThanOrEqual(400);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("createNow writes a bundle that then shows up in list", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const created = await trpcPost<{ files: number; synced: boolean }>(
+        server,
+        "backup.createNow",
+      );
+      expect(created.files).toBeGreaterThan(0);
+      expect(created.synced).toBe(false); // no cloud sync configured
+
+      const list = await trpcGet<{ name: string }[]>(server, "backup.list");
+      expect(list.length).toBe(1);
+      expect(list[0]?.name).toMatch(/^librarian-backup-/);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("round-trips a plain (non-secret) sync config", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const before = await trpcGet<{ bucket: string; hasSecretKey: boolean }>(
+        server,
+        "backup.config",
+      );
+      expect(before.bucket).toBe("");
+      expect(before.hasSecretKey).toBe(false);
+
+      await trpcPost(server, "backup.setConfig", { bucket: "my-bucket", region: "eu-west-1" });
+
+      const after = await trpcGet<{ bucket: string; region: string }>(server, "backup.config");
+      expect(after.bucket).toBe("my-bucket");
+      expect(after.region).toBe("eu-west-1");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+});


### PR DESCRIPTION
Backend half of B4 — the **async** surface for backups (the sync CLI can't do cloud sync).

- **core `runBackup`** — create the local bundle, then upload it if S3 sync is configured (a sync failure never loses the local backup — the bundle is on disk first).
- **tRPC `backup` admin router** — `createNow`, `list` (recent bundles), `config`/`setConfig` (S3 sync settings; `config` returns only *whether* credentials are set, never the values; secrets stored encrypted). Mounted in the app router.
- **scheduled backups** in `bin/http.ts` — opt-in via `LIBRARIAN_BACKUP_INTERVAL_MS`, reusing `createSerialScheduler` (same pattern as the curator tick); stopped on shutdown.
- **docs** — rewrote the stale DEPLOYMENT.md Backups section (sessions are SQLite-canonical now) with CLI/scheduled/cloud-sync/volume-snapshot/rebuild guidance; corrected the README backup line.

Test: admin-gating, `createNow`→`list`, plain config round-trip — end-to-end via the real server (exercises `runBackup`). 98 mcp-server tests green. The dashboard **/backups** page is B4b.