### PR TITLE
feat(dashboard): Backups cockpit page (B4b)

### DIFF
--- a/apps/dashboard/app/backups/actions.ts
+++ b/apps/dashboard/app/backups/actions.ts
@@ -1,0 +1,18 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { serverTRPC } from "@/lib/trpc-server";
+
+export type BackupNowResult =
+  | { ok: true; dir: string; files: number; synced: boolean }
+  | { ok: false; error: string };
+
+export async function backupNowAction(): Promise<BackupNowResult> {
+  try {
+    const r = await serverTRPC.backup.createNow.mutate();
+    revalidatePath("/backups");
+    return { ok: true, dir: r.dir, files: r.files, synced: r.synced };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}

--- a/apps/dashboard/app/backups/page.tsx
+++ b/apps/dashboard/app/backups/page.tsx
@@ -1,0 +1,52 @@
+// Backups cockpit — recent backups + a "Backup now" trigger + cloud-sync status.
+// The backend (tRPC backup router) handles the actual snapshot + optional upload.
+
+import { backupNowAction } from "./actions";
+import { BackupNowButton } from "@/components/backups/backup-now-button";
+import { serverTRPC } from "@/lib/trpc-server";
+
+export const dynamic = "force-dynamic";
+
+export default async function BackupsPage() {
+  let backups: Awaited<ReturnType<typeof serverTRPC.backup.list.query>> = [];
+  let config: Awaited<ReturnType<typeof serverTRPC.backup.config.query>> | null = null;
+  let error: string | null = null;
+  try {
+    [backups, config] = await Promise.all([
+      serverTRPC.backup.list.query(),
+      serverTRPC.backup.config.query(),
+    ]);
+  } catch (err) {
+    error = err instanceof Error ? err.message : String(err);
+  }
+
+  const syncOn = Boolean(config?.bucket && config.hasAccessKey && config.hasSecretKey);
+
+  return (
+    <main className="flex flex-col gap-6 p-6">
+      <header className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold tracking-tight">Backups</h1>
+        <BackupNowButton onRun={backupNowAction} />
+      </header>
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+      <p className="text-sm text-muted-foreground">
+        Cloud sync: {syncOn ? `enabled → ${config?.bucket}` : "not configured"}.
+      </p>
+      <section className="rounded-md border bg-card p-4" aria-label="Recent backups">
+        <h2 className="mb-3 font-semibold">Recent backups</h2>
+        {backups.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No backups yet.</p>
+        ) : (
+          <ul className="flex flex-col gap-1 text-sm">
+            {backups.map((b) => (
+              <li key={b.name} className="flex justify-between gap-4">
+                <span className="font-mono">{b.name}</span>
+                <span className="text-muted-foreground">{b.created_at}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/apps/dashboard/components/backups/backup-now-button.tsx
+++ b/apps/dashboard/components/backups/backup-now-button.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import type { BackupNowResult } from "@/app/backups/actions";
+
+export function BackupNowButton({ onRun }: { onRun: () => Promise<BackupNowResult> }) {
+  const [pending, startTransition] = useTransition();
+  const [message, setMessage] = useState<string | null>(null);
+  const router = useRouter();
+
+  const run = () =>
+    startTransition(async () => {
+      const res = await onRun();
+      if (res.ok) {
+        setMessage(`Backed up ${res.files} file(s)${res.synced ? " (synced to cloud)" : ""}.`);
+        router.refresh();
+      } else {
+        setMessage(`Error: ${res.error}`);
+      }
+    });
+
+  return (
+    <div className="flex items-center gap-3">
+      <button
+        type="button"
+        onClick={run}
+        disabled={pending}
+        className="rounded-md border bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground disabled:opacity-50"
+      >
+        {pending ? "Backing up…" : "Backup now"}
+      </button>
+      {message ? <span className="text-sm text-muted-foreground">{message}</span> : null}
+    </div>
+  );
+}

--- a/apps/dashboard/components/keyboard-host.tsx
+++ b/apps/dashboard/components/keyboard-host.tsx
@@ -21,6 +21,7 @@ const NAV_ITEMS = [
   { id: "nav-archive", label: "Go to Archive", href: "/archive", hint: "" },
   { id: "nav-logs", label: "Go to Logs", href: "/logs", hint: "" },
   { id: "nav-curator", label: "Go to Curator", href: "/curator", hint: "" },
+  { id: "nav-backups", label: "Go to Backups", href: "/backups", hint: "" },
 ];
 
 const SHORTCUTS: Array<{ keys: string; description: string }> = [

--- a/apps/dashboard/components/site-nav.tsx
+++ b/apps/dashboard/components/site-nav.tsx
@@ -17,6 +17,7 @@ const TABS = [
   { href: "/archive", label: "Archive", match: (p: string) => p === "/archive" },
   { href: "/logs", label: "Logs", match: (p: string) => p === "/logs" },
   { href: "/curator", label: "Curator", match: (p: string) => p.startsWith("/curator") },
+  { href: "/backups", label: "Backups", match: (p: string) => p.startsWith("/backups") },
 ] as const;
 
 // Routes that render their own full-screen chrome and should NOT show the nav:

--- a/apps/dashboard/tests/components/backup-now-button.test.tsx
+++ b/apps/dashboard/tests/components/backup-now-button.test.tsx
@@ -1,0 +1,30 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
+
+const { BackupNowButton } = await import("@/components/backups/backup-now-button");
+
+describe("BackupNowButton", () => {
+  it("reports success after a backup", async () => {
+    const onRun = vi.fn().mockResolvedValue({ ok: true, dir: "/d", files: 4, synced: false });
+    render(<BackupNowButton onRun={onRun} />);
+    fireEvent.click(screen.getByRole("button", { name: "Backup now" }));
+    await waitFor(() => expect(screen.getByText(/Backed up 4 file/)).toBeInTheDocument());
+    expect(onRun).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports the cloud-sync state when synced", async () => {
+    const onRun = vi.fn().mockResolvedValue({ ok: true, dir: "/d", files: 4, synced: true });
+    render(<BackupNowButton onRun={onRun} />);
+    fireEvent.click(screen.getByRole("button", { name: "Backup now" }));
+    await waitFor(() => expect(screen.getByText(/synced to cloud/)).toBeInTheDocument());
+  });
+
+  it("surfaces an error", async () => {
+    const onRun = vi.fn().mockResolvedValue({ ok: false, error: "boom" });
+    render(<BackupNowButton onRun={onRun} />);
+    fireEvent.click(screen.getByRole("button", { name: "Backup now" }));
+    await waitFor(() => expect(screen.getByText(/Error: boom/)).toBeInTheDocument());
+  });
+});

--- a/apps/dashboard/tests/components/site-nav.test.tsx
+++ b/apps/dashboard/tests/components/site-nav.test.tsx
@@ -20,6 +20,7 @@ const SECTIONS = [
   ["Archive", "/archive"],
   ["Logs", "/logs"],
   ["Curator", "/curator"],
+  ["Backups", "/backups"],
 ] as const;
 
 beforeEach(() => {


### PR DESCRIPTION
A `/backups` admin page: recent-backups list, a **Backup now** button (Server Action → `backup.createNow`), and cloud-sync status. Added **Backups** to the persistent nav + the command palette.

Test: `BackupNowButton` success / synced / error states; the nav test updated for the new link. 65 dashboard tests; `/backups` compiles in the Next build.

Completes **Phase 2 (persistence)**: core backup/restore/export (B1) → CLI (B2) → cloud sync (B3) → server + schedule (B4a) → dashboard (B4b).