### PR TITLE
feat(core): DB-stored hashed agent tokens (A3)

### DIFF
--- a/packages/core/src/auth/agent-tokens.ts
+++ b/packages/core/src/auth/agent-tokens.ts
@@ -12,9 +12,11 @@
 // NO schema bump and verification works without LIBRARIAN_SECRET_KEY.
 
 import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
+import { isReservedId } from "../caller-identity.js";
 
 const KEY_PREFIX = "agent_token:";
 const TOKEN_PREFIX = "lib";
+const MAX_AGENT_ID = 128;
 
 type SettingsLike = {
   setSetting: (key: string, value: string, options?: { secret?: boolean }) => void;
@@ -52,12 +54,20 @@ export function createAgentToken(
   store: SettingsLike,
   input: { agentId: string; label?: string },
 ): CreatedAgentToken {
+  // agentId becomes a live authorization principal (the returned identity), so
+  // validate it at mint: non-empty, bounded, and never a reserved system/dashboard
+  // /cli id that a minted token could otherwise impersonate.
+  const agentId = (input.agentId ?? "").trim();
+  if (!agentId) throw new Error("agentId is required");
+  if (agentId.length > MAX_AGENT_ID) throw new Error(`agentId is too long (max ${MAX_AGENT_ID})`);
+  if (isReservedId(agentId)) throw new Error(`agentId is reserved: ${agentId}`);
+
   const id = randomBytes(9).toString("base64url");
   const secret = randomBytes(24).toString("base64url");
   const salt = randomBytes(16).toString("hex");
   const record: TokenRecord = {
     id,
-    agentId: input.agentId,
+    agentId,
     label: input.label ?? "",
     salt,
     hash: hashSecret(salt, secret),
@@ -97,6 +107,9 @@ export function verifyAgentToken(
   if (parts.length !== 3 || parts[0] !== TOKEN_PREFIX) return null;
   const [, id, secret] = parts;
   const raw = store.getSetting(KEY_PREFIX + id);
+  // Early return on an unknown id is intentional and safe: the id is public (it
+  // travels in the token), and the secret is gated by the constant-time compare
+  // below — the only thing this "leaks" is id existence, which the holder knows.
   if (!raw) return null;
   let record: TokenRecord;
   try {

--- a/packages/core/src/auth/agent-tokens.ts
+++ b/packages/core/src/auth/agent-tokens.ts
@@ -1,0 +1,111 @@
+// DB-stored agent tokens (spec: single-owner-auth, A3).
+//
+// The owner mints agent tokens from the dashboard instead of hand-editing the
+// LIBRARIAN_AGENT_TOKENS env var. Tokens are high-entropy random values, so we
+// store a salted SHA-256 HASH (not reversible encryption) — even a settings dump
+// can't recover a token. The plaintext is returned exactly ONCE, at creation.
+//
+// Token shape: `lib.<id>.<secret>` (the id locates the record in O(1); base64url
+// never contains `.`, so the split is unambiguous). Verification recomputes the
+// hash for that id and compares timing-safe. Stored in the existing `settings`
+// table (key `agent_token:<id>`, plain — the value is already a hash), so there is
+// NO schema bump and verification works without LIBRARIAN_SECRET_KEY.
+
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
+
+const KEY_PREFIX = "agent_token:";
+const TOKEN_PREFIX = "lib";
+
+type SettingsLike = {
+  setSetting: (key: string, value: string, options?: { secret?: boolean }) => void;
+  getSetting: (key: string) => string | null;
+  deleteSetting?: (key: string) => void;
+  listSettings: () => { key: string }[];
+};
+
+interface TokenRecord {
+  id: string;
+  agentId: string;
+  label: string;
+  salt: string;
+  hash: string;
+  created_at: string;
+}
+
+export interface AgentTokenMeta {
+  id: string;
+  agentId: string;
+  label: string;
+  created_at: string;
+}
+
+export interface CreatedAgentToken {
+  id: string;
+  token: string;
+}
+
+function hashSecret(salt: string, secret: string): string {
+  return createHash("sha256").update(`${salt}:${secret}`).digest("hex");
+}
+
+export function createAgentToken(
+  store: SettingsLike,
+  input: { agentId: string; label?: string },
+): CreatedAgentToken {
+  const id = randomBytes(9).toString("base64url");
+  const secret = randomBytes(24).toString("base64url");
+  const salt = randomBytes(16).toString("hex");
+  const record: TokenRecord = {
+    id,
+    agentId: input.agentId,
+    label: input.label ?? "",
+    salt,
+    hash: hashSecret(salt, secret),
+    created_at: new Date().toISOString(),
+  };
+  store.setSetting(KEY_PREFIX + id, JSON.stringify(record));
+  return { id, token: `${TOKEN_PREFIX}.${id}.${secret}` };
+}
+
+export function listAgentTokens(store: SettingsLike): AgentTokenMeta[] {
+  const metas: AgentTokenMeta[] = [];
+  for (const { key } of store.listSettings()) {
+    if (!key.startsWith(KEY_PREFIX)) continue;
+    const raw = store.getSetting(key);
+    if (!raw) continue;
+    try {
+      const r = JSON.parse(raw) as TokenRecord;
+      metas.push({ id: r.id, agentId: r.agentId, label: r.label, created_at: r.created_at });
+    } catch {
+      // skip a malformed record rather than failing the whole list
+    }
+  }
+  return metas.sort((a, b) => a.created_at.localeCompare(b.created_at));
+}
+
+export function revokeAgentToken(store: SettingsLike, id: string): boolean {
+  if (!store.getSetting(KEY_PREFIX + id)) return false;
+  store.deleteSetting?.(KEY_PREFIX + id);
+  return true;
+}
+
+export function verifyAgentToken(
+  store: SettingsLike,
+  presented: string,
+): { agentId: string } | null {
+  const parts = presented.split(".");
+  if (parts.length !== 3 || parts[0] !== TOKEN_PREFIX) return null;
+  const [, id, secret] = parts;
+  const raw = store.getSetting(KEY_PREFIX + id);
+  if (!raw) return null;
+  let record: TokenRecord;
+  try {
+    record = JSON.parse(raw) as TokenRecord;
+  } catch {
+    return null;
+  }
+  const candidate = Buffer.from(hashSecret(record.salt, secret ?? ""), "hex");
+  const stored = Buffer.from(record.hash, "hex");
+  if (candidate.length !== stored.length || !timingSafeEqual(candidate, stored)) return null;
+  return { agentId: record.agentId };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -165,6 +165,14 @@ export { type S3SyncConfig, resolveS3SyncConfig } from "./backup/sync/config.js"
 export { createS3Target } from "./backup/sync/s3.js";
 export { type RunBackupResult, runBackup } from "./backup/run.js";
 export {
+  type AgentTokenMeta,
+  type CreatedAgentToken,
+  createAgentToken,
+  listAgentTokens,
+  revokeAgentToken,
+  verifyAgentToken,
+} from "./auth/agent-tokens.js";
+export {
   type CompleteCurationRunInput,
   type CreateCurationRunInput,
   type CurationOperation,

--- a/packages/core/tests/agent-tokens.test.ts
+++ b/packages/core/tests/agent-tokens.test.ts
@@ -27,6 +27,13 @@ describe("agent tokens", () => {
     expect(id.length).toBeGreaterThan(0);
   });
 
+  it("rejects an empty or reserved agentId at mint", () => {
+    const store = fakeSettings();
+    expect(() => createAgentToken(store, { agentId: "  " })).toThrow(/required/);
+    expect(() => createAgentToken(store, { agentId: "system-migration" })).toThrow(/reserved/);
+    expect(() => createAgentToken(store, { agentId: "x".repeat(200) })).toThrow(/too long/);
+  });
+
   it("rejects a wrong / malformed token", () => {
     const store = fakeSettings();
     createAgentToken(store, { agentId: "claude" });

--- a/packages/core/tests/agent-tokens.test.ts
+++ b/packages/core/tests/agent-tokens.test.ts
@@ -1,0 +1,69 @@
+import {
+  createAgentToken,
+  listAgentTokens,
+  revokeAgentToken,
+  verifyAgentToken,
+} from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+// A minimal in-memory settings store (the real one is SQLite-backed; agent tokens
+// are plain settings — a hash, not a secret — so no master key is involved).
+function fakeSettings() {
+  const map = new Map<string, string>();
+  return {
+    setSetting: (key: string, value: string) => map.set(key, value),
+    getSetting: (key: string) => map.get(key) ?? null,
+    deleteSetting: (key: string) => map.delete(key),
+    listSettings: () => [...map.keys()].map((key) => ({ key })),
+  };
+}
+
+describe("agent tokens", () => {
+  it("creates a token that verifies once and returns its agent id", () => {
+    const store = fakeSettings();
+    const { id, token } = createAgentToken(store, { agentId: "claude", label: "laptop" });
+    expect(token.startsWith("lib.")).toBe(true);
+    expect(verifyAgentToken(store, token)).toEqual({ agentId: "claude" });
+    expect(id.length).toBeGreaterThan(0);
+  });
+
+  it("rejects a wrong / malformed token", () => {
+    const store = fakeSettings();
+    createAgentToken(store, { agentId: "claude" });
+    expect(verifyAgentToken(store, "lib.nope.nope")).toBeNull();
+    expect(verifyAgentToken(store, "not-a-token")).toBeNull();
+    expect(verifyAgentToken(store, "")).toBeNull();
+  });
+
+  it("verifies fail after revoke", () => {
+    const store = fakeSettings();
+    const { id, token } = createAgentToken(store, { agentId: "claude" });
+    expect(revokeAgentToken(store, id)).toBe(true);
+    expect(verifyAgentToken(store, token)).toBeNull();
+    expect(revokeAgentToken(store, id)).toBe(false); // already gone
+  });
+
+  it("list returns metadata only — never the secret, hash, or salt", () => {
+    const store = fakeSettings();
+    createAgentToken(store, { agentId: "claude", label: "a" });
+    const metas = listAgentTokens(store);
+    expect(metas).toHaveLength(1);
+    expect(metas[0]).toMatchObject({ agentId: "claude", label: "a" });
+    const serialized = JSON.stringify(metas);
+    expect(serialized).not.toContain("salt");
+    expect(serialized).not.toContain("hash");
+  });
+
+  it("two tokens for the same agent both verify to that agent", () => {
+    const store = fakeSettings();
+    const a = createAgentToken(store, { agentId: "claude" });
+    const b = createAgentToken(store, { agentId: "claude" });
+    expect(a.token).not.toBe(b.token);
+    expect(verifyAgentToken(store, a.token)).toEqual({ agentId: "claude" });
+    expect(verifyAgentToken(store, b.token)).toEqual({ agentId: "claude" });
+    // revoking one leaves the other working
+    revokeAgentToken(store, a.id);
+    expect(verifyAgentToken(store, a.token)).toBeNull();
+    expect(verifyAgentToken(store, b.token)).toEqual({ agentId: "claude" });
+  });
+});


### PR DESCRIPTION
Foundation for dashboard-managed agent tokens (Phase 3 / single-owner-auth) — no more hand-editing `LIBRARIAN_AGENT_TOKENS`.

`createAgentToken` / `listAgentTokens` / `revokeAgentToken` / `verifyAgentToken` over the existing `settings` table (`agent_token:<id>`) — **no schema bump**.

- Token shape `lib.<id>.<secret>` — the id locates the record in O(1) (base64url never contains `.`). The stored value is a **salted SHA-256 hash** (not reversible) — a settings dump can't recover a token; plaintext is returned **once** at creation.
- Stored as a *plain* setting (it's a hash), so verification works **without** `LIBRARIAN_SECRET_KEY` (that key is only for the curator/S3 reversible secrets).
- `verifyAgentToken` is timing-safe; `listAgentTokens` returns metadata only (no salt/hash/secret).

Test: create→verify-once; wrong/malformed→null; revoke→null; list leaks no secret/hash/salt; two tokens per agent both verify + revoke independently. Wired into `authenticateMcp` in A4.