### PR TITLE
feat(auth): accept dashboard-minted DB agent tokens on /mcp + tRPC (A4)

### DIFF
--- a/packages/mcp-server/src/bin/http.ts
+++ b/packages/mcp-server/src/bin/http.ts
@@ -12,6 +12,7 @@ import {
   resolveOptionalSecretKey,
   runBackup,
   runCuratorTick,
+  verifyAgentToken,
 } from "@librarian/core";
 import { type AuthConfig, AgentTokensError, parseAgentTokenMap, parseCsv } from "../http/auth.js";
 import { createHttpServer } from "../http/server.js";
@@ -88,6 +89,15 @@ const auth: AuthConfig = {
   allowedOrigins,
   host,
   port,
+  // Dashboard-minted agent tokens (A3/A4). Wrapped so a store hiccup is a clean
+  // auth miss, never a 500 on the hot auth path.
+  verifyDbToken: (token) => {
+    try {
+      return verifyAgentToken(store, token);
+    } catch {
+      return null;
+    }
+  },
 };
 
 const server = createHttpServer({ store, auth, maxBodyBytes });

--- a/packages/mcp-server/src/http/auth.ts
+++ b/packages/mcp-server/src/http/auth.ts
@@ -39,6 +39,8 @@ export function authenticateMcp(req: IncomingMessage, config: AuthConfig): AuthR
   if (timingSafeEqual(token, config.adminToken)) return { role: "admin" };
   // DB-minted agent tokens, last and always agent-role (never admin). A null from
   // the verifier is indistinguishable from any other miss → one generic failure.
+  // The agentId-less branch only exists because AuthConfig permits an agentId-less
+  // match; the real injected verifier (verifyAgentToken) always carries an agentId.
   if (config.verifyDbToken) {
     const db = config.verifyDbToken(token);
     if (db) return db.agentId ? { role: "agent", agentId: db.agentId } : { role: "agent" };

--- a/packages/mcp-server/src/http/auth.ts
+++ b/packages/mcp-server/src/http/auth.ts
@@ -14,6 +14,12 @@ export interface AuthConfig {
   allowedOrigins: string[];
   host: string;
   port: number;
+  /**
+   * Optional DB-backed token verifier (dashboard-minted agent tokens). Checked
+   * AFTER the env tokens (backward compatible). Returns the agent id on a match,
+   * else null. Always resolves to the `agent` role — DB tokens can't be admin.
+   */
+  verifyDbToken?: (token: string) => { agentId?: string } | null;
 }
 
 export interface AuthResult {
@@ -31,6 +37,12 @@ export function authenticateMcp(req: IncomingMessage, config: AuthConfig): AuthR
   }
   if (config.agentToken && timingSafeEqual(token, config.agentToken)) return { role: "agent" };
   if (timingSafeEqual(token, config.adminToken)) return { role: "admin" };
+  // DB-minted agent tokens, last and always agent-role (never admin). A null from
+  // the verifier is indistinguishable from any other miss → one generic failure.
+  if (config.verifyDbToken) {
+    const db = config.verifyDbToken(token);
+    if (db) return db.agentId ? { role: "agent", agentId: db.agentId } : { role: "agent" };
+  }
   return null;
 }
 

--- a/packages/mcp-server/tests/http/db-tokens.test.ts
+++ b/packages/mcp-server/tests/http/db-tokens.test.ts
@@ -72,11 +72,12 @@ describe("DB tokens end-to-end", () => {
       expect((await mcp(dead.token)).status).toBe(401); // revoked → rejected
       expect((await mcp("lib.bogus.bogus")).status).toBe(401); // unknown → rejected
 
-      // The DB token is agent-role, so the admin tRPC surface rejects it.
+      // The DB token is agent-role, so the admin tRPC surface rejects it with a
+      // precise UNAUTHORIZED (401) — not just any error.
       const adminRes = await fetch(`${server.url}/trpc/curator.config`, {
         headers: { authorization: `Bearer ${live.token}` },
       });
-      expect(adminRes.status).toBeGreaterThanOrEqual(400);
+      expect(adminRes.status).toBe(401);
     } finally {
       await server.stop();
       cleanupTempDir(dataDir);

--- a/packages/mcp-server/tests/http/db-tokens.test.ts
+++ b/packages/mcp-server/tests/http/db-tokens.test.ts
@@ -7,7 +7,10 @@ import type { IncomingMessage } from "node:http";
 import { createAgentToken, createLibrarianStore, revokeAgentToken } from "@librarian/core";
 import { describe, expect, it } from "vitest";
 import { cleanupTempDir, makeTempDir, startHttpServer } from "../../../../test/helpers.js";
-import { type AuthConfig, authenticateMcp } from "../../src/http/auth.js";
+// Import the compiled auth seam: this package's vitest config externalizes
+// packages/mcp-server/{src,dist} to Node's own loader (so node:sqlite resolves),
+// which can't parse .ts — so tests exercise the built artifact, same as the bin.
+import { type AuthConfig, authenticateMcp } from "../../dist/http/auth.js";
 
 function reqWith(token: string): IncomingMessage {
   return { headers: { authorization: `Bearer ${token}` } } as unknown as IncomingMessage;

--- a/packages/mcp-server/tests/http/db-tokens.test.ts
+++ b/packages/mcp-server/tests/http/db-tokens.test.ts
@@ -1,0 +1,85 @@
+// A4: authenticateMcp accepts dashboard-minted DB tokens (after env tokens), as
+// agent-role only. Unit-tests the seam precedence + an end-to-end check that a
+// token minted into the data dir authenticates on /mcp, is revocable, and cannot
+// reach the admin tRPC surface.
+
+import type { IncomingMessage } from "node:http";
+import { createAgentToken, createLibrarianStore, revokeAgentToken } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+import { cleanupTempDir, makeTempDir, startHttpServer } from "../../../../test/helpers.js";
+import { type AuthConfig, authenticateMcp } from "../../src/http/auth.js";
+
+function reqWith(token: string): IncomingMessage {
+  return { headers: { authorization: `Bearer ${token}` } } as unknown as IncomingMessage;
+}
+
+const baseConfig: AuthConfig = {
+  adminToken: "admin",
+  agentToken: "env-agent",
+  agentTokenMap: new Map(),
+  allowedOrigins: [],
+  host: "127.0.0.1",
+  port: 3838,
+};
+
+describe("authenticateMcp — verifyDbToken seam", () => {
+  it("authenticates a DB token as agent (with its agentId)", () => {
+    const config = {
+      ...baseConfig,
+      verifyDbToken: (t: string) => (t === "db-tok" ? { agentId: "claude" } : null),
+    };
+    expect(authenticateMcp(reqWith("db-tok"), config)).toEqual({
+      role: "agent",
+      agentId: "claude",
+    });
+  });
+
+  it("prefers env tokens over the DB verifier, and never returns admin for a DB token", () => {
+    const verifyDbToken = (t: string) =>
+      t === "admin" || t === "env-agent" ? { agentId: "evil" } : null;
+    const config = { ...baseConfig, verifyDbToken };
+    // env admin/agent win (the DB verifier is not consulted for them)
+    expect(authenticateMcp(reqWith("admin"), config)).toEqual({ role: "admin" });
+    expect(authenticateMcp(reqWith("env-agent"), config)).toEqual({ role: "agent" });
+  });
+
+  it("returns null when neither env nor DB matches", () => {
+    const config = { ...baseConfig, verifyDbToken: () => null };
+    expect(authenticateMcp(reqWith("nope"), config)).toBeNull();
+  });
+});
+
+describe("DB tokens end-to-end", () => {
+  it("authenticate on /mcp, are revocable, and cannot reach admin tRPC", async () => {
+    const dataDir = makeTempDir();
+    // Mint two tokens into the data dir, then revoke one — all before the server boots.
+    const seed = createLibrarianStore({ dataDir });
+    const live = createAgentToken(seed, { agentId: "claude" });
+    const dead = createAgentToken(seed, { agentId: "claude" });
+    revokeAgentToken(seed, dead.id);
+    seed.close();
+
+    const server = await startHttpServer({ dataDir });
+    const mcp = (token: string) =>
+      fetch(`${server.url}/mcp`, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+      });
+    try {
+      expect((await mcp(live.token)).status).toBe(200); // minted token works
+      expect((await mcp(server.agentToken)).status).toBe(200); // env token still works
+      expect((await mcp(dead.token)).status).toBe(401); // revoked → rejected
+      expect((await mcp("lib.bogus.bogus")).status).toBe(401); // unknown → rejected
+
+      // The DB token is agent-role, so the admin tRPC surface rejects it.
+      const adminRes = await fetch(`${server.url}/trpc/curator.config`, {
+        headers: { authorization: `Bearer ${live.token}` },
+      });
+      expect(adminRes.status).toBeGreaterThanOrEqual(400);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+});


### PR DESCRIPTION
## What

Task **A4** of `docs/specs/single-owner-auth.md`: the MCP auth seam now accepts dashboard-minted DB agent tokens (created via `packages/core/src/auth/agent-tokens.ts`, A3 — salted SHA-256 hashes in the `settings` table), in addition to the existing env tokens.

## How

- `AuthConfig` gains an optional `verifyDbToken?: (token) => { agentId? } | null` seam, checked **after** the env tokens (`LIBRARIAN_AGENT_TOKEN`/`LIBRARIAN_AGENT_TOKENS`) so existing deployments are bit-for-bit unaffected.
- A DB-minted token **always** resolves to `role:"agent"` — it can never reach the admin tRPC surface (admin role is unreachable from this path by construction).
- `bin/http.ts` injects the verifier as a `try/catch` wrapper around `verifyAgentToken(store, …)`, so a store hiccup is a clean auth miss rather than a 500 on the hot path.
- Because the tRPC context shares the same `AuthConfig`, DB tokens authenticate on both `/mcp` **and** `/trpc`, and add/revoke take effect with **no server restart**.

## Tests

New `packages/mcp-server/tests/http/db-tokens.test.ts`:
- **Unit (seam precedence):** DB token → agent with its id; env tokens win over the DB verifier; a DB token never yields admin; null verifier → null.
- **End-to-end:** a token minted into the data dir authenticates on `/mcp` (200); the env agent token still works; a revoked token → 401; an unknown token → 401; the agent token is rejected on admin tRPC (`curator.config`) with a precise **401**.

Full monorepo suite + build green locally. Reviewed by the code-reviewer sub-agent (verdict: APPROVE, 0 Critical / 0 Important).

🤖 Generated with [Claude Code](https://claude.com/claude-code)