### PR TITLE
feat(dashboard): wire Auth.js v5 owner login, not yet enforced (A1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,30 @@ LIBRARIAN_AGENT_TOKENS=
 # changing it makes previously-encrypted settings unreadable.
 LIBRARIAN_SECRET_KEY=
 
+# ----- Optional: dashboard owner login (Auth.js) -----
+# Wired but OFF until LIBRARIAN_AUTH_ENABLED=true (enforcement lands in a later
+# slice). When enabled, the dashboard requires the single owner to sign in via
+# GitHub/Google. JWT sessions — the dashboard never opens the store.
+#
+# AUTH_SECRET signs the session JWT — generate with `openssl rand -base64 33`.
+# AUTH_URL is the dashboard's public origin (used to build OAuth callback URLs);
+# the OAuth app's callback is <AUTH_URL>/api/auth/callback/{github,google}.
+# Provider credentials come from each provider's developer console.
+LIBRARIAN_AUTH_ENABLED=false
+AUTH_SECRET=
+AUTH_URL=https://librarian.example.com
+AUTH_GITHUB_ID=
+AUTH_GITHUB_SECRET=
+AUTH_GOOGLE_ID=
+AUTH_GOOGLE_SECRET=
+# Single-owner allowlist — set at least one. Account ids are more robust than
+# email (email can change / be unverified). GitHub id: the numeric id from
+# https://api.github.com/users/<username>. Google id: the OIDC `sub`.
+# LIBRARIAN_OWNER_EMAILS is a comma-separated, case-insensitive fallback.
+LIBRARIAN_OWNER_GITHUB_ID=
+LIBRARIAN_OWNER_GOOGLE_ID=
+LIBRARIAN_OWNER_EMAILS=
+
 # ----- Optional: published host bindings -----
 # By default both services bind to 127.0.0.1 on the host so they only
 # accept local connections. Set these to a Tailnet IP (e.g. 100.x.y.z)

--- a/.env.example
+++ b/.env.example
@@ -44,10 +44,12 @@ AUTH_GITHUB_ID=
 AUTH_GITHUB_SECRET=
 AUTH_GOOGLE_ID=
 AUTH_GOOGLE_SECRET=
-# Single-owner allowlist — set at least one. Account ids are more robust than
-# email (email can change / be unverified). GitHub id: the numeric id from
-# https://api.github.com/users/<username>. Google id: the OIDC `sub`.
-# LIBRARIAN_OWNER_EMAILS is a comma-separated, case-insensitive fallback.
+# Single-owner allowlist — set at least one. Account ids are the robust choice.
+# GitHub id: the numeric id from https://api.github.com/users/<username>.
+# Google id: the OIDC `sub`. LIBRARIAN_OWNER_EMAILS is a comma-separated,
+# case-insensitive fallback that is ONLY honored for a provider-verified email
+# (Google) — GitHub does not assert email verification, so GitHub owners must
+# allowlist by account id, not email.
 LIBRARIAN_OWNER_GITHUB_ID=
 LIBRARIAN_OWNER_GOOGLE_ID=
 LIBRARIAN_OWNER_EMAILS=

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -143,6 +143,34 @@ LIBRARIAN_ALLOWED_ORIGINS=https://librarian.example.com
 docker compose --env-file .env -f docker/docker-compose.yml up -d
 ```
 
+## Dashboard login (single-owner)
+
+The dashboard can require the owner to sign in via GitHub or Google instead of
+relying on a VPN/private network. It is **wired but off by default** — set
+`LIBRARIAN_AUTH_ENABLED=true` to enforce it (enforcement and the token-management
+UI land in later slices; until then this only adds a `/login` page and the
+`/api/auth/*` endpoints, which change nothing while the flag is off).
+
+Sessions are **JWT** (no DB session store — the dashboard never opens the data
+store). Configure in `.env`:
+
+```sh
+LIBRARIAN_AUTH_ENABLED=true
+AUTH_SECRET=$(openssl rand -base64 33)      # signs the session JWT
+AUTH_URL=https://librarian.example.com       # dashboard's public origin
+AUTH_GITHUB_ID=…  AUTH_GITHUB_SECRET=…       # GitHub OAuth app
+AUTH_GOOGLE_ID=…  AUTH_GOOGLE_SECRET=…       # (optional) Google OAuth client
+# Allowlist the single owner — set at least one:
+LIBRARIAN_OWNER_GITHUB_ID=1234567            # numeric id from api.github.com/users/<you>
+LIBRARIAN_OWNER_GOOGLE_ID=…                  # the OIDC `sub`
+LIBRARIAN_OWNER_EMAILS=you@example.com       # comma-separated, case-insensitive fallback
+```
+
+Register the OAuth app's callback URL as `<AUTH_URL>/api/auth/callback/github`
+(and `…/google`). With no owner configured the allowlist **denies every login**
+by design, so set an owner id before enabling the flag — otherwise you lock
+yourself out.
+
 ## Backups
 
 **Back up all three load-bearing files**: `events.jsonl` (memory canonical),

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -163,13 +163,23 @@ AUTH_GOOGLE_ID=…  AUTH_GOOGLE_SECRET=…       # (optional) Google OAuth clien
 # Allowlist the single owner — set at least one:
 LIBRARIAN_OWNER_GITHUB_ID=1234567            # numeric id from api.github.com/users/<you>
 LIBRARIAN_OWNER_GOOGLE_ID=…                  # the OIDC `sub`
-LIBRARIAN_OWNER_EMAILS=you@example.com       # comma-separated, case-insensitive fallback
+LIBRARIAN_OWNER_EMAILS=you@example.com       # comma-separated; verified emails only (see below)
 ```
 
 Register the OAuth app's callback URL as `<AUTH_URL>/api/auth/callback/github`
 (and `…/google`). With no owner configured the allowlist **denies every login**
 by design, so set an owner id before enabling the flag — otherwise you lock
 yourself out.
+
+> **Allowlist by account id, not email, on GitHub.** The email fallback is only
+> honored for a provider-**verified** email. Google asserts verification, but
+> GitHub does not — an OAuth profile email there is attacker-settable — so
+> `LIBRARIAN_OWNER_EMAILS` is ignored for GitHub logins. Use
+> `LIBRARIAN_OWNER_GITHUB_ID` for GitHub.
+
+`trustHost: true` is set because the dashboard runs behind a proxy (Fly/Docker),
+so it trusts the forwarded `Host` header — the proxy must be the only ingress.
+`AUTH_URL` is set explicitly, which pins the OAuth callback origin regardless.
 
 ## Backups
 

--- a/apps/dashboard/app/api/auth/[...nextauth]/route.ts
+++ b/apps/dashboard/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,5 @@
+// Auth.js v5 route handler — re-exports the NextAuth GET/POST handlers for the
+// /api/auth/* endpoints (sign-in, callback, csrf, session, sign-out).
+import { handlers } from "@/auth";
+
+export const { GET, POST } = handlers;

--- a/apps/dashboard/app/login/page.tsx
+++ b/apps/dashboard/app/login/page.tsx
@@ -1,0 +1,50 @@
+// A1: owner sign-in page. Chrome-free (SiteNav skips /login). Two server-action
+// forms, one per provider, calling Auth.js `signIn`. The single-owner allowlist
+// runs in the signIn callback (auth.ts) — a non-owner who completes the OAuth
+// dance is bounced back here with ?error=AccessDenied.
+import { signIn } from "@/auth";
+import { Button } from "@/components/ui-v2/button";
+
+export const metadata = { title: "Sign in · Librarian" };
+
+async function signInWith(provider: "github" | "google"): Promise<void> {
+  "use server";
+  await signIn(provider, { redirectTo: "/" });
+}
+
+export default async function LoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string }>;
+}) {
+  const { error } = await searchParams;
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-8 p-6">
+      <div className="flex flex-col items-center gap-2 text-center">
+        <h1 className="font-display text-2xl text-foreground">The Librarian</h1>
+        <p className="text-sm text-foreground/60">Sign in to the owner dashboard.</p>
+      </div>
+
+      {error ? (
+        <p className="text-sm text-ink-accent" role="alert">
+          {error === "AccessDenied"
+            ? "That account is not the configured owner."
+            : "Sign-in failed. Please try again."}
+        </p>
+      ) : null}
+
+      <div className="flex w-full max-w-xs flex-col gap-3">
+        <form action={signInWith.bind(null, "github")}>
+          <Button type="submit" variant="primary" className="w-full justify-center">
+            Continue with GitHub
+          </Button>
+        </form>
+        <form action={signInWith.bind(null, "google")}>
+          <Button type="submit" variant="outline" className="w-full justify-center">
+            Continue with Google
+          </Button>
+        </form>
+      </div>
+    </main>
+  );
+}

--- a/apps/dashboard/auth.ts
+++ b/apps/dashboard/auth.ts
@@ -23,13 +23,22 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   pages: { signIn: "/login" },
   callbacks: {
     // Single-owner gate: only the allowlisted account may complete sign-in.
-    // Deny-by-default lives in isAllowedOwner (no owner configured → no login).
+    // Deny-by-default lives in isAllowedOwner (no owner configured → no login);
+    // the try/catch makes the boundary itself fail-closed so any unexpected
+    // throw denies rather than surfacing as an error the user could retry past.
     signIn({ account, profile }) {
-      return isAllowedOwner({
-        provider: account?.provider ?? null,
-        accountId: account?.providerAccountId ?? null,
-        email: profile?.email ?? null,
-      });
+      try {
+        return isAllowedOwner({
+          provider: account?.provider ?? null,
+          accountId: account?.providerAccountId ?? null,
+          email: profile?.email ?? null,
+          // GitHub profiles carry no email_verified, so it reads as unverified
+          // here — GitHub owners must allowlist by account id, not email.
+          emailVerified: profile?.email_verified === true,
+        });
+      } catch {
+        return false;
+      }
     },
   },
 });

--- a/apps/dashboard/auth.ts
+++ b/apps/dashboard/auth.ts
@@ -1,0 +1,35 @@
+// A1: dashboard owner login (Auth.js v5 / next-auth@5 beta) on Next 15 app-router.
+//
+// Wired but NOT enforced in this slice — there is no middleware yet (A2), so
+// creating this file changes nothing for existing deploys until LIBRARIAN_AUTH_ENABLED
+// flips on. JWT sessions keep the dashboard's "never opens the store" invariant:
+// the only persistent state is the owner allowlist, which lives in env.
+//
+// Provider credentials are inferred from env by Auth.js v5: AUTH_GITHUB_ID/SECRET,
+// AUTH_GOOGLE_ID/SECRET, plus AUTH_SECRET for JWT signing. The owner allowlist
+// (LIBRARIAN_OWNER_*) is enforced in the signIn callback via isAllowedOwner.
+
+import NextAuth from "next-auth";
+import GitHub from "next-auth/providers/github";
+import Google from "next-auth/providers/google";
+import { isAllowedOwner } from "@/lib/owner-allowlist";
+
+export const { handlers, auth, signIn, signOut } = NextAuth({
+  providers: [GitHub, Google],
+  session: { strategy: "jwt" },
+  // The dashboard runs behind a proxy (Fly/Docker), not on Vercel, so the host
+  // can't be auto-trusted — opt in explicitly.
+  trustHost: true,
+  pages: { signIn: "/login" },
+  callbacks: {
+    // Single-owner gate: only the allowlisted account may complete sign-in.
+    // Deny-by-default lives in isAllowedOwner (no owner configured → no login).
+    signIn({ account, profile }) {
+      return isAllowedOwner({
+        provider: account?.provider ?? null,
+        accountId: account?.providerAccountId ?? null,
+        email: profile?.email ?? null,
+      });
+    },
+  },
+});

--- a/apps/dashboard/lib/owner-allowlist.ts
+++ b/apps/dashboard/lib/owner-allowlist.ts
@@ -1,0 +1,62 @@
+// A1: single-owner allowlist for dashboard login.
+//
+// The Auth.js `signIn` callback delegates the allow/deny decision here so it can
+// be unit-tested without standing up NextAuth. The rule is deliberately strict:
+// permit a login ONLY when the OAuth account matches a configured owner identity,
+// and DENY BY DEFAULT when nothing is configured — a misconfigured deploy must
+// never accidentally let an arbitrary account in.
+//
+// Match precedence (any one is sufficient): GitHub account id, Google account id
+// (the OIDC `sub`), or an allowlisted email from any provider. Account ids are
+// preferred over email (emails can change / be unverified); email is the
+// documented fallback.
+
+export interface OwnerSignInInput {
+  /** The OAuth provider that authenticated the user ("github" | "google"). */
+  provider?: string | null;
+  /** The provider account id — GitHub's numeric id or Google's `sub`. */
+  accountId?: string | null;
+  /** The profile email, if the provider supplied one. */
+  email?: string | null;
+}
+
+export interface OwnerAllowlistEnv {
+  LIBRARIAN_OWNER_GITHUB_ID?: string;
+  LIBRARIAN_OWNER_GOOGLE_ID?: string;
+  /** Comma-separated email allowlist (matched case-insensitively). */
+  LIBRARIAN_OWNER_EMAILS?: string;
+}
+
+function clean(value: string | null | undefined): string {
+  return (value ?? "").trim();
+}
+
+function emailAllowlist(raw: string | undefined): string[] {
+  return clean(raw)
+    .toLowerCase()
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+export function isAllowedOwner(
+  input: OwnerSignInInput,
+  env: OwnerAllowlistEnv = process.env as OwnerAllowlistEnv,
+): boolean {
+  const githubId = clean(env.LIBRARIAN_OWNER_GITHUB_ID);
+  const googleId = clean(env.LIBRARIAN_OWNER_GOOGLE_ID);
+  const emails = emailAllowlist(env.LIBRARIAN_OWNER_EMAILS);
+
+  // Deny by default: with no owner configured, no one is the owner.
+  if (!githubId && !googleId && emails.length === 0) return false;
+
+  const provider = clean(input.provider);
+  const accountId = clean(input.accountId);
+  const email = clean(input.email).toLowerCase();
+
+  if (provider === "github" && githubId && accountId === githubId) return true;
+  if (provider === "google" && googleId && accountId === googleId) return true;
+  if (email && emails.includes(email)) return true;
+
+  return false;
+}

--- a/apps/dashboard/lib/owner-allowlist.ts
+++ b/apps/dashboard/lib/owner-allowlist.ts
@@ -18,6 +18,13 @@ export interface OwnerSignInInput {
   accountId?: string | null;
   /** The profile email, if the provider supplied one. */
   email?: string | null;
+  /**
+   * Whether the provider asserts the email is verified. The email branch only
+   * matches when this is true — an OAuth `email` claim is otherwise attacker-
+   * controlled (e.g. an arbitrary GitHub profile email), so trusting an
+   * unverified one would let anyone who knows the owner's address sign in.
+   */
+  emailVerified?: boolean;
 }
 
 export interface OwnerAllowlistEnv {
@@ -50,13 +57,14 @@ export function isAllowedOwner(
   // Deny by default: with no owner configured, no one is the owner.
   if (!githubId && !googleId && emails.length === 0) return false;
 
-  const provider = clean(input.provider);
+  const provider = clean(input.provider).toLowerCase();
   const accountId = clean(input.accountId);
   const email = clean(input.email).toLowerCase();
 
   if (provider === "github" && githubId && accountId === githubId) return true;
   if (provider === "google" && googleId && accountId === googleId) return true;
-  if (email && emails.includes(email)) return true;
+  // Email is a fallback and only honored when the provider verified it.
+  if (input.emailVerified && email && emails.includes(email)) return true;
 
   return false;
 }

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -25,6 +25,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.469.0",
     "next": "^15.1.4",
+    "next-auth": "5.0.0-beta.31",
     "next-themes": "^0.4.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/apps/dashboard/tests/owner-allowlist.test.ts
+++ b/apps/dashboard/tests/owner-allowlist.test.ts
@@ -42,11 +42,37 @@ describe("isAllowedOwner", () => {
     ).toBe(false);
   });
 
-  it("allows an allowlisted email, case-insensitively, from any provider", () => {
+  it("allows a VERIFIED allowlisted email, case-insensitively, from any provider", () => {
     expect(
       isAllowedOwner(
-        { provider: "google", accountId: "x", email: "Owner@Example.com" },
+        { provider: "google", accountId: "x", email: "Owner@Example.com", emailVerified: true },
         { LIBRARIAN_OWNER_EMAILS: "owner@example.com, other@example.com" },
+      ),
+    ).toBe(true);
+  });
+
+  it("denies an UNVERIFIED email even if it is on the allowlist (takeover guard)", () => {
+    // An attacker can set the owner's address as an unverified profile email.
+    expect(
+      isAllowedOwner(
+        { provider: "github", accountId: "999", email: "owner@example.com", emailVerified: false },
+        { LIBRARIAN_OWNER_EMAILS: "owner@example.com" },
+      ),
+    ).toBe(false);
+    // Absent verification flag is treated as unverified.
+    expect(
+      isAllowedOwner(
+        { provider: "github", accountId: "999", email: "owner@example.com" },
+        { LIBRARIAN_OWNER_EMAILS: "owner@example.com" },
+      ),
+    ).toBe(false);
+  });
+
+  it("matches the id branch regardless of provider-string casing", () => {
+    expect(
+      isAllowedOwner(
+        { provider: "GitHub", accountId: "12345" },
+        { LIBRARIAN_OWNER_GITHUB_ID: "12345" },
       ),
     ).toBe(true);
   });
@@ -57,12 +83,33 @@ describe("isAllowedOwner", () => {
     );
   });
 
+  it("treats empty / whitespace-only config as unconfigured (no empty-matches-empty hole)", () => {
+    // Empty config + empty input must NOT match.
+    expect(
+      isAllowedOwner({ provider: "github", accountId: "" }, { LIBRARIAN_OWNER_GITHUB_ID: "" }),
+    ).toBe(false);
+    // Whitespace-only id is not a valid owner.
+    expect(
+      isAllowedOwner({ provider: "github", accountId: "  " }, { LIBRARIAN_OWNER_GITHUB_ID: "  " }),
+    ).toBe(false);
+    // Whitespace-only email config + verified empty email must NOT match.
+    expect(
+      isAllowedOwner(
+        { provider: "google", email: "", emailVerified: true },
+        { LIBRARIAN_OWNER_EMAILS: "  ," },
+      ),
+    ).toBe(false);
+  });
+
   it("denies when the id/email is missing even though config exists", () => {
     expect(isAllowedOwner({ provider: "github" }, { LIBRARIAN_OWNER_GITHUB_ID: "12345" })).toBe(
       false,
     );
     expect(
-      isAllowedOwner({ provider: "google", email: null }, { LIBRARIAN_OWNER_EMAILS: "a@b.com" }),
+      isAllowedOwner(
+        { provider: "google", email: null, emailVerified: true },
+        { LIBRARIAN_OWNER_EMAILS: "a@b.com" },
+      ),
     ).toBe(false);
   });
 });

--- a/apps/dashboard/tests/owner-allowlist.test.ts
+++ b/apps/dashboard/tests/owner-allowlist.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { isAllowedOwner } from "@/lib/owner-allowlist";
+
+// A1: single-owner allowlist. The signIn callback delegates here; this is the
+// security gate, so the table below is the contract — deny by default, match by
+// provider account id, email as a documented fallback.
+describe("isAllowedOwner", () => {
+  it("allows the configured GitHub account id", () => {
+    expect(
+      isAllowedOwner(
+        { provider: "github", accountId: "12345", email: "owner@example.com" },
+        { LIBRARIAN_OWNER_GITHUB_ID: "12345" },
+      ),
+    ).toBe(true);
+  });
+
+  it("denies a different GitHub account id", () => {
+    expect(
+      isAllowedOwner(
+        { provider: "github", accountId: "99999" },
+        { LIBRARIAN_OWNER_GITHUB_ID: "12345" },
+      ),
+    ).toBe(false);
+  });
+
+  it("allows the configured Google account id (sub)", () => {
+    expect(
+      isAllowedOwner(
+        { provider: "google", accountId: "sub-abc" },
+        { LIBRARIAN_OWNER_GOOGLE_ID: "sub-abc" },
+      ),
+    ).toBe(true);
+  });
+
+  it("does not let a GitHub id satisfy the Google allowlist (provider-scoped)", () => {
+    // Same string, wrong provider — must not match.
+    expect(
+      isAllowedOwner(
+        { provider: "github", accountId: "shared" },
+        { LIBRARIAN_OWNER_GOOGLE_ID: "shared" },
+      ),
+    ).toBe(false);
+  });
+
+  it("allows an allowlisted email, case-insensitively, from any provider", () => {
+    expect(
+      isAllowedOwner(
+        { provider: "google", accountId: "x", email: "Owner@Example.com" },
+        { LIBRARIAN_OWNER_EMAILS: "owner@example.com, other@example.com" },
+      ),
+    ).toBe(true);
+  });
+
+  it("denies by default when nothing is configured", () => {
+    expect(isAllowedOwner({ provider: "github", accountId: "12345", email: "a@b.com" }, {})).toBe(
+      false,
+    );
+  });
+
+  it("denies when the id/email is missing even though config exists", () => {
+    expect(isAllowedOwner({ provider: "github" }, { LIBRARIAN_OWNER_GITHUB_ID: "12345" })).toBe(
+      false,
+    );
+    expect(
+      isAllowedOwner({ provider: "google", email: null }, { LIBRARIAN_OWNER_EMAILS: "a@b.com" }),
+    ).toBe(false);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       next:
         specifier: ^15.1.4
         version: 15.5.18(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next-auth:
+        specifier: 5.0.0-beta.31
+        version: 5.0.0-beta.31(next@15.5.18(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       next-themes:
         specifier: ^0.4.4
         version: 0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -243,6 +246,20 @@ packages:
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@auth/core@0.41.2':
+    resolution: {integrity: sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      nodemailer: ^7.0.7
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
+        optional: true
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -776,6 +793,9 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@panva/hkdf@1.2.1':
+    resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
@@ -2223,6 +2243,9 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
@@ -2475,6 +2498,22 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  next-auth@5.0.0-beta.31:
+    resolution: {integrity: sha512-1OBgCKPzo+S7UWWMp3xgvGvIJ0OpV7B3vR4ZDRqD9a4Ch+OT6dakLXG9ivhtmIWVa71nTSXattOHyCg8sNi8/Q==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      next: ^14.0.0-0 || ^15.0.0 || ^16.0.0
+      nodemailer: ^7.0.7
+      react: ^18.2.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
+        optional: true
+
   next-themes@0.4.6:
     resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
     peerDependencies:
@@ -2515,6 +2554,9 @@ packages:
 
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+
+  oauth4webapi@3.8.6:
+    resolution: {integrity: sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -2646,6 +2688,14 @@ packages:
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  preact-render-to-string@6.5.11:
+    resolution: {integrity: sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==}
+    peerDependencies:
+      preact: '>=10'
+
+  preact@10.24.3:
+    resolution: {integrity: sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -3261,6 +3311,14 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
 
+  '@auth/core@0.41.2':
+    dependencies:
+      '@panva/hkdf': 1.2.1
+      jose: 6.2.3
+      oauth4webapi: 3.8.6
+      preact: 10.24.3
+      preact-render-to-string: 6.5.11(preact@10.24.3)
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -3688,6 +3746,8 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@panva/hkdf@1.2.1': {}
 
   '@pinojs/redact@0.4.0': {}
 
@@ -5187,6 +5247,8 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  jose@6.2.3: {}
+
   joycon@3.1.1: {}
 
   js-tokens@4.0.0: {}
@@ -5397,6 +5459,12 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  next-auth@5.0.0-beta.31(next@15.5.18(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6):
+    dependencies:
+      '@auth/core': 0.41.2
+      next: 15.5.18(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
+
   next-themes@0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       react: 19.2.6
@@ -5442,6 +5510,8 @@ snapshots:
       validate-npm-package-license: 3.0.4
 
   nwsapi@2.2.23: {}
+
+  oauth4webapi@3.8.6: {}
 
   object-inspect@1.13.4: {}
 
@@ -5601,6 +5671,12 @@ snapshots:
       nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  preact-render-to-string@6.5.11(preact@10.24.3):
+    dependencies:
+      preact: 10.24.3
+
+  preact@10.24.3: {}
 
   prelude-ls@1.2.1: {}
 


### PR DESCRIPTION
## What

Task **A1** of `docs/specs/single-owner-auth.md` (Phase 3 of reduce-self-hosting-friction). Wires GitHub/Google owner login into the dashboard via `next-auth@5.0.0-beta.31`, **enforcing nothing yet** — there is no middleware in this slice (that's A2), so existing deploys are unaffected until `LIBRARIAN_AUTH_ENABLED` flips on later. Mergeable safely.

## How

- **`apps/dashboard/lib/owner-allowlist.ts`** — pure, unit-tested allow/deny decision. Matches by GitHub/Google **account id** (provider-scoped) or a **verified-email** fallback, and **denies by default** when no owner is configured.
- **`apps/dashboard/auth.ts`** — `NextAuth({...})` (GitHub + Google, **JWT** sessions so the dashboard still never opens the store, `trustHost: true` for the proxy). The `signIn` callback delegates to the allowlist and is **fail-closed** (try/catch → deny).
- **`app/api/auth/[...nextauth]/route.ts`** — the Auth.js GET/POST handlers.
- **`app/login/page.tsx`** — chrome-free sign-in page (server-action forms), surfacing `AccessDenied` for a non-owner.
- **`.env.example` + `DEPLOYMENT.md`** — document `AUTH_SECRET`/`AUTH_URL`, provider creds, the `LIBRARIAN_OWNER_*` allowlist, the lock-out risk, and the GitHub-email caveat.

## Security

This was reviewed by a sub-agent; the **Critical** finding (the email fallback originally accepted *any* OAuth email claim — an account-takeover vector once enforced) is fixed: the email branch now requires a **provider-verified** email. GitHub carries no `email_verified`, so GitHub owners must allowlist by account id. The `signIn` callback is fail-closed, and provider casing is normalized.

## Tests

`tests/owner-allowlist.test.ts` — 10 cases: allowed id, wrong id, provider-scoping, verified-email (case-insensitive), **unverified-email denied**, **empty/whitespace config = unconfigured**, provider-casing robustness, deny-by-default, missing id/email.

Dashboard `next build`, full monorepo suite, lint, format, typecheck all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)