### PR TITLE
feat(auth): token-management router + dashboard UI (A5)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -130,7 +130,9 @@ With:
 Authorization: Bearer <LIBRARIAN_AGENT_TOKEN>
 ```
 
-Use the shared `LIBRARIAN_AGENT_TOKEN` for ordinary agent requests, or a per-agent token from `LIBRARIAN_AGENT_TOKENS` to enforce one agent identity. Admin-only MCP tools (proposal approval, deletion, conflict resolution) require the admin token.
+**Preferred: mint per-agent tokens in the dashboard.** When auth is enabled, sign in and open **Tokens** (`/tokens`) to generate a token per agent and revoke them — these are stored (hashed) in the DB and take effect on `/mcp` immediately, with no restart. The plaintext is shown once; paste it into the client.
+
+The env tokens still work and are the fallback when you don't run the dashboard: the shared `LIBRARIAN_AGENT_TOKEN` for ordinary agent requests, or a per-agent map in `LIBRARIAN_AGENT_TOKENS` (`agent_id:token,…`) to pin an identity. `LIBRARIAN_AGENT_TOKENS` is now **optional/legacy** — prefer dashboard-minted tokens. Admin-only MCP tools (proposal approval, deletion) require the admin token.
 
 The HTTP endpoint supports JSON-RPC POST and batches. It is suitable for low-traffic agent use but is not a full Streamable HTTP MCP transport. Stdio MCP remains available locally via `pnpm start`.
 

--- a/apps/dashboard/app/tokens/actions.ts
+++ b/apps/dashboard/app/tokens/actions.ts
@@ -1,0 +1,40 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { serverTRPC } from "@/lib/trpc-server";
+
+// A5: agent-token management server actions. The owner mints/revokes DB tokens
+// from the dashboard; the plaintext token is returned to the client exactly once
+// (on create) and never stored client-side beyond the one-time reveal.
+
+export type CreateTokenResult =
+  | { ok: true; id: string; token: string }
+  | { ok: false; error: string };
+export type RevokeTokenResult = { ok: true } | { ok: false; error: string };
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function createTokenAction(input: {
+  agentId: string;
+  label?: string;
+}): Promise<CreateTokenResult> {
+  try {
+    const { id, token } = await serverTRPC.tokens.create.mutate(input);
+    revalidatePath("/tokens");
+    return { ok: true, id, token };
+  } catch (error) {
+    return { ok: false, error: message(error) };
+  }
+}
+
+export async function revokeTokenAction(id: string): Promise<RevokeTokenResult> {
+  try {
+    await serverTRPC.tokens.revoke.mutate({ id });
+    revalidatePath("/tokens");
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: message(error) };
+  }
+}

--- a/apps/dashboard/app/tokens/page.tsx
+++ b/apps/dashboard/app/tokens/page.tsx
@@ -1,0 +1,38 @@
+// A5: agent-token management cockpit. The owner mints/revokes DB-stored agent
+// tokens here instead of hand-editing LIBRARIAN_AGENT_TOKENS. Tokens authenticate
+// on /mcp immediately (no restart); the plaintext is shown once on creation.
+
+import { createTokenAction, revokeTokenAction } from "./actions";
+import { GenerateTokenForm } from "@/components/tokens/generate-form";
+import { TokenList } from "@/components/tokens/token-list";
+import { serverTRPC } from "@/lib/trpc-server";
+
+export const dynamic = "force-dynamic";
+
+export default async function TokensPage() {
+  let tokens: Awaited<ReturnType<typeof serverTRPC.tokens.list.query>> = [];
+  let error: string | null = null;
+  try {
+    tokens = await serverTRPC.tokens.list.query();
+  } catch (err) {
+    error = err instanceof Error ? err.message : String(err);
+  }
+
+  return (
+    <main className="flex flex-col gap-6 p-6">
+      <header>
+        <h1 className="text-2xl font-semibold tracking-tight">Agent tokens</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Mint a token per agent, then paste it into that client once. Revoking takes effect on{" "}
+          <code className="font-mono">/mcp</code> immediately.
+        </p>
+      </header>
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+      <GenerateTokenForm onCreate={createTokenAction} />
+      <section className="rounded-md border bg-card p-4" aria-label="Active tokens">
+        <h2 className="mb-3 font-semibold">Active tokens</h2>
+        <TokenList tokens={tokens} onRevoke={revokeTokenAction} />
+      </section>
+    </main>
+  );
+}

--- a/apps/dashboard/components/site-nav.tsx
+++ b/apps/dashboard/components/site-nav.tsx
@@ -19,6 +19,7 @@ const TABS = [
   { href: "/logs", label: "Logs", match: (p: string) => p === "/logs" },
   { href: "/curator", label: "Curator", match: (p: string) => p.startsWith("/curator") },
   { href: "/backups", label: "Backups", match: (p: string) => p.startsWith("/backups") },
+  { href: "/tokens", label: "Tokens", match: (p: string) => p.startsWith("/tokens") },
 ] as const;
 
 // Routes that render their own full-screen chrome and should NOT show the nav:

--- a/apps/dashboard/components/tokens/generate-form.tsx
+++ b/apps/dashboard/components/tokens/generate-form.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { type FormEvent, useState, useTransition } from "react";
+import type { CreateTokenResult } from "@/app/tokens/actions";
+
+// Mint an agent token. On success the plaintext is revealed ONCE in a callout
+// with a copy button — it is not recoverable afterwards, so the copy is the
+// user's only chance to capture it.
+export function GenerateTokenForm({
+  onCreate,
+}: {
+  onCreate: (input: { agentId: string; label?: string }) => Promise<CreateTokenResult>;
+}) {
+  const [agentId, setAgentId] = useState("");
+  const [label, setLabel] = useState("");
+  const [revealed, setRevealed] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [pending, startTransition] = useTransition();
+  const router = useRouter();
+
+  const submit = (event: FormEvent) => {
+    event.preventDefault();
+    const trimmedId = agentId.trim();
+    if (!trimmedId) return;
+    const trimmedLabel = label.trim();
+    startTransition(async () => {
+      setError(null);
+      setCopied(false);
+      const res = await onCreate(
+        trimmedLabel ? { agentId: trimmedId, label: trimmedLabel } : { agentId: trimmedId },
+      );
+      if (res.ok) {
+        setRevealed(res.token);
+        setAgentId("");
+        setLabel("");
+        router.refresh();
+      } else {
+        setError(res.error);
+      }
+    });
+  };
+
+  const copy = async () => {
+    if (!revealed) return;
+    await navigator.clipboard.writeText(revealed);
+    setCopied(true);
+  };
+
+  return (
+    <section className="rounded-md border bg-card p-4" aria-label="Generate token">
+      <h2 className="mb-3 font-semibold">Generate a token</h2>
+      <form onSubmit={submit} className="flex flex-wrap items-end gap-3">
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="text-muted-foreground">Agent id</span>
+          <input
+            value={agentId}
+            onChange={(e) => setAgentId(e.target.value)}
+            placeholder="claude"
+            className="rounded-md border bg-background px-2 py-1.5"
+            required
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="text-muted-foreground">Label (optional)</span>
+          <input
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            placeholder="laptop"
+            className="rounded-md border bg-background px-2 py-1.5"
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={pending}
+          className="rounded-md border bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground disabled:opacity-50"
+        >
+          {pending ? "Generating…" : "Generate"}
+        </button>
+      </form>
+
+      {error ? <p className="mt-3 text-sm text-destructive">Error: {error}</p> : null}
+
+      {revealed ? (
+        <div className="mt-4 rounded-md border border-primary/40 bg-primary/5 p-3" role="status">
+          <p className="text-sm font-medium">Copy this token now — it won’t be shown again.</p>
+          <div className="mt-2 flex items-center gap-2">
+            <code className="flex-1 break-all rounded bg-background px-2 py-1 font-mono text-xs">
+              {revealed}
+            </code>
+            <button
+              type="button"
+              onClick={copy}
+              className="rounded-md border px-2 py-1 text-sm hover:bg-muted"
+            >
+              {copied ? "Copied" : "Copy"}
+            </button>
+            <button
+              type="button"
+              onClick={() => setRevealed(null)}
+              className="rounded-md border px-2 py-1 text-sm hover:bg-muted"
+            >
+              Done
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/dashboard/components/tokens/generate-form.tsx
+++ b/apps/dashboard/components/tokens/generate-form.tsx
@@ -16,7 +16,7 @@ export function GenerateTokenForm({
   const [label, setLabel] = useState("");
   const [revealed, setRevealed] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">("idle");
   const [pending, startTransition] = useTransition();
   const router = useRouter();
 
@@ -27,7 +27,7 @@ export function GenerateTokenForm({
     const trimmedLabel = label.trim();
     startTransition(async () => {
       setError(null);
-      setCopied(false);
+      setCopyState("idle");
       const res = await onCreate(
         trimmedLabel ? { agentId: trimmedId, label: trimmedLabel } : { agentId: trimmedId },
       );
@@ -44,8 +44,14 @@ export function GenerateTokenForm({
 
   const copy = async () => {
     if (!revealed) return;
-    await navigator.clipboard.writeText(revealed);
-    setCopied(true);
+    try {
+      await navigator.clipboard.writeText(revealed);
+      setCopyState("copied");
+    } catch {
+      // Clipboard can be blocked (permissions, insecure origin); the token is
+      // still visible above for manual selection.
+      setCopyState("failed");
+    }
   };
 
   return (
@@ -94,7 +100,7 @@ export function GenerateTokenForm({
               onClick={copy}
               className="rounded-md border px-2 py-1 text-sm hover:bg-muted"
             >
-              {copied ? "Copied" : "Copy"}
+              {copyState === "copied" ? "Copied" : copyState === "failed" ? "Copy failed" : "Copy"}
             </button>
             <button
               type="button"

--- a/apps/dashboard/components/tokens/token-list.tsx
+++ b/apps/dashboard/components/tokens/token-list.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import type { RevokeTokenResult } from "@/app/tokens/actions";
+
+interface TokenMeta {
+  id: string;
+  agentId: string;
+  label: string;
+  created_at: string;
+}
+
+// The active-token list. Metadata only (the secret is never sent here); each row
+// can be revoked, which takes effect on /mcp immediately (no restart).
+export function TokenList({
+  tokens,
+  onRevoke,
+}: {
+  tokens: TokenMeta[];
+  onRevoke: (id: string) => Promise<RevokeTokenResult>;
+}) {
+  const [pending, startTransition] = useTransition();
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  const revoke = (id: string) =>
+    startTransition(async () => {
+      setError(null);
+      setBusyId(id);
+      const res = await onRevoke(id);
+      setBusyId(null);
+      if (res.ok) router.refresh();
+      else setError(res.error);
+    });
+
+  if (tokens.length === 0) {
+    return <p className="text-sm text-muted-foreground">No agent tokens yet.</p>;
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {error ? <p className="text-sm text-destructive">Error: {error}</p> : null}
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="text-left text-muted-foreground">
+            <th className="py-1 font-medium">Agent</th>
+            <th className="py-1 font-medium">Label</th>
+            <th className="py-1 font-medium">Created</th>
+            <th className="py-1" />
+          </tr>
+        </thead>
+        <tbody>
+          {tokens.map((token) => (
+            <tr key={token.id} className="border-t">
+              <td className="py-1.5 font-mono">{token.agentId}</td>
+              <td className="py-1.5 text-muted-foreground">{token.label || "—"}</td>
+              <td className="py-1.5 text-muted-foreground">{token.created_at}</td>
+              <td className="py-1.5 text-right">
+                <button
+                  type="button"
+                  onClick={() => revoke(token.id)}
+                  disabled={pending && busyId === token.id}
+                  className="rounded-md border px-2 py-1 text-sm hover:bg-muted disabled:opacity-50"
+                >
+                  {pending && busyId === token.id ? "Revoking…" : "Revoke"}
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/dashboard/e2e/tokens.spec.ts
+++ b/apps/dashboard/e2e/tokens.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "@playwright/test";
+
+// A5: the token-management flow end to end through the same-origin tRPC proxy
+// and the real mcp-server tokens router (auth is off in the shared e2e server,
+// so this exercises the UI + round-trip, not the login gate — see A2 notes).
+test.describe("tokens page", () => {
+  test("generate → one-time reveal → revoke", async ({ page }) => {
+    const agentId = `e2e-${Date.now()}`;
+    await page.goto("/tokens");
+    await expect(page.getByRole("heading", { name: "Agent tokens", level: 1 })).toBeVisible();
+
+    await page.getByPlaceholder("claude").fill(agentId);
+    await page.getByRole("button", { name: "Generate" }).click();
+
+    // The plaintext is revealed exactly once, in the status callout.
+    const reveal = page.getByRole("status");
+    await expect(reveal).toContainText(/won.t be shown again/);
+    await expect(reveal.locator("code")).toContainText("lib.");
+    await page.getByRole("button", { name: "Done" }).click();
+
+    // It shows up in the active list, then revoking removes it.
+    const row = page.locator("tr", { hasText: agentId });
+    await expect(row).toBeVisible();
+    await row.getByRole("button", { name: "Revoke" }).click();
+    await expect(page.locator("tr", { hasText: agentId })).toHaveCount(0);
+  });
+});

--- a/apps/dashboard/tests/components/site-nav.test.tsx
+++ b/apps/dashboard/tests/components/site-nav.test.tsx
@@ -24,6 +24,7 @@ const SECTIONS = [
   ["Logs", "/logs"],
   ["Curator", "/curator"],
   ["Backups", "/backups"],
+  ["Tokens", "/tokens"],
 ] as const;
 
 beforeEach(() => {

--- a/apps/dashboard/tests/components/tokens/generate-form.test.tsx
+++ b/apps/dashboard/tests/components/tokens/generate-form.test.tsx
@@ -1,0 +1,37 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
+
+const { GenerateTokenForm } = await import("@/components/tokens/generate-form");
+
+function fillAndSubmit(agentId: string) {
+  fireEvent.change(screen.getByPlaceholderText("claude"), { target: { value: agentId } });
+  fireEvent.click(screen.getByRole("button", { name: "Generate" }));
+}
+
+describe("GenerateTokenForm", () => {
+  it("reveals the new token once on success", async () => {
+    const onCreate = vi.fn().mockResolvedValue({ ok: true, id: "abc", token: "lib.abc.secret" });
+    render(<GenerateTokenForm onCreate={onCreate} />);
+    fillAndSubmit("claude");
+    await waitFor(() => expect(screen.getByText("lib.abc.secret")).toBeInTheDocument());
+    expect(onCreate).toHaveBeenCalledWith({ agentId: "claude" });
+    expect(screen.getByText(/won.t be shown again/)).toBeInTheDocument();
+  });
+
+  it("surfaces an error and reveals nothing", async () => {
+    const onCreate = vi.fn().mockResolvedValue({ ok: false, error: "boom" });
+    render(<GenerateTokenForm onCreate={onCreate} />);
+    fillAndSubmit("claude");
+    await waitFor(() => expect(screen.getByText(/Error: boom/)).toBeInTheDocument());
+    expect(screen.queryByText(/won.t be shown again/)).toBeNull();
+  });
+
+  it("does not submit an empty agent id", () => {
+    const onCreate = vi.fn();
+    render(<GenerateTokenForm onCreate={onCreate} />);
+    fireEvent.click(screen.getByRole("button", { name: "Generate" }));
+    expect(onCreate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/dashboard/tests/tokens-actions.test.ts
+++ b/apps/dashboard/tests/tokens-actions.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const createMock = vi.fn();
+const revokeMock = vi.fn();
+const revalidateMock = vi.fn();
+
+vi.mock("@/lib/trpc-server", () => ({
+  serverTRPC: {
+    tokens: {
+      create: { mutate: createMock },
+      revoke: { mutate: revokeMock },
+    },
+  },
+}));
+
+vi.mock("next/cache", () => ({ revalidatePath: revalidateMock }));
+
+const actions = await import("../app/tokens/actions");
+
+describe("tokens actions", () => {
+  afterEach(() => {
+    createMock.mockReset();
+    revokeMock.mockReset();
+    revalidateMock.mockReset();
+  });
+
+  it("returns the one-time token and revalidates on create", async () => {
+    createMock.mockResolvedValue({ id: "abc", token: "lib.abc.secret" });
+    const res = await actions.createTokenAction({ agentId: "claude", label: "laptop" });
+    expect(res).toEqual({ ok: true, id: "abc", token: "lib.abc.secret" });
+    expect(createMock).toHaveBeenCalledWith({ agentId: "claude", label: "laptop" });
+    expect(revalidateMock).toHaveBeenCalledWith("/tokens");
+  });
+
+  it("maps a create failure to an error result and does not revalidate", async () => {
+    createMock.mockRejectedValue(new Error("agentId is reserved"));
+    const res = await actions.createTokenAction({ agentId: "system-migration" });
+    expect(res).toEqual({ ok: false, error: "agentId is reserved" });
+    expect(revalidateMock).not.toHaveBeenCalled();
+  });
+
+  it("revokes by id and revalidates", async () => {
+    revokeMock.mockResolvedValue({ revoked: true });
+    const res = await actions.revokeTokenAction("abc");
+    expect(res).toEqual({ ok: true });
+    expect(revokeMock).toHaveBeenCalledWith({ id: "abc" });
+    expect(revalidateMock).toHaveBeenCalledWith("/tokens");
+  });
+});

--- a/packages/mcp-server/src/trpc/router.ts
+++ b/packages/mcp-server/src/trpc/router.ts
@@ -10,6 +10,7 @@ import { curatorRouter } from "./curator.js";
 import { healthRouter } from "./health.js";
 import { memoriesRouter } from "./memories.js";
 import { sessionsRouter } from "./sessions.js";
+import { tokensRouter } from "./tokens.js";
 import { router } from "./trpc.js";
 
 export const appRouter = router({
@@ -18,6 +19,7 @@ export const appRouter = router({
   health: healthRouter,
   memories: memoriesRouter,
   sessions: sessionsRouter,
+  tokens: tokensRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/packages/mcp-server/src/trpc/tokens.ts
+++ b/packages/mcp-server/src/trpc/tokens.ts
@@ -1,0 +1,34 @@
+// A5: agent-token management admin tRPC procedures (single-owner-auth spec).
+//
+// The authenticated owner mints/revokes DB-stored agent tokens from the dashboard
+// instead of hand-editing LIBRARIAN_AGENT_TOKENS + restarting. All admin-gated —
+// agent-role callers cannot reach this surface. `create` returns the plaintext
+// token exactly ONCE (core stores only a salted hash); `list` returns metadata
+// only. Tokens authenticate on /mcp immediately, with no restart (see A4).
+
+import { createAgentToken, listAgentTokens, revokeAgentToken } from "@librarian/core";
+import { z } from "zod";
+import { adminProcedure, router } from "./trpc.js";
+
+const CreateInput = z.strictObject({
+  agentId: z.string().min(1).max(128),
+  label: z.string().max(200).optional(),
+});
+
+export const tokensRouter = router({
+  // Metadata only — never the token, hash, or salt.
+  list: adminProcedure.query(({ ctx }) => listAgentTokens(ctx.store)),
+
+  // Mint a token; the plaintext in the response is shown once and not recoverable.
+  create: adminProcedure.input(CreateInput).mutation(({ ctx, input }) =>
+    // Cast at the validated boundary: Zod `.optional()` infers `label: string |
+    // undefined`, which the param type (optional key) rejects under
+    // exactOptionalPropertyTypes. The schema already validated the shape.
+    createAgentToken(ctx.store, input as { agentId: string; label?: string }),
+  ),
+
+  // Revoke by id; returns whether a record was actually removed.
+  revoke: adminProcedure
+    .input(z.strictObject({ id: z.string().min(1) }))
+    .mutation(({ ctx, input }) => ({ revoked: revokeAgentToken(ctx.store, input.id) })),
+});

--- a/packages/mcp-server/tests/trpc/tokens.test.ts
+++ b/packages/mcp-server/tests/trpc/tokens.test.ts
@@ -1,0 +1,112 @@
+// A5: token-management admin tRPC surface. Spawns the real HTTP bin and
+// exercises create → list → revoke end to end, plus admin gating (the agent
+// role must not reach it) and the never-leak-the-secret contract.
+
+import { describe, expect, it } from "vitest";
+import { cleanupTempDir, makeTempDir, startHttpServer } from "../../../../test/helpers.js";
+
+interface TrpcOk<T> {
+  result: { data: T };
+}
+interface TrpcErr {
+  error: unknown;
+}
+interface ServerHandle {
+  url: string;
+  token: string;
+  stop: () => Promise<void>;
+}
+
+async function trpcGet<T>(server: ServerHandle, path: string, input?: unknown): Promise<T> {
+  const url = new URL(`${server.url}/trpc/${path}`);
+  if (input !== undefined) url.searchParams.set("input", JSON.stringify(input));
+  const response = await fetch(url, { headers: { authorization: `Bearer ${server.token}` } });
+  const json = (await response.json()) as TrpcOk<T> | TrpcErr;
+  if (response.status >= 400 || "error" in json) {
+    throw new Error(`trpc GET ${path} failed: ${JSON.stringify(json)}`);
+  }
+  return (json as TrpcOk<T>).result.data;
+}
+
+async function trpcPost<T>(server: ServerHandle, path: string, input?: unknown): Promise<T> {
+  const response = await fetch(`${server.url}/trpc/${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${server.token}` },
+    body: input === undefined ? undefined : JSON.stringify(input),
+  });
+  const json = (await response.json()) as TrpcOk<T> | TrpcErr;
+  if (response.status >= 400 || "error" in json) {
+    throw new Error(`trpc POST ${path} failed: ${JSON.stringify(json)}`);
+  }
+  return (json as TrpcOk<T>).result.data;
+}
+
+interface TokenMeta {
+  id: string;
+  agentId: string;
+  label: string;
+  created_at: string;
+}
+
+describe("tRPC tokens surface", () => {
+  it("requires admin auth", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const res = await fetch(`${server.url}/trpc/tokens.list`); // no Authorization
+      expect(res.status).toBeGreaterThanOrEqual(400);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("rejects an agent-role token (only the admin owner manages tokens)", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir }); // agentToken defaults to "agent-token"
+    try {
+      const res = await fetch(`${server.url}/trpc/tokens.create`, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: "Bearer agent-token" },
+        body: JSON.stringify({ agentId: "claude" }),
+      });
+      expect(res.status).toBeGreaterThanOrEqual(400);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("creates a token (plaintext once), lists metadata only, and revokes", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const created = await trpcPost<{ id: string; token: string }>(server, "tokens.create", {
+        agentId: "claude",
+        label: "laptop",
+      });
+      expect(created.token.startsWith("lib.")).toBe(true);
+      expect(created.id.length).toBeGreaterThan(0);
+
+      const list = await trpcGet<TokenMeta[]>(server, "tokens.list");
+      const mine = list.find((t) => t.id === created.id);
+      expect(mine).toMatchObject({ agentId: "claude", label: "laptop" });
+      // Never leak the secret material.
+      const serialized = JSON.stringify(list);
+      expect(serialized).not.toContain(created.token);
+      expect(serialized).not.toContain("hash");
+      expect(serialized).not.toContain("salt");
+
+      const revoked = await trpcPost<{ revoked: boolean }>(server, "tokens.revoke", {
+        id: created.id,
+      });
+      expect(revoked.revoked).toBe(true);
+
+      const after = await trpcGet<TokenMeta[]>(server, "tokens.list");
+      expect(after.some((t) => t.id === created.id)).toBe(false);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+});


### PR DESCRIPTION
## What

Task **A5** — the final slice of `docs/specs/single-owner-auth.md`. The authenticated owner mints/revokes DB-stored agent tokens from the dashboard instead of hand-editing `LIBRARIAN_AGENT_TOKENS` + restarting. Completes the auth spec (A1 login → A2 enforcement → A3 core tokens → A4 `/mcp` accepts them → **A5 management UI**).

## How

- **`packages/mcp-server/src/trpc/tokens.ts`** — `adminProcedure` router over the core `agent-tokens` functions: `list` (metadata only), `create` (`{agentId,label}` → `{id,token}` once), `revoke` (`{id}` → `{revoked}`). Mounted as `tokens`. Agent-role callers are rejected; minted tokens authenticate on `/mcp` immediately (A4), no restart.
- **`apps/dashboard/app/tokens/{page,actions}` + `components/tokens/{generate-form,token-list}`** — a generate form with a **one-time reveal** + copy (clipboard failure now reports "Copy failed"; the token stays visible for manual select), and an active-token list with revoke. New "Tokens" nav entry. Clones the curator/backup cockpit pattern.
- **`DEPLOYMENT.md`** — `LIBRARIAN_AGENT_TOKENS` is now optional/legacy; the dashboard is the preferred path.

## Security

Reviewed by a sub-agent (verdict **APPROVE**, 0 Critical/Important). Every procedure is admin-gated; `list` never returns the token/hash/salt (asserted positively — the serialized list is checked to contain none of them); the plaintext is returned only on create, never persisted (only a salted hash) or logged, and the reveal is client-only and clearable.

## Tests

`tokens.test.ts` (admin-gated; no-auth + agent-role rejected; create→list-metadata→revoke→gone; never-leak invariant), `tokens-actions` + `generate-form` unit tests (one-time reveal, error mapping, empty-id guard), and a generate→reveal→revoke Playwright e2e.

Full monorepo suite (416 core / 105 mcp-server / 89 dashboard / …), build, lint, typecheck all green.

**Note:** the e2e runs with auth off (shared e2e server constraint — see build-notes), so it exercises the UI + real tRPC round-trip but not the in-browser login gate; the gate is covered at the router layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)