### PR TITLE
docs(todo): add feature ideas — local LLM consolidator + polyphonic recall

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -82,3 +82,10 @@ committed esbuild artifact — a coupling invisible from this repo.
 - **Codex plugin.** The codex adapter has remote-transport support but no
   distributable plugin yet (test-only) — a codex plugin could follow the Claude
   plugin's shape.
+
+## Features / functional improvements
+
+- Look at offering a tiny local LLM as an alternative to cloud / API LLM for the
+  memory consolidator (see https://github.com/tgrytnes/mnemosyne).
+- Improve memory storage & retrieval with polyphonic recall (see
+  https://github.com/tgrytnes/mnemosyne).


### PR DESCRIPTION
## What

Follow-up to #141. Adds a **Features / functional improvements** section to `docs/TODO.md` capturing two ideas (both referencing [mnemosyne](https://github.com/tgrytnes/mnemosyne)):

- A tiny **local LLM** as an alternative to the cloud/API LLM for the memory consolidator.
- **Polyphonic recall** for memory storage & retrieval.

These were added to the working copy while #141 was in flight, so they missed that merge. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)