### PR TITLE
feat(auth): D0 — credential bootstrap (master key + admin token)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,10 +3,14 @@
 #
 # Generate tokens with `openssl rand -base64 48`.
 
-# ----- Required -----
+# ----- Optional: admin token (auto-generated if unset) -----
 # Admin token for /mcp admin tools AND for the dashboard's server-side
-# tRPC client. Never exposed to the browser.
-LIBRARIAN_ADMIN_TOKEN=replace-with-a-long-random-admin-token
+# tRPC client. Never exposed to the browser. If unset AND the server binds
+# beyond localhost, it is auto-generated to ${LIBRARIAN_DATA_DIR}/admin.token
+# (mode 0600) and printed ONCE in the boot log — copy it then (e.g. into the
+# dashboard container's env). Set it here to manage the value yourself; env
+# always wins over the generated file.
+LIBRARIAN_ADMIN_TOKEN=
 
 # Agent token for normal `/mcp` traffic. Must differ from the admin
 # token. Either this or LIBRARIAN_AGENT_TOKENS (or both) must be set
@@ -19,13 +23,17 @@ LIBRARIAN_AGENT_TOKEN=replace-with-a-different-long-random-agent-token
 # the shared LIBRARIAN_AGENT_TOKEN above must be set.
 LIBRARIAN_AGENT_TOKENS=
 
-# ----- Optional: encryption key for secret settings at rest -----
+# ----- Optional: encryption key for secret settings at rest (auto-generated if unset) -----
 # An AES-256 key (NOT a bearer token) that encrypts secret settings stored in
-# the DB — today, the memory curator's LLM API token. The server runs without
-# it, but SAVING any secret setting (e.g. curator config in the dashboard) fails
-# until it's set. Must be a 32-byte CSPRNG value as 64 hex chars — generate with
-# `openssl rand -hex 32` (NOT the base64-48 above). Once set, keep it STABLE:
-# changing it makes previously-encrypted settings unreadable.
+# the DB — today, the memory curator's LLM API token. If unset, it is
+# auto-generated to ${LIBRARIAN_DATA_DIR}/secret.key (mode 0600) on first boot
+# and logged ONCE — SAVE THAT KEY: without it, secrets (and restored backups)
+# cannot be decrypted. Set it here to manage the value yourself (e.g. to keep
+# the key off the data volume); env always wins. Must be a 32-byte CSPRNG value
+# as 64 hex chars — generate with `openssl rand -hex 32` (NOT the base64-48
+# above). Once set, keep it STABLE: changing it makes previously-encrypted
+# settings unreadable. Backups never contain the key — `the-librarian restore`
+# prompts for it (or takes `--secret-key`) on a host that lacks it.
 LIBRARIAN_SECRET_KEY=
 
 # ----- Optional: dashboard owner login (Auth.js) -----

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -20,8 +20,11 @@ docker run -d --name the-librarian \
 
 - Dashboard → `http://<host>:3000`; MCP endpoint → `http://<host>:3838/mcp`.
 - `/data` is a named volume (your memories + sessions) — back it up (see the README's Backup section). It must be **writable by UID 1000** (the image's `node` user); on platforms that mount volumes root-owned, `chown` it.
-- `LIBRARIAN_SECRET_KEY` is optional but **required to save curator config** (it encrypts the curator's LLM token at rest); generate with `openssl rand -hex 32` — a 32-byte key, not the base64-48 used for tokens.
-- **Port 3838 carries the admin tRPC API (`/trpc/*`) as well as `/mcp`.** `LIBRARIAN_ADMIN_TOKEN` is therefore **mandatory** — the server refuses to start when bound beyond localhost without it — and 3838 should sit behind **TLS** (a reverse proxy). Do **not** set `LIBRARIAN_ALLOW_NO_AUTH=true` on a publicly-reachable host.
+- **Credentials auto-generate if unset.** Both `LIBRARIAN_SECRET_KEY` and `LIBRARIAN_ADMIN_TOKEN` are optional: on first boot, if unset, the server writes them to the data volume (`/data/secret.key` and — only when bound beyond localhost — `/data/admin.token`, both mode `0600`) and logs each **once**. So a fresh install needs **zero** secret/auth env vars; the commands above set them explicitly only if you'd rather manage the values yourself (env always wins over the generated files). Watch the boot log on first run:
+  - **`Generated a new master key … SAVE THIS KEY`** — copy `secret.key` somewhere safe. Without it, secrets (curator token) and restored backups can't be decrypted. The key is deliberately **excluded from backups**.
+  - **`Generated a new admin token … : libadmin_…`** — copy it; it's printed only this once (the sole sanctioned token log). You'll paste it into the dashboard to enable auth, and into a separate dashboard container's `LIBRARIAN_ADMIN_TOKEN` if you run the two-container shape.
+- `LIBRARIAN_SECRET_KEY` is **required to save curator config** (it encrypts the curator's LLM token at rest); set it with `openssl rand -hex 32` — a 32-byte key, not the base64-48 used for tokens — or let it auto-generate.
+- **Port 3838 carries the admin tRPC API (`/trpc/*`) as well as `/mcp`.** When bound beyond localhost the server needs an admin token; it now **auto-provisions one** rather than refusing to start, but 3838 should still sit behind **TLS** (a reverse proxy). Do **not** set `LIBRARIAN_ALLOW_NO_AUTH=true` on a publicly-reachable host.
 - The image runs `tini` as PID 1 (orphan reaping) and **crash-fasts** if either service dies, so your orchestrator restarts the pair.
 
 ### Fly.io
@@ -204,6 +207,8 @@ the-librarian export --format ndjson > dump.ndjson       # portable dump
 ```
 
 Inside the single-container image, run via `docker exec <container> the-librarian backup --out /data/backups`.
+
+**Restoring onto a new host (master key).** Backups are deliberately **key-free** — `secret.key` never travels in a bundle, so a leaked backup is not a leaked key. If the bundle contains encrypted secrets (e.g. the curator token), `restore` needs the original master key to unlock them on a host that lacks it: pass `--secret-key <key>` or let it **prompt** on a TTY. A correct key is verified against the restored data and saved to `<data>/secret.key` so the next boot can read it; a wrong key fails with a clear error and is never persisted. If the new host already has the key (its own `secret.key` or `LIBRARIAN_SECRET_KEY` in the env), no prompt appears.
 
 ### Scheduled backups + cloud sync
 

--- a/packages/cli/src/commands/restore.ts
+++ b/packages/cli/src/commands/restore.ts
@@ -1,17 +1,117 @@
-// `the-librarian restore --from <backup-dir> --force` — restore a snapshot bundle.
+// `the-librarian restore --from <backup-dir> --force [--secret-key <key>]`
 //
 // Destructive: it overwrites the data dir, so it requires --force. It closes the
 // store first (the SQLite file is replaced) — restore is terminal, so the handle
 // stays closed; the bin's own close is idempotent.
+//
+// D0.6 — backups are key-free, so a cross-host restore lands encrypted secrets with
+// no master key on the new host. After restoring, if the data contains secrets we
+// resolve the key (--secret-key → env → TTY prompt), verify it actually decrypts
+// them, and persist it to ${dataDir}/secret.key (mode 0600) so the next server boot
+// can read it. A key supplied via env is honored but NOT persisted — that respects
+// the deliberate key/data separation an env-only operator has chosen.
 
-import { BackupRestoreError, type LibrarianStore, restoreBackup } from "@librarian/core";
+import fs from "node:fs";
+import path from "node:path";
+import {
+  BackupRestoreError,
+  type LibrarianStore,
+  createLibrarianStore,
+  resolveSecretKey,
+  restoreBackup,
+} from "@librarian/core";
 import type { FlagMap } from "../parse-flags.js";
 import type { CliResult } from "./_shared.js";
+
+const SECRET_KEY_FILE = "secret.key";
+const MAX_PROMPTS = 3;
+
+/** The slice of a store the key-verification probe needs (small, so tests can fake it). */
+type VerifyStore = Pick<LibrarianStore, "listSettings" | "getSetting" | "close">;
+
+export interface RestoreDeps {
+  /** Open a store at `dataDir` with a candidate key (default: the real store). */
+  openStore?: (dataDir: string, secretKey: Buffer | null) => VerifyStore;
+  /** Prompt the operator for the master key; returns null when there's no TTY. */
+  promptSecretKey?: () => string | null;
+  /** Persist the validated key to the data dir (default: write secret.key 0600). */
+  writeKeyFile?: (dataDir: string, keyHex: string) => void;
+  /** Environment to read LIBRARIAN_SECRET_KEY from (default: process.env). */
+  env?: Record<string, string | undefined>;
+}
+
+function defaultPromptSecretKey(): string | null {
+  if (!process.stdin.isTTY) return null;
+  process.stdout.write(
+    "Enter the master key (LIBRARIAN_SECRET_KEY) to decrypt the restored secrets: ",
+  );
+  const buf = Buffer.alloc(4096);
+  try {
+    const read = fs.readSync(0, buf, 0, buf.length, null);
+    return buf.toString("utf8", 0, read).trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function defaultWriteKeyFile(dataDir: string, keyHex: string): void {
+  fs.writeFileSync(path.join(dataDir, SECRET_KEY_FILE), keyHex, { mode: 0o600 });
+}
+
+function resolveDeps(deps: RestoreDeps): Required<RestoreDeps> {
+  return {
+    openStore:
+      deps.openStore ?? ((dataDir, secretKey) => createLibrarianStore({ dataDir, secretKey })),
+    promptSecretKey: deps.promptSecretKey ?? defaultPromptSecretKey,
+    writeKeyFile: deps.writeKeyFile ?? defaultWriteKeyFile,
+    env: deps.env ?? process.env,
+  };
+}
+
+/** The key of one secret setting (to probe decryption), or null if there are none. */
+function firstSecretSettingKey(
+  dataDir: string,
+  open: Required<RestoreDeps>["openStore"],
+): string | null {
+  const store = open(dataDir, null); // listSettings is metadata-only — no key needed
+  try {
+    return store.listSettings().find((s) => s.is_secret)?.key ?? null;
+  } finally {
+    store.close();
+  }
+}
+
+type KeyAttempt = { ok: true; keyHex: string } | { ok: false; malformed: boolean };
+
+/** Does this raw key decrypt the probe secret? */
+function tryKey(
+  raw: string,
+  dataDir: string,
+  probeKey: string,
+  open: Required<RestoreDeps>["openStore"],
+): KeyAttempt {
+  let key: Buffer;
+  try {
+    key = resolveSecretKey(raw);
+  } catch {
+    return { ok: false, malformed: true };
+  }
+  const store = open(dataDir, key);
+  try {
+    store.getSetting(probeKey); // throws on a wrong key (GCM auth failure)
+    return { ok: true, keyHex: key.toString("hex") };
+  } catch {
+    return { ok: false, malformed: false };
+  } finally {
+    store.close();
+  }
+}
 
 export function restoreCommand(
   store: LibrarianStore,
   _positionals: string[],
   flags: FlagMap,
+  deps: RestoreDeps = {},
 ): CliResult {
   const from = typeof flags.from === "string" ? flags.from : "";
   if (!from) {
@@ -24,17 +124,84 @@ export function restoreCommand(
     };
   }
 
+  const dataDir = store.dataDir;
   store.close(); // release the SQLite handle before the file is replaced
+
+  let baseline: string;
   try {
-    const result = restoreBackup(from, { dataDir: store.dataDir });
-    return {
-      stdout: `Restored ${result.restored.length} files to ${result.dataDir} (schema v${result.schemaVersion}). Restart the server.`,
-      exitCode: 0,
-    };
+    const result = restoreBackup(from, { dataDir });
+    baseline = `Restored ${result.restored.length} files to ${result.dataDir} (schema v${result.schemaVersion}). Restart the server.`;
   } catch (err) {
     if (err instanceof BackupRestoreError) {
       return { stdout: `Restore failed: ${err.message}`, exitCode: 1 };
     }
     throw err;
   }
+
+  return verifyRestoredSecrets(dataDir, baseline, flags, resolveDeps(deps));
+}
+
+function verifyRestoredSecrets(
+  dataDir: string,
+  baseline: string,
+  flags: FlagMap,
+  deps: Required<RestoreDeps>,
+): CliResult {
+  const probeKey = firstSecretSettingKey(dataDir, deps.openStore);
+  if (!probeKey) {
+    return { stdout: baseline, exitCode: 0 }; // no encrypted secrets — nothing to unlock
+  }
+
+  // 1) Explicit --secret-key: a wrong/malformed one errors clearly (no silent prompt).
+  const flagKey = typeof flags["secret-key"] === "string" ? (flags["secret-key"] as string) : "";
+  if (flagKey) {
+    const attempt = tryKey(flagKey, dataDir, probeKey, deps.openStore);
+    if (attempt.ok) return persisted(baseline, dataDir, attempt.keyHex, "--secret-key", deps);
+    const why = attempt.malformed ? "is malformed" : "does not decrypt the restored secrets";
+    return {
+      stdout: `Restore failed: the provided --secret-key ${why} (wrong key?).`,
+      exitCode: 1,
+    };
+  }
+
+  // 2) Env key (honored but not persisted — respects key/data separation).
+  const envKey = (deps.env.LIBRARIAN_SECRET_KEY ?? "").trim();
+  if (envKey) {
+    const attempt = tryKey(envKey, dataDir, probeKey, deps.openStore);
+    if (attempt.ok) {
+      return {
+        stdout: `${baseline} Verified the restored secrets with LIBRARIAN_SECRET_KEY from the environment.`,
+        exitCode: 0,
+      };
+    }
+    // A wrong env key falls through to the prompt — the operator can supply the right one.
+  }
+
+  // 3) Prompt on a TTY, bounded retries.
+  for (let i = 0; i < MAX_PROMPTS; i++) {
+    const raw = deps.promptSecretKey();
+    if (!raw) break; // no TTY, or the operator gave up
+    const attempt = tryKey(raw, dataDir, probeKey, deps.openStore);
+    if (attempt.ok) return persisted(baseline, dataDir, attempt.keyHex, "the entered key", deps);
+  }
+
+  // 4) Nothing worked / non-interactive — actionable, not a stack trace.
+  return {
+    stdout: `${baseline}\nThe restored data contains encrypted secrets. Re-run with --secret-key <key> (or set LIBRARIAN_SECRET_KEY) to unlock them.`,
+    exitCode: 1,
+  };
+}
+
+function persisted(
+  baseline: string,
+  dataDir: string,
+  keyHex: string,
+  source: string,
+  deps: Required<RestoreDeps>,
+): CliResult {
+  deps.writeKeyFile(dataDir, keyHex);
+  return {
+    stdout: `${baseline} Verified the restored secrets with ${source} and saved the master key to ${path.join(dataDir, SECRET_KEY_FILE)}.`,
+    exitCode: 0,
+  };
 }

--- a/packages/cli/src/commands/restore.ts
+++ b/packages/cli/src/commands/restore.ts
@@ -10,6 +10,11 @@
 // them, and persist it to ${dataDir}/secret.key (mode 0600) so the next server boot
 // can read it. A key supplied via env is honored but NOT persisted — that respects
 // the deliberate key/data separation an env-only operator has chosen.
+//
+// The data is overwritten BEFORE key verification (the secrets we verify are the
+// restored ones), so every post-restore step is written to fail soft: any
+// unexpected store/probe error becomes an actionable CliResult, never a stack trace
+// over an already-mutated data dir.
 
 import fs from "node:fs";
 import path from "node:path";
@@ -34,23 +39,43 @@ export interface RestoreDeps {
   openStore?: (dataDir: string, secretKey: Buffer | null) => VerifyStore;
   /** Prompt the operator for the master key; returns null when there's no TTY. */
   promptSecretKey?: () => string | null;
+  /** Emit interactive feedback between prompt attempts (default: stderr). */
+  notify?: (message: string) => void;
   /** Persist the validated key to the data dir (default: write secret.key 0600). */
   writeKeyFile?: (dataDir: string, keyHex: string) => void;
   /** Environment to read LIBRARIAN_SECRET_KEY from (default: process.env). */
   env?: Record<string, string | undefined>;
 }
 
+// Read the master key from a TTY with echo OFF — it's a bearer-grade secret, so it
+// must not land on screen or in terminal scrollback. Reads byte-by-byte in raw mode
+// (the key is hex/base64, i.e. single-byte ASCII). No TTY → null (non-interactive).
 function defaultPromptSecretKey(): string | null {
-  if (!process.stdin.isTTY) return null;
-  process.stdout.write(
-    "Enter the master key (LIBRARIAN_SECRET_KEY) to decrypt the restored secrets: ",
-  );
-  const buf = Buffer.alloc(4096);
+  const stdin = process.stdin;
+  if (!stdin.isTTY) return null;
+  process.stdout.write("Enter the master key (LIBRARIAN_SECRET_KEY) to decrypt the secrets: ");
+  const wasRaw = stdin.isRaw === true;
   try {
-    const read = fs.readSync(0, buf, 0, buf.length, null);
-    return buf.toString("utf8", 0, read).trim() || null;
+    stdin.setRawMode?.(true);
+    const buf = Buffer.alloc(1);
+    let input = "";
+    while (true) {
+      if (fs.readSync(0, buf, 0, 1, null) === 0) break;
+      const byte = buf[0];
+      if (byte === 0x0a || byte === 0x0d) break; // Enter
+      if (byte === 0x03) return null; // Ctrl-C → cancel
+      if (byte === 0x7f || byte === 0x08) {
+        input = input.slice(0, -1); // Backspace / DEL
+        continue;
+      }
+      input += buf.toString("utf8");
+    }
+    return input.trim() || null;
   } catch {
     return null;
+  } finally {
+    stdin.setRawMode?.(wasRaw);
+    process.stdout.write("\n");
   }
 }
 
@@ -63,6 +88,7 @@ function resolveDeps(deps: RestoreDeps): Required<RestoreDeps> {
     openStore:
       deps.openStore ?? ((dataDir, secretKey) => createLibrarianStore({ dataDir, secretKey })),
     promptSecretKey: deps.promptSecretKey ?? defaultPromptSecretKey,
+    notify: deps.notify ?? ((message) => process.stderr.write(`${message}\n`)),
     writeKeyFile: deps.writeKeyFile ?? defaultWriteKeyFile,
     env: deps.env ?? process.env,
   };
@@ -83,7 +109,7 @@ function firstSecretSettingKey(
 
 type KeyAttempt = { ok: true; keyHex: string } | { ok: false; malformed: boolean };
 
-/** Does this raw key decrypt the probe secret? */
+/** Does this raw key decrypt the probe secret? Never throws (open/probe errors → not ok). */
 function tryKey(
   raw: string,
   dataDir: string,
@@ -96,7 +122,12 @@ function tryKey(
   } catch {
     return { ok: false, malformed: true };
   }
-  const store = open(dataDir, key);
+  let store: VerifyStore;
+  try {
+    store = open(dataDir, key);
+  } catch {
+    return { ok: false, malformed: false }; // store won't open — not a wrong-key signal, but not ok
+  }
   try {
     store.getSetting(probeKey); // throws on a wrong key (GCM auth failure)
     return { ok: true, keyHex: key.toString("hex") };
@@ -147,7 +178,17 @@ function verifyRestoredSecrets(
   flags: FlagMap,
   deps: Required<RestoreDeps>,
 ): CliResult {
-  const probeKey = firstSecretSettingKey(dataDir, deps.openStore);
+  // The data is already restored; if even probing it fails, report it actionably
+  // rather than throwing a stack trace over a freshly-mutated data dir.
+  let probeKey: string | null;
+  try {
+    probeKey = firstSecretSettingKey(dataDir, deps.openStore);
+  } catch (err) {
+    return {
+      stdout: `${baseline}\nThe data was restored, but opening it to verify encrypted secrets failed: ${(err as Error).message}. Check the data dir, then restart.`,
+      exitCode: 1,
+    };
+  }
   if (!probeKey) {
     return { stdout: baseline, exitCode: 0 }; // no encrypted secrets — nothing to unlock
   }
@@ -177,12 +218,17 @@ function verifyRestoredSecrets(
     // A wrong env key falls through to the prompt — the operator can supply the right one.
   }
 
-  // 3) Prompt on a TTY, bounded retries.
+  // 3) Prompt on a TTY, bounded retries with per-attempt feedback.
   for (let i = 0; i < MAX_PROMPTS; i++) {
     const raw = deps.promptSecretKey();
     if (!raw) break; // no TTY, or the operator gave up
     const attempt = tryKey(raw, dataDir, probeKey, deps.openStore);
     if (attempt.ok) return persisted(baseline, dataDir, attempt.keyHex, "the entered key", deps);
+    const remaining = MAX_PROMPTS - i - 1;
+    if (remaining > 0) {
+      const why = attempt.malformed ? "that key is malformed" : "that key did not decrypt the data";
+      deps.notify(`${why} — ${remaining} attempt${remaining === 1 ? "" : "s"} left.`);
+    }
   }
 
   // 4) Nothing worked / non-interactive — actionable, not a stack trace.

--- a/packages/cli/tests/restore-key.test.ts
+++ b/packages/cli/tests/restore-key.test.ts
@@ -111,6 +111,27 @@ describe("restore master-key recovery (D0.6)", () => {
     expect(fs.existsSync(path.join(targetDir, "secret.key"))).toBe(false);
   });
 
+  it("reports an actionable error (no stack trace) when the restored store fails to open", () => {
+    const { backupDir, targetDir, target } = backupWithSecret();
+    const r = restoreCommand(
+      target,
+      [],
+      { from: backupDir, force: true, "secret-key": SRC_KEY },
+      {
+        env: {},
+        promptSecretKey: () => null,
+        // Simulate a corrupt/unopenable restored store.
+        openStore: () => {
+          throw new Error("SQLITE_CORRUPT: database disk image is malformed");
+        },
+      },
+    );
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toMatch(/verify encrypted secrets failed/i);
+    expect(r.stdout).not.toMatch(/at .*\n\s+at /); // not a raw stack trace
+    expect(fs.existsSync(path.join(targetDir, "secret.key"))).toBe(false);
+  });
+
   it("restores without any key handling when the backup has no secrets", () => {
     const srcDir = tmp("lib-src-");
     const src = createLibrarianStore({ dataDir: srcDir });

--- a/packages/cli/tests/restore-key.test.ts
+++ b/packages/cli/tests/restore-key.test.ts
@@ -1,0 +1,148 @@
+// D0.6 — after a cross-host restore the encrypted secrets are present but the
+// master key is not (backups are key-free). The CLI must resolve the key from
+// --secret-key / env / a TTY prompt, verify it decrypts the restored secrets, and
+// persist it so the next server boot can read it.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type LibrarianStore,
+  createBackup,
+  createLibrarianStore,
+  resolveSecretKey,
+} from "@librarian/core";
+import { afterEach, describe, expect, it } from "vitest";
+import { restoreCommand } from "../src/commands/restore.js";
+
+const SRC_KEY = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
+const WRONG_KEY = "ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100";
+
+const tmpDirs: string[] = [];
+function tmp(prefix: string): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tmpDirs.push(d);
+  return d;
+}
+afterEach(() => {
+  while (tmpDirs.length) fs.rmSync(tmpDirs.pop() as string, { recursive: true, force: true });
+});
+
+function backupDirIn(out: string): string {
+  const name = fs.readdirSync(out).find((d) => d.startsWith("librarian-backup-"));
+  if (!name) throw new Error(`no backup dir in ${out}`);
+  return path.join(out, name);
+}
+
+// Build a backup that contains an encrypted secret, then a fresh target data dir
+// (the "new host") and return what restoreCommand needs.
+function backupWithSecret(): { backupDir: string; targetDir: string; target: LibrarianStore } {
+  const srcDir = tmp("lib-src-");
+  const src = createLibrarianStore({ dataDir: srcDir, secretKey: resolveSecretKey(SRC_KEY) });
+  src.setSetting("curator:llm_token", "sk-super-secret", { secret: true });
+  const out = tmp("lib-out-");
+  createBackup(src, { destDir: out });
+  src.close();
+
+  const targetDir = tmp("lib-tgt-");
+  const target = createLibrarianStore({ dataDir: targetDir }); // no key, like the CLI bin
+  return { backupDir: backupDirIn(out), targetDir, target };
+}
+
+describe("restore master-key recovery (D0.6)", () => {
+  it("decrypts restored secrets with a correct --secret-key and persists it 0600", () => {
+    const { backupDir, targetDir, target } = backupWithSecret();
+    const r = restoreCommand(
+      target,
+      [],
+      { from: backupDir, force: true, "secret-key": SRC_KEY },
+      { env: {}, promptSecretKey: () => null },
+    );
+    expect(r.exitCode).toBe(0);
+    const keyFile = path.join(targetDir, "secret.key");
+    expect(fs.readFileSync(keyFile, "utf8").trim()).toBe(SRC_KEY);
+    expect(fs.statSync(keyFile).mode & 0o077).toBe(0);
+  });
+
+  it("prompts on a TTY when no flag/env key is given, then decrypts and persists", () => {
+    const { backupDir, targetDir, target } = backupWithSecret();
+    let prompted = 0;
+    const r = restoreCommand(
+      target,
+      [],
+      { from: backupDir, force: true },
+      {
+        env: {},
+        promptSecretKey: () => {
+          prompted++;
+          return SRC_KEY;
+        },
+      },
+    );
+    expect(r.exitCode).toBe(0);
+    expect(prompted).toBe(1);
+    expect(fs.existsSync(path.join(targetDir, "secret.key"))).toBe(true);
+  });
+
+  it("errors clearly on a wrong --secret-key and never persists it", () => {
+    const { backupDir, targetDir, target } = backupWithSecret();
+    const r = restoreCommand(
+      target,
+      [],
+      { from: backupDir, force: true, "secret-key": WRONG_KEY },
+      { env: {}, promptSecretKey: () => null },
+    );
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toMatch(/does not decrypt|wrong key/i);
+    expect(fs.existsSync(path.join(targetDir, "secret.key"))).toBe(false);
+  });
+
+  it("gives an actionable error when non-interactive with no key for encrypted secrets", () => {
+    const { backupDir, targetDir, target } = backupWithSecret();
+    const r = restoreCommand(
+      target,
+      [],
+      { from: backupDir, force: true },
+      { env: {}, promptSecretKey: () => null }, // no TTY
+    );
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toMatch(/--secret-key/);
+    expect(r.stdout).not.toMatch(/at .*\n\s+at /); // not a raw stack trace
+    expect(fs.existsSync(path.join(targetDir, "secret.key"))).toBe(false);
+  });
+
+  it("restores without any key handling when the backup has no secrets", () => {
+    const srcDir = tmp("lib-src-");
+    const src = createLibrarianStore({ dataDir: srcDir });
+    src.createMemory({
+      agent_id: "claude",
+      title: "no secrets here",
+      body: "b",
+      category: "projects",
+      visibility: "common",
+      scope: "project",
+      project_key: "the-librarian",
+      priority: "normal",
+      confidence: "working",
+    });
+    const out = tmp("lib-out-");
+    createBackup(src, { destDir: out });
+    src.close();
+    const targetDir = tmp("lib-tgt-");
+    const target = createLibrarianStore({ dataDir: targetDir });
+
+    const r = restoreCommand(
+      target,
+      [],
+      { from: backupDirIn(out), force: true },
+      {
+        env: {},
+        promptSecretKey: () => {
+          throw new Error("should not prompt when there are no secrets");
+        },
+      },
+    );
+    expect(r.exitCode).toBe(0);
+    expect(fs.existsSync(path.join(targetDir, "secret.key"))).toBe(false);
+  });
+});

--- a/packages/core/src/auth/admin-token.ts
+++ b/packages/core/src/auth/admin-token.ts
@@ -12,6 +12,7 @@
 
 import { randomBytes } from "node:crypto";
 import fs from "node:fs";
+import type { FileIo } from "../secret-crypto.js";
 
 const TOKEN_PREFIX = "libadmin_";
 const ENTROPY_BYTES = 32;
@@ -50,17 +51,11 @@ export function parseAdminToken(raw: string): string {
  * - Absent → write `libadmin_<base64url>` (>=32 random bytes) with
  *   `open('wx', 0o600)`: race-safe creation, owner-only from the first byte.
  */
-export function loadOrCreateAdminTokenFile(filePath: string): LoadedAdminToken {
-  let existing: string | null = null;
-  try {
-    existing = fs.readFileSync(filePath, "utf8");
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-  }
-  if (existing !== null) {
-    return { token: parseAdminToken(existing), generated: false };
+export function loadOrCreateAdminTokenFile(filePath: string, io: FileIo = fs): LoadedAdminToken {
+  if (io.existsSync(filePath)) {
+    return { token: parseAdminToken(io.readFileSync(filePath, "utf8")), generated: false };
   }
   const token = `${TOKEN_PREFIX}${randomBytes(ENTROPY_BYTES).toString("base64url")}`;
-  fs.writeFileSync(filePath, token, { flag: "wx", mode: 0o600 });
+  io.writeFileSync(filePath, token, { flag: "wx", mode: 0o600 });
   return { token, generated: true };
 }

--- a/packages/core/src/auth/admin-token.ts
+++ b/packages/core/src/auth/admin-token.ts
@@ -1,0 +1,66 @@
+// Bootstrap admin token file (dashboard-managed-auth, D0).
+//
+// The admin token authenticates the dashboard→store tRPC proxy. Today it must be
+// supplied via LIBRARIAN_ADMIN_TOKEN; D0 lets a fresh install auto-generate one to
+// the data volume (printed once) so a bound-beyond-localhost deploy is secured with
+// zero env surgery. Env still wins when set.
+//
+// Token shape: `libadmin_<base64url>` (a prefix that makes it greppable/recognizable
+// in logs and config; base64url body of >=32 random bytes). It's a bearer secret, so
+// the file is written 0600 and the value is never logged except the one-time
+// generation notice in the boot path.
+
+import { randomBytes } from "node:crypto";
+import fs from "node:fs";
+
+const TOKEN_PREFIX = "libadmin_";
+const ENTROPY_BYTES = 32;
+
+export interface LoadedAdminToken {
+  token: string;
+  /** True when this call generated a fresh token (caller prints the one-time notice). */
+  generated: boolean;
+}
+
+/**
+ * Validate the `libadmin_<base64url>` shape and that the body carries the required
+ * entropy. Returns the token on success; throws on a malformed value so a corrupt
+ * token file is an operator signal rather than silently treated as "no token".
+ */
+export function parseAdminToken(raw: string): string {
+  const token = raw.trim();
+  if (!token.startsWith(TOKEN_PREFIX)) {
+    throw new Error(`malformed admin token (expected '${TOKEN_PREFIX}<base64url>')`);
+  }
+  const body = token.slice(TOKEN_PREFIX.length);
+  if (!/^[A-Za-z0-9_-]+$/.test(body)) {
+    throw new Error("malformed admin token (body is not base64url)");
+  }
+  if (Buffer.from(body, "base64url").length < ENTROPY_BYTES) {
+    throw new Error(`malformed admin token (needs >=${ENTROPY_BYTES} bytes of entropy)`);
+  }
+  return token;
+}
+
+/**
+ * Read the admin token from `filePath`, or generate and persist one when absent.
+ *
+ * - Exists → read + validate the shape (throws on a malformed file rather than
+ *   overwriting it). Perms are left as-is (never widened).
+ * - Absent → write `libadmin_<base64url>` (>=32 random bytes) with
+ *   `open('wx', 0o600)`: race-safe creation, owner-only from the first byte.
+ */
+export function loadOrCreateAdminTokenFile(filePath: string): LoadedAdminToken {
+  let existing: string | null = null;
+  try {
+    existing = fs.readFileSync(filePath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  if (existing !== null) {
+    return { token: parseAdminToken(existing), generated: false };
+  }
+  const token = `${TOKEN_PREFIX}${randomBytes(ENTROPY_BYTES).toString("base64url")}`;
+  fs.writeFileSync(filePath, token, { flag: "wx", mode: 0o600 });
+  return { token, generated: true };
+}

--- a/packages/core/src/auth/boot-credentials.ts
+++ b/packages/core/src/auth/boot-credentials.ts
@@ -1,0 +1,127 @@
+// Boot credential resolution (dashboard-managed-auth, D0.3).
+//
+// A pure decision matrix that turns the environment + data volume into the master
+// key and admin token the server boots with. Extracted from the bin so it's unit-
+// testable with an injected fake fs (no disk, no process). The bin (D0.4) calls
+// this once and acts on the returned signals (one-time logs, fatal checks).
+//
+// Precedence is "env wins, then the data volume, then generate":
+//   secret key  : env LIBRARIAN_SECRET_KEY → ${dataDir}/secret.key → generate
+//                 (writable) → null (read-only volume: no-secrets fallback, no crash)
+//   admin token : env LIBRARIAN_ADMIN_TOKEN | legacy LIBRARIAN_AUTH_TOKEN →
+//                 ${dataDir}/admin.token → generate ONLY when bound beyond localhost
+//                 → null. On localhost with no token, null == the unchanged no-auth
+//                 bypass; the bin keeps the fatal check for the can't-generate edge.
+
+import fs from "node:fs";
+import path from "node:path";
+import { type FileIo, type LoadedSecretKey, loadOrCreateSecretKeyFile } from "../secret-crypto.js";
+import { resolveSecretKey } from "../secret-crypto.js";
+import { type LoadedAdminToken, loadOrCreateAdminTokenFile } from "./admin-token.js";
+
+const SECRET_KEY_FILE = "secret.key";
+const ADMIN_TOKEN_FILE = "admin.token";
+
+export type CredentialSource = "env" | "file" | "generated" | "absent";
+
+export interface BootCredentialSignal {
+  credential: "secret-key" | "admin-token";
+  source: CredentialSource;
+  /** The file path involved, for `file`/`generated` sources (so the bin can log it). */
+  path?: string;
+}
+
+export interface ResolvedBootCredentials {
+  secretKey: Buffer | null;
+  adminToken: string | null;
+  signals: BootCredentialSignal[];
+}
+
+export interface BootCredentialsInput {
+  env: Record<string, string | undefined>;
+  dataDir: string;
+  /** True when the server binds to a non-loopback host (today the fatal-without-token branch). */
+  boundBeyondLocalhost: boolean;
+  io?: FileIo;
+}
+
+/** Map a load helper's `generated` flag to a signal source. */
+function loadedSource(generated: boolean): "generated" | "file" {
+  return generated ? "generated" : "file";
+}
+
+export function resolveBootCredentials(input: BootCredentialsInput): ResolvedBootCredentials {
+  const io = input.io ?? fs;
+  const signals: BootCredentialSignal[] = [];
+
+  const secretKey = resolveSecretKeyCredential(input, io, signals);
+  const adminToken = resolveAdminTokenCredential(input, io, signals);
+  return { secretKey, adminToken, signals };
+}
+
+function resolveSecretKeyCredential(
+  input: BootCredentialsInput,
+  io: FileIo,
+  signals: BootCredentialSignal[],
+): Buffer | null {
+  const envKey = (input.env.LIBRARIAN_SECRET_KEY ?? "").trim();
+  if (envKey) {
+    // A present-but-bad env key throws (fail loud) — same as today's boot.
+    const key = resolveSecretKey(envKey);
+    signals.push({ credential: "secret-key", source: "env" });
+    return key;
+  }
+
+  const keyPath = path.join(input.dataDir, SECRET_KEY_FILE);
+  let loaded: LoadedSecretKey;
+  try {
+    loaded = loadOrCreateSecretKeyFile(keyPath, io);
+  } catch (error) {
+    // A malformed *existing* file is an operator signal — rethrow. A write failure
+    // (read-only volume) means we simply can't persist a key: fall back to the
+    // no-secrets path rather than crashing the whole server.
+    if (io.existsSync(keyPath)) throw error;
+    signals.push({ credential: "secret-key", source: "absent" });
+    return null;
+  }
+  signals.push({ credential: "secret-key", source: loadedSource(loaded.generated), path: keyPath });
+  return loaded.key;
+}
+
+function resolveAdminTokenCredential(
+  input: BootCredentialsInput,
+  io: FileIo,
+  signals: BootCredentialSignal[],
+): string | null {
+  const envToken = (input.env.LIBRARIAN_ADMIN_TOKEN || input.env.LIBRARIAN_AUTH_TOKEN || "").trim();
+  if (envToken) {
+    signals.push({ credential: "admin-token", source: "env" });
+    return envToken;
+  }
+
+  // On localhost with no env token the no-auth bypass is intentional and unchanged;
+  // generating a token there would be noise. Only the bound-beyond-localhost branch
+  // (today fatal without a token) auto-provisions one.
+  if (!input.boundBeyondLocalhost) {
+    signals.push({ credential: "admin-token", source: "absent" });
+    return null;
+  }
+
+  const tokenPath = path.join(input.dataDir, ADMIN_TOKEN_FILE);
+  let loaded: LoadedAdminToken;
+  try {
+    loaded = loadOrCreateAdminTokenFile(tokenPath, io);
+  } catch (error) {
+    if (io.existsSync(tokenPath)) throw error;
+    // Bound beyond localhost but can't persist a token — the bin turns this into a
+    // fatal (it can't run open to the network), so just report absence here.
+    signals.push({ credential: "admin-token", source: "absent" });
+    return null;
+  }
+  signals.push({
+    credential: "admin-token",
+    source: loadedSource(loaded.generated),
+    path: tokenPath,
+  });
+  return loaded.token;
+}

--- a/packages/core/src/auth/boot-credentials.ts
+++ b/packages/core/src/auth/boot-credentials.ts
@@ -64,6 +64,10 @@ function loadOrAbsent<T extends { generated: boolean }>(
   try {
     return load();
   } catch (error) {
+    // Classify by presence: a file that's there now is a malformed/unreadable
+    // existing file (rethrow); absent means the write itself failed (read-only
+    // volume) → fall back to null. The re-check races a concurrent creator in
+    // theory, but the store is single-owner so that window doesn't occur here.
     if (io.existsSync(filePath)) throw error;
     return null;
   }
@@ -106,7 +110,10 @@ function resolveAdminTokenCredential(
   io: FileIo,
   signals: BootCredentialSignal[],
 ): string | null {
-  const envToken = (input.env.LIBRARIAN_ADMIN_TOKEN || input.env.LIBRARIAN_AUTH_TOKEN || "").trim();
+  // Not trimmed, deliberately: the bin's admin/agent collision checks compare these
+  // raw env values, so trimming only here could mask an identical-modulo-whitespace
+  // collision. Matches the prior boot behavior (`env || env || ""`).
+  const envToken = input.env.LIBRARIAN_ADMIN_TOKEN || input.env.LIBRARIAN_AUTH_TOKEN || "";
   if (envToken) {
     signals.push({ credential: "admin-token", source: "env" });
     return envToken;

--- a/packages/core/src/auth/boot-credentials.ts
+++ b/packages/core/src/auth/boot-credentials.ts
@@ -15,9 +15,8 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { type FileIo, type LoadedSecretKey, loadOrCreateSecretKeyFile } from "../secret-crypto.js";
-import { resolveSecretKey } from "../secret-crypto.js";
-import { type LoadedAdminToken, loadOrCreateAdminTokenFile } from "./admin-token.js";
+import { type FileIo, loadOrCreateSecretKeyFile, resolveSecretKey } from "../secret-crypto.js";
+import { loadOrCreateAdminTokenFile } from "./admin-token.js";
 
 const SECRET_KEY_FILE = "secret.key";
 const ADMIN_TOKEN_FILE = "admin.token";
@@ -50,6 +49,26 @@ function loadedSource(generated: boolean): "generated" | "file" {
   return generated ? "generated" : "file";
 }
 
+/**
+ * Run a credential-file load, distinguishing the two failure modes the resolver
+ * treats differently: a malformed *existing* file is an operator signal (rethrow,
+ * fail loud), while a *write* failure — the file is absent and the volume is
+ * read-only — means we simply can't persist, so fall back to "absent" instead of
+ * crashing. Returns the loaded value, or null for the absent/can't-persist case.
+ */
+function loadOrAbsent<T extends { generated: boolean }>(
+  filePath: string,
+  io: FileIo,
+  load: () => T,
+): T | null {
+  try {
+    return load();
+  } catch (error) {
+    if (io.existsSync(filePath)) throw error;
+    return null;
+  }
+}
+
 export function resolveBootCredentials(input: BootCredentialsInput): ResolvedBootCredentials {
   const io = input.io ?? fs;
   const signals: BootCredentialSignal[] = [];
@@ -73,14 +92,8 @@ function resolveSecretKeyCredential(
   }
 
   const keyPath = path.join(input.dataDir, SECRET_KEY_FILE);
-  let loaded: LoadedSecretKey;
-  try {
-    loaded = loadOrCreateSecretKeyFile(keyPath, io);
-  } catch (error) {
-    // A malformed *existing* file is an operator signal — rethrow. A write failure
-    // (read-only volume) means we simply can't persist a key: fall back to the
-    // no-secrets path rather than crashing the whole server.
-    if (io.existsSync(keyPath)) throw error;
+  const loaded = loadOrAbsent(keyPath, io, () => loadOrCreateSecretKeyFile(keyPath, io));
+  if (!loaded) {
     signals.push({ credential: "secret-key", source: "absent" });
     return null;
   }
@@ -108,13 +121,10 @@ function resolveAdminTokenCredential(
   }
 
   const tokenPath = path.join(input.dataDir, ADMIN_TOKEN_FILE);
-  let loaded: LoadedAdminToken;
-  try {
-    loaded = loadOrCreateAdminTokenFile(tokenPath, io);
-  } catch (error) {
-    if (io.existsSync(tokenPath)) throw error;
-    // Bound beyond localhost but can't persist a token — the bin turns this into a
-    // fatal (it can't run open to the network), so just report absence here.
+  // Bound beyond localhost but can't persist a token (read-only volume) → absent;
+  // the bin turns that into a fatal (it can't run open to the network).
+  const loaded = loadOrAbsent(tokenPath, io, () => loadOrCreateAdminTokenFile(tokenPath, io));
+  if (!loaded) {
     signals.push({ credential: "admin-token", source: "absent" });
     return null;
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -150,6 +150,7 @@ export {
   type LibrarianStore,
   type LibrarianStoreOptions,
   createLibrarianStore,
+  resolveDataDir,
 } from "./store/librarian-store.js";
 export {
   type BackupFileEntry,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -115,8 +115,10 @@ export {
   createCuratorLlmClient,
 } from "./curator-llm-client.js";
 export {
+  type LoadedSecretKey,
   decryptSecret,
   encryptSecret,
+  loadOrCreateSecretKeyFile,
   resolveOptionalSecretKey,
   resolveSecretKey,
 } from "./secret-crypto.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -115,6 +115,7 @@ export {
   createCuratorLlmClient,
 } from "./curator-llm-client.js";
 export {
+  type FileIo,
   type LoadedSecretKey,
   decryptSecret,
   encryptSecret,
@@ -179,6 +180,13 @@ export {
   loadOrCreateAdminTokenFile,
   parseAdminToken,
 } from "./auth/admin-token.js";
+export {
+  type BootCredentialSignal,
+  type BootCredentialsInput,
+  type CredentialSource,
+  type ResolvedBootCredentials,
+  resolveBootCredentials,
+} from "./auth/boot-credentials.js";
 export {
   type CompleteCurationRunInput,
   type CreateCurationRunInput,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -175,6 +175,11 @@ export {
   verifyAgentToken,
 } from "./auth/agent-tokens.js";
 export {
+  type LoadedAdminToken,
+  loadOrCreateAdminTokenFile,
+  parseAdminToken,
+} from "./auth/admin-token.js";
+export {
   type CompleteCurationRunInput,
   type CreateCurationRunInput,
   type CurationOperation,

--- a/packages/core/src/secret-crypto.ts
+++ b/packages/core/src/secret-crypto.ts
@@ -13,6 +13,7 @@
 // Server-only (node:crypto).
 
 import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+import fs from "node:fs";
 
 const ALGORITHM = "aes-256-gcm";
 const KEY_BYTES = 32;
@@ -74,6 +75,40 @@ export function resolveSecretKey(raw: string | undefined): Buffer {
  */
 export function resolveOptionalSecretKey(raw: string | undefined): Buffer | null {
   return (raw ?? "").trim() === "" ? null : resolveSecretKey(raw);
+}
+
+export interface LoadedSecretKey {
+  key: Buffer;
+  /** True when this call generated a fresh key (caller logs the one-time notice). */
+  generated: boolean;
+}
+
+/**
+ * Read the master key from `filePath`, or generate and persist one when the file
+ * is absent (the D0 credential-bootstrap path: a fresh install gets a key on the
+ * data volume with no operator action). The file is the durable home of the key
+ * when `LIBRARIAN_SECRET_KEY` is unset.
+ *
+ * - Exists → read + validate via {@link resolveSecretKey} (throws on a malformed
+ *   file rather than silently overwriting it — a bad key file is an operator
+ *   signal, not garbage to clobber). Perms are left as-is (never widened).
+ * - Absent → write a CSPRNG 32-byte key as 64-char hex with `open('wx', 0o600)`:
+ *   `wx` fails if a racing boot already created it, and `0600` keeps it
+ *   owner-only from creation (never a readable-then-chmod window).
+ */
+export function loadOrCreateSecretKeyFile(filePath: string): LoadedSecretKey {
+  let existing: string | null = null;
+  try {
+    existing = fs.readFileSync(filePath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  if (existing !== null) {
+    return { key: resolveSecretKey(existing), generated: false };
+  }
+  const keyHex = randomBytes(KEY_BYTES).toString("hex");
+  fs.writeFileSync(filePath, keyHex, { flag: "wx", mode: 0o600 });
+  return { key: resolveSecretKey(keyHex), generated: true };
 }
 
 /**

--- a/packages/core/src/secret-crypto.ts
+++ b/packages/core/src/secret-crypto.ts
@@ -84,6 +84,17 @@ export interface LoadedSecretKey {
 }
 
 /**
+ * The narrow slice of `node:fs` the credential-file helpers use. Injecting it
+ * keeps the boot-credential resolver unit-testable without touching disk (a fake
+ * models file presence + a writable/read-only volume); `node:fs` is the default.
+ */
+export interface FileIo {
+  existsSync(path: string): boolean;
+  readFileSync(path: string, encoding: "utf8"): string;
+  writeFileSync(path: string, data: string, options: { flag: string; mode: number }): void;
+}
+
+/**
  * Read the master key from `filePath`, or generate and persist one when the file
  * is absent (the D0 credential-bootstrap path: a fresh install gets a key on the
  * data volume with no operator action). The file is the durable home of the key
@@ -93,21 +104,15 @@ export interface LoadedSecretKey {
  *   file rather than silently overwriting it — a bad key file is an operator
  *   signal, not garbage to clobber). Perms are left as-is (never widened).
  * - Absent → write a CSPRNG 32-byte key as 64-char hex with `open('wx', 0o600)`:
- *   `wx` fails if a racing boot already created it, and `0600` keeps it
- *   owner-only from creation (never a readable-then-chmod window).
+ *   `wx` fails if a racing boot already created it (closing the existsSync→write
+ *   TOCTOU), and `0600` keeps it owner-only from creation.
  */
-export function loadOrCreateSecretKeyFile(filePath: string): LoadedSecretKey {
-  let existing: string | null = null;
-  try {
-    existing = fs.readFileSync(filePath, "utf8");
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-  }
-  if (existing !== null) {
-    return { key: resolveSecretKey(existing), generated: false };
+export function loadOrCreateSecretKeyFile(filePath: string, io: FileIo = fs): LoadedSecretKey {
+  if (io.existsSync(filePath)) {
+    return { key: resolveSecretKey(io.readFileSync(filePath, "utf8")), generated: false };
   }
   const keyHex = randomBytes(KEY_BYTES).toString("hex");
-  fs.writeFileSync(filePath, keyHex, { flag: "wx", mode: 0o600 });
+  io.writeFileSync(filePath, keyHex, { flag: "wx", mode: 0o600 });
   return { key: resolveSecretKey(keyHex), generated: true };
 }
 

--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -10,6 +10,16 @@ import { type SettingsStore, createSettingsStore } from "./settings-store.js";
 
 const DEFAULT_DATA_DIR = path.join(process.cwd(), "data");
 
+/**
+ * Resolve the data directory the store (and its sibling credential files) live in:
+ * an explicit option wins, then `LIBRARIAN_DATA_DIR`, then `<cwd>/data`. Exported
+ * so the boot path can place `secret.key`/`admin.token` in the exact same dir the
+ * store will use, before the store (which needs the key) is constructed.
+ */
+export function resolveDataDir(dataDir?: string): string {
+  return dataDir || process.env.LIBRARIAN_DATA_DIR || DEFAULT_DATA_DIR;
+}
+
 export interface LibrarianStoreOptions {
   dataDir?: string;
   /**
@@ -39,7 +49,7 @@ export interface LibrarianStore extends MemoryStore, SessionStore, CurationStore
 }
 
 export function createLibrarianStore(options: LibrarianStoreOptions = {}): LibrarianStore {
-  const dataDir = options.dataDir || process.env.LIBRARIAN_DATA_DIR || DEFAULT_DATA_DIR;
+  const dataDir = resolveDataDir(options.dataDir);
   const eventsPath = path.join(dataDir, "events.jsonl");
   // R3 — runtime writes timeline events to session_events.jsonl. State
   // transitions stop appearing in any JSONL (they live in SQLite +

--- a/packages/core/tests/auth/admin-token.test.ts
+++ b/packages/core/tests/auth/admin-token.test.ts
@@ -1,0 +1,52 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { loadOrCreateAdminTokenFile } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+describe("loadOrCreateAdminTokenFile", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "lib-admin-"));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("generates a libadmin_ token (>=32 bytes entropy) in a 0600 file when absent", () => {
+    const file = path.join(dir, "admin.token");
+    const { token, generated } = loadOrCreateAdminTokenFile(file);
+    expect(generated).toBe(true);
+    expect(token).toMatch(/^libadmin_[A-Za-z0-9_-]+$/);
+    // The random body must carry at least 32 bytes of entropy.
+    const body = token.slice("libadmin_".length);
+    expect(Buffer.from(body, "base64url").length).toBeGreaterThanOrEqual(32);
+    expect(fs.readFileSync(file, "utf8").trim()).toBe(token);
+    expect(fs.statSync(file).mode & 0o077).toBe(0);
+  });
+
+  it("reuses the existing token on a second call (no regeneration)", () => {
+    const file = path.join(dir, "admin.token");
+    const first = loadOrCreateAdminTokenFile(file);
+    const second = loadOrCreateAdminTokenFile(file);
+    expect(second.generated).toBe(false);
+    expect(second.token).toBe(first.token);
+  });
+
+  it("reads an existing well-formed token without widening perms", () => {
+    const file = path.join(dir, "admin.token");
+    const existing = `libadmin_${Buffer.from("a".repeat(40)).toString("base64url")}`;
+    fs.writeFileSync(file, `${existing}\n`, { mode: 0o600 });
+    const { token, generated } = loadOrCreateAdminTokenFile(file);
+    expect(generated).toBe(false);
+    expect(token).toBe(existing);
+    expect(fs.statSync(file).mode & 0o077).toBe(0);
+  });
+
+  it("throws on a malformed existing token file (fail loud, never overwrite)", () => {
+    const file = path.join(dir, "admin.token");
+    fs.writeFileSync(file, "not-an-admin-token");
+    expect(() => loadOrCreateAdminTokenFile(file)).toThrow(/admin token/i);
+    expect(fs.readFileSync(file, "utf8")).toBe("not-an-admin-token");
+  });
+});

--- a/packages/core/tests/auth/admin-token.test.ts
+++ b/packages/core/tests/auth/admin-token.test.ts
@@ -18,9 +18,10 @@ describe("loadOrCreateAdminTokenFile", () => {
     const { token, generated } = loadOrCreateAdminTokenFile(file);
     expect(generated).toBe(true);
     expect(token).toMatch(/^libadmin_[A-Za-z0-9_-]+$/);
-    // The random body must carry at least 32 bytes of entropy.
+    // The random body decodes to exactly 32 bytes of entropy (symmetry with the
+    // 32-byte secret key).
     const body = token.slice("libadmin_".length);
-    expect(Buffer.from(body, "base64url").length).toBeGreaterThanOrEqual(32);
+    expect(Buffer.from(body, "base64url").length).toBe(32);
     expect(fs.readFileSync(file, "utf8").trim()).toBe(token);
     expect(fs.statSync(file).mode & 0o077).toBe(0);
   });

--- a/packages/core/tests/auth/boot-credentials.test.ts
+++ b/packages/core/tests/auth/boot-credentials.test.ts
@@ -1,0 +1,149 @@
+import path from "node:path";
+import { type FileIo, resolveBootCredentials, resolveSecretKey } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+const KEY_HEX = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
+const ADMIN_TOKEN = `libadmin_${Buffer.from("z".repeat(40)).toString("base64url")}`;
+const DATA = "/data";
+const KEY_PATH = path.join(DATA, "secret.key");
+const TOKEN_PATH = path.join(DATA, "admin.token");
+
+// An in-memory FileIo: models file presence and a writable/read-only volume.
+function fakeFs(opts: { files?: Record<string, string>; writable?: boolean } = {}) {
+  const files = new Map(Object.entries(opts.files ?? {}));
+  const writable = opts.writable ?? true;
+  const io: FileIo = {
+    existsSync: (p) => files.has(p),
+    readFileSync: (p) => {
+      const v = files.get(p);
+      if (v === undefined) {
+        const err = new Error(`ENOENT: ${p}`) as NodeJS.ErrnoException;
+        err.code = "ENOENT";
+        throw err;
+      }
+      return v;
+    },
+    writeFileSync: (p, data) => {
+      if (!writable) {
+        const err = new Error(`EROFS: read-only file system, ${p}`) as NodeJS.ErrnoException;
+        err.code = "EROFS";
+        throw err;
+      }
+      files.set(p, data);
+    },
+  };
+  return { io, files };
+}
+
+describe("resolveBootCredentials — secret key matrix", () => {
+  it("uses the env key and writes no file", () => {
+    const { io, files } = fakeFs();
+    const r = resolveBootCredentials({
+      env: { LIBRARIAN_SECRET_KEY: KEY_HEX },
+      dataDir: DATA,
+      boundBeyondLocalhost: false,
+      io,
+    });
+    expect(r.secretKey?.equals(resolveSecretKey(KEY_HEX))).toBe(true);
+    expect(files.has(KEY_PATH)).toBe(false);
+    expect(r.signals).toContainEqual({ credential: "secret-key", source: "env" });
+  });
+
+  it("reads an existing key file", () => {
+    const { io } = fakeFs({ files: { [KEY_PATH]: KEY_HEX } });
+    const r = resolveBootCredentials({ env: {}, dataDir: DATA, boundBeyondLocalhost: false, io });
+    expect(r.secretKey?.equals(resolveSecretKey(KEY_HEX))).toBe(true);
+    expect(r.signals).toContainEqual({ credential: "secret-key", source: "file", path: KEY_PATH });
+  });
+
+  it("generates a key file when absent and the volume is writable", () => {
+    const { io, files } = fakeFs();
+    const r = resolveBootCredentials({ env: {}, dataDir: DATA, boundBeyondLocalhost: false, io });
+    expect(r.secretKey).not.toBeNull();
+    expect(files.has(KEY_PATH)).toBe(true);
+    expect(r.signals).toContainEqual({
+      credential: "secret-key",
+      source: "generated",
+      path: KEY_PATH,
+    });
+  });
+
+  it("falls back to no key (null) when absent and the volume is read-only — never crashes", () => {
+    const { io, files } = fakeFs({ writable: false });
+    const r = resolveBootCredentials({ env: {}, dataDir: DATA, boundBeyondLocalhost: false, io });
+    expect(r.secretKey).toBeNull();
+    expect(files.has(KEY_PATH)).toBe(false);
+    expect(r.signals).toContainEqual({ credential: "secret-key", source: "absent" });
+  });
+
+  it("throws on a malformed existing key file (fail loud, not fall back)", () => {
+    const { io } = fakeFs({ files: { [KEY_PATH]: "garbage" } });
+    expect(() =>
+      resolveBootCredentials({ env: {}, dataDir: DATA, boundBeyondLocalhost: false, io }),
+    ).toThrow(/32 bytes/i);
+  });
+});
+
+describe("resolveBootCredentials — admin token matrix", () => {
+  it("uses LIBRARIAN_ADMIN_TOKEN from env", () => {
+    const { io, files } = fakeFs();
+    const r = resolveBootCredentials({
+      env: { LIBRARIAN_ADMIN_TOKEN: "supplied-token" },
+      dataDir: DATA,
+      boundBeyondLocalhost: true,
+      io,
+    });
+    expect(r.adminToken).toBe("supplied-token");
+    expect(files.has(TOKEN_PATH)).toBe(false);
+    expect(r.signals).toContainEqual({ credential: "admin-token", source: "env" });
+  });
+
+  it("accepts the legacy LIBRARIAN_AUTH_TOKEN as the admin token", () => {
+    const { io } = fakeFs();
+    const r = resolveBootCredentials({
+      env: { LIBRARIAN_AUTH_TOKEN: "legacy-token" },
+      dataDir: DATA,
+      boundBeyondLocalhost: true,
+      io,
+    });
+    expect(r.adminToken).toBe("legacy-token");
+  });
+
+  it("generates an admin token when bound beyond localhost, absent, and writable", () => {
+    const { io, files } = fakeFs();
+    const r = resolveBootCredentials({ env: {}, dataDir: DATA, boundBeyondLocalhost: true, io });
+    expect(r.adminToken).toMatch(/^libadmin_/);
+    expect(files.has(TOKEN_PATH)).toBe(true);
+    expect(r.signals).toContainEqual({
+      credential: "admin-token",
+      source: "generated",
+      path: TOKEN_PATH,
+    });
+  });
+
+  it("reads an existing admin token file", () => {
+    const { io } = fakeFs({ files: { [TOKEN_PATH]: ADMIN_TOKEN } });
+    const r = resolveBootCredentials({ env: {}, dataDir: DATA, boundBeyondLocalhost: true, io });
+    expect(r.adminToken).toBe(ADMIN_TOKEN);
+    expect(r.signals).toContainEqual({
+      credential: "admin-token",
+      source: "file",
+      path: TOKEN_PATH,
+    });
+  });
+
+  it("on localhost with no token, returns no token and writes nothing (bypass unchanged)", () => {
+    const { io, files } = fakeFs();
+    const r = resolveBootCredentials({ env: {}, dataDir: DATA, boundBeyondLocalhost: false, io });
+    expect(r.adminToken).toBeNull();
+    expect(files.has(TOKEN_PATH)).toBe(false);
+    expect(r.signals).toContainEqual({ credential: "admin-token", source: "absent" });
+  });
+
+  it("does not crash when bound beyond localhost but the volume is read-only", () => {
+    const { io } = fakeFs({ writable: false });
+    const r = resolveBootCredentials({ env: {}, dataDir: DATA, boundBeyondLocalhost: true, io });
+    expect(r.adminToken).toBeNull();
+    expect(r.signals).toContainEqual({ credential: "admin-token", source: "absent" });
+  });
+});

--- a/packages/core/tests/backup.test.ts
+++ b/packages/core/tests/backup.test.ts
@@ -83,6 +83,24 @@ describe("createBackup / restoreBackup", () => {
     expect(deepSnapshot(store)).toEqual(before); // full fidelity incl. rolling_summary, timestamps, events
   });
 
+  it("never bundles the credential files (secret.key / admin.token) that live in the data dir", () => {
+    seedMemory(store);
+    // D0 writes these beside the store; a backup must stay key-free so a leaked
+    // bundle is not a leaked key/token.
+    fs.writeFileSync(path.join(dataDir, "secret.key"), "00".repeat(32), { mode: 0o600 });
+    fs.writeFileSync(path.join(dataDir, "admin.token"), "libadmin_example", { mode: 0o600 });
+
+    const { dir, manifest } = createBackup(store, { destDir });
+
+    const names = manifest.files.map((f) => f.name);
+    expect(names).not.toContain("secret.key");
+    expect(names).not.toContain("admin.token");
+    // And the files are physically absent from the bundle directory, not merely
+    // omitted from the manifest.
+    expect(fs.existsSync(path.join(dir, "secret.key"))).toBe(false);
+    expect(fs.existsSync(path.join(dir, "admin.token"))).toBe(false);
+  });
+
   it("records a sha256 + byte size for every file", () => {
     seedMemory(store);
     const { manifest } = createBackup(store, { destDir });

--- a/packages/core/tests/secret-crypto.test.ts
+++ b/packages/core/tests/secret-crypto.test.ts
@@ -6,13 +6,17 @@
 // key parsing.
 
 import { randomBytes } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import {
   decryptSecret,
   encryptSecret,
+  loadOrCreateSecretKeyFile,
   resolveOptionalSecretKey,
   resolveSecretKey,
 } from "@librarian/core";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 // A fixed 32-byte test key (hex).
 const KEY_HEX = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
@@ -103,6 +107,55 @@ describe("resolveOptionalSecretKey", () => {
   it("still throws on a present-but-malformed key (fail loud at boot)", () => {
     expect(() => resolveOptionalSecretKey("tooshort")).toThrow(/32 bytes/i);
     expect(() => resolveOptionalSecretKey("00".repeat(32))).toThrow(/entropy/i);
+  });
+});
+
+describe("loadOrCreateSecretKeyFile", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "lib-key-"));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("generates a 32-byte hex key in a 0600 file when absent", () => {
+    const file = path.join(dir, "secret.key");
+    const { key, generated } = loadOrCreateSecretKeyFile(file);
+    expect(generated).toBe(true);
+    expect(key).toHaveLength(32);
+    // 64-char hex on disk.
+    expect(fs.readFileSync(file, "utf8").trim()).toMatch(/^[0-9a-f]{64}$/);
+    // No group/other access (umask-robust check).
+    expect(fs.statSync(file).mode & 0o077).toBe(0);
+  });
+
+  it("reuses the existing key on a second call (no regeneration)", () => {
+    const file = path.join(dir, "secret.key");
+    const first = loadOrCreateSecretKeyFile(file);
+    const onDisk = fs.readFileSync(file, "utf8");
+    const second = loadOrCreateSecretKeyFile(file);
+    expect(second.generated).toBe(false);
+    expect(second.key.equals(first.key)).toBe(true);
+    // The file is untouched (same bytes).
+    expect(fs.readFileSync(file, "utf8")).toBe(onDisk);
+  });
+
+  it("returns an existing valid key without widening its perms", () => {
+    const file = path.join(dir, "secret.key");
+    fs.writeFileSync(file, KEY_HEX, { mode: 0o600 });
+    const { key, generated } = loadOrCreateSecretKeyFile(file);
+    expect(generated).toBe(false);
+    expect(key.equals(resolveSecretKey(KEY_HEX))).toBe(true);
+    expect(fs.statSync(file).mode & 0o077).toBe(0);
+  });
+
+  it("throws on a malformed existing key file (fail loud, never overwrite)", () => {
+    const file = path.join(dir, "secret.key");
+    fs.writeFileSync(file, "not-a-valid-key");
+    expect(() => loadOrCreateSecretKeyFile(file)).toThrow(/32 bytes/i);
+    // The bad file is left intact for the operator to inspect, not clobbered.
+    expect(fs.readFileSync(file, "utf8")).toBe("not-a-valid-key");
   });
 });
 

--- a/packages/mcp-server/src/bin/http.ts
+++ b/packages/mcp-server/src/bin/http.ts
@@ -5,11 +5,13 @@
 // server from `../http/server.ts`. All env parsing + boot-time
 // validation lives here so the server module itself stays pure.
 
+import fs from "node:fs";
 import path from "node:path";
 import {
   createLibrarianStore,
   createSerialScheduler,
-  resolveOptionalSecretKey,
+  resolveBootCredentials,
+  resolveDataDir,
   runBackup,
   runCuratorTick,
   verifyAgentToken,
@@ -18,19 +20,58 @@ import { type AuthConfig, AgentTokensError, parseAgentTokenMap, parseCsv } from 
 import { createHttpServer } from "../http/server.js";
 import { logger } from "../logging.js";
 
-// LIBRARIAN_SECRET_KEY (optional) unlocks encrypted admin settings (the curator's
-// LLM token). Absent → store runs without secret support; present-but-bad → fail loud.
-let secretKey: Buffer | null;
-try {
-  secretKey = resolveOptionalSecretKey(process.env.LIBRARIAN_SECRET_KEY);
-} catch (error) {
-  logger.fatal(`Invalid LIBRARIAN_SECRET_KEY: ${(error as Error).message}`);
-  process.exit(1);
-}
-const store = createLibrarianStore({ secretKey });
 const host = process.env.LIBRARIAN_HOST || process.env.LIBRARIAN_DASHBOARD_HOST || "127.0.0.1";
 const port = Number(process.env.LIBRARIAN_PORT || process.env.LIBRARIAN_DASHBOARD_PORT || 3838);
-const adminToken = process.env.LIBRARIAN_ADMIN_TOKEN || process.env.LIBRARIAN_AUTH_TOKEN || "";
+// The localhost no-auth bypass (and the explicit ALLOW_NO_AUTH opt-out) is exactly
+// the set of cases that don't require — and shouldn't auto-generate — an admin token.
+const allowNoAuth =
+  process.env.LIBRARIAN_ALLOW_NO_AUTH === "true" || host === "127.0.0.1" || host === "localhost";
+
+// Resolve the data volume first: the credential files live beside the store and
+// must be in place before the store (which needs the key) is built. mkdir up front
+// so a fresh install can persist them; a read-only volume falls back gracefully.
+const dataDir = resolveDataDir();
+try {
+  fs.mkdirSync(dataDir, { recursive: true });
+} catch {
+  // Left to the credential resolver (no-secrets fallback) and the store to surface.
+}
+
+// D0 credential bootstrap: env wins, then ${dataDir}/{secret.key,admin.token}, then
+// generate. The branch that's fatal today (bound beyond localhost with no token) now
+// auto-provisions one. A present-but-bad key still fails loud.
+let secretKey: Buffer | null;
+let adminToken: string;
+try {
+  const creds = resolveBootCredentials({
+    env: process.env,
+    dataDir,
+    boundBeyondLocalhost: !allowNoAuth,
+  });
+  secretKey = creds.secretKey;
+  adminToken = creds.adminToken ?? "";
+  for (const signal of creds.signals) {
+    if (signal.source !== "generated") continue;
+    if (signal.credential === "secret-key") {
+      logger.warn(
+        { path: signal.path },
+        "Generated a new master key (LIBRARIAN_SECRET_KEY). SAVE THIS KEY — without it, restored secrets cannot be decrypted.",
+      );
+    } else {
+      // The sole sanctioned admin-token log: a fresh install needs it once to enable
+      // auth from the dashboard. Never logged again on subsequent boots.
+      logger.warn(
+        { path: signal.path },
+        `Generated a new admin token (LIBRARIAN_ADMIN_TOKEN): ${adminToken}`,
+      );
+    }
+  }
+} catch (error) {
+  logger.fatal(`Invalid boot credentials: ${(error as Error).message}`);
+  process.exit(1);
+}
+
+const store = createLibrarianStore({ secretKey, dataDir });
 const agentToken = process.env.LIBRARIAN_AGENT_TOKEN || "";
 
 let agentTokenMap: Map<string, string>;
@@ -45,10 +86,10 @@ try {
 }
 
 const allowedOrigins = parseCsv(process.env.LIBRARIAN_ALLOWED_ORIGINS || "");
-const allowNoAuth =
-  process.env.LIBRARIAN_ALLOW_NO_AUTH === "true" || host === "127.0.0.1" || host === "localhost";
 const maxBodyBytes = Number(process.env.LIBRARIAN_MAX_BODY_BYTES || 1024 * 1024);
 
+// Reachable only if bound beyond localhost AND credential generation failed (e.g. a
+// read-only volume) — we won't run open to the network. Normally D0 generates a token.
 if (!adminToken && !allowNoAuth) {
   logger.fatal(
     "Refusing to start without LIBRARIAN_ADMIN_TOKEN or LIBRARIAN_AUTH_TOKEN when bound beyond localhost.",

--- a/packages/mcp-server/src/bin/stdio.ts
+++ b/packages/mcp-server/src/bin/stdio.ts
@@ -5,19 +5,34 @@
 // through `handleMcpMessage`, and writes responses to stdout. Roles
 // come from `LIBRARIAN_STDIO_ROLE` / `LIBRARIAN_STDIO_AGENT_ID`.
 
-import { createLibrarianStore, resolveOptionalSecretKey } from "@librarian/core";
+import fs from "node:fs";
+import { createLibrarianStore, resolveBootCredentials, resolveDataDir } from "@librarian/core";
 import { handleMcpMessage } from "../mcp/rpc.js";
 
-// LIBRARIAN_SECRET_KEY (optional) unlocks encrypted admin settings. Absent → no
-// secret support; present-but-bad → fail loud (to stderr; stdout is the RPC channel).
+// LIBRARIAN_SECRET_KEY (optional) unlocks encrypted admin settings. D0: when unset,
+// resolve it from (or generate it to) ${dataDir}/secret.key so a fresh local install
+// gets secret support with no env. stdio never binds to the network, so no admin
+// token is provisioned. present-but-bad → fail loud (to stderr; stdout is the RPC channel).
+const dataDir = resolveDataDir();
+try {
+  fs.mkdirSync(dataDir, { recursive: true });
+} catch {
+  // Read-only volume → the resolver falls back to the no-secrets path.
+}
 let secretKey: Buffer | null;
 try {
-  secretKey = resolveOptionalSecretKey(process.env.LIBRARIAN_SECRET_KEY);
+  const creds = resolveBootCredentials({ env: process.env, dataDir, boundBeyondLocalhost: false });
+  secretKey = creds.secretKey;
+  if (creds.signals.some((s) => s.credential === "secret-key" && s.source === "generated")) {
+    process.stderr.write(
+      "Generated a new master key (LIBRARIAN_SECRET_KEY) on the data volume. SAVE THIS KEY — without it, restored secrets cannot be decrypted.\n",
+    );
+  }
 } catch (error) {
   process.stderr.write(`Invalid LIBRARIAN_SECRET_KEY: ${(error as Error).message}\n`);
   process.exit(1);
 }
-const store = createLibrarianStore({ secretKey });
+const store = createLibrarianStore({ secretKey, dataDir });
 
 process.stdin.setEncoding("utf8");
 


### PR DESCRIPTION
## D0 — Credential bootstrap

First slice of **dashboard-managed-auth** (spec/plan/tasks in #143: `docs/specs/dashboard-managed-auth{,-plan,-tasks}.md`). A fresh install now needs **zero** secret/auth env vars — the master key and admin token auto-provision to the data volume, and a cross-host restore can recover the key.

### What changed (tasks D0.1–D0.7)
- **`loadOrCreateSecretKeyFile` / `loadOrCreateAdminTokenFile`** (core) — read or generate a 32-byte master key (64-char hex) and a `libadmin_<base64url>` admin token, each written `0600` via `open('wx')`; malformed existing files throw rather than being clobbered; perms never widened.
- **`resolveBootCredentials`** (core) — pure decision matrix: env → data volume → generate. Secret key falls back to *null* (no-secrets path, never a crash) on a read-only volume; admin token auto-generates **only** when bound beyond localhost — the localhost no-auth bypass is byte-for-byte unchanged. A `FileIo` seam makes the matrix unit-tested against a fake writable/read-only volume.
- **Boot wiring** (`bin/http.ts`, `bin/stdio.ts`) — generation is logged **exactly once** each; the admin-token print is the **sole** sanctioned token log; the fatal-when-bound-beyond-localhost-without-a-token check remains as a backstop for the can't-persist edge.
- **Backups stay key-free** — `createBackup` already uses a file allowlist; added a regression guard so a future change can't start bundling `secret.key`/`admin.token`.
- **`restore` master-key recovery** — after a cross-host restore, if the data has encrypted secrets, resolve the key (`--secret-key` → env → **no-echo** TTY prompt), verify it actually decrypts, and persist it to `secret.key` (0600) so the next boot can read it. An env key is honored but not persisted (key/data separation). Wrong key errors clearly; non-interactive with no key gives an actionable message, never a stack trace.
- **Docs** — `.env.example` + `DEPLOYMENT.md` document auto-generation, the one-time "save your key" log, and the restore key prompt.

### Verification
- Full local CI parity green: build, lint, format:check, typecheck, `pnpm test` (869 vitest across all packages), smoke, healthcheck, and all guards.
- Manual boot smoke: fresh boot generates+logs key+token (0600); reboot reuses them (no regen); env-set key writes no file.
- Self-reviewed via a five-axis code review; Critical (fail-soft after overwrite, handle leak) and Important (no-echo prompt, env-token trimming consistency) findings fixed in this PR.

### Notes
- Reorders the spec's `(D3 ∥ D4)` to build **D4 before D3** in later slices so recovery merges before password-login enforcement is exposed — D0 is independent of that.
- Does not depend on #143; the planning docs there can merge separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)