### PR TITLE
feat(auth): D2 — auth tRPC router + dynamic dashboard config

### DIFF
--- a/apps/dashboard/app/api/trpc/[trpc]/route.ts
+++ b/apps/dashboard/app/api/trpc/[trpc]/route.ts
@@ -1,7 +1,8 @@
 import "server-only";
 import type { NextRequest } from "next/server";
 import { auth } from "@/auth";
-import { isAuthEnforced } from "@/lib/auth-gate";
+import { getAuthConfig } from "@/lib/auth-config-client";
+import { resolveEnforcement } from "@/lib/auth-gate";
 
 const DEFAULT_SERVER_URL = "http://127.0.0.1:3838";
 const ALLOWED_METHODS = new Set(["GET", "POST"]);
@@ -27,12 +28,14 @@ async function proxy(req: NextRequest, segment: string): Promise<Response> {
   if (!isSameOrigin(req)) {
     return new Response("Forbidden", { status: 403 });
   }
-  // Critical: this proxy injects the admin bearer token, so when auth is
-  // enforced it must require a session of its own — middleware does NOT cover
-  // API routes, and without this the dashboard's admin power is reachable
-  // without logging in. Fail closed: a thrown auth() (e.g. a tampered JWT) is
-  // a deny, not a 500 — mirrors the signIn callback in auth.ts.
-  if (isAuthEnforced()) {
+  // Critical: this proxy injects the admin bearer token, so when auth is enforced
+  // it must require a session of its own — middleware does NOT cover API routes,
+  // and without this the dashboard's admin power is reachable without logging in.
+  // Enforcement is store-driven (D2.4); any non-"open" decision ("enforce" or the
+  // fail-closed "block") requires a valid session. A thrown auth() (tampered JWT)
+  // is a deny, not a 500 — mirrors the signIn callback in auth.ts.
+  const enforcement = await resolveEnforcement(() => getAuthConfig());
+  if (enforcement !== "open") {
     const session = await auth().catch(() => null);
     if (!session) return new Response("Unauthorized", { status: 401 });
   }

--- a/apps/dashboard/app/api/trpc/[trpc]/route.ts
+++ b/apps/dashboard/app/api/trpc/[trpc]/route.ts
@@ -33,7 +33,9 @@ async function proxy(req: NextRequest, segment: string): Promise<Response> {
   // and without this the dashboard's admin power is reachable without logging in.
   // Enforcement is store-driven (D2.4); any non-"open" decision ("enforce" or the
   // fail-closed "block") requires a valid session. A thrown auth() (tampered JWT)
-  // is a deny, not a 500 — mirrors the signIn callback in auth.ts.
+  // is a deny, not a 500 — mirrors the signIn callback in auth.ts. (This resolves
+  // enforcement again even though middleware did too — middleware doesn't cover
+  // /api routes, so the proxy must gate itself; both reads share the 30s cache.)
   const enforcement = await resolveEnforcement(() => getAuthConfig());
   if (enforcement !== "open") {
     const session = await auth().catch(() => null);
@@ -59,6 +61,10 @@ async function proxy(req: NextRequest, segment: string): Promise<Response> {
 
   const responseHeaders = new Headers(upstreamRes.headers);
   for (const k of STRIP_OUTBOUND) responseHeaders.delete(k);
+  // tRPC GET queries (e.g. auth.config) carry admin data — AUTH_SECRET, decrypted
+  // OAuth secrets — and GETs are cacheable by default. Force no-store so no shared
+  // cache / CDN / browser disk cache can persist secret material.
+  responseHeaders.set("cache-control", "no-store");
 
   return new Response(upstreamRes.body, {
     status: upstreamRes.status,

--- a/apps/dashboard/auth.ts
+++ b/apps/dashboard/auth.ts
@@ -1,44 +1,94 @@
-// A1: dashboard owner login (Auth.js v5 / next-auth@5 beta) on Next 15 app-router.
+// Dashboard owner login (Auth.js v5) — D2.3 made the config dynamic.
 //
-// Wired but NOT enforced in this slice — there is no middleware yet (A2), so
-// creating this file changes nothing for existing deploys until LIBRARIAN_AUTH_ENABLED
-// flips on. JWT sessions keep the dashboard's "never opens the store" invariant:
-// the only persistent state is the owner allowlist, which lives in env.
+// v5 lazy initialization: NextAuth takes an (async) config function evaluated per
+// request, so providers + secret + the owner allowlist are assembled from the
+// store auth-config (cached, 30s TTL) instead of being frozen from env at module
+// load. When the store has no auth config (a fresh or legacy A1–A5 deploy), it
+// falls back to the env-configured providers + LIBRARIAN_OWNER_* allowlist, so
+// existing deployments are untouched. JWT sessions keep the "dashboard never opens
+// the store" invariant; AUTH_SECRET is the HKDF-derived value from the config.
 //
-// Provider credentials are inferred from env by Auth.js v5: AUTH_GITHUB_ID/SECRET,
-// AUTH_GOOGLE_ID/SECRET, plus AUTH_SECRET for JWT signing. The owner allowlist
-// (LIBRARIAN_OWNER_*) is enforced in the signIn callback via isAllowedOwner.
+// The Credentials (password) provider and the login form land in D3.
 
-import NextAuth from "next-auth";
+import NextAuth, { type NextAuthConfig } from "next-auth";
 import GitHub from "next-auth/providers/github";
 import Google from "next-auth/providers/google";
-import { isAllowedOwner } from "@/lib/owner-allowlist";
+import { type DashboardAuthConfig, getAuthConfig } from "@/lib/auth-config-client";
+import { isAllowedOwner, resolveOwnerAllowlist } from "@/lib/owner-allowlist";
 
-export const { handlers, auth, signIn, signOut } = NextAuth({
-  providers: [GitHub, Google],
-  session: { strategy: "jwt" },
-  // The dashboard runs behind a proxy (Fly/Docker), not on Vercel, so the host
-  // can't be auto-trusted — opt in explicitly.
-  trustHost: true,
-  pages: { signIn: "/login" },
-  callbacks: {
-    // Single-owner gate: only the allowlisted account may complete sign-in.
-    // Deny-by-default lives in isAllowedOwner (no owner configured → no login);
-    // the try/catch makes the boundary itself fail-closed so any unexpected
-    // throw denies rather than surfacing as an error the user could retry past.
-    signIn({ account, profile }) {
-      try {
-        return isAllowedOwner({
-          provider: account?.provider ?? null,
-          accountId: account?.providerAccountId ?? null,
-          email: profile?.email ?? null,
-          // GitHub profiles carry no email_verified, so it reads as unverified
-          // here — GitHub owners must allowlist by account id, not email.
-          emailVerified: profile?.email_verified === true,
-        });
-      } catch {
-        return false;
-      }
+// Best-effort read of the store config; on any failure (store unreachable) return
+// null so we degrade to the env fallback rather than throwing during config assembly.
+async function loadAuthConfig(): Promise<DashboardAuthConfig | null> {
+  try {
+    return await getAuthConfig();
+  } catch {
+    return null;
+  }
+}
+
+type Providers = NextAuthConfig["providers"];
+
+function buildProviders(config: DashboardAuthConfig | null, storeConfigured: boolean): Providers {
+  const providers: Providers = [];
+  if (storeConfigured) {
+    const oauth = config?.oauth ?? {};
+    if (oauth.github) {
+      providers.push(
+        GitHub({ clientId: oauth.github.clientId, clientSecret: oauth.github.clientSecret }),
+      );
+    }
+    if (oauth.google) {
+      providers.push(
+        Google({ clientId: oauth.google.clientId, clientSecret: oauth.google.clientSecret }),
+      );
+    }
+    return providers;
+  }
+  // Legacy env fallback (A1): providers infer creds from AUTH_GITHUB_*/AUTH_GOOGLE_*.
+  if (process.env.AUTH_GITHUB_ID) providers.push(GitHub);
+  if (process.env.AUTH_GOOGLE_ID) providers.push(Google);
+  return providers;
+}
+
+export const { handlers, auth, signIn, signOut } = NextAuth(async (): Promise<NextAuthConfig> => {
+  const config = await loadAuthConfig();
+  const storeConfigured = !!config && config.methods.length > 0;
+  const allowlist = resolveOwnerAllowlist(config);
+  // Derived from LIBRARIAN_SECRET_KEY (config), falling back to the legacy env.
+  const secret = config?.authSecret ?? process.env.AUTH_SECRET;
+
+  return {
+    providers: buildProviders(config, storeConfigured),
+    session: { strategy: "jwt" },
+    // The dashboard runs behind a proxy (Fly/Docker), not on Vercel, so the host
+    // can't be auto-trusted — opt in explicitly.
+    trustHost: true,
+    // Omit entirely when unset (exactOptionalPropertyTypes) — NextAuth then errors
+    // loudly at use rather than being handed an explicit undefined.
+    ...(secret ? { secret } : {}),
+    pages: { signIn: "/login" },
+    callbacks: {
+      // Single-owner gate: only the allowlisted account may complete sign-in.
+      // Deny-by-default lives in isAllowedOwner; the try/catch makes the boundary
+      // itself fail-closed so any unexpected throw denies rather than letting the
+      // user retry past it.
+      signIn({ account, profile }) {
+        try {
+          return isAllowedOwner(
+            {
+              provider: account?.provider ?? null,
+              accountId: account?.providerAccountId ?? null,
+              email: profile?.email ?? null,
+              // GitHub profiles carry no email_verified, so it reads as unverified
+              // here — GitHub owners must allowlist by account id, not email.
+              emailVerified: profile?.email_verified === true,
+            },
+            allowlist,
+          );
+        } catch {
+          return false;
+        }
+      },
     },
-  },
+  };
 });

--- a/apps/dashboard/lib/auth-config-client.ts
+++ b/apps/dashboard/lib/auth-config-client.ts
@@ -11,6 +11,10 @@ import { serverTRPC } from "./trpc-server";
 // so a burst of requests doesn't fan out into parallel store calls.
 
 const DEFAULT_TTL_MS = 30_000;
+// Bound the hot-path config fetch so a half-open store (connection accepted, no
+// response) surfaces as a fast throw → fail-closed "block" in middleware, rather
+// than hanging every page request until the platform's default fetch timeout.
+const FETCH_TIMEOUT_MS = 5_000;
 
 export interface AuthConfigCache<T> {
   get(): Promise<T>;
@@ -53,7 +57,8 @@ export function createAuthConfigCache<T>(options: {
 export type DashboardAuthConfig = Awaited<ReturnType<typeof serverTRPC.auth.config.query>>;
 
 const cache = createAuthConfigCache<DashboardAuthConfig>({
-  fetcher: () => serverTRPC.auth.config.query(),
+  fetcher: () =>
+    serverTRPC.auth.config.query(undefined, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) }),
 });
 
 /** Cached auth config for enforcement + lazy NextAuth assembly. */

--- a/apps/dashboard/lib/auth-config-client.ts
+++ b/apps/dashboard/lib/auth-config-client.ts
@@ -1,0 +1,67 @@
+import "server-only";
+import { serverTRPC } from "./trpc-server";
+
+// D2.2 — in-process cache around the `auth.config` tRPC procedure.
+//
+// Auth.js v5's lazy config and the middleware enforcement both read auth config on
+// the hot path; hitting the MCP server per request would be wasteful and couple
+// every page load to the store's latency. A single dashboard instance owns this
+// cache, so a 30s TTL plus an explicit bust() on every mutation keeps it fresh
+// without cross-instance invalidation. Concurrent reads share one in-flight fetch
+// so a burst of requests doesn't fan out into parallel store calls.
+
+const DEFAULT_TTL_MS = 30_000;
+
+export interface AuthConfigCache<T> {
+  get(): Promise<T>;
+  /** Drop the cached value so the next get() refetches (call after any mutation). */
+  bust(): void;
+}
+
+export function createAuthConfigCache<T>(options: {
+  fetcher: () => Promise<T>;
+  ttlMs?: number;
+  now?: () => number;
+}): AuthConfigCache<T> {
+  const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+  const now = options.now ?? Date.now;
+  let cached: { value: T; at: number } | null = null;
+  let inflight: Promise<T> | null = null;
+
+  function get(): Promise<T> {
+    if (cached && now() - cached.at < ttlMs) return Promise.resolve(cached.value);
+    if (inflight) return inflight; // dedupe concurrent reads
+    inflight = options
+      .fetcher()
+      .then((value) => {
+        cached = { value, at: now() };
+        return value;
+      })
+      .finally(() => {
+        inflight = null; // a failed fetch is not cached — the next get() retries
+      });
+    return inflight;
+  }
+
+  function bust(): void {
+    cached = null;
+  }
+
+  return { get, bust };
+}
+
+export type DashboardAuthConfig = Awaited<ReturnType<typeof serverTRPC.auth.config.query>>;
+
+const cache = createAuthConfigCache<DashboardAuthConfig>({
+  fetcher: () => serverTRPC.auth.config.query(),
+});
+
+/** Cached auth config for enforcement + lazy NextAuth assembly. */
+export function getAuthConfig(): Promise<DashboardAuthConfig> {
+  return cache.get();
+}
+
+/** Invalidate the cache — call from every auth mutation action so changes take effect at once. */
+export function bustAuthConfig(): void {
+  cache.bust();
+}

--- a/apps/dashboard/lib/auth-gate.ts
+++ b/apps/dashboard/lib/auth-gate.ts
@@ -57,12 +57,15 @@ export function toEnforcementConfig(cfg: AuthConfigShape | null): EnforcementCon
 }
 
 /**
- * The fail-closed enforcement decision:
- * - unreachable store → block (can't verify the posture, so don't serve)
- * - no store config   → fall back to the legacy env flag
- * - disabled          → open
- * - enabled+complete  → enforce (require a session)
- * - enabled+incomplete→ block (never serve with a half-configured gate)
+ * The fail-closed enforcement decision. The legacy env flag is a FLOOR: a
+ * store-managed config can escalate enforcement but never silently drop below an
+ * env-enforced deploy (so an A1–A5 box that starts configuring auth in the
+ * dashboard, but hasn't called enable yet, keeps enforcing).
+ * - unreachable store    → block (can't verify the posture, so don't serve)
+ * - no store config      → the env flag decides
+ * - disabled             → enforce if env says so, else open
+ * - enabled + complete   → enforce (require a session)
+ * - enabled + incomplete → block (never serve with a half-configured gate)
  */
 export function decideEnforcement(
   config: EnforcementConfig | null | "unreachable",
@@ -70,7 +73,7 @@ export function decideEnforcement(
 ): Enforcement {
   if (config === "unreachable") return "block";
   if (config === null) return envEnabled ? "enforce" : "open";
-  if (!config.enabled) return "open";
+  if (!config.enabled) return envEnabled ? "enforce" : "open";
   return config.complete ? "enforce" : "block";
 }
 

--- a/apps/dashboard/lib/auth-gate.ts
+++ b/apps/dashboard/lib/auth-gate.ts
@@ -1,13 +1,92 @@
-// A2: the single source of truth for whether dashboard auth is ENFORCED.
+// Whether dashboard auth is ENFORCED, and how (A2; D2.4 made it store-driven).
 //
-// Login is wired in A1 regardless; this flag gates enforcement (middleware
-// redirects + the tRPC proxy session check) so the rollout can land login
-// first and flip enforcement on without a lock-out window. Strictly "true"
-// — any other value (unset, "false", "1", "TRUE") is off, so a typo fails
-// safe to "not enforced" rather than silently half-enforcing.
+// Enforcement now comes from the store auth-config (cached) so the owner can flip it
+// from the dashboard without a redeploy, with the legacy LIBRARIAN_AUTH_ENABLED env
+// as the fallback for A1–A5 deploys. The decision is fail-closed: an enabled-but-
+// incomplete config, or an unreachable store, blocks rather than serving open.
+//
+// This module stays pure (no store/server-only import) so the decision table is
+// unit-tested directly; callers inject the config fetcher.
 
+export type Enforcement = "open" | "enforce" | "block";
+
+/** Legacy env signal — the fallback when the store carries no auth config. */
 export function isAuthEnforced(
   env: { LIBRARIAN_AUTH_ENABLED?: string } = process.env as { LIBRARIAN_AUTH_ENABLED?: string },
 ): boolean {
+  // Strictly "true" — any other value fails safe to "not enforced".
   return env.LIBRARIAN_AUTH_ENABLED === "true";
+}
+
+/** The enforcement-relevant projection of the resolved config. */
+export interface EnforcementConfig {
+  enabled: boolean;
+  complete: boolean;
+}
+
+/** The slice of the dashboard auth-config the enforcement decision reads. */
+export interface AuthConfigShape {
+  enabled: boolean;
+  methods: string[];
+  authSecret: string | null;
+  oauth?: { github?: unknown; google?: unknown };
+  ownerOAuth?: { github?: string; google?: string };
+}
+
+// Mirror of core's isAuthConfigComplete. Deliberately re-implemented here rather
+// than imported: pulling @librarian/core (node:crypto) into the middleware bundle
+// would break on non-Node runtimes. Kept in lockstep with the core check.
+function configComplete(cfg: AuthConfigShape): boolean {
+  if (!cfg.authSecret) return false;
+  if (cfg.methods.includes("password")) return true;
+  if (cfg.oauth?.github && cfg.ownerOAuth?.github) return true;
+  if (cfg.oauth?.google && cfg.ownerOAuth?.google) return true;
+  return false;
+}
+
+/**
+ * Project a fetched config to the enforcement shape, or null when the store carries
+ * no auth config (unconfigured/legacy) — the caller then falls back to env. A config
+ * counts as "store-managed" once the flag is set or any method is configured.
+ */
+export function toEnforcementConfig(cfg: AuthConfigShape | null): EnforcementConfig | null {
+  if (!cfg) return null;
+  const storeManaged = cfg.enabled || cfg.methods.length > 0;
+  if (!storeManaged) return null;
+  return { enabled: cfg.enabled, complete: configComplete(cfg) };
+}
+
+/**
+ * The fail-closed enforcement decision:
+ * - unreachable store → block (can't verify the posture, so don't serve)
+ * - no store config   → fall back to the legacy env flag
+ * - disabled          → open
+ * - enabled+complete  → enforce (require a session)
+ * - enabled+incomplete→ block (never serve with a half-configured gate)
+ */
+export function decideEnforcement(
+  config: EnforcementConfig | null | "unreachable",
+  envEnabled: boolean,
+): Enforcement {
+  if (config === "unreachable") return "block";
+  if (config === null) return envEnabled ? "enforce" : "open";
+  if (!config.enabled) return "open";
+  return config.complete ? "enforce" : "block";
+}
+
+/**
+ * Resolve enforcement by reading the (injected) config fetcher, fail-closing to
+ * "block" if it throws (store unreachable). Callers pass `() => getAuthConfig()`.
+ */
+export async function resolveEnforcement(
+  fetchConfig: () => Promise<AuthConfigShape | null>,
+  env: { LIBRARIAN_AUTH_ENABLED?: string } = process.env as { LIBRARIAN_AUTH_ENABLED?: string },
+): Promise<Enforcement> {
+  let config: EnforcementConfig | null | "unreachable";
+  try {
+    config = toEnforcementConfig(await fetchConfig());
+  } catch {
+    config = "unreachable";
+  }
+  return decideEnforcement(config, isAuthEnforced(env));
 }

--- a/apps/dashboard/lib/owner-allowlist.ts
+++ b/apps/dashboard/lib/owner-allowlist.ts
@@ -1,15 +1,15 @@
-// A1: single-owner allowlist for dashboard login.
+// Single-owner allowlist for dashboard login (A1; D2.3 made it config-driven).
 //
-// The Auth.js `signIn` callback delegates the allow/deny decision here so it can
-// be unit-tested without standing up NextAuth. The rule is deliberately strict:
-// permit a login ONLY when the OAuth account matches a configured owner identity,
-// and DENY BY DEFAULT when nothing is configured — a misconfigured deploy must
-// never accidentally let an arbitrary account in.
+// The Auth.js `signIn` callback delegates the allow/deny decision here so it can be
+// unit-tested without standing up NextAuth. The rule is deliberately strict: permit
+// a login ONLY when the OAuth account matches a configured owner identity, and DENY
+// BY DEFAULT when nothing is configured — a misconfigured deploy must never
+// accidentally let an arbitrary account in.
 //
-// Match precedence (any one is sufficient): GitHub account id, Google account id
-// (the OIDC `sub`), or an allowlisted email from any provider. Account ids are
-// preferred over email (emails can change / be unverified); email is the
-// documented fallback.
+// The allowlist now comes from the store auth-config (D1/D2) when present, with the
+// legacy LIBRARIAN_OWNER_* env vars as the fallback (so A1–A5 deploys are untouched).
+// Account ids are preferred over email (emails can change / be unverified); email is
+// the documented fallback and lives only in the legacy env path.
 
 export interface OwnerSignInInput {
   /** The OAuth provider that authenticated the user ("github" | "google"). */
@@ -21,10 +21,18 @@ export interface OwnerSignInInput {
   /**
    * Whether the provider asserts the email is verified. The email branch only
    * matches when this is true — an OAuth `email` claim is otherwise attacker-
-   * controlled (e.g. an arbitrary GitHub profile email), so trusting an
-   * unverified one would let anyone who knows the owner's address sign in.
+   * controlled (e.g. an arbitrary GitHub profile email), so trusting an unverified
+   * one would let anyone who knows the owner's address sign in.
    */
   emailVerified?: boolean;
+}
+
+/** A resolved owner allowlist (from store config or legacy env). */
+export interface OwnerAllowlist {
+  githubId?: string;
+  googleId?: string;
+  /** Allowlisted emails (legacy env only; matched case-insensitively, verified-only). */
+  emails?: string[];
 }
 
 export interface OwnerAllowlistEnv {
@@ -34,11 +42,16 @@ export interface OwnerAllowlistEnv {
   LIBRARIAN_OWNER_EMAILS?: string;
 }
 
+/** The OAuth owner allowlist shape carried in the store auth-config. */
+export interface OwnerOAuthConfig {
+  ownerOAuth?: { github?: string; google?: string };
+}
+
 function clean(value: string | null | undefined): string {
   return (value ?? "").trim();
 }
 
-function emailAllowlist(raw: string | undefined): string[] {
+function emailList(raw: string | undefined): string[] {
   return clean(raw)
     .toLowerCase()
     .split(",")
@@ -46,13 +59,37 @@ function emailAllowlist(raw: string | undefined): string[] {
     .filter(Boolean);
 }
 
-export function isAllowedOwner(
-  input: OwnerSignInInput,
+/** Build the allowlist from legacy LIBRARIAN_OWNER_* env vars. */
+export function ownerAllowlistFromEnv(
   env: OwnerAllowlistEnv = process.env as OwnerAllowlistEnv,
-): boolean {
-  const githubId = clean(env.LIBRARIAN_OWNER_GITHUB_ID);
-  const googleId = clean(env.LIBRARIAN_OWNER_GOOGLE_ID);
-  const emails = emailAllowlist(env.LIBRARIAN_OWNER_EMAILS);
+): OwnerAllowlist {
+  return {
+    githubId: clean(env.LIBRARIAN_OWNER_GITHUB_ID),
+    googleId: clean(env.LIBRARIAN_OWNER_GOOGLE_ID),
+    emails: emailList(env.LIBRARIAN_OWNER_EMAILS),
+  };
+}
+
+/**
+ * Resolve the effective allowlist: the store config's OAuth owner ids win when set,
+ * otherwise fall back to the legacy env allowlist. Config carries account ids only;
+ * the email fallback remains an env-only concept.
+ */
+export function resolveOwnerAllowlist(
+  config: OwnerOAuthConfig | null | undefined,
+  env: OwnerAllowlistEnv = process.env as OwnerAllowlistEnv,
+): OwnerAllowlist {
+  const owner = config?.ownerOAuth;
+  if (owner && (clean(owner.github) || clean(owner.google))) {
+    return { githubId: clean(owner.github), googleId: clean(owner.google) };
+  }
+  return ownerAllowlistFromEnv(env);
+}
+
+export function isAllowedOwner(input: OwnerSignInInput, allowlist: OwnerAllowlist): boolean {
+  const githubId = clean(allowlist.githubId);
+  const googleId = clean(allowlist.googleId);
+  const emails = (allowlist.emails ?? []).map((e) => e.toLowerCase().trim()).filter(Boolean);
 
   // Deny by default: with no owner configured, no one is the owner.
   if (!githubId && !googleId && emails.length === 0) return false;

--- a/apps/dashboard/middleware.ts
+++ b/apps/dashboard/middleware.ts
@@ -1,30 +1,60 @@
-// A2: dashboard page gating. When auth is enforced, an unauthenticated request
-// to any matched (non-excluded) page is redirected to /login.
+// Dashboard page gating (A2; D2.4 made it store-driven + fail-closed).
 //
-// The matcher excludes ALL of /api on purpose — middleware is the wrong layer to
-// protect API routes (it can be skipped for them), so the security-critical
-// /api/trpc proxy gates itself with auth() (see app/api/trpc/[trpc]/route.ts).
-// /api/auth (the OAuth flow) and /api/health (liveness) must also stay open, and
-// excluding /api covers both. /login is excluded so the redirect can't loop.
+// Enforcement is resolved per request from the store auth-config (cached), with the
+// legacy LIBRARIAN_AUTH_ENABLED env as the fallback:
+//   - open    → serve (never touch the auth() wrapper, which needs AUTH_SECRET)
+//   - enforce → redirect any unauthenticated request to /login
+//   - block   → an enabled-but-incomplete config, or an unreachable store: refuse to
+//               serve with a store-independent page that names the CLI break-glass,
+//               so a store outage can't silently fail OPEN.
+//
+// The matcher excludes ALL of /api — middleware is the wrong layer to protect API
+// routes (it can be skipped), so the security-critical /api/trpc proxy gates itself
+// with the same enforcement (see app/api/trpc/[trpc]/route.ts). /login is excluded
+// so the redirect can't loop, and so the owner can still reach it under "block".
 
-import { NextResponse } from "next/server";
+import { type NextFetchEvent, type NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
-import { isAuthEnforced } from "@/lib/auth-gate";
+import { getAuthConfig } from "@/lib/auth-config-client";
+import { resolveEnforcement } from "@/lib/auth-gate";
 
-// Decided once at module init (the flag is a deploy-time setting; flipping it
-// needs a restart, which env changes require anyway). This matters: the auth()
-// wrapper ALWAYS decodes the session, which errors loudly when AUTH_SECRET is
-// unset — so the default, un-enforced deployment must never reach the wrapper.
-// When enforced, redirect any unauthenticated request to /login.
-export default isAuthEnforced()
-  ? auth((req) =>
-      req.auth ? NextResponse.next() : NextResponse.redirect(new URL("/login", req.nextUrl.origin)),
-    )
-  : () => NextResponse.next();
+// The auth() wrapper decodes the session and redirects unauthenticated requests.
+// Invoked only on the "enforce" path so the un-enforced default never reaches it.
+// auth() returns a handler that is middleware-compatible at runtime (it's the shape
+// Next calls as a default middleware export); cast to the middleware signature so we
+// can invoke it manually with the NextFetchEvent.
+const enforce = auth((req) =>
+  req.auth ? NextResponse.next() : NextResponse.redirect(new URL("/login", req.nextUrl.origin)),
+) as unknown as (req: NextRequest, ev: NextFetchEvent) => Promise<Response | undefined>;
+
+function blockResponse(): NextResponse {
+  // Store-independent: no rendering that itself needs the store. Names the recovery.
+  const body = `<!doctype html><meta charset="utf-8"><title>Authentication unavailable</title>
+<h1>Authentication is unavailable</h1>
+<p>The dashboard cannot verify its authentication configuration (the store is
+unreachable or the config is incomplete), so it is refusing to serve — failing
+closed rather than open.</p>
+<p>On the server host, run <code>the-librarian auth disable</code> to turn off
+enforcement (break-glass), then fix the configuration.</p>`;
+  return new NextResponse(body, {
+    status: 503,
+    headers: { "content-type": "text/html; charset=utf-8", "cache-control": "no-store" },
+  });
+}
+
+export default async function middleware(
+  req: NextRequest,
+  ev: NextFetchEvent,
+): Promise<Response | undefined> {
+  const decision = await resolveEnforcement(() => getAuthConfig());
+  if (decision === "open") return NextResponse.next();
+  if (decision === "block") return blockResponse();
+  return enforce(req, ev);
+}
 
 export const config = {
-  // Anchor each excluded segment so prefix lookalikes (e.g. /loginhelp,
-  // /apidocs) are still gated — only the exact /api, /_next, /login subtrees
-  // and favicon are skipped.
+  // Anchor each excluded segment so prefix lookalikes (e.g. /loginhelp, /apidocs)
+  // are still gated — only the exact /api, /_next, /login subtrees and favicon are
+  // skipped.
   matcher: ["/((?!api(?:/|$)|_next/|favicon.ico|login(?:/|$)).*)"],
 };

--- a/apps/dashboard/tests/auth-config-client.test.ts
+++ b/apps/dashboard/tests/auth-config-client.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAuthConfigCache } from "../lib/auth-config-client";
+
+// A controllable clock + a fetch spy so we can assert TTL/bust/dedupe without timers.
+function setup(initial = 0) {
+  let nowMs = initial;
+  const value = { enabled: false, methods: [] as string[] };
+  const fetcher = vi.fn(async () => ({ ...value }));
+  const cache = createAuthConfigCache({ fetcher, ttlMs: 30_000, now: () => nowMs });
+  return { cache, fetcher, advance: (ms: number) => (nowMs += ms) };
+}
+
+describe("auth-config cache (D2.2)", () => {
+  it("serves a cache hit within the TTL (one fetch)", async () => {
+    const { cache, fetcher } = setup();
+    await cache.get();
+    await cache.get();
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("refetches after the TTL elapses", async () => {
+    const { cache, fetcher, advance } = setup();
+    await cache.get();
+    advance(30_001);
+    await cache.get();
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("refetches after bust()", async () => {
+    const { cache, fetcher } = setup();
+    await cache.get();
+    cache.bust();
+    await cache.get();
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("dedupes concurrent reads into a single in-flight fetch", async () => {
+    let resolve!: (v: { enabled: boolean }) => void;
+    const fetcher = vi.fn(() => new Promise<{ enabled: boolean }>((r) => (resolve = r)));
+    const cache = createAuthConfigCache({ fetcher, ttlMs: 30_000, now: () => 0 });
+
+    const a = cache.get();
+    const b = cache.get();
+    resolve({ enabled: true });
+    await Promise.all([a, b]);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cache a failed fetch (next get retries)", async () => {
+    const fetcher = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce({ enabled: true });
+    const cache = createAuthConfigCache({ fetcher, ttlMs: 30_000, now: () => 0 });
+    await expect(cache.get()).rejects.toThrow("boom");
+    await expect(cache.get()).resolves.toEqual({ enabled: true });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/dashboard/tests/auth-gate.test.ts
+++ b/apps/dashboard/tests/auth-gate.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { isAuthEnforced } from "@/lib/auth-gate";
+import {
+  type AuthConfigShape,
+  decideEnforcement,
+  isAuthEnforced,
+  resolveEnforcement,
+  toEnforcementConfig,
+} from "@/lib/auth-gate";
 
 // A2: enforcement is feature-flagged so login can be wired (A1) before it is
 // enforced — no slice can lock the owner out mid-rollout.
@@ -14,5 +20,92 @@ describe("isAuthEnforced", () => {
     expect(isAuthEnforced({ LIBRARIAN_AUTH_ENABLED: "false" })).toBe(false);
     expect(isAuthEnforced({ LIBRARIAN_AUTH_ENABLED: "1" })).toBe(false);
     expect(isAuthEnforced({ LIBRARIAN_AUTH_ENABLED: "TRUE" })).toBe(false);
+  });
+});
+
+// D2.4: store-driven, fail-closed enforcement decision.
+describe("decideEnforcement", () => {
+  it("is open when the store config is disabled", () => {
+    expect(decideEnforcement({ enabled: false, complete: true }, false)).toBe("open");
+  });
+
+  it("enforces when enabled and complete", () => {
+    expect(decideEnforcement({ enabled: true, complete: true }, false)).toBe("enforce");
+  });
+
+  it("blocks (fail closed) when enabled but incomplete", () => {
+    expect(decideEnforcement({ enabled: true, complete: false }, false)).toBe("block");
+  });
+
+  it("blocks (fail closed) when the store is unreachable", () => {
+    expect(decideEnforcement("unreachable", false)).toBe("block");
+    expect(decideEnforcement("unreachable", true)).toBe("block");
+  });
+
+  it("falls back to the env flag when there is no store config", () => {
+    expect(decideEnforcement(null, true)).toBe("enforce"); // legacy env deploy
+    expect(decideEnforcement(null, false)).toBe("open");
+  });
+});
+
+describe("toEnforcementConfig", () => {
+  const base: AuthConfigShape = { enabled: false, methods: [], authSecret: null };
+
+  it("treats an unconfigured store as null (fall back to env)", () => {
+    expect(toEnforcementConfig(base)).toBeNull();
+    expect(toEnforcementConfig(null)).toBeNull();
+  });
+
+  it("is store-managed once a method is configured, and reports completeness", () => {
+    const cfg: AuthConfigShape = { enabled: false, methods: ["password"], authSecret: "deadbeef" };
+    expect(toEnforcementConfig(cfg)).toEqual({ enabled: false, complete: true });
+  });
+
+  it("an enabled config with no derivable secret is incomplete", () => {
+    const cfg: AuthConfigShape = { enabled: true, methods: ["password"], authSecret: null };
+    expect(toEnforcementConfig(cfg)).toEqual({ enabled: true, complete: false });
+  });
+
+  it("OAuth needs both creds and an owner to count as complete", () => {
+    const credsOnly: AuthConfigShape = {
+      enabled: true,
+      methods: ["github"],
+      authSecret: "x",
+      oauth: { github: { clientId: "a", clientSecret: "b" } },
+      ownerOAuth: {},
+    };
+    expect(toEnforcementConfig(credsOnly)).toEqual({ enabled: true, complete: false });
+
+    const withOwner: AuthConfigShape = { ...credsOnly, ownerOAuth: { github: "octocat" } };
+    expect(toEnforcementConfig(withOwner)).toEqual({ enabled: true, complete: true });
+  });
+});
+
+describe("resolveEnforcement", () => {
+  const enabledComplete: AuthConfigShape = {
+    enabled: true,
+    methods: ["password"],
+    authSecret: "deadbeef",
+  };
+
+  it("fails closed to block when the config fetch throws (store outage)", async () => {
+    const fetchConfig = async () => {
+      throw new Error("ECONNREFUSED");
+    };
+    expect(await resolveEnforcement(fetchConfig, {})).toBe("block");
+  });
+
+  it("enforces when the store says enabled + complete", async () => {
+    expect(await resolveEnforcement(async () => enabledComplete, {})).toBe("enforce");
+  });
+
+  it("env-fallback deploy still authenticates (no store config, env enabled)", async () => {
+    expect(await resolveEnforcement(async () => null, { LIBRARIAN_AUTH_ENABLED: "true" })).toBe(
+      "enforce",
+    );
+  });
+
+  it("stays open when neither the store nor the env enables auth", async () => {
+    expect(await resolveEnforcement(async () => null, {})).toBe("open");
   });
 });

--- a/apps/dashboard/tests/auth-gate.test.ts
+++ b/apps/dashboard/tests/auth-gate.test.ts
@@ -46,6 +46,13 @@ describe("decideEnforcement", () => {
     expect(decideEnforcement(null, true)).toBe("enforce"); // legacy env deploy
     expect(decideEnforcement(null, false)).toBe("open");
   });
+
+  it("treats the env flag as a floor — a store-managed-but-disabled config can't downgrade it", () => {
+    // A1–A5 box (env enforcing) that started configuring auth in the dashboard but
+    // hasn't called enable yet must keep enforcing, not silently drop to open.
+    expect(decideEnforcement({ enabled: false, complete: true }, true)).toBe("enforce");
+    expect(decideEnforcement({ enabled: false, complete: true }, false)).toBe("open");
+  });
 });
 
 describe("toEnforcementConfig", () => {

--- a/apps/dashboard/tests/owner-allowlist.test.ts
+++ b/apps/dashboard/tests/owner-allowlist.test.ts
@@ -1,44 +1,32 @@
 import { describe, expect, it } from "vitest";
-import { isAllowedOwner } from "@/lib/owner-allowlist";
+import { isAllowedOwner, resolveOwnerAllowlist } from "@/lib/owner-allowlist";
 
-// A1: single-owner allowlist. The signIn callback delegates here; this is the
+// A1/D2.3: single-owner allowlist. The signIn callback delegates here; this is the
 // security gate, so the table below is the contract — deny by default, match by
-// provider account id, email as a documented fallback.
+// provider account id, email as a documented fallback. The allowlist is now a
+// resolved shape (from store config or legacy env).
 describe("isAllowedOwner", () => {
   it("allows the configured GitHub account id", () => {
-    expect(
-      isAllowedOwner(
-        { provider: "github", accountId: "12345", email: "owner@example.com" },
-        { LIBRARIAN_OWNER_GITHUB_ID: "12345" },
-      ),
-    ).toBe(true);
+    expect(isAllowedOwner({ provider: "github", accountId: "12345" }, { githubId: "12345" })).toBe(
+      true,
+    );
   });
 
   it("denies a different GitHub account id", () => {
-    expect(
-      isAllowedOwner(
-        { provider: "github", accountId: "99999" },
-        { LIBRARIAN_OWNER_GITHUB_ID: "12345" },
-      ),
-    ).toBe(false);
+    expect(isAllowedOwner({ provider: "github", accountId: "99999" }, { githubId: "12345" })).toBe(
+      false,
+    );
   });
 
   it("allows the configured Google account id (sub)", () => {
     expect(
-      isAllowedOwner(
-        { provider: "google", accountId: "sub-abc" },
-        { LIBRARIAN_OWNER_GOOGLE_ID: "sub-abc" },
-      ),
+      isAllowedOwner({ provider: "google", accountId: "sub-abc" }, { googleId: "sub-abc" }),
     ).toBe(true);
   });
 
   it("does not let a GitHub id satisfy the Google allowlist (provider-scoped)", () => {
-    // Same string, wrong provider — must not match.
     expect(
-      isAllowedOwner(
-        { provider: "github", accountId: "shared" },
-        { LIBRARIAN_OWNER_GOOGLE_ID: "shared" },
-      ),
+      isAllowedOwner({ provider: "github", accountId: "shared" }, { googleId: "shared" }),
     ).toBe(false);
   });
 
@@ -46,35 +34,30 @@ describe("isAllowedOwner", () => {
     expect(
       isAllowedOwner(
         { provider: "google", accountId: "x", email: "Owner@Example.com", emailVerified: true },
-        { LIBRARIAN_OWNER_EMAILS: "owner@example.com, other@example.com" },
+        { emails: ["owner@example.com", "other@example.com"] },
       ),
     ).toBe(true);
   });
 
   it("denies an UNVERIFIED email even if it is on the allowlist (takeover guard)", () => {
-    // An attacker can set the owner's address as an unverified profile email.
     expect(
       isAllowedOwner(
         { provider: "github", accountId: "999", email: "owner@example.com", emailVerified: false },
-        { LIBRARIAN_OWNER_EMAILS: "owner@example.com" },
+        { emails: ["owner@example.com"] },
       ),
     ).toBe(false);
-    // Absent verification flag is treated as unverified.
     expect(
       isAllowedOwner(
         { provider: "github", accountId: "999", email: "owner@example.com" },
-        { LIBRARIAN_OWNER_EMAILS: "owner@example.com" },
+        { emails: ["owner@example.com"] },
       ),
     ).toBe(false);
   });
 
   it("matches the id branch regardless of provider-string casing", () => {
-    expect(
-      isAllowedOwner(
-        { provider: "GitHub", accountId: "12345" },
-        { LIBRARIAN_OWNER_GITHUB_ID: "12345" },
-      ),
-    ).toBe(true);
+    expect(isAllowedOwner({ provider: "GitHub", accountId: "12345" }, { githubId: "12345" })).toBe(
+      true,
+    );
   });
 
   it("denies by default when nothing is configured", () => {
@@ -84,32 +67,47 @@ describe("isAllowedOwner", () => {
   });
 
   it("treats empty / whitespace-only config as unconfigured (no empty-matches-empty hole)", () => {
-    // Empty config + empty input must NOT match.
-    expect(
-      isAllowedOwner({ provider: "github", accountId: "" }, { LIBRARIAN_OWNER_GITHUB_ID: "" }),
-    ).toBe(false);
-    // Whitespace-only id is not a valid owner.
-    expect(
-      isAllowedOwner({ provider: "github", accountId: "  " }, { LIBRARIAN_OWNER_GITHUB_ID: "  " }),
-    ).toBe(false);
-    // Whitespace-only email config + verified empty email must NOT match.
+    expect(isAllowedOwner({ provider: "github", accountId: "" }, { githubId: "" })).toBe(false);
+    expect(isAllowedOwner({ provider: "github", accountId: "  " }, { githubId: "  " })).toBe(false);
     expect(
       isAllowedOwner(
         { provider: "google", email: "", emailVerified: true },
-        { LIBRARIAN_OWNER_EMAILS: "  ," },
+        { emails: ["  ", ""] },
       ),
     ).toBe(false);
   });
 
   it("denies when the id/email is missing even though config exists", () => {
-    expect(isAllowedOwner({ provider: "github" }, { LIBRARIAN_OWNER_GITHUB_ID: "12345" })).toBe(
-      false,
-    );
+    expect(isAllowedOwner({ provider: "github" }, { githubId: "12345" })).toBe(false);
     expect(
       isAllowedOwner(
         { provider: "google", email: null, emailVerified: true },
-        { LIBRARIAN_OWNER_EMAILS: "a@b.com" },
+        { emails: ["a@b.com"] },
       ),
     ).toBe(false);
+  });
+});
+
+describe("resolveOwnerAllowlist (config wins, env fallback)", () => {
+  it("uses the store config's OAuth owner ids when present", () => {
+    const allowlist = resolveOwnerAllowlist(
+      { ownerOAuth: { github: "store-gh", google: "store-goog" } },
+      { LIBRARIAN_OWNER_GITHUB_ID: "env-gh" },
+    );
+    expect(allowlist).toEqual({ githubId: "store-gh", googleId: "store-goog" });
+  });
+
+  it("falls back to legacy env when the config has no owner", () => {
+    const allowlist = resolveOwnerAllowlist(
+      { ownerOAuth: {} },
+      { LIBRARIAN_OWNER_GITHUB_ID: "env-gh", LIBRARIAN_OWNER_EMAILS: "a@b.com" },
+    );
+    expect(allowlist.githubId).toBe("env-gh");
+    expect(allowlist.emails).toEqual(["a@b.com"]);
+  });
+
+  it("falls back to env when config is null (unconfigured store)", () => {
+    const allowlist = resolveOwnerAllowlist(null, { LIBRARIAN_OWNER_GOOGLE_ID: "env-goog" });
+    expect(allowlist.googleId).toBe("env-goog");
   });
 });

--- a/apps/dashboard/tests/trpc-proxy-gate.test.ts
+++ b/apps/dashboard/tests/trpc-proxy-gate.test.ts
@@ -9,6 +9,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const authMock = vi.fn();
 vi.mock("@/auth", () => ({ auth: () => authMock() }));
 
+// D2.4: the proxy gates on the store-driven enforcement decision. Mock it directly
+// so these tests pin the proxy's branch (require a session for any non-"open"
+// decision); the decision table itself is covered in auth-gate.test.ts.
+const enforcementMock = vi.fn();
+vi.mock("@/lib/auth-gate", () => ({ resolveEnforcement: () => enforcementMock() }));
+vi.mock("@/lib/auth-config-client", () => ({ getAuthConfig: vi.fn() }));
+
 const { GET, POST } = await import("@/app/api/trpc/[trpc]/route");
 
 const params = { params: Promise.resolve({ trpc: "curator.config" }) };
@@ -29,6 +36,8 @@ let fetchSpy: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   authMock.mockReset();
+  enforcementMock.mockReset();
+  enforcementMock.mockResolvedValue("enforce"); // default: auth on
   fetchSpy = vi.fn(async () => new Response('{"result":{"data":null}}', { status: 200 }));
   vi.stubGlobal("fetch", fetchSpy);
   process.env.LIBRARIAN_ADMIN_TOKEN = "admin-token";
@@ -36,12 +45,10 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
-  delete process.env.LIBRARIAN_AUTH_ENABLED;
 });
 
 describe("/api/trpc proxy session gate", () => {
   it("401s when auth is enforced and there is no session — without reaching upstream", async () => {
-    process.env.LIBRARIAN_AUTH_ENABLED = "true";
     authMock.mockResolvedValue(null);
 
     const res = await POST(proxyRequest(), params);
@@ -51,7 +58,6 @@ describe("/api/trpc proxy session gate", () => {
   });
 
   it("proxies through when auth is enforced and a session is present", async () => {
-    process.env.LIBRARIAN_AUTH_ENABLED = "true";
     authMock.mockResolvedValue({ user: { name: "owner" } });
 
     const res = await POST(proxyRequest(), params);
@@ -63,7 +69,6 @@ describe("/api/trpc proxy session gate", () => {
   });
 
   it("gates GET (tRPC queries) too, not just POST", async () => {
-    process.env.LIBRARIAN_AUTH_ENABLED = "true";
     authMock.mockResolvedValue(null);
 
     const res = await GET(proxyGetRequest(), params);
@@ -73,7 +78,6 @@ describe("/api/trpc proxy session gate", () => {
   });
 
   it("fails closed when auth() throws (e.g. a tampered token)", async () => {
-    process.env.LIBRARIAN_AUTH_ENABLED = "true";
     authMock.mockRejectedValue(new Error("bad jwt"));
 
     const res = await POST(proxyRequest(), params);
@@ -82,8 +86,19 @@ describe("/api/trpc proxy session gate", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("proxies through when auth is disabled (backward compatible), never calling auth()", async () => {
-    // flag unset
+  it("requires a session under the fail-closed 'block' decision too", async () => {
+    enforcementMock.mockResolvedValue("block");
+    authMock.mockResolvedValue(null);
+
+    const res = await POST(proxyRequest(), params);
+
+    expect(res.status).toBe(401);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("proxies through when enforcement is open (backward compatible), never calling auth()", async () => {
+    enforcementMock.mockResolvedValue("open");
+
     const res = await POST(proxyRequest(), params);
 
     expect(res.status).toBe(200);

--- a/packages/mcp-server/src/bin/http.ts
+++ b/packages/mcp-server/src/bin/http.ts
@@ -141,7 +141,7 @@ const auth: AuthConfig = {
   },
 };
 
-const server = createHttpServer({ store, auth, maxBodyBytes });
+const server = createHttpServer({ store, auth, maxBodyBytes, secretKey });
 
 // Memory-curator scheduler (§14): a serial tick that runs due slices on a cadence.
 // The tick self-gates on the admin config (disabled/incomplete → cheap no-op), so

--- a/packages/mcp-server/src/http/routes.ts
+++ b/packages/mcp-server/src/http/routes.ts
@@ -22,16 +22,17 @@ export interface RouteDeps {
   store: LibrarianStore;
   auth: AuthConfig;
   maxBodyBytes: number;
+  secretKey: Buffer | null;
 }
 
 export function createRouteHandler(
   deps: RouteDeps,
 ): (req: IncomingMessage, res: ServerResponse) => Promise<void> {
-  const { store, auth, maxBodyBytes } = deps;
+  const { store, auth, maxBodyBytes, secretKey } = deps;
 
   const trpcHandler = createHTTPHandler({
     router: appRouter,
-    createContext: createContextFactory({ store, auth }),
+    createContext: createContextFactory({ store, auth, secretKey }),
     basePath: "/trpc/",
   });
 

--- a/packages/mcp-server/src/http/server.ts
+++ b/packages/mcp-server/src/http/server.ts
@@ -15,6 +15,8 @@ export interface HttpServerOptions {
   store: LibrarianStore;
   auth: AuthConfig;
   maxBodyBytes?: number;
+  /** Master key — threaded to the tRPC auth router for AUTH_SECRET / OAuth secrets. */
+  secretKey?: Buffer | null;
 }
 
 export function createHttpServer(options: HttpServerOptions): http.Server {
@@ -22,6 +24,7 @@ export function createHttpServer(options: HttpServerOptions): http.Server {
     store: options.store,
     auth: options.auth,
     maxBodyBytes: options.maxBodyBytes ?? 1024 * 1024,
+    secretKey: options.secretKey ?? null,
   });
   return http.createServer((req, res) => {
     void handler(req, res);

--- a/packages/mcp-server/src/trpc/auth.ts
+++ b/packages/mcp-server/src/trpc/auth.ts
@@ -1,0 +1,99 @@
+// D2.1: dashboard-managed-auth admin tRPC surface.
+//
+// The authenticated owner configures auth from the dashboard — enable/disable,
+// password, OAuth creds + owner allowlist — over the existing admin-token proxy.
+// Every procedure is admin-gated (agent-role callers can't reach it). `config`
+// returns the resolved runtime config (incl. the HKDF-derived AUTH_SECRET the
+// dashboard signs JWTs with); `verifyPassword` runs the store-side lockout. `enable`
+// additionally requires the caller to present the admin token (timing-safe compare),
+// closing the land-grab in the open pre-enforcement window.
+
+import {
+  authenticateOwner,
+  enableAuth,
+  getAuthConfig,
+  setEnabled,
+  setOAuth,
+  setOwner,
+  setOwnerPassword,
+} from "@librarian/core";
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+import { adminProcedure, router } from "./trpc.js";
+
+const Provider = z.enum(["github", "google"]);
+
+export const authRouter = router({
+  // Resolved runtime config: enabled flag, methods, password username (never the
+  // hash), decrypted OAuth creds, owner allowlist, and the derived AUTH_SECRET.
+  config: adminProcedure.query(({ ctx }) => getAuthConfig(ctx.store, ctx.secretKey)),
+
+  // Flip enforcement on — gated by a timing-safe admin-token match AND a complete
+  // config (validated in core before the flag flips).
+  enable: adminProcedure
+    .input(z.strictObject({ adminToken: z.string().min(1) }))
+    .mutation(({ ctx, input }) => {
+      const result = enableAuth(ctx.store, {
+        presentedAdminToken: input.adminToken,
+        expectedAdminToken: ctx.adminToken,
+        secretKey: ctx.secretKey,
+      });
+      if (!result.ok) {
+        throw new TRPCError({
+          code: result.error === "bad_admin_token" ? "UNAUTHORIZED" : "BAD_REQUEST",
+          message:
+            result.error === "bad_admin_token"
+              ? "admin token does not match"
+              : "auth config is incomplete (need a usable method and a master key)",
+        });
+      }
+      return { enabled: true };
+    }),
+
+  // Break-glass: ungated off (a locked-out owner must always be able to turn it off).
+  disable: adminProcedure.mutation(({ ctx }) => {
+    setEnabled(ctx.store, false);
+    return { enabled: false };
+  }),
+
+  setPassword: adminProcedure
+    .input(z.strictObject({ username: z.string().min(1), password: z.string().min(1) }))
+    .mutation(({ ctx, input }) => {
+      try {
+        setOwnerPassword(ctx.store, input.username, input.password);
+      } catch (error) {
+        // Surface the length-floor / username policy as a 400, not a 500.
+        throw new TRPCError({ code: "BAD_REQUEST", message: (error as Error).message });
+      }
+      return { ok: true };
+    }),
+
+  configureOAuth: adminProcedure
+    .input(
+      z.strictObject({
+        provider: Provider,
+        clientId: z.string().min(1),
+        clientSecret: z.string().min(1),
+      }),
+    )
+    .mutation(({ ctx, input }) => {
+      setOAuth(ctx.store, input.provider, {
+        clientId: input.clientId,
+        clientSecret: input.clientSecret,
+      });
+      return { ok: true };
+    }),
+
+  setOwner: adminProcedure
+    .input(z.strictObject({ provider: Provider, ownerId: z.string().min(1) }))
+    .mutation(({ ctx, input }) => {
+      setOwner(ctx.store, input.provider, input.ownerId);
+      return { ok: true };
+    }),
+
+  // Store-side password check with lockout — the dashboard Credentials provider
+  // (D3) calls this; the hash and failure counters never leave the store.
+  verifyPassword: adminProcedure
+    .input(z.strictObject({ username: z.string().min(1), password: z.string().min(1) }))
+    .mutation(({ ctx, input }) => authenticateOwner(ctx.store, input.username, input.password)),
+});

--- a/packages/mcp-server/src/trpc/context.ts
+++ b/packages/mcp-server/src/trpc/context.ts
@@ -14,11 +14,16 @@ export type TrpcRole = "admin" | "anonymous";
 export interface TrpcContext {
   role: TrpcRole;
   store: LibrarianStore;
+  /** Master key for deriving AUTH_SECRET / decrypting OAuth secrets (null when unset). */
+  secretKey: Buffer | null;
+  /** The configured admin token — the auth router compares it timing-safe in `enable`. */
+  adminToken: string;
 }
 
 export interface TrpcContextDeps {
   store: LibrarianStore;
   auth: AuthConfig;
+  secretKey: Buffer | null;
 }
 
 export function createContextFactory(
@@ -29,6 +34,8 @@ export function createContextFactory(
     return {
       role: result?.role === "admin" ? "admin" : "anonymous",
       store: deps.store,
+      secretKey: deps.secretKey,
+      adminToken: deps.auth.adminToken,
     };
   };
 }

--- a/packages/mcp-server/src/trpc/router.ts
+++ b/packages/mcp-server/src/trpc/router.ts
@@ -5,6 +5,7 @@
 // intentionally empty and get populated in T4.4 and T4.5. The
 // `AppRouter` type is the public contract the dashboard imports.
 
+import { authRouter } from "./auth.js";
 import { backupRouter } from "./backup.js";
 import { curatorRouter } from "./curator.js";
 import { healthRouter } from "./health.js";
@@ -14,6 +15,7 @@ import { tokensRouter } from "./tokens.js";
 import { router } from "./trpc.js";
 
 export const appRouter = router({
+  auth: authRouter,
   backup: backupRouter,
   curator: curatorRouter,
   health: healthRouter,

--- a/packages/mcp-server/tests/trpc/auth.test.ts
+++ b/packages/mcp-server/tests/trpc/auth.test.ts
@@ -1,0 +1,140 @@
+// D2.1: the `auth` admin tRPC router. Spawns the real HTTP bin (which, via D0,
+// auto-generates a master key into the data dir, so ctx.secretKey is present and
+// AUTH_SECRET derives). Exercises admin gating, the enable admin-token check, and
+// verifyPassword lockout.
+
+import { describe, expect, it } from "vitest";
+import { cleanupTempDir, makeTempDir, startHttpServer } from "../../../../test/helpers.js";
+
+interface TrpcOk<T> {
+  result: { data: T };
+}
+interface TrpcErr {
+  error: unknown;
+}
+interface ServerHandle {
+  url: string;
+  token: string;
+  stop: () => Promise<void>;
+}
+
+async function trpcGet<T>(server: ServerHandle, path: string, input?: unknown): Promise<T> {
+  const url = new URL(`${server.url}/trpc/${path}`);
+  if (input !== undefined) url.searchParams.set("input", JSON.stringify(input));
+  const response = await fetch(url, { headers: { authorization: `Bearer ${server.token}` } });
+  const json = (await response.json()) as TrpcOk<T> | TrpcErr;
+  if (response.status >= 400 || "error" in json) {
+    throw new Error(`trpc GET ${path} failed: ${JSON.stringify(json)}`);
+  }
+  return (json as TrpcOk<T>).result.data;
+}
+
+async function trpcPost<T>(server: ServerHandle, path: string, input?: unknown): Promise<T> {
+  const response = await fetch(`${server.url}/trpc/${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${server.token}` },
+    body: input === undefined ? undefined : JSON.stringify(input),
+  });
+  const json = (await response.json()) as TrpcOk<T> | TrpcErr;
+  if (response.status >= 400 || "error" in json) {
+    throw new Error(`trpc POST ${path} failed: ${JSON.stringify(json)}`);
+  }
+  return (json as TrpcOk<T>).result.data;
+}
+
+interface AuthConfigData {
+  enabled: boolean;
+  methods: string[];
+  password: { username: string } | null;
+  authSecret: string | null;
+}
+interface OwnerAuthResultData {
+  ok: boolean;
+  locked: boolean;
+  lockedUntil: string | null;
+}
+
+const PW = "correct-horse-battery";
+
+describe("tRPC auth surface (D2.1)", () => {
+  it("requires admin auth on every procedure", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const noAuth = await fetch(`${server.url}/trpc/auth.config`); // no Authorization
+      expect(noAuth.status).toBeGreaterThanOrEqual(400);
+
+      const agentRole = await fetch(`${server.url}/trpc/auth.setPassword`, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: "Bearer agent-token" },
+        body: JSON.stringify({ username: "owner", password: PW }),
+      });
+      expect(agentRole.status).toBeGreaterThanOrEqual(400);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("config reports an empty config with a derived AUTH_SECRET", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const cfg = await trpcGet<AuthConfigData>(server, "auth.config");
+      expect(cfg.enabled).toBe(false);
+      expect(cfg.methods).toEqual([]);
+      expect(cfg.authSecret).toMatch(/^[0-9a-f]{64}$/); // D0 generated the master key
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("enable rejects a wrong admin token but accepts the configured one", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      await trpcPost(server, "auth.setPassword", { username: "owner", password: PW });
+
+      await expect(trpcPost(server, "auth.enable", { adminToken: "wrong" })).rejects.toThrow();
+      expect((await trpcGet<AuthConfigData>(server, "auth.config")).enabled).toBe(false);
+
+      await trpcPost(server, "auth.enable", { adminToken: server.token });
+      expect((await trpcGet<AuthConfigData>(server, "auth.config")).enabled).toBe(true);
+
+      await trpcPost(server, "auth.disable");
+      expect((await trpcGet<AuthConfigData>(server, "auth.config")).enabled).toBe(false);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("verifyPassword honors lockout after repeated failures", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      await trpcPost(server, "auth.setPassword", { username: "owner", password: PW });
+
+      let last: OwnerAuthResultData | undefined;
+      for (let i = 0; i < 5; i++) {
+        last = await trpcPost<OwnerAuthResultData>(server, "auth.verifyPassword", {
+          username: "owner",
+          password: "wrong-password-x",
+        });
+      }
+      expect(last?.locked).toBe(true);
+
+      // A correct password is still refused while locked.
+      const duringLock = await trpcPost<OwnerAuthResultData>(server, "auth.verifyPassword", {
+        username: "owner",
+        password: PW,
+      });
+      expect(duringLock.ok).toBe(false);
+      expect(duringLock.locked).toBe(true);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+});


### PR DESCRIPTION
## D2 — `auth` tRPC router + dynamic dashboard config

Third slice of **dashboard-managed-auth** (builds on #144, #145). Bridges the D1 core to the dashboard: the owner's auth config now drives login + enforcement at runtime, with the legacy env vars as a fallback.

### What changed (tasks D2.1–D2.4)
- **`auth` tRPC router (D2.1)** — admin-gated `config`, `enable`, `disable`, `setPassword`, `configureOAuth`, `setOwner`, `verifyPassword`. `enable` requires a timing-safe admin-token match (closes the land-grab); `verifyPassword` runs the store-side lockout; `config` returns the HKDF-derived AUTH_SECRET. Threads the master key + configured admin token into the tRPC context.
- **Auth-config cache (D2.2)** — `lib/auth-config-client.ts`: 30s TTL, `bust()` for mutations, concurrent-read dedupe, failed fetches not cached, bounded fetch timeout.
- **Lazy NextAuth (D2.3)** — `auth.ts` uses the Auth.js v5 async config form (verified via Context7): providers, `secret`, and the signIn allowlist assembled per request from the cached store config; falls back to env-configured providers + `LIBRARIAN_OWNER_*` when the store has no auth config.
- **Fail-closed enforcement (D2.4)** — `middleware.ts` + the `/api/trpc` proxy resolve enforcement from the store config: disabled → open; enabled+complete → enforce (redirect → `/login`); enabled+incomplete OR store-unreachable → **block** to a store-independent page naming `the-librarian auth disable`. The proxy now gates on store-enabled auth (not just the env flag); A2's session check stays intact. The legacy env flag is a **floor** (can't be silently downgraded).

### Verification
- TDD throughout; full local CI parity green (build, lint, format:check, typecheck, `pnpm test`, smoke, healthcheck, guards). Dashboard production build + middleware compile verified.
- Five-axis review run; fixed in this PR: **Critical** — secret-bearing `auth.config` GET is now `no-store` (no CDN/browser caching of AUTH_SECRET/OAuth secrets); **Important** — env-floor so a store-managed-disabled config can't drop env-enforced auth; **Important** — bounded config-fetch timeout so a half-open store fails closed fast.

### Notes
- `decideEnforcement`/`resolveEnforcement` are pure + dependency-injected, so the fail-closed table is unit-tested directly.
- Credentials (password) login provider + the `/login` form land in D3; CLI recovery in D4; the wizard UI in D5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)