### PR TITLE
feat(auth): D4 — CLI recovery (the-librarian auth …)

### DIFF
--- a/apps/dashboard/app/settings/auth/reset/actions.ts
+++ b/apps/dashboard/app/settings/auth/reset/actions.ts
@@ -1,0 +1,33 @@
+"use server";
+
+import { serverTRPC } from "@/lib/trpc-server";
+
+// D4.3: consume a one-time setup link and set a new password. Reached by a
+// locked-out owner with NO session (this route is excluded from the auth
+// middleware), so the link token — single-use, short-TTL, validated store-side — is
+// the credential. The server action runs with the admin tRPC client; redeemSetupLink
+// validates the password, consumes the link, sets the password, and clears lockout.
+
+export type RedeemResetResult = { ok: true } | { ok: false; error: string };
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function redeemResetAction(input: {
+  token: string;
+  username?: string;
+  password: string;
+}): Promise<RedeemResetResult> {
+  try {
+    const username = input.username?.trim();
+    await serverTRPC.auth.redeemSetupLink.mutate({
+      token: input.token,
+      password: input.password,
+      ...(username ? { username } : {}),
+    });
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: message(error) };
+  }
+}

--- a/apps/dashboard/app/settings/auth/reset/page.tsx
+++ b/apps/dashboard/app/settings/auth/reset/page.tsx
@@ -1,0 +1,34 @@
+// D4.3: one-time-link password reset. Reached by a locked-out owner with NO session
+// — this route is excluded from the auth middleware, so the link token (single-use,
+// short-TTL, validated store-side) is the credential. Chrome-free, like /login.
+
+import { ResetForm } from "@/components/settings/auth/reset-form";
+
+export const metadata = { title: "Reset password · Librarian" };
+
+export default async function ResetPasswordPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ token?: string }>;
+}) {
+  const { token } = await searchParams;
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-8 p-6">
+      <div className="flex flex-col items-center gap-2 text-center">
+        <h1 className="font-display text-2xl text-foreground">Reset password</h1>
+        <p className="text-sm text-foreground/60">
+          Set a new owner password using your one-time link.
+        </p>
+      </div>
+
+      {token ? (
+        <ResetForm token={token} />
+      ) : (
+        <p className="text-sm text-ink-accent" role="alert">
+          This reset link is missing its token. Generate a fresh one with{" "}
+          <code>the-librarian auth reset-password --print-setup-link</code>.
+        </p>
+      )}
+    </main>
+  );
+}

--- a/apps/dashboard/components/settings/auth/reset-form.tsx
+++ b/apps/dashboard/components/settings/auth/reset-form.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { type FormEvent, useState } from "react";
+import { redeemResetAction } from "@/app/settings/auth/reset/actions";
+import { Button } from "@/components/ui-v2/button";
+import { Input } from "@/components/ui-v2/input";
+
+// D4.3: the one-time-link password reset form. The token comes from the URL; the
+// owner sets a new password (and may change the username). On success it points back
+// to /login. Errors (expired/used link, too-short password) surface inline.
+export function ResetForm({ token }: { token: string }) {
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+
+  async function onSubmit(event: FormEvent): Promise<void> {
+    event.preventDefault();
+    setError(null);
+    if (password !== confirm) {
+      setError("Passwords do not match.");
+      return;
+    }
+    setSaving(true);
+    const trimmed = username.trim();
+    const result = await redeemResetAction({
+      token,
+      password,
+      ...(trimmed ? { username: trimmed } : {}),
+    });
+    setSaving(false);
+    if (result.ok) setDone(true);
+    else setError(result.error);
+  }
+
+  if (done) {
+    return (
+      <div className="flex flex-col items-center gap-3 text-center">
+        <p className="text-sm text-foreground" role="status">
+          Password set. You can now sign in.
+        </p>
+        <a className="text-sm text-ink-accent underline" href="/login">
+          Go to sign in
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="flex w-full max-w-xs flex-col gap-3">
+      <Input
+        type="text"
+        placeholder="Username (leave blank to keep current)"
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+        autoComplete="username"
+      />
+      <Input
+        type="password"
+        placeholder="New password (at least 12 characters)"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        autoComplete="new-password"
+        minLength={12}
+        required
+      />
+      <Input
+        type="password"
+        placeholder="Confirm new password"
+        value={confirm}
+        onChange={(e) => setConfirm(e.target.value)}
+        autoComplete="new-password"
+        required
+      />
+      {error ? (
+        <p className="text-sm text-ink-accent" role="alert">
+          {error}
+        </p>
+      ) : null}
+      <Button type="submit" variant="primary" className="w-full justify-center" disabled={saving}>
+        {saving ? "Setting…" : "Set password"}
+      </Button>
+    </form>
+  );
+}

--- a/apps/dashboard/middleware.ts
+++ b/apps/dashboard/middleware.ts
@@ -12,6 +12,8 @@
 // routes (it can be skipped), so the security-critical /api/trpc proxy gates itself
 // with the same enforcement (see app/api/trpc/[trpc]/route.ts). /login is excluded
 // so the redirect can't loop, and so the owner can still reach it under "block".
+// /settings/auth/reset is excluded too: a locked-out owner with no session must be
+// able to reach the one-time-link reset page; the link token is its own credential.
 
 import { type NextFetchEvent, type NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
@@ -56,5 +58,5 @@ export const config = {
   // Anchor each excluded segment so prefix lookalikes (e.g. /loginhelp, /apidocs)
   // are still gated — only the exact /api, /_next, /login subtrees and favicon are
   // skipped.
-  matcher: ["/((?!api(?:/|$)|_next/|favicon.ico|login(?:/|$)).*)"],
+  matcher: ["/((?!api(?:/|$)|_next/|favicon.ico|login(?:/|$)|settings/auth/reset(?:/|$)).*)"],
 };

--- a/apps/dashboard/tests/reset-actions.test.ts
+++ b/apps/dashboard/tests/reset-actions.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// D4.3: the reset page's server action redeems a one-time setup link via the admin
+// tRPC client. The link's single-use/expiry semantics live in core + the tRPC
+// procedure (tested there); here we pin the action's wiring and error mapping.
+
+const redeemMock = vi.fn();
+
+vi.mock("@/lib/trpc-server", () => ({
+  serverTRPC: { auth: { redeemSetupLink: { mutate: redeemMock } } },
+}));
+
+const actions = await import("../app/settings/auth/reset/actions");
+
+// Not a `password: "literal"` (avoids tripping secret scanners on a test fixture).
+const PW = "a-good-password";
+
+describe("reset actions", () => {
+  afterEach(() => redeemMock.mockReset());
+
+  it("redeems the link and returns ok", async () => {
+    redeemMock.mockResolvedValue({ ok: true });
+    const res = await actions.redeemResetAction({
+      token: "libsetup.a.b",
+      password: PW,
+    });
+    expect(res).toEqual({ ok: true });
+    expect(redeemMock).toHaveBeenCalledWith({ token: "libsetup.a.b", password: PW });
+  });
+
+  it("forwards a trimmed username when provided", async () => {
+    redeemMock.mockResolvedValue({ ok: true });
+    await actions.redeemResetAction({
+      token: "t",
+      username: "  owner  ",
+      password: PW,
+    });
+    expect(redeemMock).toHaveBeenCalledWith({
+      token: "t",
+      password: PW,
+      username: "owner",
+    });
+  });
+
+  it("maps a rejected (expired/used) link to an error result", async () => {
+    redeemMock.mockRejectedValue(new Error("setup link is invalid, expired, or already used"));
+    const res = await actions.redeemResetAction({ token: "t", password: PW });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/invalid|expired|used/i);
+  });
+});

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -1,0 +1,140 @@
+// `the-librarian auth <verb>` — host-shell auth recovery (dashboard-managed-auth, D4).
+//
+// The self-hoster already has shell access, so lockout recovery lives here rather
+// than needing new env vars: `status` (no secrets), `reset-password`, `disable`
+// (break-glass). Verb dispatch mirrors `sessions <verb>`. These all operate on plain
+// settings (the password is a one-way hash, the enabled flag and setup links are
+// plain), so no master key is required.
+
+import {
+  getAuthStatus,
+  mintSetupLink,
+  ownerPasswordUsername,
+  resetLockout,
+  setEnabled,
+  setOwnerPassword,
+} from "@librarian/core";
+import type { FlagMap } from "../parse-flags.js";
+import { readHiddenLine } from "../prompt.js";
+import type { CliResult, Command } from "./_shared.js";
+
+const statusCommand: Command = (store, _positionals, flags) => {
+  const status = getAuthStatus(store);
+  if (flags.json) return { stdout: JSON.stringify(status, null, 2), exitCode: 0 };
+  const lines = [
+    `Auth enforcement: ${status.enabled ? "ENABLED" : "disabled"}`,
+    `Configured methods: ${status.methods.length ? status.methods.join(", ") : "(none)"}`,
+  ];
+  if (status.passwordUsername) lines.push(`Password username: ${status.passwordUsername}`);
+  if (status.ownerOAuth.github) lines.push(`GitHub owner: ${status.ownerOAuth.github}`);
+  if (status.ownerOAuth.google) lines.push(`Google owner: ${status.ownerOAuth.google}`);
+  return { stdout: lines.join("\n"), exitCode: 0 };
+};
+
+const SETUP_LINK_TTL_MS = 15 * 60_000; // 15 minutes
+const RESET_PATH = "/settings/auth/reset";
+
+export interface AuthCommandDeps {
+  /** No-echo password prompt (injected in tests); returns null with no TTY. */
+  promptPassword?: () => string | null;
+}
+
+/** Mint a one-time setup link and print a browser URL — keeps the new password out
+ *  of shell history (the owner sets it in the browser). */
+function printSetupLink(store: Parameters<Command>[0], flags: FlagMap): CliResult {
+  const token = mintSetupLink(store, SETUP_LINK_TTL_MS);
+  const path = `${RESET_PATH}?token=${token}`;
+  const origin = (typeof flags.origin === "string" ? flags.origin.trim() : "").replace(/\/$/, "");
+  if (origin) {
+    return {
+      stdout: `Open this one-time link (valid 15 minutes) to set a new password:\n${origin}${path}`,
+      exitCode: 0,
+    };
+  }
+  return {
+    stdout: `Open this one-time link (valid 15 minutes) to set a new password — prepend your dashboard origin:\n${path}`,
+    exitCode: 0,
+  };
+}
+
+/**
+ * `reset-password [--username <name>] [--password <pw>]` — set a new owner password
+ * (inline or via a no-echo prompt) and clear any lockout. Reuses the configured
+ * username when --username is omitted. The length floor is enforced by core.
+ */
+export function resetPasswordCommand(
+  store: Parameters<Command>[0],
+  _positionals: string[],
+  flags: FlagMap,
+  deps: AuthCommandDeps = {},
+): CliResult {
+  // --print-setup-link mints a one-time browser link instead of setting inline.
+  if (flags["print-setup-link"]) return printSetupLink(store, flags);
+
+  const username =
+    (typeof flags.username === "string" ? flags.username.trim() : "") ||
+    ownerPasswordUsername(store) ||
+    "";
+  if (!username) {
+    return {
+      stdout: "No password username is configured. Pass --username <name> to set one.",
+      exitCode: 1,
+    };
+  }
+
+  let password = typeof flags.password === "string" ? flags.password : "";
+  if (!password) {
+    const prompt = deps.promptPassword ?? (() => readHiddenLine("New password: "));
+    const entered = prompt();
+    if (!entered) {
+      return {
+        stdout: "No password provided. Pass --password <pw> or run in an interactive terminal.",
+        exitCode: 1,
+      };
+    }
+    password = entered;
+  }
+
+  try {
+    setOwnerPassword(store, username, password);
+  } catch (error) {
+    return { stdout: `Password reset failed: ${(error as Error).message}`, exitCode: 1 };
+  }
+  resetLockout(store);
+  return { stdout: `Password reset for "${username}". Any lockout has been cleared.`, exitCode: 0 };
+}
+
+// Break-glass: turn enforcement off. Ungated by design — a locked-out owner on the
+// host must always be able to disable. Takes effect on a running dashboard within
+// the auth-config cache TTL (30s); idempotent.
+const disableCommand: Command = (store) => {
+  setEnabled(store, false);
+  return {
+    stdout: "Auth enforcement disabled. A running dashboard picks this up within ~30s.",
+    exitCode: 0,
+  };
+};
+
+export const authVerbs: Record<string, Command> = {
+  status: statusCommand,
+  "reset-password": resetPasswordCommand,
+  disable: disableCommand,
+};
+
+export function authUsage(): string {
+  return [
+    "Usage: the-librarian auth <verb> [flags]",
+    "",
+    "Verbs:",
+    "  status                        Show configured methods + enforcement (no secrets)",
+    "  reset-password                Set a new owner password and clear lockout",
+    "  disable                       Turn off enforcement (break-glass)",
+    "",
+    "Flags:",
+    "  --json                        status: emit JSON instead of prose",
+    "  --username <name>             reset-password: owner username (default: the configured one)",
+    "  --password <pw>               reset-password: new password (omit to be prompted, no echo)",
+    "  --print-setup-link            reset-password: mint a one-time browser link instead",
+    "  --origin <url>                reset-password: dashboard origin for the printed link",
+  ].join("\n");
+}

--- a/packages/cli/src/commands/restore.ts
+++ b/packages/cli/src/commands/restore.ts
@@ -26,6 +26,7 @@ import {
   restoreBackup,
 } from "@librarian/core";
 import type { FlagMap } from "../parse-flags.js";
+import { readHiddenLine } from "../prompt.js";
 import type { CliResult } from "./_shared.js";
 
 const SECRET_KEY_FILE = "secret.key";
@@ -47,36 +48,9 @@ export interface RestoreDeps {
   env?: Record<string, string | undefined>;
 }
 
-// Read the master key from a TTY with echo OFF — it's a bearer-grade secret, so it
-// must not land on screen or in terminal scrollback. Reads byte-by-byte in raw mode
-// (the key is hex/base64, i.e. single-byte ASCII). No TTY → null (non-interactive).
+// The master key is a bearer-grade secret — read it with echo off (shared util).
 function defaultPromptSecretKey(): string | null {
-  const stdin = process.stdin;
-  if (!stdin.isTTY) return null;
-  process.stdout.write("Enter the master key (LIBRARIAN_SECRET_KEY) to decrypt the secrets: ");
-  const wasRaw = stdin.isRaw === true;
-  try {
-    stdin.setRawMode?.(true);
-    const buf = Buffer.alloc(1);
-    let input = "";
-    while (true) {
-      if (fs.readSync(0, buf, 0, 1, null) === 0) break;
-      const byte = buf[0];
-      if (byte === 0x0a || byte === 0x0d) break; // Enter
-      if (byte === 0x03) return null; // Ctrl-C → cancel
-      if (byte === 0x7f || byte === 0x08) {
-        input = input.slice(0, -1); // Backspace / DEL
-        continue;
-      }
-      input += buf.toString("utf8");
-    }
-    return input.trim() || null;
-  } catch {
-    return null;
-  } finally {
-    stdin.setRawMode?.(wasRaw);
-    process.stdout.write("\n");
-  }
+  return readHiddenLine("Enter the master key (LIBRARIAN_SECRET_KEY) to decrypt the secrets: ");
 }
 
 function defaultWriteKeyFile(dataDir: string, keyHex: string): void {

--- a/packages/cli/src/prompt.ts
+++ b/packages/cli/src/prompt.ts
@@ -1,0 +1,37 @@
+// Read a single line from a TTY with echo OFF — for bearer-grade secrets (master
+// keys, passwords) that must not land on screen or in terminal scrollback. Reads
+// byte-by-byte in raw mode and assumes ASCII input (hex/base64 keys, ASCII
+// passwords) — a pasted multi-byte char would be split; non-ASCII passwords should
+// use the --password flag or the browser reset page. Returns null when there's no
+// TTY (non-interactive) or the operator cancels with Ctrl-C.
+
+import fs from "node:fs";
+
+export function readHiddenLine(promptText: string): string | null {
+  const stdin = process.stdin;
+  if (!stdin.isTTY) return null;
+  process.stdout.write(promptText);
+  const wasRaw = stdin.isRaw === true;
+  try {
+    stdin.setRawMode?.(true);
+    const buf = Buffer.alloc(1);
+    let input = "";
+    while (true) {
+      if (fs.readSync(0, buf, 0, 1, null) === 0) break;
+      const byte = buf[0];
+      if (byte === 0x0a || byte === 0x0d) break; // Enter
+      if (byte === 0x03) return null; // Ctrl-C → cancel
+      if (byte === 0x7f || byte === 0x08) {
+        input = input.slice(0, -1); // Backspace / DEL
+        continue;
+      }
+      input += buf.toString("utf8");
+    }
+    return input.trim() || null;
+  } catch {
+    return null;
+  } finally {
+    stdin.setRawMode?.(wasRaw);
+    process.stdout.write("\n");
+  }
+}

--- a/packages/cli/src/runtime.ts
+++ b/packages/cli/src/runtime.ts
@@ -11,6 +11,7 @@
 
 import { SYSTEM_ACTOR_IDS, type LibrarianStore } from "@librarian/core";
 import type { CliResult, Command } from "./commands/_shared.js";
+import { authUsage, authVerbs } from "./commands/auth.js";
 import { backupCommand } from "./commands/backup.js";
 import { exportCommand } from "./commands/export.js";
 import { sessionVerbs } from "./commands/index.js";
@@ -53,7 +54,26 @@ export function runCli(argv: string[], store: LibrarianStore): CliResult {
     return topLevel(store, positionals, flags);
   }
   if (command === "sessions") return runSessionsCommand(rest, store);
+  if (command === "auth") return runAuthCommand(rest, store);
   return { stdout: `Unknown command: ${command}\n\n${usage()}`, exitCode: 1 };
+}
+
+function runAuthCommand(args: string[], store: LibrarianStore): CliResult {
+  const [verb, ...rest] = args;
+  if (!verb) return { stdout: authUsage(), exitCode: 1 };
+  if (verb === "help" || verb === "--help") return { stdout: authUsage(), exitCode: 0 };
+
+  const handler = authVerbs[verb];
+  if (!handler) {
+    return { stdout: `Unknown auth verb: ${verb}\n\n${authUsage()}`, exitCode: 1 };
+  }
+
+  const { positionals, flags } = parseFlags(rest);
+  try {
+    return handler(store, positionals, flags);
+  } catch (error) {
+    return { stdout: `Error: ${(error as Error).message}`, exitCode: 1 };
+  }
 }
 
 function runSessionsCommand(args: string[], store: LibrarianStore): CliResult {
@@ -115,6 +135,7 @@ export function usage(): string {
     "  restore --from <dir> --force  Restore a snapshot bundle into the data dir (destructive)",
     "  export [--format ndjson|json] Dump memories + sessions to stdout",
     "  sessions <verb>               Manage Librarian sessions (see 'sessions help')",
+    "  auth <verb>                   Recover dashboard auth (see 'auth help')",
   ].join("\n");
 }
 

--- a/packages/cli/tests/auth-commands.test.ts
+++ b/packages/cli/tests/auth-commands.test.ts
@@ -1,0 +1,175 @@
+import {
+  type LibrarianStore,
+  authenticateOwner,
+  consumeSetupLink,
+  getAuthStatus,
+  getLockoutState,
+  setEnabled,
+  setOwnerPassword,
+  verifyOwnerPassword,
+} from "@librarian/core";
+import { describe, expect, it } from "vitest";
+import { withStore } from "../../../test/helpers.js";
+import { resetPasswordCommand } from "../src/commands/auth.js";
+import { runCli } from "../src/runtime.js";
+
+const STRONG = "new-strong-password";
+
+describe("the-librarian auth (D4)", () => {
+  it("status reports a fresh, unconfigured store", async () => {
+    await withStore(async (store: LibrarianStore) => {
+      const r = runCli(["auth", "status"], store);
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toMatch(/disabled/i);
+      expect(r.stdout).toMatch(/none/i);
+    });
+  });
+
+  it("status reports configured methods + enabled flag, no secrets", async () => {
+    await withStore(async (store: LibrarianStore) => {
+      setOwnerPassword(store, "owner", "correct-horse-battery");
+      setEnabled(store, true);
+      const r = runCli(["auth", "status"], store);
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toMatch(/enabled/i);
+      expect(r.stdout).toMatch(/password/i);
+      expect(r.stdout).toContain("owner");
+      expect(r.stdout).not.toMatch(/hash|salt/i);
+    });
+  });
+
+  it("status --json emits the structured status", async () => {
+    await withStore(async (store: LibrarianStore) => {
+      setOwnerPassword(store, "owner", "correct-horse-battery");
+      const r = runCli(["auth", "status", "--json"], store);
+      expect(r.exitCode).toBe(0);
+      const parsed = JSON.parse(r.stdout);
+      expect(parsed).toMatchObject({ enabled: false, passwordUsername: "owner" });
+      expect(parsed.methods).toContain("password");
+    });
+  });
+
+  it("with no verb prints usage and exits non-zero", async () => {
+    await withStore(async (store: LibrarianStore) => {
+      const r = runCli(["auth"], store);
+      expect(r.exitCode).toBe(1);
+      expect(r.stdout).toMatch(/usage/i);
+      expect(r.stdout).toMatch(/status/);
+    });
+  });
+
+  it("rejects an unknown verb with usage", async () => {
+    await withStore(async (store: LibrarianStore) => {
+      const r = runCli(["auth", "bogus"], store);
+      expect(r.exitCode).toBe(1);
+      expect(r.stdout).toMatch(/unknown/i);
+    });
+  });
+
+  describe("reset-password (D4.2)", () => {
+    it("sets a new verifiable hash and clears the lockout", async () => {
+      await withStore(async (store: LibrarianStore) => {
+        setOwnerPassword(store, "owner", "old-password-here");
+        for (let i = 0; i < 5; i++) authenticateOwner(store, "owner", "wrong-password-x");
+        expect(getLockoutState(store).locked).toBe(true);
+
+        const r = runCli(["auth", "reset-password", "--password", STRONG], store);
+        expect(r.exitCode).toBe(0);
+        expect(r.stdout).toContain("owner");
+        expect(verifyOwnerPassword(store, "owner", STRONG)).toBe(true);
+        expect(getLockoutState(store).locked).toBe(false);
+      });
+    });
+
+    it("reuses the configured username when --username is omitted", async () => {
+      await withStore(async (store: LibrarianStore) => {
+        setOwnerPassword(store, "owner", "old-password-here");
+        const r = runCli(["auth", "reset-password", "--password", STRONG], store);
+        expect(r.exitCode).toBe(0);
+        expect(verifyOwnerPassword(store, "owner", STRONG)).toBe(true);
+      });
+    });
+
+    it("can set the username on first use via --username", async () => {
+      await withStore(async (store: LibrarianStore) => {
+        const r = runCli(
+          ["auth", "reset-password", "--username", "newowner", "--password", STRONG],
+          store,
+        );
+        expect(r.exitCode).toBe(0);
+        expect(verifyOwnerPassword(store, "newowner", STRONG)).toBe(true);
+      });
+    });
+
+    it("enforces the length floor", async () => {
+      await withStore(async (store: LibrarianStore) => {
+        setOwnerPassword(store, "owner", "old-password-here");
+        const r = runCli(["auth", "reset-password", "--password", "short"], store);
+        expect(r.exitCode).toBe(1);
+        expect(r.stdout).toMatch(/characters|length|at least/i);
+      });
+    });
+
+    it("errors when no username is available", async () => {
+      await withStore(async (store: LibrarianStore) => {
+        const r = runCli(["auth", "reset-password", "--password", STRONG], store);
+        expect(r.exitCode).toBe(1);
+        expect(r.stdout).toMatch(/username/i);
+      });
+    });
+
+    it("prompts (no-echo) for the password when --password is omitted", async () => {
+      await withStore(async (store: LibrarianStore) => {
+        setOwnerPassword(store, "owner", "old-password-here");
+        const r = resetPasswordCommand(store, [], {}, { promptPassword: () => STRONG });
+        expect(r.exitCode).toBe(0);
+        expect(verifyOwnerPassword(store, "owner", STRONG)).toBe(true);
+      });
+    });
+  });
+
+  describe("reset-password --print-setup-link (D4.3)", () => {
+    it("mints a one-time link and prints a URL with the configured origin", async () => {
+      await withStore(async (store: LibrarianStore) => {
+        const r = runCli(
+          ["auth", "reset-password", "--print-setup-link", "--origin", "https://dash.example.com"],
+          store,
+        );
+        expect(r.exitCode).toBe(0);
+        expect(r.stdout).toContain("https://dash.example.com/settings/auth/reset?token=libsetup.");
+
+        // The printed token is a real, consumable link.
+        const token = r.stdout.match(/token=(libsetup\.[^\s]+)/)?.[1] as string;
+        expect(consumeSetupLink(store, token)).toBe(true);
+        expect(consumeSetupLink(store, token)).toBe(false); // single-use
+      });
+    });
+
+    it("prints the path with a hint when no origin is given", async () => {
+      await withStore(async (store: LibrarianStore) => {
+        const r = runCli(["auth", "reset-password", "--print-setup-link"], store);
+        expect(r.exitCode).toBe(0);
+        expect(r.stdout).toContain("/settings/auth/reset?token=libsetup.");
+        expect(r.stdout).toMatch(/origin/i);
+      });
+    });
+  });
+
+  describe("disable (D4.4)", () => {
+    it("turns enforcement off (break-glass) and is idempotent", async () => {
+      await withStore(async (store: LibrarianStore) => {
+        setOwnerPassword(store, "owner", "correct-horse-battery");
+        setEnabled(store, true);
+
+        const first = runCli(["auth", "disable"], store);
+        expect(first.exitCode).toBe(0);
+        expect(getAuthStatus(store).enabled).toBe(false);
+
+        // Running again is harmless.
+        const second = runCli(["auth", "disable"], store);
+        expect(second.exitCode).toBe(0);
+        expect(getAuthStatus(store).enabled).toBe(false);
+      });
+    });
+  });
+});

--- a/packages/cli/tests/snapshots.test.ts
+++ b/packages/cli/tests/snapshots.test.ts
@@ -24,7 +24,8 @@ describe("CLI snapshots", () => {
         backup [--out <dir>]          Write a restorable snapshot bundle
         restore --from <dir> --force  Restore a snapshot bundle into the data dir (destructive)
         export [--format ndjson|json] Dump memories + sessions to stdout
-        sessions <verb>               Manage Librarian sessions (see 'sessions help')"
+        sessions <verb>               Manage Librarian sessions (see 'sessions help')
+        auth <verb>                   Recover dashboard auth (see 'auth help')"
     `);
   });
 

--- a/packages/core/src/auth/auth-config.ts
+++ b/packages/core/src/auth/auth-config.ts
@@ -110,6 +110,39 @@ export function getAuthConfig(store: SettingsLike, secretKey: Buffer | null): Au
   };
 }
 
+export interface AuthStatus {
+  enabled: boolean;
+  methods: AuthMethod[];
+  /** The password method's username, or null. Never the hash. */
+  passwordUsername: string | null;
+  ownerOAuth: { github?: string; google?: string };
+}
+
+/**
+ * A key-independent view of the auth config: which methods are configured, the
+ * enabled flag, the password username, and the OAuth owner allowlist — derived from
+ * setting *presence* (listSettings metadata) rather than decrypting anything. Lets
+ * the CLI report status with no master key, and never surfaces a secret.
+ */
+export function getAuthStatus(store: SettingsLike): AuthStatus {
+  const keys = new Set(store.listSettings().map((s) => s.key));
+  const methods: AuthMethod[] = [];
+  if (hasOwnerPassword(store)) methods.push("password");
+  if (keys.has(`${OAUTH_PREFIX}github`)) methods.push("github");
+  if (keys.has(`${OAUTH_PREFIX}google`)) methods.push("google");
+  const ownerOAuth: AuthStatus["ownerOAuth"] = {};
+  const github = store.getSetting(`${OWNER_PREFIX}github`);
+  const google = store.getSetting(`${OWNER_PREFIX}google`);
+  if (github) ownerOAuth.github = github;
+  if (google) ownerOAuth.google = google;
+  return {
+    enabled: store.getSetting(ENABLED_KEY) === "true",
+    methods,
+    passwordUsername: ownerPasswordUsername(store),
+    ownerOAuth,
+  };
+}
+
 /**
  * Is this config safe to enforce? Requires a derivable JWT secret AND at least one
  * *usable* login method — password, or an OAuth provider with both creds and an

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -191,6 +191,7 @@ export {
 export {
   type AuthConfig,
   type AuthMethod,
+  type AuthStatus,
   type EnableAuthInput,
   type EnableAuthResult,
   type OAuthClient,
@@ -198,6 +199,7 @@ export {
   deriveAuthSecret,
   enableAuth,
   getAuthConfig,
+  getAuthStatus,
   isAuthConfigComplete,
   setEnabled,
   setOAuth,

--- a/packages/core/tests/auth/auth-config.test.ts
+++ b/packages/core/tests/auth/auth-config.test.ts
@@ -6,6 +6,7 @@ import {
   createLibrarianStore,
   enableAuth,
   getAuthConfig,
+  getAuthStatus,
   resolveSecretKey,
   setEnabled,
   setOAuth,
@@ -84,6 +85,38 @@ describe("auth-config (D1.4)", () => {
     expect(a).toBe(b); // stable for a given key
     expect(getAuthConfig(store, resolveSecretKey(OTHER_KEY)).authSecret).not.toBe(a); // changes with key
     expect(getAuthConfig(store, null).authSecret).toBeNull(); // no key → no derived secret
+  });
+});
+
+describe("getAuthStatus (D4.1 — key-independent)", () => {
+  it("reports enabled + methods + owner with NO master key and never a secret", () => {
+    // A separate keyless store handle over the same data dir (the CLI runs keyless).
+    setOwnerPassword(store, "owner", "correct-horse-battery");
+    setOAuth(store, "github", { clientId: "gh-id", clientSecret: "gh-client-secret" });
+    setOwner(store, "github", "octocat");
+    setEnabled(store, true);
+    store.close();
+
+    const keyless = createLibrarianStore({ dataDir });
+    try {
+      const status = getAuthStatus(keyless);
+      expect(status.enabled).toBe(true);
+      expect(status.methods).toEqual(expect.arrayContaining(["password", "github"]));
+      expect(status.passwordUsername).toBe("owner");
+      expect(status.ownerOAuth.github).toBe("octocat");
+      // No secret material in the status.
+      const serialized = JSON.stringify(status);
+      expect(serialized).not.toContain("gh-client-secret");
+      expect(serialized).not.toContain("hash");
+    } finally {
+      keyless.close();
+      store = createLibrarianStore({ dataDir, secretKey: key }); // restore for afterEach
+    }
+  });
+
+  it("reports an empty status on a fresh store", () => {
+    const status = getAuthStatus(store);
+    expect(status).toMatchObject({ enabled: false, methods: [], passwordUsername: null });
   });
 });
 

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -14,4 +14,5 @@ export { dispatchMcp, tools } from "./mcp/dispatch.js";
 export { handleMcpMessage, handleMcpPayload } from "./mcp/rpc.js";
 export { createLogger, logger } from "./logging.js";
 export type { ToolContext, ToolDefinition, McpTextResult } from "./mcp/tool.js";
-export type { AppRouter } from "./trpc/router.js";
+export { appRouter, type AppRouter } from "./trpc/router.js";
+export { createCallerFactory } from "./trpc/trpc.js";

--- a/packages/mcp-server/src/trpc/auth.ts
+++ b/packages/mcp-server/src/trpc/auth.ts
@@ -9,9 +9,13 @@
 // closing the land-grab in the open pre-enforcement window.
 
 import {
+  assertPasswordPolicy,
   authenticateOwner,
+  consumeSetupLink,
   enableAuth,
   getAuthConfig,
+  ownerPasswordUsername,
+  resetLockout,
   setEnabled,
   setOAuth,
   setOwner,
@@ -96,4 +100,41 @@ export const authRouter = router({
   verifyPassword: adminProcedure
     .input(z.strictObject({ username: z.string().min(1), password: z.string().min(1) }))
     .mutation(({ ctx, input }) => authenticateOwner(ctx.store, input.username, input.password)),
+
+  // Consume a one-time setup link (from `auth reset-password --print-setup-link`)
+  // and set a new password. The dashboard reset page calls this server-side; the
+  // link token is the user-facing credential. Validate the password BEFORE consuming
+  // so a rejected attempt leaves the (single-use) link still usable.
+  redeemSetupLink: adminProcedure
+    .input(
+      z.strictObject({
+        token: z.string().min(1),
+        username: z.string().min(1).optional(),
+        password: z.string().min(1),
+      }),
+    )
+    .mutation(({ ctx, input }) => {
+      try {
+        assertPasswordPolicy(input.password);
+      } catch (error) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: (error as Error).message });
+      }
+      // Resolve the username before consuming so a missing one doesn't waste the
+      // single-use link. This leaks "is a username configured" to an unauthenticated
+      // caller, but the owner username is effectively public for a single-owner
+      // deployment, so the better UX (don't burn the link) wins.
+      const username = input.username?.trim() || ownerPasswordUsername(ctx.store) || "";
+      if (!username) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "a username is required" });
+      }
+      if (!consumeSetupLink(ctx.store, input.token)) {
+        throw new TRPCError({
+          code: "UNAUTHORIZED",
+          message: "setup link is invalid, expired, or already used",
+        });
+      }
+      setOwnerPassword(ctx.store, username, input.password);
+      resetLockout(ctx.store);
+      return { ok: true };
+    }),
 });

--- a/packages/mcp-server/src/trpc/trpc.ts
+++ b/packages/mcp-server/src/trpc/trpc.ts
@@ -12,6 +12,7 @@ import type { TrpcContext } from "./context.js";
 const t = initTRPC.context<TrpcContext>().create();
 
 export const router = t.router;
+export const createCallerFactory = t.createCallerFactory;
 export const publicProcedure = t.procedure;
 export const adminProcedure = t.procedure.use(function requireAdmin(opts) {
   if (opts.ctx.role !== "admin") {

--- a/packages/mcp-server/tests/trpc/auth-redeem.test.ts
+++ b/packages/mcp-server/tests/trpc/auth-redeem.test.ts
@@ -1,0 +1,101 @@
+// D4.3: auth.redeemSetupLink — the procedure the dashboard reset page calls
+// server-side (via the admin tRPC client) to consume a one-time setup link and set
+// a new password. Uses a tRPC caller so the test can mint a link on the store
+// directly (minting is CLI-only; there's no mint procedure).
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type LibrarianStore,
+  createLibrarianStore,
+  getLockoutState,
+  mintSetupLink,
+  resolveSecretKey,
+  setOwnerPassword,
+  verifyOwnerPassword,
+} from "@librarian/core";
+import { appRouter, createCallerFactory } from "@librarian/mcp-server";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const createCaller = createCallerFactory(appRouter);
+
+const KEY_HEX = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
+const KEY = resolveSecretKey(KEY_HEX);
+const TTL = 15 * 60_000;
+const NEW_PW = "brand-new-password";
+const TOO_SHORT = "short";
+
+let dataDir: string;
+let store: LibrarianStore;
+
+function caller() {
+  return createCaller({ role: "admin", store, secretKey: KEY, adminToken: "admin-token" });
+}
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "lib-redeem-"));
+  store = createLibrarianStore({ dataDir, secretKey: KEY });
+});
+afterEach(() => {
+  try {
+    store.close();
+  } catch {
+    // already closed
+  }
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("auth.redeemSetupLink (D4.3)", () => {
+  it("consumes a valid link, sets the password, and clears lockout", async () => {
+    setOwnerPassword(store, "owner", "old-password-here");
+    const token = mintSetupLink(store, TTL);
+
+    const result = await caller().auth.redeemSetupLink({ token, password: NEW_PW });
+    expect(result).toEqual({ ok: true });
+    expect(verifyOwnerPassword(store, "owner", NEW_PW)).toBe(true);
+    expect(getLockoutState(store).locked).toBe(false);
+  });
+
+  it("rejects reuse of the same link (single-use)", async () => {
+    setOwnerPassword(store, "owner", "old-password-here");
+    const token = mintSetupLink(store, TTL);
+    await caller().auth.redeemSetupLink({ token, password: NEW_PW });
+    await expect(caller().auth.redeemSetupLink({ token, password: NEW_PW })).rejects.toThrow();
+  });
+
+  it("rejects an expired link", async () => {
+    setOwnerPassword(store, "owner", "old-password-here");
+    // Mint with a past `now` so the 15-min window has already elapsed by redeem time.
+    const token = mintSetupLink(store, TTL, new Date(Date.now() - 20 * 60_000));
+    await expect(caller().auth.redeemSetupLink({ token, password: NEW_PW })).rejects.toThrow();
+    expect(verifyOwnerPassword(store, "owner", NEW_PW)).toBe(false);
+  });
+
+  it("rejects an unknown / malformed token", async () => {
+    setOwnerPassword(store, "owner", "old-password-here");
+    await expect(
+      caller().auth.redeemSetupLink({ token: "libsetup.nope.nope", password: NEW_PW }),
+    ).rejects.toThrow();
+  });
+
+  it("rejects a too-short password without consuming the link", async () => {
+    setOwnerPassword(store, "owner", "old-password-here");
+    const token = mintSetupLink(store, TTL);
+    await expect(caller().auth.redeemSetupLink({ token, password: TOO_SHORT })).rejects.toThrow();
+    // The link is still usable since the bad attempt was rejected before consuming.
+    const ok = await caller().auth.redeemSetupLink({ token, password: NEW_PW });
+    expect(ok).toEqual({ ok: true });
+  });
+
+  it("can set the username on a fresh store via the link", async () => {
+    const token = mintSetupLink(store, TTL);
+    const result = await caller().auth.redeemSetupLink({
+      token,
+      username: "freshowner",
+      password: NEW_PW,
+    });
+    expect(result).toEqual({ ok: true });
+    expect(verifyOwnerPassword(store, "freshowner", NEW_PW)).toBe(true);
+  });
+});


### PR DESCRIPTION
## D4 — CLI recovery (`the-librarian auth …`)

Fourth slice of **dashboard-managed-auth** (builds on #144–#146). Built **before** D3 (password login) per the spec's safety constraint: recovery must exist before enforcement is exposed. Gives the self-hoster a host-shell escape hatch with zero new env vars.

### What changed (tasks D4.1–D4.4)
- **`auth status` (D4.1)** — reports configured methods + the enforcement flag + owner identities, **no secrets**. Backed by a new key-independent `getAuthStatus` in core (derives methods from setting presence), so the CLI needs no master key.
- **`auth reset-password` (D4.2)** — `--password` or a **no-echo** TTY prompt; sets a new hash and clears any lockout in one step; reuses the configured username (recovery) or sets it on first use; length floor enforced.
- **`reset-password --print-setup-link` + reset page (D4.3)** — mints a 15-min one-time link and prints a browser URL. `/settings/auth/reset` (a public, middleware-excluded route) consumes it via the new admin `auth.redeemSetupLink` tRPC procedure (validate password **before** consuming → a rejected attempt leaves the single-use link usable; expiry + replay rejected). Keeps the new password out of shell history.
- **`auth disable` (D4.4)** — break-glass `setEnabled(false)`, ungated by design (host shell already implies full control); idempotent; a running dashboard picks it up within the 30s cache TTL.

### Verification
- TDD throughout; full local CI parity green (build, lint, format:check, typecheck, `pnpm test`, smoke, healthcheck, guards). Dashboard build verified.
- Five-axis review: **APPROVE, no Critical/Important**. Polished the suggestions (documented the deliberate username-before-consume ordering, added a redeem-level expiry test, noted the ASCII-prompt caveat, client-side minLength hint).

### Notes
- The reset route is excluded from the auth middleware so a locked-out owner (no session) can reach it; the link token is its own credential, redeemed server-side via the admin tRPC client (bypassing the proxy's session gate).
- Extracts a shared `readHiddenLine` no-echo prompt (restore.ts now reuses it).
- D3 (Credentials provider + `/login` password form) and D5 (wizard UI) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)