### PR TITLE
feat(auth): D3 — password login (Credentials provider + lockout)

### DIFF
--- a/apps/dashboard/app/api/auth/[...nextauth]/route.ts
+++ b/apps/dashboard/app/api/auth/[...nextauth]/route.ts
@@ -8,8 +8,10 @@ import { handlers } from "@/auth";
 import { createRateLimiter } from "@/lib/rate-limit";
 
 const CREDENTIALS_PATH = "/api/auth/callback/credentials";
-// ~10 attempts/minute per client before the dashboard itself starts refusing.
-const limiter = createRateLimiter({ limit: 10, windowMs: 60_000 });
+// ~10 attempts/minute per client before the dashboard itself starts refusing
+// (tunable via env — e.g. e2e raises it so the store-side lockout is the gate under test).
+const RATE_LIMIT = Number(process.env.LIBRARIAN_CREDENTIALS_RATE_LIMIT) || 10;
+const limiter = createRateLimiter({ limit: RATE_LIMIT, windowMs: 60_000 });
 
 function clientKey(req: NextRequest): string {
   const forwarded = req.headers.get("x-forwarded-for");

--- a/apps/dashboard/app/api/auth/[...nextauth]/route.ts
+++ b/apps/dashboard/app/api/auth/[...nextauth]/route.ts
@@ -14,6 +14,10 @@ const RATE_LIMIT = Number(process.env.LIBRARIAN_CREDENTIALS_RATE_LIMIT) || 10;
 const limiter = createRateLimiter({ limit: RATE_LIMIT, windowMs: 60_000 });
 
 function clientKey(req: NextRequest): string {
+  // Best-effort client id. The leftmost x-forwarded-for hop is client-appendable,
+  // so this is spoofable — but it only evades the dashboard throttle, never the
+  // authoritative store-side lockout (which is single-owner, account-scoped). For
+  // the throttle to bite, front it with a proxy that overwrites (not appends) XFF.
   const forwarded = req.headers.get("x-forwarded-for");
   return forwarded?.split(",")[0]?.trim() || req.headers.get("x-real-ip") || "global";
 }

--- a/apps/dashboard/app/api/auth/[...nextauth]/route.ts
+++ b/apps/dashboard/app/api/auth/[...nextauth]/route.ts
@@ -1,5 +1,29 @@
-// Auth.js v5 route handler — re-exports the NextAuth GET/POST handlers for the
-// /api/auth/* endpoints (sign-in, callback, csrf, session, sign-out).
-import { handlers } from "@/auth";
+// Auth.js v5 route handler for /api/auth/* (sign-in, callback, csrf, session,
+// sign-out). D3.2 wraps the credentials callback POST with a per-client rate limit —
+// defense in depth atop the store-side lockout — returning a generic 429 (no user or
+// lockout-state enumeration). All other auth routes pass straight through.
 
-export const { GET, POST } = handlers;
+import type { NextRequest } from "next/server";
+import { handlers } from "@/auth";
+import { createRateLimiter } from "@/lib/rate-limit";
+
+const CREDENTIALS_PATH = "/api/auth/callback/credentials";
+// ~10 attempts/minute per client before the dashboard itself starts refusing.
+const limiter = createRateLimiter({ limit: 10, windowMs: 60_000 });
+
+function clientKey(req: NextRequest): string {
+  const forwarded = req.headers.get("x-forwarded-for");
+  return forwarded?.split(",")[0]?.trim() || req.headers.get("x-real-ip") || "global";
+}
+
+export const GET = handlers.GET;
+
+export async function POST(req: NextRequest): Promise<Response> {
+  if (req.nextUrl.pathname === CREDENTIALS_PATH && !limiter.check(clientKey(req))) {
+    return new Response("Too many sign-in attempts. Please wait and try again.", {
+      status: 429,
+      headers: { "cache-control": "no-store" },
+    });
+  }
+  return handlers.POST(req);
+}

--- a/apps/dashboard/app/login/page.tsx
+++ b/apps/dashboard/app/login/page.tsx
@@ -1,9 +1,14 @@
-// A1: owner sign-in page. Chrome-free (SiteNav skips /login). Two server-action
-// forms, one per provider, calling Auth.js `signIn`. The single-owner allowlist
-// runs in the signIn callback (auth.ts) — a non-owner who completes the OAuth
-// dance is bounced back here with ?error=AccessDenied.
+// Owner sign-in page (A1; D3.3 made it config-driven). Chrome-free (SiteNav skips
+// /login). Renders only the methods the owner has configured: a username/password
+// form when a password method is set, and an OAuth button per configured provider.
+// When the store has no auth config (fresh / legacy A1–A5 deploy), it falls back to
+// the env-configured OAuth providers. The single-owner gate runs in auth.ts
+// (signIn callback for OAuth; the store-side lockout-aware verify for password).
+
 import { signIn } from "@/auth";
 import { Button } from "@/components/ui-v2/button";
+import { Input } from "@/components/ui-v2/input";
+import { getAuthConfig } from "@/lib/auth-config-client";
 
 export const metadata = { title: "Sign in · Librarian" };
 
@@ -12,12 +17,36 @@ async function signInWith(provider: "github" | "google"): Promise<void> {
   await signIn(provider, { redirectTo: "/" });
 }
 
+async function signInWithPassword(formData: FormData): Promise<void> {
+  "use server";
+  await signIn("credentials", {
+    username: formData.get("username"),
+    password: formData.get("password"),
+    redirectTo: "/",
+  });
+}
+
+async function loadConfig() {
+  try {
+    return await getAuthConfig();
+  } catch {
+    return null;
+  }
+}
+
 export default async function LoginPage({
   searchParams,
 }: {
   searchParams: Promise<{ error?: string }>;
 }) {
   const { error } = await searchParams;
+  const config = await loadConfig();
+  const storeConfigured = !!config && config.methods.length > 0;
+
+  const showPassword = storeConfigured && config.methods.includes("password");
+  const showGithub = storeConfigured ? !!config.oauth?.github : !!process.env.AUTH_GITHUB_ID;
+  const showGoogle = storeConfigured ? !!config.oauth?.google : !!process.env.AUTH_GOOGLE_ID;
+
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-8 p-6">
       <div className="flex flex-col items-center gap-2 text-center">
@@ -34,16 +63,42 @@ export default async function LoginPage({
       ) : null}
 
       <div className="flex w-full max-w-xs flex-col gap-3">
-        <form action={signInWith.bind(null, "github")}>
-          <Button type="submit" variant="primary" className="w-full justify-center">
-            Continue with GitHub
-          </Button>
-        </form>
-        <form action={signInWith.bind(null, "google")}>
-          <Button type="submit" variant="outline" className="w-full justify-center">
-            Continue with Google
-          </Button>
-        </form>
+        {showPassword ? (
+          <form action={signInWithPassword} className="flex flex-col gap-3">
+            <Input
+              type="text"
+              name="username"
+              placeholder="Username"
+              autoComplete="username"
+              required
+            />
+            <Input
+              type="password"
+              name="password"
+              placeholder="Password"
+              autoComplete="current-password"
+              required
+            />
+            <Button type="submit" variant="primary" className="w-full justify-center">
+              Sign in
+            </Button>
+          </form>
+        ) : null}
+
+        {showGithub ? (
+          <form action={signInWith.bind(null, "github")}>
+            <Button type="submit" variant="outline" className="w-full justify-center">
+              Continue with GitHub
+            </Button>
+          </form>
+        ) : null}
+        {showGoogle ? (
+          <form action={signInWith.bind(null, "google")}>
+            <Button type="submit" variant="outline" className="w-full justify-center">
+              Continue with Google
+            </Button>
+          </form>
+        ) : null}
       </div>
     </main>
   );

--- a/apps/dashboard/app/login/page.tsx
+++ b/apps/dashboard/app/login/page.tsx
@@ -10,7 +10,7 @@ import { AuthError } from "next-auth";
 import { signIn } from "@/auth";
 import { Button } from "@/components/ui-v2/button";
 import { Input } from "@/components/ui-v2/input";
-import { getAuthConfig } from "@/lib/auth-config-client";
+import { getAuthConfigSafe } from "@/lib/auth-config-client";
 
 export const metadata = { title: "Sign in · Librarian" };
 
@@ -36,21 +36,13 @@ async function signInWithPassword(formData: FormData): Promise<void> {
   }
 }
 
-async function loadConfig() {
-  try {
-    return await getAuthConfig();
-  } catch {
-    return null;
-  }
-}
-
 export default async function LoginPage({
   searchParams,
 }: {
   searchParams: Promise<{ error?: string }>;
 }) {
   const { error } = await searchParams;
-  const config = await loadConfig();
+  const config = await getAuthConfigSafe();
   const storeConfigured = !!config && config.methods.length > 0;
 
   const showPassword = storeConfigured && config.methods.includes("password");

--- a/apps/dashboard/app/login/page.tsx
+++ b/apps/dashboard/app/login/page.tsx
@@ -5,6 +5,8 @@
 // the env-configured OAuth providers. The single-owner gate runs in auth.ts
 // (signIn callback for OAuth; the store-side lockout-aware verify for password).
 
+import { redirect } from "next/navigation";
+import { AuthError } from "next-auth";
 import { signIn } from "@/auth";
 import { Button } from "@/components/ui-v2/button";
 import { Input } from "@/components/ui-v2/input";
@@ -19,11 +21,19 @@ async function signInWith(provider: "github" | "google"): Promise<void> {
 
 async function signInWithPassword(formData: FormData): Promise<void> {
   "use server";
-  await signIn("credentials", {
-    username: formData.get("username"),
-    password: formData.get("password"),
-    redirectTo: "/",
-  });
+  try {
+    await signIn("credentials", {
+      username: formData.get("username"),
+      password: formData.get("password"),
+      redirectTo: "/",
+    });
+  } catch (error) {
+    // A failed/locked credentials sign-in throws an AuthError → back to /login with a
+    // generic error (no lockout/user enumeration). Success throws NEXT_REDIRECT,
+    // which must propagate, so only AuthError is handled here.
+    if (error instanceof AuthError) redirect("/login?error=CredentialsSignin");
+    throw error;
+  }
 }
 
 async function loadConfig() {

--- a/apps/dashboard/auth.ts
+++ b/apps/dashboard/auth.ts
@@ -14,20 +14,10 @@ import NextAuth, { type NextAuthConfig } from "next-auth";
 import Credentials from "next-auth/providers/credentials";
 import GitHub from "next-auth/providers/github";
 import Google from "next-auth/providers/google";
-import { type DashboardAuthConfig, getAuthConfig } from "@/lib/auth-config-client";
+import { type DashboardAuthConfig, getAuthConfigSafe } from "@/lib/auth-config-client";
 import { authorizeOwnerCredentials } from "@/lib/credentials-authorize";
 import { isAllowedOwner, resolveOwnerAllowlist } from "@/lib/owner-allowlist";
 import { serverTRPC } from "@/lib/trpc-server";
-
-// Best-effort read of the store config; on any failure (store unreachable) return
-// null so we degrade to the env fallback rather than throwing during config assembly.
-async function loadAuthConfig(): Promise<DashboardAuthConfig | null> {
-  try {
-    return await getAuthConfig();
-  } catch {
-    return null;
-  }
-}
 
 type Providers = NextAuthConfig["providers"];
 
@@ -66,7 +56,7 @@ function buildProviders(config: DashboardAuthConfig | null, storeConfigured: boo
 }
 
 export const { handlers, auth, signIn, signOut } = NextAuth(async (): Promise<NextAuthConfig> => {
-  const config = await loadAuthConfig();
+  const config = await getAuthConfigSafe();
   const storeConfigured = !!config && config.methods.length > 0;
   const allowlist = resolveOwnerAllowlist(config);
   // Derived from LIBRARIAN_SECRET_KEY (config), falling back to the legacy env.

--- a/apps/dashboard/auth.ts
+++ b/apps/dashboard/auth.ts
@@ -11,10 +11,13 @@
 // The Credentials (password) provider and the login form land in D3.
 
 import NextAuth, { type NextAuthConfig } from "next-auth";
+import Credentials from "next-auth/providers/credentials";
 import GitHub from "next-auth/providers/github";
 import Google from "next-auth/providers/google";
 import { type DashboardAuthConfig, getAuthConfig } from "@/lib/auth-config-client";
+import { authorizeOwnerCredentials } from "@/lib/credentials-authorize";
 import { isAllowedOwner, resolveOwnerAllowlist } from "@/lib/owner-allowlist";
+import { serverTRPC } from "@/lib/trpc-server";
 
 // Best-effort read of the store config; on any failure (store unreachable) return
 // null so we degrade to the env fallback rather than throwing during config assembly.
@@ -40,6 +43,18 @@ function buildProviders(config: DashboardAuthConfig | null, storeConfigured: boo
     if (oauth.google) {
       providers.push(
         Google({ clientId: oauth.google.clientId, clientSecret: oauth.google.clientSecret }),
+      );
+    }
+    if (config?.methods.includes("password")) {
+      // The store owns the hash + lockout; authorize() just calls verifyPassword.
+      providers.push(
+        Credentials({
+          credentials: { username: {}, password: {} },
+          authorize: (creds) =>
+            authorizeOwnerCredentials(creds ?? {}, (username, password) =>
+              serverTRPC.auth.verifyPassword.mutate({ username, password }),
+            ),
+        }),
       );
     }
     return providers;
@@ -74,6 +89,9 @@ export const { handlers, auth, signIn, signOut } = NextAuth(async (): Promise<Ne
       // user retry past it.
       signIn({ account, profile }) {
         try {
+          // The Credentials provider already validated the password store-side (with
+          // lockout) in authorize(); the OAuth owner allowlist doesn't apply to it.
+          if (account?.provider === "credentials") return true;
           return isAllowedOwner(
             {
               provider: account?.provider ?? null,

--- a/apps/dashboard/e2e/auth-password.spec.ts
+++ b/apps/dashboard/e2e/auth-password.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "@playwright/test";
+import { E2E_OWNER, E2E_PASSWORD } from "./global-setup";
+
+// D3.4: password login + lockout, against the store auth configured in global-setup
+// (password + OAuth methods; enforcement left OFF so other specs are unaffected).
+// "Lock persists across a store restart" is covered by unit tests (D1.2 — the lock
+// is a plain setting that survives a fresh store handle); a server restart isn't
+// expressible in the shared e2e webServer.
+
+const WRONG = "e2e-wrong-password";
+
+async function submitLogin(
+  page: import("@playwright/test").Page,
+  username: string,
+  password: string,
+): Promise<void> {
+  await page.goto("/login");
+  await page.locator('input[name="username"]').fill(username);
+  await page.locator('input[name="password"]').fill(password);
+  await page.getByRole("button", { name: "Sign in" }).click();
+  await page.waitForLoadState("networkidle");
+}
+
+async function sessionUser(page: import("@playwright/test").Page): Promise<string | null> {
+  const res = await page.request.get("/api/auth/session");
+  const body = (await res.json().catch(() => null)) as { user?: { name?: string } } | null;
+  return body?.user?.name ?? null;
+}
+
+test.describe("password login", () => {
+  test("renders the username + password form when a password is configured", async ({ page }) => {
+    await page.goto("/login");
+    await expect(page.locator('input[name="username"]')).toBeVisible();
+    await expect(page.locator('input[name="password"]')).toBeVisible();
+    await expect(page.getByRole("button", { name: "Sign in" })).toBeVisible();
+  });
+
+  test("signs in with the correct password", async ({ page }) => {
+    await submitLogin(page, E2E_OWNER, E2E_PASSWORD);
+    expect(await sessionUser(page)).toBe(E2E_OWNER);
+  });
+
+  test("locks out after repeated wrong passwords — even the correct one is then refused", async ({
+    page,
+  }) => {
+    // Each test gets a fresh browser context, but the lockout is server-side. The
+    // preceding success test clears it; these 5 misses trip it again.
+    for (let i = 0; i < 5; i++) {
+      await submitLogin(page, E2E_OWNER, WRONG);
+      expect(await sessionUser(page)).toBeNull();
+    }
+    // Locked: the correct password is now refused too.
+    await submitLogin(page, E2E_OWNER, E2E_PASSWORD);
+    expect(await sessionUser(page)).toBeNull();
+  });
+});

--- a/apps/dashboard/e2e/global-setup.ts
+++ b/apps/dashboard/e2e/global-setup.ts
@@ -1,0 +1,37 @@
+// D3.4: configure the e2e store's auth methods once, before any spec runs, so the
+// /login page renders a realistic configured deploy (password + both OAuth providers)
+// and the password spec has something to sign in against. Enforcement is left OFF
+// (we don't call enable) so the other specs keep running without a session — the
+// shared dashboard never redirects. Talks straight to the mcp-server admin tRPC.
+
+const SERVER_URL = process.env.LIBRARIAN_E2E_SERVER_URL ?? "http://127.0.0.1:3838";
+const ADMIN_TOKEN = process.env.LIBRARIAN_E2E_ADMIN_TOKEN ?? "e2e-admin-token";
+
+export const E2E_OWNER = "e2e-owner";
+export const E2E_PASSWORD = "e2e-correct-password";
+
+async function mutate(procedure: string, input: unknown): Promise<void> {
+  const res = await fetch(`${SERVER_URL}/trpc/${procedure}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${ADMIN_TOKEN}` },
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) {
+    throw new Error(`e2e setup ${procedure} failed: ${res.status} ${await res.text()}`);
+  }
+}
+
+export default async function globalSetup(): Promise<void> {
+  await mutate("auth.setPassword", { username: E2E_OWNER, password: E2E_PASSWORD });
+  await mutate("auth.configureOAuth", {
+    provider: "github",
+    clientId: "e2e-github-id",
+    clientSecret: "e2e-github-secret",
+  });
+  await mutate("auth.configureOAuth", {
+    provider: "google",
+    clientId: "e2e-google-id",
+    clientSecret: "e2e-google-secret",
+  });
+  await mutate("auth.setOwner", { provider: "github", ownerId: "e2e-github-owner" });
+}

--- a/apps/dashboard/e2e/login.spec.ts
+++ b/apps/dashboard/e2e/login.spec.ts
@@ -1,10 +1,11 @@
 import { expect, test } from "@playwright/test";
 
-// A2: the login surface. The shared e2e webServer runs with auth OFF (enabling
-// it would redirect every other spec to /login), so this is a render smoke that
-// the new page works in a real browser. The unauth-redirect and authed-session
-// flows are unit-tested (tests/auth-gate, tests/trpc-proxy-gate) and require a
-// dedicated auth-enabled server — see AUTONOMOUS-BUILD-NOTES.
+// A2/D3.3: the login surface. global-setup configures the store's auth methods
+// (password + both OAuth providers) but leaves enforcement OFF, so this stays a
+// render smoke (no redirect of other specs). The OAuth buttons render from the
+// configured store providers. The unauth-redirect / fail-closed flows are
+// unit-tested (tests/auth-gate, tests/trpc-proxy-gate); password sign-in + lockout
+// are exercised in auth-password.spec.ts.
 test.describe("login page", () => {
   test("renders the provider sign-in controls chrome-free", async ({ page }) => {
     await page.goto("/login");

--- a/apps/dashboard/lib/auth-config-client.ts
+++ b/apps/dashboard/lib/auth-config-client.ts
@@ -68,6 +68,16 @@ export function getAuthConfig(): Promise<DashboardAuthConfig> {
   return cache.get();
 }
 
+/** Like getAuthConfig but degrades to null on any failure (store unreachable) —
+ *  for callers that fall back to the env path rather than throwing. */
+export async function getAuthConfigSafe(): Promise<DashboardAuthConfig | null> {
+  try {
+    return await cache.get();
+  } catch {
+    return null;
+  }
+}
+
 /** Invalidate the cache — call from every auth mutation action so changes take effect at once. */
 export function bustAuthConfig(): void {
   cache.bust();

--- a/apps/dashboard/lib/auth-config-client.ts
+++ b/apps/dashboard/lib/auth-config-client.ts
@@ -10,7 +10,9 @@ import { serverTRPC } from "./trpc-server";
 // without cross-instance invalidation. Concurrent reads share one in-flight fetch
 // so a burst of requests doesn't fan out into parallel store calls.
 
-const DEFAULT_TTL_MS = 30_000;
+// Default 30s; tunable via env (lower for tests, or for operators who want faster
+// propagation of auth changes at the cost of more store reads).
+const DEFAULT_TTL_MS = Number(process.env.LIBRARIAN_AUTH_CONFIG_TTL_MS) || 30_000;
 // Bound the hot-path config fetch so a half-open store (connection accepted, no
 // response) surfaces as a fast throw → fail-closed "block" in middleware, rather
 // than hanging every page request until the platform's default fetch timeout.

--- a/apps/dashboard/lib/credentials-authorize.ts
+++ b/apps/dashboard/lib/credentials-authorize.ts
@@ -1,0 +1,24 @@
+// D3.1: the Credentials provider's authorize logic, extracted so it's unit-testable
+// without NextAuth. The store owns the password hash + lockout (auth.verifyPassword);
+// authorize just calls it and maps the result to the single-owner identity. Fails
+// closed (null → no session) on bad input, a failed/locked verify, or any error.
+
+export interface OwnerCredential {
+  id: string;
+  name: string;
+}
+
+export async function authorizeOwnerCredentials(
+  credentials: Partial<Record<string, unknown>>,
+  verify: (username: string, password: string) => Promise<{ ok: boolean }>,
+): Promise<OwnerCredential | null> {
+  const username = typeof credentials.username === "string" ? credentials.username : "";
+  const password = typeof credentials.password === "string" ? credentials.password : "";
+  if (!username || !password) return null;
+  try {
+    const result = await verify(username, password);
+    return result.ok ? { id: username, name: username } : null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/dashboard/lib/credentials-authorize.ts
+++ b/apps/dashboard/lib/credentials-authorize.ts
@@ -17,6 +17,8 @@ export async function authorizeOwnerCredentials(
   if (!username || !password) return null;
   try {
     const result = await verify(username, password);
+    // Deliberately read only `.ok` — a wrong password and a lockout look identical
+    // here, so no lockout state leaks to the client.
     return result.ok ? { id: username, name: username } : null;
   } catch {
     return null;

--- a/apps/dashboard/lib/rate-limit.ts
+++ b/apps/dashboard/lib/rate-limit.ts
@@ -9,6 +9,11 @@ export interface RateLimiter {
   check(key: string): boolean;
 }
 
+// Bounds memory under a high-cardinality (e.g. spoofed-IP) flood: once the map
+// exceeds this, fully-expired keys are swept. The store-side lockout is the
+// authoritative gate, so this only protects the dashboard's own memory.
+const MAX_KEYS = 10_000;
+
 export function createRateLimiter(options: {
   limit: number;
   windowMs: number;
@@ -19,6 +24,11 @@ export function createRateLimiter(options: {
   return {
     check(key: string): boolean {
       const t = now();
+      if (hits.size > MAX_KEYS) {
+        for (const [k, ts] of hits) {
+          if (ts.every((x) => t - x >= options.windowMs)) hits.delete(k);
+        }
+      }
       const recent = (hits.get(key) ?? []).filter((ts) => t - ts < options.windowMs);
       if (recent.length >= options.limit) {
         hits.set(key, recent);

--- a/apps/dashboard/lib/rate-limit.ts
+++ b/apps/dashboard/lib/rate-limit.ts
@@ -1,0 +1,32 @@
+// D3.2: a minimal in-process sliding-window rate limiter. Defense in depth on the
+// credentials login route, layered on top of the authoritative store-side lockout —
+// it bounds raw request volume per client before a request even reaches the store.
+// In-process is sufficient for a single-instance dashboard (same assumption as the
+// auth-config cache); a multi-instance deploy would want a shared store.
+
+export interface RateLimiter {
+  /** Record an attempt for `key`; returns true if allowed, false if over the limit. */
+  check(key: string): boolean;
+}
+
+export function createRateLimiter(options: {
+  limit: number;
+  windowMs: number;
+  now?: () => number;
+}): RateLimiter {
+  const now = options.now ?? Date.now;
+  const hits = new Map<string, number[]>();
+  return {
+    check(key: string): boolean {
+      const t = now();
+      const recent = (hits.get(key) ?? []).filter((ts) => t - ts < options.windowMs);
+      if (recent.length >= options.limit) {
+        hits.set(key, recent);
+        return false;
+      }
+      recent.push(t);
+      hits.set(key, recent);
+      return true;
+    },
+  };
+}

--- a/apps/dashboard/playwright.config.ts
+++ b/apps/dashboard/playwright.config.ts
@@ -29,6 +29,9 @@ process.env.LIBRARIAN_E2E_DASHBOARD_URL = E2E_DASHBOARD_URL;
 
 export default defineConfig({
   testDir: "./e2e",
+  // Configure the store's auth methods once before any spec (D3.4) — see
+  // e2e/global-setup.ts. Enforcement stays off so other specs are unaffected.
+  globalSetup: "./e2e/global-setup.ts",
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
@@ -69,6 +72,11 @@ export default defineConfig({
         ...(process.env as Record<string, string>),
         LIBRARIAN_ADMIN_TOKEN: E2E_ADMIN_TOKEN,
         LIBRARIAN_SERVER_URL: E2E_SERVER_URL,
+        // Short auth-config cache so globalSetup's config propagates within a test.
+        LIBRARIAN_AUTH_CONFIG_TTL_MS: "1000",
+        // Raise the credentials rate limit so the store-side LOCKOUT is what the
+        // password spec exercises, not the dashboard throttle.
+        LIBRARIAN_CREDENTIALS_RATE_LIMIT: "100",
       },
     },
   ],

--- a/apps/dashboard/tests/credentials-authorize.test.ts
+++ b/apps/dashboard/tests/credentials-authorize.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import { authorizeOwnerCredentials } from "@/lib/credentials-authorize";
+
+// D3.1: the Credentials provider's authorize logic, extracted so it's testable
+// without standing up NextAuth. verify() is the store-side auth.verifyPassword
+// (lockout-aware); authorize returns the single-owner identity on ok, null otherwise.
+
+describe("authorizeOwnerCredentials", () => {
+  it("returns the owner identity when verify succeeds", async () => {
+    const verify = vi.fn().mockResolvedValue({ ok: true, locked: false });
+    const user = await authorizeOwnerCredentials({ username: "owner", password: "pw" }, verify);
+    expect(user).toEqual({ id: "owner", name: "owner" });
+    expect(verify).toHaveBeenCalledWith("owner", "pw");
+  });
+
+  it("returns null when verify fails", async () => {
+    const verify = vi.fn().mockResolvedValue({ ok: false, locked: false });
+    expect(
+      await authorizeOwnerCredentials({ username: "owner", password: "bad" }, verify),
+    ).toBeNull();
+  });
+
+  it("returns null when locked out (verify ok:false)", async () => {
+    const verify = vi.fn().mockResolvedValue({ ok: false, locked: true });
+    expect(
+      await authorizeOwnerCredentials({ username: "owner", password: "pw" }, verify),
+    ).toBeNull();
+  });
+
+  it("returns null on missing/invalid credentials without calling verify", async () => {
+    const verify = vi.fn();
+    expect(await authorizeOwnerCredentials({ username: "owner" }, verify)).toBeNull();
+    expect(await authorizeOwnerCredentials({ password: "pw" }, verify)).toBeNull();
+    expect(await authorizeOwnerCredentials({ username: 123, password: "pw" }, verify)).toBeNull();
+    expect(verify).not.toHaveBeenCalled();
+  });
+
+  it("fails closed (null) when verify throws (store/proxy error)", async () => {
+    const verify = vi.fn().mockRejectedValue(new Error("unreachable"));
+    expect(
+      await authorizeOwnerCredentials({ username: "owner", password: "pw" }, verify),
+    ).toBeNull();
+  });
+});

--- a/apps/dashboard/tests/credentials-rate-limit.test.ts
+++ b/apps/dashboard/tests/credentials-rate-limit.test.ts
@@ -1,0 +1,58 @@
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// D3.2: the credentials callback route is rate-limited (defense in depth on top of
+// the store-side lockout). A burst over the limit is throttled with a generic 429;
+// other auth routes pass straight through.
+
+const postMock = vi.fn();
+vi.mock("@/auth", () => ({
+  handlers: { GET: vi.fn(), POST: (req: NextRequest) => postMock(req) },
+}));
+
+const { POST } = await import("@/app/api/auth/[...nextauth]/route");
+
+function credentialsRequest(ip = "1.2.3.4"): NextRequest {
+  return new NextRequest("http://localhost:3000/api/auth/callback/credentials", {
+    method: "POST",
+    headers: { "x-forwarded-for": ip },
+  });
+}
+
+beforeEach(() => {
+  postMock.mockReset();
+  postMock.mockResolvedValue(new Response("ok", { status: 200 }));
+});
+afterEach(() => vi.clearAllMocks());
+
+describe("/api/auth credentials rate limit", () => {
+  it("passes requests under the limit through to NextAuth", async () => {
+    for (let i = 0; i < 10; i++) {
+      const res = await POST(credentialsRequest());
+      expect(res.status).toBe(200);
+    }
+    expect(postMock).toHaveBeenCalledTimes(10);
+  });
+
+  it("throttles a burst over the limit with a generic 429 (no enumeration)", async () => {
+    for (let i = 0; i < 10; i++) await POST(credentialsRequest("9.9.9.9"));
+    postMock.mockClear();
+
+    const res = await POST(credentialsRequest("9.9.9.9"));
+    expect(res.status).toBe(429);
+    expect(postMock).not.toHaveBeenCalled(); // never reaches NextAuth / the store
+    const body = await res.text();
+    expect(body).not.toMatch(/lock|user|password/i); // generic, no enumeration
+  });
+
+  it("does not rate-limit non-credentials auth routes", async () => {
+    const sessionReq = new NextRequest("http://localhost:3000/api/auth/session", {
+      method: "POST",
+    });
+    for (let i = 0; i < 20; i++) {
+      const res = await POST(sessionReq);
+      expect(res.status).toBe(200);
+    }
+    expect(postMock).toHaveBeenCalledTimes(20);
+  });
+});

--- a/apps/dashboard/tests/login-page.test.tsx
+++ b/apps/dashboard/tests/login-page.test.tsx
@@ -1,0 +1,57 @@
+import { renderToString } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// D3.3: /login renders only the configured methods — a password form when a password
+// method is set, and an OAuth button per configured provider.
+
+const getAuthConfigMock = vi.fn();
+vi.mock("@/auth", () => ({ signIn: vi.fn() }));
+vi.mock("@/lib/auth-config-client", () => ({ getAuthConfig: () => getAuthConfigMock() }));
+
+const { default: LoginPage } = await import("../app/login/page");
+
+function render(config: unknown): Promise<string> {
+  getAuthConfigMock.mockResolvedValueOnce(config);
+  return LoginPage({ searchParams: Promise.resolve({}) }).then((el) => renderToString(el));
+}
+
+afterEach(() => getAuthConfigMock.mockReset());
+
+describe("apps/dashboard/app/login/page.tsx", () => {
+  it("shows the password form when a password method is configured", async () => {
+    const html = await render({
+      methods: ["password"],
+      oauth: {},
+      password: { username: "owner" },
+    });
+    expect(html).toMatch(/name="username"/);
+    expect(html).toMatch(/name="password"/);
+  });
+
+  it("hides the password form when no password method is configured", async () => {
+    const html = await render({ methods: ["github"], oauth: { github: { clientId: "x" } } });
+    expect(html).not.toMatch(/name="password"/);
+    expect(html).toMatch(/Continue with GitHub/);
+  });
+
+  it("renders an OAuth button only for each configured provider", async () => {
+    const html = await render({ methods: ["google"], oauth: { google: { clientId: "x" } } });
+    expect(html).toMatch(/Continue with Google/);
+    expect(html).not.toMatch(/Continue with GitHub/);
+  });
+
+  it("shows nothing extra for an unconfigured store with no env providers", async () => {
+    const prevGh = process.env.AUTH_GITHUB_ID;
+    const prevGg = process.env.AUTH_GOOGLE_ID;
+    process.env.AUTH_GITHUB_ID = "";
+    process.env.AUTH_GOOGLE_ID = "";
+    try {
+      const html = await render({ methods: [], oauth: {} });
+      expect(html).not.toMatch(/name="password"/);
+      expect(html).not.toMatch(/Continue with/);
+    } finally {
+      process.env.AUTH_GITHUB_ID = prevGh;
+      process.env.AUTH_GOOGLE_ID = prevGg;
+    }
+  });
+});

--- a/apps/dashboard/tests/login-page.test.tsx
+++ b/apps/dashboard/tests/login-page.test.tsx
@@ -6,7 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const getAuthConfigMock = vi.fn();
 vi.mock("@/auth", () => ({ signIn: vi.fn() }));
-vi.mock("@/lib/auth-config-client", () => ({ getAuthConfig: () => getAuthConfigMock() }));
+vi.mock("@/lib/auth-config-client", () => ({ getAuthConfigSafe: () => getAuthConfigMock() }));
 // next-auth's runtime pulls next/server, which vitest can't resolve; the page only
 // needs AuthError as a type guard in a server action (not exercised by render).
 vi.mock("next-auth", () => ({ AuthError: class AuthError extends Error {} }));

--- a/apps/dashboard/tests/login-page.test.tsx
+++ b/apps/dashboard/tests/login-page.test.tsx
@@ -7,6 +7,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const getAuthConfigMock = vi.fn();
 vi.mock("@/auth", () => ({ signIn: vi.fn() }));
 vi.mock("@/lib/auth-config-client", () => ({ getAuthConfig: () => getAuthConfigMock() }));
+// next-auth's runtime pulls next/server, which vitest can't resolve; the page only
+// needs AuthError as a type guard in a server action (not exercised by render).
+vi.mock("next-auth", () => ({ AuthError: class AuthError extends Error {} }));
+vi.mock("next/navigation", () => ({ redirect: vi.fn() }));
 
 const { default: LoginPage } = await import("../app/login/page");
 

--- a/apps/dashboard/tests/rate-limit.test.ts
+++ b/apps/dashboard/tests/rate-limit.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { createRateLimiter } from "@/lib/rate-limit";
+
+// D3.2: a small in-memory sliding-window limiter — defense in depth on the
+// credentials route, atop the authoritative store-side lockout.
+
+describe("createRateLimiter", () => {
+  it("allows up to the limit within the window, then throttles", () => {
+    const now = 0;
+    const limiter = createRateLimiter({ limit: 3, windowMs: 1000, now: () => now });
+    expect(limiter.check("ip")).toBe(true);
+    expect(limiter.check("ip")).toBe(true);
+    expect(limiter.check("ip")).toBe(true);
+    expect(limiter.check("ip")).toBe(false); // 4th over the limit
+  });
+
+  it("resets after the window elapses", () => {
+    let now = 0;
+    const limiter = createRateLimiter({ limit: 2, windowMs: 1000, now: () => now });
+    expect(limiter.check("ip")).toBe(true);
+    expect(limiter.check("ip")).toBe(true);
+    expect(limiter.check("ip")).toBe(false);
+    now += 1001; // window passed
+    expect(limiter.check("ip")).toBe(true);
+  });
+
+  it("tracks keys independently", () => {
+    const now = 0;
+    const limiter = createRateLimiter({ limit: 1, windowMs: 1000, now: () => now });
+    expect(limiter.check("a")).toBe(true);
+    expect(limiter.check("a")).toBe(false);
+    expect(limiter.check("b")).toBe(true); // different key, own budget
+  });
+});


### PR DESCRIPTION
## D3 — Password login

Fifth slice of **dashboard-managed-auth** (builds on #144–#147). Lands password login end-to-end. Safe to expose now that D4 recovery is merged (the spec's sequencing constraint).

### What changed (tasks D3.1–D3.4)
- **Credentials provider (D3.1)** — when a password method is configured, `auth.ts` adds an Auth.js Credentials provider whose `authorize()` calls the store-side `auth.verifyPassword` (hash + lockout live in the store) and maps success to the single-owner identity. The signIn callback lets the credentials provider through (the password is the gate); fails closed on bad input / failed / locked / error.
- **Rate limit (D3.2)** — a per-client sliding-window limiter (10/min, env-tunable) wraps the credentials callback POST: defense in depth atop the store lockout, generic 429 (no enumeration), other `/api/auth` routes untouched. Map growth is bounded.
- **Config-driven /login (D3.3)** — renders the username/password form only when a password method is configured, and an OAuth button per configured provider; env fallback when the store has no config. A failed/locked sign-in maps to `/login?error` (no lockout/user enumeration); success redirects.
- **E2E (D3.4)** — `auth-password.spec.ts`: form renders, correct password signs in, 5 wrong attempts lock the account so even the correct one is refused. A globalSetup configures the store's auth methods (enforcement OFF) so the shared webServer doesn't redirect other specs. Verified locally (4 specs green).

### Verification
- TDD throughout; 130 dashboard unit tests + the e2e suite pass locally; full CI parity green (build, lint, format:check, typecheck, `pnpm test`, smoke, healthcheck, guards).
- Five-axis review: **APPROVE, no Critical/Important**. Hardened per suggestions (bounded limiter map, XFF spoofability documented, no-lockout-leak comment).

### Notes
- New env knobs (safe defaults): `LIBRARIAN_AUTH_CONFIG_TTL_MS` (cache TTL, 30s), `LIBRARIAN_CREDENTIALS_RATE_LIMIT` (login throttle, 10). e2e tunes them.
- Only D5 (setup wizard UI) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)