### PR TITLE
feat(auth): D5 — setup wizard UI (final slice)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,15 +36,19 @@ LIBRARIAN_AGENT_TOKENS=
 # prompts for it (or takes `--secret-key`) on a host that lacks it.
 LIBRARIAN_SECRET_KEY=
 
-# ----- Optional: dashboard owner login (Auth.js) -----
-# Wired but OFF until LIBRARIAN_AUTH_ENABLED=true (enforcement lands in a later
-# slice). When enabled, the dashboard requires the single owner to sign in via
-# GitHub/Google. JWT sessions — the dashboard never opens the store.
+# ----- Optional: dashboard owner login — LEGACY env path (deprecated) -----
+# RECOMMENDED: configure auth from the dashboard at /settings/auth instead — it
+# stores config (password and/or GitHub/Google) in the data store, adds a
+# username+password option, and enforces without a redeploy. You only need the
+# admin token (auto-generated, printed once on first boot) to enable it there.
 #
-# AUTH_SECRET signs the session JWT — generate with `openssl rand -base64 33`.
-# AUTH_URL is the dashboard's public origin (used to build OAuth callback URLs);
-# the OAuth app's callback is <AUTH_URL>/api/auth/callback/{github,google}.
-# Provider credentials come from each provider's developer console.
+# The vars below are the DEPRECATED fallback for existing A1–A5 deployments: they
+# still work (store config wins when present), but new installs should leave them
+# unset and use the wizard. When set, the dashboard requires the single owner to
+# sign in via GitHub/Google; JWT sessions — the dashboard never opens the store.
+# AUTH_SECRET signs the session JWT (with the wizard it's derived from
+# LIBRARIAN_SECRET_KEY, nothing to set). AUTH_URL is the dashboard's public origin;
+# the OAuth callback is <AUTH_URL>/api/auth/callback/{github,google}.
 LIBRARIAN_AUTH_ENABLED=false
 AUTH_SECRET=
 AUTH_URL=https://librarian.example.com

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -150,17 +150,40 @@ docker compose --env-file .env -f docker/docker-compose.yml up -d
 
 ## Dashboard login (single-owner)
 
-The dashboard can require the owner to sign in via GitHub or Google instead of
-relying on a VPN/private network. It is **off by default** — set
-`LIBRARIAN_AUTH_ENABLED=true` to enforce it. **Recommended for any
-internet-exposed deployment.** When enabled, every dashboard page redirects an
-unauthenticated visitor to `/login`, and the same-origin `/api/trpc` proxy (which
-carries the admin token) refuses requests without a session. While off, nothing
-changes — the `/login` page and `/api/auth/*` endpoints exist but enforce
-nothing, so a fresh `docker run` works with no auth config.
+The dashboard can require the owner to sign in instead of relying on a VPN/private
+network. It is **off by default** and **recommended for any internet-exposed
+deployment.** When enabled, every dashboard page redirects an unauthenticated
+visitor to `/login`, and the same-origin `/api/trpc` proxy (which carries the admin
+token) refuses requests without a session. Sessions are **JWT** (no DB session
+store — the dashboard never opens the data store).
 
-Sessions are **JWT** (no DB session store — the dashboard never opens the data
-store). Configure in `.env`:
+### Recommended: configure auth in the dashboard (no redeploy)
+
+Open **`/settings/auth`** and use the wizard:
+
+1. **Set a method** — a username + password (no GitHub/Google account required),
+   and/or wire GitHub/Google OAuth (the wizard shows the exact callback URL to
+   register and takes the client id/secret + your owner account id).
+2. **Enable** — paste the **admin token** (auto-generated and printed once on first
+   boot, or at `${LIBRARIAN_DATA_DIR}/admin.token`) into the "Enable authentication"
+   card. Enforcement flips on immediately — no redeploy.
+
+Config lives in the store, the JWT secret is derived from `LIBRARIAN_SECRET_KEY`
+(nothing extra to set), and N wrong passwords trigger a lockout. **Recovery from the
+host shell** if you lock yourself out or forget the password:
+
+```sh
+the-librarian auth status                      # what's configured (no secrets)
+the-librarian auth reset-password              # set a new password (prompted), clears lockout
+the-librarian auth reset-password --print-setup-link --origin https://librarian.example.com
+the-librarian auth disable                     # break-glass: turn enforcement off
+```
+
+### Legacy: env-configured auth (deprecated)
+
+Existing A1–A5 deployments can still configure auth entirely through env vars
+(store config wins when present; otherwise these are the fallback). New installs
+should prefer the wizard above. Configure in `.env`:
 
 ```sh
 LIBRARIAN_AUTH_ENABLED=true

--- a/apps/dashboard/app/settings/auth/actions.ts
+++ b/apps/dashboard/app/settings/auth/actions.ts
@@ -1,0 +1,56 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { bustAuthConfig } from "@/lib/auth-config-client";
+import { serverTRPC } from "@/lib/trpc-server";
+
+// D5: server actions for the auth setup wizard. Each wraps an admin auth.* mutation
+// and busts the in-process auth-config cache so the change takes effect at once
+// (rather than waiting out the TTL), then revalidates the settings page.
+
+export type AuthActionResult = { ok: true } | { ok: false; error: string };
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function run(mutation: () => Promise<unknown>): Promise<AuthActionResult> {
+  try {
+    await mutation();
+    bustAuthConfig();
+    revalidatePath("/settings/auth");
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: message(error) };
+  }
+}
+
+export function enableAuthAction(adminToken: string): Promise<AuthActionResult> {
+  return run(() => serverTRPC.auth.enable.mutate({ adminToken }));
+}
+
+export function disableAuthAction(): Promise<AuthActionResult> {
+  return run(() => serverTRPC.auth.disable.mutate());
+}
+
+export function setPasswordAction(input: {
+  username: string;
+  password: string;
+}): Promise<AuthActionResult> {
+  return run(() => serverTRPC.auth.setPassword.mutate(input));
+}
+
+export function configureOAuthAction(input: {
+  provider: "github" | "google";
+  clientId: string;
+  clientSecret: string;
+}): Promise<AuthActionResult> {
+  return run(() => serverTRPC.auth.configureOAuth.mutate(input));
+}
+
+export function setOwnerAction(input: {
+  provider: "github" | "google";
+  ownerId: string;
+}): Promise<AuthActionResult> {
+  return run(() => serverTRPC.auth.setOwner.mutate(input));
+}

--- a/apps/dashboard/app/settings/auth/actions.ts
+++ b/apps/dashboard/app/settings/auth/actions.ts
@@ -25,22 +25,22 @@ async function run(mutation: () => Promise<unknown>): Promise<AuthActionResult> 
   }
 }
 
-export function enableAuthAction(adminToken: string): Promise<AuthActionResult> {
+export async function enableAuthAction(adminToken: string): Promise<AuthActionResult> {
   return run(() => serverTRPC.auth.enable.mutate({ adminToken }));
 }
 
-export function disableAuthAction(): Promise<AuthActionResult> {
+export async function disableAuthAction(): Promise<AuthActionResult> {
   return run(() => serverTRPC.auth.disable.mutate());
 }
 
-export function setPasswordAction(input: {
+export async function setPasswordAction(input: {
   username: string;
   password: string;
 }): Promise<AuthActionResult> {
   return run(() => serverTRPC.auth.setPassword.mutate(input));
 }
 
-export function configureOAuthAction(input: {
+export async function configureOAuthAction(input: {
   provider: "github" | "google";
   clientId: string;
   clientSecret: string;
@@ -48,9 +48,26 @@ export function configureOAuthAction(input: {
   return run(() => serverTRPC.auth.configureOAuth.mutate(input));
 }
 
-export function setOwnerAction(input: {
+export async function setOwnerAction(input: {
   provider: "github" | "google";
   ownerId: string;
 }): Promise<AuthActionResult> {
   return run(() => serverTRPC.auth.setOwner.mutate(input));
+}
+
+// The OAuth wizard saves creds + the owner allowlist together. If the creds save
+// fails, the owner is not set (the whole action reports the error). `provider` is
+// first so the page can .bind() it, leaving the wizard's (input) => result shape.
+export async function saveOAuthAction(
+  provider: "github" | "google",
+  input: { clientId: string; clientSecret: string; ownerId: string },
+): Promise<AuthActionResult> {
+  return run(async () => {
+    await serverTRPC.auth.configureOAuth.mutate({
+      provider,
+      clientId: input.clientId,
+      clientSecret: input.clientSecret,
+    });
+    await serverTRPC.auth.setOwner.mutate({ provider, ownerId: input.ownerId });
+  });
 }

--- a/apps/dashboard/app/settings/auth/actions.ts
+++ b/apps/dashboard/app/settings/auth/actions.ts
@@ -63,11 +63,17 @@ export async function saveOAuthAction(
   input: { clientId: string; clientSecret: string; ownerId: string },
 ): Promise<AuthActionResult> {
   return run(async () => {
-    await serverTRPC.auth.configureOAuth.mutate({
-      provider,
-      clientId: input.clientId,
-      clientSecret: input.clientSecret,
-    });
-    await serverTRPC.auth.setOwner.mutate({ provider, ownerId: input.ownerId });
+    // Update the creds only when both are supplied — blank means "keep the existing
+    // ones" (so the owner can change just the allowlist without re-entering the secret).
+    if (input.clientId && input.clientSecret) {
+      await serverTRPC.auth.configureOAuth.mutate({
+        provider,
+        clientId: input.clientId,
+        clientSecret: input.clientSecret,
+      });
+    }
+    if (input.ownerId) {
+      await serverTRPC.auth.setOwner.mutate({ provider, ownerId: input.ownerId });
+    }
   });
 }

--- a/apps/dashboard/app/settings/auth/page.tsx
+++ b/apps/dashboard/app/settings/auth/page.tsx
@@ -1,0 +1,52 @@
+// D5.1: the auth setup wizard. Gated like the rest of the dashboard (it's under
+// /settings, which the middleware enforces when auth is on). Reads the current
+// config server-side and renders the management cards. Only non-secret fields are
+// surfaced — the OAuth client secrets and AUTH_SECRET in the config object are never
+// written into the response.
+
+import { serverTRPC } from "@/lib/trpc-server";
+
+export const metadata = { title: "Authentication · Librarian" };
+
+async function loadConfig() {
+  try {
+    return await serverTRPC.auth.config.query();
+  } catch {
+    return null;
+  }
+}
+
+export default async function AuthSettingsPage() {
+  const config = await loadConfig();
+  const enabled = config?.enabled ?? false;
+  const methods = config?.methods ?? [];
+
+  return (
+    <main className="mx-auto flex w-full max-w-2xl flex-col gap-6 p-6">
+      <header className="flex flex-col gap-1">
+        <h1 className="font-display text-2xl text-foreground">Authentication</h1>
+        <p className="text-sm text-foreground/60">
+          Configure how you sign in to this dashboard. Changes take effect without a redeploy.
+        </p>
+      </header>
+
+      <section
+        className="flex items-center justify-between rounded-lg border border-border bg-muted/20 px-4 py-3"
+        aria-label="Authentication status"
+      >
+        <span className="text-sm text-foreground">Enforcement</span>
+        <span
+          className={`text-sm font-medium ${enabled ? "text-foreground" : "text-foreground/50"}`}
+        >
+          {enabled ? "Enabled" : "Disabled"}
+        </span>
+      </section>
+
+      <p className="text-sm text-foreground/60">
+        Configured methods: {methods.length ? methods.join(", ") : "none yet"}
+      </p>
+
+      {/* Cards land in D5.2 (enable) · D5.3 (password) · D5.4 (OAuth) · D5.5 (methods/disable). */}
+    </main>
+  );
+}

--- a/apps/dashboard/app/settings/auth/page.tsx
+++ b/apps/dashboard/app/settings/auth/page.tsx
@@ -1,9 +1,20 @@
-// D5.1: the auth setup wizard. Gated like the rest of the dashboard (it's under
+// D5: the auth setup wizard. Gated like the rest of the dashboard (it's under
 // /settings, which the middleware enforces when auth is on). Reads the current
 // config server-side and renders the management cards. Only non-secret fields are
 // surfaced — the OAuth client secrets and AUTH_SECRET in the config object are never
-// written into the response.
+// passed to the client components.
 
+import { headers } from "next/headers";
+import {
+  disableAuthAction,
+  enableAuthAction,
+  saveOAuthAction,
+  setPasswordAction,
+} from "@/app/settings/auth/actions";
+import { EnableCard } from "@/components/settings/auth/enable-card";
+import { MethodsPanel } from "@/components/settings/auth/methods-panel";
+import { OAuthWizard } from "@/components/settings/auth/oauth-wizard";
+import { PasswordForm } from "@/components/settings/auth/password-form";
 import { serverTRPC } from "@/lib/trpc-server";
 
 export const metadata = { title: "Authentication · Librarian" };
@@ -16,10 +27,19 @@ async function loadConfig() {
   }
 }
 
+async function resolveOrigin(): Promise<string> {
+  const h = await headers();
+  const host = h.get("host") ?? "localhost:3000";
+  const proto = h.get("x-forwarded-proto") ?? (host.startsWith("localhost") ? "http" : "https");
+  return `${proto}://${host}`;
+}
+
 export default async function AuthSettingsPage() {
   const config = await loadConfig();
+  const origin = await resolveOrigin();
   const enabled = config?.enabled ?? false;
   const methods = config?.methods ?? [];
+  const canEnable = methods.length > 0;
 
   return (
     <main className="mx-auto flex w-full max-w-2xl flex-col gap-6 p-6">
@@ -30,23 +50,34 @@ export default async function AuthSettingsPage() {
         </p>
       </header>
 
-      <section
-        className="flex items-center justify-between rounded-lg border border-border bg-muted/20 px-4 py-3"
-        aria-label="Authentication status"
-      >
-        <span className="text-sm text-foreground">Enforcement</span>
-        <span
-          className={`text-sm font-medium ${enabled ? "text-foreground" : "text-foreground/50"}`}
-        >
-          {enabled ? "Enabled" : "Disabled"}
-        </span>
-      </section>
+      <EnableCard enabled={enabled} canEnable={canEnable} onEnable={enableAuthAction} />
 
-      <p className="text-sm text-foreground/60">
-        Configured methods: {methods.length ? methods.join(", ") : "none yet"}
-      </p>
+      <PasswordForm username={config?.password?.username ?? null} onSave={setPasswordAction} />
 
-      {/* Cards land in D5.2 (enable) · D5.3 (password) · D5.4 (OAuth) · D5.5 (methods/disable). */}
+      <OAuthWizard
+        provider="github"
+        callbackUrl={`${origin}/api/auth/callback/github`}
+        ownerId={config?.ownerOAuth?.github ?? null}
+        configured={!!config?.oauth?.github}
+        onSave={saveOAuthAction.bind(null, "github")}
+      />
+      <OAuthWizard
+        provider="google"
+        callbackUrl={`${origin}/api/auth/callback/google`}
+        ownerId={config?.ownerOAuth?.google ?? null}
+        configured={!!config?.oauth?.google}
+        onSave={saveOAuthAction.bind(null, "google")}
+      />
+
+      <MethodsPanel
+        enabled={enabled}
+        methods={{
+          password: config?.password ?? null,
+          github: config?.oauth?.github ? { ownerId: config.ownerOAuth?.github ?? null } : null,
+          google: config?.oauth?.google ? { ownerId: config.ownerOAuth?.google ?? null } : null,
+        }}
+        onDisable={disableAuthAction}
+      />
     </main>
   );
 }

--- a/apps/dashboard/components/settings/auth/enable-card.tsx
+++ b/apps/dashboard/components/settings/auth/enable-card.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { type FormEvent, useState } from "react";
+import type { AuthActionResult } from "@/app/settings/auth/actions";
+import { Button } from "@/components/ui-v2/button";
+import { Input } from "@/components/ui-v2/input";
+
+// D5.2: the "enable authentication" card. Enabling requires the admin token (the
+// land-grab guard) AND at least one configured method, so the button is disabled
+// until a method exists. A wrong token / incomplete config surfaces as an error.
+export function EnableCard({
+  enabled,
+  canEnable,
+  onEnable,
+}: {
+  enabled: boolean;
+  canEnable: boolean;
+  onEnable: (adminToken: string) => Promise<AuthActionResult>;
+}) {
+  const [token, setToken] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onSubmit(event: FormEvent): Promise<void> {
+    event.preventDefault();
+    setError(null);
+    setBusy(true);
+    const result = await onEnable(token);
+    setBusy(false);
+    if (result.ok) setToken("");
+    else setError(result.error);
+  }
+
+  if (enabled) {
+    return (
+      <section className="rounded-lg border border-border p-4" aria-label="Enable authentication">
+        <p className="text-sm text-foreground" role="status">
+          Authentication is enabled.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section
+      className="flex flex-col gap-3 rounded-lg border border-border p-4"
+      aria-label="Enable authentication"
+    >
+      <div className="flex flex-col gap-1">
+        <h2 className="font-medium text-foreground">Enable authentication</h2>
+        <p className="text-sm text-foreground/60">
+          Paste the admin token (printed once on first boot, or at
+          <code> ${"{DATA_DIR}"}/admin.token</code>) to turn on enforcement.
+        </p>
+      </div>
+      <form onSubmit={onSubmit} className="flex flex-col gap-3">
+        <Input
+          type="password"
+          placeholder="Admin token"
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+          autoComplete="off"
+          required
+        />
+        {!canEnable ? (
+          <p className="text-sm text-foreground/60">Configure at least one login method first.</p>
+        ) : null}
+        {error ? (
+          <p className="text-sm text-ink-accent" role="alert">
+            {error}
+          </p>
+        ) : null}
+        <Button
+          type="submit"
+          variant="primary"
+          className="w-full justify-center"
+          disabled={busy || !canEnable}
+        >
+          {busy ? "Enabling…" : "Enable authentication"}
+        </Button>
+      </form>
+    </section>
+  );
+}

--- a/apps/dashboard/components/settings/auth/methods-panel.tsx
+++ b/apps/dashboard/components/settings/auth/methods-panel.tsx
@@ -23,16 +23,24 @@ export function MethodsPanel({
 }) {
   const [confirming, setConfirming] = useState(false);
   const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const rows: string[] = [];
   if (methods.password) rows.push(`Password — ${methods.password.username}`);
   if (methods.github) rows.push(`GitHub — ${methods.github.ownerId ?? "(no owner set)"}`);
   if (methods.google) rows.push(`Google — ${methods.google.ownerId ?? "(no owner set)"}`);
 
   async function disable(): Promise<void> {
+    setError(null);
     setBusy(true);
-    await onDisable();
+    const result = await onDisable();
     setBusy(false);
-    setConfirming(false);
+    if (result.ok) {
+      setConfirming(false);
+    } else {
+      // Surface the failure and keep the confirm open — a break-glass control must
+      // never silently leave the owner believing enforcement is off when it isn't.
+      setError(result.error);
+    }
   }
 
   return (
@@ -51,19 +59,34 @@ export function MethodsPanel({
         <p className="text-sm text-foreground/60">No methods configured yet.</p>
       )}
 
+      {error ? (
+        <p className="text-sm text-ink-accent" role="alert">
+          {error}
+        </p>
+      ) : null}
       {enabled ? (
         confirming ? (
           <div className="flex items-center gap-2">
             <span className="text-sm text-foreground/70">Disable enforcement?</span>
-            <Button variant="primary" onClick={disable} disabled={busy}>
+            <Button type="button" variant="primary" onClick={disable} disabled={busy}>
               {busy ? "Disabling…" : "Confirm disable"}
             </Button>
-            <Button variant="outline" onClick={() => setConfirming(false)} disabled={busy}>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setConfirming(false)}
+              disabled={busy}
+            >
               Cancel
             </Button>
           </div>
         ) : (
-          <Button variant="outline" className="self-start" onClick={() => setConfirming(true)}>
+          <Button
+            type="button"
+            variant="outline"
+            className="self-start"
+            onClick={() => setConfirming(true)}
+          >
             Disable authentication
           </Button>
         )

--- a/apps/dashboard/components/settings/auth/methods-panel.tsx
+++ b/apps/dashboard/components/settings/auth/methods-panel.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+import type { AuthActionResult } from "@/app/settings/auth/actions";
+import { Button } from "@/components/ui-v2/button";
+
+export interface AuthMethodsView {
+  password: { username: string } | null;
+  github: { ownerId: string | null } | null;
+  google: { ownerId: string | null } | null;
+}
+
+// D5.5: lists the configured methods + owner identities (never secrets) and offers a
+// confirmed "disable authentication" break-glass.
+export function MethodsPanel({
+  enabled,
+  methods,
+  onDisable,
+}: {
+  enabled: boolean;
+  methods: AuthMethodsView;
+  onDisable: () => Promise<AuthActionResult>;
+}) {
+  const [confirming, setConfirming] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const rows: string[] = [];
+  if (methods.password) rows.push(`Password — ${methods.password.username}`);
+  if (methods.github) rows.push(`GitHub — ${methods.github.ownerId ?? "(no owner set)"}`);
+  if (methods.google) rows.push(`Google — ${methods.google.ownerId ?? "(no owner set)"}`);
+
+  async function disable(): Promise<void> {
+    setBusy(true);
+    await onDisable();
+    setBusy(false);
+    setConfirming(false);
+  }
+
+  return (
+    <section
+      className="flex flex-col gap-3 rounded-lg border border-border p-4"
+      aria-label="Configured methods"
+    >
+      <h2 className="font-medium text-foreground">Configured methods</h2>
+      {rows.length ? (
+        <ul className="flex flex-col gap-1 text-sm text-foreground/80">
+          {rows.map((row) => (
+            <li key={row}>{row}</li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-sm text-foreground/60">No methods configured yet.</p>
+      )}
+
+      {enabled ? (
+        confirming ? (
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-foreground/70">Disable enforcement?</span>
+            <Button variant="primary" onClick={disable} disabled={busy}>
+              {busy ? "Disabling…" : "Confirm disable"}
+            </Button>
+            <Button variant="outline" onClick={() => setConfirming(false)} disabled={busy}>
+              Cancel
+            </Button>
+          </div>
+        ) : (
+          <Button variant="outline" className="self-start" onClick={() => setConfirming(true)}>
+            Disable authentication
+          </Button>
+        )
+      ) : null}
+    </section>
+  );
+}

--- a/apps/dashboard/components/settings/auth/oauth-wizard.tsx
+++ b/apps/dashboard/components/settings/auth/oauth-wizard.tsx
@@ -70,21 +70,19 @@ export function OAuthWizard({
       <form onSubmit={onSubmit} className="flex flex-col gap-3">
         <Input
           type="text"
-          placeholder="Client ID"
+          placeholder={configured ? "Client ID (leave blank to keep)" : "Client ID"}
           value={clientId}
           onChange={(e) => setClientId(e.target.value)}
           autoComplete="off"
-          required
+          required={!configured}
         />
         <Input
           type="password"
-          placeholder={
-            configured ? "Client secret (leave set; re-enter to change)" : "Client secret"
-          }
+          placeholder={configured ? "Client secret (leave blank to keep)" : "Client secret"}
           value={clientSecret}
           onChange={(e) => setClientSecret(e.target.value)}
           autoComplete="off"
-          required
+          required={!configured}
         />
         <Input
           type="text"

--- a/apps/dashboard/components/settings/auth/oauth-wizard.tsx
+++ b/apps/dashboard/components/settings/auth/oauth-wizard.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { type FormEvent, useState } from "react";
+import type { AuthActionResult } from "@/app/settings/auth/actions";
+import { Button } from "@/components/ui-v2/button";
+import { Input } from "@/components/ui-v2/input";
+
+const LABEL: Record<"github" | "google", string> = { github: "GitHub", google: "Google" };
+
+// D5.4: configure one OAuth provider. Shows the exact callback URL to register with
+// the provider, takes the client id/secret + the allowlisted owner account id, and
+// saves both (creds + owner). The secret is never rendered back — only ever sent.
+export function OAuthWizard({
+  provider,
+  callbackUrl,
+  ownerId: currentOwnerId,
+  configured,
+  onSave,
+}: {
+  provider: "github" | "google";
+  callbackUrl: string;
+  ownerId: string | null;
+  configured: boolean;
+  onSave: (input: {
+    clientId: string;
+    clientSecret: string;
+    ownerId: string;
+  }) => Promise<AuthActionResult>;
+}) {
+  const [clientId, setClientId] = useState("");
+  const [clientSecret, setClientSecret] = useState("");
+  const [ownerId, setOwnerId] = useState(currentOwnerId ?? "");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  async function onSubmit(event: FormEvent): Promise<void> {
+    event.preventDefault();
+    setError(null);
+    setSaved(false);
+    setBusy(true);
+    const result = await onSave({
+      clientId: clientId.trim(),
+      clientSecret,
+      ownerId: ownerId.trim(),
+    });
+    setBusy(false);
+    if (result.ok) {
+      setSaved(true);
+      setClientSecret("");
+    } else {
+      setError(result.error);
+    }
+  }
+
+  return (
+    <section
+      className="flex flex-col gap-3 rounded-lg border border-border p-4"
+      aria-label={`${LABEL[provider]} OAuth`}
+    >
+      <h2 className="font-medium text-foreground">{LABEL[provider]} OAuth</h2>
+      <div className="flex flex-col gap-1">
+        <span className="text-sm text-foreground/60">
+          Register this callback URL with {LABEL[provider]}:
+        </span>
+        <code className="break-all rounded bg-muted/40 px-2 py-1 text-xs text-foreground">
+          {callbackUrl}
+        </code>
+      </div>
+      <form onSubmit={onSubmit} className="flex flex-col gap-3">
+        <Input
+          type="text"
+          placeholder="Client ID"
+          value={clientId}
+          onChange={(e) => setClientId(e.target.value)}
+          autoComplete="off"
+          required
+        />
+        <Input
+          type="password"
+          placeholder={
+            configured ? "Client secret (leave set; re-enter to change)" : "Client secret"
+          }
+          value={clientSecret}
+          onChange={(e) => setClientSecret(e.target.value)}
+          autoComplete="off"
+          required
+        />
+        <Input
+          type="text"
+          placeholder={`Owner ${provider === "github" ? "account id" : "sub"} (allowlisted)`}
+          value={ownerId}
+          onChange={(e) => setOwnerId(e.target.value)}
+          autoComplete="off"
+          required
+        />
+        {error ? (
+          <p className="text-sm text-ink-accent" role="alert">
+            {error}
+          </p>
+        ) : null}
+        {saved ? (
+          <p className="flex items-center gap-2 text-sm text-foreground" role="status">
+            Saved.{" "}
+            <a className="text-ink-accent underline" href="/login">
+              Verify by signing in
+            </a>
+          </p>
+        ) : null}
+        <Button type="submit" variant="primary" className="w-full justify-center" disabled={busy}>
+          {busy ? "Saving…" : `Save ${LABEL[provider]}`}
+        </Button>
+      </form>
+    </section>
+  );
+}

--- a/apps/dashboard/components/settings/auth/password-form.tsx
+++ b/apps/dashboard/components/settings/auth/password-form.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { type FormEvent, useState } from "react";
+import type { AuthActionResult } from "@/app/settings/auth/actions";
+import { Button } from "@/components/ui-v2/button";
+import { Input } from "@/components/ui-v2/input";
+
+const MIN_LENGTH = 12;
+
+// D5.3: set the owner username + password. Client-side checks (match + length) give
+// immediate feedback; the store enforces the real length floor. The password is
+// never echoed back from the server (the form only ever sends it).
+export function PasswordForm({
+  username: currentUsername,
+  onSave,
+}: {
+  username: string | null;
+  onSave: (input: { username: string; password: string }) => Promise<AuthActionResult>;
+}) {
+  const [username, setUsername] = useState(currentUsername ?? "");
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  async function onSubmit(event: FormEvent): Promise<void> {
+    event.preventDefault();
+    setError(null);
+    setSaved(false);
+    if (password.length < MIN_LENGTH) {
+      setError(`Password must be at least ${MIN_LENGTH} characters.`);
+      return;
+    }
+    if (password !== confirm) {
+      setError("Passwords do not match.");
+      return;
+    }
+    setBusy(true);
+    const result = await onSave({ username: username.trim(), password });
+    setBusy(false);
+    if (result.ok) {
+      setSaved(true);
+      setPassword("");
+      setConfirm("");
+    } else {
+      setError(result.error);
+    }
+  }
+
+  return (
+    <section
+      className="flex flex-col gap-3 rounded-lg border border-border p-4"
+      aria-label="Password login"
+    >
+      <h2 className="font-medium text-foreground">Password login</h2>
+      <form onSubmit={onSubmit} className="flex flex-col gap-3">
+        <Input
+          type="text"
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          autoComplete="username"
+          required
+        />
+        <Input
+          type="password"
+          placeholder={`New password (at least ${MIN_LENGTH} characters)`}
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          autoComplete="new-password"
+          minLength={MIN_LENGTH}
+          required
+        />
+        <Input
+          type="password"
+          placeholder="Confirm password"
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+          autoComplete="new-password"
+          required
+        />
+        {error ? (
+          <p className="text-sm text-ink-accent" role="alert">
+            {error}
+          </p>
+        ) : null}
+        {saved ? (
+          <p className="text-sm text-foreground" role="status">
+            Password saved.
+          </p>
+        ) : null}
+        <Button type="submit" variant="primary" className="w-full justify-center" disabled={busy}>
+          {busy ? "Saving…" : "Save password"}
+        </Button>
+      </form>
+    </section>
+  );
+}

--- a/apps/dashboard/components/site-nav.tsx
+++ b/apps/dashboard/components/site-nav.tsx
@@ -20,12 +20,19 @@ const TABS = [
   { href: "/curator", label: "Curator", match: (p: string) => p.startsWith("/curator") },
   { href: "/backups", label: "Backups", match: (p: string) => p.startsWith("/backups") },
   { href: "/tokens", label: "Tokens", match: (p: string) => p.startsWith("/tokens") },
+  { href: "/settings/auth", label: "Auth", match: (p: string) => p.startsWith("/settings/auth") },
 ] as const;
 
 // Routes that render their own full-screen chrome and should NOT show the nav:
 // the diagnostic health probe today, and the login page when auth lands.
 function isChromeFree(pathname: string): boolean {
-  return pathname === "/health" || pathname.startsWith("/login");
+  // /settings/auth/reset is the one-time-link reset page — reached without a session,
+  // so it renders chrome-free like /login (the /settings/auth wizard itself shows nav).
+  return (
+    pathname === "/health" ||
+    pathname.startsWith("/login") ||
+    pathname.startsWith("/settings/auth/reset")
+  );
 }
 
 export function SiteNav({ signedIn = false }: { signedIn?: boolean }) {

--- a/apps/dashboard/e2e/auth-setup.spec.ts
+++ b/apps/dashboard/e2e/auth-setup.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@playwright/test";
+import { E2E_OWNER } from "./global-setup";
+
+// D5.6: the /settings/auth wizard. global-setup configured the store's methods
+// (enforcement OFF), so the page is reachable without a session and the cards render
+// the configured state. We exercise the wizard UI → server action → store path
+// (the saved confirmations prove the wiring). The full enable → enforce → login →
+// lockout → CLI-reset chain is covered piecewise by unit tests (enable card,
+// decideEnforcement, proxy-gate) and the auth-password e2e (login + lockout);
+// enabling enforcement here would redirect every other spec on the shared webServer.
+
+const NEW_PASSWORD = "wizard-chosen-passphrase";
+
+test.describe("auth setup wizard", () => {
+  test("renders all configuration cards with the current state", async ({ page }) => {
+    await page.goto("/settings/auth");
+    await expect(page.getByRole("heading", { name: "Enable authentication" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Password login" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "GitHub OAuth" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Google OAuth" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Configured methods" })).toBeVisible();
+    // The methods panel lists what global-setup configured (no secrets).
+    await expect(page.getByText(`Password — ${E2E_OWNER}`)).toBeVisible();
+    await expect(page.getByText(/GitHub —/)).toBeVisible();
+  });
+
+  test("shows the exact OAuth callback URL to register", async ({ page }) => {
+    await page.goto("/settings/auth");
+    await expect(page.getByText(/\/api\/auth\/callback\/github$/)).toBeVisible();
+  });
+
+  test("saves a new password through the wizard", async ({ page }) => {
+    await page.goto("/settings/auth");
+    await page.getByPlaceholder(/New password/).fill(NEW_PASSWORD);
+    await page.getByPlaceholder("Confirm password").fill(NEW_PASSWORD);
+    await page.getByRole("button", { name: "Save password" }).click();
+    await expect(page.getByText("Password saved.")).toBeVisible();
+  });
+
+  test("saves OAuth creds + owner through the wizard", async ({ page }) => {
+    await page.goto("/settings/auth");
+    // Scope to the GitHub OAuth card.
+    const github = page.locator("section", { hasText: "GitHub OAuth" });
+    await github.getByPlaceholder("Client ID").fill("e2e-github-id-2");
+    await github.getByPlaceholder("Client secret").fill("e2e-github-secret-2");
+    await github.getByPlaceholder(/Owner account id/).fill("e2e-github-owner-2");
+    await github.getByRole("button", { name: "Save GitHub" }).click();
+    await expect(github.getByText(/Verify by signing in/)).toBeVisible();
+  });
+});

--- a/apps/dashboard/tests/components/settings-auth/enable-card.test.tsx
+++ b/apps/dashboard/tests/components/settings-auth/enable-card.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { EnableCard } from "@/components/settings/auth/enable-card";
+
+describe("EnableCard (D5.2)", () => {
+  it("enables auth with the admin token", async () => {
+    const onEnable = vi.fn().mockResolvedValue({ ok: true });
+    render(<EnableCard enabled={false} canEnable={true} onEnable={onEnable} />);
+    fireEvent.change(screen.getByPlaceholderText("Admin token"), {
+      target: { value: "libadmin_x" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Enable authentication/ }));
+    await waitFor(() => expect(onEnable).toHaveBeenCalledWith("libadmin_x"));
+  });
+
+  it("surfaces a wrong-token error", async () => {
+    const onEnable = vi.fn().mockResolvedValue({ ok: false, error: "admin token does not match" });
+    render(<EnableCard enabled={false} canEnable={true} onEnable={onEnable} />);
+    fireEvent.change(screen.getByPlaceholderText("Admin token"), { target: { value: "nope" } });
+    fireEvent.click(screen.getByRole("button", { name: /Enable authentication/ }));
+    await waitFor(() => expect(screen.getByText(/does not match/)).toBeInTheDocument());
+  });
+
+  it("disables the button until a method is configured", () => {
+    const onEnable = vi.fn();
+    render(<EnableCard enabled={false} canEnable={false} onEnable={onEnable} />);
+    expect(screen.getByRole("button", { name: /Enable authentication/ })).toBeDisabled();
+    expect(screen.getByText(/Configure at least one login method/)).toBeInTheDocument();
+  });
+
+  it("shows the enabled state without a form", () => {
+    render(<EnableCard enabled={true} canEnable={true} onEnable={vi.fn()} />);
+    expect(screen.getByText(/Authentication is enabled/)).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("Admin token")).toBeNull();
+  });
+});

--- a/apps/dashboard/tests/components/settings-auth/methods-panel.test.tsx
+++ b/apps/dashboard/tests/components/settings-auth/methods-panel.test.tsx
@@ -26,6 +26,16 @@ describe("MethodsPanel (D5.5)", () => {
     await waitFor(() => expect(onDisable).toHaveBeenCalledTimes(1));
   });
 
+  it("surfaces a disable failure and keeps enforcement visibly on", async () => {
+    const onDisable = vi.fn().mockResolvedValue({ ok: false, error: "store unreachable" });
+    render(<MethodsPanel enabled={true} methods={METHODS} onDisable={onDisable} />);
+    fireEvent.click(screen.getByRole("button", { name: "Disable authentication" }));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm disable" }));
+    await waitFor(() => expect(screen.getByText(/store unreachable/)).toBeInTheDocument());
+    // Still confirming (not silently dismissed) so the owner knows it didn't disable.
+    expect(screen.getByRole("button", { name: "Confirm disable" })).toBeInTheDocument();
+  });
+
   it("hides the disable control when auth is not enabled", () => {
     render(<MethodsPanel enabled={false} methods={METHODS} onDisable={vi.fn()} />);
     expect(screen.queryByRole("button", { name: "Disable authentication" })).toBeNull();

--- a/apps/dashboard/tests/components/settings-auth/methods-panel.test.tsx
+++ b/apps/dashboard/tests/components/settings-auth/methods-panel.test.tsx
@@ -1,0 +1,33 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MethodsPanel } from "@/components/settings/auth/methods-panel";
+
+const METHODS = {
+  password: { username: "owner" },
+  github: { ownerId: "octocat" },
+  google: null,
+};
+
+describe("MethodsPanel (D5.5)", () => {
+  it("lists configured methods + owners (no secrets)", () => {
+    render(<MethodsPanel enabled={false} methods={METHODS} onDisable={vi.fn()} />);
+    expect(screen.getByText(/Password — owner/)).toBeInTheDocument();
+    expect(screen.getByText(/GitHub — octocat/)).toBeInTheDocument();
+    expect(screen.queryByText(/Google/)).toBeNull();
+  });
+
+  it("requires confirmation before disabling", async () => {
+    const onDisable = vi.fn().mockResolvedValue({ ok: true });
+    render(<MethodsPanel enabled={true} methods={METHODS} onDisable={onDisable} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Disable authentication" }));
+    expect(onDisable).not.toHaveBeenCalled(); // not yet — needs confirm
+    fireEvent.click(screen.getByRole("button", { name: "Confirm disable" }));
+    await waitFor(() => expect(onDisable).toHaveBeenCalledTimes(1));
+  });
+
+  it("hides the disable control when auth is not enabled", () => {
+    render(<MethodsPanel enabled={false} methods={METHODS} onDisable={vi.fn()} />);
+    expect(screen.queryByRole("button", { name: "Disable authentication" })).toBeNull();
+  });
+});

--- a/apps/dashboard/tests/components/settings-auth/oauth-wizard.test.tsx
+++ b/apps/dashboard/tests/components/settings-auth/oauth-wizard.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { OAuthWizard } from "@/components/settings/auth/oauth-wizard";
+
+const CALLBACK = "https://dash.example.com/api/auth/callback/github";
+
+describe("OAuthWizard (D5.4)", () => {
+  it("shows the exact callback URL to register", () => {
+    render(
+      <OAuthWizard
+        provider="github"
+        callbackUrl={CALLBACK}
+        ownerId={null}
+        configured={false}
+        onSave={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(CALLBACK)).toBeInTheDocument();
+  });
+
+  it("saves creds + owner and offers verify-by-signing-in", async () => {
+    const onSave = vi.fn().mockResolvedValue({ ok: true });
+    render(
+      <OAuthWizard
+        provider="github"
+        callbackUrl={CALLBACK}
+        ownerId={null}
+        configured={false}
+        onSave={onSave}
+      />,
+    );
+    fireEvent.change(screen.getByPlaceholderText("Client ID"), { target: { value: "gh-id" } });
+    fireEvent.change(screen.getByPlaceholderText("Client secret"), { target: { value: "gh-sec" } });
+    fireEvent.change(screen.getByPlaceholderText(/Owner account id/), {
+      target: { value: "octocat" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save GitHub" }));
+    await waitFor(() =>
+      expect(onSave).toHaveBeenCalledWith({
+        clientId: "gh-id",
+        clientSecret: "gh-sec",
+        ownerId: "octocat",
+      }),
+    );
+    await waitFor(() => expect(screen.getByText(/Verify by signing in/)).toBeInTheDocument());
+  });
+
+  it("surfaces a save error", async () => {
+    const onSave = vi
+      .fn()
+      .mockResolvedValue({ ok: false, error: "clientId and clientSecret are required" });
+    render(
+      <OAuthWizard
+        provider="google"
+        callbackUrl="https://x/api/auth/callback/google"
+        ownerId={null}
+        configured={false}
+        onSave={onSave}
+      />,
+    );
+    fireEvent.change(screen.getByPlaceholderText("Client ID"), { target: { value: "x" } });
+    fireEvent.change(screen.getByPlaceholderText("Client secret"), { target: { value: "y" } });
+    fireEvent.change(screen.getByPlaceholderText(/Owner sub/), { target: { value: "z" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save Google" }));
+    await waitFor(() => expect(screen.getByText(/are required/)).toBeInTheDocument());
+  });
+});

--- a/apps/dashboard/tests/components/settings-auth/password-form.test.tsx
+++ b/apps/dashboard/tests/components/settings-auth/password-form.test.tsx
@@ -1,0 +1,42 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { PasswordForm } from "@/components/settings/auth/password-form";
+
+function fill(label: string, value: string) {
+  fireEvent.change(screen.getByPlaceholderText(label), { target: { value } });
+}
+
+describe("PasswordForm (D5.3)", () => {
+  it("saves a valid username + password", async () => {
+    const onSave = vi.fn().mockResolvedValue({ ok: true });
+    render(<PasswordForm username={null} onSave={onSave} />);
+    fill("Username", "owner");
+    fill("New password (at least 12 characters)", "a-strong-passphrase");
+    fill("Confirm password", "a-strong-passphrase");
+    fireEvent.click(screen.getByRole("button", { name: "Save password" }));
+    await waitFor(() =>
+      expect(onSave).toHaveBeenCalledWith({ username: "owner", password: "a-strong-passphrase" }),
+    );
+    await waitFor(() => expect(screen.getByText("Password saved.")).toBeInTheDocument());
+  });
+
+  it("rejects a too-short password without calling onSave", () => {
+    const onSave = vi.fn();
+    render(<PasswordForm username="owner" onSave={onSave} />);
+    fill("New password (at least 12 characters)", "short");
+    fill("Confirm password", "short");
+    fireEvent.click(screen.getByRole("button", { name: "Save password" }));
+    expect(onSave).not.toHaveBeenCalled();
+    expect(screen.getByText(/at least 12 characters/)).toBeInTheDocument();
+  });
+
+  it("rejects a mismatch without calling onSave", () => {
+    const onSave = vi.fn();
+    render(<PasswordForm username="owner" onSave={onSave} />);
+    fill("New password (at least 12 characters)", "a-strong-passphrase");
+    fill("Confirm password", "different-passphrase");
+    fireEvent.click(screen.getByRole("button", { name: "Save password" }));
+    expect(onSave).not.toHaveBeenCalled();
+    expect(screen.getByText(/do not match/)).toBeInTheDocument();
+  });
+});

--- a/apps/dashboard/tests/settings-auth-actions.test.ts
+++ b/apps/dashboard/tests/settings-auth-actions.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// D5.1: the auth setup-wizard server actions call the right admin procedures and
+// bust the auth-config cache so changes take effect immediately.
+
+const enableMock = vi.fn();
+const disableMock = vi.fn();
+const setPasswordMock = vi.fn();
+const configureOAuthMock = vi.fn();
+const setOwnerMock = vi.fn();
+const bustMock = vi.fn();
+const revalidateMock = vi.fn();
+
+vi.mock("@/lib/trpc-server", () => ({
+  serverTRPC: {
+    auth: {
+      enable: { mutate: enableMock },
+      disable: { mutate: disableMock },
+      setPassword: { mutate: setPasswordMock },
+      configureOAuth: { mutate: configureOAuthMock },
+      setOwner: { mutate: setOwnerMock },
+    },
+  },
+}));
+vi.mock("@/lib/auth-config-client", () => ({ bustAuthConfig: bustMock }));
+vi.mock("next/cache", () => ({ revalidatePath: revalidateMock }));
+
+const actions = await import("../app/settings/auth/actions");
+
+afterEach(() => {
+  for (const m of [
+    enableMock,
+    disableMock,
+    setPasswordMock,
+    configureOAuthMock,
+    setOwnerMock,
+    bustMock,
+    revalidateMock,
+  ]) {
+    m.mockReset();
+  }
+});
+
+describe("settings/auth actions", () => {
+  it("enable calls auth.enable with the admin token, then busts + revalidates", async () => {
+    enableMock.mockResolvedValue({ enabled: true });
+    const res = await actions.enableAuthAction("libadmin_token");
+    expect(res).toEqual({ ok: true });
+    expect(enableMock).toHaveBeenCalledWith({ adminToken: "libadmin_token" });
+    expect(bustMock).toHaveBeenCalledTimes(1);
+    expect(revalidateMock).toHaveBeenCalledWith("/settings/auth");
+  });
+
+  it("setPassword / configureOAuth / setOwner / disable call their procedures and bust", async () => {
+    setPasswordMock.mockResolvedValue({ ok: true });
+    await actions.setPasswordAction({ username: "owner", password: "a-strong-passphrase" });
+    expect(setPasswordMock).toHaveBeenCalledWith({
+      username: "owner",
+      password: "a-strong-passphrase",
+    });
+
+    configureOAuthMock.mockResolvedValue({ ok: true });
+    await actions.configureOAuthAction({ provider: "github", clientId: "id", clientSecret: "sec" });
+    expect(configureOAuthMock).toHaveBeenCalledWith({
+      provider: "github",
+      clientId: "id",
+      clientSecret: "sec",
+    });
+
+    setOwnerMock.mockResolvedValue({ ok: true });
+    await actions.setOwnerAction({ provider: "github", ownerId: "octocat" });
+    expect(setOwnerMock).toHaveBeenCalledWith({ provider: "github", ownerId: "octocat" });
+
+    disableMock.mockResolvedValue({ enabled: false });
+    await actions.disableAuthAction();
+    expect(disableMock).toHaveBeenCalledTimes(1);
+
+    expect(bustMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("maps a mutation failure to an error result without busting", async () => {
+    enableMock.mockRejectedValue(new Error("admin token does not match"));
+    const res = await actions.enableAuthAction("wrong");
+    expect(res).toEqual({ ok: false, error: "admin token does not match" });
+    expect(bustMock).not.toHaveBeenCalled();
+    expect(revalidateMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/dashboard/tests/settings-auth-actions.test.ts
+++ b/apps/dashboard/tests/settings-auth-actions.test.ts
@@ -78,6 +78,24 @@ describe("settings/auth actions", () => {
     expect(bustMock).toHaveBeenCalledTimes(4);
   });
 
+  it("saveOAuthAction saves creds then owner under one bust", async () => {
+    configureOAuthMock.mockResolvedValue({ ok: true });
+    setOwnerMock.mockResolvedValue({ ok: true });
+    const res = await actions.saveOAuthAction("github", {
+      clientId: "id",
+      clientSecret: "sec",
+      ownerId: "octocat",
+    });
+    expect(res).toEqual({ ok: true });
+    expect(configureOAuthMock).toHaveBeenCalledWith({
+      provider: "github",
+      clientId: "id",
+      clientSecret: "sec",
+    });
+    expect(setOwnerMock).toHaveBeenCalledWith({ provider: "github", ownerId: "octocat" });
+    expect(bustMock).toHaveBeenCalledTimes(1);
+  });
+
   it("maps a mutation failure to an error result without busting", async () => {
     enableMock.mockRejectedValue(new Error("admin token does not match"));
     const res = await actions.enableAuthAction("wrong");


### PR DESCRIPTION
## D5 — Setup wizard UI

Final slice of **dashboard-managed-auth** (builds on #144–#148). Adds the `/settings/auth` wizard so the owner configures auth entirely from the dashboard — no env surgery, no redeploy.

### What changed (tasks D5.1–D5.6)
- **Scaffold + nav + actions (D5.1)** — `/settings/auth` page, an "Auth" nav tab, and server actions wrapping the admin `auth.*` mutations that bust the config cache + revalidate so changes take effect at once.
- **Enable card (D5.2)** — paste the admin token to turn on enforcement; the button stays disabled until a method is configured; wrong/incomplete surfaces a generic error.
- **Password form (D5.3)** — username + password (+confirm) with client length/match checks; never echoes the password.
- **OAuth wizard (D5.4)** — shows the exact callback URL to register, takes client id/secret + owner id, saves both, offers verify-by-signing-in; the secret is never rendered back and is optional once configured (update the allowlist without re-entering it).
- **Methods/owner panel (D5.5)** — lists configured methods + owners (no secrets) with a confirmed disable break-glass that surfaces failures.
- **Docs + e2e (D5.6)** — `.env.example`/`DEPLOYMENT.md` now lead with the wizard and mark the A1–A5 auth env vars deprecated/optional; `auth-setup.spec.ts` drives the wizard (render → set password → save OAuth) end to end.

### Verification
- TDD throughout; 148 dashboard unit tests + the e2e suite pass locally; full CI parity green (build, lint, format:check, typecheck, `pnpm test`, smoke, healthcheck, guards).
- Five-axis review: **APPROVE**. The secret boundary is verified — `page.tsx` reads the full (decrypted) config server-side but only non-secret fields (enabled, methods, username, owner ids, oauth *presence*) ever cross to client components; no `dangerouslySetInnerHTML`. Fixed the two Important findings (break-glass disable now surfaces failures; OAuth secret optional-when-configured).

### This completes the dashboard-managed-auth initiative
All six slices shipped: D0 (credential bootstrap) · D1 (core auth-config + password) · D2 (tRPC + dynamic config) · D4 (CLI recovery) · D3 (password login) · D5 (wizard). A fresh install needs **zero** auth/secret env vars; the owner enables auth from the dashboard with password and/or GitHub/Google, recoverable from the host shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)