### PR TITLE
fix(dashboard): stop auth-middleware 500s (verify sessions with getToken)

### DIFF
--- a/apps/dashboard/e2e/z-enforced-auth.spec.ts
+++ b/apps/dashboard/e2e/z-enforced-auth.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "@playwright/test";
+
+// D2.4 regression: exercise the middleware with enforcement ACTUALLY ON. This is the
+// path the other specs never hit (global-setup leaves enforcement off), and where a
+// bug shipped — manually invoking the Auth.js v5 auth() wrapper threw at runtime
+// ("js is not a function"), 500ing every gated page. Enabling auth on the shared
+// webServer redirects every other spec, so this file is named to sort LAST (nothing
+// runs after it) and it disables enforcement again in afterAll.
+
+const SERVER_URL = process.env.LIBRARIAN_E2E_SERVER_URL ?? "http://127.0.0.1:3838";
+const ADMIN_TOKEN = process.env.LIBRARIAN_E2E_ADMIN_TOKEN ?? "e2e-admin-token";
+const CACHE_TTL_MS = 1500; // > the e2e LIBRARIAN_AUTH_CONFIG_TTL_MS so the dashboard refetches
+
+async function setEnforcement(enabled: boolean): Promise<void> {
+  const procedure = enabled ? "auth.enable" : "auth.disable";
+  const init: RequestInit = {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${ADMIN_TOKEN}` },
+    ...(enabled ? { body: JSON.stringify({ adminToken: ADMIN_TOKEN }) } : {}),
+  };
+  const res = await fetch(`${SERVER_URL}/trpc/${procedure}`, init);
+  if (!res.ok) throw new Error(`${procedure} failed: ${res.status} ${await res.text()}`);
+}
+
+test.describe("enforced auth (middleware)", () => {
+  test.beforeAll(async () => {
+    await setEnforcement(true);
+    await new Promise((r) => setTimeout(r, CACHE_TTL_MS)); // let the config cache expire
+  });
+  test.afterAll(async () => {
+    await setEnforcement(false);
+  });
+
+  test("redirects an unauthenticated request to /login — not a 500", async ({ page }) => {
+    const res = await page.goto("/");
+    await expect(page).toHaveURL(/\/login/); // middleware redirected, didn't crash
+    expect(res?.status()).toBeLessThan(400); // the /login page rendered (no 500)
+  });
+
+  test("still serves the excluded /login page under enforcement", async ({ page }) => {
+    const res = await page.goto("/login");
+    expect(res?.status()).toBe(200);
+    await expect(page.getByRole("button", { name: "Sign in" })).toBeVisible();
+  });
+});

--- a/apps/dashboard/middleware.ts
+++ b/apps/dashboard/middleware.ts
@@ -2,11 +2,17 @@
 //
 // Enforcement is resolved per request from the store auth-config (cached), with the
 // legacy LIBRARIAN_AUTH_ENABLED env as the fallback:
-//   - open    → serve (never touch the auth() wrapper, which needs AUTH_SECRET)
+//   - open    → serve (no session check; no secret needed)
 //   - enforce → redirect any unauthenticated request to /login
 //   - block   → an enabled-but-incomplete config, or an unreachable store: refuse to
 //               serve with a store-independent page that names the CLI break-glass,
 //               so a store outage can't silently fail OPEN.
+//
+// This is a PLAIN function default export — NOT `export default auth(...)`. The
+// project's auth.ts uses the lazy `NextAuth(async () => …)` form, whose `auth`
+// middleware-wrapper is not a usable default export here (Next: "must export a
+// default function"), and invoking the wrapper manually throws at runtime. So we
+// verify the session directly with getToken, only on the enforce path.
 //
 // The matcher excludes ALL of /api — middleware is the wrong layer to protect API
 // routes (it can be skipped), so the security-critical /api/trpc proxy gates itself
@@ -15,19 +21,10 @@
 // /settings/auth/reset is excluded too: a locked-out owner with no session must be
 // able to reach the one-time-link reset page; the link token is its own credential.
 
-import { type NextFetchEvent, type NextRequest, NextResponse } from "next/server";
-import { auth } from "@/auth";
-import { getAuthConfig } from "@/lib/auth-config-client";
-import { resolveEnforcement } from "@/lib/auth-gate";
-
-// The auth() wrapper decodes the session and redirects unauthenticated requests.
-// Invoked only on the "enforce" path so the un-enforced default never reaches it.
-// auth() returns a handler that is middleware-compatible at runtime (it's the shape
-// Next calls as a default middleware export); cast to the middleware signature so we
-// can invoke it manually with the NextFetchEvent.
-const enforce = auth((req) =>
-  req.auth ? NextResponse.next() : NextResponse.redirect(new URL("/login", req.nextUrl.origin)),
-) as unknown as (req: NextRequest, ev: NextFetchEvent) => Promise<Response | undefined>;
+import { type NextRequest, NextResponse } from "next/server";
+import { getToken } from "next-auth/jwt";
+import { getAuthConfigSafe } from "@/lib/auth-config-client";
+import { decideEnforcement, isAuthEnforced, toEnforcementConfig } from "@/lib/auth-gate";
 
 function blockResponse(): NextResponse {
   // Store-independent: no rendering that itself needs the store. Names the recovery.
@@ -44,14 +41,36 @@ enforcement (break-glass), then fix the configuration.</p>`;
   });
 }
 
-export default async function middleware(
-  req: NextRequest,
-  ev: NextFetchEvent,
-): Promise<Response | undefined> {
-  const decision = await resolveEnforcement(() => getAuthConfig());
+// Verify the session JWT with the store-derived secret. Tries both cookie variants
+// (the `__Secure-` prefix is used on https) so it matches however the session was set
+// behind a proxy. Any failure → no session (fail closed).
+async function hasValidSession(req: NextRequest, secret: string): Promise<boolean> {
+  for (const secureCookie of [true, false]) {
+    try {
+      if (await getToken({ req, secret, secureCookie })) return true;
+    } catch {
+      // try the other cookie variant; a decode failure is "no session"
+    }
+  }
+  return false;
+}
+
+export default async function middleware(req: NextRequest): Promise<Response> {
+  // null = the store was unreachable (getAuthConfigSafe swallows the error); a real
+  // config with no methods configured → toEnforcementConfig null → env fallback.
+  const config = await getAuthConfigSafe();
+  const decision = decideEnforcement(
+    config === null ? "unreachable" : toEnforcementConfig(config),
+    isAuthEnforced(),
+  );
   if (decision === "open") return NextResponse.next();
   if (decision === "block") return blockResponse();
-  return enforce(req, ev);
+
+  const secret = config?.authSecret ?? process.env.AUTH_SECRET;
+  const authed = secret ? await hasValidSession(req, secret) : false;
+  return authed
+    ? NextResponse.next()
+    : NextResponse.redirect(new URL("/login", req.nextUrl.origin));
 }
 
 export const config = {


### PR DESCRIPTION
## Problem

Enabling auth enforcement 500'd **every gated dashboard page**:

```
TypeError: js is not a function
    at jt (.next/server/middleware.js:423:154)
...
ERR_HTTP_HEADERS_SENT
```

D2.4 made the middleware enforce auth by manually invoking the Auth.js v5 `auth()` wrapper. The project's `auth.ts` uses the **lazy** `NextAuth(async () => config)` form, whose `auth` export is not usable as Next.js middleware — calling it threw at runtime, crashing the request before a response could be sent.

## Fix

Rewrite `middleware.ts` as a **plain default-export function** that verifies the session JWT directly with `getToken` (`next-auth/jwt`) on the enforce path only. The store-driven, fail-closed decision is unchanged:

- `open` → serve (no session check)
- `enforce` → `getToken` valid? serve : redirect to `/login`
- `block` → 503 break-glass page (enabled-but-incomplete config, or store unreachable — never fail open)

`getToken` is tried against both cookie variants (`__Secure-` prefix on https) so it matches whether the session was set directly or behind an https proxy.

## Regression test

`e2e/z-enforced-auth.spec.ts` runs with enforcement **actually on** — the path the other specs never hit (global-setup leaves it off), and exactly where this bug shipped. Named to sort last so enabling enforcement doesn't redirect the other specs; disables again in `afterAll`.

## Verification

Manual end-to-end against a fresh mcp + dashboard pair with enforcement on:

| Case | Result |
|------|--------|
| Unauthenticated → gated page | `307` → `/login` |
| Logged-in (valid session) → gated page | `200` (getToken validates) |
| Store unreachable | `503` block page (fail-closed) |

Full e2e suite green (18/18); production build OK (middleware bundles at 52.9 kB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)