### PR TITLE
feat(recall): opt-in include_ids so callers can verify_memory after recall

### DIFF
--- a/packages/core/src/formatters/index.ts
+++ b/packages/core/src/formatters/index.ts
@@ -30,16 +30,31 @@ export function renderHandover(handover: HandoverPayload, format: string): strin
 }
 
 export interface RecallItem {
+  id?: string;
   title: string;
   body: string;
+}
+
+export interface FormatRecallOptions {
+  // When true, prefix each line with the memory's id in brackets so callers can
+  // pass it to `verify_memory` after using a recalled item. Default off so the
+  // existing prose-only output stays byte-identical for system-prompt injection
+  // and other consumers that don't need ids.
+  includeIds?: boolean;
 }
 
 export function formatRecall(
   memories: RecallItem[],
   heading: string = "Relevant Memories",
+  options: FormatRecallOptions = {},
 ): string {
   if (!memories.length) return `${heading}\n\nNo relevant memories found.`;
-  return `${heading}\n\n${memories.map((memory) => `- ${memory.title}: ${memory.body}`).join("\n")}`;
+  return `${heading}\n\n${memories
+    .map((memory) => {
+      const idPrefix = options.includeIds && memory.id ? `[${memory.id}] ` : "";
+      return `- ${idPrefix}${memory.title}: ${memory.body}`;
+    })
+    .join("\n")}`;
 }
 
 export { renderHandoverMarkdown, renderHandoverProse };

--- a/packages/core/tests/formatters/formatters.test.ts
+++ b/packages/core/tests/formatters/formatters.test.ts
@@ -221,4 +221,42 @@ describe("formatRecall", () => {
       "The Librarian Memories\n\n- Use pnpm: Workspaces are configured.\n- Lint via Lefthook: Pre-commit runs Prettier + ESLint.",
     );
   });
+
+  it("omits ids by default even when items carry them", () => {
+    // Default output stays byte-identical so system-prompt injection and other
+    // consumers that don't need ids don't change shape.
+    const text = formatRecall([
+      { id: "mem_abc", title: "Use pnpm", body: "Workspaces are configured." },
+    ]);
+    expect(text).toBe("Relevant Memories\n\n- Use pnpm: Workspaces are configured.");
+  });
+
+  it("prefixes each line with the id when includeIds is true", () => {
+    const text = formatRecall(
+      [
+        { id: "mem_abc", title: "Use pnpm", body: "Workspaces are configured." },
+        {
+          id: "mem_def",
+          title: "Lint via Lefthook",
+          body: "Pre-commit runs Prettier + ESLint.",
+        },
+      ],
+      "Relevant Memories",
+      { includeIds: true },
+    );
+    expect(text).toBe(
+      "Relevant Memories\n\n- [mem_abc] Use pnpm: Workspaces are configured.\n- [mem_def] Lint via Lefthook: Pre-commit runs Prettier + ESLint.",
+    );
+  });
+
+  it("skips the prefix for items without an id even when includeIds is true", () => {
+    // Defensive: callers may mix structured records with bare RecallItems
+    // (e.g. proposals or future synthetic entries); never render '[undefined]'.
+    const text = formatRecall(
+      [{ title: "No id here", body: "Should render plain." }],
+      "Relevant Memories",
+      { includeIds: true },
+    );
+    expect(text).toBe("Relevant Memories\n\n- No id here: Should render plain.");
+  });
 });

--- a/packages/mcp-server/src/mcp/tools/recall.ts
+++ b/packages/mcp-server/src/mcp/tools/recall.ts
@@ -5,7 +5,10 @@ import { scopeAgentArgs } from "../visibility.js";
 
 const recall: ToolDefinition = {
   name: "recall",
-  description: "Search memories by query and filters. Returns clean prose only.",
+  description:
+    "Search memories by query and filters. Returns clean prose; pass " +
+    "`include_ids: true` to prefix each result with its memory id so the " +
+    "caller can verify it via `verify_memory`.",
   inputSchema: {
     type: "object",
     properties: {
@@ -14,6 +17,7 @@ const recall: ToolDefinition = {
       categories: { type: "array", items: { type: "string" } },
       project_key: { type: "string" },
       include_private: { type: "boolean" },
+      include_ids: { type: "boolean" },
       limit: { type: "number" },
     },
   },
@@ -25,7 +29,8 @@ const recall: ToolDefinition = {
       (scoped.agent_id as string) || DEFAULT_AGENT_ID,
       (scoped.query as string) || "",
     );
-    return textResult(formatRecall(memories));
+    const includeIds = scoped.include_ids === true;
+    return textResult(formatRecall(memories, "Relevant Memories", { includeIds }));
   },
 };
 

--- a/packages/mcp-server/tests/mcp/mcp.test.ts
+++ b/packages/mcp-server/tests/mcp/mcp.test.ts
@@ -119,6 +119,48 @@ describe("MCP dispatch", () => {
     });
   });
 
+  it("recall prefixes each line with the memory id when include_ids is true", async () => {
+    // Lets callers (e.g. the Hermes plugin's `recall` wrapper) plumb ids
+    // through to a subsequent `verify_memory` call — the verify-after-recall
+    // loop documented in the harness slash-command guide.
+    await withStore(async (store) => {
+      await handleMcpPayload(store, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "remember",
+          arguments: {
+            agent_id: "codex",
+            title: "Verify-after-recall needs ids",
+            body: "Recall must surface memory ids so verify_memory can target one.",
+            category: "tools",
+            scope: "tool",
+          },
+        },
+      });
+
+      const recall = (await handleMcpPayload(store, {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: {
+          name: "recall",
+          arguments: {
+            agent_id: "codex",
+            query: "verify after recall",
+            include_ids: true,
+            limit: 3,
+          },
+        },
+      })) as { result: { content: { text: string }[] } };
+
+      const text = recall.result.content[0].text;
+      expect(text).toMatch(/^- \[mem_[a-f0-9-]+\] /m);
+      expect(text).toMatch(/Verify-after-recall needs ids/);
+    });
+  });
+
   it("start_context always includes approved identity and relationship context", async () => {
     await withStore(async (store) => {
       const identity = store.createMemory({


### PR DESCRIPTION
## Why

`recall` returns clean prose with no memory ids — great for system-prompt injection, but it breaks the verify-after-recall loop documented in [`docs/slash-commands.md`](docs/slash-commands.md): `verify_memory` requires `memory_id`, and a caller (e.g. [the Hermes plugin's `recall` wrapper](https://github.com/JimJafar/the-librarian-hermes-plugin/blob/main/provider.py)) has nowhere to read one from. The native MCP bridge has the same problem; collapsing the result to `content[0].text` is the contract.

## What

Add an opt-in `include_ids: boolean` to `recall`'s inputSchema (default off). When true, `formatRecall` prefixes each line with `[id] ` so the caller can pluck the id back out. `start_context` injection, `list_proposals`, and any plain `recall` callers stay byte-identical because they don't set the flag.

## Defensive design

- `includeIds && memory.id` guards against `[undefined]` for items without ids (proposals or future synthetic entries).
- Default off preserves the prose contract other consumers rely on.

## Checks

core: **473 tests** ✅ · mcp-server: **116 tests** ✅ · eslint ✅ · tsc --noEmit ✅ · prettier --check ✅

Follow-up: I'll open a PR on `the-librarian-hermes-plugin` to have its `recall` wrapper pass `include_ids: true` automatically, so verify-after-recall works through the plugin's wrapper-tool surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
