### PR TITLE
feat(curator): configurable LLM request timeout (cockpit setting)

### DIFF
--- a/apps/dashboard/components/curator/config-form.tsx
+++ b/apps/dashboard/components/curator/config-form.tsx
@@ -31,6 +31,7 @@ export function CuratorConfigForm({
   const [provider, setProvider] = useState(initial.llm.provider);
   const [endpoint, setEndpoint] = useState(initial.llm.endpoint);
   const [model, setModel] = useState(initial.llm.model);
+  const [timeoutMs, setTimeoutMs] = useState(String(initial.llm.timeoutMs));
   const [token, setToken] = useState("");
   const [level, setLevel] = useState<AutoApplyLevel>(initial.defaultAutoApply);
   const [confidence, setConfidence] = useState(String(initial.autoApplyConfidence));
@@ -43,7 +44,7 @@ export function CuratorConfigForm({
     startTransition(async () => {
       const patch: CuratorConfigPatch = {
         enabled,
-        llm: { provider, endpoint, model },
+        llm: { provider, endpoint, model, timeoutMs: Number(timeoutMs) },
         defaultAutoApply: level,
         autoApplyConfidence: Number(confidence),
         schedule: { intervalDays: Number(intervalDays), time },
@@ -90,15 +91,28 @@ export function CuratorConfigForm({
           <input className={inputClass} value={model} onChange={(e) => setModel(e.target.value)} />
         </Field>
       </div>
-      <Field label="API token (blank = keep current)">
-        <input
-          className={inputClass}
-          type="password"
-          value={token}
-          placeholder={initial.hasToken ? "•••••• (configured)" : "not set"}
-          onChange={(e) => setToken(e.target.value)}
-        />
-      </Field>
+      <div className="grid gap-3 sm:grid-cols-[1fr_auto]">
+        <Field label="API token (blank = keep current)">
+          <input
+            className={inputClass}
+            type="password"
+            value={token}
+            placeholder={initial.hasToken ? "•••••• (configured)" : "not set"}
+            onChange={(e) => setToken(e.target.value)}
+          />
+        </Field>
+        <Field label="LLM request timeout (ms)">
+          <input
+            className={inputClass}
+            type="number"
+            min="1000"
+            max="600000"
+            step="1000"
+            value={timeoutMs}
+            onChange={(e) => setTimeoutMs(e.target.value)}
+          />
+        </Field>
+      </div>
       <div className="grid gap-3 sm:grid-cols-3">
         <Field label="Auto-apply">
           <select

--- a/apps/dashboard/tests/components/curator/cockpit-actions.test.tsx
+++ b/apps/dashboard/tests/components/curator/cockpit-actions.test.tsx
@@ -48,7 +48,7 @@ describe("RunNowButton", () => {
 
 const config: CuratorConfig = {
   enabled: false,
-  llm: { provider: "openai", endpoint: "https://e/v1", model: "gpt-x" },
+  llm: { provider: "openai", endpoint: "https://e/v1", model: "gpt-x", timeoutMs: 60_000 },
   hasToken: true,
   promptAddendum: "",
   defaultAutoApply: "safe_only",
@@ -71,7 +71,7 @@ describe("CuratorConfigForm", () => {
     const patch = onSave.mock.calls[0]![0];
     expect(patch).toMatchObject({
       enabled: false,
-      llm: { provider: "openai", endpoint: "https://e/v1", model: "gpt-x" },
+      llm: { provider: "openai", endpoint: "https://e/v1", model: "gpt-x", timeoutMs: 60_000 },
       defaultAutoApply: "safe_only",
       autoApplyConfidence: 0.9,
       schedule: { intervalDays: 1, time: "03:00" },

--- a/apps/dashboard/tests/components/curator/cockpit.test.tsx
+++ b/apps/dashboard/tests/components/curator/cockpit.test.tsx
@@ -7,7 +7,7 @@ import { CuratorRunsTable } from "@/components/curator/runs-table";
 function config(over: Partial<CuratorConfig> = {}): CuratorConfig {
   return {
     enabled: false,
-    llm: { provider: "", endpoint: "", model: "" },
+    llm: { provider: "", endpoint: "", model: "", timeoutMs: 60_000 },
     hasToken: false,
     promptAddendum: "",
     defaultAutoApply: "safe_only",
@@ -59,7 +59,7 @@ describe("CuratorConfigSummary", () => {
           hasToken: true,
           isLlmComplete: true,
           isOperational: true,
-          llm: { provider: "openai", endpoint: "https://e/v1", model: "gpt-x" },
+          llm: { provider: "openai", endpoint: "https://e/v1", model: "gpt-x", timeoutMs: 60_000 },
         })}
       />,
     );

--- a/packages/core/src/curator-config.ts
+++ b/packages/core/src/curator-config.ts
@@ -16,6 +16,7 @@ const KEYS = {
   provider: "curator.llm.provider",
   endpoint: "curator.llm.endpoint",
   model: "curator.llm.model",
+  llmTimeoutMs: "curator.llm.timeout_ms",
   token: "curator.llm.token",
   promptAddendum: "curator.prompt_addendum",
   defaultAutoApply: "curator.default_auto_apply",
@@ -33,10 +34,16 @@ const DEFAULT_AUTO_APPLY: AutoApplyLevel = "safe_only";
 const DEFAULT_CONFIDENCE = 0.9;
 const DEFAULT_INTERVAL_DAYS = 1;
 const DEFAULT_TIME = "03:00";
+// Curator LLM request timeout — matches `curator-llm-client`'s DEFAULT_TIMEOUT_MS.
+// Operator-configurable so a slow provider (especially a self-hosted model on
+// modest hardware) doesn't time out mid-batch with an `llm_timeout` error.
+const DEFAULT_LLM_TIMEOUT_MS = 60_000;
+const MIN_LLM_TIMEOUT_MS = 1_000;
+const MAX_LLM_TIMEOUT_MS = 600_000;
 
 export interface CuratorConfig {
   enabled: boolean;
-  llm: { provider: string; endpoint: string; model: string };
+  llm: { provider: string; endpoint: string; model: string; timeoutMs: number };
   /** Whether an LLM token is stored — never the value. */
   hasToken: boolean;
   promptAddendum: string;
@@ -51,7 +58,7 @@ export interface CuratorConfig {
 
 export interface CuratorConfigPatch {
   enabled?: boolean;
-  llm?: { provider?: string; endpoint?: string; model?: string };
+  llm?: { provider?: string; endpoint?: string; model?: string; timeoutMs?: number };
   /** Plaintext token; stored encrypted. Empty string clears it. */
   token?: string;
   promptAddendum?: string;
@@ -70,6 +77,7 @@ export const CuratorConfigPatchSchema = z.strictObject({
       provider: z.string().optional(),
       endpoint: z.string().optional(),
       model: z.string().optional(),
+      timeoutMs: z.number().optional(),
     })
     .optional(),
   token: z.string().optional(),
@@ -109,10 +117,11 @@ export function readCuratorConfig(store: ConfigReader): CuratorConfig {
   const hasToken = store.listSettings().some((setting) => setting.key === KEYS.token);
   const enabled = store.getSetting(KEYS.enabled) === "true";
 
+  const timeoutMs = parseNumber(store.getSetting(KEYS.llmTimeoutMs), DEFAULT_LLM_TIMEOUT_MS);
   const isLlmComplete = Boolean(provider && endpoint && model && hasToken);
   return {
     enabled,
-    llm: { provider, endpoint, model },
+    llm: { provider, endpoint, model, timeoutMs },
     hasToken,
     promptAddendum: store.getSetting(KEYS.promptAddendum) ?? "",
     defaultAutoApply: parseAutoApply(store.getSetting(KEYS.defaultAutoApply)),
@@ -157,11 +166,21 @@ export function writeCuratorConfig(store: ConfigWriter, patch: CuratorConfigPatc
   ) {
     throw new Error("schedule time must be HH:MM (24-hour)");
   }
+  if (patch.llm?.timeoutMs !== undefined) {
+    const t = patch.llm.timeoutMs;
+    if (!Number.isInteger(t) || t < MIN_LLM_TIMEOUT_MS || t > MAX_LLM_TIMEOUT_MS) {
+      throw new Error(
+        `llm timeout_ms must be an integer between ${MIN_LLM_TIMEOUT_MS} and ${MAX_LLM_TIMEOUT_MS} (1s and 10min)`,
+      );
+    }
+  }
 
   if (patch.enabled !== undefined) store.setSetting(KEYS.enabled, patch.enabled ? "true" : "false");
   if (patch.llm?.provider !== undefined) store.setSetting(KEYS.provider, patch.llm.provider);
   if (patch.llm?.endpoint !== undefined) store.setSetting(KEYS.endpoint, patch.llm.endpoint);
   if (patch.llm?.model !== undefined) store.setSetting(KEYS.model, patch.llm.model);
+  if (patch.llm?.timeoutMs !== undefined)
+    store.setSetting(KEYS.llmTimeoutMs, String(patch.llm.timeoutMs));
   if (patch.token !== undefined) {
     if (patch.token === "") store.deleteSetting(KEYS.token);
     else store.setSetting(KEYS.token, patch.token, { secret: true });

--- a/packages/core/src/curator-llm-client.ts
+++ b/packages/core/src/curator-llm-client.ts
@@ -18,6 +18,12 @@ export interface LlmClientConfig {
   /** Bearer token (secret). Never logged or surfaced in errors. */
   token: string;
   model: string;
+  /**
+   * Default request timeout in ms applied when `complete()` is called without
+   * an explicit `timeoutMs`. Falls back to 60s when unset. Operator-configurable
+   * on the curator path so a slow self-hosted model doesn't time out mid-batch.
+   */
+  timeoutMs?: number;
 }
 
 export type LlmRole = "system" | "user" | "assistant";
@@ -87,6 +93,7 @@ export function createCuratorLlmClient(
   const endpoint = config.endpoint.trim();
   const { token, model: rawModel } = config;
   const model = rawModel.trim();
+  const configuredTimeoutMs = config.timeoutMs;
   if (!endpoint) throw new Error("LLM client requires a non-empty endpoint");
   if (!token) throw new Error("LLM client requires a non-empty token");
   if (!model) throw new Error("LLM client requires a non-empty model");
@@ -101,7 +108,7 @@ export function createCuratorLlmClient(
         jsonResponse = true,
         temperature,
         maxTokens,
-        timeoutMs = DEFAULT_TIMEOUT_MS,
+        timeoutMs = configuredTimeoutMs ?? DEFAULT_TIMEOUT_MS,
       } = request;
       if (!(timeoutMs > 0)) throw new Error("LLM client timeoutMs must be a positive number");
 

--- a/packages/core/src/curator-tick.ts
+++ b/packages/core/src/curator-tick.ts
@@ -64,7 +64,12 @@ export async function runCuratorTick(options: CuratorTickOptions): Promise<Curat
   const buildClient =
     options.buildClient ??
     ((llm, secret) =>
-      createCuratorLlmClient({ endpoint: llm.endpoint, token: secret, model: llm.model }));
+      createCuratorLlmClient({
+        endpoint: llm.endpoint,
+        token: secret,
+        model: llm.model,
+        timeoutMs: llm.timeoutMs,
+      }));
 
   const summary = await runDueCuration({
     store,

--- a/packages/core/tests/curator-config.test.ts
+++ b/packages/core/tests/curator-config.test.ts
@@ -64,6 +64,20 @@ describe("curator config", () => {
     expect(cfg.hasToken).toBe(false);
     expect(cfg.isLlmComplete).toBe(false);
     expect(cfg.isOperational).toBe(false);
+    // Matches curator-llm-client's DEFAULT_TIMEOUT_MS so unconfigured installs
+    // behave identically to before this field landed.
+    expect(cfg.llm.timeoutMs).toBe(60_000);
+  });
+
+  it("round-trips a custom llm timeout and clamps invalid values", () => {
+    const { store } = s!;
+    writeCuratorConfig(store, { llm: { timeoutMs: 180_000 } });
+    expect(readCuratorConfig(store).llm.timeoutMs).toBe(180_000);
+    expect(() => writeCuratorConfig(store, { llm: { timeoutMs: 0 } })).toThrow(/timeout/);
+    expect(() => writeCuratorConfig(store, { llm: { timeoutMs: 1_000_000 } })).toThrow(/timeout/);
+    expect(() => writeCuratorConfig(store, { llm: { timeoutMs: 1.5 } })).toThrow(/timeout/);
+    // The earlier valid value is preserved when later writes are rejected.
+    expect(readCuratorConfig(store).llm.timeoutMs).toBe(180_000);
   });
 
   it("round-trips config and never exposes the token in the readable config", () => {

--- a/packages/core/tests/curator-tick.test.ts
+++ b/packages/core/tests/curator-tick.test.ts
@@ -85,7 +85,12 @@ describe("runCuratorTick — operational", () => {
     expect(buildClient).toHaveBeenCalledTimes(1);
     // The decrypted token + the configured connection flow into the builder.
     expect(buildClient).toHaveBeenCalledWith(
-      { provider: "openai", endpoint: "https://api.example.com/v1", model: "gpt-x" },
+      {
+        provider: "openai",
+        endpoint: "https://api.example.com/v1",
+        model: "gpt-x",
+        timeoutMs: 60_000,
+      },
       "dummy-decrypted-token",
     );
     if (result.ran) expect(result.summary.ran).toBeGreaterThanOrEqual(1);


### PR DESCRIPTION
## Why

The curator's LLM call had a hard-coded 60-second timeout. Slow providers — especially self-hosted models on modest hardware — were surfacing `llm_timeout` errors mid-batch with no operator knob to widen the window.

## What

`CuratorConfig.llm` gains `timeoutMs: number` (default `60_000`, matching the client's existing default — unconfigured installs behave identically). The cockpit's settings form gets an "LLM request timeout (ms)" input next to the API token. Validation: integer in `[1_000, 600_000]` (1s..10min).

## Wiring

- `packages/core/curator-config` — new `curator.llm.timeout_ms` setting key, on the read/write paths, in `CuratorConfigPatchSchema`, and validated by `writeCuratorConfig`.
- `packages/core/curator-llm-client` — `LlmClientConfig` accepts an optional `timeoutMs` default that's applied when a per-request `timeoutMs` is omitted.
- `packages/core/curator-tick` — threads `config.llm.timeoutMs` into `createCuratorLlmClient`.
- `apps/dashboard/components/curator/config-form` — new number input (min/max/step), state, and patch wiring.

## Tests

- New `curator-config` cases pin the default (60_000) and the validation envelope (rejects 0, 1_000_000, and 1.5; preserves earlier valid value on later failed writes).
- `curator-tick` test updated to assert `timeoutMs: 60_000` flows into the injected `buildClient`.
- Dashboard test fixtures (`cockpit.test.tsx`, `cockpit-actions.test.tsx`) updated for the new required field.

## Checks

core: **474 tests** ✅ · mcp-server: **116 tests** ✅ · dashboard: **148 tests** ✅ · eslint ✅ · tsc --noEmit ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)