### PR TITLE
fix(core): wrap rowToMemory JSON.parse in defensive helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ changes from this point forward are catalogued here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`rowToMemory` JSON-parse crash on corrupt `_json` columns.** A single
+  corrupt `tags_json`, `applies_to_json`, `supersedes_json`,
+  `conflicts_with_json`, or `curator_note` column in the SQLite `memories`
+  table would crash every query that reads memory rows (`listMemories`,
+  `listAll`, `getMemory`) with an uncaught `SyntaxError`, manifesting as a
+  500 / JSON-RPC -32603 on the dashboard and MCP calls. The read path now
+  wraps each `JSON.parse` in defensive helpers that log the corruption to
+  stderr and fall back to safe defaults (`[]` or `null`) — one bad row no
+  longer blocks the user's turn (fail-soft principle).
+
 ### Added
 
 - `AGENTS.md` with the family-wide house rules (privacy, fail-soft,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/core/src/store/memory-store.ts
+++ b/packages/core/src/store/memory-store.ts
@@ -777,16 +777,46 @@ export function createMemoryStore(deps: MemoryStoreDeps): MemoryStore {
 function rowToMemory(row: Record<string, unknown>): Memory {
   return {
     ...row,
-    tags: JSON.parse((row.tags_json as string) || "[]"),
-    applies_to: JSON.parse((row.applies_to_json as string) || "[]"),
-    supersedes: JSON.parse((row.supersedes_json as string) || "[]"),
-    conflicts_with: JSON.parse((row.conflicts_with_json as string) || "[]"),
+    tags: safeJsonParseArray((row.tags_json as string) || "[]", row.id),
+    applies_to: safeJsonParseArray((row.applies_to_json as string) || "[]", row.id),
+    supersedes: safeJsonParseArray((row.supersedes_json as string) || "[]", row.id),
+    conflicts_with: safeJsonParseArray((row.conflicts_with_json as string) || "[]", row.id),
     recall_count: Number(row.recall_count || 0),
     usefulness_score: Number(row.usefulness_score || 0),
     curator_note: row.curator_note
-      ? (JSON.parse(row.curator_note as string) as Record<string, unknown>)
+      ? safeJsonParseObject(row.curator_note as string, row.id, "curator_note")
       : null,
   } as Memory;
+}
+
+// Defensive JSON-parse helpers — a single corrupt _json column must never
+// crash the entire query (fail-soft principle). Log + return a safe default.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function safeJsonParseArray(raw: string, memoryId: unknown): any[] {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    // Use process.stderr.write so this fires even before the logger boots.
+    process.stderr.write(
+      `[librarian] rowToMemory: corrupt JSON array column on memory ${String(memoryId)} — falling back to []\n`,
+    );
+    return [];
+  }
+}
+
+function safeJsonParseObject(
+  raw: string,
+  memoryId: unknown,
+  column: string,
+): Record<string, unknown> | null {
+  try {
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    process.stderr.write(
+      `[librarian] rowToMemory: corrupt JSON column "${column}" on memory ${String(memoryId)} — falling back to null\n`,
+    );
+    return null;
+  }
 }
 
 function tokenize(text: string): string[] {

--- a/packages/core/tests/store/memory-store.test.ts
+++ b/packages/core/tests/store/memory-store.test.ts
@@ -11,7 +11,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { type LibrarianStore, createLibrarianStore } from "@librarian/core";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 interface ScopedStore {
   store: LibrarianStore;
@@ -245,5 +245,183 @@ describe("LibrarianStore memory CRUD", () => {
     expect(second.status).toBe("active");
     expect(second.memory.id).toBeTruthy();
     expect(second.duplicates.length).toBeGreaterThanOrEqual(1);
+  });
+
+  describe("rowToMemory corrupt-JSON defence", () => {
+    it("getMemory survives a corrupt tags_json column and falls back to []", () => {
+      const { store } = scope!;
+      const { memory } = store.createMemory({
+        agent_id: "test",
+        title: "Corrupt tags test",
+        body: "This memory will have its tags_json column manually corrupted.",
+        category: "tools",
+        visibility: "common",
+        scope: "project",
+        tags: ["valid-tag"],
+      });
+
+      // Verify clean read before corruption.
+      const before = store.getMemory(memory.id);
+      expect(before.tags).toEqual(["valid-tag"]);
+
+      // Directly corrupt the SQLite column (bypass the projection).
+      store.db.exec(
+        `UPDATE memories SET tags_json = 'memory-hygiene-crash' WHERE id = '${memory.id}'`,
+      );
+
+      // Must not throw — fail-soft fallback to [].
+      const after = store.getMemory(memory.id);
+      expect(after).toBeTruthy();
+      expect(after.tags).toEqual([]);
+      expect(after.title).toBe("Corrupt tags test");
+    });
+
+    it("getMemory survives a corrupt applies_to_json column and falls back to []", () => {
+      const { store } = scope!;
+      const { memory } = store.createMemory({
+        agent_id: "test",
+        title: "Corrupt applies_to test",
+        body: "Testing applies_to_json corruption.",
+        category: "tools",
+        visibility: "common",
+        scope: "project",
+        applies_to: ["agent-a"],
+      });
+
+      store.db.exec(
+        `UPDATE memories SET applies_to_json = 'not-json-at-all' WHERE id = '${memory.id}'`,
+      );
+
+      const after = store.getMemory(memory.id);
+      expect(after.applies_to).toEqual([]);
+    });
+
+    it("getMemory survives a corrupt supersedes_json column and falls back to []", () => {
+      const { store } = scope!;
+      const { memory } = store.createMemory({
+        agent_id: "test",
+        title: "Corrupt supersedes test",
+        body: "Testing supersedes_json corruption.",
+        category: "tools",
+        visibility: "common",
+        scope: "project",
+      });
+
+      store.db.exec(
+        `UPDATE memories SET supersedes_json = 'garbage-data' WHERE id = '${memory.id}'`,
+      );
+
+      const after = store.getMemory(memory.id);
+      expect(after.supersedes).toEqual([]);
+    });
+
+    it("getMemory survives a corrupt conflicts_with_json column and falls back to []", () => {
+      const { store } = scope!;
+      const { memory } = store.createMemory({
+        agent_id: "test",
+        title: "Corrupt conflicts_with test",
+        body: "Testing conflicts_with_json corruption.",
+        category: "tools",
+        visibility: "common",
+        scope: "project",
+      });
+
+      store.db.exec(
+        `UPDATE memories SET conflicts_with_json = 'raw-string-boom' WHERE id = '${memory.id}'`,
+      );
+
+      const after = store.getMemory(memory.id);
+      expect(after.conflicts_with).toEqual([]);
+    });
+
+    it("getMemory survives a corrupt curator_note column and falls back to null", () => {
+      const { store } = scope!;
+      const { memory } = store.createMemory({
+        agent_id: "test",
+        title: "Corrupt curator_note test",
+        body: "Testing curator_note corruption.",
+        category: "tools",
+        visibility: "common",
+        scope: "project",
+      });
+
+      // curator_note starts as null for a non-curated memory — set it to
+      // a raw string to simulate corruption.
+      store.db.exec(
+        `UPDATE memories SET curator_note = 'corrupt-curator-note' WHERE id = '${memory.id}'`,
+      );
+
+      const after = store.getMemory(memory.id);
+      expect(after.curator_note).toBeNull();
+    });
+
+    it("listMemories does not crash when a row has a corrupt JSON column", () => {
+      const { store } = scope!;
+      // Create two clean rows and one corrupt row.
+      store.createMemory({
+        agent_id: "test",
+        title: "Clean memory one",
+        body: "This one is fine.",
+        category: "tools",
+        visibility: "common",
+        scope: "project",
+      });
+      const { memory: corrupt } = store.createMemory({
+        agent_id: "test",
+        title: "Soon to be corrupt",
+        body: "Will be corrupted.",
+        category: "tools",
+        visibility: "common",
+        scope: "project",
+      });
+      store.createMemory({
+        agent_id: "test",
+        title: "Clean memory two",
+        body: "Also fine.",
+        category: "tools",
+        visibility: "common",
+        scope: "project",
+      });
+
+      store.db.exec(`UPDATE memories SET tags_json = 'memory-hygiene' WHERE id = '${corrupt.id}'`);
+
+      // listMemories must return all three rows — the corrupt row gets
+      // tags: [] and the query doesn't crash.
+      const result = store.listMemories({});
+      expect(result.total).toBe(3);
+      expect(result.memories).toHaveLength(3);
+
+      const corruptRow = result.memories.find((m) => m.id === corrupt.id);
+      expect(corruptRow).toBeTruthy();
+      expect(corruptRow.tags).toEqual([]);
+    });
+
+    it("stderr is written when corrupt JSON is detected", () => {
+      const { store } = scope!;
+      const { memory } = store.createMemory({
+        agent_id: "test",
+        title: "Stderr test",
+        body: "Corruption should produce a stderr log line.",
+        category: "tools",
+        visibility: "common",
+        scope: "project",
+      });
+
+      const writeSpy = vi.spyOn(process.stderr, "write");
+      try {
+        store.db.exec(
+          `UPDATE memories SET applies_to_json = 'broken-json' WHERE id = '${memory.id}'`,
+        );
+
+        store.getMemory(memory.id);
+
+        expect(writeSpy).toHaveBeenCalledTimes(1);
+        const call = writeSpy.mock.calls[0]?.[0] as string;
+        expect(call).toContain("[librarian] rowToMemory: corrupt JSON array column");
+        expect(call).toContain(memory.id);
+      } finally {
+        writeSpy.mockRestore();
+      }
+    });
   });
 });


### PR DESCRIPTION
## Problem

A single corrupt `_json` column in the SQLite `memories` table crashes every query that reads memory rows (`listMemories`, `listAll`, `getMemory`) with an uncaught `SyntaxError`. This manifests as a 500/JSON-RPC -32603 error on the dashboard and MCP calls.

For example, if any of `tags_json`, `applies_to_json`, `supersedes_json`, `conflicts_with_json`, or `curator_note` contains a raw string like `memory-hygiene` (instead of properly JSON-encoded `["memory-hygiene"]`), the entire query fails:

```
JSON.parse("memory-hygiene")
// SyntaxError: Unexpected token 'm', "memory-hygiene" is not valid JSON
```

## Root cause

`rowToMemory()` called `JSON.parse` on five columns with no error handling. While the write path (`rebuildMemoryIndex`) always produces valid JSON via `JSON.stringify(asArray(...))`, corrupt rows can arise from historical code bugs, manual DB edits, or disk issues.

## Fix

Wrapped each `JSON.parse` with defensive helpers (`safeJsonParseArray`, `safeJsonParseObject`) that catch parse failures, log the corruption to stderr, and return safe defaults (`[]` or `null`).

This follows the project's fail-soft principle: one bad row must never block the user's dashboard or memory queries.

## Changes

- `packages/core/src/store/memory-store.ts` — `rowToMemory` now uses `safeJsonParseArray` / `safeJsonParseObject` instead of raw `JSON.parse`
- `packages/core/tests/store/memory-store.test.ts` — 7 new tests covering all five corruptable columns individually plus `listMemories` resilience and stderr logging
- `CHANGELOG.md` — entry under `## [Unreleased]` → `### Fixed`
- `package.json` — version bumped to `0.1.1` (patch)

## Testing

- All 481 core tests pass (474 original + 7 new)
- All 116 MCP server tests pass
- Lint (prettier + eslint) passes