### PR TITLE
PR 1: Memory domain-isolation foundation (additive schema)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ changes from this point forward are catalogued here.
 
 ## [Unreleased]
 
+### Added
+
+- **Memory domain-isolation foundation (PR 1 of 8).** Additive schema for
+  the new owner-controlled isolation model (`domain`, `is_global`,
+  `requires_approval` columns on memories, `domain` on sessions, plus the
+  four authoritative tables `conversation_state`, `domains`,
+  `signal_rules`, `token_domain_bindings`). The two policy booleans are
+  derived from the legacy `category` column as a temporary bridge until
+  the write-path classifier ships in PR 6. The `general` domain is
+  auto-seeded on first boot, and the `legacy-private` domain is
+  synthesised on the fly by `scripts/migrate-add-domain-and-conv-state.mjs`
+  for any historical `agent_private` memories. No behaviour change on
+  reads or writes — existing tools see the new columns as defaulted
+  metadata.
+
 ### Fixed
 
 - **`rowToMemory` JSON-parse crash on corrupt `_json` columns.** A single

--- a/docs/specs/memory-domain-isolation-and-conv-state-plan.md
+++ b/docs/specs/memory-domain-isolation-and-conv-state-plan.md
@@ -1,0 +1,1000 @@
+# Plan: Memory Domain Isolation & Conversation State
+
+Companion to [`memory-domain-isolation-and-conv-state.md`](./memory-domain-isolation-and-conv-state.md). The spec defines **what** and **why**; this plan defines **how**, in what **order**, what's parallelisable, what the **risks** are, and how each phase is **verified**.
+
+## Status
+
+Drafted 2026-05-27. Not started.
+
+---
+
+## Component dependency graph
+
+```
+                ┌──────────────────────────┐
+                │  PR 1 — Additive schema  │
+                │  new columns + tables,   │
+                │  legacy-derived booleans │
+                │  + backfill script       │
+                └────────────┬─────────────┘
+                             │
+              ┌──────────────┴──────────────┐
+              │                             │
+   ┌──────────▼───────────┐     ┌───────────▼──────────┐
+   │ PR 2 — conv_state    │     │ PR 4 — Dashboard     │
+   │ store + MCP tools +  │     │ surface (can start   │
+   │ hook helpers         │     │ as soon as schema is │
+   └──────────┬───────────┘     │ live; deeper work    │
+              │                 │ blocked on PR 2/3)   │
+              │                 └───────────┬──────────┘
+              │                             │
+   ┌──────────▼───────────┐                 │
+   │ PR 3 — Domain        │                 │
+   │ enforcement in       │                 │
+   │ remember/recall/     │                 │
+   │ start_session/resume │                 │
+   └──────────┬───────────┘                 │
+              │                             │
+              ├─────────────────────────────┘
+              │
+   ┌──────────▼───────────┐    ┌──────────────────────┐
+   │ PR 5 — Harness       │    │ PR 6 — Classifier in │
+   │ integrations         │    │ shadow mode (can     │
+   │ (Claude, Hermes,     │    │ run in parallel with │
+   │ CLI) — sibling repos │    │ PR 5; independent)   │
+   └──────────┬───────────┘    └───────────┬──────────┘
+              │                            │
+              └──────────────┬─────────────┘
+                             │
+                ┌────────────▼─────────────┐
+                │ PR 7 — Classifier        │
+                │ cutover. Drop category/  │
+                │ visibility/scope columns │
+                └────────────┬─────────────┘
+                             │
+                ┌────────────▼─────────────┐
+                │ PR 8 — Documentation     │
+                │ (can start in P5/P6;     │
+                │ finalised after P7)      │
+                └──────────────────────────┘
+```
+
+Pre-work (off-graph but must land before PR 6): **`classifier-implementation-spec.md`** — defines the model choice, serving topology, prompt-versioning workflow, eval-harness shape. See §9 of the main spec.
+
+---
+
+## Execution mode
+
+**Solo, serial.** One PR in flight at a time, walking the critical path. The parallelisation map below is retained as a reference for the case where a second agent joins; it does not drive day-to-day execution.
+
+---
+
+## What could run in parallel (reference only)
+
+| Pair / set | Parallelisable? | Reason |
+|---|---|---|
+| PR 1 + anything | **No.** Hard prerequisite. | Every other PR reads or writes the new columns/tables. |
+| PR 2 + PR 4 (early) | **Yes, partly.** | T4.1 (`/domains` page) is pure CRUD against the `domains` table from PR 1 — no dependency on conv_state. Deeper PR 4 work (proposal modal, detail-panel toggles) is independent of PR 2 too. The cross-cut is the `<conversation-state>` rendering surface, which is one helper used by PR 5 hooks, not the dashboard. |
+| PR 2 vs PR 3 | **Sequential.** | PR 3 imports the conv_state store and tools from PR 2. |
+| PR 3 + PR 4 | **Yes.** | Dashboard and server tools are independent consumers of the schema. Can land in either order. |
+| PR 5 + PR 6 | **Yes.** | Harness integrations and the classifier are fully independent. Different repos, different teams' attention if any. |
+| PR 5 sibling repos (Claude, Hermes, CLI) | **Yes.** | Each is its own repo and its own PR. |
+| PR 6 vs PR 7 | **Sequential, with validation window.** | PR 7 cannot land until shadow-mode telemetry from PR 6 shows acceptable classifier quality. Allow a deliberate week+ of shadow operation before PR 7. |
+| PR 8 | **Throughout.** | Doc updates land as each PR ships. Final pass after PR 7. |
+
+---
+
+## Phase 1 — Additive schema (PR 1)
+
+Land all new tables and columns; keep all old columns. Existing reads/writes continue to work. Booleans are derived from category via legacy logic so the rest of the system can start consuming them.
+
+### Tasks
+
+#### T1.1 — Add new tables to projection
+
+**Description:** Create `conversation_state`, `domains`, `signal_rules`, `token_domain_bindings` tables in the SQLite projection. Seed `domains` with one row (`general`).
+
+**Acceptance criteria:**
+- [ ] All four tables exist after mcp-server startup against a fresh database
+- [ ] `domains` contains one row (`name = 'general'`) after startup
+- [ ] Re-running startup is idempotent (no duplicate seeds, no errors)
+
+**Verification:**
+- [ ] Unit test in `packages/core/test/projection.test.ts` verifying table creation and seed
+- [ ] `pnpm test --filter @librarian/core`
+
+**Files likely touched:**
+- `packages/core/src/store/projection.ts`
+- `packages/core/test/projection.test.ts`
+
+**Scope:** S
+
+**Dependencies:** none.
+
+#### T1.2 — Add new columns to `memories` and `sessions`
+
+**Description:** Add `domain`, `is_global`, `requires_approval` to `memories` and `domain` to `sessions`. Defaults match spec §7.1.
+
+**Acceptance criteria:**
+- [ ] `memories` rows get `domain='general', is_global=0, requires_approval=0` by default
+- [ ] `sessions` rows get `domain='general'` by default
+- [ ] Legacy `category`, `visibility`, `scope` columns are untouched
+- [ ] Existing `INSERT`s without the new columns succeed (defaults apply)
+
+**Verification:**
+- [ ] Unit test exercising INSERT with and without the new columns
+- [ ] `pnpm test --filter @librarian/core`
+
+**Files likely touched:**
+- `packages/core/src/store/projection.ts`
+- `packages/core/src/schemas/memory.ts`
+- `packages/core/src/schemas/session.ts`
+- corresponding tests
+
+**Scope:** S
+
+**Dependencies:** T1.1.
+
+#### T1.3 — Derive booleans from category (legacy bridge)
+
+**Description:** Update `normalizeMemoryInput` and the projection handler for `memory.created` to derive `is_global` and `requires_approval` from the existing `category` value. This bridges the gap until the classifier ships.
+
+Derivation rules (from spec §7.2):
+- `identity | relationship` → `requires_approval = 1`
+- `identity | relationship | preferences` → `is_global = 1`
+- everything else → both `0`
+
+**Acceptance criteria:**
+- [ ] A new memory created with `category='identity'` lands with `requires_approval=1, is_global=1`
+- [ ] A new memory created with `category='preferences'` lands with `requires_approval=0, is_global=1`
+- [ ] A new memory created with `category='tools'` lands with `requires_approval=0, is_global=0`
+- [ ] Existing `PROTECTED_CATEGORIES`-driven proposal routing keeps working (i.e. category-derived `requires_approval` triggers the proposal flow)
+
+**Verification:**
+- [ ] Unit tests covering each derivation rule
+- [ ] Integration test: write an `identity` memory via the existing `propose_memory` flow; confirm `status='proposed'` and `requires_approval=1`
+- [ ] `pnpm test --filter @librarian/core`
+
+**Files likely touched:**
+- `packages/core/src/constants.ts` (`normalizeMemoryInput`)
+- `packages/core/src/store/memory-store.ts` (`createMemory` — read derived value)
+- `packages/core/src/store/projection.ts` (projection of `memory.created`)
+- corresponding tests
+
+**Scope:** M
+
+**Dependencies:** T1.2.
+
+#### T1.4 — Migration script: backfill historical projection
+
+**Description:** New script `scripts/migrate-add-domain-and-conv-state.mjs`. Reads `events.jsonl` and `sessions.jsonl`, populates the new columns on every historical row in the projection. Idempotent.
+
+Migration rules per spec §7.2:
+- Convert the original category value to a tag (deduped). For `identity`/`relationship`, also add the tag `profile`.
+- Derive `requires_approval` and `is_global` from original category.
+- Assign `domain = 'legacy-private'` if original `visibility = 'agent_private'`; else `'general'`.
+- Auto-create the `legacy-private` domain if at least one memory needs it.
+- For sessions: assign `domain = 'general'`.
+
+**Acceptance criteria:**
+- [ ] Running on a snapshot of production-shape data produces the expected column values per the rules above
+- [ ] Running the script twice produces identical projection state
+- [ ] The script logs counts: memories backfilled, sessions backfilled, `legacy-private` memories migrated
+- [ ] No new events are appended to `events.jsonl` or `sessions.jsonl`
+- [ ] Existing recall behaviour is unchanged for non-private memories (`domain='general'` matches the single-domain default filter)
+
+**Verification:**
+- [ ] Unit test with a fixture JSONL covering all derivation branches
+- [ ] Idempotency test: run twice, assert identical state
+- [ ] Smoke test: run against a copy of the canonical instance's data; manually inspect 10 random memories
+
+**Files likely touched:**
+- `scripts/migrate-add-domain-and-conv-state.mjs`
+- `test/migrate-add-domain-and-conv-state.test.mjs`
+
+**Scope:** M
+
+**Dependencies:** T1.2, T1.3.
+
+#### T1.5 — Releasability gate for PR 1
+
+**Description:** Final integration tests proving PR 1 leaves `main` releasable — agents writing and recalling memories with the existing tool surface see no behaviour change.
+
+**Acceptance criteria:**
+- [ ] All existing tests pass
+- [ ] `remember` followed by `recall` returns the memory (single-domain default, no conv_state, all memories share `domain='general'`)
+- [ ] `propose_memory` with `category='identity'` lands as `proposed`
+
+**Verification:**
+- [ ] Full repo test suite green: `pnpm test`
+- [ ] Manual integration check against a local mcp-server
+
+**Files likely touched:** none new — this is a verification task.
+
+**Scope:** XS
+
+**Dependencies:** T1.1–T1.4.
+
+### Phase 1 risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Schema migration on production database fails partway through | low | high | Take a JSONL backup before running the migration. Script is idempotent — failed runs can be retried after fixing the root cause. |
+| Derivation logic mismatches existing PROTECTED_CATEGORIES routing | medium | high | T1.3 acceptance criterion explicitly covers this. Add a regression test for an identity memory landing in `status='proposed'`. |
+| Backfill rule for `agent_private` → `legacy-private` surfaces formerly-hidden content | low | high | The whole point of the `legacy-private` domain is to *not* mix this content into `general`. T1.4 acceptance criterion covers this. PR 4 will add the dashboard prompt to review the domain. |
+| `requires_approval` flag on existing active memories retroactively re-routes them to the proposal queue | low | medium | The flag is metadata only on existing rows — only NEW memories check `requires_approval` to determine initial `status`. T1.3 must verify existing active rows are not affected. |
+
+### Checkpoint: end of Phase 1
+
+- [ ] All Phase 1 tasks merged
+- [ ] Full test suite passing on `main`
+- [ ] Migration script run against the canonical instance; backup confirmed
+- [ ] Manual review: pick 10 random pre-migration memories and verify their new column values look right
+- [ ] Reviewed with Jim before starting Phase 2
+
+---
+
+## Phase 2 — conv_state registry + MCP tools + hook helpers (PR 2)
+
+Build the server-side machinery that PR 3 and PR 5 will consume. No user-visible behaviour change.
+
+### Tasks
+
+#### T2.1 — `conversation-state-store.ts` module
+
+**Description:** New module in `@librarian/core` exposing `get(conv_id)`, `upsert(conv_id, patch)`, `clear(conv_id)`. Backed by the `conversation_state` table from T1.1.
+
+**Acceptance criteria:**
+- [ ] `get` returns the row or `null`
+- [ ] `upsert` creates or updates; bumps `updated_at`
+- [ ] `clear` deletes the row
+- [ ] All operations are atomic per call
+
+**Verification:**
+- [ ] Unit tests in `packages/core/test/store/conversation-state-store.test.ts`
+- [ ] `pnpm test --filter @librarian/core`
+
+**Files likely touched:**
+- `packages/core/src/store/conversation-state-store.ts`
+- `packages/core/src/schemas/conversation-state.ts`
+- corresponding test
+
+**Scope:** S
+
+**Dependencies:** PR 1.
+
+#### T2.2 — MCP tools for conv_state
+
+**Description:** Three new MCP tools: `conv_state.get`, `conv_state.upsert`, `conv_state.clear`. Available to agents (no admin gate — the conversation owns its own state).
+
+**Acceptance criteria:**
+- [ ] Tools register in dispatch and are listed by `tools/list`
+- [ ] Input schemas validate `conv_id` as required
+- [ ] Each tool calls into the T2.1 store
+- [ ] Returns documented MCP shapes
+
+**Verification:**
+- [ ] Unit tests per tool in `packages/mcp-server/test/mcp/tools/`
+- [ ] End-to-end test: call `conv_state.upsert` then `conv_state.get`, assert round-trip
+
+**Files likely touched:**
+- `packages/mcp-server/src/mcp/tools/conv-state-get.ts`
+- `packages/mcp-server/src/mcp/tools/conv-state-upsert.ts`
+- `packages/mcp-server/src/mcp/tools/conv-state-clear.ts`
+- `packages/mcp-server/src/mcp/dispatch.ts` (register)
+- corresponding tests
+
+**Scope:** S
+
+**Dependencies:** T2.1.
+
+#### T2.3 — Hook-injection helper
+
+**Description:** Pure function `renderConvStateBlock(state: ConversationState | null): string`. Returns the `<conversation-state>...</conversation-state>` block from spec §4.9, or empty string for `null`. Used by PR 5 hook implementations across harnesses; lives in `@librarian/core` so all integrations share one canonical format.
+
+**Acceptance criteria:**
+- [ ] Format matches §4.9 exactly (whitespace, key order, field names)
+- [ ] Handles missing `session_id` (renders `none`)
+- [ ] Handles `off_record=true` and `off_record=false`
+- [ ] Returns empty string for `null` input (no state, no block)
+
+**Verification:**
+- [ ] Snapshot test against the exact expected format
+- [ ] `pnpm test --filter @librarian/core`
+
+**Files likely touched:**
+- `packages/core/src/conv-state-render.ts`
+- corresponding test
+
+**Scope:** XS
+
+**Dependencies:** T2.1.
+
+#### T2.4 — Releasability gate for PR 2
+
+**Acceptance criteria:**
+- [ ] All existing tests pass
+- [ ] New conv_state tools callable via MCP
+- [ ] No behavioural changes for memory write/read
+
+**Scope:** XS
+
+**Dependencies:** T2.1–T2.3.
+
+### Phase 2 risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| `conv_id` collision across harnesses (Claude Code and Hermes both produce the same string) | low | high | Prefix in PR 5 hook implementations: `claude:<id>`, `hermes:<channel>:<thread>`. Treat this as a convention, not a server-side check. |
+| MCP tool surface for conv_state encourages agents to manipulate their own state | medium | medium | Document in PR 8 that agents should not call `conv_state.upsert` directly; this is for hook code. No server-side enforcement in V1, but worth flagging. |
+| Snapshot test on the hook-injection block locks in a format that turns out to be wrong | low | low | Re-snapshot is cheap. Treat the test as "this is the format" not "this is the truth". |
+
+### Checkpoint: end of Phase 2
+
+- [ ] All Phase 2 tasks merged
+- [ ] Full test suite green
+- [ ] `conv_state.upsert` + `conv_state.get` round-trips against a running mcp-server
+- [ ] Reviewed with Jim before starting Phase 3
+
+---
+
+## Phase 3 — Domain enforcement in remember/recall/sessions (PR 3)
+
+The first phase where the new model actually changes behaviour. Domain filtering activates. Server-side `domain` assignment activates. Single-domain installs see no change (the special case in §4.10).
+
+### Tasks
+
+#### T3.1 — `remember` reads conv_state, server-sets `domain`
+
+**Description:** Update the `remember` tool handler to look up `conv_state` via the new MCP context (the harness should pass `conv_id`). Server-set `domain` from `conv_state.domain`. Strip any caller-supplied `domain`, `is_global`, `requires_approval` from the input (ignore silently in V1; log a warning).
+
+**Acceptance criteria:**
+- [ ] If `conv_id` is in context and `conv_state` exists: memory gets `domain = conv_state.domain`
+- [ ] If no `conv_id` or no `conv_state`: memory enters the proposal queue per §4.14 (`domain = NULL`, `requires_approval = true`)
+- [ ] Caller-supplied `domain` / `is_global` / `requires_approval` are ignored
+
+**Verification:**
+- [ ] Unit tests covering all three branches above
+- [ ] Integration test: upsert conv_state with `domain='coding'`, call `remember`, recall and verify the memory tag
+
+**Files likely touched:**
+- `packages/mcp-server/src/mcp/tools/remember.ts`
+- `packages/mcp-server/src/mcp/tools/schemas.ts` (remove the now-ignored fields from `memoryInputSchema()`)
+- corresponding tests
+
+**Scope:** M
+
+**Dependencies:** PR 2.
+
+#### T3.2 — `recall` applies domain hard filter; new `tags` and `include_other_domains` inputs
+
+**Description:** Update `recall` handler per spec §4.11. Apply `WHERE (domain = :current_domain OR is_global = 1) AND status = 'active'` against the projection. Remove `categories` and `include_private` from the input schema; add `tags` and `include_other_domains`. Admin callers bypass the domain filter.
+
+**Acceptance criteria:**
+- [ ] In a `coding` conv_state, `recall` returns only memories with `domain='coding'` or `is_global=1`
+- [ ] `include_other_domains: true` returns all domains
+- [ ] `tags: ['react']` filters to memories carrying that tag
+- [ ] Admin role (no `conv_id`) sees all memories
+- [ ] No conv_state, no `include_other_domains`: returns only globals (defensive — agents without context should not see arbitrary content)
+
+**Verification:**
+- [ ] Comprehensive filter test matrix in `packages/mcp-server/test/mcp/tools/recall.test.ts`
+- [ ] Integration test against seeded projection
+
+**Files likely touched:**
+- `packages/mcp-server/src/mcp/tools/recall.ts`
+- `packages/core/src/store/memory-store.ts` (`searchMemories`)
+- corresponding tests
+
+**Scope:** M
+
+**Dependencies:** T3.1.
+
+#### T3.3 — `start_session` inherits domain; resume seeds conv_state
+
+**Description:** Update `start_session` to read `conv_state.domain` and persist it on the session row. Update the `/lib-session-resume` flow to write `domain = session.domain` into the resuming conv_state (overwriting any existing value per D10).
+
+**Acceptance criteria:**
+- [ ] `start_session` called from a `domain='coding'` conv_state produces a session with `domain='coding'`
+- [ ] `start_session` called without a conv_state defaults to `domain='general'`
+- [ ] `lib-session-resume` of a `domain='coding'` session into a fresh conv_id sets `conv_state.domain='coding'`
+- [ ] Signal-precedence chain (PR 5 work) is bypassed on resume — verified by integration test passing `domain=coding` through resume with no signal rules configured
+
+**Verification:**
+- [ ] Unit tests for the start_session inheritance
+- [ ] Unit + integration tests for the resume seeding
+- [ ] `pnpm test --filter @librarian/mcp-server`
+
+**Files likely touched:**
+- `packages/mcp-server/src/mcp/tools/start-session.ts`
+- `packages/mcp-server/src/mcp/tools/resume-session.ts` (or wherever `lib-session-resume` lives)
+- `packages/core/src/store/session-store.ts`
+- corresponding tests
+
+**Scope:** M
+
+**Dependencies:** T3.1, T3.2.
+
+#### T3.4 — `listMemories` (dashboard read path) honours new filters
+
+**Description:** Update `listMemories` to filter by `domain`, `is_global`, `requires_approval`, and `tags`. Remove `category`-based filtering. Keep the existing `agent_id` and `status` filters.
+
+**Acceptance criteria:**
+- [ ] Dashboard list filtering by `domain='coding'` returns only those memories
+- [ ] Dashboard filter "Pending approval" returns `requires_approval=1` AND `status='proposed'`
+- [ ] Existing tests for the older filter shape are updated, not skipped
+
+**Verification:**
+- [ ] Unit tests for each new filter axis
+- [ ] `pnpm test --filter @librarian/core`
+
+**Files likely touched:**
+- `packages/core/src/store/memory-store.ts` (`listMemories`)
+- corresponding tests
+
+**Scope:** S
+
+**Dependencies:** T3.1.
+
+#### T3.5 — Releasability gate for PR 3
+
+**Acceptance criteria:**
+- [ ] All existing tests pass
+- [ ] Manual: upsert conv_state to `domain='coding'`; call `remember` with a coding-related fact; call `recall` and confirm presence; switch conv_state to `domain='family-admin'`; recall the same query and confirm absence
+- [ ] Single-domain install (only `general` exists): behaviour unchanged from PR 1
+
+**Scope:** XS
+
+**Dependencies:** T3.1–T3.4.
+
+### Phase 3 risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Without PR 5 (harness integrations), there's no `conv_id` in context — `remember` always falls to the outside-session branch | high | medium | Expected during transition. Manual conv_state upsert via the new MCP tool is the workaround until PR 5 lands. Document this in the PR description. |
+| Cross-harness resume overwrites a fresh conv_state's `domain` and surprises the user | low | medium | Document explicitly in the dashboard's resume confirmation. Out of scope for PR 3 itself but worth flagging for PR 4. |
+| Removing `categories` from `recall` breaks any external caller still passing it | low | low | We control all known callers (Claude Code plugin, Hermes plugin, CLI). The MCP server can log-and-ignore unknown inputs rather than rejecting. |
+| Admin filter bypass is implemented as "no `conv_id`" but admins might legitimately have one | low | medium | The bypass is keyed off `role === 'admin'` from ToolContext, not off `conv_id` absence. T3.2 acceptance criterion explicitly covers this. |
+
+### Checkpoint: end of Phase 3
+
+- [ ] All Phase 3 tasks merged
+- [ ] Full test suite green
+- [ ] Manual cross-domain demo working (see T3.5 acceptance)
+- [ ] Reviewed with Jim before starting Phase 4
+
+---
+
+## Phase 4 — Dashboard surface (PR 4)
+
+User-facing controls. Can begin as soon as PR 1 lands (the schema is in place); proposal-modal work depends on PR 3 routing semantics.
+
+### Tasks
+
+#### T4.1 — `/domains` page
+
+**Description:** New Next.js page at `apps/dashboard/app/(memories)/domains/page.tsx`. Flat list of domains. Add/remove/rename. Removing a domain that has memories warns and requires confirmation (memories revert to `general`).
+
+**Acceptance criteria:**
+- [ ] List shows all rows from `domains` table
+- [ ] Add form creates a new row
+- [ ] Remove confirms; on confirm, deletes the domain and reassigns its memories to `general`
+- [ ] Cannot remove `general` (the floor)
+
+**Verification:**
+- [ ] Component + server-action unit tests
+- [ ] e2e Playwright test for the add/remove flow
+
+**Files likely touched:**
+- `apps/dashboard/app/(memories)/domains/page.tsx`
+- `apps/dashboard/app/(memories)/domains/actions.ts`
+- `apps/dashboard/components/domains/domain-list.tsx`
+- e2e: `apps/dashboard/e2e/domains.spec.ts`
+
+**Scope:** M
+
+**Dependencies:** PR 1 (schema only).
+
+#### T4.2 — `/signal-rules` page
+
+**Description:** New page combining the two signal-precedence sources from §4.10: harness-pattern rules (signal_rules table) and token-bound defaults (token_domain_bindings table). CRUD on both.
+
+**Acceptance criteria:**
+- [ ] List shows all rules grouped by harness
+- [ ] Add form creates a rule with `{harness, pattern, domain, priority}`
+- [ ] List shows token bindings; add form creates `{token_id, domain}`
+- [ ] Remove on either
+- [ ] Validation: domain must exist in `domains` table
+
+**Verification:**
+- [ ] Component + server-action unit tests
+- [ ] e2e test for the add flow on both rule types
+
+**Files likely touched:**
+- `apps/dashboard/app/(memories)/signal-rules/page.tsx` and supporting components
+- corresponding actions
+
+**Scope:** M
+
+**Dependencies:** T4.1 (validation depends on the domains list).
+
+#### T4.3 — Proposal-approval modal with domain picker
+
+**Description:** Update `components/memories/proposals-view.tsx` per spec §4.14. If `proposal.domain` is set: Approve is one-click. If `NULL`: Approve opens a modal with a domain picker; submit applies the domain and approves.
+
+**Acceptance criteria:**
+- [ ] Proposals with set domain: existing one-click flow unchanged
+- [ ] Proposals with `NULL` domain: Approve button opens modal
+- [ ] Modal lists all domains from `domains` table
+- [ ] Modal submit calls `updateMemoryAction` to set the domain, then `approveProposalAction`
+- [ ] Cancel closes modal without changes
+
+**Verification:**
+- [ ] Component test for modal open/close
+- [ ] e2e test exercising both paths (set-domain vs NULL-domain)
+
+**Files likely touched:**
+- `apps/dashboard/components/memories/proposals-view.tsx`
+- new `apps/dashboard/components/memories/approve-modal.tsx`
+- corresponding tests
+
+**Scope:** M
+
+**Dependencies:** PR 3 (routing creates the NULL-domain proposals).
+
+#### T4.4 — Memory detail panel: domain + boolean toggles
+
+**Description:** Update `components/memories/detail-panel.tsx` (which already supports edit) to surface and edit `domain`, `is_global`, `requires_approval`. Booleans render as toggles; domain as a dropdown sourced from `domains`. Saving emits `memory.classification_overridden` per D19.
+
+**Acceptance criteria:**
+- [ ] Domain dropdown lists all domains
+- [ ] Toggles for the two booleans
+- [ ] Save persists via `updateMemoryAction`
+- [ ] When either boolean is overridden, the event ledger gets `memory.classification_overridden`
+
+**Verification:**
+- [ ] Component test
+- [ ] Integration test: toggle, save, assert event in ledger
+
+**Files likely touched:**
+- `apps/dashboard/components/memories/detail-panel.tsx`
+- `packages/core/src/store/memory-store.ts` (record override event)
+- corresponding tests
+
+**Scope:** M
+
+**Dependencies:** PR 1.
+
+#### T4.5 — Replace category-grouped views with tag/domain/boolean filters
+
+**Description:** Audit existing dashboard views that group or filter by `category`. Replace with the new axes: domain, tags, `is_global`, `requires_approval`. Sidebar nav reflects the change.
+
+**Acceptance criteria:**
+- [ ] No remaining UI references to `category`
+- [ ] New filter UI shows: domain selector, tag multi-select, "Global only" toggle, "Pending approval" toggle
+- [ ] List shows the chosen axis values per row
+
+**Verification:**
+- [ ] e2e test exercising each new filter
+- [ ] Manual: visually compare before/after on the staging dashboard
+
+**Files likely touched:**
+- `apps/dashboard/components/memories/simple-list.tsx`
+- `apps/dashboard/components/memories/filters.tsx` (if it exists; otherwise the page-level filter UI)
+- `apps/dashboard/app/(memories)/page.tsx`
+- corresponding tests
+
+**Scope:** M
+
+**Dependencies:** T4.1, T4.4.
+
+#### T4.6 — Releasability gate for PR 4
+
+**Acceptance criteria:**
+- [ ] All dashboard tests pass
+- [ ] e2e suite green
+- [ ] Manual walk-through of: create domain → create signal rule → trigger a proposal via outside-session write → approve via modal → see in domain-filtered list
+
+**Scope:** XS
+
+**Dependencies:** T4.1–T4.5.
+
+### Phase 4 risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Removing a domain with assigned memories is destructive | medium | high | T4.1 explicit confirmation; reassign to `general` rather than delete the memories. Disallow removal of `general` and `legacy-private` (the latter has owner-review semantics). |
+| Override event emission ties dashboard writes to the ledger format | low | medium | Tested in T4.4. The event schema is owned by `@librarian/core` and versioned alongside other ledger events. |
+| Dashboard PR is too large (5 sub-tasks each medium-sized) | high | medium | Split into 2-3 sub-PRs if any one task balloons. T4.1+T4.2 together; T4.3 alone; T4.4+T4.5 together. |
+
+### Checkpoint: end of Phase 4
+
+- [ ] All Phase 4 tasks merged (possibly as 2-3 sub-PRs)
+- [ ] e2e suite green
+- [ ] Manual walk-through complete
+- [ ] Reviewed with Jim before starting Phase 5
+
+---
+
+## Phase 5 — Harness integrations (PR 5, sibling repos)
+
+Each integration is its own PR in its own repo. **None of these can land before PR 2 (conv_state tools)**. The Claude Code plugin and Hermes plugin are independent of each other.
+
+### Tasks
+
+#### T5.1 — Claude Code plugin: hook + session-start prompt
+
+**Repo:** sibling `the-librarian-claude-plugin` (per the existing structure).
+
+**Description:** Implement the per-turn hook contract from §4.9 using `UserPromptSubmit`. Reads `CLAUDE_SESSION_ID` as `conv_id` (prefixed `claude:`). Fetches `conv_state`, injects via `renderConvStateBlock` (from T2.3). On new conversation (no conv_state), runs the signal-precedence chain from §4.10.
+
+**Acceptance criteria:**
+- [ ] Every user prompt in a Claude Code session triggers the hook
+- [ ] First-turn behaviour: signal-precedence chain runs; for single-domain installs, no prompt
+- [ ] Subsequent turns: state is re-injected from the registry
+- [ ] After context compaction, the next turn still has the correct domain in the injected block
+
+**Verification:**
+- [ ] Manual test against a real Claude Code session
+- [ ] Unit tests for the precedence-chain logic
+- [ ] Long-conversation test: force compaction, verify state survives
+
+**Files likely touched (sibling repo):**
+- Plugin entry point (existing)
+- New hook handler module
+- Tests
+
+**Scope:** L (in its own repo, this is a feature)
+
+**Dependencies:** PR 2 (conv_state tools).
+
+#### T5.2 — Hermes plugin: hook + session-start prompt
+
+**Repo:** sibling `the-librarian-hermes-plugin`.
+
+**Description:** Equivalent to T5.1 for Hermes. `conv_id` = `hermes:<channel-id>:<thread-id>`. Session-start prompt fires the first time the agent is invoked in a new thread.
+
+**Acceptance criteria:**
+- [ ] First message in a new Discord/Slack thread triggers the hook
+- [ ] Subsequent messages re-inject state
+- [ ] Multiple threads in the same channel get distinct conv_states
+
+**Verification:**
+- [ ] Manual test against a Hermes agent
+- [ ] Unit tests for the conv_id derivation
+
+**Pre-work:**
+- [ ] **Verify Hermes has a hook surface equivalent to UserPromptSubmit.** If not, this task blocks on adding one.
+
+**Scope:** L
+
+**Dependencies:** PR 2; Hermes hook-surface verification.
+
+#### T5.3 — CLI wrapper: conv_id from env
+
+**Repo:** `packages/cli` in this repo.
+
+**Description:** The CLI is mostly one-shot — it has no real "conversation" — but for symmetry, generate or accept a `conv_id` per invocation. For interactive CLI use, persist across the session.
+
+**Acceptance criteria:**
+- [ ] Each CLI invocation has a `conv_id`
+- [ ] `--conv-id` flag accepts an override
+- [ ] Interactive sessions persist the conv_id across commands
+
+**Verification:**
+- [ ] Unit tests for the conv_id derivation logic
+- [ ] Manual CLI session
+
+**Files likely touched:**
+- `packages/cli/src/runtime.ts`
+- `packages/cli/src/bin.ts`
+- corresponding tests
+
+**Scope:** S
+
+**Dependencies:** PR 2.
+
+### Phase 5 risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Hermes lacks a `UserPromptSubmit`-equivalent hook | unknown | high | **Verify before starting T5.2.** If absent, add it to Hermes core first. This may block T5.2 indefinitely. |
+| Signal-precedence chain implementation differs subtly between Claude and Hermes plugins | high | medium | Extract the precedence logic into `@librarian/lifecycle` (existing package) so both plugins call the same function. Plugin code shrinks to "fetch signal, call precedence helper, prompt or assign." |
+| Session-start prompt UX in Claude Code (a CLI) is awkward | medium | medium | First implementation: simple inline prompt that reads stdin. Iterate if it's painful. |
+| Compaction window between hook firing and tool call dropping state | low | medium | The hook fires on `UserPromptSubmit`, before the LLM is invoked. State is in the next turn's context window from the start; compaction can't drop it mid-turn. |
+
+### Checkpoint: end of Phase 5
+
+- [ ] All three sibling PRs merged
+- [ ] Manual end-to-end: open Claude Code in `~/code/X`, see signal-rule pre-selection, confirm, write a memory, recall in same session, switch to a different conversation, confirm domain isolation
+- [ ] Reviewed with Jim before starting Phase 6
+
+---
+
+## Phase 6 — Classifier in shadow mode (PR 6)
+
+Ship the classifier service. It runs on every write, logs its verdict, but does not yet determine the persisted booleans. Validates quality before cutover.
+
+### Pre-work
+
+- [ ] **`classifier-implementation-spec.md`** drafted and approved. Defines model choice, serving infrastructure (in-process vs sidecar vs separate service), prompt versioning, eval-harness shape. Spec §9 flagged this as a hard prerequisite.
+
+### Tasks
+
+#### T6.1 — `@librarian/classifier` package skeleton
+
+**Description:** New package owning the local-model lifecycle, the classification prompt, the JSON parser, the timeout/fallback logic. Exposes a single function: `classify({title, body, tags}): Promise<{is_global, requires_approval, fallback_used, raw_output, latency_ms}>`.
+
+**Acceptance criteria:**
+- [ ] Package loads model on startup (or lazily on first call — TBD per the impl spec)
+- [ ] `classify` returns within 500ms or returns fallback
+- [ ] Returns `fallback_used: true` on timeout, malformed JSON, or service unavailable
+- [ ] Conservative fallback values per D20: `requires_approval: true, is_global: false`
+
+**Verification:**
+- [ ] Unit tests with a mocked model that returns each branch
+- [ ] Integration test against the real local model (gated behind a flag to keep CI fast)
+
+**Files likely touched:**
+- `packages/classifier/src/index.ts`
+- `packages/classifier/src/prompt.ts`
+- `packages/classifier/src/json-parser.ts`
+- `packages/classifier/src/model-runner.ts`
+- corresponding tests
+
+**Scope:** L
+
+**Dependencies:** classifier-implementation-spec.
+
+#### T6.2 — Wire classifier into `remember` (log-only / shadow mode)
+
+**Description:** Call the classifier on every `remember`. Append a `memory.classified` event to `events.jsonl` with `{memory_id, input, classifier_output, latency, fallback_used}`. Continue to derive persisted booleans from category (legacy logic from T1.3).
+
+**Acceptance criteria:**
+- [ ] Every `remember` call appends one `memory.classified` event
+- [ ] The persisted memory's `is_global`/`requires_approval` still come from category derivation
+- [ ] Classifier failures do not block `remember` (logged + fallback used)
+
+**Verification:**
+- [ ] Integration test: write a memory, assert the ledger has both `memory.created` and `memory.classified`
+- [ ] Failure-mode test: stop the classifier; assert `remember` still succeeds
+
+**Files likely touched:**
+- `packages/mcp-server/src/mcp/tools/remember.ts`
+- `packages/core/src/store/memory-store.ts` (event append)
+- `packages/core/src/schemas/events.ts` (new event type)
+- corresponding tests
+
+**Scope:** M
+
+**Dependencies:** T6.1.
+
+#### T6.3 — Dashboard: classifier-vs-derived disagreement view
+
+**Description:** New page or panel showing memories where the classifier's verdict differs from the category-derived value. Owner can spot-check classifier quality before cutover.
+
+**Acceptance criteria:**
+- [ ] Page lists memories with `classifier.requires_approval ≠ derived.requires_approval` or `classifier.is_global ≠ derived.is_global`
+- [ ] Shows both verdicts side-by-side
+- [ ] Sortable by latency, by date, by disagreement direction
+
+**Verification:**
+- [ ] Component test
+- [ ] Manual: run the classifier in shadow mode for a few days, review the page
+
+**Files likely touched:**
+- `apps/dashboard/app/(memories)/classifier-quality/page.tsx`
+- corresponding actions
+
+**Scope:** M
+
+**Dependencies:** T6.2.
+
+#### T6.4 — Releasability gate for PR 6
+
+**Acceptance criteria:**
+- [ ] All existing tests pass
+- [ ] Classifier service runs in production for at least one week with no `remember` failures attributable to it
+- [ ] Owner has reviewed the disagreement view and judged classifier quality acceptable
+
+**Scope:** XS
+
+**Dependencies:** T6.1–T6.3, plus elapsed-time validation.
+
+### Phase 6 risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Classifier quality is poor (high disagreement rate, lots of false positives on `requires_approval`) | medium | high | Shadow mode is designed for exactly this. Iterate on the prompt. Acceptable disagreement rate is a soft judgement call; owner decides when good-enough. |
+| Local model adds significant startup time to mcp-server | medium | medium | Lazy-load on first `remember`. First call is slow; subsequent are fast. Or run as a sidecar service that warms independently. |
+| `memory.classified` event volume bloats `events.jsonl` | medium | medium | Each event is small (~500 bytes). At 100 memories/day = 50KB/day. Worst case: rotate the event log monthly. |
+| The classifier prompt drifts from spec semantics over iteration | medium | medium | Version the prompt in `@librarian/classifier/prompt/v1.md` etc. Every `memory.classified` event records the prompt version. The eval harness can replay against any version. |
+
+### Checkpoint: end of Phase 6
+
+- [ ] All Phase 6 tasks merged
+- [ ] Classifier shadow-mode running on canonical instance
+- [ ] Disagreement view reviewed; classifier quality judged acceptable by Jim
+- [ ] **Explicit go/no-go decision with Jim before starting Phase 7.** This is the irreversible step.
+
+---
+
+## Phase 7 — Classifier cutover (PR 7)
+
+Flip source-of-truth. Drop the legacy columns. This is the only phase that is hard to roll back — drops are destructive in SQLite without a re-projection.
+
+### Tasks
+
+#### T7.1 — Flip `remember` to persist classifier verdict
+
+**Description:** Update `remember` so the persisted `is_global` / `requires_approval` come from the classifier, not category derivation. Remove the legacy derivation code path from `normalizeMemoryInput`.
+
+**Acceptance criteria:**
+- [ ] `remember` persists the classifier's verdict
+- [ ] Legacy derivation code is deleted, not just bypassed
+- [ ] Tests previously asserting category-derived values are updated to assert classifier-driven values (using a deterministic test classifier mock)
+
+**Verification:**
+- [ ] Unit + integration tests
+- [ ] `pnpm test`
+
+**Files likely touched:**
+- `packages/mcp-server/src/mcp/tools/remember.ts`
+- `packages/core/src/constants.ts` (`normalizeMemoryInput`)
+- `packages/core/src/store/memory-store.ts`
+- corresponding tests
+
+**Scope:** M
+
+**Dependencies:** PR 6 validation.
+
+#### T7.2 — Re-run migration to convert category → tag
+
+**Description:** Re-run `scripts/migrate-add-domain-and-conv-state.mjs` with cutover-mode behaviour: for each historical memory, append the old category value to `tags[]`. Idempotent (running twice produces no duplicates).
+
+**Acceptance criteria:**
+- [ ] Every memory previously carrying `category='tools'` now carries `tags: [..., 'tools']`
+- [ ] No memory loses information
+- [ ] Idempotent
+
+**Verification:**
+- [ ] Test fixture covers the conversion
+- [ ] Manual spot-check 20 memories after running
+
+**Files likely touched:**
+- `scripts/migrate-add-domain-and-conv-state.mjs` (or a sibling script)
+- corresponding tests
+
+**Scope:** S
+
+**Dependencies:** T7.1.
+
+#### T7.3 — Drop `category`, `visibility`, `scope` columns
+
+**Description:** Migration to drop the three legacy columns. Applied at mcp-server startup via the projection-rebuild flow. The projection handlers for old `memory.created` events ignore those fields rather than reading them.
+
+**Acceptance criteria:**
+- [ ] After migration, the `memories` table has no `category`, `visibility`, or `scope` columns
+- [ ] Old `memory.created` events in `events.jsonl` still parse (projection handler ignores legacy fields)
+- [ ] Re-running migration is idempotent (drop-if-exists semantics)
+
+**Verification:**
+- [ ] Schema-introspection test
+- [ ] Projection-rebuild test from a JSONL containing both pre- and post-cutover events
+
+**Files likely touched:**
+- `packages/core/src/store/projection.ts`
+- corresponding tests
+
+**Scope:** M
+
+**Dependencies:** T7.2.
+
+#### T7.4 — Remove `PROTECTED_CATEGORIES`, `Category` enum, `Visibility` enum, `Scope` enum
+
+**Description:** Source-level cleanup. Delete all references to the removed concepts in `@librarian/core`, `@librarian/mcp-server`, dashboard, integration docs.
+
+**Acceptance criteria:**
+- [ ] `grep -rn "PROTECTED_CATEGORIES\|Visibility\|Scope\|Category" packages/` returns only references in irrelevant contexts (e.g. doc comments about migration history)
+- [ ] All tests pass
+- [ ] All packages build clean
+
+**Verification:**
+- [ ] Full test suite green
+- [ ] `pnpm build` succeeds across the workspace
+
+**Files likely touched:** broad. Audit pass across the workspace.
+
+**Scope:** L (touches many files but each touch is small)
+
+**Dependencies:** T7.3.
+
+#### T7.5 — Releasability gate for PR 7
+
+**Acceptance criteria:**
+- [ ] All tests pass
+- [ ] Manual smoke: write a memory in each domain; recall it; verify isolation
+- [ ] Backup of pre-cutover JSONL taken before T7.3 runs in production
+
+**Scope:** XS
+
+**Dependencies:** T7.1–T7.4.
+
+### Phase 7 risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Column drop is irreversible without re-projection from JSONL | high | medium | Take a full JSONL backup before T7.3 in production. Projection can always be rebuilt from JSONL; we never lose data, only the SQL-level shape. |
+| A consumer somewhere still reads `category` and breaks silently | medium | high | T7.4 grep audit covers source; e2e tests cover behaviour. Watch logs after deploy. |
+| The classifier's first-day-of-production verdicts are worse than category-derived | medium | medium | Phase 6 validation should catch this. If it surfaces post-cutover, owner overrides are the recovery path — every override is recorded and can be reviewed. |
+
+### Checkpoint: end of Phase 7
+
+- [ ] All Phase 7 tasks merged
+- [ ] Production migration run with JSONL backup
+- [ ] One week of post-cutover operation reviewed; no regressions
+- [ ] Reviewed with Jim before starting Phase 8
+
+---
+
+## Phase 8 — Documentation (PR 8)
+
+Can be written progressively from PR 5 onward. Final pass after PR 7.
+
+### Tasks
+
+#### T8.1 — Integration docs
+
+**Description:** Update `docs/integration-docs-memory-verbs.md` and per-integration READMEs (Claude plugin, Hermes plugin, CLI) to reflect the new model. Document the conv_state hook contract, the signal-precedence chain, and the absence of category/visibility/scope.
+
+**Acceptance criteria:**
+- [ ] No remaining references to removed concepts
+- [ ] New harness integrators have a clear "how to implement the hook" guide
+- [ ] CLAUDE.md / SOUL.md guidance updated to reflect that agents no longer set policy fields
+
+**Files:** `docs/`, sibling repo READMEs, `CLAUDE.md`, agent SOUL files.
+
+**Scope:** M
+
+#### T8.2 — Classifier prompt documentation
+
+**Description:** Document the classifier prompt design, versioning workflow, and eval-harness usage in `docs/classifier.md`.
+
+**Files:** `docs/classifier.md` (new).
+
+**Scope:** S
+
+#### T8.3 — Update `/lib-session-*` command help
+
+**Description:** Per-command help text for the `/lib-session-*` family now mentions domain inheritance on resume. The `/lib-toggle-private` doc clarifies it integrates with conv_state.
+
+**Files:** `.claude/commands/lib-session-*.md`, `.claude/commands/lib-toggle-private.md`.
+
+**Scope:** XS
+
+### Checkpoint: end of Phase 8 (project complete)
+
+- [ ] All documentation updated
+- [ ] Spec status moved to "Implemented YYYY-MM-DD"
+- [ ] Working doc archived alongside the spec
+
+---
+
+## Open questions
+
+- **Classifier-implementation-spec.** Must be drafted before PR 6 starts. Model choice is the key undefined.
+- **Hermes hook surface.** Needs verification before T5.2 starts. If missing, T5.2 blocks on adding one to Hermes core.
+- **Single-PR vs split-PRs for Phase 4.** T4.1–T4.5 collectively might be too large for a single review. Split into 2-3 sub-PRs if so.
+- **Acceptable classifier quality threshold.** §6 Checkpoint says "judged acceptable by Jim." Worth defining a concrete metric before shadow mode starts — e.g. ≥95% agreement with derived values on the migration backfill, plus owner sampling of disagreements.
+- **`memory.classified` event volume.** ~500 bytes × write rate. If this becomes a concern, consider sampling (log only a subset) or rotating the event log.
+
+---
+
+## Verification before starting
+
+- [ ] Spec read and approved
+- [ ] Component dependency graph confirms PR order
+- [ ] Risks per phase acknowledged
+- [ ] Classifier-implementation-spec prerequisite scheduled
+- [ ] Hermes hook-surface verification scheduled
+- [ ] Reviewed with Jim before starting PR 1

--- a/docs/specs/memory-domain-isolation-and-conv-state.md
+++ b/docs/specs/memory-domain-isolation-and-conv-state.md
@@ -1,0 +1,415 @@
+# Spec: Memory Domain Isolation & Conversation State
+
+**Author:** Claude, with Jim
+**Date:** 2026-05-27
+**Status:** Draft v3 — `category` dropped entirely; write-path classifier sets `is_global` and `requires_approval`; `visibility` and `scope` removed (per Jim, 2026-05-27); awaiting implementation review
+
+---
+
+## 1. Purpose
+
+Replace the current memory-isolation model with one that actually does what it claims. Today, of eight nominal isolation axes (`agent_id`, `project_key`, `visibility`, `scope`, `category`, `environment`, `harness`, `actor_kind`), only three function as isolation — and only two of those well. The remainder are either advisory labels, session-only concepts, or schema fields the read/write paths never use.
+
+This spec introduces a simpler, owner-controlled model. The guiding principle: **agents should not be responsible for deciding policy.** The owner decides what is partitioned (via domains) and how memories are classified (via dashboard overrides on top of an automated classifier). Agents just write content; the server places it correctly.
+
+1. A new memory field — **`domain`** — owner-defined via dashboard, assigned per *conversation*, hard-filtered on recall.
+2. A new memory field — **`is_global`** — boolean. When true, the memory bypasses domain filtering. Set by a write-path classifier; overridable by the owner.
+3. A new memory field — **`requires_approval`** — boolean. When true, the memory enters the proposal queue instead of going active. Set by the same write-path classifier; overridable by the owner.
+4. A new server-side **conversation-state registry** that survives context compaction and centralises per-conversation state (current `domain`, attached `session_id`, `off_record` flag, future flags).
+5. A **harness hook contract** that re-injects conversation state into the prompt on every turn, defeating compaction-driven state loss.
+6. A **signal-precedence chain** for choosing the domain at conversation start, owner-configured via the dashboard.
+7. A **write-path memory classifier** (small local LLM) that examines each new memory and decides `is_global` and `requires_approval`. Sync, with a conservative fallback on failure.
+8. **Removal of `visibility`** — the `common | agent_private` distinction is redundant once domains exist. Privacy is owner-controlled via domain assignment, not agent-self-declared.
+9. **Removal of `category`** — the enum conflated semantic labels (`tools`, `lessons`, `people`, ...) with policy signals (`identity`/`relationship` → protected, those plus `preferences` → global). Policy is now expressed directly via the two booleans; semantic labels move to the existing `tags[]` field.
+10. **Removal of `scope`** — the enum was advisory metadata with no read-path consumer. `domain` subsumes its intended purpose.
+
+The design is **opt-in to complexity**: a default install ships with a single domain (`general`) and prompts no one. Multi-domain partitioning activates only when the owner adds a second domain.
+
+---
+
+## 2. Non-goals
+
+- **Not redesigning sessions.** Session lifecycle, resume semantics, and the session/memory boundary are unchanged. Sessions gain one new field (`domain`) but otherwise behave identically. See §4.12 for the resume-seeding rule.
+- **Not touching `agent_id` or `project_key`.** Both remain. `agent_id` continues to be derived from authenticated context (per the [Agent Naming Contract](done/agent-naming-contract-spec.md)). `project_key` becomes a tag, not an isolation axis — agents may still set it for grouping, but it does not gate recall.
+- **Not introducing per-domain RBAC or capability gates.** Domains scope memory visibility; they do not gate tool access or imply roles. An agent in `domain=coding` has the same MCP capabilities as one in `domain=family-admin`.
+- **Not addressing multi-tenant / multi-user use.** The Librarian remains single-owner. Domains are an organisational tool for the owner, not a multi-user partition.
+- **Not building a domain-hierarchy UI.** The dashboard surface is a flat list of strings. Hierarchies, colours, and per-domain settings are deferred until usage proves the need.
+
+---
+
+## 3. Background
+
+See the brainstorm working doc at `~/Documents/obsidian-md/Notes/Work/The Librarian/memory-isolation.md` for the full evidence base. Compressed audit findings:
+
+- **`environment` and `harness` are not memory fields.** They appear in spec docs but no column exists. Memories cannot be scoped or filtered by either.
+- **`scope` is stored but never queried.** Not exposed in any tool input schema.
+- **`project_key` is unenforced.** Any agent can write any value; recall does not default-scope by it.
+- **`agent_id` is enforced on write but not on update.** A memory's owner can be patched by any caller holding the id.
+- **`ToolContext` collapses identity to `"admin" | "agent"`.** Rich `actor_kind` (`agent | admin | system | cli`) exists in the data layer but is never piped to dispatch.
+- **The current agent-self-declared-name pattern is brittle.** A renamed agent loses access to its prior memories. SOUL.md instructions are advisory; agents have demonstrated willingness to drift.
+
+The user-facing problem this creates: the owner cannot reliably partition memories by role (coding vs research vs family admin), and even soft partitioning by agent name fails under agent-side drift.
+
+---
+
+## 4. The contract
+
+### 4.1 Domain — a new memory field
+
+A **domain** is a short string identifying the operational context in which a memory was created and to which it should be returned. The owner manages the list of valid domains via the dashboard.
+
+- **Storage:** new column `domain TEXT NOT NULL DEFAULT 'general'` on `memories`.
+- **Cardinality:** single-valued. A memory belongs to exactly one domain.
+- **Source of truth:** the conversation-state registry at the moment of write. The agent does not supply `domain`; the server sets it from `conv_state.domain`.
+- **Lifecycle:** assigned once at write time. Can be changed by the owner via the dashboard. Cannot be changed by agents.
+- **Out-of-box default:** every install ships with a single domain, `general`. Existing memories are backfilled to `general` (see §7).
+
+### 4.2 `is_global` — global-scope flag
+
+A boolean column indicating that a memory should be returned regardless of session domain.
+
+- **Storage:** new column `is_global INTEGER NOT NULL DEFAULT 0` on `memories` (SQLite boolean idiom).
+- **Set by the write-path classifier** (see §4.4). Agents cannot supply this field on `remember`; the input schema does not advertise it. If supplied, it is ignored.
+- **Overridable by the owner** via the dashboard (uses existing `updateMemoryAction`). An owner can flip `is_global` on any memory at any time.
+
+### 4.3 `requires_approval` — proposal-routing flag
+
+A boolean column indicating that a memory should enter the proposal queue rather than going active.
+
+- **Storage:** new column `requires_approval INTEGER NOT NULL DEFAULT 0` on `memories`.
+- **Set by the write-path classifier** (see §4.4). Agents cannot supply this field on `remember`; the input schema does not advertise it. If supplied, it is ignored.
+- **Replaces `PROTECTED_CATEGORIES`.** The old logic — "if `category ∈ {identity, relationship}` then `status = proposed`" — becomes "if `requires_approval` then `status = proposed`". Same proposal workflow, keyed differently.
+- **Overridable by the owner** via the dashboard. Setting `requires_approval = true` on an active memory routes it back to the proposal queue. Setting it to `false` on a proposed memory activates it (equivalent to approval).
+
+### 4.4 The write-path classifier
+
+A small local LLM that examines each new memory at write time and decides `is_global` and `requires_approval`.
+
+- **Sync on the write path.** `remember` blocks until the classifier returns or the timeout elapses. The persisted memory has both booleans set in a single transaction.
+- **Target latency:** <200ms for the classifier call on a warm model. The overall `remember` budget gains at most ~200ms vs. today's path.
+- **Timeout:** 500ms. On timeout, fall through to the conservative fallback.
+- **Conservative fallback** (classifier unavailable, timeout, malformed output, network failure to local service): `requires_approval = true`, `is_global = false`. Rationale: an unreviewed sensitive fact landing in active is a leak; a non-sensitive fact landing in the proposal queue is a recoverable nuisance. Failures must be loud (logged, surfaced in the dashboard's proposal queue), not silent.
+- **Model:** a small open-weights model (Phi-3 Mini, Gemma 2B, or similar) running locally. Specific choice and infrastructure are out of scope for this spec — captured as a follow-up sub-spec (see §9).
+- **Prompt:** versioned, stored alongside the classifier service. Includes a short system instruction plus 4-6 few-shot examples covering the four `{is_global, requires_approval}` quadrants. JSON output, strictly validated.
+- **Observability:** every classifier call appends a `memory.classified` event to `events.jsonl` containing the input, the raw model output, the parsed booleans, the latency, and whether a fallback was used. This is the eval substrate — we can replay events later to score classifier quality.
+- **Owner override is the ground truth.** Once an owner overrides either boolean via the dashboard, the override is recorded as a `memory.classification_overridden` event and the classifier's original verdict is preserved alongside for evaluation purposes.
+
+### 4.5 Removal of `category`
+
+The `category` column and the `Category` enum are **dropped from the memory schema entirely**.
+
+- **Rationale:** of the nine former category values, only `identity`, `relationship`, and `preferences` drove behaviour (protection routing and global-scope derivation). Both behaviours are now expressed directly via §4.2 and §4.3. The remaining categories (`projects`, `environment`, `tools`, `lessons`, `people`, `open_threads`) were semantic labels that never drove system behaviour. Conflating policy with labels in a single enum forced the agent to make policy decisions disguised as classification choices.
+- **What replaces semantic labels:** the existing `tags[]` array on memories. Migration converts the former category value into a tag (e.g. `category=tools` → `tags: [..., 'tools']`).
+- **Recall filtering:** the `categories: []` input on `recall` is removed and **replaced with `tags: []`** (new — the recall tool currently has no tag filter; this spec adds one). Semantic filtering on recall continues to work, just keyed differently.
+- **Dashboard grouping:** the category-grouped views in the dashboard are reworked to group by `tags`, `domain`, and the two booleans. The dashboard gains explicit filters for "Global only" and "Pending approval" since these are now the load-bearing distinctions.
+- **Removed surface:**
+  - `category` column on `memories`
+  - `Category` enum and `PROTECTED_CATEGORIES` constant
+  - `categories: []` input on `recall`
+  - All `category` references in `normalizeMemoryInput`, dashboard category filters, and integration docs.
+
+### 4.6 Removal of `visibility`
+
+The `visibility` column (`common | agent_private`) is **dropped from the memory schema entirely**.
+
+- **Rationale:** agent-private visibility existed because there was no other way to keep one agent's memories out of another agent's recall. Domains now solve that, and they do so under owner control rather than agent self-declaration.
+- **What replaces agent-private memories:** the owner creates a domain (e.g. `personal-notes`, `agent-X-scratch`) and routes those memories there via signal rules or manual session-start picks.
+- **Removed surface:**
+  - `visibility` column on `memories`
+  - `Visibility` enum
+  - `include_private` input on `recall`
+  - All `visibility`-related logic in `searchMemories`, `listMemories`, `visibleResourceMemories`, `scopeAgentArgs`
+- **Admin role retains its bypass.** Role-based access (admin sees all, agents see only their domain + globals) replaces visibility-based access. Admin status is a property of the caller, not a per-memory flag.
+
+### 4.7 Removal of `scope`
+
+The `scope` column and the `Scope` enum are **dropped from the memory schema entirely**.
+
+- **Rationale:** the audit confirmed `scope` (`global | project | environment | tool | session`) is not exposed as a filter on any read-path tool. It was advisory metadata with no consumer. `domain` subsumes its intended purpose.
+- **Removed surface:**
+  - `scope` column on `memories`
+  - `Scope` enum
+  - `scope` field in `normalizeMemoryInput`
+  - `scope` parameter in `listMemories`
+
+### 4.8 Conversation-state registry
+
+A new server-side keyed store for per-conversation runtime state.
+
+- **Storage:** new table `conversation_state`:
+  ```sql
+  CREATE TABLE conversation_state (
+    conv_id TEXT PRIMARY KEY,
+    harness TEXT NOT NULL,
+    domain TEXT NOT NULL,
+    session_id TEXT,
+    off_record INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+  );
+  ```
+- **`conv_id` is harness-supplied.** Each integration is responsible for providing a stable conversation identifier. For Claude Code: the value of `CLAUDE_SESSION_ID`. For Hermes: `<channel-id>:<thread-id>`. New integrations must specify their `conv_id` convention.
+- **MCP/HTTP surface:**
+  - `conv_state.get(conv_id)` — returns current state or `null`
+  - `conv_state.upsert(conv_id, patch)` — creates or updates
+  - `conv_state.clear(conv_id)` — for explicit teardown (e.g. end of conversation)
+- **The registry is *not* a session.** It is ephemeral per-conversation runtime state. Sessions remain the durable, human-curated work artefact.
+
+### 4.9 Hook contract — per-turn state injection
+
+Every harness integration that uses the domain model must implement a `before-user-message` hook (or harness equivalent) that:
+
+1. Reads the stable `conv_id` from harness environment.
+2. Calls `conv_state.get(conv_id)`.
+3. Injects a system reminder of the form:
+   ```
+   <conversation-state>
+     conv_id: <id>
+     domain: <domain>
+     session_id: <id or none>
+     off_record: <true|false>
+   </conversation-state>
+   ```
+
+This re-injection on every turn is what defeats context compaction. The conv-state is restored from outside the prompt every time the LLM is invoked, so the state cannot fall out of the context window.
+
+For Claude Code, this uses the existing `UserPromptSubmit` hook mechanism (same machinery that powers `/lib-toggle-private`).
+
+### 4.10 Session-start prompt — signal-precedence chain
+
+When a harness detects the start of a new conversation (no existing `conv_state` for the `conv_id`), it runs the precedence chain to determine the initial domain:
+
+1. **Token-bound default.** If the owner has registered the calling token as bound to a specific domain (e.g. `research-bot-token → research`), assign that domain. No prompt. **Highest precedence.**
+2. **Source signal.** The harness supplies a signal string (cwd, channel-id, etc.). The dashboard stores `{harness, signal-pattern} → domain` rules. First matching rule wins; the matched domain is pre-selected for the prompt.
+3. **Recency.** The owner's most recently used domain in this harness becomes the pre-selected default.
+4. **Manual prompt.** The owner is shown the domain picker with the pre-selection from steps 2/3 (or no pre-selection). Always available as an override.
+
+**Special case:** if the domain list contains exactly one entry, the entire chain is skipped. The single domain is assigned automatically. This is the zero-friction baseline for owners who do not partition.
+
+### 4.11 Recall — hard filter with explicit broaden
+
+`recall` and equivalent read-path tools apply the following filter:
+
+```
+WHERE (domain = :current_domain OR is_global = 1)
+  AND status = 'active'
+```
+
+`current_domain` is read from `conv_state` by the server (not supplied by the agent). Admin callers bypass the domain filter entirely.
+
+New inputs on `recall`:
+
+- `include_other_domains: boolean` (default `false`). When `true`, the domain filter is dropped. Globals are always included. This is the only way for an agent to see cross-domain memories during a domain-bound conversation. The flag is per-call; it does not persist or change `conv_state`.
+- `tags: array<string>` (new). Filters results to memories carrying any of the listed tags. Replaces the retired `categories: []` input.
+
+Retired inputs:
+- `include_private` — removed (no replacement; visibility no longer exists).
+- `categories` — removed (no replacement at the category level; use `tags` for semantic filtering).
+
+### 4.12 Sessions and resume — D10
+
+Sessions carry their own `domain`:
+
+- **Storage:** new column `domain TEXT NOT NULL DEFAULT 'general'` on `sessions`.
+- **Set at `start_session`:** inherited from the creating conv-state's domain. Defaults to `general` if no conv-state (e.g. CLI-initiated session).
+- **Immutable for the session's life.** Sessions cannot change domain mid-flight (consistent with §4.13).
+- **Resume semantics:** `/lib-session-resume <id>` into a new harness/conversation creates (or overwrites) the new `conv_state` with `domain = session.domain`. The signal-precedence chain is **skipped** on resume — the user's resume action is itself the signal of intent.
+
+### 4.13 No mid-conversation domain switching
+
+Conversations are bound to a single domain for their life. If work drifts to a different domain, the owner starts a new conversation. This keeps the model predictable and discourages sloppy session bounding.
+
+A future iteration may add an explicit slash-command to switch, but the current default is no-switching.
+
+### 4.14 Outside-session memories — proposal flow
+
+Memories created without a `conv_state` context (curator job, scheduled agents, direct CLI/API, dashboard writes) do not auto-assign a domain. They are routed to the proposal queue with `domain = NULL`. The write-path classifier still runs and sets `is_global` / `requires_approval` as it would for any other write; `requires_approval` is forced to `true` for outside-session writes regardless of the classifier's verdict, since the absence of a conv-state is itself a signal that owner review is warranted.
+
+The dashboard's proposal approval flow gains a domain selector:
+
+- **If the proposal already has `domain` set** (e.g. inherited from source memories during curator distillation — see §4.15), **Approve** is one-click.
+- **If `domain` is `NULL`**, **Approve** opens a small modal requiring the owner to pick a domain before the approval lands.
+
+**Reject** remains one-click in both cases.
+
+### 4.15 Curator distillation — source-domain inheritance
+
+When the curator creates a candidate memory derived from N source memories:
+
+- **If all sources share a domain**, the proposal is created with that domain pre-set. Owner approval is one-click.
+- **If sources span multiple domains**, the proposal is created with `domain = NULL`. Owner picks at approval time.
+
+The classifier still runs on curator-distilled candidates. Its `is_global` / `requires_approval` verdicts apply normally; the source-inheritance rule only concerns `domain`.
+
+---
+
+## 5. Tech stack
+
+One new infrastructure component: the write-path classifier. Otherwise no new dependencies. Changes live in:
+
+- `@librarian/core` — schemas (`memory.ts`, new `conversation-state.ts`), store (`memory-store.ts`, new `conversation-state-store.ts`), projection (`projection.ts`).
+- `@librarian/mcp-server` — tool handlers (`recall.ts`, `remember.ts`, `start_session.ts`), new dispatch surface for `conv_state.*` tools, hook-injection helpers, classifier client.
+- **New: `@librarian/classifier`** — a small package owning the local-model lifecycle, the classification prompt, the JSON parser, the timeout/fallback logic, and the eval-replay harness. The specific model choice (Phi-3 Mini vs Gemma 2B vs distilled in-house) is deferred to a follow-up sub-spec.
+- `apps/dashboard` — new `/domains` page, signal-rules page, proposal-approval modal, memory detail panel gains a `domain` field and `is_global` / `requires_approval` toggles, new tag-based grouping replaces the category-based views.
+- `packages/cli` — wrapper updated to read `conv_id` from env and pass to MCP.
+- `packages/lifecycle` and the sibling Claude/Hermes plugin repos — implement the per-turn hook contract from §4.9.
+- New script: `scripts/migrate-add-domain-and-conv-state.mjs` (see §7).
+
+---
+
+## 6. Decisions (resolved)
+
+Each item below was settled during the design session. Decision IDs match the working doc.
+
+- **D1.** Spec scope is *memories only*. Sessions are owner-initiated for resume; cross-harness state transfer for sessions is a separate concern.
+- **D2.** Partitioning is desirable. Retrieval-quality alone is insufficient: scoping serves both retrieval tractability (top-K competition) and defence-in-depth against asymmetric leakage (personal context into code artefacts).
+- **D3.** Agent-name as the unit of scoping is dead. The unit must be owner-controlled, not agent-self-declared.
+- **D4.** Recall hard-filters by domain. `include_other_domains: true` is the only broaden path.
+- **D5.** Some memories bypass the domain filter. Expressed as a per-memory `is_global` boolean. (Originally "defaulted by category" — superseded by D18: now set by the write-path classifier.)
+- **D6.** Outside-session writes route to the proposal queue with `domain = NULL` (or inherited from sources). Approval requires domain assignment.
+- **D7.** No mid-conversation domain switching.
+- **D8.** Single-column storage. Single-domain installs skip the prompt entirely.
+- **D9.** The session-start prompt is harness-hook driven, not coupled to Librarian session lifecycle.
+- **D10.** Sessions carry their own `domain`. Resume seeds the new conv-state from `session.domain` and skips the signal-precedence chain.
+- **D11.** Agents cannot set `is_global` directly. It is server-derived (originally from category; per D18, by the classifier). Owner promotion is via dashboard.
+- **D12.** Dashboard surface for domain management is a flat list of strings. No hierarchies, colours, or per-domain settings in V1.
+- **D13.** Proposal approval is one-click when `domain` is already set; modal-with-picker only when `domain` is `NULL`.
+- **D15.** `visibility` is removed entirely. Privacy is owner-controlled via domains, not agent-self-declared. The `Visibility` enum, the `visibility` column, `include_private` on `recall`, and all related filtering logic are deleted.
+- **D16.** *(Superseded by D18.)* Original: `identity` and `relationship` collapse into a single category `profile`. Replaced by: drop `category` entirely; the protection-routing behaviour previously triggered by `identity`/`relationship` is now expressed via `requires_approval`, which is set by the classifier.
+- **D17.** `scope` is removed entirely. The `Scope` enum, the `scope` column on `memories`, the field in `normalizeMemoryInput`, and the `scope` parameter in `listMemories` are deleted. The audit confirmed `scope` is not exposed as a filter on any read-path tool; it was advisory metadata with no consumer. `domain` subsumes its intended purpose.
+- **D18.** `category` is removed entirely. Policy moves to two booleans: `is_global` and `requires_approval`. Semantic labels (`tools`, `lessons`, `people`, ...) move to the existing `tags[]` array. Migration converts each former category value into a tag and derives the booleans from the old category at the cutover point; thereafter the classifier is the source of truth for new writes.
+- **D19.** A write-path classifier (small local LLM, sync, ≤500ms timeout) sets `is_global` and `requires_approval` on every new memory. Owner overrides via the dashboard are the ground truth; classifier verdicts are preserved alongside for evaluation.
+- **D20.** Classifier failure mode is **conservative**: `requires_approval = true`, `is_global = false`. Rationale: a non-sensitive fact briefly stuck in the proposal queue is a recoverable nuisance; an unreviewed sensitive fact going active is a leak. Failures are loud (logged + surfaced in dashboard).
+- **D21.** The classifier runs as a local-model service (`@librarian/classifier`), not as a call to an external API. Local wins on latency, cost, and self-containment. Specific model choice deferred to a follow-up sub-spec.
+- **D22.** Outside-session memories (no `conv_state`) force `requires_approval = true` regardless of classifier verdict. The absence of a conv-state is itself a signal that owner review is warranted.
+
+---
+
+## 7. Migration
+
+A one-shot script: `scripts/migrate-add-domain-and-conv-state.mjs`.
+
+Following the precedent of `scripts/replay-verify-outcomes.mjs` (from the memory-simplification rollout), the script is idempotent and works against the canonical instance.
+
+### 7.1 Schema changes (end-state)
+
+The end-state schema after PR 7. Additions land in PR 1; drops land in PR 7. See §7.3 for the per-PR breakdown.
+
+- `memories` table:
+  - **Add (PR 1)** `domain TEXT NOT NULL DEFAULT 'general'`
+  - **Add (PR 1)** `is_global INTEGER NOT NULL DEFAULT 0`
+  - **Add (PR 1)** `requires_approval INTEGER NOT NULL DEFAULT 0`
+  - **Drop (PR 7)** `category` column
+  - **Drop (PR 7)** `visibility` column
+  - **Drop (PR 7)** `scope` column
+- `sessions` table — **add (PR 1)** `domain TEXT NOT NULL DEFAULT 'general'`.
+- New `conversation_state` table (see §4.8).
+- New `domains` table:
+  ```sql
+  CREATE TABLE domains (
+    name TEXT PRIMARY KEY,
+    created_at TEXT NOT NULL
+  );
+  -- seeded with one row: ('general', <now>)
+  ```
+- New `signal_rules` table:
+  ```sql
+  CREATE TABLE signal_rules (
+    id TEXT PRIMARY KEY,
+    harness TEXT NOT NULL,
+    pattern TEXT NOT NULL,
+    domain TEXT NOT NULL,
+    priority INTEGER NOT NULL DEFAULT 0
+  );
+  ```
+- New `token_domain_bindings` table:
+  ```sql
+  CREATE TABLE token_domain_bindings (
+    token_id TEXT PRIMARY KEY,
+    domain TEXT NOT NULL
+  );
+  ```
+
+### 7.2 Historical JSONL cleanup
+
+The script reads `events.jsonl` and `sessions.jsonl` and produces a normalised projection without rewriting the ledger (ledger remains byte-compatible — old events parse unchanged).
+
+For each `memory.created` event in `events.jsonl`:
+
+1. **Convert category to tag.** Append the original category value to the memory's `tags[]` (deduped). For `identity` and `relationship`, append the tag `profile` (collapsing the two into one tag to match the spec's previous intermediate state).
+2. **Derive `requires_approval`** from the original category:
+   - `identity | relationship` → `requires_approval = 1`
+   - else → `requires_approval = 0`
+   This preserves the protected-routing behaviour for already-existing memories. The classifier is only authoritative for *new* writes post-cutover; historical memories keep the routing they were created under.
+3. **Derive `is_global`** from the original category:
+   - `identity | relationship | preferences` → `is_global = 1`
+   - else → `is_global = 0`
+4. **Assign `domain`:**
+   - **If the memory's original `visibility` was `agent_private`:** assign `domain = 'legacy-private'`. The migration creates this domain automatically and adds it to the `domains` table. Rationale: agent-private memories were created with an expectation of restricted visibility; silently merging them into `general` would surface formerly-private content unexpectedly. The owner can review the `legacy-private` domain post-migration and re-route, archive, or rename as they prefer.
+   - **Otherwise:** assign `domain = 'general'`.
+5. **Drop the `category`, `visibility`, and `scope` fields** from the projection row. The columns no longer exist in the new schema. The ledger events remain unchanged — the projection handler ignores those fields when replaying old events.
+
+The classifier is **not** retroactively run on historical memories during migration. Doing so would risk reclassifying long-stable memories under a model whose calibration has not yet been validated. A separate, opt-in "reclassify-all" admin tool can be added later if the owner wants the classifier's verdict applied retrospectively.
+
+For each `session.started` event in `sessions.jsonl`:
+
+1. Assign `domain = 'general'`. (Sessions never had a `visibility` field, so there is nothing to migrate.)
+
+The script:
+
+- Is idempotent. Running twice produces the same projection. Re-running after manual domain assignment by the owner does not overwrite owner-set values (uses `INSERT OR IGNORE` semantics).
+- Logs counts: memories backfilled, sessions backfilled, conv-state entries created (zero — conv-state starts empty).
+- Does not write any new events to `events.jsonl`. The projection is the source of the new shape; the ledger remains the historical source of truth for everything prior.
+
+### 7.3 Rollout order
+
+The classifier is load-bearing for the category drop, so it must ship and be validated *before* the cutover that removes `category`. The intermediate state keeps `category` alongside the two new booleans, with the booleans derived from category until the classifier takes over.
+
+1. **PR 1 — Additive schema.** Add `domain`, `is_global`, `requires_approval` columns (with defaults); add `conversation_state`, `domains`, `signal_rules`, `token_domain_bindings` tables; add `domain` to `sessions`. Keep `category`, `visibility`, `scope` columns in place for now. Existing reads/writes continue to work. Booleans are derived from category (legacy logic). Releasable.
+2. **PR 2 — `conv_state` registry + MCP tools + hook helpers.** Server-side machinery for §4.8 and §4.9. No harness integrations consume it yet. Releasable.
+3. **PR 3 — Domain enforcement in `recall` and `remember`.** Server reads `conv_state.domain` when present; falls back to `general` when not. Single-domain installs experience no change. Releasable.
+4. **PR 4 — Dashboard surface.** Domain list page, signal rules page, proposal modal, memory detail panel additions (including `is_global` / `requires_approval` toggles). Releasable.
+5. **PR 5 — Harness integrations.** Claude Code hook, Hermes hook, CLI wrapper updates. Each integration is its own PR in its own repo. Releasable.
+6. **PR 6 — Classifier in shadow mode.** Ship `@librarian/classifier`. On every `remember`, the classifier runs and its verdict is logged to `events.jsonl` as `memory.classified`, but the persisted booleans continue to be derived from category. Dashboard surfaces classifier-vs-derived disagreements. Owner reviews quality. Releasable; nothing user-visible changes.
+7. **PR 7 — Classifier cutover.** Once quality is validated against owner expectations, flip the source of truth: the classifier's verdict is now persisted; the category-derived fallback is removed. The migration script (from PR 1) is re-run to convert `category` values into tags and remove the column. `category`, `visibility`, and `scope` columns are dropped. Releasable.
+8. **PR 8 — Documentation.** Update integration docs, `/lib-session-*` command help, agent-facing CLAUDE.md / SOUL.md guidance, classifier prompt documentation.
+
+---
+
+## 8. Success criteria
+
+Concrete, testable conditions for "done":
+
+- [ ] Out-of-box install (one domain, no signal rules, no token bindings) prompts the user for **nothing** at session start; all memories save and recall with `domain=general`; behaviour is indistinguishable from pre-spec behaviour from the user's perspective.
+- [ ] An owner who adds a second domain via the dashboard sees the session-start prompt fire on the next new conversation. Choosing a domain causes subsequent `remember` writes to be tagged with it.
+- [ ] An owner with rules `cwd ~/code/* → coding` and `channel-id 12345 → family` sees the correct pre-selection in each context.
+- [ ] A `coding` session's `recall` returns coding-domain memories and global memories; does not return `family-admin`-domain memories. Setting `include_other_domains: true` returns all.
+- [ ] Cross-harness resume of a `coding` session into a Hermes conversation establishes `conv_state.domain = coding` for the new conv-id without prompting.
+- [ ] A long Claude Code conversation that triggers context compaction continues to operate with the correct `domain` and `session_id` after compaction — verified by inspecting the system-reminder injected on the next turn.
+- [ ] A curator-produced proposal whose source memories all have `domain=coding` arrives in the proposal queue with `domain=coding` pre-set, approvable in one click.
+- [ ] A curator-produced proposal whose source memories span domains arrives with `domain=NULL` and cannot be approved without an explicit pick.
+- [ ] An agent attempting to set `is_global`, `requires_approval`, `visibility`, `category`, or `scope` in a `remember` call has all those fields ignored. The MCP tool input schema for `remember` no longer advertises any of them.
+- [ ] The classifier returns `{is_global, requires_approval}` for every `remember` call within the 500ms timeout in normal operation. A `memory.classified` event is appended to `events.jsonl` capturing input, raw output, parsed booleans, latency, and fallback flag.
+- [ ] When the classifier service is forcibly stopped, the next `remember` call completes within ≤500ms (the timeout) and persists with `requires_approval=true, is_global=false`. The fallback is logged and visible in the dashboard.
+- [ ] An owner toggling `is_global` or `requires_approval` on a memory via the dashboard records a `memory.classification_overridden` event preserving the classifier's original verdict.
+- [ ] Existing memories that were category `identity` or `relationship` arrive post-migration with `requires_approval=1, is_global=1`, the former category name appended to `tags[]`, and no `category` column on the row.
+- [ ] Existing `agent_private` memories appear in a domain called `legacy-private` after migration; the owner sees one prompt to review them on first dashboard load post-migration.
+- [ ] After PR 7 cutover, the `memories` table has no `category`, `visibility`, or `scope` columns. Reading an old `memory.created` event from `events.jsonl` does not crash the projection.
+- [ ] Migration script run twice produces identical results.
+
+---
+
+## 9. Open questions
+
+**Deferred to follow-up specs (referenced from this one):**
+
+- **Classifier implementation details.** Specific model choice (Phi-3 Mini vs Gemma 2B vs distilled in-house), serving infrastructure (in-process vs sidecar vs separate service), prompt versioning workflow, eval harness specification, retraining/fine-tuning cadence. A `classifier-implementation-spec.md` follow-up should land before PR 6.
+
+**Deferred to future iterations:**
+
+- **Retroactive reclassification.** An admin tool to run the classifier over historical memories and surface disagreements with the migrated derived values. Useful once classifier quality is well-understood. Out of scope for V1.
+- **Tag-based classifier assistance.** The classifier could also propose `tags[]` to reduce agent-driven tag inconsistency, in the same spirit as the booleans. Out of scope for V1 — agents continue to set their own tags.
+- **Mid-conversation domain switching.** D7 forbids it for V1. Real usage may surface a need; revisit if so.
+- **Domain hierarchies / metadata.** D12 keeps the dashboard surface flat for V1. Add structure if usage justifies it.
+- **`agent_id` ownership enforcement on update.** Surfaced in the audit — any caller holding a memory id can patch its `agent_id`. Out of scope for this spec but should be addressed separately.
+- **Per-domain capability gates.** Domains scope memory only, not tool access. If we ever want "the family-admin domain cannot call `archive_memory`", that's a separate RBAC spec.

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -60,6 +60,32 @@ export interface NormalizedMemoryInput {
   confidence: Confidence;
   tags: string[];
   status: MemoryStatus;
+  // memory-domain-isolation PR 1 / T1.2 + T1.3. `domain` defaults to
+  // 'general' until PR 3 wires conv_state-driven assignment. The two
+  // booleans are derived from `category` here as a legacy bridge — PR 6
+  // (classifier shadow mode) starts logging an alternate verdict, and
+  // PR 7 (cutover) replaces this derivation with the classifier output.
+  domain: string;
+  is_global: boolean;
+  requires_approval: boolean;
+}
+
+// Derive the two write-path policy booleans from the legacy category enum.
+// Lives next to `PROTECTED_CATEGORIES` so the relationship is obvious:
+// `requires_approval` is a superset of the existing protected-routing
+// behaviour, expressed as a column rather than a hard-coded set.
+//
+// Rules (spec §7.2 — legacy bridge):
+//   identity, relationship                            → requires_approval=1
+//   identity, relationship, preferences               → is_global=1
+//   everything else                                   → both 0
+export function deriveLegacyMemoryFlags(category: Category): {
+  is_global: boolean;
+  requires_approval: boolean;
+} {
+  const isProtected = category === Category.Identity || category === Category.Relationship;
+  const isGlobal = isProtected || category === Category.Preferences;
+  return { is_global: isGlobal, requires_approval: isProtected };
 }
 
 export function normalizeMemoryInput(input: Record<string, unknown> = {}): NormalizedMemoryInput {
@@ -70,6 +96,7 @@ export function normalizeMemoryInput(input: Record<string, unknown> = {}): Norma
     Object.values(Scope),
     category === Category.Projects ? Scope.Project : Scope.Global,
   );
+  const flags = deriveLegacyMemoryFlags(category);
 
   return {
     title: normalizeString(input.title || input.content || "Untitled memory"),
@@ -84,6 +111,13 @@ export function normalizeMemoryInput(input: Record<string, unknown> = {}): Norma
     confidence: normalizeEnum(input.confidence, Object.values(Confidence), Confidence.Working),
     tags: asArray(input.tags),
     status: normalizeEnum(input.status, Object.values(MemoryStatus), MemoryStatus.Active),
+    // PR 1: domain is always 'general' on write. PR 3 (T3.1) reads
+    // conv_state and sets it server-side from the conversation's domain;
+    // out-of-session writes will route to the proposal queue with
+    // domain=NULL per §4.14.
+    domain: "general",
+    is_global: flags.is_global,
+    requires_approval: flags.requires_approval,
   };
 }
 

--- a/packages/core/src/schemas/memory.ts
+++ b/packages/core/src/schemas/memory.ts
@@ -53,6 +53,14 @@ export const MemorySchema = z.object({
   // Curator provenance + superseded reference (memory-curator spec §8). Set by
   // the curator's apply layer; null for agent/user-authored memories.
   curator_note: CuratorNoteSchema.nullable().optional(),
+  // memory-domain-isolation PR 1 / T1.2 — owner-controlled isolation
+  // axis. Defaults to 'general' on the row; the classifier-cutover PR
+  // will replace the legacy category/visibility/scope columns. Optional
+  // on `MemorySchema` while PR 1 keeps the agent/store paths unaware of
+  // the new fields; subsequent PRs tighten this.
+  domain: z.string().optional(),
+  is_global: z.boolean().optional(),
+  requires_approval: z.boolean().optional(),
 });
 export type Memory = z.infer<typeof MemorySchema>;
 

--- a/packages/core/src/schemas/session.ts
+++ b/packages/core/src/schemas/session.ts
@@ -47,6 +47,11 @@ export const SessionSchema = z.object({
   archived_at: IsoTimestampSchema.nullable(),
   deleted_at: IsoTimestampSchema.nullable(),
   metadata: z.record(z.string(), z.unknown()),
+  // memory-domain-isolation PR 1 / T1.2 — sessions inherit a domain
+  // from the conv_state at `start_session` time. Defaults to 'general'.
+  // Optional on the schema while PR 1 keeps start_session unaware of
+  // the new field; PR 3 (T3.3) sets it from conv_state.
+  domain: z.string().optional(),
 });
 export type Session = z.infer<typeof SessionSchema>;
 

--- a/packages/core/src/store/memory-store.ts
+++ b/packages/core/src/store/memory-store.ts
@@ -50,6 +50,13 @@ export type Memory = Record<string, unknown> & {
   project_key?: string | null;
   updated_at: string;
   curator_note?: Record<string, unknown> | null;
+  // memory-domain-isolation PR 1 — owner-controlled isolation axis +
+  // legacy-bridge booleans. Always populated post-T1.3 (defaults +
+  // category-derived); the classifier cutover (PR 7) replaces the
+  // derivation with the local model's verdict.
+  domain: string;
+  is_global: boolean;
+  requires_approval: boolean;
 };
 
 export interface AppendMemoryEventOptions {
@@ -786,6 +793,11 @@ function rowToMemory(row: Record<string, unknown>): Memory {
     curator_note: row.curator_note
       ? safeJsonParseObject(row.curator_note as string, row.id, "curator_note")
       : null,
+    // SQLite stores booleans as INTEGER 0/1; surface them as native
+    // booleans on the agent-visible memory object.
+    domain: (row.domain as string) || "general",
+    is_global: Boolean(row.is_global),
+    requires_approval: Boolean(row.requires_approval),
   } as Memory;
 }
 

--- a/packages/core/src/store/projection.ts
+++ b/packages/core/src/store/projection.ts
@@ -19,12 +19,15 @@
 import fs from "node:fs";
 import type { DatabaseSync } from "node:sqlite";
 import { actorKind } from "../caller-identity.js";
+import { deriveLegacyMemoryFlags } from "../constants.js";
 import {
+  Category,
   MemoryEventType,
   MemoryStatus,
   SessionEventType,
   SessionStatus,
   VerifyResult,
+  Visibility,
 } from "../schemas/common.js";
 import { appendJsonl, readJsonl } from "./jsonl.js";
 
@@ -437,6 +440,36 @@ export function ensureAuthoritativeTableColumns(db: DatabaseSync): void {
 // follow-up after T3.3 has settled the canonical shape.
 type MemoryRecord = Record<string, unknown> & { id: string };
 
+/**
+ * Derive the three new domain-isolation columns (`domain`, `is_global`,
+ * `requires_approval`) for a single reduced memory record before it
+ * lands in the projection.
+ *
+ * Pre-T1.3 events have none of these on their snapshot; post-T1.3 events
+ * have all three. The fallback path keeps the rebuild from any-era JSONL
+ * coherent with the spec — `agent_private` rows go to the synthetic
+ * `legacy-private` domain, and the booleans come from the category-based
+ * derivation that PR 1's classifier-shadow phase will later supersede.
+ *
+ * Returned as a positional tuple so `insertMemory.run(...)` can spread
+ * it directly into the prepared statement's bind list.
+ */
+function deriveDomainColumns(m: Record<string, unknown>): [string, number, number] {
+  const category = m.category as Category | undefined;
+  const visibility = m.visibility as Visibility | undefined;
+  const derived = category ? deriveLegacyMemoryFlags(category) : undefined;
+  const fallbackDomain = visibility === Visibility.AgentPrivate ? "legacy-private" : "general";
+
+  const domain = (m.domain as string) || fallbackDomain;
+  const isGlobal = m.is_global === undefined ? Boolean(derived?.is_global) : Boolean(m.is_global);
+  const requiresApproval =
+    m.requires_approval === undefined
+      ? Boolean(derived?.requires_approval)
+      : Boolean(m.requires_approval);
+
+  return [domain, isGlobal ? 1 : 0, requiresApproval ? 1 : 0];
+}
+
 interface MemoryLogEvent {
   event_id: string;
   event_type: MemoryEventType;
@@ -678,15 +711,7 @@ export function rebuildMemoryIndex({
         Number(m.recall_count || 0),
         Number(m.usefulness_score || 0),
         m.curator_note ? JSON.stringify(m.curator_note) : null,
-        // memory-domain-isolation PR 1 — `domain` falls back to 'general'
-        // for historical memories that predate the column (the migration
-        // script in T1.4 reassigns agent_private rows to 'legacy-private'
-        // when run). `is_global` / `requires_approval` come straight off
-        // the snapshot post-T1.3; pre-T1.3 events land as 0/0 which is
-        // also the schema default.
-        (m.domain as string) || "general",
-        m.is_global ? 1 : 0,
-        m.requires_approval ? 1 : 0,
+        ...deriveDomainColumns(m),
       );
       insertFts.run(
         m.id as string,

--- a/packages/core/src/store/projection.ts
+++ b/packages/core/src/store/projection.ts
@@ -86,7 +86,16 @@ function asArray(value: unknown): string[] {
 //         ORDER BY still uses a tiny temp sort over the filtered rows).
 //         Index-only change; the bump recreates them on next boot (both
 //         indexed tables are dropped+rebuilt on a bump anyway).
-export const PROJECTION_SCHEMA_VERSION = 11;
+//   - 12: memory-domain-isolation PR 1 / T1.1 — adds the four owner-
+//         controlled tables for the new domain model: `conversation_state`
+//         (per-conversation runtime state surviving compaction),
+//         `domains` (flat owner-managed list, seeded with `general`),
+//         `signal_rules` (harness-pattern → domain), and
+//         `token_domain_bindings` (token → default domain). All four are
+//         SQLite-authoritative — no JSONL ledger backs them — so they
+//         are explicitly preserved across future bumps alongside
+//         `sessions` and `settings`.
+export const PROJECTION_SCHEMA_VERSION = 12;
 
 export function getSchemaVersion(db: DatabaseSync): number {
   const row = db.prepare("PRAGMA user_version").get() as { user_version: number };
@@ -101,8 +110,11 @@ function dropProjectionTables(db: DatabaseSync): void {
   // R3 — `sessions` and `session_state_changes` are SQLite-authoritative
   // and must survive schema-version bumps. The `memory_curation_*` tables
   // (memory-curator §8) and `settings` (§7.1 admin secret-store) are likewise
-  // authoritative and intentionally absent here. Future DDL changes to those
-  // tables should use ALTER TABLE rather
+  // authoritative and intentionally absent here. T1.1 adds four more
+  // SQLite-authoritative tables (`conversation_state`, `domains`,
+  // `signal_rules`, `token_domain_bindings`) which must also survive
+  // bumps — they're intentionally absent from this drop list. Future DDL
+  // changes to authoritative tables should use ALTER TABLE rather
   // than the drop-and-rebuild pattern below. The other tables are projections
   // (memory side stays JSONL-canonical; session_events is rebuilt from
   // session_events.jsonl on every bump).
@@ -156,6 +168,7 @@ export function ensureSchema(db: DatabaseSync, paths: EnsureSchemaPaths): boolea
   const onDisk = getSchemaVersion(db);
   if (onDisk >= PROJECTION_SCHEMA_VERSION) {
     initSchema(db);
+    seedDomains(db);
     return false;
   }
   // R3 — sessions table is SQLite-authoritative for instances at v5+.
@@ -168,6 +181,7 @@ export function ensureSchema(db: DatabaseSync, paths: EnsureSchemaPaths): boolea
     dropProjectionTables(db);
   }
   initSchema(db);
+  seedDomains(db);
   rebuildMemoryIndex({
     db,
     eventsPath: paths.eventsPath,
@@ -335,10 +349,48 @@ export const SCHEMA_DDL = `
       is_secret INTEGER NOT NULL DEFAULT 0,
       updated_at TEXT NOT NULL
     );
+    CREATE TABLE IF NOT EXISTS conversation_state (
+      conv_id TEXT PRIMARY KEY,
+      harness TEXT NOT NULL,
+      domain TEXT NOT NULL,
+      session_id TEXT,
+      off_record INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS domains (
+      name TEXT PRIMARY KEY,
+      created_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS signal_rules (
+      id TEXT PRIMARY KEY,
+      harness TEXT NOT NULL,
+      pattern TEXT NOT NULL,
+      domain TEXT NOT NULL,
+      priority INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE TABLE IF NOT EXISTS token_domain_bindings (
+      token_id TEXT PRIMARY KEY,
+      domain TEXT NOT NULL
+    );
   `;
 
 export function initSchema(db: DatabaseSync): void {
   db.exec(SCHEMA_DDL);
+}
+
+/**
+ * Seed the floor of the owner-managed domain list with `general`. The
+ * domain model treats single-domain installs as zero-friction (the
+ * session-start prompt collapses to a no-op), so every install needs
+ * at least this one row present. Uses `INSERT OR IGNORE` so subsequent
+ * boots are idempotent — owner-added domains are untouched.
+ */
+export function seedDomains(db: DatabaseSync): void {
+  db.prepare("INSERT OR IGNORE INTO domains (name, created_at) VALUES (?, ?)").run(
+    "general",
+    new Date().toISOString(),
+  );
 }
 
 // ---------- Memory side ----------

--- a/packages/core/src/store/projection.ts
+++ b/packages/core/src/store/projection.ts
@@ -642,8 +642,8 @@ export function rebuildMemoryIndex({
         id, title, body, category, visibility, agent_id, actor_kind, scope, project_key,
         status, priority, confidence, tags_json, applies_to_json, supersedes_json,
         conflicts_with_json, created_at, updated_at, last_recalled_at, recall_count,
-        usefulness_score, curator_note
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        usefulness_score, curator_note, domain, is_global, requires_approval
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
     const insertFts = db.prepare(
       "INSERT INTO memories_fts (id, title, body, category, tags) VALUES (?, ?, ?, ?, ?)",
@@ -678,6 +678,15 @@ export function rebuildMemoryIndex({
         Number(m.recall_count || 0),
         Number(m.usefulness_score || 0),
         m.curator_note ? JSON.stringify(m.curator_note) : null,
+        // memory-domain-isolation PR 1 — `domain` falls back to 'general'
+        // for historical memories that predate the column (the migration
+        // script in T1.4 reassigns agent_private rows to 'legacy-private'
+        // when run). `is_global` / `requires_approval` come straight off
+        // the snapshot post-T1.3; pre-T1.3 events land as 0/0 which is
+        // also the schema default.
+        (m.domain as string) || "general",
+        m.is_global ? 1 : 0,
+        m.requires_approval ? 1 : 0,
       );
       insertFts.run(
         m.id as string,

--- a/packages/core/src/store/projection.ts
+++ b/packages/core/src/store/projection.ts
@@ -95,7 +95,14 @@ function asArray(value: unknown): string[] {
 //         SQLite-authoritative — no JSONL ledger backs them — so they
 //         are explicitly preserved across future bumps alongside
 //         `sessions` and `settings`.
-export const PROJECTION_SCHEMA_VERSION = 12;
+//   - 13: memory-domain-isolation PR 1 / T1.2 — adds `domain`,
+//         `is_global`, `requires_approval` to `memories` and `domain` to
+//         `sessions`. The memories columns ride the standard drop-and-
+//         rebuild path (JSONL is canonical; defaults apply during
+//         re-insertion). The sessions column is added via ALTER TABLE in
+//         `ensureAuthoritativeTableColumns` because the sessions table
+//         is SQLite-authoritative post-R1 and must not be dropped.
+export const PROJECTION_SCHEMA_VERSION = 13;
 
 export function getSchemaVersion(db: DatabaseSync): number {
   const row = db.prepare("PRAGMA user_version").get() as { user_version: number };
@@ -168,6 +175,7 @@ export function ensureSchema(db: DatabaseSync, paths: EnsureSchemaPaths): boolea
   const onDisk = getSchemaVersion(db);
   if (onDisk >= PROJECTION_SCHEMA_VERSION) {
     initSchema(db);
+    ensureAuthoritativeTableColumns(db);
     seedDomains(db);
     return false;
   }
@@ -181,6 +189,7 @@ export function ensureSchema(db: DatabaseSync, paths: EnsureSchemaPaths): boolea
     dropProjectionTables(db);
   }
   initSchema(db);
+  ensureAuthoritativeTableColumns(db);
   seedDomains(db);
   rebuildMemoryIndex({
     db,
@@ -223,7 +232,10 @@ export const SCHEMA_DDL = `
       last_recalled_at TEXT,
       recall_count INTEGER NOT NULL,
       usefulness_score INTEGER NOT NULL,
-      curator_note TEXT
+      curator_note TEXT,
+      domain TEXT NOT NULL DEFAULT 'general',
+      is_global INTEGER NOT NULL DEFAULT 0,
+      requires_approval INTEGER NOT NULL DEFAULT 0
     );
     CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
       id UNINDEXED,
@@ -270,7 +282,8 @@ export const SCHEMA_DDL = `
       archived_at TEXT,
       deleted_at TEXT,
       metadata_json TEXT NOT NULL,
-      state_version INTEGER NOT NULL DEFAULT 0
+      state_version INTEGER NOT NULL DEFAULT 0,
+      domain TEXT NOT NULL DEFAULT 'general'
     );
     CREATE TABLE IF NOT EXISTS session_state_changes (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -391,6 +404,29 @@ export function seedDomains(db: DatabaseSync): void {
     "general",
     new Date().toISOString(),
   );
+}
+
+function hasColumn(db: DatabaseSync, table: string, column: string): boolean {
+  const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+  return rows.some((r) => r.name === column);
+}
+
+/**
+ * Add columns to SQLite-authoritative tables that CREATE TABLE IF NOT
+ * EXISTS can't introduce on existing instances. The `sessions` table is
+ * preserved across schema bumps (post-R1), so additive columns on it
+ * have to land via ALTER TABLE.
+ *
+ * Idempotent: each ALTER is guarded by a PRAGMA table_info() probe, so
+ * fresh databases (where the columns came in via SCHEMA_DDL) are
+ * untouched.
+ */
+export function ensureAuthoritativeTableColumns(db: DatabaseSync): void {
+  // T1.2 — `sessions.domain` defaults to 'general' so existing rows
+  // pick up the no-op single-domain value without any per-row backfill.
+  if (!hasColumn(db, "sessions", "domain")) {
+    db.exec(`ALTER TABLE sessions ADD COLUMN domain TEXT NOT NULL DEFAULT 'general'`);
+  }
 }
 
 // ---------- Memory side ----------

--- a/packages/core/tests/store/memory-store.test.ts
+++ b/packages/core/tests/store/memory-store.test.ts
@@ -424,4 +424,95 @@ describe("LibrarianStore memory CRUD", () => {
       }
     });
   });
+
+  describe("legacy category → is_global / requires_approval derivation (T1.3)", () => {
+    it("identity memories derive requires_approval=1, is_global=1 and route to proposed", () => {
+      const { store } = scope!;
+      const { memory, status } = store.createMemory({
+        agent_id: "codex",
+        title: "Owner identity",
+        body: "Jim is the owner.",
+        category: "identity",
+        visibility: "common",
+        scope: "global",
+      });
+      expect(status).toBe("proposed");
+      const row = store.db
+        .prepare("SELECT is_global, requires_approval FROM memories WHERE id = ?")
+        .get(memory.id) as { is_global: number; requires_approval: number };
+      expect(row.is_global).toBe(1);
+      expect(row.requires_approval).toBe(1);
+    });
+
+    it("relationship memories derive requires_approval=1, is_global=1", () => {
+      const { store } = scope!;
+      const { memory } = store.createMemory({
+        agent_id: "codex",
+        title: "Working relationship",
+        body: "Jim collaborates with Claude as a senior peer.",
+        category: "relationship",
+        visibility: "common",
+        scope: "global",
+      });
+      const row = store.db
+        .prepare("SELECT is_global, requires_approval FROM memories WHERE id = ?")
+        .get(memory.id) as { is_global: number; requires_approval: number };
+      expect(row.is_global).toBe(1);
+      expect(row.requires_approval).toBe(1);
+    });
+
+    it("preferences memories derive is_global=1 but requires_approval=0", () => {
+      const { store } = scope!;
+      const { memory, status } = store.createMemory({
+        agent_id: "codex",
+        title: "Coding preference",
+        body: "Prefers terse responses.",
+        category: "preferences",
+        visibility: "common",
+        scope: "global",
+      });
+      expect(status).toBe("active");
+      const row = store.db
+        .prepare("SELECT is_global, requires_approval FROM memories WHERE id = ?")
+        .get(memory.id) as { is_global: number; requires_approval: number };
+      expect(row.is_global).toBe(1);
+      expect(row.requires_approval).toBe(0);
+    });
+
+    it("non-protected non-global categories derive both booleans as 0", () => {
+      const { store } = scope!;
+      for (const category of ["tools", "lessons", "projects", "environment", "people"] as const) {
+        const { memory } = store.createMemory({
+          agent_id: "codex",
+          title: `Note about ${category}`,
+          body: `A ${category} memory.`,
+          category,
+          visibility: "common",
+          scope: "global",
+        });
+        const row = store.db
+          .prepare("SELECT is_global, requires_approval FROM memories WHERE id = ?")
+          .get(memory.id) as { is_global: number; requires_approval: number };
+        expect(row.is_global, `is_global for category=${category}`).toBe(0);
+        expect(row.requires_approval, `requires_approval for category=${category}`).toBe(0);
+      }
+    });
+
+    it("rowToMemory surfaces is_global / requires_approval as booleans on the read path", () => {
+      const { store } = scope!;
+      const { memory } = store.createMemory({
+        agent_id: "codex",
+        title: "Identity for readback",
+        body: "Boolean roundtrip.",
+        category: "identity",
+        visibility: "common",
+        scope: "global",
+      });
+      const fetched = store.getMemory(memory.id);
+      expect(fetched).toBeTruthy();
+      expect(fetched.is_global).toBe(true);
+      expect(fetched.requires_approval).toBe(true);
+      expect(fetched.domain).toBe("general");
+    });
+  });
 });

--- a/packages/core/tests/store/projection.test.ts
+++ b/packages/core/tests/store/projection.test.ts
@@ -294,3 +294,132 @@ describe("Schema-version sentinel (T3.6)", () => {
     }
   });
 });
+
+describe("Memory domain isolation tables (T1.1)", () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-domain-tables-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  function tableExists(store: ReturnType<typeof createLibrarianStore>, name: string): boolean {
+    const row = store.db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+      .get(name);
+    return Boolean(row);
+  }
+
+  it("creates the conversation_state, domains, signal_rules, and token_domain_bindings tables on first open", () => {
+    const store = createLibrarianStore({ dataDir });
+    try {
+      expect(tableExists(store, "conversation_state")).toBe(true);
+      expect(tableExists(store, "domains")).toBe(true);
+      expect(tableExists(store, "signal_rules")).toBe(true);
+      expect(tableExists(store, "token_domain_bindings")).toBe(true);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("seeds a single 'general' domain on first open", () => {
+    const store = createLibrarianStore({ dataDir });
+    try {
+      const rows = store.db.prepare("SELECT name FROM domains ORDER BY name").all() as Array<{
+        name: string;
+      }>;
+      expect(rows.map((r) => r.name)).toEqual(["general"]);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("is idempotent across reopens (no duplicate 'general' seed, no errors)", () => {
+    for (let i = 0; i < 3; i++) {
+      const store = createLibrarianStore({ dataDir });
+      try {
+        const count = (
+          store.db.prepare("SELECT COUNT(*) AS n FROM domains WHERE name = 'general'").get() as {
+            n: number;
+          }
+        ).n;
+        expect(count).toBe(1);
+      } finally {
+        store.close();
+      }
+    }
+  });
+
+  it("preserves owner-curated domains, signal_rules, and token_domain_bindings across schema-version bumps", () => {
+    // The four new tables are SQLite-authoritative (no JSONL ledger
+    // source-of-truth), so they must survive the drop-and-rebuild path
+    // that fires when the on-disk user_version is below PROJECTION_SCHEMA_VERSION.
+    {
+      const store = createLibrarianStore({ dataDir });
+      try {
+        store.db
+          .prepare("INSERT INTO domains (name, created_at) VALUES (?, ?)")
+          .run("coding", "2026-05-27T00:00:00.000Z");
+        store.db
+          .prepare(
+            "INSERT INTO signal_rules (id, harness, pattern, domain, priority) VALUES (?, ?, ?, ?, ?)",
+          )
+          .run("rule_1", "claude-code", "~/code/*", "coding", 0);
+        store.db
+          .prepare("INSERT INTO token_domain_bindings (token_id, domain) VALUES (?, ?)")
+          .run("tok_test", "coding");
+        store.db
+          .prepare(
+            "INSERT INTO conversation_state (conv_id, harness, domain, session_id, off_record, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+          )
+          .run(
+            "claude:abc",
+            "claude-code",
+            "coding",
+            null,
+            0,
+            "2026-05-27T00:00:00.000Z",
+            "2026-05-27T00:00:00.000Z",
+          );
+        store.db.exec("PRAGMA user_version = 5");
+      } finally {
+        store.close();
+      }
+    }
+
+    {
+      const store = createLibrarianStore({ dataDir });
+      try {
+        expect(
+          (store.db.prepare("SELECT COUNT(*) AS n FROM domains").get() as { n: number }).n,
+        ).toBe(2);
+        expect(
+          (
+            store.db.prepare("SELECT COUNT(*) AS n FROM signal_rules").get() as {
+              n: number;
+            }
+          ).n,
+        ).toBe(1);
+        expect(
+          (
+            store.db.prepare("SELECT COUNT(*) AS n FROM token_domain_bindings").get() as {
+              n: number;
+            }
+          ).n,
+        ).toBe(1);
+        expect(
+          (
+            store.db.prepare("SELECT COUNT(*) AS n FROM conversation_state").get() as {
+              n: number;
+            }
+          ).n,
+        ).toBe(1);
+      } finally {
+        store.close();
+      }
+    }
+  });
+});

--- a/packages/core/tests/store/projection.test.ts
+++ b/packages/core/tests/store/projection.test.ts
@@ -423,3 +423,123 @@ describe("Memory domain isolation tables (T1.1)", () => {
     }
   });
 });
+
+describe("Domain columns on memories + sessions (T1.2)", () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-domain-columns-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  function columnExists(
+    store: ReturnType<typeof createLibrarianStore>,
+    table: string,
+    column: string,
+  ): boolean {
+    const rows = store.db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+    return rows.some((r) => r.name === column);
+  }
+
+  it("creates memories with domain/is_global/requires_approval columns on first open", () => {
+    const store = createLibrarianStore({ dataDir });
+    try {
+      expect(columnExists(store, "memories", "domain")).toBe(true);
+      expect(columnExists(store, "memories", "is_global")).toBe(true);
+      expect(columnExists(store, "memories", "requires_approval")).toBe(true);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("creates sessions with a domain column on first open", () => {
+    const store = createLibrarianStore({ dataDir });
+    try {
+      expect(columnExists(store, "sessions", "domain")).toBe(true);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("defaults a newly created memory to domain='general', is_global=0, requires_approval=0", () => {
+    const store = createLibrarianStore({ dataDir });
+    try {
+      const { memory } = store.createMemory({
+        agent_id: "codex",
+        title: "Default domain test",
+        body: "A memory with no domain inputs.",
+        category: "tools",
+        visibility: "common",
+        scope: "tool",
+      });
+      const row = store.db
+        .prepare("SELECT domain, is_global, requires_approval FROM memories WHERE id = ?")
+        .get(memory.id) as {
+        domain: string;
+        is_global: number;
+        requires_approval: number;
+      };
+      expect(row.domain).toBe("general");
+      expect(row.is_global).toBe(0);
+      expect(row.requires_approval).toBe(0);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("defaults a newly started session to domain='general'", () => {
+    const store = createLibrarianStore({ dataDir });
+    try {
+      const { session } = store.startSession({
+        agent_id: "bede",
+        title: "Default domain session",
+        harness: "claude-code",
+      });
+      const row = store.db.prepare("SELECT domain FROM sessions WHERE id = ?").get(session.id) as {
+        domain: string;
+      };
+      expect(row.domain).toBe("general");
+    } finally {
+      store.close();
+    }
+  });
+
+  it("adds the sessions.domain column to existing post-R1 instances without dropping session rows", () => {
+    // Set up an instance at v11 (post-R1, pre-T1.2) so the sessions table
+    // is authoritative and the schema bump must use ALTER TABLE rather
+    // than drop-and-rebuild.
+    let sessionId: string;
+    {
+      const store = createLibrarianStore({ dataDir });
+      try {
+        sessionId = store.startSession({
+          agent_id: "bede",
+          title: "Pre-bump session",
+          harness: "claude-code",
+        }).session.id;
+        // Drop the new column to simulate the pre-T1.2 shape on a warm
+        // post-R1 install.
+        store.db.exec("ALTER TABLE sessions DROP COLUMN domain");
+        store.db.exec("PRAGMA user_version = 11");
+      } finally {
+        store.close();
+      }
+    }
+
+    const store = createLibrarianStore({ dataDir });
+    try {
+      expect(columnExists(store, "sessions", "domain")).toBe(true);
+      const row = store.db
+        .prepare("SELECT title, domain FROM sessions WHERE id = ?")
+        .get(sessionId) as { title: string; domain: string };
+      expect(row).toBeTruthy();
+      expect(row.title).toBe("Pre-bump session");
+      expect(row.domain).toBe("general");
+    } finally {
+      store.close();
+    }
+  });
+});

--- a/scripts/migrate-add-domain-and-conv-state.mjs
+++ b/scripts/migrate-add-domain-and-conv-state.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+// T1.4 — Backfill script for the memory-domain-isolation rollout.
+//
+// PR 1 lands additive schema columns (`domain`, `is_global`,
+// `requires_approval` on memories; `domain` on sessions) plus four new
+// owner-controlled tables. This script populates the new columns on
+// every historical row in the projection per spec §7.2 of
+// `docs/specs/memory-domain-isolation-and-conv-state.md`:
+//
+//   - identity / relationship                    → requires_approval = 1
+//   - identity / relationship / preferences      → is_global = 1
+//   - everything else                            → both 0
+//   - visibility=agent_private                   → domain='legacy-private'
+//   - everything else                            → domain='general'
+//   - sessions                                   → domain='general'
+//   - tags[] gains the original category value (deduped)
+//   - identity/relationship also gain a 'profile' tag
+//   - if any memory needs 'legacy-private', the script creates that
+//     row in the `domains` table on the fly.
+//
+// Dry-run by default. Use `--apply` to actually write.
+//
+// Usage:
+//   node scripts/migrate-add-domain-and-conv-state.mjs                # dry-run
+//   node scripts/migrate-add-domain-and-conv-state.mjs --data-dir ./data
+//   node scripts/migrate-add-domain-and-conv-state.mjs --apply
+//
+// Idempotent. Writes only to the SQLite projection (`librarian.sqlite`) —
+// the JSONL ledgers (`events.jsonl`, `session_events.jsonl`) are NOT
+// modified. The projection itself derives the same booleans + domain on
+// rebuild (see `deriveDomainColumns` in projection.ts), so re-running
+// this script after a rebuild produces the same final state.
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const args = parseArgs(process.argv.slice(2));
+const dataDir = path.resolve(args.dataDir ?? process.env.LIBRARIAN_DATA_DIR ?? "./data");
+const eventsPath = path.join(dataDir, "events.jsonl");
+const apply = args.apply === true;
+
+if (!fs.existsSync(eventsPath)) {
+  console.error(`[migrate-add-domain-and-conv-state] FAIL: ${eventsPath} not found.`);
+  process.exit(1);
+}
+
+const { createLibrarianStore } = await import("@librarian/core");
+
+const PROTECTED = new Set(["identity", "relationship"]);
+const GLOBAL = new Set(["identity", "relationship", "preferences"]);
+
+const store = createLibrarianStore({ dataDir });
+
+let memoriesBackfilled = 0;
+let sessionsBackfilled = 0;
+let legacyPrivateMemories = 0;
+
+try {
+  const memoryRows = store.db
+    .prepare(
+      "SELECT id, category, visibility, tags_json, domain, is_global, requires_approval FROM memories",
+    )
+    .all();
+
+  for (const row of memoryRows) {
+    const targetIsGlobal = GLOBAL.has(row.category) ? 1 : 0;
+    const targetRequiresApproval = PROTECTED.has(row.category) ? 1 : 0;
+    const targetDomain = row.visibility === "agent_private" ? "legacy-private" : "general";
+
+    let tags = parseTags(row.tags_json);
+    tags = dedupeAppend(tags, row.category);
+    if (PROTECTED.has(row.category)) tags = dedupeAppend(tags, "profile");
+    const targetTagsJson = JSON.stringify(tags);
+
+    const drift =
+      row.is_global !== targetIsGlobal ||
+      row.requires_approval !== targetRequiresApproval ||
+      row.domain !== targetDomain ||
+      row.tags_json !== targetTagsJson;
+
+    if (drift) memoriesBackfilled++;
+    if (targetDomain === "legacy-private") legacyPrivateMemories++;
+  }
+
+  // Session rows just normalise their domain to 'general' — this is
+  // currently a no-op against the schema default but keeps the script
+  // honest as the source of truth for the migration.
+  const sessionRows = store.db
+    .prepare("SELECT id, domain FROM sessions WHERE domain != 'general'")
+    .all();
+  sessionsBackfilled = sessionRows.length;
+
+  const verb = apply ? "APPLY" : "DRY-RUN";
+  console.log(
+    `[migrate-add-domain-and-conv-state] ${verb}: memories backfilled: ${memoriesBackfilled}, ` +
+      `sessions backfilled: ${sessionsBackfilled}, legacy-private memories: ${legacyPrivateMemories}`,
+  );
+
+  if (!apply) {
+    if (memoriesBackfilled || sessionsBackfilled) {
+      console.log(
+        "[migrate-add-domain-and-conv-state] Re-run with --apply to update the projection.",
+      );
+    }
+    process.exit(0);
+  }
+
+  // Apply phase — wrap in a single transaction so a partial failure
+  // leaves the projection untouched.
+  const tx = store.db.prepare("BEGIN");
+  const commit = store.db.prepare("COMMIT");
+  const rollback = store.db.prepare("ROLLBACK");
+  tx.run();
+  try {
+    if (legacyPrivateMemories > 0) {
+      store.db
+        .prepare("INSERT OR IGNORE INTO domains (name, created_at) VALUES (?, ?)")
+        .run("legacy-private", new Date().toISOString());
+    }
+
+    const updateMemory = store.db.prepare(
+      "UPDATE memories SET domain = ?, is_global = ?, requires_approval = ?, tags_json = ? WHERE id = ?",
+    );
+    for (const row of memoryRows) {
+      const targetIsGlobal = GLOBAL.has(row.category) ? 1 : 0;
+      const targetRequiresApproval = PROTECTED.has(row.category) ? 1 : 0;
+      const targetDomain = row.visibility === "agent_private" ? "legacy-private" : "general";
+
+      let tags = parseTags(row.tags_json);
+      tags = dedupeAppend(tags, row.category);
+      if (PROTECTED.has(row.category)) tags = dedupeAppend(tags, "profile");
+      const targetTagsJson = JSON.stringify(tags);
+
+      updateMemory.run(
+        targetDomain,
+        targetIsGlobal,
+        targetRequiresApproval,
+        targetTagsJson,
+        row.id,
+      );
+    }
+
+    store.db.prepare("UPDATE sessions SET domain = 'general' WHERE domain != 'general'").run();
+
+    commit.run();
+  } catch (error) {
+    rollback.run();
+    throw error;
+  }
+
+  console.log(
+    "[migrate-add-domain-and-conv-state] APPLY done. The classifier cutover (PR 7) will replace " +
+      "this category-derived bridge with the local-model verdict.",
+  );
+} finally {
+  store.close();
+}
+
+// ---------- helpers ----------
+
+function parseArgs(argv) {
+  const out = { apply: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--apply") out.apply = true;
+    else if (a === "--data-dir") out.dataDir = argv[++i];
+    else if (a.startsWith("--data-dir=")) out.dataDir = a.slice("--data-dir=".length);
+    else if (a === "--help" || a === "-h") {
+      printHelp();
+      process.exit(0);
+    }
+  }
+  return out;
+}
+
+function printHelp() {
+  console.log(
+    [
+      "migrate-add-domain-and-conv-state — PR 1 backfill for memory-domain-isolation",
+      "",
+      "  --data-dir <path>   Path to the Librarian data dir (default: $LIBRARIAN_DATA_DIR or ./data)",
+      "  --apply             Apply updates. Without this, the script is a dry-run.",
+      "  --help              Show this help.",
+    ].join("\n"),
+  );
+}
+
+function parseTags(raw) {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((t) => typeof t === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+function dedupeAppend(tags, value) {
+  if (!value) return tags;
+  return tags.includes(value) ? tags : [...tags, value];
+}

--- a/test/migrate-add-domain-and-conv-state.test.ts
+++ b/test/migrate-add-domain-and-conv-state.test.ts
@@ -1,0 +1,245 @@
+// T1.4 — backfill script for the memory-domain-isolation rollout.
+//
+// Exercises `scripts/migrate-add-domain-and-conv-state.mjs` end-to-end
+// against a synthetic data directory. Asserts:
+//
+// - identity/relationship/preferences memories pick up the new booleans
+//   and (for identity/relationship) the `profile` tag
+// - agent_private memories land in a synthetic `legacy-private` domain
+//   (created on the fly if any memory needs it)
+// - sessions get `domain='general'`
+// - dry-run vs --apply
+// - idempotent across a second --apply run
+
+import { exec as execCb } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { type LibrarianStore, createLibrarianStore } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const exec = promisify(execCb);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const scriptPath = path.join(repoRoot, "scripts", "migrate-add-domain-and-conv-state.mjs");
+
+interface Scope {
+  dataDir: string;
+  ids: {
+    identity: string;
+    relationship: string;
+    preferences: string;
+    tools: string;
+    privateNote: string;
+  };
+  sessionId: string;
+}
+
+function makeScope(): Scope {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-domain-migrate-"));
+  const store = createLibrarianStore({ dataDir });
+  const ids = {
+    identity: seed(store, "User identity", "identity", "common"),
+    relationship: seed(store, "Working rapport", "relationship", "common"),
+    preferences: seed(store, "Terse responses", "preferences", "common"),
+    tools: seed(store, "pnpm test layout", "tools", "common"),
+    privateNote: seed(store, "Codex scratch", "lessons", "agent_private"),
+  };
+  const { session } = store.startSession({
+    agent_id: "codex",
+    title: "Pre-migration session",
+    harness: "claude-code",
+  });
+  const sessionId = session.id;
+  // Wipe the post-T1.3 fields off the projection rows so the scenario
+  // looks like an installation that predates this rollout.
+  store.db.exec(
+    "UPDATE memories SET domain='general', is_global=0, requires_approval=0; " +
+      "UPDATE sessions SET domain='general';",
+  );
+  store.close();
+  return { dataDir, ids, sessionId };
+}
+
+function seed(store: LibrarianStore, title: string, category: string, visibility: string): string {
+  const created = store.createMemory({
+    agent_id: "codex",
+    title,
+    body: `${title} — body pinned by migration test.`,
+    category,
+    visibility,
+    scope: "global",
+  });
+  return created.memory.id;
+}
+
+async function runScript(dataDir: string, apply: boolean): Promise<string> {
+  const cmd = `node --no-warnings ${JSON.stringify(scriptPath)} --data-dir ${JSON.stringify(
+    dataDir,
+  )}${apply ? " --apply" : ""}`;
+  const { stdout, stderr } = await exec(cmd);
+  return stdout + stderr;
+}
+
+describe("T1.4 — migrate-add-domain-and-conv-state script", () => {
+  let scope: Scope | null = null;
+
+  beforeEach(() => {
+    scope = makeScope();
+  });
+
+  afterEach(() => {
+    if (scope) fs.rmSync(scope.dataDir, { recursive: true, force: true });
+    scope = null;
+  });
+
+  it("dry-run reports the planned counts without mutating the projection", async () => {
+    const { dataDir, ids } = scope!;
+    const stdout = await runScript(dataDir, false);
+    expect(stdout).toMatch(/DRY-RUN/);
+    expect(stdout).toMatch(/memories backfilled: 5/);
+    expect(stdout).toMatch(/sessions backfilled: \d+/);
+    expect(stdout).toMatch(/legacy-private memories: 1/);
+
+    const store = createLibrarianStore({ dataDir });
+    try {
+      const row = store.db
+        .prepare("SELECT is_global, requires_approval, domain FROM memories WHERE id = ?")
+        .get(ids.identity) as { is_global: number; requires_approval: number; domain: string };
+      expect(row.is_global).toBe(0);
+      expect(row.requires_approval).toBe(0);
+      expect(row.domain).toBe("general");
+    } finally {
+      store.close();
+    }
+  });
+
+  it("applies derived booleans, domain assignment, and tag conversion", async () => {
+    const { dataDir, ids } = scope!;
+    const stdout = await runScript(dataDir, true);
+    expect(stdout).toMatch(/APPLY/);
+
+    const store = createLibrarianStore({ dataDir });
+    try {
+      const identity = store.getMemory(ids.identity);
+      expect(identity.is_global).toBe(true);
+      expect(identity.requires_approval).toBe(true);
+      expect(identity.domain).toBe("general");
+      expect(identity.tags).toContain("identity");
+      expect(identity.tags).toContain("profile");
+
+      const rel = store.getMemory(ids.relationship);
+      expect(rel.is_global).toBe(true);
+      expect(rel.requires_approval).toBe(true);
+      expect(rel.tags).toContain("relationship");
+      expect(rel.tags).toContain("profile");
+
+      const pref = store.getMemory(ids.preferences);
+      expect(pref.is_global).toBe(true);
+      expect(pref.requires_approval).toBe(false);
+      expect(pref.tags).toContain("preferences");
+      expect(pref.tags).not.toContain("profile");
+
+      const tools = store.getMemory(ids.tools);
+      expect(tools.is_global).toBe(false);
+      expect(tools.requires_approval).toBe(false);
+      expect(tools.tags).toContain("tools");
+
+      const priv = store.getMemory(ids.privateNote);
+      expect(priv.domain).toBe("legacy-private");
+
+      const domain = store.db
+        .prepare("SELECT name FROM domains WHERE name = ?")
+        .get("legacy-private");
+      expect(domain).toBeTruthy();
+    } finally {
+      store.close();
+    }
+  });
+
+  it("assigns domain='general' to sessions", async () => {
+    const { dataDir, sessionId } = scope!;
+    await runScript(dataDir, true);
+    const store = createLibrarianStore({ dataDir });
+    try {
+      const row = store.db.prepare("SELECT domain FROM sessions WHERE id = ?").get(sessionId) as {
+        domain: string;
+      };
+      expect(row.domain).toBe("general");
+    } finally {
+      store.close();
+    }
+  });
+
+  it("is idempotent across a second --apply", async () => {
+    const { dataDir, ids } = scope!;
+    await runScript(dataDir, true);
+    const first = readProjection(scope!);
+    await runScript(dataDir, true);
+    const second = readProjection(scope!);
+    expect(second).toEqual(first);
+
+    // Tags must not duplicate.
+    const store = createLibrarianStore({ dataDir });
+    try {
+      const identity = store.getMemory(ids.identity);
+      expect(identity.tags.filter((t: string) => t === "identity").length).toBe(1);
+      expect(identity.tags.filter((t: string) => t === "profile").length).toBe(1);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("does not append new events to events.jsonl or session_events.jsonl", async () => {
+    const { dataDir } = scope!;
+    const eventsBefore = fs.readFileSync(path.join(dataDir, "events.jsonl"), "utf8");
+    const sessionsBefore = fs.existsSync(path.join(dataDir, "session_events.jsonl"))
+      ? fs.readFileSync(path.join(dataDir, "session_events.jsonl"), "utf8")
+      : "";
+
+    await runScript(dataDir, true);
+
+    const eventsAfter = fs.readFileSync(path.join(dataDir, "events.jsonl"), "utf8");
+    const sessionsAfter = fs.existsSync(path.join(dataDir, "session_events.jsonl"))
+      ? fs.readFileSync(path.join(dataDir, "session_events.jsonl"), "utf8")
+      : "";
+
+    expect(eventsAfter).toBe(eventsBefore);
+    expect(sessionsAfter).toBe(sessionsBefore);
+  });
+});
+
+interface ProjectionSnapshot {
+  memories: Array<{
+    id: string;
+    domain: string;
+    is_global: number;
+    requires_approval: number;
+    tags_json: string;
+  }>;
+  sessions: Array<{ id: string; domain: string }>;
+  domains: Array<{ name: string }>;
+}
+
+function readProjection(scope: Scope): ProjectionSnapshot {
+  const store = createLibrarianStore({ dataDir: scope.dataDir });
+  try {
+    return {
+      memories: store.db
+        .prepare(
+          "SELECT id, domain, is_global, requires_approval, tags_json FROM memories ORDER BY id",
+        )
+        .all() as ProjectionSnapshot["memories"],
+      sessions: store.db
+        .prepare("SELECT id, domain FROM sessions ORDER BY id")
+        .all() as ProjectionSnapshot["sessions"],
+      domains: store.db
+        .prepare("SELECT name FROM domains ORDER BY name")
+        .all() as ProjectionSnapshot["domains"],
+    };
+  } finally {
+    store.close();
+  }
+}

--- a/test/schema-snapshot.json
+++ b/test/schema-snapshot.json
@@ -1,4 +1,4 @@
 {
-  "version": 12,
-  "fingerprint": "7e181b5dd906d2e8113170e6638eec024f70e144445580e141c3945f7f0234b7"
+  "version": 13,
+  "fingerprint": "7a8d9e6843765cc3288b6b45e395f135a6f504793b001f96aff9908fef29a3d7"
 }

--- a/test/schema-snapshot.json
+++ b/test/schema-snapshot.json
@@ -1,4 +1,4 @@
 {
-  "version": 11,
-  "fingerprint": "211c74c3ed97a3b356e463414898c73f61c9125ec380d45353e4cfef7920bd4c"
+  "version": 12,
+  "fingerprint": "7e181b5dd906d2e8113170e6638eec024f70e144445580e141c3945f7f0234b7"
 }


### PR DESCRIPTION
## Summary

First PR of an 8-PR rollout introducing the new owner-controlled memory-isolation model from `docs/specs/memory-domain-isolation-and-conv-state.md`. **Purely additive** — all behaviour through the existing tool surface is unchanged.

Plan: `docs/specs/memory-domain-isolation-and-conv-state-plan.md` (Phase 1, T1.1–T1.5).

### What lands

- **Schema** — new memory columns (`domain`, `is_global`, `requires_approval`) and one new session column (`domain`), plus four SQLite-authoritative tables: `conversation_state`, `domains`, `signal_rules`, `token_domain_bindings`. `general` is auto-seeded on first boot.
- **Bumps** `PROJECTION_SCHEMA_VERSION` 11 → 12 → 13 across T1.1 / T1.2; snapshot fingerprint refreshed.
- **Legacy bridge** (T1.3) — `deriveLegacyMemoryFlags` derives `is_global` / `requires_approval` from the existing `category` column. Replaces `PROTECTED_CATEGORIES` semantics as a column rather than a hard-coded set; the classifier cutover in PR 7 replaces the derivation with the local-model verdict.
- **Migration script** (T1.4) — `scripts/migrate-add-domain-and-conv-state.mjs` walks the existing projection, appends category-as-tag, derives the booleans, assigns `legacy-private` to historical `agent_private` rows, and synthesises the `legacy-private` domain if needed. Fully idempotent, dry-run by default. The projection-rebuild path now uses the same derivation so any future rebuild is coherent even without re-running the script.
- **CHANGELOG** entry under Unreleased.

### Security

Agents cannot set `domain`, `is_global`, or `requires_approval`:
- `normalizeMemoryInput` hard-codes the domain (`'general'`) and derives the booleans from `category` — it never reads them from input.
- `cleanPatch` uses an allow-list that excludes all three.
- The projection's Updated / BulkUpdated reducers only spread `payload.patch`, which has already passed through `cleanPatch`.

This matches the spec's §391 (success criteria): "An agent attempting to set is_global, requires_approval, visibility, category, or scope in a remember call has all those fields ignored."

### What does NOT change

- `category`, `visibility`, `scope` columns remain. (Removed in PR 7 after the classifier validates.)
- `remember` and `recall` input schemas are untouched. (PR 3 swaps `categories` for `tags` and adds `include_other_domains`.)
- No new JSONL events. The ledger remains canonical.

## Test plan

- [x] `pnpm test` — 553 workspace tests + 27 root tests green
- [x] `pnpm typecheck` — green across core, mcp-server, cli, dashboard
- [x] `node scripts/check-schema-version.mjs` — fingerprint matches
- [x] Code-reviewer agent ran a five-axis review — APPROVE, no Critical/Important findings
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)