### PR TITLE
PR 2: conv-state registry + MCP tools + hook helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ changes from this point forward are catalogued here.
 
 ### Added
 
+- **Conversation-state registry and hook helpers (PR 2 of 8).**
+  Per-conversation runtime state from spec §4.8 lands as a new SQLite-
+  authoritative store on top of the `conversation_state` table from
+  PR 1. The agent surface gains three MCP tools — `conv_state_get`,
+  `conv_state_upsert`, `conv_state_clear` — that hook code in PR 5 will
+  call every turn to defeat compaction-driven state loss. The pure
+  helper `renderConvStateBlock(state)` returns the canonical
+  `<conversation-state>` block from spec §4.9 byte-for-byte, so every
+  harness integration reads one source of truth. No agent-visible
+  behaviour change yet — PR 3 wires `remember` and `recall` to consume
+  the registry.
+
 - **Memory domain-isolation foundation (PR 1 of 8).** Additive schema for
   the new owner-controlled isolation model (`domain`, `is_global`,
   `requires_approval` columns on memories, `domain` on sessions, plus the

--- a/packages/core/src/conv-state-render.ts
+++ b/packages/core/src/conv-state-render.ts
@@ -1,0 +1,39 @@
+// Hook-injection helper — renders the per-turn `<conversation-state>`
+// system reminder from memory-domain-isolation §4.9.
+//
+// Lives in @librarian/core so every harness integration — Claude Code's
+// UserPromptSubmit hook, Hermes's equivalent, the CLI wrapper — produces
+// identical bytes from the same registry state. The exact wire shape is
+// part of the spec contract: changing the rendered format means changing
+// what every harness reinjects on every turn.
+
+import type { ConversationState } from "./schemas/conversation-state.js";
+
+/**
+ * Render the per-turn conv-state block that hook code injects ahead of
+ * each user message. Returns the empty string when there is no state
+ * yet — first-turn behaviour falls through to the signal-precedence
+ * chain (§4.10), which is harness-side and out of scope for this helper.
+ *
+ * Shape pinned by spec §4.9:
+ *
+ *   <conversation-state>
+ *     conv_id: <id>
+ *     domain: <domain>
+ *     session_id: <id or none>
+ *     off_record: <true|false>
+ *   </conversation-state>
+ */
+export function renderConvStateBlock(state: ConversationState | null): string {
+  if (!state) return "";
+  const sessionId = state.session_id ?? "none";
+  const offRecord = state.off_record ? "true" : "false";
+  return [
+    "<conversation-state>",
+    `  conv_id: ${state.conv_id}`,
+    `  domain: ${state.domain}`,
+    `  session_id: ${sessionId}`,
+    `  off_record: ${offRecord}`,
+    "</conversation-state>",
+  ].join("\n");
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -237,3 +237,9 @@ export {
   type SettingsStore,
   createSettingsStore,
 } from "./store/settings-store.js";
+export {
+  type ConversationStateStore,
+  createConversationStateStore,
+} from "./store/conversation-state-store.js";
+export type { ConversationState, ConversationStatePatch } from "./schemas/conversation-state.js";
+export { renderConvStateBlock } from "./conv-state-render.js";

--- a/packages/core/src/schemas/conversation-state.ts
+++ b/packages/core/src/schemas/conversation-state.ts
@@ -1,0 +1,36 @@
+// Conversation-state row schema — per-conversation runtime state that
+// survives context compaction via the per-turn hook contract from
+// memory-domain-isolation §4.8.
+//
+// A conv_state row is keyed by `conv_id` (harness-supplied: Claude Code
+// passes `CLAUDE_SESSION_ID`, Hermes passes `<channel>:<thread>`, etc.)
+// and carries the current `domain`, attached `session_id`, and the
+// `off_record` toggle. The registry is intentionally ephemeral — the
+// canonical work artefact is still the Librarian session; conv_state is
+// the connective tissue between a harness's notion of "this conversation"
+// and the Librarian's session/memory surface.
+
+import { z } from "zod";
+import { IdSchema, IsoTimestampSchema } from "./common.js";
+
+export const ConversationStateSchema = z.object({
+  conv_id: z.string().min(1),
+  harness: z.string().min(1),
+  domain: z.string().min(1),
+  session_id: IdSchema.nullable(),
+  off_record: z.boolean(),
+  created_at: IsoTimestampSchema,
+  updated_at: IsoTimestampSchema,
+});
+export type ConversationState = z.infer<typeof ConversationStateSchema>;
+
+// Patch accepted by `conv_state.upsert`. Every field is optional on
+// update; on first-create, `harness` and `domain` are required to satisfy
+// the NOT NULL columns. The store enforces the create-time requirement.
+export const ConversationStatePatchSchema = z.object({
+  harness: z.string().min(1).optional(),
+  domain: z.string().min(1).optional(),
+  session_id: IdSchema.nullable().optional(),
+  off_record: z.boolean().optional(),
+});
+export type ConversationStatePatch = z.infer<typeof ConversationStatePatchSchema>;

--- a/packages/core/src/schemas/index.ts
+++ b/packages/core/src/schemas/index.ts
@@ -2,3 +2,4 @@ export * from "./common.js";
 export * from "./memory.js";
 export * from "./session.js";
 export * from "./events.js";
+export * from "./conversation-state.js";

--- a/packages/core/src/store/conversation-state-store.ts
+++ b/packages/core/src/store/conversation-state-store.ts
@@ -1,0 +1,125 @@
+// Conversation-state store — owns the per-conversation runtime registry
+// from memory-domain-isolation §4.8.
+//
+// The registry is a small key/value surface on top of the
+// `conversation_state` SQLite table (introduced in T1.1). Each row is
+// keyed by the harness-supplied `conv_id` and carries the current
+// `domain`, attached `session_id`, and `off_record` flag. Hook code in
+// PR 5 will fetch via `get` on every turn; `upsert` lands on session
+// start / resume; `clear` runs on explicit conv-id teardown.
+//
+// All three operations are atomic per call (single prepared-statement
+// execution).
+
+import type { DatabaseSync } from "node:sqlite";
+import { nowIso } from "../constants.js";
+import type { ConversationState, ConversationStatePatch } from "../schemas/conversation-state.js";
+
+export interface ConversationStateStoreDeps {
+  db: DatabaseSync;
+}
+
+export interface ConversationStateStore {
+  get(convId: string): ConversationState | null;
+  upsert(convId: string, patch: ConversationStatePatch): ConversationState;
+  clear(convId: string): void;
+}
+
+interface ConversationStateRow {
+  conv_id: string;
+  harness: string;
+  domain: string;
+  session_id: string | null;
+  off_record: number;
+  created_at: string;
+  updated_at: string;
+}
+
+function rowToState(row: ConversationStateRow): ConversationState {
+  return {
+    conv_id: row.conv_id,
+    harness: row.harness,
+    domain: row.domain,
+    session_id: row.session_id,
+    off_record: Boolean(row.off_record),
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+export function createConversationStateStore(
+  deps: ConversationStateStoreDeps,
+): ConversationStateStore {
+  const { db } = deps;
+
+  function get(convId: string): ConversationState | null {
+    const row = db.prepare("SELECT * FROM conversation_state WHERE conv_id = ?").get(convId) as
+      | ConversationStateRow
+      | undefined;
+    return row ? rowToState(row) : null;
+  }
+
+  function upsert(convId: string, patch: ConversationStatePatch): ConversationState {
+    const existing = get(convId);
+    const now = nowIso();
+    if (existing) {
+      const next: ConversationState = {
+        ...existing,
+        harness: patch.harness ?? existing.harness,
+        domain: patch.domain ?? existing.domain,
+        session_id: patch.session_id === undefined ? existing.session_id : patch.session_id,
+        off_record: patch.off_record ?? existing.off_record,
+        updated_at: now,
+      };
+      db.prepare(
+        `UPDATE conversation_state
+            SET harness = ?, domain = ?, session_id = ?, off_record = ?, updated_at = ?
+          WHERE conv_id = ?`,
+      ).run(
+        next.harness,
+        next.domain,
+        next.session_id,
+        next.off_record ? 1 : 0,
+        next.updated_at,
+        convId,
+      );
+      return next;
+    }
+
+    if (!patch.harness || !patch.domain) {
+      throw new Error(
+        "conv_state.upsert: first-create requires both `harness` and `domain` " +
+          "(they map to NOT NULL columns).",
+      );
+    }
+    const next: ConversationState = {
+      conv_id: convId,
+      harness: patch.harness,
+      domain: patch.domain,
+      session_id: patch.session_id ?? null,
+      off_record: patch.off_record ?? false,
+      created_at: now,
+      updated_at: now,
+    };
+    db.prepare(
+      `INSERT INTO conversation_state (
+        conv_id, harness, domain, session_id, off_record, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      next.conv_id,
+      next.harness,
+      next.domain,
+      next.session_id,
+      next.off_record ? 1 : 0,
+      next.created_at,
+      next.updated_at,
+    );
+    return next;
+  }
+
+  function clear(convId: string): void {
+    db.prepare("DELETE FROM conversation_state WHERE conv_id = ?").run(convId);
+  }
+
+  return { get, upsert, clear };
+}

--- a/packages/core/src/store/conversation-state-store.ts
+++ b/packages/core/src/store/conversation-state-store.ts
@@ -13,7 +13,11 @@
 
 import type { DatabaseSync } from "node:sqlite";
 import { nowIso } from "../constants.js";
-import type { ConversationState, ConversationStatePatch } from "../schemas/conversation-state.js";
+import {
+  type ConversationState,
+  type ConversationStatePatch,
+  ConversationStatePatchSchema,
+} from "../schemas/conversation-state.js";
 
 export interface ConversationStateStoreDeps {
   db: DatabaseSync;
@@ -52,7 +56,14 @@ export function createConversationStateStore(
 ): ConversationStateStore {
   const { db } = deps;
 
+  function assertConvId(convId: string): void {
+    if (typeof convId !== "string" || convId.length === 0) {
+      throw new Error("conv_state: conv_id must be a non-empty string.");
+    }
+  }
+
   function get(convId: string): ConversationState | null {
+    assertConvId(convId);
     const row = db.prepare("SELECT * FROM conversation_state WHERE conv_id = ?").get(convId) as
       | ConversationStateRow
       | undefined;
@@ -60,15 +71,19 @@ export function createConversationStateStore(
   }
 
   function upsert(convId: string, patch: ConversationStatePatch): ConversationState {
+    assertConvId(convId);
+    // Validate at the boundary — every caller (MCP handler, future
+    // HTTP routes, hook code) gets one canonical shape check.
+    const parsed = ConversationStatePatchSchema.parse(patch);
     const existing = get(convId);
     const now = nowIso();
     if (existing) {
       const next: ConversationState = {
         ...existing,
-        harness: patch.harness ?? existing.harness,
-        domain: patch.domain ?? existing.domain,
-        session_id: patch.session_id === undefined ? existing.session_id : patch.session_id,
-        off_record: patch.off_record ?? existing.off_record,
+        harness: parsed.harness ?? existing.harness,
+        domain: parsed.domain ?? existing.domain,
+        session_id: parsed.session_id === undefined ? existing.session_id : parsed.session_id,
+        off_record: parsed.off_record ?? existing.off_record,
         updated_at: now,
       };
       db.prepare(
@@ -86,7 +101,7 @@ export function createConversationStateStore(
       return next;
     }
 
-    if (!patch.harness || !patch.domain) {
+    if (!parsed.harness || !parsed.domain) {
       throw new Error(
         "conv_state.upsert: first-create requires both `harness` and `domain` " +
           "(they map to NOT NULL columns).",
@@ -94,10 +109,10 @@ export function createConversationStateStore(
     }
     const next: ConversationState = {
       conv_id: convId,
-      harness: patch.harness,
-      domain: patch.domain,
-      session_id: patch.session_id ?? null,
-      off_record: patch.off_record ?? false,
+      harness: parsed.harness,
+      domain: parsed.domain,
+      session_id: parsed.session_id ?? null,
+      off_record: parsed.off_record ?? false,
       created_at: now,
       updated_at: now,
     };
@@ -118,6 +133,7 @@ export function createConversationStateStore(
   }
 
   function clear(convId: string): void {
+    assertConvId(convId);
     db.prepare("DELETE FROM conversation_state WHERE conv_id = ?").run(convId);
   }
 

--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -1,6 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
+import {
+  type ConversationStateStore,
+  createConversationStateStore,
+} from "./conversation-state-store.js";
 import { type CurationStore, createCurationStore } from "./curation-store.js";
 import { readJsonl } from "./jsonl.js";
 import { type MemoryStore, createMemoryStore } from "./memory-store.js";
@@ -31,6 +35,7 @@ export interface LibrarianStoreOptions {
 }
 
 export interface LibrarianStore extends MemoryStore, SessionStore, CurationStore, SettingsStore {
+  convState: ConversationStateStore;
   dataDir: string;
   eventsPath: string;
   // R3 — sessionsPath is the timeline ledger (post-R3, new file).
@@ -104,12 +109,14 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Libra
   });
   const curationStore = createCurationStore({ db });
   const settingsStore = createSettingsStore({ db, secretKey: options.secretKey ?? null });
+  const convState = createConversationStateStore({ db });
 
   return {
     ...memoryStore,
     ...sessionStore,
     ...curationStore,
     ...settingsStore,
+    convState,
     dataDir,
     eventsPath,
     sessionsPath,

--- a/packages/core/tests/conv-state-render.test.ts
+++ b/packages/core/tests/conv-state-render.test.ts
@@ -1,0 +1,75 @@
+// T2.3 — Snapshot tests for the hook-injection helper.
+//
+// The exact rendered shape is contractual — every harness integration
+// reads it via the same helper, and the LLM consumes a stable byte
+// sequence each turn. Locking it down here.
+
+import { renderConvStateBlock } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+describe("renderConvStateBlock (T2.3)", () => {
+  it("returns empty string when there is no state", () => {
+    expect(renderConvStateBlock(null)).toBe("");
+  });
+
+  it("renders the canonical block with all fields set", () => {
+    const out = renderConvStateBlock({
+      conv_id: "claude:abc-123",
+      harness: "claude-code",
+      domain: "coding",
+      session_id: "ses_xyz",
+      off_record: false,
+      created_at: "2026-05-27T00:00:00.000Z",
+      updated_at: "2026-05-27T00:00:00.000Z",
+    });
+    expect(out).toBe(
+      [
+        "<conversation-state>",
+        "  conv_id: claude:abc-123",
+        "  domain: coding",
+        "  session_id: ses_xyz",
+        "  off_record: false",
+        "</conversation-state>",
+      ].join("\n"),
+    );
+  });
+
+  it("renders 'none' for a null session_id", () => {
+    const out = renderConvStateBlock({
+      conv_id: "claude:abc-123",
+      harness: "claude-code",
+      domain: "coding",
+      session_id: null,
+      off_record: false,
+      created_at: "2026-05-27T00:00:00.000Z",
+      updated_at: "2026-05-27T00:00:00.000Z",
+    });
+    expect(out).toContain("  session_id: none");
+  });
+
+  it("renders off_record true when the flag is on", () => {
+    const out = renderConvStateBlock({
+      conv_id: "claude:abc-123",
+      harness: "claude-code",
+      domain: "coding",
+      session_id: null,
+      off_record: true,
+      created_at: "2026-05-27T00:00:00.000Z",
+      updated_at: "2026-05-27T00:00:00.000Z",
+    });
+    expect(out).toContain("  off_record: true");
+  });
+
+  it("produces deterministic bytes across calls — every harness sees the same shape", () => {
+    const state = {
+      conv_id: "hermes:thread-7",
+      harness: "hermes",
+      domain: "family-admin",
+      session_id: "ses_qa",
+      off_record: false,
+      created_at: "2026-05-27T00:00:00.000Z",
+      updated_at: "2026-05-27T00:00:00.000Z",
+    };
+    expect(renderConvStateBlock(state)).toBe(renderConvStateBlock({ ...state }));
+  });
+});

--- a/packages/core/tests/store/conversation-state-store.test.ts
+++ b/packages/core/tests/store/conversation-state-store.test.ts
@@ -1,0 +1,154 @@
+// T2.1 — Conversation-state registry behaviour tests.
+//
+// Pins the contract for the new per-conversation runtime store
+// introduced in memory-domain-isolation §4.8. The registry is the
+// connective tissue between a harness's conv_id and the Librarian
+// session/memory surface — every test here is at the
+// `createLibrarianStore.convState.*` boundary.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { type LibrarianStore, createLibrarianStore } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+interface Scope {
+  store: LibrarianStore;
+  dataDir: string;
+}
+
+function makeScope(): Scope {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-conv-state-"));
+  const store = createLibrarianStore({ dataDir });
+  return { store, dataDir };
+}
+
+function teardown(scope: Scope | null): void {
+  if (!scope) return;
+  try {
+    scope.store.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(scope.dataDir, { recursive: true, force: true });
+}
+
+describe("conversation-state store (T2.1)", () => {
+  let scope: Scope | null = null;
+
+  beforeEach(() => {
+    scope = makeScope();
+  });
+
+  afterEach(() => {
+    teardown(scope);
+    scope = null;
+  });
+
+  it("get returns null for an unknown conv_id", () => {
+    expect(scope!.store.convState.get("claude:never-seen")).toBeNull();
+  });
+
+  it("upsert creates a row with all required fields, defaulting session_id and off_record", () => {
+    const created = scope!.store.convState.upsert("claude:abc", {
+      harness: "claude-code",
+      domain: "coding",
+    });
+    expect(created).toMatchObject({
+      conv_id: "claude:abc",
+      harness: "claude-code",
+      domain: "coding",
+      session_id: null,
+      off_record: false,
+    });
+    expect(created.created_at).toBe(created.updated_at);
+
+    const fetched = scope!.store.convState.get("claude:abc");
+    expect(fetched).toEqual(created);
+  });
+
+  it("upsert without harness/domain on a new row throws", () => {
+    expect(() => scope!.store.convState.upsert("claude:new", { off_record: true })).toThrow(
+      /first-create requires both `harness` and `domain`/,
+    );
+  });
+
+  it("upsert applies a patch to an existing row, preserves created_at, bumps updated_at", async () => {
+    const created = scope!.store.convState.upsert("claude:abc", {
+      harness: "claude-code",
+      domain: "coding",
+    });
+    // Force a millisecond gap so updated_at moves.
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const updated = scope!.store.convState.upsert("claude:abc", {
+      domain: "family-admin",
+      off_record: true,
+      session_id: "ses_test",
+    });
+    expect(updated.domain).toBe("family-admin");
+    expect(updated.off_record).toBe(true);
+    expect(updated.session_id).toBe("ses_test");
+    expect(updated.created_at).toBe(created.created_at);
+    expect(updated.updated_at).not.toBe(created.updated_at);
+    expect(updated.updated_at >= created.updated_at).toBe(true);
+  });
+
+  it("upsert preserves fields that are not in the patch", () => {
+    scope!.store.convState.upsert("claude:abc", {
+      harness: "claude-code",
+      domain: "coding",
+      session_id: "ses_initial",
+      off_record: false,
+    });
+    const updated = scope!.store.convState.upsert("claude:abc", { off_record: true });
+    expect(updated.session_id).toBe("ses_initial");
+    expect(updated.harness).toBe("claude-code");
+    expect(updated.domain).toBe("coding");
+  });
+
+  it("upsert explicitly null-ing session_id clears it", () => {
+    scope!.store.convState.upsert("claude:abc", {
+      harness: "claude-code",
+      domain: "coding",
+      session_id: "ses_attached",
+    });
+    const cleared = scope!.store.convState.upsert("claude:abc", { session_id: null });
+    expect(cleared.session_id).toBeNull();
+  });
+
+  it("clear removes the row", () => {
+    scope!.store.convState.upsert("claude:abc", {
+      harness: "claude-code",
+      domain: "coding",
+    });
+    scope!.store.convState.clear("claude:abc");
+    expect(scope!.store.convState.get("claude:abc")).toBeNull();
+  });
+
+  it("clear is a no-op for an unknown conv_id", () => {
+    expect(() => scope!.store.convState.clear("never-seen")).not.toThrow();
+  });
+
+  it("survives a store reopen — the row is SQLite-authoritative", () => {
+    const { dataDir } = scope!;
+    scope!.store.convState.upsert("claude:abc", {
+      harness: "claude-code",
+      domain: "coding",
+      session_id: "ses_durable",
+    });
+    scope!.store.close();
+    const reopened = createLibrarianStore({ dataDir });
+    try {
+      const fetched = reopened.convState.get("claude:abc");
+      expect(fetched).toMatchObject({
+        conv_id: "claude:abc",
+        harness: "claude-code",
+        domain: "coding",
+        session_id: "ses_durable",
+      });
+    } finally {
+      reopened.close();
+      scope = { store: reopened, dataDir };
+    }
+  });
+});

--- a/packages/mcp-server/src/mcp/tools/conv-state-clear.ts
+++ b/packages/mcp-server/src/mcp/tools/conv-state-clear.ts
@@ -1,5 +1,6 @@
 import { textResult } from "../result.js";
 import type { ToolDefinition } from "../tool.js";
+import { requireString } from "./conv-state-shared.js";
 
 const convStateClear: ToolDefinition = {
   name: "conv_state_clear",
@@ -9,13 +10,13 @@ const convStateClear: ToolDefinition = {
   inputSchema: {
     type: "object",
     required: ["conv_id"],
+    additionalProperties: false,
     properties: {
-      conv_id: { type: "string" },
+      conv_id: { type: "string", minLength: 1, description: "Harness-supplied conv identifier." },
     },
   },
   handler(store, args) {
-    const convId = String(args.conv_id ?? "");
-    if (!convId) return textResult("conv_state.clear: conv_id is required.");
+    const convId = requireString(args.conv_id, "conv_state.clear: conv_id is required.");
     store.convState.clear(convId);
     return textResult(`Cleared conversation state for conv_id ${convId}.`);
   },

--- a/packages/mcp-server/src/mcp/tools/conv-state-clear.ts
+++ b/packages/mcp-server/src/mcp/tools/conv-state-clear.ts
@@ -1,0 +1,24 @@
+import { textResult } from "../result.js";
+import type { ToolDefinition } from "../tool.js";
+
+const convStateClear: ToolDefinition = {
+  name: "conv_state_clear",
+  description:
+    "Delete the conversation-state row for the supplied conv_id. Safe to call when the row does " +
+    "not exist; the operation is idempotent.",
+  inputSchema: {
+    type: "object",
+    required: ["conv_id"],
+    properties: {
+      conv_id: { type: "string" },
+    },
+  },
+  handler(store, args) {
+    const convId = String(args.conv_id ?? "");
+    if (!convId) return textResult("conv_state.clear: conv_id is required.");
+    store.convState.clear(convId);
+    return textResult(`Cleared conversation state for conv_id ${convId}.`);
+  },
+};
+
+export default convStateClear;

--- a/packages/mcp-server/src/mcp/tools/conv-state-get.ts
+++ b/packages/mcp-server/src/mcp/tools/conv-state-get.ts
@@ -1,0 +1,25 @@
+import { textResult } from "../result.js";
+import type { ToolDefinition } from "../tool.js";
+
+const convStateGet: ToolDefinition = {
+  name: "conv_state_get",
+  description:
+    "Return the conversation-state row for the supplied conv_id, or report 'no state' if absent. " +
+    "Hook code calls this on every turn to re-inject the canonical block from spec §4.9.",
+  inputSchema: {
+    type: "object",
+    required: ["conv_id"],
+    properties: {
+      conv_id: { type: "string", description: "Harness-supplied conversation identifier." },
+    },
+  },
+  handler(store, args) {
+    const convId = String(args.conv_id ?? "");
+    if (!convId) return textResult("conv_state.get: conv_id is required.");
+    const state = store.convState.get(convId);
+    if (!state) return textResult(`No conversation state for conv_id ${convId}.`);
+    return textResult(JSON.stringify(state, null, 2));
+  },
+};
+
+export default convStateGet;

--- a/packages/mcp-server/src/mcp/tools/conv-state-get.ts
+++ b/packages/mcp-server/src/mcp/tools/conv-state-get.ts
@@ -1,5 +1,6 @@
 import { textResult } from "../result.js";
 import type { ToolDefinition } from "../tool.js";
+import { requireString } from "./conv-state-shared.js";
 
 const convStateGet: ToolDefinition = {
   name: "conv_state_get",
@@ -9,13 +10,17 @@ const convStateGet: ToolDefinition = {
   inputSchema: {
     type: "object",
     required: ["conv_id"],
+    additionalProperties: false,
     properties: {
-      conv_id: { type: "string", description: "Harness-supplied conversation identifier." },
+      conv_id: {
+        type: "string",
+        minLength: 1,
+        description: "Harness-supplied conversation identifier.",
+      },
     },
   },
   handler(store, args) {
-    const convId = String(args.conv_id ?? "");
-    if (!convId) return textResult("conv_state.get: conv_id is required.");
+    const convId = requireString(args.conv_id, "conv_state.get: conv_id is required.");
     const state = store.convState.get(convId);
     if (!state) return textResult(`No conversation state for conv_id ${convId}.`);
     return textResult(JSON.stringify(state, null, 2));

--- a/packages/mcp-server/src/mcp/tools/conv-state-shared.ts
+++ b/packages/mcp-server/src/mcp/tools/conv-state-shared.ts
@@ -1,0 +1,11 @@
+// Shared input-validation helper for the three conv_state tools. The
+// MCP layer raises JSON-RPC errors by throwing; centralising the
+// non-empty-string assertion here means all three handlers return the
+// same failure shape for the same precondition.
+
+export function requireString(value: unknown, message: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(message);
+  }
+  return value;
+}

--- a/packages/mcp-server/src/mcp/tools/conv-state-upsert.ts
+++ b/packages/mcp-server/src/mcp/tools/conv-state-upsert.ts
@@ -1,0 +1,42 @@
+import { textResult } from "../result.js";
+import type { ToolDefinition } from "../tool.js";
+
+const convStateUpsert: ToolDefinition = {
+  name: "conv_state_upsert",
+  description:
+    "Create or update the conversation-state row for the supplied conv_id. " +
+    "First-create requires both `harness` and `domain`; subsequent updates accept any subset of " +
+    "the four mutable fields. Setting `session_id: null` explicitly clears the attached session.",
+  inputSchema: {
+    type: "object",
+    required: ["conv_id"],
+    properties: {
+      conv_id: { type: "string" },
+      harness: { type: "string" },
+      domain: { type: "string" },
+      session_id: { type: ["string", "null"] },
+      off_record: { type: "boolean" },
+    },
+  },
+  handler(store, args) {
+    const convId = String(args.conv_id ?? "");
+    if (!convId) return textResult("conv_state.upsert: conv_id is required.");
+    const patch: Record<string, unknown> = {};
+    if (typeof args.harness === "string") patch.harness = args.harness;
+    if (typeof args.domain === "string") patch.domain = args.domain;
+    if (args.session_id === null || typeof args.session_id === "string") {
+      patch.session_id = args.session_id;
+    }
+    if (typeof args.off_record === "boolean") patch.off_record = args.off_record;
+    try {
+      const next = store.convState.upsert(convId, patch);
+      return textResult(JSON.stringify(next, null, 2));
+    } catch (error) {
+      return textResult(
+        `conv_state.upsert failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  },
+};
+
+export default convStateUpsert;

--- a/packages/mcp-server/src/mcp/tools/conv-state-upsert.ts
+++ b/packages/mcp-server/src/mcp/tools/conv-state-upsert.ts
@@ -1,26 +1,44 @@
 import { textResult } from "../result.js";
 import type { ToolDefinition } from "../tool.js";
+import { requireString } from "./conv-state-shared.js";
 
 const convStateUpsert: ToolDefinition = {
   name: "conv_state_upsert",
   description:
     "Create or update the conversation-state row for the supplied conv_id. " +
     "First-create requires both `harness` and `domain`; subsequent updates accept any subset of " +
-    "the four mutable fields. Setting `session_id: null` explicitly clears the attached session.",
+    "the four mutable fields. Setting `session_id: null` explicitly clears the attached session. " +
+    "TODO(PR 3): cross-check `domain` against the `domains` table — agents currently can write " +
+    "rows pointing at a non-existent domain; `start_session` will gate this once PR 3 lands.",
   inputSchema: {
     type: "object",
     required: ["conv_id"],
+    additionalProperties: false,
     properties: {
-      conv_id: { type: "string" },
-      harness: { type: "string" },
-      domain: { type: "string" },
-      session_id: { type: ["string", "null"] },
-      off_record: { type: "boolean" },
+      conv_id: { type: "string", minLength: 1, description: "Harness-supplied conv identifier." },
+      harness: {
+        type: "string",
+        minLength: 1,
+        description: "Harness name (e.g. 'claude-code', 'hermes'). Required on first create.",
+      },
+      domain: {
+        type: "string",
+        minLength: 1,
+        description:
+          "Owner-defined domain (e.g. 'coding', 'family-admin'). Required on first create.",
+      },
+      session_id: {
+        type: ["string", "null"],
+        description: "Attached Librarian session id, or explicit null to clear.",
+      },
+      off_record: {
+        type: "boolean",
+        description: "When true, automatic capture into the session ledger pauses.",
+      },
     },
   },
   handler(store, args) {
-    const convId = String(args.conv_id ?? "");
-    if (!convId) return textResult("conv_state.upsert: conv_id is required.");
+    const convId = requireString(args.conv_id, "conv_state.upsert: conv_id is required.");
     const patch: Record<string, unknown> = {};
     if (typeof args.harness === "string") patch.harness = args.harness;
     if (typeof args.domain === "string") patch.domain = args.domain;
@@ -28,14 +46,8 @@ const convStateUpsert: ToolDefinition = {
       patch.session_id = args.session_id;
     }
     if (typeof args.off_record === "boolean") patch.off_record = args.off_record;
-    try {
-      const next = store.convState.upsert(convId, patch);
-      return textResult(JSON.stringify(next, null, 2));
-    } catch (error) {
-      return textResult(
-        `conv_state.upsert failed: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    }
+    const next = store.convState.upsert(convId, patch);
+    return textResult(JSON.stringify(next, null, 2));
   },
 };
 

--- a/packages/mcp-server/src/mcp/tools/index.ts
+++ b/packages/mcp-server/src/mcp/tools/index.ts
@@ -8,6 +8,9 @@ import archiveMemory from "./archive-memory.js";
 import attachSession from "./attach-session.js";
 import checkpointSession from "./checkpoint-session.js";
 import continueSession from "./continue-session.js";
+import convStateClear from "./conv-state-clear.js";
+import convStateGet from "./conv-state-get.js";
+import convStateUpsert from "./conv-state-upsert.js";
 import endSession from "./end-session.js";
 import getSession from "./get-session.js";
 import listProposals from "./list-proposals.js";
@@ -49,6 +52,9 @@ export const tools: ToolDefinition[] = [
   continueSession,
   promoteSessionFact,
   purgeSession,
+  convStateGet,
+  convStateUpsert,
+  convStateClear,
 ];
 
 export const toolsByName: Map<string, ToolDefinition> = new Map(

--- a/packages/mcp-server/tests/mcp/conv-state.mcp.test.ts
+++ b/packages/mcp-server/tests/mcp/conv-state.mcp.test.ts
@@ -1,0 +1,118 @@
+// T2.2 — MCP tool surface for the conversation-state registry.
+//
+// Pins the dispatch wiring, input-schema shape, and round-trip
+// behaviour for `conv_state_get`, `conv_state_upsert`, and
+// `conv_state_clear`. These tools are agent-callable (no admin gate —
+// the conversation owns its own state per spec §4.8).
+
+import type { LibrarianStore } from "@librarian/core";
+import { handleMcpPayload } from "@librarian/mcp-server";
+import { describe, expect, it } from "vitest";
+import { withStore } from "../../../../test/helpers.js";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyResponse = any;
+
+function call(
+  store: LibrarianStore,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<AnyResponse> {
+  return handleMcpPayload(
+    store,
+    { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name, arguments: args } },
+    { role: "agent", agentId: "codex" },
+  ) as Promise<AnyResponse>;
+}
+
+function extractText(response: AnyResponse): string {
+  return response.result.content[0].text as string;
+}
+
+describe("MCP conv_state tools (T2.2)", () => {
+  it("tools/list exposes get/upsert/clear", async () => {
+    await withStore(async (store) => {
+      const list = await handleMcpPayload(store, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+        params: {},
+      });
+      const names = list.result.tools.map((tool: { name: string }) => tool.name);
+      expect(names).toContain("conv_state_get");
+      expect(names).toContain("conv_state_upsert");
+      expect(names).toContain("conv_state_clear");
+    });
+  });
+
+  it("get reports 'no conversation state' for an unknown conv_id", async () => {
+    await withStore(async (store) => {
+      const response = await call(store, "conv_state_get", { conv_id: "claude:nope" });
+      expect(extractText(response)).toMatch(/No conversation state/);
+    });
+  });
+
+  it("upsert then get round-trips a new row", async () => {
+    await withStore(async (store) => {
+      const upsert = await call(store, "conv_state_upsert", {
+        conv_id: "claude:abc",
+        harness: "claude-code",
+        domain: "coding",
+      });
+      const upsertJson = JSON.parse(extractText(upsert));
+      expect(upsertJson.conv_id).toBe("claude:abc");
+      expect(upsertJson.domain).toBe("coding");
+
+      const get = await call(store, "conv_state_get", { conv_id: "claude:abc" });
+      const getJson = JSON.parse(extractText(get));
+      expect(getJson).toEqual(upsertJson);
+    });
+  });
+
+  it("upsert on first-create without harness/domain returns an error message", async () => {
+    await withStore(async (store) => {
+      const response = await call(store, "conv_state_upsert", {
+        conv_id: "claude:incomplete",
+        off_record: true,
+      });
+      expect(extractText(response)).toMatch(/first-create requires both `harness` and `domain`/);
+    });
+  });
+
+  it("upsert with session_id: null clears the attached session", async () => {
+    await withStore(async (store) => {
+      await call(store, "conv_state_upsert", {
+        conv_id: "claude:abc",
+        harness: "claude-code",
+        domain: "coding",
+        session_id: "ses_initial",
+      });
+      const cleared = await call(store, "conv_state_upsert", {
+        conv_id: "claude:abc",
+        session_id: null,
+      });
+      const json = JSON.parse(extractText(cleared));
+      expect(json.session_id).toBeNull();
+    });
+  });
+
+  it("clear removes the row; subsequent get reports 'no state'", async () => {
+    await withStore(async (store) => {
+      await call(store, "conv_state_upsert", {
+        conv_id: "claude:abc",
+        harness: "claude-code",
+        domain: "coding",
+      });
+      await call(store, "conv_state_clear", { conv_id: "claude:abc" });
+      const get = await call(store, "conv_state_get", { conv_id: "claude:abc" });
+      expect(extractText(get)).toMatch(/No conversation state/);
+    });
+  });
+
+  it("clear is idempotent — returns success even when the row is absent", async () => {
+    await withStore(async (store) => {
+      const response = await call(store, "conv_state_clear", { conv_id: "never-seen" });
+      expect(extractText(response)).toMatch(/Cleared conversation state/);
+    });
+  });
+});

--- a/packages/mcp-server/tests/mcp/conv-state.mcp.test.ts
+++ b/packages/mcp-server/tests/mcp/conv-state.mcp.test.ts
@@ -69,13 +69,22 @@ describe("MCP conv_state tools (T2.2)", () => {
     });
   });
 
-  it("upsert on first-create without harness/domain returns an error message", async () => {
+  it("upsert on first-create without harness/domain returns a JSON-RPC error", async () => {
     await withStore(async (store) => {
       const response = await call(store, "conv_state_upsert", {
         conv_id: "claude:incomplete",
         off_record: true,
       });
-      expect(extractText(response)).toMatch(/first-create requires both `harness` and `domain`/);
+      expect(response.error).toBeTruthy();
+      expect(response.error.message).toMatch(/first-create requires both `harness` and `domain`/);
+    });
+  });
+
+  it("empty conv_id is rejected as a JSON-RPC error, not as text content", async () => {
+    await withStore(async (store) => {
+      const response = await call(store, "conv_state_get", { conv_id: "" });
+      expect(response.error).toBeTruthy();
+      expect(response.error.message).toMatch(/conv_id is required/);
     });
   });
 


### PR DESCRIPTION
## Summary

Second PR of the memory-domain-isolation rollout (Phase 2 of the plan). Lands the server-side machinery that PR 3 and PR 5 will consume; no agent-visible behaviour change.

- **T2.1 — conversation-state store.** New SQLite-authoritative store on top of the `conversation_state` table from PR 1. `get` / `upsert` / `clear` exposed off `LibrarianStore.convState`. First-create requires `harness` and `domain`; updates accept any subset of the four mutable fields; setting `session_id: null` explicitly clears the attached session. Validates the patch through `ConversationStatePatchSchema` at the boundary and asserts a non-empty `conv_id` on every entry point.
- **T2.2 — three agent-callable MCP tools.** `conv_state_get`, `conv_state_upsert`, `conv_state_clear`. Registered through the existing `tools/index.ts` registry. Throw on precondition failures so dispatch returns a real JSON-RPC error envelope rather than wrapped success text. Input schemas use `additionalProperties: false` and `minLength: 1`.
- **T2.3 — hook-injection helper.** Pure `renderConvStateBlock(state)` in `@librarian/core` emits the canonical `<conversation-state>` block from spec §4.9 byte-for-byte. PR 5 (Claude / Hermes / CLI hooks) will read from this one source.

### Open follow-up

- `conv_state_upsert` does NOT yet cross-check `domain` against the `domains` table. PR 3 (T3.1) gates this through `start_session` and the `remember` handler. A TODO is on the tool description so it's not silently forgotten.

## Test plan

- [x] `pnpm -w test` — 509 (core) + 124 (mcp-server) + 27 (root) green
- [x] `pnpm typecheck` — green across the workspace
- [x] Code-reviewer agent — APPROVED after the two Important fixes (error propagation + Zod boundary validation) landed in 1a5ebad
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)