### PR TITLE
PR 3: domain enforcement on remember + recall + sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,30 @@ changes from this point forward are catalogued here.
 
 ### Added
 
+- **Domain enforcement on memory + session writes (PR 3 of 8).** The
+  `remember`, `recall`, `start_session`, and `continue_session` MCP
+  tools now consume the conv-state registry from PR 2:
+  - `remember` reads `conv_state.domain` for the supplied `conv_id` and
+    server-sets the memory's `domain` accordingly. Calls without a
+    matching conv_state row on a multi-domain install route to the
+    proposal queue with `domain=NULL` and `requires_approval=true` per
+    spec §4.14, so the dashboard owner picks the domain at approval
+    time. The §4.10 single-domain fast path keeps zero-config installs
+    zero-friction — when only `general` exists, the sole domain is
+    auto-assigned without the proposal hop.
+  - `recall` applies the §4.11 hard filter
+    `(domain = current_domain OR is_global = 1) AND status = active`,
+    drops the legacy `categories` and `include_private` inputs, and
+    adds `tags` plus `include_other_domains`. Admin callers bypass the
+    filter via the existing role flag.
+  - `start_session` inherits its `domain` from the calling conv_state;
+    `continue_session` seeds the resuming conv_state's domain from
+    `session.domain` when a `conv_id` is supplied (skipping the
+    signal-precedence chain on resume per §4.12).
+  - `listMemories` (the dashboard read path) gains
+    `domain` / `is_global` / `requires_approval` / `tags` filter axes
+    alongside the existing surface.
+
 - **Conversation-state registry and hook helpers (PR 2 of 8).**
   Per-conversation runtime state from spec §4.8 lands as a new SQLite-
   authoritative store on top of the `conversation_state` table from

--- a/packages/core/src/store/memory-store.ts
+++ b/packages/core/src/store/memory-store.ts
@@ -253,10 +253,14 @@ export function createMemoryStore(deps: MemoryStoreDeps): MemoryStore {
       params.push(filters.requires_approval ? 1 : 0);
     }
     if (Array.isArray(filters.tags) && filters.tags.length > 0) {
+      // Use json_each to do exact-token matching rather than LIKE — a
+      // substring match would conflate `tag="a"` with `tag="abc"` and
+      // LIKE metacharacters (`%`, `_`) in user-supplied tag strings
+      // would silently turn into wildcards.
       const tagClauses: string[] = [];
       for (const tag of filters.tags as string[]) {
-        tagClauses.push("tags_json LIKE ?");
-        params.push(`%${JSON.stringify(tag).slice(1, -1)}%`);
+        tagClauses.push("EXISTS (SELECT 1 FROM json_each(tags_json) WHERE value = ?)");
+        params.push(tag);
       }
       clauses.push(`(${tagClauses.join(" OR ")})`);
     }

--- a/packages/core/src/store/memory-store.ts
+++ b/packages/core/src/store/memory-store.ts
@@ -50,11 +50,12 @@ export type Memory = Record<string, unknown> & {
   project_key?: string | null;
   updated_at: string;
   curator_note?: Record<string, unknown> | null;
-  // memory-domain-isolation PR 1 — owner-controlled isolation axis +
-  // legacy-bridge booleans. Always populated post-T1.3 (defaults +
-  // category-derived); the classifier cutover (PR 7) replaces the
-  // derivation with the local model's verdict.
-  domain: string;
+  // memory-domain-isolation — owner-controlled isolation axis + the two
+  // policy booleans. `domain` is null for outside-session writes that
+  // sit in the proposal queue awaiting owner assignment (spec §4.14);
+  // otherwise it's the in-conversation domain assigned by `remember`
+  // (PR 3 / T3.1) or the legacy 'general' default.
+  domain: string | null;
   is_global: boolean;
   requires_approval: boolean;
 };
@@ -397,21 +398,37 @@ export function createMemoryStore(deps: MemoryStoreDeps): MemoryStore {
       agent_id = DEFAULT_AGENT_ID,
       query = "",
       categories = [],
+      tags = [],
       project_key = "",
       include_private = true,
       limit = 8,
       status = MemoryStatus.Active,
+      domain,
+      include_other_domains = false,
+      admin = false,
     } = input as {
       agent_id?: string;
       query?: string;
       categories?: unknown;
+      tags?: unknown;
       project_key?: string;
       include_private?: boolean;
       limit?: number;
       status?: string;
+      // memory-domain-isolation PR 3 — `domain` is opt-in. When the
+      // caller (typically the `recall` handler) supplies it, the §4.11
+      // hard filter applies: rows must match the domain OR be global.
+      // When omitted (legacy internal callers like startContext, the
+      // memory-store tests), no domain filtering happens — the call
+      // behaves identically to PR 2.
+      domain?: string | null;
+      include_other_domains?: boolean;
+      admin?: boolean;
     };
     const cleaned = normalizeString(query);
     const categorySet = new Set(asArray(categories));
+    const tagSet = new Set(asArray(tags));
+    const explicitDomain = Object.prototype.hasOwnProperty.call(input, "domain");
     const all = listAll({ status, agent_id: include_private ? agent_id : "", project_key });
     const allowed = all.filter((memory) => {
       if (categorySet.size && !categorySet.has(memory.category)) return false;
@@ -420,6 +437,28 @@ export function createMemoryStore(deps: MemoryStoreDeps): MemoryStore {
         (!include_private || memory.agent_id !== agent_id)
       )
         return false;
+      // §4.11 — admin bypasses the domain hard filter entirely; non-
+      // admin callers see only rows matching their conv_state domain
+      // plus globals, unless they explicitly broaden with
+      // `include_other_domains`. Defensive default for "no conv_state":
+      // domain=null on the call → only globals come back.
+      if (explicitDomain && !admin && !include_other_domains) {
+        if (memory.is_global !== true) {
+          if (domain === null || domain === undefined) return false;
+          if (memory.domain !== domain) return false;
+        }
+      }
+      if (tagSet.size) {
+        const memoryTags = new Set(memory.tags || []);
+        let hit = false;
+        for (const t of tagSet) {
+          if (memoryTags.has(t)) {
+            hit = true;
+            break;
+          }
+        }
+        if (!hit) return false;
+      }
       return true;
     });
 
@@ -485,7 +524,26 @@ export function createMemoryStore(deps: MemoryStoreDeps): MemoryStore {
     // informational — the agent can decide whether to consolidate via
     // update + verify(outdated). No more refused writes.
     const normalized = normalizeMemoryInput(input);
-    const protectedWrite = isProtectedCategory(normalized.category) && !options.forceActive;
+    // memory-domain-isolation §4.14 — writes that arrive without a
+    // conv_state context route through the proposal queue with
+    // `domain = NULL` and `requires_approval = true`. The MCP layer
+    // sets `outsideSession: true` for the curator / direct CLI / API
+    // entry points and for in-conversation calls that find no
+    // matching conv_state row.
+    const outsideSession = options.outsideSession === true;
+    const explicitDomain = Object.prototype.hasOwnProperty.call(options, "domain")
+      ? (options.domain as string | null)
+      : undefined;
+    const domain = outsideSession
+      ? null
+      : explicitDomain === undefined
+        ? normalized.domain
+        : explicitDomain;
+    const requiresApproval = outsideSession ? true : normalized.requires_approval;
+
+    const protectedWrite =
+      (isProtectedCategory(normalized.category) || requiresApproval || outsideSession) &&
+      !options.forceActive;
     const status =
       (options.status as MemoryStatus | undefined) ||
       (protectedWrite ? MemoryStatus.Proposed : normalized.status);
@@ -500,6 +558,8 @@ export function createMemoryStore(deps: MemoryStoreDeps): MemoryStore {
     const memory: Memory = {
       id: makeId("mem"),
       ...normalized,
+      domain,
+      requires_approval: requiresApproval,
       status,
       created_at: nowIso(),
       updated_at: nowIso(),
@@ -795,7 +855,11 @@ function rowToMemory(row: Record<string, unknown>): Memory {
       : null,
     // SQLite stores booleans as INTEGER 0/1; surface them as native
     // booleans on the agent-visible memory object.
-    domain: (row.domain as string) || "general",
+    // SQLite returns null exactly when the row was inserted with null;
+    // preserve it so the dashboard's outside-session proposal flow can
+    // distinguish "domain not yet picked" from "domain explicitly set
+    // to general".
+    domain: (row.domain as string | null) ?? null,
     is_global: Boolean(row.is_global),
     requires_approval: Boolean(row.requires_approval),
   } as Memory;

--- a/packages/core/src/store/memory-store.ts
+++ b/packages/core/src/store/memory-store.ts
@@ -230,6 +230,36 @@ export function createMemoryStore(deps: MemoryStoreDeps): MemoryStore {
       clauses.push("scope = ?");
       params.push(filters.scope);
     }
+    // memory-domain-isolation PR 3 / T3.4 — new filter axes the
+    // dashboard uses to slice memories. `domain` accepts a string or
+    // an explicit null (matches outside-session writes awaiting owner
+    // assignment). `is_global` / `requires_approval` are bool inputs
+    // mapped to the INTEGER 0/1 column shape. `tags` filters by any
+    // matching tag via JSON containment.
+    if (filters.domain !== undefined) {
+      if (filters.domain === null) {
+        clauses.push("domain IS NULL");
+      } else {
+        clauses.push("domain = ?");
+        params.push(filters.domain);
+      }
+    }
+    if (filters.is_global !== undefined) {
+      clauses.push("is_global = ?");
+      params.push(filters.is_global ? 1 : 0);
+    }
+    if (filters.requires_approval !== undefined) {
+      clauses.push("requires_approval = ?");
+      params.push(filters.requires_approval ? 1 : 0);
+    }
+    if (Array.isArray(filters.tags) && filters.tags.length > 0) {
+      const tagClauses: string[] = [];
+      for (const tag of filters.tags as string[]) {
+        tagClauses.push("tags_json LIKE ?");
+        params.push(`%${JSON.stringify(tag).slice(1, -1)}%`);
+      }
+      clauses.push(`(${tagClauses.join(" OR ")})`);
+    }
     if (filters.from) {
       clauses.push("created_at >= ?");
       params.push(filters.from);

--- a/packages/core/src/store/projection.ts
+++ b/packages/core/src/store/projection.ts
@@ -105,7 +105,14 @@ function asArray(value: unknown): string[] {
 //         re-insertion). The sessions column is added via ALTER TABLE in
 //         `ensureAuthoritativeTableColumns` because the sessions table
 //         is SQLite-authoritative post-R1 and must not be dropped.
-export const PROJECTION_SCHEMA_VERSION = 13;
+//   - 14: memory-domain-isolation PR 3 / T3.1 — drops the NOT NULL
+//         constraint on `memories.domain`. Outside-session writes (spec
+//         §4.14) land with `domain = NULL` and route to the proposal
+//         queue, where the dashboard owner picks a domain at approval
+//         time. Memories is JSONL-canonical so the bump drops + rebuilds
+//         the table from the ledger; the default 'general' still applies
+//         to writes that omit the column.
+export const PROJECTION_SCHEMA_VERSION = 14;
 
 export function getSchemaVersion(db: DatabaseSync): number {
   const row = db.prepare("PRAGMA user_version").get() as { user_version: number };
@@ -236,7 +243,7 @@ export const SCHEMA_DDL = `
       recall_count INTEGER NOT NULL,
       usefulness_score INTEGER NOT NULL,
       curator_note TEXT,
-      domain TEXT NOT NULL DEFAULT 'general',
+      domain TEXT DEFAULT 'general',
       is_global INTEGER NOT NULL DEFAULT 0,
       requires_approval INTEGER NOT NULL DEFAULT 0
     );
@@ -454,13 +461,19 @@ type MemoryRecord = Record<string, unknown> & { id: string };
  * Returned as a positional tuple so `insertMemory.run(...)` can spread
  * it directly into the prepared statement's bind list.
  */
-function deriveDomainColumns(m: Record<string, unknown>): [string, number, number] {
+function deriveDomainColumns(m: Record<string, unknown>): [string | null, number, number] {
   const category = m.category as Category | undefined;
   const visibility = m.visibility as Visibility | undefined;
   const derived = category ? deriveLegacyMemoryFlags(category) : undefined;
   const fallbackDomain = visibility === Visibility.AgentPrivate ? "legacy-private" : "general";
 
-  const domain = (m.domain as string) || fallbackDomain;
+  // PR 3 / spec §4.14 — outside-session writes carry an explicit
+  // `domain: null` on the snapshot to mark them as awaiting owner
+  // assignment in the proposal queue. Distinguish this from "field
+  // absent on a legacy event" via `hasOwn`: absent → fall back to the
+  // visibility-derived value; present null → preserve.
+  const explicitDomain = Object.prototype.hasOwnProperty.call(m, "domain");
+  const domain = explicitDomain ? ((m.domain as string | null) ?? null) : fallbackDomain;
   const isGlobal = m.is_global === undefined ? Boolean(derived?.is_global) : Boolean(m.is_global);
   const requiresApproval =
     m.requires_approval === undefined

--- a/packages/core/src/store/projection.ts
+++ b/packages/core/src/store/projection.ts
@@ -910,6 +910,11 @@ interface SessionSnapshot {
   archived_at?: string | null;
   deleted_at?: string | null;
   metadata?: unknown;
+  // memory-domain-isolation §4.12 — session-level domain inherited
+  // from the conv_state at start. Optional on the snapshot for backward
+  // compatibility with pre-T3.3 events; the projection defaults to
+  // 'general' when missing.
+  domain?: string | null;
 }
 
 function insertSessionRow(db: DatabaseSync, session: SessionSnapshot): void {
@@ -923,8 +928,8 @@ function insertSessionRow(db: DatabaseSync, session: SessionSnapshot): void {
       source_ref, cwd, start_summary, rolling_summary, end_summary,
       next_steps_json, tags_json, capture_mode,
       started_at, updated_at, last_activity_at,
-      paused_at, ended_at, archived_at, deleted_at, metadata_json, state_version
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      paused_at, ended_at, archived_at, deleted_at, metadata_json, state_version, domain
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     session.id,
     session.title,
@@ -953,6 +958,7 @@ function insertSessionRow(db: DatabaseSync, session: SessionSnapshot): void {
     session.deleted_at || null,
     JSON.stringify(session.metadata || {}),
     1,
+    session.domain || "general",
   );
 }
 

--- a/packages/core/src/store/session-store.ts
+++ b/packages/core/src/store/session-store.ts
@@ -73,6 +73,9 @@ export type Session = Record<string, unknown> & {
   archived_at: string | null;
   deleted_at: string | null;
   metadata: Record<string, unknown>;
+  // memory-domain-isolation §4.12 — session-level domain inherited
+  // from conv_state at start; immutable for the session's life.
+  domain: string;
 };
 
 export interface SessionEventRecord {
@@ -228,6 +231,11 @@ export function createSessionStore(deps: SessionStoreDeps): SessionStore {
     const title =
       normalizeString(input.title) || `${projectKey || harness || "agent"} session @ ${now}`;
 
+    // memory-domain-isolation §4.12 — sessions inherit the calling
+    // conversation's domain. The handler resolves it from conv_state
+    // (or the single-domain fast path) and passes it through; a missing
+    // value defaults to 'general' so the column stays valid.
+    const domain = normalizeString(input.domain) || "general";
     const session: Session = {
       id: makeId("ses"),
       title,
@@ -255,6 +263,7 @@ export function createSessionStore(deps: SessionStoreDeps): SessionStore {
       archived_at: null,
       deleted_at: null,
       metadata: isPlainObject(input.metadata) ? (input.metadata as Record<string, unknown>) : {},
+      domain,
     };
 
     appendSessionEvent(
@@ -933,5 +942,6 @@ function rowToSession(row: Record<string, unknown>): Session {
     archived_at: (row.archived_at as string | null) ?? null,
     deleted_at: (row.deleted_at as string | null) ?? null,
     metadata: JSON.parse((row.metadata_json as string) || "{}") as Record<string, unknown>,
+    domain: (row.domain as string | null) ?? "general",
   };
 }

--- a/packages/core/tests/store/memory-store.test.ts
+++ b/packages/core/tests/store/memory-store.test.ts
@@ -425,6 +425,123 @@ describe("LibrarianStore memory CRUD", () => {
     });
   });
 
+  describe("listMemories domain filters (T3.4)", () => {
+    function seed(
+      store: LibrarianStore,
+      domain: string,
+      title: string,
+      category = "tools",
+    ): string {
+      const result = store.createMemory(
+        {
+          agent_id: "codex",
+          title,
+          body: `${title} body`,
+          category,
+          visibility: "common",
+          scope: "tool",
+        },
+        { domain },
+      );
+      return result.memory.id;
+    }
+
+    it("filters by domain (string)", () => {
+      const { store } = scope!;
+      const codingId = seed(store, "coding", "coding note");
+      seed(store, "family-admin", "family note");
+      const list = store.listMemories({ domain: "coding" });
+      expect(list.memories.map((m) => m.id)).toEqual([codingId]);
+    });
+
+    it("filters by domain = NULL for outside-session proposals", () => {
+      const { store } = scope!;
+      // Multi-domain so the §4.10 fast path doesn't intercept.
+      store.db
+        .prepare("INSERT INTO domains (name, created_at) VALUES (?, ?)")
+        .run("coding", new Date().toISOString());
+      const outside = store.createMemory(
+        {
+          agent_id: "codex",
+          title: "outside-session",
+          body: "no conv_state",
+          category: "tools",
+          visibility: "common",
+          scope: "tool",
+        },
+        { outsideSession: true },
+      );
+      seed(store, "coding", "in-session");
+      const list = store.listMemories({ domain: null });
+      expect(list.memories.map((m) => m.id)).toEqual([outside.memory.id]);
+    });
+
+    it("filters by requires_approval=true + status=proposed (pending-approval view)", () => {
+      const { store } = scope!;
+      const protectedId = store.createMemory({
+        agent_id: "codex",
+        title: "identity",
+        body: "Jim is the owner",
+        category: "identity",
+        visibility: "common",
+        scope: "global",
+      }).memory.id;
+      seed(store, "coding", "active note");
+      const list = store.listMemories({ requires_approval: true, status: "proposed" });
+      expect(list.memories.map((m) => m.id)).toEqual([protectedId]);
+    });
+
+    it("filters by is_global=true", () => {
+      const { store } = scope!;
+      const prefId = store.createMemory({
+        agent_id: "codex",
+        title: "preferences",
+        body: "terse",
+        category: "preferences",
+        visibility: "common",
+        scope: "global",
+      }).memory.id;
+      seed(store, "coding", "ordinary note");
+      const list = store.listMemories({ is_global: true });
+      expect(list.memories.map((m) => m.id)).toContain(prefId);
+      expect(list.memories.every((m) => m.is_global === true)).toBe(true);
+    });
+
+    it("filters by tags (OR semantics across multiple tags)", () => {
+      const { store } = scope!;
+      const calId = store.createMemory(
+        {
+          agent_id: "codex",
+          title: "calendar note",
+          body: "tuesdays",
+          category: "tools",
+          visibility: "common",
+          scope: "tool",
+          tags: ["calendar"],
+        },
+        { domain: "general" },
+      ).memory.id;
+      const pnpmId = store.createMemory(
+        {
+          agent_id: "codex",
+          title: "pnpm note",
+          body: "use pnpm",
+          category: "tools",
+          visibility: "common",
+          scope: "tool",
+          tags: ["pnpm"],
+        },
+        { domain: "general" },
+      ).memory.id;
+      seed(store, "general", "no tag note");
+      const list = store.listMemories({ tags: ["calendar", "pnpm"] });
+      const ids = list.memories.map((m) => m.id);
+      expect(ids).toContain(calId);
+      expect(ids).toContain(pnpmId);
+      expect(ids.length).toBe(2);
+    });
+  });
+
   describe("legacy category → is_global / requires_approval derivation (T1.3)", () => {
     it("identity memories derive requires_approval=1, is_global=1 and route to proposed", () => {
       const { store } = scope!;

--- a/packages/mcp-server/src/mcp/domain-resolution.ts
+++ b/packages/mcp-server/src/mcp/domain-resolution.ts
@@ -1,0 +1,42 @@
+// Shared domain-resolution helper for the MCP tool handlers.
+//
+// `remember`, `recall`, and `start_session` all need to answer the same
+// question: "given a tool call from an agent (or admin), what domain
+// should this write/read be scoped to?" The precedence chain comes
+// from memory-domain-isolation §4.10:
+//
+//   1. Admin role → null (bypasses the hard filter; admin sees all).
+//   2. conv_id matches a `conversation_state` row → conv_state.domain.
+//   3. Single-domain install (only one row in `domains`) → that domain.
+//   4. Otherwise → null. Callers decide whether to translate null into
+//      a defensive default (recall returns globals only) or an
+//      outside-session route (remember opens a proposal).
+
+import type { LibrarianStore } from "@librarian/core";
+import type { ToolContext } from "./tool.js";
+
+export type DomainSource = "admin" | "conv_state" | "single_domain" | "none";
+
+export interface ResolvedDomain {
+  domain: string | null;
+  source: DomainSource;
+}
+
+export function resolveCallerDomain(
+  store: LibrarianStore,
+  convId: string,
+  context: ToolContext,
+): ResolvedDomain {
+  if (context.role === "admin") return { domain: null, source: "admin" };
+  if (convId) {
+    const state = store.convState.get(convId);
+    if (state) return { domain: state.domain, source: "conv_state" };
+  }
+  const rows = store.db.prepare("SELECT name FROM domains LIMIT 2").all() as Array<{
+    name: string;
+  }>;
+  if (rows.length === 1) {
+    return { domain: rows[0]?.name ?? null, source: "single_domain" };
+  }
+  return { domain: null, source: "none" };
+}

--- a/packages/mcp-server/src/mcp/tools/continue-session.ts
+++ b/packages/mcp-server/src/mcp/tools/continue-session.ts
@@ -5,7 +5,10 @@ import { isSessionVisible, scopeAgentArgs } from "../visibility.js";
 const continueSession: ToolDefinition = {
   name: "continue_session",
   description:
-    "Generate a handover package for the session and (by default) attach to the target harness.",
+    "Generate a handover package for the session and (by default) attach to the target harness. " +
+    "When `conv_id` is supplied, the resuming conv_state is seeded (or overwritten) with the " +
+    "session's `domain` per spec §4.12 — the signal-precedence chain is intentionally bypassed " +
+    "on resume since the operator's resume action is itself the domain signal.",
   inputSchema: {
     type: "object",
     required: ["session_id"],
@@ -15,6 +18,7 @@ const continueSession: ToolDefinition = {
       target_source_ref: { type: "string" },
       target_cwd: { type: "string" },
       attach: { type: "boolean" },
+      conv_id: { type: "string" },
       format: {
         type: "string",
         enum: ["prose", "markdown", "claude", "codex", "opencode", "hermes", "pi"],
@@ -23,11 +27,27 @@ const continueSession: ToolDefinition = {
   },
   handler(store, args, context) {
     const scoped = scopeAgentArgs(args, context);
+    const convId = typeof scoped.conv_id === "string" ? scoped.conv_id : "";
+    delete scoped.conv_id;
     const session = store.getSession(scoped.session_id as string);
     if (!isSessionVisible(session, context)) {
       return textResult(`No session found for id ${scoped.session_id as string}.`);
     }
     const result = store.continueSession(scoped);
+    if (convId && session) {
+      // §4.12 — seed the resuming conv_state's domain from the session.
+      // Uses `upsert` rather than a direct INSERT so existing rows are
+      // overwritten (the operator's resume action is the canonical
+      // signal of intent, overriding whatever the conv had before).
+      store.convState.upsert(convId, {
+        harness:
+          typeof scoped.target_harness === "string"
+            ? scoped.target_harness
+            : (session.current_harness ?? "unknown"),
+        domain: session.domain,
+        session_id: session.id,
+      });
+    }
     return textResult(result.text);
   },
 };

--- a/packages/mcp-server/src/mcp/tools/recall.ts
+++ b/packages/mcp-server/src/mcp/tools/recall.ts
@@ -1,6 +1,7 @@
-import { DEFAULT_AGENT_ID, type LibrarianStore, formatRecall } from "@librarian/core";
+import { DEFAULT_AGENT_ID, formatRecall } from "@librarian/core";
+import { resolveCallerDomain } from "../domain-resolution.js";
 import { textResult } from "../result.js";
-import type { ToolContext, ToolDefinition } from "../tool.js";
+import type { ToolDefinition } from "../tool.js";
 import { scopeAgentArgs } from "../visibility.js";
 
 const recall: ToolDefinition = {
@@ -29,7 +30,7 @@ const recall: ToolDefinition = {
     const scoped = scopeAgentArgs(args, context);
     const convId = typeof scoped.conv_id === "string" ? scoped.conv_id : "";
     delete scoped.conv_id;
-    const domain = resolveCallerDomain(store, convId, context);
+    const { domain } = resolveCallerDomain(store, convId, context);
     const memories = store.searchMemories({
       ...scoped,
       domain,
@@ -45,25 +46,5 @@ const recall: ToolDefinition = {
     return textResult(formatRecall(memories, "Relevant Memories", { includeIds }));
   },
 };
-
-// Match the `remember` handler's domain-resolution logic: prefer the
-// conv_state row when one exists; otherwise fall through to the §4.10
-// single-domain fast path; otherwise null (defensive — see §4.11).
-function resolveCallerDomain(
-  store: LibrarianStore,
-  convId: string,
-  context: ToolContext,
-): string | null {
-  if (context.role === "admin") return null;
-  if (convId) {
-    const state = store.convState.get(convId);
-    if (state) return state.domain;
-  }
-  const rows = store.db.prepare("SELECT name FROM domains LIMIT 2").all() as Array<{
-    name: string;
-  }>;
-  if (rows.length === 1) return rows[0]?.name ?? null;
-  return null;
-}
 
 export default recall;

--- a/packages/mcp-server/src/mcp/tools/recall.ts
+++ b/packages/mcp-server/src/mcp/tools/recall.ts
@@ -1,29 +1,41 @@
-import { DEFAULT_AGENT_ID, formatRecall } from "@librarian/core";
+import { DEFAULT_AGENT_ID, type LibrarianStore, formatRecall } from "@librarian/core";
 import { textResult } from "../result.js";
-import type { ToolDefinition } from "../tool.js";
+import type { ToolContext, ToolDefinition } from "../tool.js";
 import { scopeAgentArgs } from "../visibility.js";
 
 const recall: ToolDefinition = {
   name: "recall",
   description:
-    "Search memories by query and filters. Returns clean prose; pass " +
-    "`include_ids: true` to prefix each result with its memory id so the " +
-    "caller can verify it via `verify_memory`.",
+    "Search memories by query, tags, and conv-state domain. Domain filtering " +
+    "is automatic: results are scoped to the calling conversation's domain " +
+    "plus globals. Pass `include_other_domains: true` to broaden a single " +
+    "call to all domains. `tags` filters to memories carrying any of the " +
+    "supplied tags. Pass `include_ids: true` to prefix each result with its " +
+    "memory id for the verify-after-recall loop.",
   inputSchema: {
     type: "object",
     properties: {
       agent_id: { type: "string" },
       query: { type: "string" },
-      categories: { type: "array", items: { type: "string" } },
+      tags: { type: "array", items: { type: "string" } },
       project_key: { type: "string" },
-      include_private: { type: "boolean" },
+      conv_id: { type: "string", description: "Conversation identifier from the harness hook." },
+      include_other_domains: { type: "boolean", default: false },
       include_ids: { type: "boolean" },
       limit: { type: "number" },
     },
   },
   handler(store, args, context) {
     const scoped = scopeAgentArgs(args, context);
-    const memories = store.searchMemories(scoped);
+    const convId = typeof scoped.conv_id === "string" ? scoped.conv_id : "";
+    delete scoped.conv_id;
+    const domain = resolveCallerDomain(store, convId, context);
+    const memories = store.searchMemories({
+      ...scoped,
+      domain,
+      include_other_domains: scoped.include_other_domains === true,
+      admin: context.role === "admin",
+    });
     store.recordRecall(
       memories,
       (scoped.agent_id as string) || DEFAULT_AGENT_ID,
@@ -33,5 +45,25 @@ const recall: ToolDefinition = {
     return textResult(formatRecall(memories, "Relevant Memories", { includeIds }));
   },
 };
+
+// Match the `remember` handler's domain-resolution logic: prefer the
+// conv_state row when one exists; otherwise fall through to the §4.10
+// single-domain fast path; otherwise null (defensive — see §4.11).
+function resolveCallerDomain(
+  store: LibrarianStore,
+  convId: string,
+  context: ToolContext,
+): string | null {
+  if (context.role === "admin") return null;
+  if (convId) {
+    const state = store.convState.get(convId);
+    if (state) return state.domain;
+  }
+  const rows = store.db.prepare("SELECT name FROM domains LIMIT 2").all() as Array<{
+    name: string;
+  }>;
+  if (rows.length === 1) return rows[0]?.name ?? null;
+  return null;
+}
 
 export default recall;

--- a/packages/mcp-server/src/mcp/tools/remember.ts
+++ b/packages/mcp-server/src/mcp/tools/remember.ts
@@ -1,19 +1,8 @@
-import type { LibrarianStore } from "@librarian/core";
+import { resolveCallerDomain } from "../domain-resolution.js";
 import { textResult } from "../result.js";
 import type { ToolDefinition } from "../tool.js";
 import { scopeAgentArgs } from "../visibility.js";
 import { memoryInputSchema } from "./schemas.js";
-
-// Returns the sole domain name when the install has exactly one row in
-// the `domains` table; otherwise null. Used by `remember` to honour the
-// §4.10 single-domain fast path that keeps zero-config installs from
-// having to set up conv_state.
-function readSingleDomain(store: LibrarianStore): string | null {
-  const rows = store.db.prepare("SELECT name FROM domains LIMIT 2").all() as Array<{
-    name: string;
-  }>;
-  return rows.length === 1 ? (rows[0]?.name ?? null) : null;
-}
 
 const remember: ToolDefinition = {
   name: "remember",
@@ -31,24 +20,19 @@ const remember: ToolDefinition = {
     // Strip the conv_id wrapper before it reaches createMemory — it's a
     // routing signal for the handler, not a memory field.
     delete scoped.conv_id;
-    const state = convId ? store.convState.get(convId) : null;
-    // Spec §4.10 special case — when the operator has not added a
-    // second domain, the entire signal-precedence chain (and the
-    // outside-session proposal route) collapses to "use the single
-    // domain." This keeps zero-config installs zero-friction and
-    // preserves PR 1's behaviour for callers that don't yet supply a
-    // conv_id.
-    const singleDomain = !state ? readSingleDomain(store) : null;
-    const result = state
-      ? store.createMemory(scoped, { domain: state.domain })
-      : singleDomain
-        ? store.createMemory(scoped, { domain: singleDomain })
-        : store.createMemory(scoped, { outsideSession: true });
+    const { domain, source } = resolveCallerDomain(store, convId, context);
+    // §4.14: an unresolvable domain on a multi-domain install routes
+    // the write to the proposal queue with domain=NULL. The §4.10 fast
+    // path and the conv_state hit both produce a concrete domain.
+    const result =
+      source === "none"
+        ? store.createMemory(scoped, { outsideSession: true })
+        : store.createMemory(scoped, { domain });
     const suffix =
       result.status === "proposed"
-        ? state || singleDomain
-          ? "This memory is protected and has been saved as a proposal for review."
-          : "No conversation state for this caller; memory saved as a proposal awaiting an owner-assigned domain."
+        ? source === "none"
+          ? "No conversation state for this caller; memory saved as a proposal awaiting an owner-assigned domain."
+          : "This memory is protected and has been saved as a proposal for review."
         : "Memory saved.";
     const duplicateText = result.duplicates?.length
       ? `\n\nPossible duplicates:\n${result.duplicates

--- a/packages/mcp-server/src/mcp/tools/remember.ts
+++ b/packages/mcp-server/src/mcp/tools/remember.ts
@@ -1,20 +1,54 @@
+import type { LibrarianStore } from "@librarian/core";
 import { textResult } from "../result.js";
 import type { ToolDefinition } from "../tool.js";
 import { scopeAgentArgs } from "../visibility.js";
 import { memoryInputSchema } from "./schemas.js";
 
+// Returns the sole domain name when the install has exactly one row in
+// the `domains` table; otherwise null. Used by `remember` to honour the
+// §4.10 single-domain fast path that keeps zero-config installs from
+// having to set up conv_state.
+function readSingleDomain(store: LibrarianStore): string | null {
+  const rows = store.db.prepare("SELECT name FROM domains LIMIT 2").all() as Array<{
+    name: string;
+  }>;
+  return rows.length === 1 ? (rows[0]?.name ?? null) : null;
+}
+
 const remember: ToolDefinition = {
   name: "remember",
   description:
-    "Save a durable memory. Protected categories become proposals. " +
-    "Returns informational `duplicates` when similar memories already exist — the write always succeeds.",
+    "Save a durable memory. The server sets `domain` from the calling " +
+    "conversation's conv_state (if `conv_id` is supplied and a row exists); " +
+    "otherwise the memory routes to the proposal queue with `domain=NULL` " +
+    "and `requires_approval=true` so the owner can pick a domain at approval " +
+    "time. Caller-supplied `domain`, `is_global`, and `requires_approval` " +
+    "are ignored (spec §4.1–§4.4).",
   inputSchema: memoryInputSchema(),
   handler(store, args, context) {
     const scoped = scopeAgentArgs(args, context);
-    const result = store.createMemory(scoped);
+    const convId = typeof scoped.conv_id === "string" ? scoped.conv_id : "";
+    // Strip the conv_id wrapper before it reaches createMemory — it's a
+    // routing signal for the handler, not a memory field.
+    delete scoped.conv_id;
+    const state = convId ? store.convState.get(convId) : null;
+    // Spec §4.10 special case — when the operator has not added a
+    // second domain, the entire signal-precedence chain (and the
+    // outside-session proposal route) collapses to "use the single
+    // domain." This keeps zero-config installs zero-friction and
+    // preserves PR 1's behaviour for callers that don't yet supply a
+    // conv_id.
+    const singleDomain = !state ? readSingleDomain(store) : null;
+    const result = state
+      ? store.createMemory(scoped, { domain: state.domain })
+      : singleDomain
+        ? store.createMemory(scoped, { domain: singleDomain })
+        : store.createMemory(scoped, { outsideSession: true });
     const suffix =
       result.status === "proposed"
-        ? "This memory is protected and has been saved as a proposal for review."
+        ? state || singleDomain
+          ? "This memory is protected and has been saved as a proposal for review."
+          : "No conversation state for this caller; memory saved as a proposal awaiting an owner-assigned domain."
         : "Memory saved.";
     const duplicateText = result.duplicates?.length
       ? `\n\nPossible duplicates:\n${result.duplicates

--- a/packages/mcp-server/src/mcp/tools/schemas.ts
+++ b/packages/mcp-server/src/mcp/tools/schemas.ts
@@ -26,6 +26,12 @@ export function memoryInputSchema(): Record<string, unknown> {
       priority: { type: "string" },
       confidence: { type: "string" },
       tags: { type: "array", items: { type: "string" } },
+      // memory-domain-isolation PR 3 — agents pass `conv_id` so the
+      // server can read conv_state and place the memory in the right
+      // domain. Caller-supplied `domain` / `is_global` /
+      // `requires_approval` are NOT advertised here and are silently
+      // ignored by normalizeMemoryInput (spec §4.1–§4.4).
+      conv_id: { type: "string" },
     },
   };
 }

--- a/packages/mcp-server/src/mcp/tools/start-session.ts
+++ b/packages/mcp-server/src/mcp/tools/start-session.ts
@@ -1,3 +1,4 @@
+import { resolveCallerDomain } from "../domain-resolution.js";
 import { formatSessionStart } from "../formatters.js";
 import { textResult } from "../result.js";
 import type { ToolDefinition } from "../tool.js";
@@ -30,15 +31,14 @@ const startSession: ToolDefinition = {
     const scoped = scopeAgentArgs(args, context);
     const convId = typeof scoped.conv_id === "string" ? scoped.conv_id : "";
     delete scoped.conv_id;
-    const state = convId ? store.convState.get(convId) : null;
-    if (state) {
-      scoped.domain = state.domain;
-    } else if (!scoped.domain) {
-      const rows = store.db.prepare("SELECT name FROM domains LIMIT 2").all() as Array<{
-        name: string;
-      }>;
-      scoped.domain = rows.length === 1 ? (rows[0]?.name ?? "general") : "general";
-    }
+    // Sessions always need a concrete `domain` value (§4.12 — the
+    // column is NOT NULL and resume relies on it being load-bearing).
+    // When the resolver can't pick one (multi-domain install + no
+    // conv_state), default to 'general' rather than the proposal route
+    // — start_session is itself an explicit owner-driven action so the
+    // outside-session semantics that apply to remember don't fit here.
+    const { domain } = resolveCallerDomain(store, convId, context);
+    scoped.domain = domain ?? "general";
     const result = store.startSession(scoped);
     return textResult(formatSessionStart(result.session!));
   },

--- a/packages/mcp-server/src/mcp/tools/start-session.ts
+++ b/packages/mcp-server/src/mcp/tools/start-session.ts
@@ -5,7 +5,11 @@ import { scopeAgentArgs } from "../visibility.js";
 
 const startSession: ToolDefinition = {
   name: "start_session",
-  description: "Start a new Librarian session, attributed to the calling agent.",
+  description:
+    "Start a new Librarian session, attributed to the calling agent. The " +
+    "session inherits its `domain` from the calling conv_state (when `conv_id` " +
+    "is supplied and a row exists); otherwise the §4.10 single-domain fast " +
+    "path applies; otherwise the session defaults to `general`.",
   inputSchema: {
     type: "object",
     properties: {
@@ -19,10 +23,22 @@ const startSession: ToolDefinition = {
       start_summary: { type: "string" },
       tags: { type: "array", items: { type: "string" } },
       next_steps: { type: "array", items: { type: "string" } },
+      conv_id: { type: "string", description: "Conversation identifier from the harness hook." },
     },
   },
   handler(store, args, context) {
     const scoped = scopeAgentArgs(args, context);
+    const convId = typeof scoped.conv_id === "string" ? scoped.conv_id : "";
+    delete scoped.conv_id;
+    const state = convId ? store.convState.get(convId) : null;
+    if (state) {
+      scoped.domain = state.domain;
+    } else if (!scoped.domain) {
+      const rows = store.db.prepare("SELECT name FROM domains LIMIT 2").all() as Array<{
+        name: string;
+      }>;
+      scoped.domain = rows.length === 1 ? (rows[0]?.name ?? "general") : "general";
+    }
     const result = store.startSession(scoped);
     return textResult(formatSessionStart(result.session!));
   },

--- a/packages/mcp-server/tests/mcp/recall-domain.mcp.test.ts
+++ b/packages/mcp-server/tests/mcp/recall-domain.mcp.test.ts
@@ -1,0 +1,196 @@
+// T3.2 — `recall` applies the domain hard filter, supports the new
+// `tags` and `include_other_domains` inputs, and admin bypasses the
+// filter entirely. Spec §4.11.
+
+import type { LibrarianStore } from "@librarian/core";
+import { handleMcpPayload } from "@librarian/mcp-server";
+import { describe, expect, it } from "vitest";
+import { withStore } from "../../../../test/helpers.js";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyResponse = any;
+
+function call(
+  store: LibrarianStore,
+  args: Record<string, unknown>,
+  context: { role?: "admin" | "agent"; agentId?: string } = {},
+): Promise<AnyResponse> {
+  return handleMcpPayload(
+    store,
+    { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "recall", arguments: args } },
+    { role: context.role || "agent", agentId: context.agentId || "codex" },
+  ) as Promise<AnyResponse>;
+}
+
+function seedDomains(store: LibrarianStore): {
+  codingMemoryId: string;
+  familyMemoryId: string;
+  globalMemoryId: string;
+} {
+  // Multi-domain install.
+  store.db
+    .prepare("INSERT INTO domains (name, created_at) VALUES (?, ?), (?, ?)")
+    .run("coding", new Date().toISOString(), "family-admin", new Date().toISOString());
+
+  // One memory per domain plus a global memory that bypasses domain
+  // filtering (`is_global=1`).
+  store.convState.upsert("claude:coding", { harness: "claude-code", domain: "coding" });
+  store.convState.upsert("claude:family", { harness: "claude-code", domain: "family-admin" });
+
+  const codingMemoryId = createInDomain(
+    store,
+    "claude:coding",
+    "pnpm not npm",
+    "this repo uses pnpm",
+    ["pnpm"],
+  );
+  const familyMemoryId = createInDomain(
+    store,
+    "claude:family",
+    "tuesday family slot",
+    "family slot is tuesday evening",
+    ["calendar"],
+  );
+
+  // Global via identity category (is_global=1 by legacy derivation).
+  const globalMemoryId = createInDomain(
+    store,
+    "claude:coding",
+    "owner identity",
+    "Jim is the owner of the librarian",
+    [],
+    "identity",
+  );
+
+  return { codingMemoryId, familyMemoryId, globalMemoryId };
+}
+
+function createInDomain(
+  store: LibrarianStore,
+  convId: string,
+  title: string,
+  body: string,
+  tags: string[],
+  category = "tools",
+): string {
+  const result = handleMcpPayload(
+    store,
+    {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: {
+        name: "remember",
+        arguments: { agent_id: "codex", title, body, category, conv_id: convId, tags },
+      },
+    },
+    { role: "agent", agentId: "codex" },
+  );
+  void result;
+  // The mem id is awkward to extract from the prose; pull it from the
+  // store directly by title.
+  return (store.db.prepare("SELECT id FROM memories WHERE title = ?").get(title) as { id: string })
+    .id;
+}
+
+describe("MCP recall + domain hard filter (T3.2)", () => {
+  it("returns coding-domain memories and globals when called from a coding conv_state", async () => {
+    await withStore(async (store) => {
+      const { codingMemoryId, familyMemoryId, globalMemoryId } = seedDomains(store);
+      const response = await call(store, {
+        agent_id: "codex",
+        query: "pnpm tuesday Jim",
+        conv_id: "claude:coding",
+        include_ids: true,
+        limit: 10,
+      });
+      const text = response.result.content[0].text;
+      expect(text).toContain(codingMemoryId);
+      // Global proposals are status=proposed (identity routes through
+      // requires_approval); recall only returns active rows. Approve the
+      // global, then re-query.
+      store.approveProposal(globalMemoryId, "approve", {}, "dashboard");
+      const reopened = await call(store, {
+        agent_id: "codex",
+        query: "pnpm tuesday Jim",
+        conv_id: "claude:coding",
+        include_ids: true,
+        limit: 10,
+      });
+      const text2 = reopened.result.content[0].text;
+      expect(text2).toContain(codingMemoryId);
+      expect(text2).toContain(globalMemoryId);
+      expect(text2).not.toContain(familyMemoryId);
+    });
+  });
+
+  it("include_other_domains: true drops the domain filter", async () => {
+    await withStore(async (store) => {
+      const { codingMemoryId, familyMemoryId } = seedDomains(store);
+      const response = await call(store, {
+        agent_id: "codex",
+        query: "pnpm tuesday",
+        conv_id: "claude:coding",
+        include_other_domains: true,
+        include_ids: true,
+        limit: 10,
+      });
+      const text = response.result.content[0].text;
+      expect(text).toContain(codingMemoryId);
+      expect(text).toContain(familyMemoryId);
+    });
+  });
+
+  it("tags filter narrows results to matching memories", async () => {
+    await withStore(async (store) => {
+      const { codingMemoryId, familyMemoryId } = seedDomains(store);
+      const response = await call(store, {
+        agent_id: "codex",
+        query: "pnpm tuesday",
+        conv_id: "claude:coding",
+        include_other_domains: true,
+        tags: ["calendar"],
+        include_ids: true,
+        limit: 10,
+      });
+      const text = response.result.content[0].text;
+      expect(text).toContain(familyMemoryId);
+      expect(text).not.toContain(codingMemoryId);
+    });
+  });
+
+  it("admin role sees memories across all domains without supplying conv_id", async () => {
+    await withStore(async (store) => {
+      const { codingMemoryId, familyMemoryId } = seedDomains(store);
+      const response = await call(
+        store,
+        {
+          query: "pnpm tuesday",
+          include_ids: true,
+          limit: 10,
+        },
+        { role: "admin" },
+      );
+      const text = response.result.content[0].text;
+      expect(text).toContain(codingMemoryId);
+      expect(text).toContain(familyMemoryId);
+    });
+  });
+
+  it("no conv_state on a multi-domain install returns only globals (defensive default)", async () => {
+    await withStore(async (store) => {
+      const { codingMemoryId, familyMemoryId, globalMemoryId } = seedDomains(store);
+      store.approveProposal(globalMemoryId, "approve", {}, "dashboard");
+      const response = await call(store, {
+        agent_id: "codex",
+        query: "pnpm tuesday Jim",
+        include_ids: true,
+        limit: 10,
+      });
+      const text = response.result.content[0].text;
+      expect(text).toContain(globalMemoryId);
+      expect(text).not.toContain(codingMemoryId);
+      expect(text).not.toContain(familyMemoryId);
+    });
+  });
+});

--- a/packages/mcp-server/tests/mcp/remember-domain.mcp.test.ts
+++ b/packages/mcp-server/tests/mcp/remember-domain.mcp.test.ts
@@ -1,0 +1,172 @@
+// T3.1 — `remember` reads conv_state and server-sets `domain`.
+//
+// Branches per spec §4.10 + §4.14:
+//   - conv_id present + matching conv_state → memory carries
+//     conv_state.domain.
+//   - conv_id present but no conv_state row → outside-session: status
+//     proposed, domain NULL, requires_approval=true.
+//   - conv_id absent (no routing signal at all) → outside-session
+//     same shape. PR 5 starts injecting conv_id from hook context.
+//   - Single-domain installs (the §4.10 fast path) bypass the outside-
+//     session route entirely: the sole domain is auto-assigned. The
+//     outside-session tests below add a second domain so the fast path
+//     doesn't fire.
+//
+// Also pins: caller-supplied `domain` / `is_global` / `requires_approval`
+// in the input are silently ignored, matching spec §4.1–§4.4.
+
+import type { LibrarianStore } from "@librarian/core";
+import { handleMcpPayload } from "@librarian/mcp-server";
+import { describe, expect, it } from "vitest";
+import { withStore } from "../../../../test/helpers.js";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyResponse = any;
+
+function call(
+  store: LibrarianStore,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<AnyResponse> {
+  return handleMcpPayload(
+    store,
+    { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name, arguments: args } },
+    { role: "agent", agentId: "codex" },
+  ) as Promise<AnyResponse>;
+}
+
+function lastMemory(store: LibrarianStore): {
+  domain: string | null;
+  is_global: number;
+  requires_approval: number;
+  status: string;
+} {
+  return store.db
+    .prepare(
+      "SELECT domain, is_global, requires_approval, status FROM memories ORDER BY created_at DESC LIMIT 1",
+    )
+    .get() as {
+    domain: string | null;
+    is_global: number;
+    requires_approval: number;
+    status: string;
+  };
+}
+
+describe("MCP remember + conv_state (T3.1)", () => {
+  it("in-conversation write picks up conv_state.domain", async () => {
+    await withStore(async (store) => {
+      store.convState.upsert("claude:coding", {
+        harness: "claude-code",
+        domain: "coding",
+      });
+      await call(store, "remember", {
+        agent_id: "codex",
+        title: "use pnpm",
+        body: "this repo uses pnpm not npm",
+        category: "tools",
+        conv_id: "claude:coding",
+      });
+      const row = lastMemory(store);
+      expect(row.domain).toBe("coding");
+      expect(row.status).toBe("active");
+      expect(row.requires_approval).toBe(0);
+    });
+  });
+
+  it("outside-session write (no conv_id) routes to proposal with domain=NULL once the install is multi-domain", async () => {
+    await withStore(async (store) => {
+      store.db
+        .prepare("INSERT INTO domains (name, created_at) VALUES (?, ?)")
+        .run("coding", new Date().toISOString());
+      await call(store, "remember", {
+        agent_id: "codex",
+        title: "outside note",
+        body: "no conversation context here",
+        category: "tools",
+      });
+      const row = lastMemory(store);
+      expect(row.domain).toBeNull();
+      expect(row.requires_approval).toBe(1);
+      expect(row.status).toBe("proposed");
+    });
+  });
+
+  it("conv_id present but no conv_state row is treated as outside-session", async () => {
+    await withStore(async (store) => {
+      store.db
+        .prepare("INSERT INTO domains (name, created_at) VALUES (?, ?)")
+        .run("coding", new Date().toISOString());
+      await call(store, "remember", {
+        agent_id: "codex",
+        title: "stray id",
+        body: "harness sent a conv_id but no one upserted",
+        category: "tools",
+        conv_id: "claude:dangling",
+      });
+      const row = lastMemory(store);
+      expect(row.domain).toBeNull();
+      expect(row.requires_approval).toBe(1);
+      expect(row.status).toBe("proposed");
+    });
+  });
+
+  it("single-domain install assigns the sole domain without prompting (§4.10 fast path)", async () => {
+    await withStore(async (store) => {
+      // Default install has only `general`.
+      await call(store, "remember", {
+        agent_id: "codex",
+        title: "single-domain note",
+        body: "no conv_id but only one domain exists",
+        category: "tools",
+      });
+      const row = lastMemory(store);
+      expect(row.domain).toBe("general");
+      expect(row.status).toBe("active");
+    });
+  });
+
+  it("caller-supplied domain / is_global / requires_approval are ignored", async () => {
+    await withStore(async (store) => {
+      store.convState.upsert("claude:coding", {
+        harness: "claude-code",
+        domain: "coding",
+      });
+      await call(store, "remember", {
+        agent_id: "codex",
+        title: "spoofed",
+        body: "agent tries to set everything",
+        category: "tools",
+        conv_id: "claude:coding",
+        domain: "family-admin",
+        is_global: true,
+        requires_approval: false,
+      });
+      const row = lastMemory(store);
+      expect(row.domain).toBe("coding");
+      expect(row.is_global).toBe(0);
+      expect(row.requires_approval).toBe(0);
+    });
+  });
+
+  it("identity category still triggers requires_approval=1 inside a conversation", async () => {
+    await withStore(async (store) => {
+      store.convState.upsert("claude:coding", {
+        harness: "claude-code",
+        domain: "coding",
+      });
+      await call(store, "remember", {
+        agent_id: "codex",
+        title: "user identity",
+        body: "Jim is the owner",
+        category: "identity",
+        conv_id: "claude:coding",
+      });
+      const row = lastMemory(store);
+      expect(row.domain).toBe("coding");
+      expect(row.is_global).toBe(1);
+      expect(row.requires_approval).toBe(1);
+      expect(row.status).toBe("proposed");
+    });
+  });
+});

--- a/packages/mcp-server/tests/mcp/session-domain.mcp.test.ts
+++ b/packages/mcp-server/tests/mcp/session-domain.mcp.test.ts
@@ -1,0 +1,119 @@
+// T3.3 — `start_session` inherits the calling conv_state's domain, and
+// `continue_session` seeds the resuming conv_state with the session's
+// stored domain. Spec §4.12.
+
+import type { LibrarianStore } from "@librarian/core";
+import { handleMcpPayload } from "@librarian/mcp-server";
+import { describe, expect, it } from "vitest";
+import { withStore } from "../../../../test/helpers.js";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyResponse = any;
+
+function call(
+  store: LibrarianStore,
+  name: string,
+  args: Record<string, unknown>,
+  context: { role?: "admin" | "agent"; agentId?: string } = {},
+): Promise<AnyResponse> {
+  return handleMcpPayload(
+    store,
+    { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name, arguments: args } },
+    { role: context.role || "agent", agentId: context.agentId || "codex" },
+  ) as Promise<AnyResponse>;
+}
+
+function readSessionDomain(store: LibrarianStore, sessionId: string): string {
+  return (
+    store.db.prepare("SELECT domain FROM sessions WHERE id = ?").get(sessionId) as {
+      domain: string;
+    }
+  ).domain;
+}
+
+describe("MCP start_session + continue_session + domain (T3.3)", () => {
+  it("start_session inherits the calling conv_state's domain", async () => {
+    await withStore(async (store) => {
+      store.db
+        .prepare("INSERT INTO domains (name, created_at) VALUES (?, ?)")
+        .run("coding", new Date().toISOString());
+      store.convState.upsert("claude:coding", {
+        harness: "claude-code",
+        domain: "coding",
+      });
+      const response = await call(store, "start_session", {
+        title: "implement T3.3",
+        harness: "claude-code",
+        conv_id: "claude:coding",
+      });
+      const text = response.result.content[0].text as string;
+      const match = text.match(/(ses_[a-f0-9-]+)/);
+      expect(match).toBeTruthy();
+      const sessionId = match![1];
+      expect(readSessionDomain(store, sessionId)).toBe("coding");
+    });
+  });
+
+  it("start_session without a conv_state defaults to the single-domain fast path", async () => {
+    await withStore(async (store) => {
+      const response = await call(store, "start_session", {
+        title: "single-domain install",
+        harness: "claude-code",
+      });
+      const text = response.result.content[0].text as string;
+      const sessionId = text.match(/(ses_[a-f0-9-]+)/)![1];
+      expect(readSessionDomain(store, sessionId)).toBe("general");
+    });
+  });
+
+  it("continue_session with conv_id seeds the new conv_state from session.domain", async () => {
+    await withStore(async (store) => {
+      store.db
+        .prepare("INSERT INTO domains (name, created_at) VALUES (?, ?)")
+        .run("coding", new Date().toISOString());
+      store.convState.upsert("claude:coding", {
+        harness: "claude-code",
+        domain: "coding",
+      });
+      const start = await call(store, "start_session", {
+        title: "resume target",
+        harness: "claude-code",
+        conv_id: "claude:coding",
+      });
+      const sessionId = (start.result.content[0].text as string).match(/(ses_[a-f0-9-]+)/)![1];
+
+      // Resume into a different conv_id (e.g. a fresh Hermes thread).
+      await call(store, "continue_session", {
+        session_id: sessionId,
+        target_harness: "hermes",
+        attach: false,
+        conv_id: "hermes:resumed",
+      });
+
+      const resumed = store.convState.get("hermes:resumed");
+      expect(resumed).toBeTruthy();
+      expect(resumed?.domain).toBe("coding");
+      expect(resumed?.session_id).toBe(sessionId);
+    });
+  });
+
+  it("continue_session without conv_id leaves the conv_state registry untouched", async () => {
+    await withStore(async (store) => {
+      const start = await call(store, "start_session", {
+        title: "no resume seed",
+        harness: "claude-code",
+      });
+      const sessionId = (start.result.content[0].text as string).match(/(ses_[a-f0-9-]+)/)![1];
+      await call(store, "continue_session", {
+        session_id: sessionId,
+        target_harness: "hermes",
+        attach: false,
+      });
+      // Nothing seeded — registry is empty.
+      const rows = store.db.prepare("SELECT COUNT(*) AS n FROM conversation_state").get() as {
+        n: number;
+      };
+      expect(rows.n).toBe(0);
+    });
+  });
+});

--- a/test/schema-snapshot.json
+++ b/test/schema-snapshot.json
@@ -1,4 +1,4 @@
 {
-  "version": 13,
-  "fingerprint": "7a8d9e6843765cc3288b6b45e395f135a6f504793b001f96aff9908fef29a3d7"
+  "version": 14,
+  "fingerprint": "8448e96dfff0726bd4b9f6222454eef8ab0f6cb1e889efbd2a94ef5aac8c4c1a"
 }


### PR DESCRIPTION
## Summary

Third PR of the memory-domain-isolation rollout (Phase 3 of the plan). This is the first PR that *actually changes behaviour* for agents — the new conv-state-driven domain filter goes live on `remember` / `recall` / `start_session` / `continue_session`, and `listMemories` gains new filter axes for the dashboard.

### What changed

- **T3.1 — `remember` reads `conv_state` and server-sets `domain`.** Calls with a matching conv_state row land in that domain; calls without one on a multi-domain install route to the proposal queue with `domain=NULL` and `requires_approval=true` per spec §4.14. The §4.10 single-domain fast path keeps zero-config installs zero-friction — when only `general` exists, the sole domain is auto-assigned and behaviour matches PR 1.
- **T3.2 — `recall` applies the §4.11 hard filter** `(domain = current OR is_global = 1) AND status = active`. Drops `categories` / `include_private` from the advertised input schema and adds `conv_id` / `tags` / `include_other_domains`. Admin role bypasses the filter via the existing role flag. Defensive default: non-admin call with no resolvable conv_state on a multi-domain install returns only globals.
- **T3.3 — `start_session` inherits its domain** from the calling conv_state; `continue_session` seeds the resuming conv_state's domain from `session.domain` per §4.12 (skipping the signal-precedence chain on resume).
- **T3.4 — `listMemories` filter surface** gains `domain` (string or explicit null) / `is_global` / `requires_approval` / `tags` axes. Dashboard work in PR 4 will consume these.
- **Schema bump 13 → 14** — drops the `NOT NULL` constraint on `memories.domain` so outside-session writes can carry the explicit `NULL` state.

### Security

Spec §4.1–§4.4 verified: `normalizeMemoryInput` ignores any caller-supplied `domain` / `is_global` / `requires_approval`; `cleanPatch`'s allow-list excludes them; the new tests explicitly assert spoofed values are dropped.

### Test plan

- [x] 9 new MCP tests across `remember-domain`, `recall-domain`, `session-domain` (single-domain fast path, conv_state hit, outside-session, admin bypass, `include_other_domains`, tags, defensive default, identity routing, resume seeding)
- [x] 5 new core tests for `listMemories` filters
- [x] `pnpm test` — 514 (core) + 139 (mcp-server) + 27 (root) = 680 green
- [x] `pnpm typecheck` green across the workspace
- [x] Code-reviewer agent → APPROVE; two Important findings (LIKE-based tag filter, duplicated resolver) addressed in 128b21d
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)