### PR TITLE
PR 4 (T4.1 only): domains CRUD page + tRPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ changes from this point forward are catalogued here.
 
 ### Added
 
+- **Dashboard `/domains` page (PR 4 of 8, T4.1 only).** Owner-curated
+  list of domains via a new admin tRPC router (`domains.list`,
+  `domains.add`, `domains.remove`) on top of a `createDomainsStore`
+  surface in `@librarian/core`. Removing a non-floor domain reassigns
+  its memories to `general` rather than deleting them — agents can't
+  lose content because the owner tidied up. The `general` floor cannot
+  be removed (the §4.10 fast path depends on it). T4.2 (signal-rules),
+  T4.3 (proposal modal), T4.4 (memory detail panel toggles), and T4.5
+  (filter UI rewrite) deferred to follow-up sub-PRs per the plan's
+  "split if any one task balloons" guidance.
+
 - **Domain enforcement on memory + session writes (PR 3 of 8).** The
   `remember`, `recall`, `start_session`, and `continue_session` MCP
   tools now consume the conv-state registry from PR 2:

--- a/apps/dashboard/app/(memories)/domains/actions.ts
+++ b/apps/dashboard/app/(memories)/domains/actions.ts
@@ -1,0 +1,37 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { serverTRPC } from "@/lib/trpc-server";
+
+export type DomainsActionResult = { ok: true } | { ok: false; error: string };
+
+function fail(message: string): DomainsActionResult {
+  return { ok: false, error: message };
+}
+
+function string(form: FormData, key: string): string | undefined {
+  const value = form.get(key);
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+export async function addDomainAction(form: FormData): Promise<DomainsActionResult> {
+  try {
+    const name = string(form, "name");
+    if (!name) return fail("Domain name is required.");
+    await serverTRPC.domains.add.mutate({ name });
+    revalidatePath("/domains");
+    return { ok: true };
+  } catch (err) {
+    return fail(err instanceof Error ? err.message : String(err));
+  }
+}
+
+export async function removeDomainAction(name: string): Promise<DomainsActionResult> {
+  try {
+    await serverTRPC.domains.remove.mutate({ name });
+    revalidatePath("/domains");
+    return { ok: true };
+  } catch (err) {
+    return fail(err instanceof Error ? err.message : String(err));
+  }
+}

--- a/apps/dashboard/app/(memories)/domains/page.tsx
+++ b/apps/dashboard/app/(memories)/domains/page.tsx
@@ -1,0 +1,21 @@
+import { DomainList } from "@/components/domains/domain-list";
+import { serverTRPC } from "@/lib/trpc-server";
+
+export const dynamic = "force-dynamic";
+
+export default async function DomainsPage() {
+  const domains = await serverTRPC.domains.list.query();
+  return (
+    <main className="flex flex-col gap-6 p-6">
+      <header className="flex flex-col gap-1">
+        <h1 className="text-2xl font-semibold">Domains</h1>
+        <p className="text-sm text-muted-foreground">
+          Owner-curated list. New conversations inherit one of these via the signal-precedence chain
+          or an explicit pick. Removing a non-floor domain reassigns its memories to{" "}
+          <code>general</code>.
+        </p>
+      </header>
+      <DomainList initial={domains} />
+    </main>
+  );
+}

--- a/apps/dashboard/components/domains/domain-list.tsx
+++ b/apps/dashboard/components/domains/domain-list.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { addDomainAction, removeDomainAction } from "@/app/(memories)/domains/actions";
+import { Button } from "@/components/ui-v2/button";
+import { Input } from "@/components/ui-v2/input";
+import { Pill } from "@/components/ui-v2/pill";
+
+interface DomainRecord {
+  name: string;
+  created_at: string;
+  memory_count: number;
+}
+
+interface Props {
+  initial: DomainRecord[];
+}
+
+const FLOOR_DOMAIN = "general";
+
+export function DomainList({ initial }: Props) {
+  const [domains, setDomains] = useState(initial);
+  const [name, setName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function handleAdd(form: FormData): void {
+    setError(null);
+    startTransition(async () => {
+      const result = await addDomainAction(form);
+      if (!result.ok) {
+        setError(result.error);
+        return;
+      }
+      // Optimistically add; the next revalidate cycle reconciles.
+      const next = name.trim();
+      setName("");
+      setDomains((rows) =>
+        rows.some((r) => r.name === next)
+          ? rows
+          : [...rows, { name: next, created_at: new Date().toISOString(), memory_count: 0 }].sort(
+              (a, b) => a.name.localeCompare(b.name),
+            ),
+      );
+    });
+  }
+
+  function handleRemove(target: DomainRecord): void {
+    setError(null);
+    const message =
+      target.memory_count > 0
+        ? `Remove '${target.name}'? Its ${target.memory_count} memor${
+            target.memory_count === 1 ? "y" : "ies"
+          } will be reassigned to '${FLOOR_DOMAIN}'.`
+        : `Remove '${target.name}'?`;
+    if (!confirm(message)) return;
+    startTransition(async () => {
+      const result = await removeDomainAction(target.name);
+      if (!result.ok) {
+        setError(result.error);
+        return;
+      }
+      setDomains((rows) => rows.filter((r) => r.name !== target.name));
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <form action={handleAdd} className="flex items-start gap-2">
+        <Input
+          name="name"
+          placeholder="Domain name (e.g. coding, family-admin)"
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          maxLength={64}
+          disabled={pending}
+          aria-label="New domain name"
+        />
+        <Button type="submit" variant="primary" disabled={pending || name.trim().length === 0}>
+          Add
+        </Button>
+      </form>
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      <ul className="flex flex-col gap-2">
+        {domains.length === 0 ? (
+          <li className="text-sm text-muted-foreground">No domains yet.</li>
+        ) : (
+          domains.map((domain) => (
+            <li
+              key={domain.name}
+              className="flex items-center justify-between rounded-md border bg-card p-3"
+            >
+              <div className="flex flex-col gap-1">
+                <div className="flex items-center gap-2">
+                  <span className="font-medium">{domain.name}</span>
+                  <Pill>
+                    {domain.memory_count} memor{domain.memory_count === 1 ? "y" : "ies"}
+                  </Pill>
+                  {domain.name === FLOOR_DOMAIN && <Pill>floor</Pill>}
+                </div>
+                <span className="text-xs text-muted-foreground">
+                  created {new Date(domain.created_at).toLocaleString()}
+                </span>
+              </div>
+              <Button
+                variant="outline"
+                disabled={pending || domain.name === FLOOR_DOMAIN}
+                aria-label={`Remove ${domain.name}`}
+                onClick={() => handleRemove(domain)}
+              >
+                Remove
+              </Button>
+            </li>
+          ))
+        )}
+      </ul>
+    </div>
+  );
+}

--- a/apps/dashboard/tests/components/domain-list.test.tsx
+++ b/apps/dashboard/tests/components/domain-list.test.tsx
@@ -1,0 +1,86 @@
+// T4.1 — DomainList component tests.
+//
+// Covers the add → optimistic-render flow and the confirmation-guarded
+// remove flow. The floor domain (`general`) renders the Remove button
+// disabled so the owner can't accidentally hit it.
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const addMock = vi.fn();
+const removeMock = vi.fn();
+const confirmMock = vi.fn();
+
+vi.mock("@/app/(memories)/domains/actions", () => ({
+  addDomainAction: (...args: unknown[]) => addMock(...args),
+  removeDomainAction: (...args: unknown[]) => removeMock(...args),
+}));
+
+const { DomainList } = await import("@/components/domains/domain-list");
+
+beforeEach(() => {
+  vi.stubGlobal("confirm", confirmMock);
+});
+
+afterEach(() => {
+  addMock.mockReset();
+  removeMock.mockReset();
+  confirmMock.mockReset();
+  vi.unstubAllGlobals();
+});
+
+const initial = [
+  { name: "coding", created_at: "2026-05-27T00:00:00.000Z", memory_count: 3 },
+  { name: "general", created_at: "2026-05-27T00:00:00.000Z", memory_count: 7 },
+];
+
+describe("DomainList", () => {
+  it("renders each domain with its memory_count and disables Remove on `general`", () => {
+    render(<DomainList initial={initial} />);
+    expect(screen.getByText("coding")).toBeInTheDocument();
+    expect(screen.getByText("general")).toBeInTheDocument();
+    expect(screen.getByText("3 memories")).toBeInTheDocument();
+    expect(screen.getByText("7 memories")).toBeInTheDocument();
+    expect(screen.getByLabelText("Remove general")).toBeDisabled();
+    expect(screen.getByLabelText("Remove coding")).toBeEnabled();
+  });
+
+  it("submits the add form and optimistically renders the new domain", async () => {
+    addMock.mockResolvedValueOnce({ ok: true });
+    render(<DomainList initial={initial} />);
+    await userEvent.type(screen.getByLabelText("New domain name"), "family-admin");
+    await userEvent.click(screen.getByRole("button", { name: "Add" }));
+    expect(addMock).toHaveBeenCalledTimes(1);
+    const form = addMock.mock.calls[0]?.[0] as FormData;
+    expect(form.get("name")).toBe("family-admin");
+    await vi.waitFor(() => expect(screen.getByText("family-admin")).toBeInTheDocument());
+  });
+
+  it("renders the server error when add fails", async () => {
+    addMock.mockResolvedValueOnce({ ok: false, error: "already exists" });
+    render(<DomainList initial={initial} />);
+    await userEvent.type(screen.getByLabelText("New domain name"), "coding");
+    await userEvent.click(screen.getByRole("button", { name: "Add" }));
+    await vi.waitFor(() => expect(screen.getByText("already exists")).toBeInTheDocument());
+  });
+
+  it("removes a domain after explicit confirmation", async () => {
+    confirmMock.mockReturnValueOnce(true);
+    removeMock.mockResolvedValueOnce({ ok: true });
+    render(<DomainList initial={initial} />);
+    await userEvent.click(screen.getByLabelText("Remove coding"));
+    expect(confirmMock).toHaveBeenCalledTimes(1);
+    expect(removeMock).toHaveBeenCalledWith("coding");
+    await vi.waitFor(() => expect(screen.queryByText("coding")).not.toBeInTheDocument());
+  });
+
+  it("does not call the action when the user cancels the confirm", async () => {
+    confirmMock.mockReturnValueOnce(false);
+    render(<DomainList initial={initial} />);
+    await userEvent.click(screen.getByLabelText("Remove coding"));
+    expect(confirmMock).toHaveBeenCalledTimes(1);
+    expect(removeMock).not.toHaveBeenCalled();
+    expect(screen.getByText("coding")).toBeInTheDocument();
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -241,5 +241,6 @@ export {
   type ConversationStateStore,
   createConversationStateStore,
 } from "./store/conversation-state-store.js";
+export { type DomainRecord, type DomainsStore, createDomainsStore } from "./store/domains-store.js";
 export type { ConversationState, ConversationStatePatch } from "./schemas/conversation-state.js";
 export { renderConvStateBlock } from "./conv-state-render.js";

--- a/packages/core/src/store/domains-store.ts
+++ b/packages/core/src/store/domains-store.ts
@@ -1,0 +1,81 @@
+// Domains store — owner-curated list of valid domain names from
+// memory-domain-isolation §4.1.
+//
+// The `domains` table is SQLite-authoritative (no JSONL ledger backs
+// it) and is reserved with `general` on every fresh boot via
+// `seedDomains` in projection.ts. This module exposes the CRUD surface
+// the dashboard's `/domains` page consumes through tRPC.
+//
+// Removing a domain that has memories reassigns those memories to
+// `general` rather than deleting them — agents shouldn't ever lose
+// content because an owner cleaned up their domain list. Removing the
+// floor (`general`) is rejected outright since the §4.10 fast path
+// depends on at least one domain existing.
+
+import type { DatabaseSync } from "node:sqlite";
+
+export interface DomainsStoreDeps {
+  db: DatabaseSync;
+}
+
+export interface DomainRecord {
+  name: string;
+  created_at: string;
+  memory_count: number;
+}
+
+export interface DomainsStore {
+  list(): DomainRecord[];
+  add(name: string): DomainRecord;
+  remove(name: string): { reassigned: number };
+}
+
+const RESERVED_DOMAINS: ReadonlySet<string> = new Set(["general"]);
+
+export function createDomainsStore(deps: DomainsStoreDeps): DomainsStore {
+  const { db } = deps;
+
+  function list(): DomainRecord[] {
+    return db
+      .prepare(
+        `SELECT d.name, d.created_at,
+                (SELECT COUNT(*) FROM memories m WHERE m.domain = d.name) AS memory_count
+           FROM domains d
+          ORDER BY d.name`,
+      )
+      .all() as unknown as DomainRecord[];
+  }
+
+  function add(name: string): DomainRecord {
+    const cleaned = normalizeName(name);
+    if (!cleaned) throw new Error("Domain name must be a non-empty string.");
+    if (cleaned.length > 64) throw new Error("Domain name must be 64 characters or fewer.");
+    db.prepare("INSERT INTO domains (name, created_at) VALUES (?, ?)").run(
+      cleaned,
+      new Date().toISOString(),
+    );
+    return list().find((row) => row.name === cleaned)!;
+  }
+
+  function remove(name: string): { reassigned: number } {
+    const cleaned = normalizeName(name);
+    if (!cleaned) throw new Error("Domain name must be a non-empty string.");
+    if (RESERVED_DOMAINS.has(cleaned)) {
+      throw new Error(`Cannot remove the floor domain '${cleaned}'.`);
+    }
+    const existing = db.prepare("SELECT name FROM domains WHERE name = ?").get(cleaned);
+    if (!existing) throw new Error(`Domain '${cleaned}' does not exist.`);
+    const reassignResult = db
+      .prepare("UPDATE memories SET domain = 'general' WHERE domain = ?")
+      .run(cleaned);
+    db.prepare("DELETE FROM domains WHERE name = ?").run(cleaned);
+    return { reassigned: Number(reassignResult.changes ?? 0) };
+  }
+
+  return { list, add, remove };
+}
+
+function normalizeName(value: unknown): string {
+  if (typeof value !== "string") return "";
+  return value.trim();
+}

--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -6,6 +6,7 @@ import {
   createConversationStateStore,
 } from "./conversation-state-store.js";
 import { type CurationStore, createCurationStore } from "./curation-store.js";
+import { type DomainsStore, createDomainsStore } from "./domains-store.js";
 import { readJsonl } from "./jsonl.js";
 import { type MemoryStore, createMemoryStore } from "./memory-store.js";
 import { ensureSchema, rebuildMemoryIndex, rebuildSessionIndex } from "./projection.js";
@@ -36,6 +37,7 @@ export interface LibrarianStoreOptions {
 
 export interface LibrarianStore extends MemoryStore, SessionStore, CurationStore, SettingsStore {
   convState: ConversationStateStore;
+  domains: DomainsStore;
   dataDir: string;
   eventsPath: string;
   // R3 — sessionsPath is the timeline ledger (post-R3, new file).
@@ -110,6 +112,7 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Libra
   const curationStore = createCurationStore({ db });
   const settingsStore = createSettingsStore({ db, secretKey: options.secretKey ?? null });
   const convState = createConversationStateStore({ db });
+  const domains = createDomainsStore({ db });
 
   return {
     ...memoryStore,
@@ -117,6 +120,7 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Libra
     ...curationStore,
     ...settingsStore,
     convState,
+    domains,
     dataDir,
     eventsPath,
     sessionsPath,

--- a/packages/core/tests/store/domains-store.test.ts
+++ b/packages/core/tests/store/domains-store.test.ts
@@ -1,0 +1,128 @@
+// T4.1 — domains CRUD behaviour tests.
+//
+// The owner curates the domain list via the dashboard's `/domains`
+// page, which calls into `store.domains.{list, add, remove}`. Pins:
+//   - The `general` floor is always present and can't be removed.
+//   - Removing a domain reassigns its memories to `general` rather
+//     than deleting them (no data loss on owner cleanup).
+//   - `memory_count` is accurate on list.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { type LibrarianStore, createLibrarianStore } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+interface Scope {
+  store: LibrarianStore;
+  dataDir: string;
+}
+
+function makeScope(): Scope {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-domains-"));
+  const store = createLibrarianStore({ dataDir });
+  return { store, dataDir };
+}
+
+function teardown(scope: Scope | null): void {
+  if (!scope) return;
+  try {
+    scope.store.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(scope.dataDir, { recursive: true, force: true });
+}
+
+describe("domains store (T4.1)", () => {
+  let scope: Scope | null = null;
+
+  beforeEach(() => {
+    scope = makeScope();
+  });
+
+  afterEach(() => {
+    teardown(scope);
+    scope = null;
+  });
+
+  it("list returns the seeded `general` domain on a fresh install", () => {
+    const rows = scope!.store.domains.list();
+    expect(rows.map((r) => r.name)).toEqual(["general"]);
+    expect(rows[0].memory_count).toBe(0);
+  });
+
+  it("add inserts a new domain and the returned row carries memory_count: 0", () => {
+    const created = scope!.store.domains.add("coding");
+    expect(created.name).toBe("coding");
+    expect(created.memory_count).toBe(0);
+    const names = scope!.store.domains.list().map((r) => r.name);
+    expect(names).toEqual(["coding", "general"]);
+  });
+
+  it("add trims whitespace and rejects empty / oversized names", () => {
+    const trimmed = scope!.store.domains.add("  family  ");
+    expect(trimmed.name).toBe("family");
+    expect(() => scope!.store.domains.add("")).toThrow(/non-empty/);
+    expect(() => scope!.store.domains.add("   ")).toThrow(/non-empty/);
+    expect(() => scope!.store.domains.add("x".repeat(65))).toThrow(/64 characters/);
+  });
+
+  it("list reports an accurate memory_count per domain", () => {
+    scope!.store.domains.add("coding");
+    scope!.store.createMemory(
+      {
+        agent_id: "codex",
+        title: "pnpm note",
+        body: "use pnpm",
+        category: "tools",
+        visibility: "common",
+        scope: "tool",
+      },
+      { domain: "coding" },
+    );
+    scope!.store.createMemory(
+      {
+        agent_id: "codex",
+        title: "general note",
+        body: "general body",
+        category: "tools",
+        visibility: "common",
+        scope: "tool",
+      },
+      { domain: "general" },
+    );
+    const rows = scope!.store.domains.list();
+    expect(rows.find((r) => r.name === "coding")?.memory_count).toBe(1);
+    expect(rows.find((r) => r.name === "general")?.memory_count).toBe(1);
+  });
+
+  it("remove reassigns the domain's memories to `general`", () => {
+    scope!.store.domains.add("coding");
+    const codingMemory = scope!.store.createMemory(
+      {
+        agent_id: "codex",
+        title: "coding memory",
+        body: "stays alive",
+        category: "tools",
+        visibility: "common",
+        scope: "tool",
+      },
+      { domain: "coding" },
+    );
+    const result = scope!.store.domains.remove("coding");
+    expect(result.reassigned).toBe(1);
+    const survivor = scope!.store.getMemory(codingMemory.memory.id);
+    expect(survivor).toBeTruthy();
+    expect(survivor?.domain).toBe("general");
+    expect(scope!.store.domains.list().map((r) => r.name)).toEqual(["general"]);
+  });
+
+  it("remove rejects the floor domain `general`", () => {
+    expect(() => scope!.store.domains.remove("general")).toThrow(/floor domain/);
+  });
+
+  it("remove rejects an unknown domain", () => {
+    expect(() => scope!.store.domains.remove("never-was")).toThrow(/does not exist/);
+  });
+});

--- a/packages/mcp-server/src/trpc/domains.ts
+++ b/packages/mcp-server/src/trpc/domains.ts
@@ -1,0 +1,23 @@
+// Domains admin tRPC router — memory-domain-isolation §4.1 + PR 4 / T4.1.
+//
+// Backs the dashboard's `/domains` page. Admin-only by design: the owner
+// curates the domain list; agents never reach this surface (the
+// `domain` field in `remember` is server-set from conv_state, not from
+// a caller-supplied string).
+
+import { z } from "zod";
+import { adminProcedure, router } from "./trpc.js";
+
+const DomainNameSchema = z.string().min(1).max(64);
+
+export const domainsRouter = router({
+  list: adminProcedure.query(({ ctx }) => ctx.store.domains.list()),
+
+  add: adminProcedure
+    .input(z.strictObject({ name: DomainNameSchema }))
+    .mutation(({ ctx, input }) => ctx.store.domains.add(input.name)),
+
+  remove: adminProcedure
+    .input(z.strictObject({ name: DomainNameSchema }))
+    .mutation(({ ctx, input }) => ctx.store.domains.remove(input.name)),
+});

--- a/packages/mcp-server/src/trpc/router.ts
+++ b/packages/mcp-server/src/trpc/router.ts
@@ -8,6 +8,7 @@
 import { authRouter } from "./auth.js";
 import { backupRouter } from "./backup.js";
 import { curatorRouter } from "./curator.js";
+import { domainsRouter } from "./domains.js";
 import { healthRouter } from "./health.js";
 import { memoriesRouter } from "./memories.js";
 import { sessionsRouter } from "./sessions.js";
@@ -18,6 +19,7 @@ export const appRouter = router({
   auth: authRouter,
   backup: backupRouter,
   curator: curatorRouter,
+  domains: domainsRouter,
   health: healthRouter,
   memories: memoriesRouter,
   sessions: sessionsRouter,

--- a/packages/mcp-server/tests/trpc/domains.test.ts
+++ b/packages/mcp-server/tests/trpc/domains.test.ts
@@ -1,0 +1,119 @@
+// T4.1 — tRPC admin surface for the `/domains` page.
+//
+// Covers admin-only gating, list/add/remove flows, and the cleanup-
+// reassign behaviour: removing a domain reassigns its memories to
+// `general` rather than deleting them.
+
+import { describe, expect, it } from "vitest";
+import { cleanupTempDir, makeTempDir, startHttpServer } from "../../../../test/helpers.js";
+
+interface TrpcOk<T> {
+  result: { data: T };
+}
+interface TrpcErr {
+  error: unknown;
+}
+interface ServerHandle {
+  url: string;
+  token: string;
+  stop: () => Promise<void>;
+}
+
+async function trpcGet<T>(server: ServerHandle, path: string, input?: unknown): Promise<T> {
+  const url = new URL(`${server.url}/trpc/${path}`);
+  if (input !== undefined) url.searchParams.set("input", JSON.stringify(input));
+  const response = await fetch(url, { headers: { authorization: `Bearer ${server.token}` } });
+  const json = (await response.json()) as TrpcOk<T> | TrpcErr;
+  if (response.status >= 400 || "error" in json) {
+    throw new Error(`trpc GET ${path} failed: ${JSON.stringify(json)}`);
+  }
+  return (json as TrpcOk<T>).result.data;
+}
+
+async function trpcPost<T>(server: ServerHandle, path: string, input?: unknown): Promise<T> {
+  const response = await fetch(`${server.url}/trpc/${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${server.token}` },
+    body: input === undefined ? undefined : JSON.stringify(input),
+  });
+  const json = (await response.json()) as TrpcOk<T> | TrpcErr;
+  if (response.status >= 400 || "error" in json) {
+    throw new Error(`trpc POST ${path} failed: ${JSON.stringify(json)}`);
+  }
+  return (json as TrpcOk<T>).result.data;
+}
+
+interface DomainRecord {
+  name: string;
+  created_at: string;
+  memory_count: number;
+}
+
+describe("tRPC domains surface (T4.1)", () => {
+  it("requires admin auth", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const response = await fetch(`${server.url}/trpc/domains.list`);
+      expect(response.status).toBeGreaterThanOrEqual(400);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("lists the seeded `general` domain on a fresh install", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const rows = await trpcGet<DomainRecord[]>(server, "domains.list");
+      expect(rows.map((r) => r.name)).toEqual(["general"]);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("supports the add → list → remove round trip with memory reassignment", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const added = await trpcPost<DomainRecord>(server, "domains.add", { name: "coding" });
+      expect(added.name).toBe("coding");
+
+      const namesAfterAdd = (await trpcGet<DomainRecord[]>(server, "domains.list")).map(
+        (r) => r.name,
+      );
+      expect(namesAfterAdd).toEqual(["coding", "general"]);
+
+      const removed = await trpcPost<{ reassigned: number }>(server, "domains.remove", {
+        name: "coding",
+      });
+      expect(removed.reassigned).toBe(0); // no memories existed in that domain
+      const namesAfterRemove = (await trpcGet<DomainRecord[]>(server, "domains.list")).map(
+        (r) => r.name,
+      );
+      expect(namesAfterRemove).toEqual(["general"]);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("rejects removal of the `general` floor", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const response = await fetch(`${server.url}/trpc/domains.remove`, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: `Bearer ${server.token}` },
+        body: JSON.stringify({ name: "general" }),
+      });
+      const json = (await response.json()) as TrpcErr;
+      expect(json.error).toBeTruthy();
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fourth PR of the memory-domain-isolation rollout, scoped to **T4.1 only**. The rest of Phase 4 (T4.2 signal-rules page, T4.3 proposal-approval modal, T4.4 memory detail toggles, T4.5 filter UI rewrite) lands as follow-up sub-PRs — each is medium-sized on its own and the plan's own risk table flags Phase 4 as a candidate for 2-3 sub-PRs.

### What lands

- **`@librarian/core` — `createDomainsStore`** (`list` / `add` / `remove`) on top of the `domains` table from PR 1. `list` joins against `memories` for the per-domain count. `remove` reassigns the domain's memories to `general` rather than deleting them, and rejects the floor (`general`) outright. Validation: non-empty trim, 64-char cap.
- **`@librarian/mcp-server` — admin tRPC `domains.{list,add,remove}` router** composed into `appRouter`. Admin-only — agents never reach this surface.
- **`apps/dashboard` — `/domains` page** with optimistic add and confirm-guarded remove. Server actions wrap the tRPC mutations. Floor domain renders Remove disabled.

### Deferred (see `AUTONOMOUS-BUILD-NOTES-26-05-27.md`)

- **T4.2** — signal-rules page (`/signal-rules`)
- **T4.3** — proposal-approval modal with domain picker
- **T4.4** — memory detail panel toggles for `domain` / `is_global` / `requires_approval`, plus the new `memory.classification_overridden` event type
- **T4.5** — replace category-grouped views with tag/domain/boolean filters

### Test plan

- [x] 7 store-level tests covering the floor invariant, reassignment, validation, memory-count accuracy
- [x] 4 tRPC integration tests covering admin gating, list/add/remove round-trip, floor rejection
- [x] 5 component tests covering the optimistic add, error rendering, confirm-guarded remove, cancel flow, and floor-disabled state
- [x] `pnpm test` — 521 (core) + 143 (mcp-server) + 153 (dashboard) + 27 (root) green
- [x] `pnpm typecheck` green across the workspace
- [ ] Playwright e2e coverage — intentionally omitted in this PR; documented in AUTONOMOUS-BUILD-NOTES for a follow-up dashboard pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)