### PR TITLE
PR 5 (T5.3 only): CLI --conv-id flag on sessions start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ changes from this point forward are catalogued here.
 
 ### Added
 
+- **CLI `--conv-id` flag on `sessions start` (PR 5 of 8, T5.3 only).**
+  Mirrors the new harness hook contract — when the operator pipes a
+  series of CLI invocations together (e.g. `LIBRARIAN_CONV_ID=cli:work`
+  in their shell), `sessions start` now inherits the domain from the
+  matching `conversation_state` row. Single-domain installs continue
+  to default to `general` through the §4.10 fast path. The Claude
+  Code and Hermes plugin work (T5.1 + T5.2) lives in sibling repos
+  and is out of scope for this PR.
+
 - **Dashboard `/domains` page (PR 4 of 8, T4.1 only).** Owner-curated
   list of domains via a new admin tRPC router (`domains.list`,
   `domains.add`, `domains.remove`) on top of a `createDomainsStore`

--- a/packages/cli/src/commands/_conv-id.ts
+++ b/packages/cli/src/commands/_conv-id.ts
@@ -1,0 +1,35 @@
+// CLI conv_id helpers — T5.3 of the memory-domain-isolation rollout.
+//
+// The CLI is mostly one-shot, but we accept an opt-in `--conv-id` flag
+// (or the `LIBRARIAN_CONV_ID` env var) so an operator can stitch a
+// series of CLI invocations into one conceptual conversation. When a
+// matching `conversation_state` row exists, commands like `sessions
+// start` inherit the domain from it.
+//
+// When neither flag nor env var is set, we deliberately do NOT
+// auto-generate an id. The store-level fast path (single-domain
+// installs default to `general`; multi-domain installs need an
+// explicit domain) does the right thing without a synthetic conv-id
+// polluting the registry.
+
+import type { LibrarianStore } from "@librarian/core";
+import { type FlagMap, flagString } from "../parse-flags.js";
+
+export function resolveCliConvId(flags: FlagMap): string | null {
+  const fromFlag = flagString(flags["conv-id"]);
+  if (fromFlag) return fromFlag;
+  const fromEnv = process.env.LIBRARIAN_CONV_ID;
+  return fromEnv && fromEnv.length > 0 ? fromEnv : null;
+}
+
+export function resolveCliDomain(store: LibrarianStore, convId: string | null): string | null {
+  if (convId) {
+    const state = store.convState.get(convId);
+    if (state) return state.domain;
+  }
+  const rows = store.db.prepare("SELECT name FROM domains LIMIT 2").all() as Array<{
+    name: string;
+  }>;
+  if (rows.length === 1) return rows[0]?.name ?? null;
+  return null;
+}

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1,14 +1,21 @@
 import { formatSessionStart } from "@librarian/mcp-server";
 import { callerAgent, collectArray, flagString } from "../parse-flags.js";
+import { resolveCliDomain, resolveCliConvId } from "./_conv-id.js";
 import { type Command, requireSession } from "./_shared.js";
 
 export const start: Command = (store, _positionals, flags) => {
   const visibility = flags.private ? "agent_private" : flagString(flags.visibility) || "common";
+  // T5.3 — the CLI is mostly one-shot, but we accept `--conv-id` for
+  // symmetry with the harness integrations: if the caller supplies it
+  // and an existing conv_state row matches, the session inherits the
+  // domain from there. Otherwise the single-domain fast path applies.
+  const convId = resolveCliConvId(flags);
+  const domain = resolveCliDomain(store, convId) ?? "general";
   const result = store.startSession({
     agent_id: callerAgent(flags),
     title: flagString(flags.title),
     project_key: flagString(flags.project),
-    harness: flagString(flags.harness),
+    harness: flagString(flags.harness) || "cli",
     source_ref: flagString(flags["source-ref"]),
     cwd: flagString(flags.cwd),
     capture_mode: flagString(flags["capture-mode"]),
@@ -16,6 +23,7 @@ export const start: Command = (store, _positionals, flags) => {
     start_summary: flagString(flags["start-summary"]),
     tags: collectArray(flags.tag),
     next_steps: collectArray(flags["next-step"]),
+    domain,
   });
   if (flags.json) return { stdout: JSON.stringify(result, null, 2), exitCode: 0 };
   return {

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -449,4 +449,72 @@ describe("CLI runtime", () => {
       expect(agents).not.toContain("system");
     });
   });
+
+  describe("sessions start + --conv-id (T5.3)", () => {
+    it("defaults to the single-domain fast path when no conv_state and only `general` exists", async () => {
+      await withStore(async (store) => {
+        runCli(
+          ["sessions", "start", "--agent", "codex", "--title", "no conv id", "--harness", "cli"],
+          store,
+        );
+        const sessions = store.listSessions({ agent_id: "codex" }).sessions as unknown as Array<{
+          domain: string;
+        }>;
+        expect(sessions[0]?.domain).toBe("general");
+      });
+    });
+
+    it("inherits the domain from conv_state when --conv-id matches an existing row", async () => {
+      await withStore(async (store) => {
+        store.db
+          .prepare("INSERT INTO domains (name, created_at) VALUES (?, ?)")
+          .run("coding", new Date().toISOString());
+        store.convState.upsert("cli:work", {
+          harness: "cli",
+          domain: "coding",
+        });
+        runCli(
+          [
+            "sessions",
+            "start",
+            "--agent",
+            "codex",
+            "--title",
+            "from conv-id",
+            "--conv-id",
+            "cli:work",
+          ],
+          store,
+        );
+        const sessions = store.listSessions({ agent_id: "codex" }).sessions as unknown as Array<{
+          domain: string;
+        }>;
+        expect(sessions[0]?.domain).toBe("coding");
+      });
+    });
+
+    it("LIBRARIAN_CONV_ID env var stands in for --conv-id", async () => {
+      await withStore(async (store) => {
+        store.db
+          .prepare("INSERT INTO domains (name, created_at) VALUES (?, ?)")
+          .run("coding", new Date().toISOString());
+        store.convState.upsert("cli:env", {
+          harness: "cli",
+          domain: "coding",
+        });
+        const previous = process.env.LIBRARIAN_CONV_ID;
+        process.env.LIBRARIAN_CONV_ID = "cli:env";
+        try {
+          runCli(["sessions", "start", "--agent", "codex", "--title", "from env"], store);
+        } finally {
+          if (previous === undefined) delete process.env.LIBRARIAN_CONV_ID;
+          else process.env.LIBRARIAN_CONV_ID = previous;
+        }
+        const sessions = store.listSessions({ agent_id: "codex" }).sessions as unknown as Array<{
+          domain: string;
+        }>;
+        expect(sessions[0]?.domain).toBe("coding");
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fifth PR of the memory-domain-isolation rollout, scoped to **T5.3 only** — the in-repo CLI piece of Phase 5. T5.1 (Claude Code plugin) and T5.2 (Hermes plugin) live in sibling repos and are out of scope for this main-repo PR.

### What lands

- `sessions start --conv-id <id>` (or `LIBRARIAN_CONV_ID=<id>`) looks up the matching `conversation_state` row and inherits the domain from it. Matches the harness hook contract from PR 2.
- When no conv-id is supplied, the store-level §4.10 single-domain fast path keeps the existing zero-config CLI behaviour intact.
- No synthetic conv-id auto-generation. The registry stays empty unless the operator opts in.

### Test plan

- [x] 3 new CLI tests: single-domain fast path, explicit `--conv-id` flag, `LIBRARIAN_CONV_ID` env fallback
- [x] `pnpm test` + `pnpm typecheck` green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)