### PR TITLE
docs(specs): four follow-up specs + classifier-driven parent sync

### DIFF
--- a/docs/specs/classifier-implementation-spec.md
+++ b/docs/specs/classifier-implementation-spec.md
@@ -2,7 +2,7 @@
 
 **Author:** Claude, with Jim
 **Date:** 2026-05-27
-**Status:** Draft v3 — async lifecycle; configurable provider (local default, remote alternative); dashboard-driven evaluation (no CI quality gate); collapsed shadow+cutover into one PR; awaiting implementation
+**Status:** Draft v4 — async lifecycle; configurable provider (local default, remote alternative); curated local-model catalog with custom-HF override (LFM2.5-1.2B-Instruct as default, not Thinking); dashboard-driven evaluation; collapsed shadow+cutover into one PR; ready for review
 
 ---
 
@@ -110,7 +110,7 @@ Admins choose between two providers via a new dashboard setting. The default is 
 
 - New admin settings keys, mirroring the curator's:
   - `classifier.provider` = `"local"` | `"remote"`
-  - `classifier.local.model` (HuggingFace identifier or local path; default `LiquidAI/LFM2.5-1.2B-Thinking-GGUF`)
+  - `classifier.local.model` (HuggingFace identifier or local path; default `LiquidAI/LFM2.5-1.2B-Instruct-GGUF` — see §4.3 catalog)
   - `classifier.local.quantisation` (default `Q4_K_M`)
   - `classifier.remote.endpoint`
   - `classifier.remote.model`
@@ -122,13 +122,35 @@ Admins choose between two providers via a new dashboard setting. The default is 
 
 **Memory-content leakage warning.** Remote mode sends memory titles + bodies to a third party. The dashboard config page explicitly says so when the admin selects `remote`. A future redaction layer (out of scope for V1) may gate classifier inputs through the existing `curator-redaction` module; for now, it's an admin-informed trade-off.
 
-### 4.3 Default local model
+### 4.3 Local model selection
 
-**[LiquidAI/LFM2.5-1.2B-Thinking-GGUF](https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking-GGUF)** — 1.2B-parameter Liquid Foundation Model with chain-of-thought, GGUF-packaged for native llama.cpp loading.
+Admins pick from a curated catalog of GGUF models or supply their own HuggingFace identifier. The catalog covers the practical range of hardware profiles — from Raspberry Pi to desktop — without forcing any particular choice. The dashboard evaluation tool (§4.6) is the natural pre-flight check before switching models in production.
 
-- **Quantisation:** Q4_K_M default (~700MB on disk, ~1.5GB resident with KV cache). Q8_0 is the fallback if Q4 quality is empirically poor against the calibration set.
-- **Why this model.** Small enough to load anywhere; open weights; designed for edge inference. The Thinking variant has chain-of-thought headroom for the two-boolean decision without a 7B-class memory footprint.
-- **The async lifecycle eliminates the latency budget.** The Thinking variant can think as long as it needs (within the 30s per-item ceiling). No prompt-side thinking-budget constraint, no contingency ladder for "the model is too slow" — slow but correct is exactly what async classification was designed for.
+**Curated catalog:**
+
+| Model | Params | RAM (Q4_K_M) | License | Profile |
+|---|---|---|---|---|
+| [Qwen3.5-0.8B-Instruct-GGUF](https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF) | 0.8B | ~1GB | Apache 2.0 | **Smallest.** Raspberry Pi 4 and constrained hardware. Non-thinking mode only — the 0.8B Thinking variant has documented loop behaviours. |
+| **[LFM2.5-1.2B-Instruct-GGUF](https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct-GGUF)** *(default)* | 1.2B | ~1.5GB | LFM1.0 | **Laptop default.** Best balance of size, quality, and structured-output reliability for the classifier's task. |
+| [LFM2.5-1.2B-Thinking-GGUF](https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking-GGUF) | 1.2B | ~1.5GB | LFM1.0 | Same architecture as the default with chain-of-thought. Worth trying via the dashboard eval if Instruct misclassifies your boundary cases. Expect higher parse-failure rates; verify with the eval before promoting. |
+| [Qwen3.5-2B-Instruct-GGUF](https://huggingface.co/unsloth/Qwen3.5-2B-GGUF) | 2B | ~2.5GB | Apache 2.0 | Mid-tier. Multimodal-capable (vision/audio inside the parameter count; not used by the classifier). MoE + Gated Delta Networks architecture; 262K context. |
+| [Phi-4-mini-instruct-GGUF](https://huggingface.co/unsloth/Phi-4-mini-instruct-GGUF) | 3.8B | ~3.5GB | MIT | **Desktop choice for reasoning quality.** Strongest published benchmarks at this size class. Text-only, dense decoder-only (no MoE / multimodal complexity), 128K context, function calling. |
+| [gemma-4-E2B-it-GGUF](https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF) | 2.3B effective | ~3.5GB | Apache 2.0 | Desktop. Multimodal (text/image/audio), configurable thinking, 128K context. |
+
+All catalog entries use Unsloth's Dynamic 2.0 quantisation where available — meaningfully better than vanilla llama.cpp quants at small model sizes where Q2/Q3 starts to degrade. The recommended quantisation per model is Q4_K_M; Q8_0 is the fallback if Q4 classification quality is empirically poor on your real data (verifiable via the dashboard eval).
+
+**Custom-model support.** Admins can paste any HuggingFace identifier (e.g. `org/model-GGUF`) into the dashboard. On save, the system downloads the model, loads it via node-llama-cpp, and runs a self-test prompt to confirm it produces parseable JSON before persisting the config. If the self-test fails, the admin sees the model output verbatim and can choose a different quant, model, or back out. No silent broken-classifier states.
+
+**Picking guidance** (also surfaced inline on the dashboard config page):
+
+- **Hardware-constrained?** Start with Qwen3.5-0.8B — half the RAM, still classifies two booleans reliably in non-thinking mode.
+- **Default laptop install?** LFM2.5-1.2B-Instruct — selected by default. Run the dashboard eval on a 100-sample stratified subset within the first week to confirm it works for your real-data distribution.
+- **Boundary-case performance matters more than speed?** Try Phi-4-mini if you have the RAM; its reasoning benchmarks are the strongest of the catalog.
+- **Want to A/B Thinking vs Instruct?** Configure both as candidate / production, run the dashboard eval against each, promote the better one. The eval makes this a 10-minute exercise rather than a faith-based choice.
+
+**License caveat on LFM2.5.** The LFM1.0 license is more restrictive than Apache/MIT — permissive for personal and small-commercial use, restrictive above a revenue threshold. For a personal-memory tool this is rarely relevant; for an organisational deployment, admins should check the LFM1.0 terms or choose an Apache/MIT alternative (Qwen3.5 or Phi-4-mini).
+
+**Soft alert on high fallback rate.** The dashboard surfaces a warning when more than 20% of classifications in the last 100 hit `fallback_used: "max_retries"` — a strong signal that the configured model is producing malformed output. Catches the "admin enables a custom model that doesn't follow instructions, classifier silently degrades" failure mode without nagging during normal operation.
 
 ### 4.4 Prompt design + versioning
 
@@ -164,6 +186,8 @@ TAGS: {{tags}}
 ```
 
 **No thinking-budget constraint.** Async lifecycle means we want the model's best work, not its fastest work. The eval harness reports per-call inference time so we can see whether thinking is helping; the choice is data-driven, not budget-driven.
+
+**Prompt is tuned for Instruct-style output by default.** The v1 prompt expects the model to emit JSON directly without a thinking preamble — the Instruct variants in the catalog produce exactly that shape. Admins who switch to a Thinking variant (e.g. LFM2.5-1.2B-Thinking) should run the dashboard eval before promoting it, because Thinking variants emit a chain-of-thought block ahead of the JSON. The parser handles both shapes (it trims to the last `{...}` block on the output), but Thinking variants have higher parse-failure rates if the model's CoT happens to include JSON-shaped text mid-thought. If the eval shows materially elevated `fallback_used: "parse"` rate against a Thinking model, a prompt variant tuned for explicit thinking-block delimiting may be needed — see §9.
 
 **Versioning workflow:**
 
@@ -284,7 +308,7 @@ The public synthetic fixture is generated by a multi-model consensus filter — 
   "payload": {
     "input": { "title": "...", "body": "...", "tags": [...] },
     "provider": "local" | "remote",
-    "model": "LiquidAI/LFM2.5-1.2B-Thinking-GGUF" | "gpt-4o-mini" | ...,
+    "model": "LiquidAI/LFM2.5-1.2B-Instruct-GGUF" | "gpt-4o-mini" | ...,
     "model_quant": "Q4_K_M" | null,
     "prompt_version": "v1",
     "raw_output": "<full model text incl. thinking>",
@@ -322,7 +346,7 @@ The public synthetic fixture is generated by a multi-model consensus filter — 
 - **D3.** **No separate queue.** Worker polls the projection (`WHERE classified=0`). Single classifier instance, sequential, crash-safe by construction.
 - **D4.** **30-second per-item timeout, 3 retries, then giveup.** Giveup marks `classified=1` with conservative defaults and emits `memory.classified` with `fallback_used: "max_retries"`.
 - **D5.** **Configurable provider** (local | remote OpenAI-compatible). Reuses the curator's LLM client *code*; has its own *config* so admins can use different providers/models for the two jobs.
-- **D6.** **Local default: LFM2.5-1.2B-Thinking-GGUF, Q4_K_M.** No thinking-budget constraint; async absorbs the latency.
+- **D6.** **Local model: curated catalog with admin choice + custom-HF override.** Default is LFM2.5-1.2B-Instruct-GGUF at Q4_K_M for laptops; Qwen3.5-0.8B-Instruct for Pi-class hardware; Phi-4-mini-instruct for desktop where reasoning quality matters more than RAM. Instruct variants are preferred over Thinking for the classifier's structured-output task (cleaner JSON, lower parse-failure rate); admins can A/B the Thinking variant via the dashboard eval. Custom models are validated against a self-test prompt before persisting config to prevent silent broken-classifier states.
 - **D7.** **Dashboard-driven evaluation, not CI quality gate.** CI tests the machinery (parser, retries, migration) with mocked models; the operator runs evaluation against the synthetic fixture from the dashboard when promoting prompts or candidate models. The eval is *advisory*, not blocking — the operator's judgement is the actual gate. Avoids the cost (local CI has no GPU; remote CI burns tokens) and the flakiness (LLM non-determinism) of automated quality gates. Backfill + day-to-day use is the real-data signal.
 - **D8.** **Synthetic fixture by multi-model consensus filter** (Claude + GPT-4o + Gemini, unanimous). 60/40 straight/boundary; over-generate boundaries to survive pruning. No ambiguous cases. Lives in the repo; used by the dashboard evaluation tool, not by CI.
 - **D9.** **Backfill on migration.** Existing memories are marked `classified=0` at upgrade time and the worker drains the queue over the first hours/days. Verdicts replace the legacy category-derived booleans where they disagree.
@@ -381,5 +405,7 @@ The public synthetic fixture is generated by a multi-model consensus filter — 
 - **Boundary case survival rate under consensus.** ~50% is the working assumption; the first batch will tell us. If it's <30% we over-generate harder; if it's >70% the boundary cases probably aren't boundary enough — we tighten the synth prompt.
 - **Remote-mode input redaction.** Out of scope for V1: should the classifier's inputs (memory title + body) flow through `curator-redaction` before being sent to a third-party provider? Probably yes; not blocking initial release. The dashboard UI for remote-mode explicitly says "contents leave your machine" so admins choosing remote know what they're trading away.
 - **Worker-process isolation.** The worker runs in-process on a Node worker thread. For multi-user or multi-process supervision scenarios we'd want a separate process or even a separate machine; not for V1.
-- **Backfill performance regression.** If backfill of 200 memories takes much longer than the 2-hour estimate (e.g. local mode on a Raspberry Pi), the owner-facing experience on day one is "the dashboard says half my memories are still unclassified." Acceptable for V1 — the worker will catch up — but worth noting that for low-spec hosts, remote mode is the practical default.
-- **What happens to the parent spec.** `memory-domain-isolation-and-conv-state.md` §4.4 + §7.3 + §8 contain language inconsistent with this document (sync, shadow phase, latency budget). They should be updated in the same PR as the classifier implementation lands, with cross-references to this spec for the detailed contract.
+- **Backfill performance on low-spec hosts.** A Pi-class machine running Qwen3.5-0.8B at Q4_K_M will still take several hours to backfill the canonical instance's ~200 memories. The owner-facing experience is "the dashboard shows N% classified, increasing over the next few hours." Acceptable but worth noting that low-spec hosts should consider configuring remote mode for backfill if they have an API key handy, then optionally switching to local for ongoing classifications.
+- **Thinking-variant prompt tuning.** The v1 prompt assumes Instruct-style direct JSON output. If an admin runs the dashboard eval against a Thinking variant and sees elevated `fallback_used: "parse"` rates (the CoT block confusing the parser), a v2 prompt with explicit thinking-block delimiting (`<think>...</think>{...}`) might be warranted. Empirical question for V2.
+- **Custom prompts per model.** Out of scope for V1: admins promote prompts from the in-repo `prompt/v<N>.md` library; they don't author their own. The escape hatch (fork the repo, edit the prompt) exists for power users. Revisit if catalog growth surfaces a model that needs a meaningfully different prompt shape.
+- **What happens to the parent spec.** `memory-domain-isolation-and-conv-state.md` §4.4 + §7.3 + §8 are now in sync with this document. If either spec drifts in a future revision, the other should be brought along in the same PR — they cross-reference each other heavily.

--- a/docs/specs/classifier-implementation-spec.md
+++ b/docs/specs/classifier-implementation-spec.md
@@ -2,7 +2,7 @@
 
 **Author:** Claude, with Jim
 **Date:** 2026-05-27
-**Status:** Draft v2 — async lifecycle; configurable provider (local default, remote alternative); two-tier eval; collapsed shadow+cutover into one PR; awaiting implementation
+**Status:** Draft v3 — async lifecycle; configurable provider (local default, remote alternative); dashboard-driven evaluation (no CI quality gate); collapsed shadow+cutover into one PR; awaiting implementation
 
 ---
 
@@ -181,30 +181,60 @@ The model is prompted to output a JSON object on its last line: `{"requires_appr
 
 The Thinking variant's reasoning preamble is discarded by step (1). Remote providers that don't emit chain-of-thought just emit the JSON directly — same parser, same code path.
 
-### 4.6 Eval harness — two-tier
+### 4.6 Eval harness — operator-driven, not CI-driven
 
-**Tier 1: public synthetic fixture.** ~900 memories committed to the repo, OSS-safe, no real PII. CI gates on this. See §4.7 for generation. Catches gross classifier regressions in public PRs from contributors who don't have access to the calibration set.
+The eval surface is **a dashboard tool, not a CI gate**. Three reasons:
 
-**Tier 2: private calibration set.** The canonical instance's real memories — initially the owner's hand-labelled ~200, growing organically as `memory.classification_overridden` events accumulate. Lives only in the canonical instance. Runs nightly (or per-release) in the operator's private environment. Catches the subtle regressions the synthetic set won't see.
+1. **Running 1000 classifications in CI is expensive.** Local-model CI runners don't have GPUs; remote-API CI burns through tokens on every PR. Neither is justifiable for a project this size.
+2. **LLM non-determinism makes automated quality gates flaky.** Even with temperature=0 and pinned models, providers occasionally produce different outputs for the same input — every flake erodes trust in the gate.
+3. **The operator's real signal comes from running memory through it.** Backfill on day one + daily use is the ground truth; a synthetic-fixture CI gate is a poor proxy for it and adds infrastructure cost in exchange.
 
-**Tier-1 acceptance:** agreement vs labelled ground truth must not drop by >2 percentage points on the public fixture from one PR to the next, joint across both booleans, without an explicit override line in the PR description. Reports per-boolean breakdown alongside.
+CI tests the *machinery* — parser, retry logic, worker drain, migration backfill — with mocked models. Quality evaluation lives on the dashboard.
 
-**Tier-2 trust signal:** the operator runs the private eval before tagging releases. If tier-1 and tier-2 disagree (tier-1 green, tier-2 regressed), tier-2 wins — the public fixture is a proxy, the private one is reality.
+**What CI actually does** (mocked, deterministic, fast):
 
-**Eval harness CLI** (`@librarian/classifier-eval`):
+- Parser handles thinking-preamble + JSON, multiple JSON objects (last wins), malformed output (rejects with parse error), missing keys (rejects), extra keys (rejects).
+- Worker correctly drains `WHERE classified=0`, increments `classification_attempts` on failure, gives up after 3 attempts with `fallback_used="max_retries"`, never double-processes a row.
+- Migration backfill marks existing memories `classified=0, classification_attempts=0`.
+- Provider router correctly dispatches to local vs remote based on config, including hot-swap mid-operation.
+- All of the above run against a mock classifier (`{ classify: (input) => returnPresetVerdict(input) }`). Zero actual model invocations. <1s in CI.
 
-- `eval public` — runs the model against the committed synthetic fixture, prints agreement + latency stats.
-- `eval private --data-dir <path>` — runs against the operator's `events.jsonl`, treating owner-override events as ground truth.
-- `eval replay --event-id <id> --prompt v2` — re-runs a single historical event against a different prompt version, prints both verdicts.
-- `eval generate-fixture --candidates 1500 --target 900` — generates a new candidate fixture (used during fixture refresh; see §4.7).
+**Dashboard evaluation surface:**
 
-**Per-call telemetry recorded by every eval run:**
+A new admin page, "Classifier Evaluation," lets the operator on-demand:
 
-- Provider + model identity (which one ran it).
-- Inference time (model think + response).
-- Prompt version.
-- Fixture entry id + the fixture's labelled answer.
-- Classifier's verdict.
+1. **Pick a provider + model** (defaults to the current production config; can select a candidate for comparison).
+2. **Pick a sample size**: 10 (smoke test, ~1 minute), 100 (standard, ~10 minutes locally), or "all 1000" (deep eval, ~hours locally / ~minutes remote).
+3. **Pick a category filter**: all, straight-only, boundary-only. Boundary-only is the harder eval and often the more informative one.
+4. **Run.** Each sample is stratified-random from the fixture (proportional draw across `straight`/`boundary` unless the filter narrows it).
+5. **See the report:**
+   - Joint agreement (% of samples where both booleans match the fixture label).
+   - Per-boolean agreement (one boolean might be reliable while the other isn't).
+   - Disagreement breakdown by category (straight misses are alarming; boundary misses are expected at some rate).
+   - Latency distribution (p50 / p95 / p99 / max).
+   - Sample-level results table with diff highlighting so the operator can read the actual disagreements.
+
+**Persisted between runs:**
+
+- Each evaluation run writes a `classifier.evaluation_completed` event to the events ledger with the run parameters (provider, model, prompt_version, sample_size, filter) and the summary stats. The dashboard's history view shows the timeline.
+- Sample-level disagreements are linked from the report — the operator can click a row to see the fixture entry, the classifier's verdict, and the fixture's labelled answer side by side. Useful for diagnosing "the model thinks identity facts are preferences" patterns.
+
+**Natural workflow this enables:**
+
+1. Operator wants to try a candidate model. They configure it in a "candidate" slot (not the production slot).
+2. Dashboard → Classifier Evaluation → run 100-sample evaluation against the candidate.
+3. Report says 94% agreement. Operator clicks the disagreements, sees they're mostly boundary cases on identity/preferences edges. Acceptable.
+4. Operator promotes the candidate to production. Backfill behaviour or daily use is the longer-term signal.
+
+If steps 2-3 produce bad results, the candidate never reaches production. No CI involved.
+
+**Eval harness CLI** (`@librarian/classifier-eval`, the headless interface the dashboard calls into):
+
+- `eval run --provider local --model <id> --sample 100 --category boundary` — runs an evaluation, prints the report as JSON. The dashboard wraps this; ops can also invoke it directly for scripting / cron.
+- `eval replay --event-id <id> --prompt v2` — re-runs a single historical `memory.classified` event against a different prompt version. Useful for "would v2 have changed this decision?" spot checks.
+- `eval generate-fixture --candidates 1500 --target 900` — generates a new candidate fixture via the §4.7 consensus pipeline. Used during refresh; not part of normal eval.
+
+**Promotion is a deliberate admin action, gated by eval results.** Prompt changes (promote `v2`) and model swaps (production slot ↔ candidate slot) both require the admin to click a button. The natural-but-non-binding workflow is: change → eval → if happy, promote. There's no automated "block promotion if agreement drops" rule — the operator's judgement is the gate. (We can add a soft warning to the promote button: "Last evaluation was N days ago at X% joint agreement — run a fresh eval first?")
 
 ### 4.7 Public fixture generation
 
@@ -276,7 +306,7 @@ The public synthetic fixture is generated by a multi-model consensus filter — 
 ## 5. Tech stack
 
 - **New package:** `@librarian/classifier` — owns the worker, the provider router (local vs remote), the prompt files, the JSON parser, the retry + giveup wrapper. Exports `runOnce(deps)` for the worker tick and `classify({title, body, tags}, providerConfig)` for the eval harness.
-- **New package:** `@librarian/classifier-eval` — CLI for public + private eval, fixture generator, CI runner.
+- **New package:** `@librarian/classifier-eval` — CLI for dashboard-triggered evaluation, fixture generator, replay helper. The dashboard wraps the CLI; operators can also script against it.
 - **New runtime dep:** [`node-llama-cpp`](https://github.com/withcatai/node-llama-cpp) — only loaded when `classifier.provider === "local"`. Pinned to a specific minor; native module; must build cleanly on Apple Silicon / Linux x86_64 / Linux aarch64.
 - **Reused:** `@librarian/core`'s LLM-client abstraction (the curator's). The classifier consumes the same client code with its own config namespace.
 - **Reused:** `secret-crypto.ts` for encrypted token storage.
@@ -293,8 +323,8 @@ The public synthetic fixture is generated by a multi-model consensus filter — 
 - **D4.** **30-second per-item timeout, 3 retries, then giveup.** Giveup marks `classified=1` with conservative defaults and emits `memory.classified` with `fallback_used: "max_retries"`.
 - **D5.** **Configurable provider** (local | remote OpenAI-compatible). Reuses the curator's LLM client *code*; has its own *config* so admins can use different providers/models for the two jobs.
 - **D6.** **Local default: LFM2.5-1.2B-Thinking-GGUF, Q4_K_M.** No thinking-budget constraint; async absorbs the latency.
-- **D7.** **Two-tier eval:** public synthetic fixture in repo (CI gate), private calibration set on the operator's instance (release gate).
-- **D8.** **Public fixture by multi-model consensus filter** (Claude + GPT-4o + Gemini, unanimous). 60/40 straight/boundary; over-generate boundaries to survive pruning. No ambiguous cases.
+- **D7.** **Dashboard-driven evaluation, not CI quality gate.** CI tests the machinery (parser, retries, migration) with mocked models; the operator runs evaluation against the synthetic fixture from the dashboard when promoting prompts or candidate models. The eval is *advisory*, not blocking — the operator's judgement is the actual gate. Avoids the cost (local CI has no GPU; remote CI burns tokens) and the flakiness (LLM non-determinism) of automated quality gates. Backfill + day-to-day use is the real-data signal.
+- **D8.** **Synthetic fixture by multi-model consensus filter** (Claude + GPT-4o + Gemini, unanimous). 60/40 straight/boundary; over-generate boundaries to survive pruning. No ambiguous cases. Lives in the repo; used by the dashboard evaluation tool, not by CI.
 - **D9.** **Backfill on migration.** Existing memories are marked `classified=0` at upgrade time and the worker drains the queue over the first hours/days. Verdicts replace the legacy category-derived booleans where they disagree.
 - **D10.** **Agent response from `remember` is always "Memory saved"** regardless of classification state. The agent's contract is durability, not policy.
 - **D11.** **No shadow phase.** PR 6 + PR 7 from the parent plan collapse into one. Risk management is: the synth eval gates CI; the operator manually reviews the dashboard during week one; PR revert + bridge restore is the rollback path.
@@ -337,8 +367,9 @@ The public synthetic fixture is generated by a multi-model consensus filter — 
 - [ ] Provider switch (local ↔ remote) is hot-swappable via the dashboard; in-flight retries keep their original provider.
 - [ ] Every `memory.classified` event includes provider, model, prompt version, queue_wait_ms, inference_ms, attempt_number, fallback_used. Owner-overrides emit `memory.classification_overridden` preserving the classifier's original verdict.
 - [ ] Backfill of the canonical instance's ~200 existing memories completes within hours of the upgrade, with classifier verdicts visible in the dashboard alongside the legacy-derived "before" snapshot.
-- [ ] The eval harness's public-fixture run produces a regression report; CI gates PRs that drop joint agreement by >2 percentage points without an explicit override.
-- [ ] The eval harness's private-calibration run produces the same shape of report against the canonical instance's `events.jsonl`, using owner-override events as ground truth.
+- [ ] CI runs the machinery tests (parser, worker, retries, migration) against mocked classifiers, in <5 seconds, with zero actual model invocations.
+- [ ] The dashboard's "Classifier Evaluation" page lets the operator pick provider + model + sample size + category filter, runs the evaluation, and renders a report covering joint agreement, per-boolean agreement, disagreement breakdown, latency distribution, and sample-level diffs.
+- [ ] Every evaluation run emits a `classifier.evaluation_completed` event so the dashboard's history view shows the timeline of runs and their results.
 - [ ] The dashboard's proposal-queue view shows `requires_approval=true AND classified=1` memories — `classified=0` ones don't appear until the worker has decided.
 - [ ] On a fresh install with `classifier.provider="remote"`, no local-model download is triggered; the install footprint is unchanged from pre-classifier mcp-server.
 - [ ] On a fresh install with `classifier.provider="local"`, the model is downloaded lazily on first classification call (or immediately on admin-enable, configurable).

--- a/docs/specs/classifier-implementation-spec.md
+++ b/docs/specs/classifier-implementation-spec.md
@@ -1,0 +1,220 @@
+# Spec: Memory-Classifier Implementation
+
+**Author:** Claude, with Jim
+**Date:** 2026-05-27
+**Status:** Draft v1 — model + serving chosen (LFM2.5-1.2B-Thinking-GGUF, in-process); eval harness + prompt versioning pinned; awaiting implementation
+
+---
+
+## 1. Purpose
+
+The parent spec ([`memory-domain-isolation-and-conv-state.md`](./memory-domain-isolation-and-conv-state.md) §4.4, §9, §21) introduces a write-path classifier — a small local LLM that examines every new memory and decides the two new policy booleans, `is_global` and `requires_approval`. This document fills the gap §9 explicitly left open: which model, how it's served, how its prompt is versioned, and how its quality is measured and watched in production.
+
+The parent spec already nails down four things this document treats as fixed:
+
+- **Behaviour contract** — sync on the write path of `remember`; 500ms timeout; conservative fallback (`requires_approval=true, is_global=false`); `memory.classified` event appended to `events.jsonl` on every call.
+- **Owner override** — every dashboard toggle of either boolean appends a `memory.classification_overridden` event preserving the classifier's original verdict.
+- **Cutover order** — PR 6 ships in shadow mode (classifier verdicts logged, persisted booleans still come from the category-derived bridge); PR 7 flips the source of truth. This document targets the PR 6 + PR 7 work but does not redefine that order.
+- **No retroactive reclassification at migration time** — historical memories keep their migrated values until and unless an opt-in admin tool fires the classifier across them.
+
+Anything outside those four is in scope here.
+
+---
+
+## 2. Non-goals
+
+- **Not a general-purpose classifier.** This model decides *exactly* two booleans for a single classification task. We're not adding tag suggestions, summary generation, or recall re-ranking in the same surface.
+- **Not retrainable from this repo.** We use a stock open-weights checkpoint with prompt engineering, not fine-tuning. If empirical quality demands a tuned model later, that's a follow-up sub-spec; the eval harness defined here is the substrate that decision would be made on.
+- **Not exposed to agents.** Agents see only `requires_approval`/`is_global` on the resulting memory. They never call the classifier directly, never see the raw verdict text, never see the prompt version.
+- **Not configurable at the prompt level for end users.** The owner can override individual verdicts via the dashboard (and that override is the eval ground truth); they cannot edit the prompt. Prompt evolution is a development-time activity gated by the eval harness.
+
+---
+
+## 3. Background
+
+The parent spec §4.4 settled the principle ("a small local LLM decides the two write-path booleans, owner-overridable") and §9 deferred the implementation details ("specific model choice, serving infrastructure, prompt versioning workflow, eval harness specification"). The rollout plan §6 makes this document a hard pre-work blocker for Phase 6 ("shadow mode"): nothing in PR 6 can land until the model and serving topology are committed.
+
+The legacy bridge in [PR 1 / T1.3](./memory-domain-isolation-and-conv-state-plan.md) gives us a behavioural baseline: every existing and PR 1-era memory has booleans derived from the old `category` enum. That baseline doubles as the migration-shaped eval set — we already know the "right" booleans for every historical memory, so the classifier's first-day job is to agree with the derivation, not to outperform it. The classifier's actual value shows up later, when it generalises *beyond* the seven category values into the new tag-driven world post-cutover.
+
+---
+
+## 4. The contract
+
+### 4.1 Model choice
+
+**[LiquidAI/LFM2.5-1.2B-Thinking-GGUF](https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking-GGUF)** — 1.2B-parameter Liquid Foundation Model variant with chain-of-thought ("Thinking") reasoning, packaged as GGUF for native llama.cpp / node-llama-cpp loading.
+
+- **Why this model.** Small enough to load in the same Node process as the mcp-server (≤2GB RAM at the recommended quantisation), open weights, and the architecture is designed for edge inference. The "Thinking" variant gives us internal reasoning headroom for the two-boolean decision without paying a 7B-class memory or latency cost.
+- **Quantisation.** Default Q4_K_M (~700MB on disk, fits in ~1.5GB RAM with KV cache). Fallback to Q8_0 if Q4 quality is empirically poor; Q2_K is below the floor we'll accept.
+- **Risk we're accepting.** Thinking-variant models tokenise their internal reasoning before the final answer. The 500ms budget includes that reasoning time. The prompt (see §4.3) explicitly constrains the thinking budget; the eval harness (§4.6) measures latency including the thinking block. If empirical p99 latency exceeds 500ms on the reference hardware, we either constrain thinking further or switch to a non-Thinking sibling variant. This is the dominant Open Question for PR 6 shadow mode — see §9.
+
+### 4.2 Serving topology
+
+**In-process** via [`node-llama-cpp`](https://github.com/withcatai/node-llama-cpp), loaded into the existing `@librarian/mcp-server` process.
+
+- **Why in-process.** One process to deploy, one config file to manage, no IPC failure mode. The Librarian's whole pitch is "portable memory layer that runs anywhere" — a separate sidecar service breaks that.
+- **Cold start.** Lazy-loaded on the first `remember` call. The mcp-server startup time is unchanged; the first user write pays a one-time ~2s model load. Subsequent calls are warm.
+- **Memory budget.** Up to 2GB RSS attributable to the classifier. Documented in the server's operational guidance; the mcp-server should warn on startup if the system has <4GB free.
+- **Worker thread.** The inference call runs on a Node worker thread (`worker_threads`) so the main event loop stays responsive to other MCP requests during the (up to) 500ms classification window. Without this, every `remember` would block the server for everyone.
+- **Concurrent calls.** A single model instance is reused across requests; concurrent inferences serialise through llama.cpp's batch queue. This is fine for the expected single-owner workload; if we ever hit multi-tenant scale, we revisit.
+
+### 4.3 Prompt design + versioning
+
+**Prompt lives in `@librarian/classifier/prompt/v<N>.md`** as plain markdown. Each prompt version is a committed file; the file path *is* the version identifier. Every `memory.classified` event records which version produced the verdict.
+
+**Prompt shape** (v1, normative):
+
+```
+You classify durable memories for a personal memory store. For each
+memory, decide two booleans:
+
+- requires_approval: true if the memory contains identity facts,
+  relationship facts, or anything an owner would want to review
+  before it becomes active. False otherwise.
+- is_global: true if the memory should bypass per-conversation domain
+  filtering and be available everywhere (identity, relationships,
+  preferences). False if it's contextual to a specific domain (tools,
+  projects, lessons, environment).
+
+Output strictly:
+
+{"requires_approval": <bool>, "is_global": <bool>}
+
+Think briefly (≤30 tokens) before answering. Do not include the
+thinking in the JSON output — the parser reads only the final line.
+
+Few-shot examples:
+[... 4–6 examples covering each quadrant ...]
+
+Now classify:
+TITLE: {{title}}
+BODY: {{body}}
+TAGS: {{tags}}
+```
+
+**Versioning workflow:**
+
+- Adding a new prompt file (`v2.md`) does *not* deploy it. The classifier defaults to `LIBRARIAN_CLASSIFIER_PROMPT_VERSION ?? latest committed`. A dashboard switch (admin-only) flips the active version.
+- The eval harness (§4.6) can replay any past `memory.classified` event against any prompt version, so we can answer "would v2 have changed this decision?" before promoting v2.
+- Prompt changes that materially shift verdicts must land alongside a CHANGELOG entry and an eval-harness diff showing the new agreement rate.
+
+### 4.4 Output schema + validation
+
+The model is prompted to output a single-line JSON object: `{"requires_approval": bool, "is_global": bool}`. The parser:
+
+1. Trims everything before the last `{` and after the matching `}`.
+2. Runs `JSON.parse` and validates the result against a Zod schema (two booleans, exactly those keys, no extras).
+3. On any parse / schema failure, treats it as a model failure and falls through to the conservative fallback (§4.5).
+
+The Thinking variant's reasoning preamble is discarded by step (1). If the model emits multiple JSON objects, the last one wins (the model's "final answer" by convention).
+
+### 4.5 Latency + reliability budget
+
+- **Timeout:** 500ms per `remember` call (parent spec §4.4 — fixed).
+- **Target p99 (warm):** <300ms. The 200ms headroom absorbs an occasional slow turn or a busy host.
+- **Fallback (parent spec D20 — fixed):** on timeout / malformed output / model unavailable, persist `{requires_approval: true, is_global: false}` and append a `memory.classified` event with `fallback_used: true`.
+- **Cold-start exemption:** the first `remember` after server start may exceed 500ms while the model loads. The classifier returns the fallback for that one call (with `fallback_used: "cold_start"` for observability) and is warm by the next.
+- **Loud failures (parent spec §4.4 — fixed):** the dashboard's proposal queue surfaces every memory that landed via the fallback, with a "classifier was down" tag, so the owner sees that the safety net is engaging.
+
+### 4.6 Eval harness
+
+A new package `@librarian/classifier-eval` (CLI + test fixtures) that:
+
+1. **Reads `events.jsonl`** and selects every `memory.classified` event (each carries the input title/body/tags, the raw model output, the parsed verdict, and the prompt version).
+2. **For each event, optionally reruns** against a chosen prompt version (`--prompt v2`) and/or a chosen model variant (`--model …`). Produces a row: `{event_id, ground_truth, original_verdict, replayed_verdict, replayed_latency_ms}`.
+3. **Ground truth** is the most authoritative of: an explicit `memory.classification_overridden` event (owner override), else the legacy category-derived booleans (until they're removed in PR 7), else `null` (no signal — not counted in agreement).
+4. **Reports:**
+   - Overall agreement rate vs ground truth (per boolean and joint).
+   - Disagreement breakdown by category / domain / age.
+   - Latency distribution (p50 / p95 / p99 / max, separated for warm vs first-after-load).
+   - Fallback rate.
+5. **CI integration:** every PR that touches `packages/classifier/` or `packages/mcp-server/src/mcp/tools/remember.ts` runs the harness against a checked-in 1000-memory fixture (anonymised, derived from the canonical instance). Regression threshold: agreement on the fixture must not drop by >2 percentage points vs the previous baseline without an explicit override line in the PR description.
+
+### 4.7 `memory.classified` event shape
+
+Recorded on every `remember` call (shadow mode and post-cutover alike) per parent spec §4.4:
+
+```json
+{
+  "event_type": "memory.classified",
+  "event_id": "evt_<uuid>",
+  "memory_id": "mem_<uuid>",
+  "agent_id": "<resolved>",
+  "created_at": "<iso>",
+  "payload": {
+    "input": { "title": "...", "body": "...", "tags": [...] },
+    "model": "LiquidAI/LFM2.5-1.2B-Thinking-GGUF",
+    "model_quant": "Q4_K_M",
+    "prompt_version": "v1",
+    "raw_output": "<full model text incl. thinking>",
+    "parsed": { "requires_approval": false, "is_global": false } | null,
+    "fallback_used": false | "timeout" | "parse" | "model_unavailable" | "cold_start",
+    "latency_ms": 187
+  }
+}
+```
+
+The `raw_output` is the eval substrate — we keep it indefinitely. At ~500B per event × 100 memories/day = ~50KB/day on `events.jsonl`. If this proves too expensive over years, we'll add a `--rotate-classified-events` migration that trims old entries to a sampled subset; not in V1 scope.
+
+---
+
+## 5. Tech stack
+
+- **New package:** `@librarian/classifier` — owns the model lifecycle, the prompt files, the JSON parser, the timeout + fallback wrapper. Exports a single `classify({title, body, tags}): Promise<ClassifyResult>` function. Test-mockable via a deterministic stub.
+- **New package:** `@librarian/classifier-eval` — CLI for the eval harness, plus the CI runner.
+- **New runtime dep:** [`node-llama-cpp`](https://github.com/withcatai/node-llama-cpp) (current major; pinned to a specific minor in `package.json`). Native module; we'll need to confirm it builds cleanly on Apple Silicon, Linux x86_64, and Linux aarch64 — the same platforms the mcp-server supports.
+- **Model checkpoint:** downloaded at install time (`pnpm install` hook) or lazily on first server start (preferred — keeps `pnpm install` offline-friendly). Cache lives under `~/.librarian/models/<model-name>/`.
+- **No new database surface.** Verdicts ride existing JSONL events; the projection-level columns (`is_global`, `requires_approval`) are already in place from PR 1.
+
+---
+
+## 6. Decisions
+
+- **D1.** Model: LFM2.5-1.2B-Thinking-GGUF. Rationale in §4.1; the dominant risk is the Thinking-variant latency, mitigated by the eval-harness latency report and the §9 contingency.
+- **D2.** Serving: in-process via node-llama-cpp on a worker thread. Rationale in §4.2.
+- **D3.** Quantisation: Q4_K_M default, with Q8_0 as the empirical-quality fallback.
+- **D4.** Prompt files are the version identifier. Each `memory.classified` event records the path. Single active version at a time, admin-switchable.
+- **D5.** JSON output, schema-validated. Multiple objects → last one wins. Parse failure → conservative fallback.
+- **D6.** Eval harness reads `events.jsonl`; ground truth is owner-override-first, category-derived-second. CI gate: agreement on the fixture cannot drop >2 percentage points without an explicit override.
+- **D7.** Cold-start latency is exempted from the 500ms budget — the first post-restart `remember` gets the fallback with `fallback_used: "cold_start"`. Operators can warm the classifier with a dummy call at startup if cold-start fallbacks are unwanted.
+- **D8.** Model download is lazy on first server start (not at `pnpm install`). Keeps installs offline-friendly and lets operators on a metered connection control the download moment.
+
+---
+
+## 7. Migration / rollout
+
+- **Phase 6 (PR 6, classifier shadow mode)** — ship `@librarian/classifier`; wire it into `remember` to run on every write and log a `memory.classified` event; persisted booleans still come from the legacy bridge. Dashboard gains the "classifier-vs-derived disagreement" view from rollout plan §T6.3. Owner reviews quality over a week+; eval-harness summary is the go/no-go signal.
+- **Phase 7 (PR 7, cutover)** — flip the source of truth. The classifier's verdict becomes the persisted booleans; the legacy `category`-derived path is deleted. Plan-defined acceptance: ≥95% agreement on the fixture, p99 latency <300ms warm, fallback rate <2%.
+- **No data migration required for this spec.** PR 1 already wired the columns. PR 6 starts logging the events. PR 7 starts persisting the verdicts.
+
+---
+
+## 8. Success criteria
+
+- [ ] `@librarian/classifier.classify({...})` returns within 500ms (warm) for >99% of calls on the reference hardware (M2 MacBook Air, 16GB RAM; Linux x86_64, 4 vCPU, 8GB RAM).
+- [ ] Every `remember` call appends exactly one `memory.classified` event. The payload includes the raw model output, the parsed verdict, the model + quant + prompt version, the latency, and the fallback flag.
+- [ ] The conservative fallback fires on every model failure path (timeout, parse, schema, model-unavailable, cold-start) and is observable on the dashboard.
+- [ ] The eval harness can replay any historical event against any committed prompt version and any installed model variant.
+- [ ] The classifier-quality CI gate runs on every relevant PR and blocks merges that regress agreement by >2 percentage points without an explicit override.
+- [ ] The first-time install of mcp-server on a fresh machine downloads the model lazily on first `remember` (offline-friendly install).
+- [ ] Spec §4.4's existing success criterion is satisfied: "An owner toggling `is_global` or `requires_approval` on a memory via the dashboard records a `memory.classification_overridden` event preserving the classifier's original verdict." (Already in the parent spec; this document inherits it.)
+- [ ] The mcp-server's startup self-test verifies the classifier package is loadable and the configured model exists or downloads, exiting non-zero if either is broken (loud failure on install misconfiguration).
+
+---
+
+## 9. Open questions
+
+- **Thinking-variant latency.** LFM2.5-1.2B-Thinking includes a chain-of-thought preamble. We are explicitly choosing this model for its reasoning headroom on a small parameter count, but the 500ms budget *includes* the thinking time. **Contingency:** if PR 6 shadow-mode latency exceeds 500ms p99 on either reference machine, the eval harness will compare against:
+  1. A more aggressive prompt-side thinking constraint (≤15 tokens of internal reasoning).
+  2. The non-Thinking sibling variant (LFM2.5-1.2B base, if published).
+  3. Qwen2.5-0.5B-Instruct as a smaller / faster alternative.
+
+  The decision is taken once we have warm-call latency numbers from the fixture, not before.
+
+- **Quantisation floor.** Q4_K_M is the default but we don't know yet whether classification quality holds at that quantisation on this specific architecture. PR 6's shadow-mode evidence answers this — if Q4 disagreement is materially worse than Q8 against the migration baseline, we ship Q8 (~1.2GB on disk, ~2.2GB resident) instead.
+
+- **`memory.classified` event volume.** At ~500B × 100 writes/day = ~50KB/day = ~18MB/year. Acceptable. Past three years (~55MB) we should look at log rotation; not now.
+
+- **CI fixture provenance.** The 1000-memory eval fixture has to come from real-world data to be meaningful, but cannot include any PII or owner-specific content. Open: build a derivation pipeline that pulls from the canonical instance, redacts via the existing `curator-redaction` module, and commits the result. PR 6 blocker — but a small one.
+
+- **Worker-thread concurrency under load.** node-llama-cpp's batch queue serialises concurrent calls; the worker thread keeps the main event loop responsive. Open: is there a non-trivial workload where two concurrent `remember`s queue badly? Probably not for single-owner use; revisit if we ever multi-tenant.

--- a/docs/specs/classifier-implementation-spec.md
+++ b/docs/specs/classifier-implementation-spec.md
@@ -2,67 +2,139 @@
 
 **Author:** Claude, with Jim
 **Date:** 2026-05-27
-**Status:** Draft v1 — model + serving chosen (LFM2.5-1.2B-Thinking-GGUF, in-process); eval harness + prompt versioning pinned; awaiting implementation
+**Status:** Draft v2 — async lifecycle; configurable provider (local default, remote alternative); two-tier eval; collapsed shadow+cutover into one PR; awaiting implementation
 
 ---
 
 ## 1. Purpose
 
-The parent spec ([`memory-domain-isolation-and-conv-state.md`](./memory-domain-isolation-and-conv-state.md) §4.4, §9, §21) introduces a write-path classifier — a small local LLM that examines every new memory and decides the two new policy booleans, `is_global` and `requires_approval`. This document fills the gap §9 explicitly left open: which model, how it's served, how its prompt is versioned, and how its quality is measured and watched in production.
+The parent spec ([`memory-domain-isolation-and-conv-state.md`](./memory-domain-isolation-and-conv-state.md) §4.4, §9, §21) introduces a write-path classifier — a small LLM that examines every new memory and decides the two new policy booleans, `is_global` and `requires_approval`. This document fills the gap §9 explicitly left open and, in three places, **departs from** the parent spec where downstream design work surfaced a better path. The departures are explicit:
 
-The parent spec already nails down four things this document treats as fixed:
+- **Async classification, not sync** (parent §4.4 said "sync on the write path"). `remember` writes the memory with conservative defaults and returns immediately; a background worker classifies. See §4.1.
+- **Configurable provider, not local-only** (parent §4.4 implied local). Admins choose local (default) or a remote OpenAI-compatible API via the existing curator LLM client infrastructure. See §4.2.
+- **One PR, no shadow/cutover phase** (parent §7.3 / plan §6 + §7 staged it). The shadow phase was risk management for multi-user installs; for the current single-user shape we collapse the work into one PR with a backfill of existing memories. See §7.
 
-- **Behaviour contract** — sync on the write path of `remember`; 500ms timeout; conservative fallback (`requires_approval=true, is_global=false`); `memory.classified` event appended to `events.jsonl` on every call.
-- **Owner override** — every dashboard toggle of either boolean appends a `memory.classification_overridden` event preserving the classifier's original verdict.
-- **Cutover order** — PR 6 ships in shadow mode (classifier verdicts logged, persisted booleans still come from the category-derived bridge); PR 7 flips the source of truth. This document targets the PR 6 + PR 7 work but does not redefine that order.
-- **No retroactive reclassification at migration time** — historical memories keep their migrated values until and unless an opt-in admin tool fires the classifier across them.
+If/when the parent spec gets a second pass, these three deltas should propagate up to it. Until then, this document is the source of truth for the classifier surface.
 
-Anything outside those four is in scope here.
+The parent spec items this document treats as fixed:
+
+- **Two-boolean output** — the classifier decides `is_global` and `requires_approval`, nothing else.
+- **Conservative fallback values** — `requires_approval=true, is_global=false` on any failure or before classification completes.
+- **Owner override is ground truth** — every dashboard override appends `memory.classification_overridden`, the original verdict is preserved.
+- **`memory.classified` events go to `events.jsonl`** as the eval substrate.
 
 ---
 
 ## 2. Non-goals
 
-- **Not a general-purpose classifier.** This model decides *exactly* two booleans for a single classification task. We're not adding tag suggestions, summary generation, or recall re-ranking in the same surface.
-- **Not retrainable from this repo.** We use a stock open-weights checkpoint with prompt engineering, not fine-tuning. If empirical quality demands a tuned model later, that's a follow-up sub-spec; the eval harness defined here is the substrate that decision would be made on.
-- **Not exposed to agents.** Agents see only `requires_approval`/`is_global` on the resulting memory. They never call the classifier directly, never see the raw verdict text, never see the prompt version.
-- **Not configurable at the prompt level for end users.** The owner can override individual verdicts via the dashboard (and that override is the eval ground truth); they cannot edit the prompt. Prompt evolution is a development-time activity gated by the eval harness.
+- **Not a general-purpose classifier.** Two booleans, one task. No tag suggestions, no recall re-ranking, no summary generation in the same surface.
+- **Not retrainable from this repo.** Stock open-weights checkpoints + prompt engineering. If empirical quality demands a tuned model later, it's a follow-up sub-spec; the eval harness defined here is the substrate that decision would be made on.
+- **Not exposed to agents.** Agents see only the booleans on the resulting memory. They never call the classifier, never see the raw verdict, never see the prompt version.
+- **Not user-configurable at the prompt level.** Owner overrides individual verdicts via the dashboard; the prompt itself evolves through development-time releases gated by the eval harness.
 
 ---
 
 ## 3. Background
 
-The parent spec §4.4 settled the principle ("a small local LLM decides the two write-path booleans, owner-overridable") and §9 deferred the implementation details ("specific model choice, serving infrastructure, prompt versioning workflow, eval harness specification"). The rollout plan §6 makes this document a hard pre-work blocker for Phase 6 ("shadow mode"): nothing in PR 6 can land until the model and serving topology are committed.
+The parent spec §4.4 settled the principle ("a small LLM decides the two write-path booleans, owner-overridable"); §9 deferred specific model choice, serving topology, prompt versioning, and eval harness; plan §6 marked all of that as hard pre-work for the rollout.
 
-The legacy bridge in [PR 1 / T1.3](./memory-domain-isolation-and-conv-state-plan.md) gives us a behavioural baseline: every existing and PR 1-era memory has booleans derived from the old `category` enum. That baseline doubles as the migration-shaped eval set — we already know the "right" booleans for every historical memory, so the classifier's first-day job is to agree with the derivation, not to outperform it. The classifier's actual value shows up later, when it generalises *beyond* the seven category values into the new tag-driven world post-cutover.
+Two insights surfaced during this spec's drafting that changed the architecture:
+
+- **Sync was a constraint, not a requirement.** Nothing in the agent surface or the durability story actually needed the verdict to land synchronously. Decoupling them removes the dominant risk in the original sync design (the 500ms latency budget on a Thinking-variant model) without weakening any guarantee.
+- **The Librarian already has an LLM-client abstraction.** The curator (`packages/core/src/curator-llm-client.ts` + `curator-config.ts`) already speaks to OpenAI-compatible endpoints with encrypted token storage. Making the classifier provider configurable costs almost nothing and lets the Librarian run on low-spec hardware that can't host a local model.
+
+Both decisions are made in this spec, not deferred.
 
 ---
 
 ## 4. The contract
 
-### 4.1 Model choice
+### 4.1 Async classification lifecycle
 
-**[LiquidAI/LFM2.5-1.2B-Thinking-GGUF](https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking-GGUF)** — 1.2B-parameter Liquid Foundation Model variant with chain-of-thought ("Thinking") reasoning, packaged as GGUF for native llama.cpp / node-llama-cpp loading.
+`remember` returns instantly with the memory persisted at conservative defaults. A background worker classifies; results commit later.
 
-- **Why this model.** Small enough to load in the same Node process as the mcp-server (≤2GB RAM at the recommended quantisation), open weights, and the architecture is designed for edge inference. The "Thinking" variant gives us internal reasoning headroom for the two-boolean decision without paying a 7B-class memory or latency cost.
-- **Quantisation.** Default Q4_K_M (~700MB on disk, fits in ~1.5GB RAM with KV cache). Fallback to Q8_0 if Q4 quality is empirically poor; Q2_K is below the floor we'll accept.
-- **Risk we're accepting.** Thinking-variant models tokenise their internal reasoning before the final answer. The 500ms budget includes that reasoning time. The prompt (see §4.3) explicitly constrains the thinking budget; the eval harness (§4.6) measures latency including the thinking block. If empirical p99 latency exceeds 500ms on the reference hardware, we either constrain thinking further or switch to a non-Thinking sibling variant. This is the dominant Open Question for PR 6 shadow mode — see §9.
+**Per-memory state machine:**
 
-### 4.2 Serving topology
+```
+remember()                 worker run                worker run (retry)
+   │                          │                            │
+   ▼                          ▼                            ▼
+classified=0              classifier ok?               attempts ≥ 3?
+attempts=0                ─ yes ──▶ classified=1       ─ yes ──▶ classified=1
+status=proposed                    + verdict booleans            + conservative
+requires_approval=true             + memory.classified           + memory.classified
+is_global=false                                                    fallback_used=
+                          ─ no ──▶ attempts++                       "max_retries"
+                                    classified=0
+```
 
-**In-process** via [`node-llama-cpp`](https://github.com/withcatai/node-llama-cpp), loaded into the existing `@librarian/mcp-server` process.
+**The `memories` table gains two columns** (additive PR ahead of any worker code):
 
-- **Why in-process.** One process to deploy, one config file to manage, no IPC failure mode. The Librarian's whole pitch is "portable memory layer that runs anywhere" — a separate sidecar service breaks that.
-- **Cold start.** Lazy-loaded on the first `remember` call. The mcp-server startup time is unchanged; the first user write pays a one-time ~2s model load. Subsequent calls are warm.
-- **Memory budget.** Up to 2GB RSS attributable to the classifier. Documented in the server's operational guidance; the mcp-server should warn on startup if the system has <4GB free.
-- **Worker thread.** The inference call runs on a Node worker thread (`worker_threads`) so the main event loop stays responsive to other MCP requests during the (up to) 500ms classification window. Without this, every `remember` would block the server for everyone.
-- **Concurrent calls.** A single model instance is reused across requests; concurrent inferences serialise through llama.cpp's batch queue. This is fine for the expected single-owner workload; if we ever hit multi-tenant scale, we revisit.
+- `classified INTEGER NOT NULL DEFAULT 0` — `1` once the classifier has either produced a verdict or given up after `max_retries`.
+- `classification_attempts INTEGER NOT NULL DEFAULT 0` — survives server restarts; incremented per failed attempt; capped at 3 before giveup.
 
-### 4.3 Prompt design + versioning
+**No separate queue.** The projection *is* the queue. The worker polls:
 
-**Prompt lives in `@librarian/classifier/prompt/v<N>.md`** as plain markdown. Each prompt version is a committed file; the file path *is* the version identifier. Every `memory.classified` event records which version produced the verdict.
+```sql
+SELECT id FROM memories
+WHERE classified = 0
+ORDER BY created_at
+LIMIT 1
+```
 
-**Prompt shape** (v1, normative):
+processes the one row, updates it. Single classifier instance = single inference in flight = no race possible. A crash mid-inference leaves the row at `classified=0` and the next worker iteration picks it up (at most one wasted inference).
+
+**Worker pacing.** Idle: poll every 500ms. Busy: process back-to-back with no sleep. The poll is a single indexed query; cost is negligible.
+
+**Per-item timeout: 30s, killable.** Generous enough that even a slow local model never gets cut off mid-thought. If it times out, `classification_attempts++` and the row stays `classified=0` for the next iteration.
+
+**Give-up after 3 failed attempts.** Set `classified=1` with the conservative-defaults verdict persisted (`requires_approval=true, is_global=false`) and emit a `memory.classified` event with `fallback_used: "max_retries"`. The memory ends up in the dashboard's proposal queue — the same place the owner would look for any pending review. Eval harness identifies these via the fallback flag and excludes them from agreement scoring.
+
+**`remember`'s agent response is unchanged regardless of state.** Always "Memory saved." The agent's contract is "I wrote it durably" which is true the instant the row lands. Owner-side policy (proposed vs active, global vs scoped) is not the agent's concern.
+
+**Intra-conversation race (acknowledged, accepted).** A `remember(X)` followed by `recall(query)` ~300ms later will miss X if X should have been global but isn't yet — conservative defaults give `is_global=0` + `status=proposed`, both of which fail the §4.11 recall filter. Cross-conversation recall is unaffected. The intra-conversation gap is small enough that the agent has X in its own context window anyway; documented as an explicit non-issue.
+
+### 4.2 Configurable provider
+
+Admins choose between two providers via a new dashboard setting. The default is local-on-this-machine; remote is the alternative for low-spec hardware or admins who already have an API key they prefer to use.
+
+**`local`** — runs the model in-process via [`node-llama-cpp`](https://github.com/withcatai/node-llama-cpp), loaded into the existing `@librarian/mcp-server` process.
+
+- Model loaded lazily on first classification call (or immediately on admin-enable, configurable). No model download until local mode is enabled.
+- Runs on a Node worker thread (`worker_threads`) so other MCP calls stay responsive.
+- Memory budget: up to 2GB RSS attributable to the classifier. Documented; the server should warn on startup if free RAM is <4GB.
+
+**`remote`** — OpenAI-compatible HTTP API. Reuses the curator's LLM client code (`@librarian/core/curator-llm-client.ts`) but **with its own config**: endpoint, model name, encrypted token. An admin can run the classifier against GPT-4o-mini while the curator runs against Claude (or vice versa, or both against the same provider — fully decoupled).
+
+**Configuration storage:**
+
+- New admin settings keys, mirroring the curator's:
+  - `classifier.provider` = `"local"` | `"remote"`
+  - `classifier.local.model` (HuggingFace identifier or local path; default `LiquidAI/LFM2.5-1.2B-Thinking-GGUF`)
+  - `classifier.local.quantisation` (default `Q4_K_M`)
+  - `classifier.remote.endpoint`
+  - `classifier.remote.model`
+  - `classifier.remote.token` (encrypted via existing `secret-crypto`)
+- Stored in the existing `settings` table; tokens encrypted; dashboard surface lives alongside the curator config page.
+- Provider switch is hot-swappable. The next classification run uses whatever's current. In-flight retries keep the provider they were started with (the `memory.classified` event records which provider produced the verdict).
+
+**Reuse, not duplication.** The internal LLM-client abstraction is shared between curator and classifier. Only the config (which provider, which endpoint, which model) is separate.
+
+**Memory-content leakage warning.** Remote mode sends memory titles + bodies to a third party. The dashboard config page explicitly says so when the admin selects `remote`. A future redaction layer (out of scope for V1) may gate classifier inputs through the existing `curator-redaction` module; for now, it's an admin-informed trade-off.
+
+### 4.3 Default local model
+
+**[LiquidAI/LFM2.5-1.2B-Thinking-GGUF](https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking-GGUF)** — 1.2B-parameter Liquid Foundation Model with chain-of-thought, GGUF-packaged for native llama.cpp loading.
+
+- **Quantisation:** Q4_K_M default (~700MB on disk, ~1.5GB resident with KV cache). Q8_0 is the fallback if Q4 quality is empirically poor against the calibration set.
+- **Why this model.** Small enough to load anywhere; open weights; designed for edge inference. The Thinking variant has chain-of-thought headroom for the two-boolean decision without a 7B-class memory footprint.
+- **The async lifecycle eliminates the latency budget.** The Thinking variant can think as long as it needs (within the 30s per-item ceiling). No prompt-side thinking-budget constraint, no contingency ladder for "the model is too slow" — slow but correct is exactly what async classification was designed for.
+
+### 4.4 Prompt design + versioning
+
+**Prompt files** live in `@librarian/classifier/prompt/v<N>.md`. The file path *is* the version identifier. Each `memory.classified` event records which version produced the verdict.
+
+**Prompt shape (v1, normative):**
 
 ```
 You classify durable memories for a personal memory store. For each
@@ -76,15 +148,14 @@ memory, decide two booleans:
   preferences). False if it's contextual to a specific domain (tools,
   projects, lessons, environment).
 
-Output strictly:
-
+Think as long as you need. When ready, output a single line:
 {"requires_approval": <bool>, "is_global": <bool>}
 
-Think briefly (≤30 tokens) before answering. Do not include the
-thinking in the JSON output — the parser reads only the final line.
+The parser reads only the last JSON object on stdout; reasoning before
+that line is ignored.
 
 Few-shot examples:
-[... 4–6 examples covering each quadrant ...]
+[... 4–6 examples covering each {requires_approval, is_global} quadrant ...]
 
 Now classify:
 TITLE: {{title}}
@@ -92,47 +163,86 @@ BODY: {{body}}
 TAGS: {{tags}}
 ```
 
+**No thinking-budget constraint.** Async lifecycle means we want the model's best work, not its fastest work. The eval harness reports per-call inference time so we can see whether thinking is helping; the choice is data-driven, not budget-driven.
+
 **Versioning workflow:**
 
-- Adding a new prompt file (`v2.md`) does *not* deploy it. The classifier defaults to `LIBRARIAN_CLASSIFIER_PROMPT_VERSION ?? latest committed`. A dashboard switch (admin-only) flips the active version.
-- The eval harness (§4.6) can replay any past `memory.classified` event against any prompt version, so we can answer "would v2 have changed this decision?" before promoting v2.
-- Prompt changes that materially shift verdicts must land alongside a CHANGELOG entry and an eval-harness diff showing the new agreement rate.
+- Adding `v2.md` doesn't deploy it. The classifier reads `LIBRARIAN_CLASSIFIER_PROMPT_VERSION ?? latest_committed`. A dashboard switch (admin-only) promotes a version.
+- The eval harness can replay any past `memory.classified` event against any prompt version, so "would v2 have changed this decision?" is answerable before promotion.
+- Prompt changes that shift verdicts materially land alongside a CHANGELOG entry + an eval-harness diff.
 
-### 4.4 Output schema + validation
+### 4.5 Output schema + validation
 
-The model is prompted to output a single-line JSON object: `{"requires_approval": bool, "is_global": bool}`. The parser:
+The model is prompted to output a JSON object on its last line: `{"requires_approval": bool, "is_global": bool}`. The parser:
 
-1. Trims everything before the last `{` and after the matching `}`.
-2. Runs `JSON.parse` and validates the result against a Zod schema (two booleans, exactly those keys, no extras).
-3. On any parse / schema failure, treats it as a model failure and falls through to the conservative fallback (§4.5).
+1. Trims everything before the last `{` and after the matching `}` on the last line.
+2. Runs `JSON.parse` and validates against a Zod schema (two booleans, exactly those keys, no extras).
+3. On any parse / schema failure, treats this attempt as a failure → `classification_attempts++`, retry on the next worker iteration. Eventually hits the max-retries giveup at attempt 3.
 
-The Thinking variant's reasoning preamble is discarded by step (1). If the model emits multiple JSON objects, the last one wins (the model's "final answer" by convention).
+The Thinking variant's reasoning preamble is discarded by step (1). Remote providers that don't emit chain-of-thought just emit the JSON directly — same parser, same code path.
 
-### 4.5 Latency + reliability budget
+### 4.6 Eval harness — two-tier
 
-- **Timeout:** 500ms per `remember` call (parent spec §4.4 — fixed).
-- **Target p99 (warm):** <300ms. The 200ms headroom absorbs an occasional slow turn or a busy host.
-- **Fallback (parent spec D20 — fixed):** on timeout / malformed output / model unavailable, persist `{requires_approval: true, is_global: false}` and append a `memory.classified` event with `fallback_used: true`.
-- **Cold-start exemption:** the first `remember` after server start may exceed 500ms while the model loads. The classifier returns the fallback for that one call (with `fallback_used: "cold_start"` for observability) and is warm by the next.
-- **Loud failures (parent spec §4.4 — fixed):** the dashboard's proposal queue surfaces every memory that landed via the fallback, with a "classifier was down" tag, so the owner sees that the safety net is engaging.
+**Tier 1: public synthetic fixture.** ~900 memories committed to the repo, OSS-safe, no real PII. CI gates on this. See §4.7 for generation. Catches gross classifier regressions in public PRs from contributors who don't have access to the calibration set.
 
-### 4.6 Eval harness
+**Tier 2: private calibration set.** The canonical instance's real memories — initially the owner's hand-labelled ~200, growing organically as `memory.classification_overridden` events accumulate. Lives only in the canonical instance. Runs nightly (or per-release) in the operator's private environment. Catches the subtle regressions the synthetic set won't see.
 
-A new package `@librarian/classifier-eval` (CLI + test fixtures) that:
+**Tier-1 acceptance:** agreement vs labelled ground truth must not drop by >2 percentage points on the public fixture from one PR to the next, joint across both booleans, without an explicit override line in the PR description. Reports per-boolean breakdown alongside.
 
-1. **Reads `events.jsonl`** and selects every `memory.classified` event (each carries the input title/body/tags, the raw model output, the parsed verdict, and the prompt version).
-2. **For each event, optionally reruns** against a chosen prompt version (`--prompt v2`) and/or a chosen model variant (`--model …`). Produces a row: `{event_id, ground_truth, original_verdict, replayed_verdict, replayed_latency_ms}`.
-3. **Ground truth** is the most authoritative of: an explicit `memory.classification_overridden` event (owner override), else the legacy category-derived booleans (until they're removed in PR 7), else `null` (no signal — not counted in agreement).
-4. **Reports:**
-   - Overall agreement rate vs ground truth (per boolean and joint).
-   - Disagreement breakdown by category / domain / age.
-   - Latency distribution (p50 / p95 / p99 / max, separated for warm vs first-after-load).
-   - Fallback rate.
-5. **CI integration:** every PR that touches `packages/classifier/` or `packages/mcp-server/src/mcp/tools/remember.ts` runs the harness against a checked-in 1000-memory fixture (anonymised, derived from the canonical instance). Regression threshold: agreement on the fixture must not drop by >2 percentage points vs the previous baseline without an explicit override line in the PR description.
+**Tier-2 trust signal:** the operator runs the private eval before tagging releases. If tier-1 and tier-2 disagree (tier-1 green, tier-2 regressed), tier-2 wins — the public fixture is a proxy, the private one is reality.
 
-### 4.7 `memory.classified` event shape
+**Eval harness CLI** (`@librarian/classifier-eval`):
 
-Recorded on every `remember` call (shadow mode and post-cutover alike) per parent spec §4.4:
+- `eval public` — runs the model against the committed synthetic fixture, prints agreement + latency stats.
+- `eval private --data-dir <path>` — runs against the operator's `events.jsonl`, treating owner-override events as ground truth.
+- `eval replay --event-id <id> --prompt v2` — re-runs a single historical event against a different prompt version, prints both verdicts.
+- `eval generate-fixture --candidates 1500 --target 900` — generates a new candidate fixture (used during fixture refresh; see §4.7).
+
+**Per-call telemetry recorded by every eval run:**
+
+- Provider + model identity (which one ran it).
+- Inference time (model think + response).
+- Prompt version.
+- Fixture entry id + the fixture's labelled answer.
+- Classifier's verdict.
+
+### 4.7 Public fixture generation
+
+The public synthetic fixture is generated by a multi-model consensus filter — multiple strong models grade each candidate, only candidates where all models agree on the label survive. Eliminates per-model bias and produces high-confidence labels.
+
+**Generation pipeline:**
+
+1. **Generate candidates** with a strong LLM, prompted to produce a 60/40 split of straight vs boundary cases:
+   - **Straight cases** (60%): clear examples of each `{requires_approval, is_global}` quadrant. ~900 candidates.
+   - **Boundary cases** (40%): things that *look* like one quadrant but belong in another (a tool-shaped note that contains a relationship fact; an identity-shaped note that's actually a preference). **Over-generate boundaries — expect ~50% survival under consensus vs ~80% for straight cases**, so generate ~1000 boundary candidates to yield ~400 survivors.
+
+2. **Consensus filter.** Run each candidate through 3 frontier models from different families (Claude Sonnet, GPT-4o, Gemini 2.x). Keep only candidates where all three models agree on both booleans. If a candidate has any disagreement, drop it.
+
+3. **Trim to ~900 maintaining the 60/40 ratio.** If boundary survivors come up short (e.g. 250 boundary, 750 straight), generate another boundary batch and re-filter. Iterate until both buckets meet target.
+
+4. **Commit the fixture** as JSON to the repo:
+   ```json
+   [
+     {
+       "id": "fix_<uuid>",
+       "title": "...",
+       "body": "...",
+       "tags": [...],
+       "label": { "requires_approval": false, "is_global": false },
+       "category": "straight" | "boundary",
+       "consensus_models": ["claude-sonnet-x", "gpt-4o", "gemini-2.x"]
+     },
+     ...
+   ]
+   ```
+
+5. **Refresh cadence.** Manually, when the classifier prompt evolves materially or when fixture coverage proves inadequate (a regression slips through CI). Not automated.
+
+**Provenance.** The CHANGELOG records which generation models / versions produced each fixture refresh. If a model is deprecated or significantly updated, a refresh is appropriate.
+
+**No ambiguous cases.** Items where reasonable graders disagree contribute no signal to the eval and burn compute — explicitly excluded. (See §9 if we ever want to test "calibrated uncertainty"; out of scope for V1.)
+
+### 4.8 `memory.classified` event shape
 
 ```json
 {
@@ -143,78 +253,102 @@ Recorded on every `remember` call (shadow mode and post-cutover alike) per paren
   "created_at": "<iso>",
   "payload": {
     "input": { "title": "...", "body": "...", "tags": [...] },
-    "model": "LiquidAI/LFM2.5-1.2B-Thinking-GGUF",
-    "model_quant": "Q4_K_M",
+    "provider": "local" | "remote",
+    "model": "LiquidAI/LFM2.5-1.2B-Thinking-GGUF" | "gpt-4o-mini" | ...,
+    "model_quant": "Q4_K_M" | null,
     "prompt_version": "v1",
     "raw_output": "<full model text incl. thinking>",
     "parsed": { "requires_approval": false, "is_global": false } | null,
-    "fallback_used": false | "timeout" | "parse" | "model_unavailable" | "cold_start",
-    "latency_ms": 187
+    "fallback_used": false | "timeout" | "parse" | "provider_unavailable" | "max_retries",
+    "queue_wait_ms": 47,
+    "inference_ms": 1832,
+    "attempt_number": 1
   }
 }
 ```
 
-The `raw_output` is the eval substrate — we keep it indefinitely. At ~500B per event × 100 memories/day = ~50KB/day on `events.jsonl`. If this proves too expensive over years, we'll add a `--rotate-classified-events` migration that trims old entries to a sampled subset; not in V1 scope.
+`raw_output` is the eval substrate — kept indefinitely. ~500B per event × 100 writes/day = ~50KB/day = ~18MB/year. Log rotation is a follow-up if the volume ever becomes a concern.
+
+`queue_wait_ms` + `inference_ms` are reported separately so the eval harness can distinguish "the queue was deep" from "the model was slow."
 
 ---
 
 ## 5. Tech stack
 
-- **New package:** `@librarian/classifier` — owns the model lifecycle, the prompt files, the JSON parser, the timeout + fallback wrapper. Exports a single `classify({title, body, tags}): Promise<ClassifyResult>` function. Test-mockable via a deterministic stub.
-- **New package:** `@librarian/classifier-eval` — CLI for the eval harness, plus the CI runner.
-- **New runtime dep:** [`node-llama-cpp`](https://github.com/withcatai/node-llama-cpp) (current major; pinned to a specific minor in `package.json`). Native module; we'll need to confirm it builds cleanly on Apple Silicon, Linux x86_64, and Linux aarch64 — the same platforms the mcp-server supports.
-- **Model checkpoint:** downloaded at install time (`pnpm install` hook) or lazily on first server start (preferred — keeps `pnpm install` offline-friendly). Cache lives under `~/.librarian/models/<model-name>/`.
-- **No new database surface.** Verdicts ride existing JSONL events; the projection-level columns (`is_global`, `requires_approval`) are already in place from PR 1.
+- **New package:** `@librarian/classifier` — owns the worker, the provider router (local vs remote), the prompt files, the JSON parser, the retry + giveup wrapper. Exports `runOnce(deps)` for the worker tick and `classify({title, body, tags}, providerConfig)` for the eval harness.
+- **New package:** `@librarian/classifier-eval` — CLI for public + private eval, fixture generator, CI runner.
+- **New runtime dep:** [`node-llama-cpp`](https://github.com/withcatai/node-llama-cpp) — only loaded when `classifier.provider === "local"`. Pinned to a specific minor; native module; must build cleanly on Apple Silicon / Linux x86_64 / Linux aarch64.
+- **Reused:** `@librarian/core`'s LLM-client abstraction (the curator's). The classifier consumes the same client code with its own config namespace.
+- **Reused:** `secret-crypto.ts` for encrypted token storage.
+- **No new database surface beyond the two new `memories` columns** (`classified`, `classification_attempts`). Verdicts ride existing JSONL events; the projection columns from PR 1 are already in place.
+- **Dashboard:** the classifier config page extends the existing curator settings UI (same component, separate config namespace). Provider toggle, model/endpoint/token inputs, prompt-version dropdown.
 
 ---
 
 ## 6. Decisions
 
-- **D1.** Model: LFM2.5-1.2B-Thinking-GGUF. Rationale in §4.1; the dominant risk is the Thinking-variant latency, mitigated by the eval-harness latency report and the §9 contingency.
-- **D2.** Serving: in-process via node-llama-cpp on a worker thread. Rationale in §4.2.
-- **D3.** Quantisation: Q4_K_M default, with Q8_0 as the empirical-quality fallback.
-- **D4.** Prompt files are the version identifier. Each `memory.classified` event records the path. Single active version at a time, admin-switchable.
-- **D5.** JSON output, schema-validated. Multiple objects → last one wins. Parse failure → conservative fallback.
-- **D6.** Eval harness reads `events.jsonl`; ground truth is owner-override-first, category-derived-second. CI gate: agreement on the fixture cannot drop >2 percentage points without an explicit override.
-- **D7.** Cold-start latency is exempted from the 500ms budget — the first post-restart `remember` gets the fallback with `fallback_used: "cold_start"`. Operators can warm the classifier with a dummy call at startup if cold-start fallbacks are unwanted.
-- **D8.** Model download is lazy on first server start (not at `pnpm install`). Keeps installs offline-friendly and lets operators on a metered connection control the download moment.
+- **D1.** **Async lifecycle.** Conservative defaults at write time; background worker classifies; no latency budget on the agent path.
+- **D2.** **`classified` boolean + `classification_attempts` integer** on the `memories` table. Simpler than tri-state; retry count survives restarts.
+- **D3.** **No separate queue.** Worker polls the projection (`WHERE classified=0`). Single classifier instance, sequential, crash-safe by construction.
+- **D4.** **30-second per-item timeout, 3 retries, then giveup.** Giveup marks `classified=1` with conservative defaults and emits `memory.classified` with `fallback_used: "max_retries"`.
+- **D5.** **Configurable provider** (local | remote OpenAI-compatible). Reuses the curator's LLM client *code*; has its own *config* so admins can use different providers/models for the two jobs.
+- **D6.** **Local default: LFM2.5-1.2B-Thinking-GGUF, Q4_K_M.** No thinking-budget constraint; async absorbs the latency.
+- **D7.** **Two-tier eval:** public synthetic fixture in repo (CI gate), private calibration set on the operator's instance (release gate).
+- **D8.** **Public fixture by multi-model consensus filter** (Claude + GPT-4o + Gemini, unanimous). 60/40 straight/boundary; over-generate boundaries to survive pruning. No ambiguous cases.
+- **D9.** **Backfill on migration.** Existing memories are marked `classified=0` at upgrade time and the worker drains the queue over the first hours/days. Verdicts replace the legacy category-derived booleans where they disagree.
+- **D10.** **Agent response from `remember` is always "Memory saved"** regardless of classification state. The agent's contract is durability, not policy.
+- **D11.** **No shadow phase.** PR 6 + PR 7 from the parent plan collapse into one. Risk management is: the synth eval gates CI; the operator manually reviews the dashboard during week one; PR revert + bridge restore is the rollback path.
 
 ---
 
 ## 7. Migration / rollout
 
-- **Phase 6 (PR 6, classifier shadow mode)** — ship `@librarian/classifier`; wire it into `remember` to run on every write and log a `memory.classified` event; persisted booleans still come from the legacy bridge. Dashboard gains the "classifier-vs-derived disagreement" view from rollout plan §T6.3. Owner reviews quality over a week+; eval-harness summary is the go/no-go signal.
-- **Phase 7 (PR 7, cutover)** — flip the source of truth. The classifier's verdict becomes the persisted booleans; the legacy `category`-derived path is deleted. Plan-defined acceptance: ≥95% agreement on the fixture, p99 latency <300ms warm, fallback rate <2%.
-- **No data migration required for this spec.** PR 1 already wired the columns. PR 6 starts logging the events. PR 7 starts persisting the verdicts.
+**One PR, not two.** Collapses the parent plan's PR 6 (shadow) + PR 7 (cutover) into a single PR that ships the classifier as source of truth from merge time. The category-derived bridge code is deleted in the same PR.
+
+**Contents:**
+
+- New `@librarian/classifier` package (worker + provider router + prompt files + parser).
+- New `@librarian/classifier-eval` package (CLI + fixture generator + CI runner).
+- New columns on `memories`: `classified`, `classification_attempts`. Schema version bumped.
+- Worker started by `@librarian/mcp-server` on boot (in-process; same supervision as the existing curator scheduler).
+- Dashboard settings page for classifier provider + model + token + prompt version.
+- Removal of the legacy `deriveLegacyMemoryFlags` code path in `@librarian/core/constants.ts`.
+- Migration: existing memories get `classified=0, classification_attempts=0`. Pre-existing booleans (set by the legacy bridge during PR 1's migration) remain in place as the "before" snapshot for the eval; the worker overwrites them with the classifier's verdict on first run.
+- Public fixture committed to `packages/classifier-eval/fixtures/public-v1.json`.
+- CHANGELOG entry.
+
+**Backfill rollout on the canonical instance:** ~200 memories × p99 inference time = expected total < 2 hours of background load on first boot post-merge. The owner watches the dashboard during the backfill; visible disagreements between the legacy verdict and the classifier's verdict are the first real eval data, and inform whether the model / prompt are working.
+
+**Rollback path:**
+
+- Revert the PR.
+- The migration's downgrade re-derives the legacy booleans from `category` on the next mcp-server boot (deterministic — same code that produced them in PR 1).
+- The `memory.classified` events from the failed run stay in the ledger but are inert because the projection no longer reads them. Eval data preserved for post-mortem.
+- The new `classified` / `classification_attempts` columns get dropped on downgrade (next schema version bump removes them).
 
 ---
 
 ## 8. Success criteria
 
-- [ ] `@librarian/classifier.classify({...})` returns within 500ms (warm) for >99% of calls on the reference hardware (M2 MacBook Air, 16GB RAM; Linux x86_64, 4 vCPU, 8GB RAM).
-- [ ] Every `remember` call appends exactly one `memory.classified` event. The payload includes the raw model output, the parsed verdict, the model + quant + prompt version, the latency, and the fallback flag.
-- [ ] The conservative fallback fires on every model failure path (timeout, parse, schema, model-unavailable, cold-start) and is observable on the dashboard.
-- [ ] The eval harness can replay any historical event against any committed prompt version and any installed model variant.
-- [ ] The classifier-quality CI gate runs on every relevant PR and blocks merges that regress agreement by >2 percentage points without an explicit override.
-- [ ] The first-time install of mcp-server on a fresh machine downloads the model lazily on first `remember` (offline-friendly install).
-- [ ] Spec §4.4's existing success criterion is satisfied: "An owner toggling `is_global` or `requires_approval` on a memory via the dashboard records a `memory.classification_overridden` event preserving the classifier's original verdict." (Already in the parent spec; this document inherits it.)
-- [ ] The mcp-server's startup self-test verifies the classifier package is loadable and the configured model exists or downloads, exiting non-zero if either is broken (loud failure on install misconfiguration).
+- [ ] `remember` returns "Memory saved" in <50ms p99, with the row at conservative defaults and `classified=0`.
+- [ ] The background worker drains `WHERE classified=0` rows sequentially without blocking the mcp-server's other MCP calls.
+- [ ] Per-item 30s timeout enforced; 3 retries before giveup; giveup emits `memory.classified` with `fallback_used: "max_retries"`.
+- [ ] Crash-mid-inference leaves the row at `classified=0` and the next worker iteration re-processes it (at most one wasted inference).
+- [ ] Provider switch (local ↔ remote) is hot-swappable via the dashboard; in-flight retries keep their original provider.
+- [ ] Every `memory.classified` event includes provider, model, prompt version, queue_wait_ms, inference_ms, attempt_number, fallback_used. Owner-overrides emit `memory.classification_overridden` preserving the classifier's original verdict.
+- [ ] Backfill of the canonical instance's ~200 existing memories completes within hours of the upgrade, with classifier verdicts visible in the dashboard alongside the legacy-derived "before" snapshot.
+- [ ] The eval harness's public-fixture run produces a regression report; CI gates PRs that drop joint agreement by >2 percentage points without an explicit override.
+- [ ] The eval harness's private-calibration run produces the same shape of report against the canonical instance's `events.jsonl`, using owner-override events as ground truth.
+- [ ] The dashboard's proposal-queue view shows `requires_approval=true AND classified=1` memories — `classified=0` ones don't appear until the worker has decided.
+- [ ] On a fresh install with `classifier.provider="remote"`, no local-model download is triggered; the install footprint is unchanged from pre-classifier mcp-server.
+- [ ] On a fresh install with `classifier.provider="local"`, the model is downloaded lazily on first classification call (or immediately on admin-enable, configurable).
 
 ---
 
 ## 9. Open questions
 
-- **Thinking-variant latency.** LFM2.5-1.2B-Thinking includes a chain-of-thought preamble. We are explicitly choosing this model for its reasoning headroom on a small parameter count, but the 500ms budget *includes* the thinking time. **Contingency:** if PR 6 shadow-mode latency exceeds 500ms p99 on either reference machine, the eval harness will compare against:
-  1. A more aggressive prompt-side thinking constraint (≤15 tokens of internal reasoning).
-  2. The non-Thinking sibling variant (LFM2.5-1.2B base, if published).
-  3. Qwen2.5-0.5B-Instruct as a smaller / faster alternative.
-
-  The decision is taken once we have warm-call latency numbers from the fixture, not before.
-
-- **Quantisation floor.** Q4_K_M is the default but we don't know yet whether classification quality holds at that quantisation on this specific architecture. PR 6's shadow-mode evidence answers this — if Q4 disagreement is materially worse than Q8 against the migration baseline, we ship Q8 (~1.2GB on disk, ~2.2GB resident) instead.
-
-- **`memory.classified` event volume.** At ~500B × 100 writes/day = ~50KB/day = ~18MB/year. Acceptable. Past three years (~55MB) we should look at log rotation; not now.
-
-- **CI fixture provenance.** The 1000-memory eval fixture has to come from real-world data to be meaningful, but cannot include any PII or owner-specific content. Open: build a derivation pipeline that pulls from the canonical instance, redacts via the existing `curator-redaction` module, and commits the result. PR 6 blocker — but a small one.
-
-- **Worker-thread concurrency under load.** node-llama-cpp's batch queue serialises concurrent calls; the worker thread keeps the main event loop responsive. Open: is there a non-trivial workload where two concurrent `remember`s queue badly? Probably not for single-owner use; revisit if we ever multi-tenant.
+- **Boundary case survival rate under consensus.** ~50% is the working assumption; the first batch will tell us. If it's <30% we over-generate harder; if it's >70% the boundary cases probably aren't boundary enough — we tighten the synth prompt.
+- **Remote-mode input redaction.** Out of scope for V1: should the classifier's inputs (memory title + body) flow through `curator-redaction` before being sent to a third-party provider? Probably yes; not blocking initial release. The dashboard UI for remote-mode explicitly says "contents leave your machine" so admins choosing remote know what they're trading away.
+- **Worker-process isolation.** The worker runs in-process on a Node worker thread. For multi-user or multi-process supervision scenarios we'd want a separate process or even a separate machine; not for V1.
+- **Backfill performance regression.** If backfill of 200 memories takes much longer than the 2-hour estimate (e.g. local mode on a Raspberry Pi), the owner-facing experience on day one is "the dashboard says half my memories are still unclassified." Acceptable for V1 — the worker will catch up — but worth noting that for low-spec hosts, remote mode is the practical default.
+- **What happens to the parent spec.** `memory-domain-isolation-and-conv-state.md` §4.4 + §7.3 + §8 contain language inconsistent with this document (sync, shadow phase, latency budget). They should be updated in the same PR as the classifier implementation lands, with cross-references to this spec for the detailed contract.

--- a/docs/specs/claude-plugin-lifecycle-restoration-spec.md
+++ b/docs/specs/claude-plugin-lifecycle-restoration-spec.md
@@ -1,0 +1,182 @@
+# Spec: Claude Plugin Lifecycle-Source Restoration
+
+**Author:** Claude, with Jim
+**Date:** 2026-05-27
+**Status:** Draft v1 — vendor approach chosen; awaiting implementation
+
+---
+
+## 1. Purpose
+
+The `the-librarian-claude-plugin` repo ships two committed hook bins (`bin/librarian-claude-hook.js` and `bin/librarian-mcp-call.js`) that were generated from `@librarian/lifecycle` source living in this repo at `integrations/shared/librarian-lifecycle/`. That source tree was **deleted entirely in PR #153** (see CHANGELOG.md §Removed). The committed bundles still run at runtime, but `scripts/build-bundle.mjs` can no longer regenerate them — it points at a path that does not exist.
+
+The drift guard in `scripts/validate.mjs` (which hashes the bundles against `bin/PROVENANCE.json`) means we *also* cannot edit the bundles by hand — any change will fail CI. We have working artefacts with no path back to source.
+
+The recent conv-state-injection PR ([the-librarian-claude-plugin#9](https://github.com/JimJafar/the-librarian-claude-plugin/pull/9)) sidestepped the problem by adding a *separate* self-contained `bin/librarian-conv-state-inject.mjs` that does not depend on the lifecycle bundle. That works for one bounded addition, but the lifecycle bundle itself is now frozen until we restore a buildable source tree.
+
+This spec defines that restoration.
+
+---
+
+## 2. Non-goals
+
+- **Not redesigning the Claude plugin.** The intent is to recover the buildable state we had before PR #153, not to take the opportunity to refactor.
+- **Not changing the runtime behaviour of the lifecycle hook.** The currently committed bundle is the bug-for-bug-compatible baseline. The first-merge build of the restored source must produce a bundle that runs the existing tests / smoke suite identically (modulo whitespace / minification).
+- **Not unifying the five plugin lifecycle implementations.** Codex, opencode, pi, and hermes each own their own source already. Claude is the outlier we're bringing in line — peer parity, not unification.
+- **Not consolidating into a new shared package.** The deletion in PR #153 was deliberate (per CHANGELOG: "the `@librarian/lifecycle` workspace package was orphaned (zero consumers outside its own package.json) and removed"). Re-creating it as a shared dependency would re-introduce the cross-repo coupling the deletion eliminated.
+
+---
+
+## 3. Background
+
+Pre-PR-#153 layout:
+
+```
+the-librarian/
+  integrations/
+    shared/
+      librarian-lifecycle/      ← TypeScript source
+        src/                    (lifecycle, harness adapters, mcp-call helper)
+        dist/                   (compiled output)
+        package.json            ← @librarian/lifecycle
+    claude-code/                ← in-tree thin plugin, since deleted
+the-librarian-claude-plugin/    (sibling repo)
+  scripts/build-bundle.mjs       ← esbuild that reads ../the-librarian/integrations/shared/librarian-lifecycle/dist/
+  bin/
+    librarian-claude-hook.js    ← committed bundle (output of build)
+    librarian-mcp-call.js       ← committed bundle (output of build)
+    PROVENANCE.json             ← sha256 of the two bundles, recorded at build time
+```
+
+Post-PR-#153 layout:
+
+```
+the-librarian/                  ← integrations/ deleted entirely
+the-librarian-claude-plugin/
+  scripts/build-bundle.mjs      ← still references the deleted path; broken
+  bin/
+    librarian-claude-hook.js    ← committed; still runs; cannot be regenerated
+    librarian-mcp-call.js       ← committed; still runs; cannot be regenerated
+    PROVENANCE.json             ← still hash-validated by validate.mjs
+```
+
+The source of truth for the bundle bytes lives in git history (any commit pre-PR-#153 in the main repo). It does not live in either repo's working tree as of today.
+
+The four other plugin repos (`codex`, `opencode`, `pi-extension`, `hermes`) each ship their own `src/` tree post-graduation. The Claude plugin was the lone holdout because it was the most-coupled to the shared package.
+
+---
+
+## 4. The contract
+
+### 4.1 Where the source lives
+
+`the-librarian-claude-plugin/src/` — a new directory in the plugin repo, structured to mirror the other plugins:
+
+```
+the-librarian-claude-plugin/
+  src/
+    bin/
+      claude-code-hook.mts        ← entry point bundled to bin/librarian-claude-hook.js
+      mcp-call.mts                ← entry point bundled to bin/librarian-mcp-call.js
+    lifecycle.mts                 ← createLibrarianLifecycle (the engine)
+    mcp-client.mts                ← the HTTP MCP client (DEFAULT_TIMEOUT_MS, callTool, etc.)
+    remote-cli.mts                ← createRemoteLibrarianCli (the subprocess wrapper)
+    harness/
+      claude-code.mts             ← createClaudeCodeLifecycle, claudeLocationFromEvent
+    privacy.mts                   ← DEFAULT_PRIVATE_MARKERS, DEFAULT_PUBLIC_MARKERS, detectPrivacySignal
+    state.mts                     ← loadState / updateState / composeState
+    config.mts                    ← config schema + defaults
+    types.mts                     ← shared types
+  bin/                            ← unchanged; committed bundle outputs
+  scripts/
+    build-bundle.mjs              ← rewritten to read from ./src/, not ../the-librarian/...
+```
+
+`.mts` (TypeScript with explicit ESM extension) is chosen to match the family convention used by the opencode plugin's `src/`. Codex and Pi use `.mjs` plain JS; we could match them instead. Recommendation: TS for type safety since the lifecycle is the most complex of the five plugins. **Open question — §9.**
+
+### 4.2 Source provenance
+
+The bytes for `src/` come from **`@librarian/lifecycle/src/`** as of its last commit in `the-librarian` before PR #153. Specifically, the commit immediately preceding the `integrations/` deletion. The CHANGELOG entry for PR #153 names the rev range; the restoration commit message must cite the exact SHA the source was extracted from.
+
+This is bug-for-bug compatible by construction — we are bringing back the same source that produced the currently-committed bundles. Any subsequent improvements ride on top, but the first commit of `src/` must produce a bundle whose runtime behaviour is unchanged.
+
+### 4.3 Build pipeline
+
+`scripts/build-bundle.mjs` is rewritten to:
+
+- Read entry points from `./src/bin/claude-code-hook.mts` and `./src/bin/mcp-call.mts`.
+- Bundle each with `esbuild` (already a devDependency) into `bin/librarian-claude-hook.js` and `bin/librarian-mcp-call.js`, ESM format, `node18` target — same flags as the pre-PR-#153 build.
+- Stamp `bin/PROVENANCE.json` with: `{ source: "in-tree", repoSha: <plugin-repo HEAD>, bins: { … sha256s … } }`. (The previous PROVENANCE had `monorepoSha` and `lifecycleVersion` fields tied to the cross-repo dependency — those become moot and are dropped.)
+- Refuse to build if any committed `src/` file has uncommitted changes (so the PROVENANCE always points at a real, push-able commit).
+
+The pre-commit / CI hash check in `validate.mjs` continues to work unchanged — it doesn't care where the source came from, only that the bundle on disk matches the recorded hash.
+
+### 4.4 Co-existence with the conv-state-inject bin
+
+The recent `bin/librarian-conv-state-inject.mjs` is a separate, self-contained bin that does *not* live under `src/`. Two options:
+
+- **Leave it as a self-contained `.mjs`** — simplest, keeps the conv-state surface decoupled from the lifecycle. Hash-validation gets extended to cover this bin too.
+- **Move it under `src/` and bundle it like the others** — uniformity. Slightly more friction (the conv-state helper has to live alongside the lifecycle modules) but a single build pipeline.
+
+Recommendation: **move under `src/`** at the same time as the restoration, so there's exactly one build path. The restoration is the natural moment to absorb the inject bin into the same source tree.
+
+### 4.5 Privacy-detector marker list parity
+
+The privacy marker list (`DEFAULT_PRIVATE_MARKERS` / `DEFAULT_PUBLIC_MARKERS`) is one of the "five peer implementations, no canonical source" things from AGENTS.md §2. The restoration imports those markers from the previously-bundled source. **Any change to those lists is still cross-repo coordinated work** — the restoration must not change them.
+
+The other four plugins (codex, opencode, pi, hermes) have their own copies of the marker list. The restoration does not introduce a dependency between them.
+
+---
+
+## 5. Tech stack
+
+- **Plugin repo:** the-librarian-claude-plugin (unchanged scope).
+- **Build tool:** esbuild (already devDependency; no change).
+- **TypeScript runtime:** node-native `.mts` modules, no transpilation in the bundle pipeline (esbuild handles it). If we go with `.mjs` plain JS, no TypeScript dep at all.
+- **No new runtime dependencies.** The bundle is dependency-light by design.
+- **No changes to the main `the-librarian` repo.** All work lives in the plugin repo.
+
+---
+
+## 6. Decisions
+
+- **D1.** Vendor approach: extract `@librarian/lifecycle/src/` from main-repo git history pre-PR-#153 and commit it into the plugin's new `src/`. Rationale: bug-for-bug compatibility is free; no behavioural drift to debug.
+- **D2.** `.mts` TypeScript modules. Matches the opencode plugin (the most recent peer) and gives the most-complex of the five plugins compile-time safety. **Re-evaluate if the `.mts` runtime story is bumpy on user machines.**
+- **D3.** Single `src/` for both lifecycle and the conv-state inject. The inject bin moves under `src/` as part of the restoration so there's one build pipeline.
+- **D4.** PROVENANCE drops `monorepoSha` and `lifecycleVersion`; gains a plain `repoSha` of the plugin repo. Old PROVENANCE bytes are not preserved.
+- **D5.** Privacy markers are imported verbatim from the pre-deletion source. The five-peer no-canonical-source contract is preserved; cross-repo coordination remains the only path to changing them.
+
+---
+
+## 7. Migration / rollout
+
+One PR in the plugin repo. Stages:
+
+1. **Recover the source.** Use `git -C ../the-librarian checkout <pre-PR-#153-sha> -- integrations/shared/librarian-lifecycle/src/` into a temp dir, then `git mv` the relevant files into `the-librarian-claude-plugin/src/`. Commit message records the SHA.
+2. **Rewrite `scripts/build-bundle.mjs`** to read from `./src/`. Run it; confirm the output `bin/librarian-claude-hook.js` is functionally equivalent (smoke suite passes byte-by-byte may differ but behaviour is identical).
+3. **Move `bin/librarian-conv-state-inject.mjs` under `src/`** and rewire its build entry. Update `hooks/hooks.json` if the bin path changes; otherwise it can stay at `bin/librarian-conv-state-inject.js` (compiled).
+4. **Update `scripts/validate.mjs`** to hash-check all three bins (lifecycle hook, mcp-call, conv-state inject) against PROVENANCE.
+5. **Regenerate PROVENANCE.json** with the new schema (no more `monorepoSha`/`lifecycleVersion`).
+6. **CHANGELOG entry** under `## [Unreleased]` describing the restoration, the new build pipeline, and the dropped PROVENANCE fields.
+
+No data / state migration on user machines. The user's installed plugin keeps running the committed bundle; the next plugin update ships the rebuilt-from-source bundles.
+
+---
+
+## 8. Success criteria
+
+- [ ] `scripts/build-bundle.mjs` runs end-to-end without referencing any path outside `the-librarian-claude-plugin/`.
+- [ ] `scripts/validate.mjs` passes against the rebuilt bins, with PROVENANCE entries for all three.
+- [ ] `scripts/smoke.mjs` (all three test paths — mcp-call, dispatch, inject-conv-state) passes against the rebuilt bins.
+- [ ] The user-visible runtime behaviour is unchanged: identical privacy gate, identical lifecycle dispatch, identical conv-state injection.
+- [ ] The plugin can ship a new release independently of the main repo, with no cross-repo path resolution required to build.
+- [ ] The CHANGELOG entry explicitly records that the marker list is unchanged from pre-restoration and remains coordinated across the five peer plugins.
+
+---
+
+## 9. Open questions
+
+- **`.mts` vs `.mjs`.** TypeScript gives compile-time safety on the most-complex of the five plugins; plain JS matches codex / pi exactly and avoids the `.mts` resolver edge cases that occasionally surface on older Node versions. Recommendation TS, but worth a 5-minute look at any user-machine issues from the opencode plugin's `.mts` adoption before locking in.
+- **Should we also commit a `dist/` ahead of the bundle?** Esbuild bundles directly from source; an intermediate `dist/` is not strictly needed, but having it gives users with weird esbuild versions a working tree to point at. Probably not — keep the build path single-shot.
+- **What about the deleted `integrations/claude-code/` thin plugin?** That was the user-facing install surface that PR #153 also removed. The standalone plugin already replaces it; nothing to restore. (Noted here only so the question is closed in the spec.)
+- **Marker-list five-peer drift.** Out of scope for restoration but worth flagging: with five peer copies of the privacy marker list and no canonical source, any change is a five-repo coordinated push. We have no automated detector for drift. A small "compare marker lists across the five repos" CI job in this repo (or any one of them) would catch silent drift. Not blocking; a follow-up.

--- a/docs/specs/memory-domain-isolation-and-conv-state.md
+++ b/docs/specs/memory-domain-isolation-and-conv-state.md
@@ -2,7 +2,7 @@
 
 **Author:** Claude, with Jim
 **Date:** 2026-05-27
-**Status:** Draft v3 — `category` dropped entirely; write-path classifier sets `is_global` and `requires_approval`; `visibility` and `scope` removed (per Jim, 2026-05-27); awaiting implementation review
+**Status:** Draft v4 — async classifier with configurable provider (revised from sync local-only); PR 6 + PR 7 collapsed into one; in line with [`classifier-implementation-spec.md`](./classifier-implementation-spec.md); implementation in flight (PRs 1–5 merged)
 
 ---
 
@@ -83,16 +83,16 @@ A boolean column indicating that a memory should enter the proposal queue rather
 
 ### 4.4 The write-path classifier
 
-A small local LLM that examines each new memory at write time and decides `is_global` and `requires_approval`.
+A small LLM (local by default, configurable to a remote OpenAI-compatible endpoint) that classifies each new memory and decides `is_global` and `requires_approval`. **Implementation details, model choice, eval design, and lifecycle live in the [classifier implementation spec](./classifier-implementation-spec.md).** This section captures the binding contract; that document captures the rest.
 
-- **Sync on the write path.** `remember` blocks until the classifier returns or the timeout elapses. The persisted memory has both booleans set in a single transaction.
-- **Target latency:** <200ms for the classifier call on a warm model. The overall `remember` budget gains at most ~200ms vs. today's path.
-- **Timeout:** 500ms. On timeout, fall through to the conservative fallback.
-- **Conservative fallback** (classifier unavailable, timeout, malformed output, network failure to local service): `requires_approval = true`, `is_global = false`. Rationale: an unreviewed sensitive fact landing in active is a leak; a non-sensitive fact landing in the proposal queue is a recoverable nuisance. Failures must be loud (logged, surfaced in the dashboard's proposal queue), not silent.
-- **Model:** a small open-weights model (Phi-3 Mini, Gemma 2B, or similar) running locally. Specific choice and infrastructure are out of scope for this spec — captured as a follow-up sub-spec (see §9).
-- **Prompt:** versioned, stored alongside the classifier service. Includes a short system instruction plus 4-6 few-shot examples covering the four `{is_global, requires_approval}` quadrants. JSON output, strictly validated.
-- **Observability:** every classifier call appends a `memory.classified` event to `events.jsonl` containing the input, the raw model output, the parsed booleans, the latency, and whether a fallback was used. This is the eval substrate — we can replay events later to score classifier quality.
+- **Async, not sync.** `remember` writes the memory with conservative defaults and returns immediately; a background worker classifies and updates the booleans + status when the verdict lands. The agent's `remember` response is always "Memory saved" regardless of classification state.
+- **Conservative defaults at write time:** `requires_approval = true`, `is_global = false`. The same values the sync design used as a fallback are now the *default* state until the classifier commits. Rationale: an unreviewed sensitive fact landing in active is a leak; a non-sensitive fact briefly sitting in the proposal queue is a recoverable nuisance.
+- **30-second per-attempt timeout, 3 retries, then giveup.** A classifier that never produces a verdict (after 3 failed attempts) leaves the memory at conservative defaults and emits `memory.classified` with `fallback_used: "max_retries"` so the eval substrate sees it.
+- **Configurable provider.** Admin picks local (default, in-process via node-llama-cpp) or remote (OpenAI-compatible HTTP API). Provider config is independent of the curator's. See classifier-spec §4.2.
+- **Prompt:** versioned, stored alongside the classifier service. Strictly JSON-validated output.
+- **Observability:** every classifier call appends a `memory.classified` event to `events.jsonl` carrying provider, model, prompt version, raw model output, parsed booleans, queue-wait + inference time, attempt number, and `fallback_used` (false / "timeout" / "parse" / "provider_unavailable" / "max_retries"). The eval substrate replays from this.
 - **Owner override is the ground truth.** Once an owner overrides either boolean via the dashboard, the override is recorded as a `memory.classification_overridden` event and the classifier's original verdict is preserved alongside for evaluation purposes.
+- **Evaluation is operator-driven from the dashboard, not CI-driven.** A synthetic fixture (~1000 memories, multi-model consensus-labelled) lives in the repo; the dashboard runs the classifier against a stratified sample on demand when promoting prompts or candidate models. CI tests the machinery (parser, retry, migration) with mocked classifiers — quality judgement is the operator's. See classifier-spec §4.6.
 
 ### 4.5 Removal of `category`
 
@@ -249,7 +249,7 @@ One new infrastructure component: the write-path classifier. Otherwise no new de
 
 - `@librarian/core` — schemas (`memory.ts`, new `conversation-state.ts`), store (`memory-store.ts`, new `conversation-state-store.ts`), projection (`projection.ts`).
 - `@librarian/mcp-server` — tool handlers (`recall.ts`, `remember.ts`, `start_session.ts`), new dispatch surface for `conv_state.*` tools, hook-injection helpers, classifier client.
-- **New: `@librarian/classifier`** — a small package owning the local-model lifecycle, the classification prompt, the JSON parser, the timeout/fallback logic, and the eval-replay harness. The specific model choice (Phi-3 Mini vs Gemma 2B vs distilled in-house) is deferred to a follow-up sub-spec.
+- **New: `@librarian/classifier`** — owns the background worker, the provider router (local vs remote OpenAI-compatible), the prompt files, the JSON parser, and the retry + giveup logic. **New: `@librarian/classifier-eval`** — owns the dashboard-driven evaluation tool and the synthetic-fixture generator. The classifier implementation, model choice, provider configuration, and evaluation design are pinned by the [classifier implementation spec](./classifier-implementation-spec.md).
 - `apps/dashboard` — new `/domains` page, signal-rules page, proposal-approval modal, memory detail panel gains a `domain` field and `is_global` / `requires_approval` toggles, new tag-based grouping replaces the category-based views.
 - `packages/cli` — wrapper updated to read `conv_id` from env and pass to MCP.
 - `packages/lifecycle` and the sibling Claude/Hermes plugin repos — implement the per-turn hook contract from §4.9.
@@ -278,9 +278,9 @@ Each item below was settled during the design session. Decision IDs match the wo
 - **D16.** *(Superseded by D18.)* Original: `identity` and `relationship` collapse into a single category `profile`. Replaced by: drop `category` entirely; the protection-routing behaviour previously triggered by `identity`/`relationship` is now expressed via `requires_approval`, which is set by the classifier.
 - **D17.** `scope` is removed entirely. The `Scope` enum, the `scope` column on `memories`, the field in `normalizeMemoryInput`, and the `scope` parameter in `listMemories` are deleted. The audit confirmed `scope` is not exposed as a filter on any read-path tool; it was advisory metadata with no consumer. `domain` subsumes its intended purpose.
 - **D18.** `category` is removed entirely. Policy moves to two booleans: `is_global` and `requires_approval`. Semantic labels (`tools`, `lessons`, `people`, ...) move to the existing `tags[]` array. Migration converts each former category value into a tag and derives the booleans from the old category at the cutover point; thereafter the classifier is the source of truth for new writes.
-- **D19.** A write-path classifier (small local LLM, sync, ≤500ms timeout) sets `is_global` and `requires_approval` on every new memory. Owner overrides via the dashboard are the ground truth; classifier verdicts are preserved alongside for evaluation.
-- **D20.** Classifier failure mode is **conservative**: `requires_approval = true`, `is_global = false`. Rationale: a non-sensitive fact briefly stuck in the proposal queue is a recoverable nuisance; an unreviewed sensitive fact going active is a leak. Failures are loud (logged + surfaced in dashboard).
-- **D21.** The classifier runs as a local-model service (`@librarian/classifier`), not as a call to an external API. Local wins on latency, cost, and self-containment. Specific model choice deferred to a follow-up sub-spec.
+- **D19.** A write-path classifier sets `is_global` and `requires_approval` on every new memory. **Async, not sync** — `remember` returns instantly at conservative defaults; a background worker classifies and updates the row when the verdict lands. Owner overrides via the dashboard are the ground truth; classifier verdicts are preserved alongside for evaluation. (Originally specified sync with ≤500ms timeout; revised when the [classifier implementation spec](./classifier-implementation-spec.md) surfaced the async architecture.)
+- **D20.** **Conservative defaults at write time**: `requires_approval = true`, `is_global = false`. Same values the sync design used as a fallback are now the *default* until classification commits. The classifier worker either replaces them with a real verdict, or — after 3 failed 30s attempts — leaves them in place and emits `memory.classified` with `fallback_used: "max_retries"`. Either way the memory ends up reviewable in the dashboard if `requires_approval=true` survives.
+- **D21.** **Configurable classifier provider.** Local (default, in-process via node-llama-cpp) or remote (OpenAI-compatible HTTP API, reusing the curator's LLM-client code with a separate config namespace). Admins on low-spec hardware can lean on a remote endpoint; default installs are self-contained. (Originally specified local-only; revised when the implementation spec confirmed the curator already had the right LLM-client abstraction for reuse.)
 - **D22.** Outside-session memories (no `conv_state`) force `requires_approval = true` regardless of classifier verdict. The absence of a conv-state is itself a signal that owner review is warranted.
 
 ---
@@ -363,16 +363,15 @@ The script:
 
 ### 7.3 Rollout order
 
-The classifier is load-bearing for the category drop, so it must ship and be validated *before* the cutover that removes `category`. The intermediate state keeps `category` alongside the two new booleans, with the booleans derived from category until the classifier takes over.
+The classifier is load-bearing for the category drop, so it must ship before the cutover that removes `category`. The intermediate state keeps `category` alongside the two new booleans, with the booleans derived from category until the classifier takes over.
 
 1. **PR 1 — Additive schema.** Add `domain`, `is_global`, `requires_approval` columns (with defaults); add `conversation_state`, `domains`, `signal_rules`, `token_domain_bindings` tables; add `domain` to `sessions`. Keep `category`, `visibility`, `scope` columns in place for now. Existing reads/writes continue to work. Booleans are derived from category (legacy logic). Releasable.
 2. **PR 2 — `conv_state` registry + MCP tools + hook helpers.** Server-side machinery for §4.8 and §4.9. No harness integrations consume it yet. Releasable.
 3. **PR 3 — Domain enforcement in `recall` and `remember`.** Server reads `conv_state.domain` when present; falls back to `general` when not. Single-domain installs experience no change. Releasable.
-4. **PR 4 — Dashboard surface.** Domain list page, signal rules page, proposal modal, memory detail panel additions (including `is_global` / `requires_approval` toggles). Releasable.
+4. **PR 4 — Dashboard surface.** Domain list page, signal rules page, proposal modal, memory detail panel additions (including `is_global` / `requires_approval` toggles), classifier-evaluation page (the dashboard tool from classifier-spec §4.6). Releasable.
 5. **PR 5 — Harness integrations.** Claude Code hook, Hermes hook, CLI wrapper updates. Each integration is its own PR in its own repo. Releasable.
-6. **PR 6 — Classifier in shadow mode.** Ship `@librarian/classifier`. On every `remember`, the classifier runs and its verdict is logged to `events.jsonl` as `memory.classified`, but the persisted booleans continue to be derived from category. Dashboard surfaces classifier-vs-derived disagreements. Owner reviews quality. Releasable; nothing user-visible changes.
-7. **PR 7 — Classifier cutover.** Once quality is validated against owner expectations, flip the source of truth: the classifier's verdict is now persisted; the category-derived fallback is removed. The migration script (from PR 1) is re-run to convert `category` values into tags and remove the column. `category`, `visibility`, and `scope` columns are dropped. Releasable.
-8. **PR 8 — Documentation.** Update integration docs, `/lib-session-*` command help, agent-facing CLAUDE.md / SOUL.md guidance, classifier prompt documentation.
+6. **PR 6 — Classifier + cutover (single PR).** Ships `@librarian/classifier` + `@librarian/classifier-eval`, the async worker, the new `classified` + `classification_attempts` columns, the configurable provider, and the deletion of the category-derived bridge. Migration backfills existing memories so the classifier's real-data quality is visible from day one. Originally split as PR 6 (shadow) + PR 7 (cutover); collapsed into one because the eval design (dashboard-driven, operator-judged) doesn't need a shadow-mode telemetry phase to gate the cutover. The classifier becomes source of truth from merge time. The migration script (from PR 1) is re-run to convert `category` values into tags and remove the column. `category`, `visibility`, and `scope` columns are dropped in the same PR. Releasable; the eval page lets the operator validate quality before and after the backfill completes.
+7. **PR 7 — Documentation.** Update integration docs, `/lib-session-*` command help, agent-facing CLAUDE.md / SOUL.md guidance, classifier prompt documentation. (Was PR 8 in the original eight-PR plan; renumbered after PR 6 + 7 collapsed.)
 
 ---
 
@@ -389,21 +388,21 @@ Concrete, testable conditions for "done":
 - [ ] A curator-produced proposal whose source memories all have `domain=coding` arrives in the proposal queue with `domain=coding` pre-set, approvable in one click.
 - [ ] A curator-produced proposal whose source memories span domains arrives with `domain=NULL` and cannot be approved without an explicit pick.
 - [ ] An agent attempting to set `is_global`, `requires_approval`, `visibility`, `category`, or `scope` in a `remember` call has all those fields ignored. The MCP tool input schema for `remember` no longer advertises any of them.
-- [ ] The classifier returns `{is_global, requires_approval}` for every `remember` call within the 500ms timeout in normal operation. A `memory.classified` event is appended to `events.jsonl` capturing input, raw output, parsed booleans, latency, and fallback flag.
-- [ ] When the classifier service is forcibly stopped, the next `remember` call completes within ≤500ms (the timeout) and persists with `requires_approval=true, is_global=false`. The fallback is logged and visible in the dashboard.
+- [ ] `remember` returns "Memory saved" in under 50ms p99, with the row persisted at conservative defaults and queued for classification. A `memory.classified` event is appended to `events.jsonl` once the background worker decides — capturing input, provider, model, prompt version, raw output, parsed booleans, queue_wait_ms, inference_ms, attempt_number, and the fallback flag.
+- [ ] When the classifier provider is unreachable, the background worker retries (30s per attempt, 3 attempts). After the third failed attempt, the memory ends up at `classified=1` with conservative defaults persisted and a `memory.classified` event carrying `fallback_used: "max_retries"`. `remember` is never blocked by classifier failures.
 - [ ] An owner toggling `is_global` or `requires_approval` on a memory via the dashboard records a `memory.classification_overridden` event preserving the classifier's original verdict.
-- [ ] Existing memories that were category `identity` or `relationship` arrive post-migration with `requires_approval=1, is_global=1`, the former category name appended to `tags[]`, and no `category` column on the row.
+- [ ] Existing memories that were category `identity` or `relationship` arrive post-migration with the legacy-derived booleans in place; the PR 6 backfill subsequently re-classifies them via the production classifier, overwriting the legacy values with the classifier's verdicts.
 - [ ] Existing `agent_private` memories appear in a domain called `legacy-private` after migration; the owner sees one prompt to review them on first dashboard load post-migration.
-- [ ] After PR 7 cutover, the `memories` table has no `category`, `visibility`, or `scope` columns. Reading an old `memory.created` event from `events.jsonl` does not crash the projection.
+- [ ] After PR 6 (classifier + cutover), the `memories` table has no `category`, `visibility`, or `scope` columns. Reading an old `memory.created` event from `events.jsonl` does not crash the projection.
 - [ ] Migration script run twice produces identical results.
 
 ---
 
 ## 9. Open questions
 
-**Deferred to follow-up specs (referenced from this one):**
+**Resolved in follow-up specs:**
 
-- **Classifier implementation details.** Specific model choice (Phi-3 Mini vs Gemma 2B vs distilled in-house), serving infrastructure (in-process vs sidecar vs separate service), prompt versioning workflow, eval harness specification, retraining/fine-tuning cadence. A `classifier-implementation-spec.md` follow-up should land before PR 6.
+- **Classifier implementation details.** Closed by [`classifier-implementation-spec.md`](./classifier-implementation-spec.md). Async lifecycle, configurable provider (local default LFM2.5-1.2B-Thinking-GGUF via node-llama-cpp, or remote OpenAI-compatible API), prompt-file versioning, dashboard-driven evaluation against a 1000-item synthetic fixture, single-PR rollout with backfill at migration time.
 
 **Deferred to future iterations:**
 

--- a/docs/specs/opencode-conv-state-injection-spec.md
+++ b/docs/specs/opencode-conv-state-injection-spec.md
@@ -2,7 +2,7 @@
 
 **Author:** Claude, with Jim
 **Date:** 2026-05-27
-**Status:** Draft v1 — investigation phase; design pinned to whatever opencode's SDK surfaces
+**Status:** Draft v2 — Phase A investigation complete; hook identified as `experimental.chat.system.transform`; design ready for implementation
 
 ---
 
@@ -53,53 +53,106 @@ The right answer is almost certainly somewhere else in opencode's SDK — a syst
 
 ## 4. The contract
 
-### 4.1 Phase A — investigation (mandatory pre-work)
+### 4.1 Phase A — investigation findings
 
-Goal: identify, in opencode's public SDK + extension docs, the hook that lets an integration add text to the LLM's prompt context **without** mutating the user's literal message.
+Phase A was completed on 2026-05-27 against opencode SDK version 1.15.10 (the version pinned in the plugin's `package.json`).
 
-Tasks (in order; each is a single PR-equivalent against this spec, not against code):
+**The hook surface is `experimental.chat.system.transform`.** Defined in `@opencode-ai/plugin/dist/index.d.ts` lines 264-269:
 
-1. **Read the opencode hook reference.** Document every hook event the integration surface exposes, plus the signature of each.
-2. **Walk the existing plugin's handlers** (`src/handlers/`) and the dispatch site (`src/index.ts`). Note every place that already touches model context. The `session-bootstrap` and `chat-message` handlers are the most relevant.
-3. **Specifically look for, in this priority order:**
-   - A `before-message-to-model` / `system-prompt-build` / `augment-context` hook that takes additive text.
-   - A system-prompt-block API that contributes a frozen string to every turn (cheap-but-stale; same shape as Hermes' `system_prompt_block`).
-   - A tool-call hook that fires before each LLM round and can prepend a hidden system message.
-   - A "side-channel context" API distinct from the user message.
-4. **Confirm with a 20-line spike** in a throwaway opencode plugin: emit a known string via the candidate mechanism and verify the LLM reads it without it appearing in the user-visible transcript.
-5. **Update this spec's §4.2 with the chosen mechanism and the spike's evidence.** No code lands in the plugin until §4.2 is filled in.
+```typescript
+"experimental.chat.system.transform"?: (input: {
+    sessionID?: string;
+    model: Model;
+}, output: {
+    system: string[];
+}) => Promise<void>;
+```
 
-If no such surface exists in opencode today, the outcome of Phase A is a small upstream feature request to opencode and a documented "blocked on upstream" status for this spec — not a "let's prepend to the user message anyway" compromise.
+**How it works:** opencode assembles the system prompt internally, then calls every registered plugin's `experimental.chat.system.transform`, giving each plugin a chance to mutate the `output.system` array — adding, removing, or replacing entries. The host then concatenates the array as the LLM's system prompt. Safety fallback documented: if a plugin empties the array entirely, opencode restores the original.
 
-### 4.2 Phase B — design (filled in after Phase A)
+**Cadence:** fires before each LLM call (per-turn), exactly the cadence §4.9 needs to defeat compaction. Confirmed by the existence of in-production plugins using this hook for memory injection (see "Real-world validation" below).
 
-*Placeholder. Populated by Phase A.*
+**Type-level spike clean.** A throwaway handler that does `output.system.push(renderConvStateBlock(state))` typechecks cleanly against the SDK types — no signature mismatches, no missing field issues.
 
-Expected shape (subject to the investigation):
+**Real-world validation.** Published memory-integration plugins use exactly this hook for the same purpose (see Sources at §10). Specifically: `rohitg00/agentmemory/plugin/opencode` injects a multi-layer context block (project profile, recent session summaries, observations) via `output.system.push(...)` on every turn. That plugin reports operational status against opencode v1.14.41+; our target is the slightly-newer v1.15.10 against which the type signature is unchanged.
 
-- **Hook event:** `<TBD — likely a system-prompt or before-completion hook>`.
-- **Mechanism:** call `conv_state_get` against the configured Librarian endpoint (via the existing `src/mcp-client.ts`), parse the JSON state, render the canonical block via the family-wide helper, return it via whatever path the chosen hook expects.
-- **Conv-id derivation:** `opencode:<session-id>` where `<session-id>` is opencode's `input.sessionID` (which the existing handlers already capture; see `chat-message.ts` `ChatMessageInput`).
-- **Privacy gating:** unchanged — the existing off-record flag suppresses the call entirely, mirroring the other plugins.
-- **Fail-soft:** unchanged — any error (network, parse, missing config) returns the no-op response; the LLM never sees a stack trace.
+**Known issue worth noting (closed-as-not-planned).** [`anomalyco/opencode#17100`](https://github.com/anomalyco/opencode/issues/17100) reports "`experimental.chat.system.transform` silently discards plugin mutations" against the Go binary at an unspecified version. The issue was closed without resolution. The agentmemory plugin's continued operational status suggests the bug, if it exists, is condition-specific rather than the common path; our implementation includes an eyeball-test post-deploy step to confirm injection is reaching the LLM (see §7).
 
-### 4.3 Conv-id convention
+**Why `experimental.chat.messages.transform` was rejected.** The sibling hook (lines 258-263) mutates the entire messages array, which would let us prepend a synthetic system or user message. More invasive than necessary, semantically wrong (the conv-state block is *system* context, not a *message*), and harder to reason about if multiple plugins register transforms in unspecified order.
 
-`opencode:<sessionID>` where `<sessionID>` is `input.sessionID` as passed to `chat.message`. This matches the prefix convention from spec §4.8 (`claude:<id>`, `codex:run:<id>:cwd:<path>`, `hermes:<id>`). Documented here so it's set before Phase A picks the mechanism — the conv-id is the same regardless of which hook we wire it to.
+**Why `chat.params` was rejected.** It mutates temperature / topP / maxOutputTokens, not prompt content. Wrong tool.
 
-### 4.4 Privacy + fail-soft contracts (binding from Phase A onward)
+### 4.2 Phase B — design
 
-These come from the plugin's AGENTS.md and the parent spec. They are non-negotiable in any Phase B design:
+**Hook handler:**
 
-- **No MCP call while off-record.** The plugin's existing `privacy-detector.ts` + `state-store.ts` gate every Librarian call; the conv-state injection adopts the same gate.
-- **Fail-soft on every error path.** Network, parse, schema, model-unavailable, missing-token, missing-endpoint — all of them return the no-op response.
-- **Sub-second budget.** Whatever opencode hook we wire into, the conv-state lookup must complete in under 500ms or the turn proceeds without injection. The block matters less than the turn.
+```typescript
+// src/handlers/system-transform.ts
+import type { Hooks } from "@opencode-ai/plugin";
+import type { Deps } from "../deps.ts";
+import { renderConvStateBlock } from "../conv-state-render.ts";
 
-### 4.5 What we won't do
+const CONV_STATE_TIMEOUT_MS = 500;
 
-- Mutate `output.message.text` to inject context. This is explicitly off the table: it would surface in the user-visible transcript and corrupt the conversation log.
+export const handleSystemTransform =
+  (deps: Deps): NonNullable<Hooks["experimental.chat.system.transform"]> =>
+  async (input, output) => {
+    // No sessionID → no conv-id → nothing to inject. (Per the SDK type, this
+    // field is optional; the hook can fire in contexts without a session.)
+    if (!input.sessionID) return;
+
+    // Privacy gate: off-record state suppresses every Librarian call.
+    try {
+      const state = await deps.loadState();
+      if (state.private) return;
+    } catch {
+      // State unreadable → fail closed (treat as private, no injection).
+      return;
+    }
+
+    const convId = `opencode:${input.sessionID}`;
+
+    // Fail-soft: any failure leaves system unchanged. The turn proceeds.
+    let convState: { conv_id: string; domain: string; session_id: string | null; off_record: boolean } | null = null;
+    try {
+      convState = await fetchConvStateWithTimeout(deps, convId, CONV_STATE_TIMEOUT_MS);
+    } catch (err) {
+      await deps.log({ event: "system-transform", outcome: "conv_state_lookup_failed",
+                       error: String((err as Error)?.message ?? err) });
+      return;
+    }
+
+    if (!convState) return;
+
+    output.system.push(renderConvStateBlock(convState));
+  };
+```
+
+**Wired into the existing dispatch site** (`src/index.ts`) alongside the current `chat.message` handler. No changes to existing handlers.
+
+**Conv-id derivation:** `opencode:${input.sessionID}` — guarded by the `if (!input.sessionID) return` early-out for hook invocations where sessionID is absent.
+
+**Privacy gating:** reuses the plugin's existing `state-store.ts` + privacy detector. Identical guard pattern to the existing `chat-message` handler.
+
+**Fail-soft contracts:**
+- Missing sessionID → silent return.
+- Off-record → silent return.
+- conv_state_get timeout (500ms) → log + silent return.
+- conv_state_get network failure → log + silent return.
+- conv_state_get parse failure → log + silent return.
+- Missing config (no endpoint/token) → silent return.
+- `output.system` push throws → propagates back to opencode which has its own safety fallback (the original system array is restored if we somehow empty it).
+
+**Where the renderer lives:** new file `src/conv-state-render.ts`, byte-identical with the other four plugins' implementations (per the AGENTS.md "five peer implementations" rule). Replicates `renderConvStateBlock` locally rather than depending on `@librarian/core`.
+
+**Where the MCP call goes:** the existing `src/mcp-client.ts` already speaks to the Librarian endpoint and is used by the plugin's other Librarian calls. We add a `convStateGet(convId)` helper alongside the existing `recall` / `remember` / session helpers.
+
+### 4.3 What we won't do
+
+- Mutate `output.message.text` to inject context. This is explicitly off the table: it would surface in the user-visible transcript and corrupt the conversation log. (Mentioned for completeness; the chosen hook makes this irrelevant — `output.system` is the right field.)
 - Inject via a tool-call that masquerades as a recall. The block is *state*, not a memory; rolling it into the recall surface would conflate two distinct things.
 - Add a new "system prompt" config that ships the block as part of the plugin's static config. That would be stale by design — the whole point of the contract is that the block reflects *current* registry state, recomputed every turn.
+- Use `experimental.chat.messages.transform` instead of `experimental.chat.system.transform`. The messages hook would let us prepend a synthetic system or user message but it's more invasive than needed and harder to reason about with multiple plugins registered.
 
 ---
 
@@ -113,21 +166,27 @@ These come from the plugin's AGENTS.md and the parent spec. They are non-negotia
 
 ## 6. Decisions
 
-- **D1.** Investigation-first. No code lands until the opencode hook surface for additive context is identified and demonstrated by spike.
-- **D2.** Never mutate `output.message`. The conv-state block belongs in a side-channel, not in the user's apparent message.
-- **D3.** Conv-id convention: `opencode:<sessionID>`. Set now, independent of the hook we land on.
+- **D1.** Hook surface is `experimental.chat.system.transform`. Identified in Phase A; confirmed by type-level spike + published in-production usage (rohitg00/agentmemory).
+- **D2.** Never mutate `output.message`. The conv-state block belongs in `output.system`, not in the user's apparent message.
+- **D3.** Conv-id convention: `opencode:<sessionID>`.
 - **D4.** Privacy gate, fail-soft, sub-500ms budget — all binding, all from existing house rules.
+- **D5.** Local renderer (`src/conv-state-render.ts`) rather than a `@librarian/core` dependency. Five peer implementations, no canonical source — same as the other four plugins.
+- **D6.** Despite being in the `experimental.*` namespace, the hook is the right choice for V1. Real plugins ship with it; the type signature is stable across the recent SDK minor versions; the alternative would be waiting for opencode to graduate it to a stable namespace (no announced timeline). We accept the risk that opencode could break the surface in a major version and commit to tracking it.
 
 ---
 
 ## 7. Migration / rollout
 
-One PR in the plugin repo, contingent on Phase A producing a workable mechanism:
+One PR in the plugin repo. Phase A is now closed (§4.1 evidence committed; §4.2 design ready).
 
-1. Land Phase A as documentation only (this spec's §4.2 filled in, plus a short spike report committed alongside).
-2. PR the implementation: new handler under `src/handlers/`, wired into `src/index.ts`'s dispatch table.
-3. Tests: the existing test layout in `tests/` already has handler-level coverage; mirror the pattern (4 cases — hit, miss, throw, off-record).
-4. CHANGELOG entry under `## [Unreleased]`.
+1. **Create the handler + supporting modules:**
+   - `src/handlers/system-transform.ts` — the new hook implementation.
+   - `src/conv-state-render.ts` — the family-canonical block renderer (byte-identical with peer plugins).
+   - Extend `src/mcp-client.ts` with `convStateGet(convId)` alongside the existing tool helpers.
+2. **Wire into the dispatch site** (`src/index.ts`) alongside the existing `chat.message` handler. No changes to existing handlers.
+3. **Tests** (`tests/system-transform.test.ts`): four cases mirroring the codex / hermes pattern — state hit prepends the block; no state → silent; conv_state_get throws → silent; off-record → no MCP call at all.
+4. **Eyeball-test post-deploy** to confirm injection reaches the LLM. Given the unresolved [#17100 silent-discard issue](https://github.com/anomalyco/opencode/issues/17100) (closed-as-not-planned), the eyeball test is non-negotiable for the first deploy: in a real opencode session against a Librarian with a seeded conv_state row, ask the LLM "what domain are you in?" — if it can answer correctly, injection is working; if it can't, we hit the documented bug and need to escalate upstream.
+5. **CHANGELOG entry under `## [Unreleased]`.**
 
 No user-facing migration. Existing users keep running the current plugin; the next release ships injection.
 
@@ -135,18 +194,35 @@ No user-facing migration. Existing users keep running the current plugin; the ne
 
 ## 8. Success criteria
 
-- [ ] Phase A produces a named opencode hook + a 20-line spike showing the LLM reads injected text that is not in the visible transcript.
-- [ ] The implementation renders the canonical `<conversation-state>` block byte-identically with the other four plugins (regression-tested against the family contract).
-- [ ] `conv_state_get` is called at most once per user turn (no duplicate fetches under retries or reconnects).
-- [ ] Off-record state suppresses every Librarian call for the turn.
-- [ ] A Librarian outage produces no stack trace, no blocked turn, no visible artefact in the transcript.
-- [ ] Adding a second domain to a fresh install and seeding a `conv_state` row makes the next opencode turn carry the canonical block; clearing the row makes the following turn carry nothing.
+- [ ] `experimental.chat.system.transform` is registered as a hook in the plugin and fires on every chat turn.
+- [ ] The handler renders the canonical `<conversation-state>` block byte-identically with the other four plugins (asserted by a fixture test comparing the block string against a captured snapshot).
+- [ ] `conv_state_get` is called at most once per `system.transform` invocation (no duplicate fetches).
+- [ ] Off-record state suppresses every Librarian call for the turn — the privacy gate's `state.private` is read before the MCP client is touched.
+- [ ] A Librarian outage (port closed, network failure, or 500 response) produces no stack trace, no blocked turn, and no visible artefact in the user transcript.
+- [ ] Adding a second domain to a fresh Librarian install + seeding a `conv_state` row via the dashboard causes the next opencode turn to carry the canonical block in its system prompt. Clearing the row causes the following turn to carry nothing.
+- [ ] **Eyeball-test gate (pre-release):** in a real opencode session, ask the model a question that requires the conv-state context to answer; verify the model answers correctly. Closes the residual risk from issue #17100.
 
 ---
 
 ## 9. Open questions
 
-- **Does opencode have a "system prompt fragment" hook?** This is the unknown that gates the whole spec. The investigation in §4.1 answers it.
-- **If not — is there an upstream PR worth opening?** Could plausibly be a 20-line change in opencode itself if the hook genuinely doesn't exist. Lower-priority alternative to a workaround.
-- **Should `is_global` filtering be visible to opencode plugins?** Not in this spec, but worth raising: the §4.11 hard filter on `recall` is server-side and uniform across all integrations. opencode users get domain isolation for free once the injection is in place.
-- **Pi extension parity.** The sibling spec [`pi-extension-conv-state-injection-spec.md`](./pi-extension-conv-state-injection-spec.md) faces a similar investigation; useful to do both in the same week so we can share any opencode/pi SDK conventions we learn.
+- **Issue #17100 confirmation.** The closed-as-not-planned bug claims `experimental.chat.system.transform` mutations are silently discarded under some conditions. The agentmemory plugin's continued operational status suggests the bug is condition-specific rather than the common path, but until we run the eyeball-test step ourselves we don't know which condition we're in. If injection silently fails on first deploy, escalate upstream with a fresh repro.
+- **`experimental.*` namespace stability.** The hook lives in the experimental namespace, meaning opencode may rename or remove it in a major version. We accept this risk and commit to tracking it. The dependency footprint is small enough that a one-day re-wire is the worst case.
+- **Should `is_global` filtering be visible to opencode plugins?** Out of scope. The §4.11 hard filter on `recall` is server-side and uniform across all integrations. opencode users get domain isolation for free once the injection is in place.
+- **Pi extension parity.** The sibling spec [`pi-extension-conv-state-injection-spec.md`](./pi-extension-conv-state-injection-spec.md) faces a similar investigation but is not closed yet. Reading Phase A findings from this spec may give Pi's investigation a head start on what to look for.
+
+---
+
+## 10. Sources
+
+Phase A findings drew on these references. Linked here so future readers can verify or update.
+
+- [`@opencode-ai/plugin/dist/index.d.ts`](https://www.npmjs.com/package/@opencode-ai/plugin) at v1.15.10 — authoritative hook surface. The plugin repo's `node_modules/@opencode-ai/plugin/dist/index.d.ts` lines 264-269 define the `experimental.chat.system.transform` signature.
+- [johnlindquist's OpenCode plugin guide gist](https://gist.github.com/johnlindquist/0adf1032b4e84942f3e1050aba3c5e4a) — community-maintained reference; shows the basic injection pattern.
+- [rohitg00/agentmemory `/plugin/opencode`](https://github.com/rohitg00/agentmemory/tree/main/plugin/opencode) — production plugin using exactly this hook for memory-style context injection. Two-layer pipeline (project profile + recent observations).
+- [rmk40's "OpenCode prompt construction" gist](https://gist.github.com/rmk40/cde7a98c1c90614a27478216cc01551f) — explains the system-prompt assembly pipeline and where plugin hooks fit.
+- [obra/superpowers OpenCode README](https://github.com/obra/superpowers/blob/main/docs/README.opencode.md) — another community example of plugin hook usage.
+- [`anomalyco/opencode#17100`](https://github.com/anomalyco/opencode/issues/17100) — closed-as-not-planned bug report on silent-discard. Risk we're tracking.
+- [`anomalyco/opencode#17637`](https://github.com/anomalyco/opencode/issues/17637) — feature request to include user message text in the hook's input. Confirms the hook does NOT currently see the user message, which is fine for our use case (conv-state is independent of the user's current message).
+- [`anomalyco/opencode#6142`](https://github.com/anomalyco/opencode/issues/6142) — older request to add sessionID to the hook input. The type signature confirms sessionID is now present (as an optional field), so this request was satisfied in some prior release.
+- [opencode plugin docs](https://opencode.ai/docs/plugins) — public documentation. The `experimental.chat.system.transform` hook is not currently documented here (only `experimental.session.compacting` is) but the type definition is authoritative.

--- a/docs/specs/opencode-conv-state-injection-spec.md
+++ b/docs/specs/opencode-conv-state-injection-spec.md
@@ -1,0 +1,152 @@
+# Spec: opencode Plugin — Conv-State Injection
+
+**Author:** Claude, with Jim
+**Date:** 2026-05-27
+**Status:** Draft v1 — investigation phase; design pinned to whatever opencode's SDK surfaces
+
+---
+
+## 1. Purpose
+
+[`memory-domain-isolation-and-conv-state.md`](./memory-domain-isolation-and-conv-state.md) §4.9 defines a per-turn hook contract: every harness integration injects a `<conversation-state>` block ahead of each user message so the LLM sees the current `domain` / `session_id` / `off_record` on every turn — defeating context-compaction-driven state loss.
+
+Three of the five Librarian plugins already implement this (Claude Code, Hermes, Codex — landed in the recent rollout). The remaining two — `the-librarian-opencode-plugin` and `the-librarian-pi-extension` — use hook models that don't trivially map to the §4.9 contract, and were deferred with a note. This document closes the deferral for opencode.
+
+---
+
+## 2. Non-goals
+
+- **Not redefining the §4.9 contract.** The rendered block is byte-identical across all five plugins (`renderConvStateBlock` in `@librarian/core` is the canonical source). This spec adapts the *injection mechanism* to opencode's SDK, not the *payload*.
+- **Not changing what `conv_state_get` returns.** The MCP surface (PR 2) is the same for every plugin.
+- **Not introducing a new opencode-specific Librarian feature.** This is a parity-with-Claude-Code piece of work, scoped to the existing contract.
+- **Not refactoring the opencode plugin's existing hook handlers.** The conv-state injection rides alongside the existing privacy gate and session-bootstrap flow.
+
+---
+
+## 3. Background
+
+### 3.1 What works in the other three plugins
+
+| Plugin | Hook event | Mechanism |
+|---|---|---|
+| Claude Code | `UserPromptSubmit` | Stdout JSON envelope: `{"hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": "..."}}` |
+| Codex | `UserPromptSubmit` | Same envelope shape (Codex models its hook protocol on Claude Code's) |
+| Hermes | `prefetch(query)` Memory Provider method | Return-value concatenation — Hermes appends the provider's return string into the model's context |
+
+Each lets the integration add text to the model's context without modifying the user's literal prompt. The conv-state block sits alongside any recall results and the LLM reads both.
+
+### 3.2 What opencode exposes
+
+From the existing plugin handler at `the-librarian-opencode-plugin/src/handlers/chat-message.ts`:
+
+> opencode's `chat.message` hook fires when a new user message is received, with a **mutable `output.message`** — meaning it runs BEFORE the LLM sees the prompt.
+
+This is structurally different. The opencode hook signature implies the integration *mutates* `output.message` rather than *returns context to concatenate*. Prepending the conv-state block to `output.message.text` would change what the user "said" from the LLM's perspective — which is wrong both semantically (the user didn't say it) and from a UX point of view (it could appear in the rendered conversation).
+
+The deferral note in the autonomous-build artefact reads:
+
+> opencode's `chat.message` hook fires with a mutable `output.message`, not a `hookSpecificOutput.additionalContext` envelope. Injection would have to prepend to the user's message text, which changes what the user sees as their prompt — different semantics from the §4.9 contract.
+
+The right answer is almost certainly somewhere else in opencode's SDK — a system-prompt hook, a tool-call-before hook, a separate "augment context" surface. The first phase of this spec is to find it. The second phase is to implement against it.
+
+---
+
+## 4. The contract
+
+### 4.1 Phase A — investigation (mandatory pre-work)
+
+Goal: identify, in opencode's public SDK + extension docs, the hook that lets an integration add text to the LLM's prompt context **without** mutating the user's literal message.
+
+Tasks (in order; each is a single PR-equivalent against this spec, not against code):
+
+1. **Read the opencode hook reference.** Document every hook event the integration surface exposes, plus the signature of each.
+2. **Walk the existing plugin's handlers** (`src/handlers/`) and the dispatch site (`src/index.ts`). Note every place that already touches model context. The `session-bootstrap` and `chat-message` handlers are the most relevant.
+3. **Specifically look for, in this priority order:**
+   - A `before-message-to-model` / `system-prompt-build` / `augment-context` hook that takes additive text.
+   - A system-prompt-block API that contributes a frozen string to every turn (cheap-but-stale; same shape as Hermes' `system_prompt_block`).
+   - A tool-call hook that fires before each LLM round and can prepend a hidden system message.
+   - A "side-channel context" API distinct from the user message.
+4. **Confirm with a 20-line spike** in a throwaway opencode plugin: emit a known string via the candidate mechanism and verify the LLM reads it without it appearing in the user-visible transcript.
+5. **Update this spec's §4.2 with the chosen mechanism and the spike's evidence.** No code lands in the plugin until §4.2 is filled in.
+
+If no such surface exists in opencode today, the outcome of Phase A is a small upstream feature request to opencode and a documented "blocked on upstream" status for this spec — not a "let's prepend to the user message anyway" compromise.
+
+### 4.2 Phase B — design (filled in after Phase A)
+
+*Placeholder. Populated by Phase A.*
+
+Expected shape (subject to the investigation):
+
+- **Hook event:** `<TBD — likely a system-prompt or before-completion hook>`.
+- **Mechanism:** call `conv_state_get` against the configured Librarian endpoint (via the existing `src/mcp-client.ts`), parse the JSON state, render the canonical block via the family-wide helper, return it via whatever path the chosen hook expects.
+- **Conv-id derivation:** `opencode:<session-id>` where `<session-id>` is opencode's `input.sessionID` (which the existing handlers already capture; see `chat-message.ts` `ChatMessageInput`).
+- **Privacy gating:** unchanged — the existing off-record flag suppresses the call entirely, mirroring the other plugins.
+- **Fail-soft:** unchanged — any error (network, parse, missing config) returns the no-op response; the LLM never sees a stack trace.
+
+### 4.3 Conv-id convention
+
+`opencode:<sessionID>` where `<sessionID>` is `input.sessionID` as passed to `chat.message`. This matches the prefix convention from spec §4.8 (`claude:<id>`, `codex:run:<id>:cwd:<path>`, `hermes:<id>`). Documented here so it's set before Phase A picks the mechanism — the conv-id is the same regardless of which hook we wire it to.
+
+### 4.4 Privacy + fail-soft contracts (binding from Phase A onward)
+
+These come from the plugin's AGENTS.md and the parent spec. They are non-negotiable in any Phase B design:
+
+- **No MCP call while off-record.** The plugin's existing `privacy-detector.ts` + `state-store.ts` gate every Librarian call; the conv-state injection adopts the same gate.
+- **Fail-soft on every error path.** Network, parse, schema, model-unavailable, missing-token, missing-endpoint — all of them return the no-op response.
+- **Sub-second budget.** Whatever opencode hook we wire into, the conv-state lookup must complete in under 500ms or the turn proceeds without injection. The block matters less than the turn.
+
+### 4.5 What we won't do
+
+- Mutate `output.message.text` to inject context. This is explicitly off the table: it would surface in the user-visible transcript and corrupt the conversation log.
+- Inject via a tool-call that masquerades as a recall. The block is *state*, not a memory; rolling it into the recall surface would conflate two distinct things.
+- Add a new "system prompt" config that ships the block as part of the plugin's static config. That would be stale by design — the whole point of the contract is that the block reflects *current* registry state, recomputed every turn.
+
+---
+
+## 5. Tech stack
+
+- **Plugin repo:** `the-librarian-opencode-plugin` (TypeScript, `bun` toolchain, `src/handlers/` layout).
+- **New runtime deps:** none anticipated. The plugin already has an MCP client (`src/mcp-client.ts`) and a privacy gate.
+- **Family-wide block renderer:** the canonical block format is the contract; we replicate the renderer locally (consistent with the AGENTS.md "five peer implementations" rule) rather than depending on `@librarian/core`.
+
+---
+
+## 6. Decisions
+
+- **D1.** Investigation-first. No code lands until the opencode hook surface for additive context is identified and demonstrated by spike.
+- **D2.** Never mutate `output.message`. The conv-state block belongs in a side-channel, not in the user's apparent message.
+- **D3.** Conv-id convention: `opencode:<sessionID>`. Set now, independent of the hook we land on.
+- **D4.** Privacy gate, fail-soft, sub-500ms budget — all binding, all from existing house rules.
+
+---
+
+## 7. Migration / rollout
+
+One PR in the plugin repo, contingent on Phase A producing a workable mechanism:
+
+1. Land Phase A as documentation only (this spec's §4.2 filled in, plus a short spike report committed alongside).
+2. PR the implementation: new handler under `src/handlers/`, wired into `src/index.ts`'s dispatch table.
+3. Tests: the existing test layout in `tests/` already has handler-level coverage; mirror the pattern (4 cases — hit, miss, throw, off-record).
+4. CHANGELOG entry under `## [Unreleased]`.
+
+No user-facing migration. Existing users keep running the current plugin; the next release ships injection.
+
+---
+
+## 8. Success criteria
+
+- [ ] Phase A produces a named opencode hook + a 20-line spike showing the LLM reads injected text that is not in the visible transcript.
+- [ ] The implementation renders the canonical `<conversation-state>` block byte-identically with the other four plugins (regression-tested against the family contract).
+- [ ] `conv_state_get` is called at most once per user turn (no duplicate fetches under retries or reconnects).
+- [ ] Off-record state suppresses every Librarian call for the turn.
+- [ ] A Librarian outage produces no stack trace, no blocked turn, no visible artefact in the transcript.
+- [ ] Adding a second domain to a fresh install and seeding a `conv_state` row makes the next opencode turn carry the canonical block; clearing the row makes the following turn carry nothing.
+
+---
+
+## 9. Open questions
+
+- **Does opencode have a "system prompt fragment" hook?** This is the unknown that gates the whole spec. The investigation in §4.1 answers it.
+- **If not — is there an upstream PR worth opening?** Could plausibly be a 20-line change in opencode itself if the hook genuinely doesn't exist. Lower-priority alternative to a workaround.
+- **Should `is_global` filtering be visible to opencode plugins?** Not in this spec, but worth raising: the §4.11 hard filter on `recall` is server-side and uniform across all integrations. opencode users get domain isolation for free once the injection is in place.
+- **Pi extension parity.** The sibling spec [`pi-extension-conv-state-injection-spec.md`](./pi-extension-conv-state-injection-spec.md) faces a similar investigation; useful to do both in the same week so we can share any opencode/pi SDK conventions we learn.

--- a/docs/specs/opencode-conv-state-injection-spec.md
+++ b/docs/specs/opencode-conv-state-injection-spec.md
@@ -171,7 +171,7 @@ export const handleSystemTransform =
 - **D3.** Conv-id convention: `opencode:<sessionID>`.
 - **D4.** Privacy gate, fail-soft, sub-500ms budget — all binding, all from existing house rules.
 - **D5.** Local renderer (`src/conv-state-render.ts`) rather than a `@librarian/core` dependency. Five peer implementations, no canonical source — same as the other four plugins.
-- **D6.** Despite being in the `experimental.*` namespace, the hook is the right choice for V1. Real plugins ship with it; the type signature is stable across the recent SDK minor versions; the alternative would be waiting for opencode to graduate it to a stable namespace (no announced timeline). We accept the risk that opencode could break the surface in a major version and commit to tracking it.
+- **D6.** Despite being in the `experimental.*` namespace, the hook is the right choice for V1. Real plugins ship with it; the type signature is stable across the recent SDK minor versions; the alternative would be waiting for opencode to graduate it to a stable namespace (no announced timeline). We accept the risk that opencode could break the surface in a major version and commit to tracking it — see §7.1 for the monitoring plan.
 
 ---
 
@@ -189,6 +189,20 @@ One PR in the plugin repo. Phase A is now closed (§4.1 evidence committed; §4.
 5. **CHANGELOG entry under `## [Unreleased]`.**
 
 No user-facing migration. Existing users keep running the current plugin; the next release ships injection.
+
+### 7.1 Tracking SDK changes (binding, not optional)
+
+The hook lives in `experimental.*`. opencode may rename it, graduate it to a stable namespace, change the signature, or remove it entirely. We commit to four monitoring mechanisms so a breaking change reaches us *before* it reaches users:
+
+1. **Pinned SDK version + CI guard on bumps.** `peerDependencies` and `devDependencies` pin `@opencode-ai/plugin` to a specific minor (`^1.15.10` today). The plugin's CI runs `tsc --noEmit` against the pinned version. Any future SDK bump (via a manual PR or a dependabot proposal) re-runs the typecheck — a signature change fails the build loudly.
+
+2. **CHANGELOG release-note check on the SDK side.** Before merging any SDK bump, the merging reviewer scans the [opencode CHANGELOG](https://github.com/anomalyco/opencode/blob/main/CHANGELOG.md) (or release notes) for any line mentioning `chat.system.transform`, `system.transform`, or `experimental` deprecations. A CI step grepping the release notes when an SDK version is bumped catches this automatically.
+
+3. **Watch graduation: experimental → stable.** If the hook moves from `experimental.chat.system.transform` to `chat.system.transform` (or similar), opencode typically keeps the experimental alias working for a transition period. Our handler should be rewritten to use the new stable name in the same PR that bumps the SDK version. The eyeball test (§7 step 4) verifies the migration works.
+
+4. **Periodic re-verification.** Quarterly (or before each `the-librarian` minor release, whichever is sooner), an operator runs the eyeball test in a real opencode session to confirm injection still reaches the LLM. Catches silent-discard regressions even if the type signature is unchanged.
+
+These four are listed in the plugin repo's `AGENTS.md` so future maintainers inherit the responsibility.
 
 ---
 

--- a/docs/specs/pi-extension-conv-state-injection-spec.md
+++ b/docs/specs/pi-extension-conv-state-injection-spec.md
@@ -2,7 +2,7 @@
 
 **Author:** Claude, with Jim
 **Date:** 2026-05-27
-**Status:** Draft v1 — investigation phase; design pinned to whatever the pi-coding-agent SDK surfaces
+**Status:** Draft v2 — Phase A investigation complete; hook identified as `before_agent_start` (stable namespace); design ready for implementation
 
 ---
 
@@ -64,48 +64,136 @@ The right answer almost certainly exists in the `@earendil-works/pi-coding-agent
 
 ## 4. The contract
 
-### 4.1 Phase A — investigation (mandatory pre-work)
+### 4.1 Phase A — investigation findings
 
-Goal: identify, in `@earendil-works/pi-coding-agent`'s public TypeScript types and any extension docs the package ships, the mechanism that lets an extension add text to the model's context per turn **without** modifying the user's literal input.
+Phase A was completed on 2026-05-27 against `@earendil-works/pi-coding-agent` v0.75.5 (the version pinned in the plugin's `package.json`).
 
-Tasks:
+**The hook is `before_agent_start`.** Defined in `@earendil-works/pi-coding-agent/dist/core/extensions/types.d.ts` (lines 467-478 + result type 735-739):
 
-1. **Read the SDK types.** Walk `node_modules/@earendil-works/pi-coding-agent/dist/`. List every event `pi.on(...)` accepts, plus the full type of each handler's return value. Look specifically for a discriminated union with a `"augment"` / `"inject"` / `"add-context"` variant.
-2. **Read the extension API surface.** Beyond `pi.on(...)`, walk every method on `ExtensionAPI`. The existing extension uses `pi.registerCommand`, `pi.getSessionName()`, `pi.ui.*`, `pi.status.*`. Look for a `pi.systemPrompt.*` / `pi.context.*` / `pi.prompt.*` surface that contributes to the model's prompt build.
-3. **Check the SDK's own example extensions** in `node_modules/@earendil-works/pi-coding-agent/examples/` if present. Real example code is the fastest disambiguator.
-4. **Spike.** A 30-line throwaway extension that emits a known string via the candidate mechanism. Verify the LLM reads it and it does not appear in the visible chat transcript.
-5. **Update this spec's §4.2 with the chosen mechanism and the spike's evidence.** No production code until §4.2 is filled in.
+```typescript
+interface BeforeAgentStartEvent {
+    type: "before_agent_start";
+    /** The raw user prompt text (after expansion). */
+    prompt: string;
+    /** Images attached to the user prompt, if any. */
+    images?: ImageContent[];
+    /** The fully assembled system prompt string. */
+    systemPrompt: string;
+    /** Structured options used to build the system prompt. */
+    systemPromptOptions: BuildSystemPromptOptions;
+}
 
-If no such surface exists in the SDK today, the outcome is an upstream feature request to Pi and a documented "blocked on upstream" status. The fallback "modify `event.text`" is explicitly off the table — that would surface in the visible transcript.
+interface BeforeAgentStartEventResult {
+    message?: Pick<CustomMessage, "customType" | "content" | "display" | "details">;
+    /** Replace the system prompt for this turn.
+     *  If multiple extensions return this, they are chained. */
+    systemPrompt?: string;
+}
+```
 
-### 4.2 Phase B — design (filled in after Phase A)
+**Why this is even better than opencode's surface:**
 
-*Placeholder. Populated by Phase A.*
+- **Stable namespace, not experimental.** Unlike `experimental.chat.system.transform`, this is a load-bearing public surface that the SDK ships with usage examples. No risk of namespace graduation breaking the integration.
+- **Receives the assembled system prompt.** We get `event.systemPrompt` already built, append our block, return the result. No ambiguity about position or concatenation order.
+- **Explicit chaining for multiple extensions.** The result-type comment confirms: "If multiple extensions return this, they are chained." Multiple plugins can safely append without stomping each other.
+- **Operates on `systemPrompt` not `event.prompt`.** Our additions are system-prompt-shaped, semantically correct — the LLM sees them as instructions, not as user input.
 
-Expected shape:
+**Cadence:** fires "after user submits prompt but before agent loop" per the SDK comment. Per-turn, exactly the cadence §4.9 needs.
 
-- **Hook event / API call:** `<TBD — likely a system-prompt or before-completion surface>`.
-- **Mechanism:** call `conv_state_get` against the configured endpoint via the existing `mcp-client.ts` vendor module, parse, render the canonical block, return via the chosen mechanism.
-- **Conv-id derivation:** `pi:<session-name>` where `<session-name>` is `pi.getSessionName()`. This matches the family prefix convention from spec §4.8.
-- **Privacy gating:** the existing `state.private` flag suppresses every Librarian call; the conv-state lookup adopts the same gate.
-- **Fail-soft:** unchanged — any error returns the no-op continuation, the LLM never sees a stack trace.
+**Type-level spike clean.** A throwaway extension that does `return { systemPrompt: event.systemPrompt + "\n\n" + renderConvStateBlock(state) }` from a `pi.on("before_agent_start", ...)` handler typechecks cleanly against the SDK types.
 
-### 4.3 Conv-id convention
+**SDK ships five canonical examples.** The pattern is officially blessed. Most directly relevant:
 
-`pi:<session-name>` where `<session-name>` is the value `pi.getSessionName()` returns at the moment of the input hook. The existing extension already uses `pi.getSessionName()` to derive `source_ref` — we reuse the same value so the conv-id is stable per Pi session. Documented here so it's set before Phase A picks the mechanism.
+- `examples/extensions/claude-rules.ts` — appends a fixed block (project rules) to `event.systemPrompt` via the chained-systemPrompt return. The exact shape we need.
+- `examples/extensions/pirate.ts` — same pattern, simpler payload (style instructions).
+- `examples/extensions/preset.ts` — same pattern, dynamic payload (active preset's instructions). Template-string interpolation.
+- `examples/extensions/ssh.ts` — uses `event.systemPrompt.replace(...)` to swap-rather-than-append. Different shape, same hook.
 
-### 4.4 Privacy + fail-soft contracts (binding from Phase A onward)
+**Other surfaces considered and rejected:**
 
-Same set as the opencode spec — these come from `the-librarian-pi-extension/AGENTS.md` and the parent spec, and are non-negotiable in any Phase B design:
+- `pi.on("input", ...)` — the existing extension already uses this; its `InputEventResult` return supports `{ action: "transform", text: ... }` which modifies the user's literal text. Off-the-table per spec §4.3.
+- `pi.on("context", ...)` — receives the messages array, can mutate. Too low-level; would let us prepend a synthetic message but `before_agent_start.systemPrompt` is the cleaner semantic.
+- `ExtensionContext.getSystemPrompt()` — a query method, not a mutate-able hook. Wrong direction.
+- `pi.ui.*` surface — display-only, not prompt-affecting.
 
-- **No MCP call while off-record.** The orchestrator's existing state check gates every Librarian call.
-- **Fail-soft on every error path.** Network, parse, schema, model-unavailable, missing-token, missing-endpoint — all of them return the existing `{ action: "continue" }` response.
-- **Sub-500ms budget.** The input hook must not stall the turn for more than half a second. If `conv_state_get` exceeds the budget, the turn proceeds without injection.
+### 4.2 Phase B — design
 
-### 4.5 What we won't do
+**Hook handler:**
 
-- Modify `event.text` to inject context. Would corrupt the visible transcript.
-- Inject via the existing memory-tools surface (e.g. by treating the block as a synthetic recall result). The block is *state*, not a memory — different surface.
+```typescript
+// extensions/librarian/handlers/system-prompt-augment.ts
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { renderConvStateBlock } from "../conv-state-render.js";
+
+const CONV_STATE_TIMEOUT_MS = 500;
+
+export function registerSystemPromptAugment(
+  pi: ExtensionAPI,
+  deps: {
+    mcp: { convStateGet: (convId: string, timeoutMs: number) => Promise<...> | null };
+    state: { isPrivate: () => Promise<boolean> };
+    log: (entry: object) => Promise<void>;
+  },
+): void {
+  pi.on("before_agent_start", async (event, _ctx) => {
+    try {
+      // Privacy gate: off-record suppresses every Librarian call.
+      if (await deps.state.isPrivate()) return;
+
+      // Conv-id from the Pi session name. Stable per Pi session; same
+      // value the existing extension uses for source_ref derivation.
+      const sessionName = pi.getSessionName();
+      if (!sessionName) return;
+      const convId = `pi:${sessionName}`;
+
+      // Fail-soft fetch. Any error → silent return, system prompt unchanged.
+      const state = await deps.mcp.convStateGet(convId, CONV_STATE_TIMEOUT_MS);
+      if (!state) return;
+
+      // Append the canonical block to the assembled system prompt.
+      // The chained-extensions contract means we concatenate, never replace.
+      return {
+        systemPrompt: event.systemPrompt + "\n\n" + renderConvStateBlock(state),
+      };
+    } catch (err) {
+      await deps.log({
+        event: "before_agent_start",
+        outcome: "conv_state_inject_threw",
+        error: String((err as Error)?.message ?? err),
+      });
+      // Silent return — never block the turn.
+      return;
+    }
+  });
+}
+```
+
+**Wired into the existing extension entry point** (`extensions/librarian/index.ts`) alongside the existing `pi.on("input", ...)` and `pi.on("session_*", ...)` registrations. No changes to existing handlers.
+
+**Conv-id derivation:** `pi:${pi.getSessionName()}` — guarded by an early-out when `getSessionName()` returns undefined (the existing extension already uses this value for `derivePiSourceRef`, so the conv-id is stable for the same session that owns the source_ref).
+
+**Privacy gating:** reuses the plugin's existing orchestrator state check. Identical guard pattern to the existing `pi.on("input", ...)` handler.
+
+**Fail-soft contracts:**
+- Missing `getSessionName()` → silent return.
+- Off-record → silent return.
+- `convStateGet` timeout (500ms) → silent return.
+- `convStateGet` network failure → silent return.
+- `convStateGet` parse failure → silent return.
+- Any unexpected throw → caught, logged, silent return.
+
+When the handler returns nothing (no block to inject) or returns `undefined`, the SDK leaves the system prompt unchanged. Multiple extensions returning `systemPrompt` are chained — our extension is one chain element, not a replacement.
+
+**Where the renderer lives:** new file `extensions/librarian/conv-state-render.ts`, byte-identical with the other four plugins' implementations (per the AGENTS.md "five peer implementations" rule).
+
+**Where the MCP call goes:** the existing `extensions/librarian/vendor/mcp-client.ts` already speaks to the Librarian endpoint. We add a `convStateGet(convId, timeoutMs)` helper alongside the existing tool helpers.
+
+### 4.3 What we won't do
+
+- Modify `event.prompt` from `before_agent_start` — corrupts the visible transcript and isn't what the hook is for. The `systemPrompt` return is the right field.
+- Modify `event.text` in `pi.on("input", ...)` via the `transform` action. Off-the-table per the parent spec's §4.9 contract.
+- Inject via the existing memory-tools surface (treating the block as a synthetic recall result). The block is *state*, not a memory — different surface.
+- Use `pi.on("context", ...)` to prepend a message. The `before_agent_start.systemPrompt` route is the cleaner semantic.
 - Add a static config-file injection. Stale by design.
 
 ---
@@ -115,46 +203,67 @@ Same set as the opencode spec — these come from `the-librarian-pi-extension/AG
 - **Plugin repo:** `the-librarian-pi-extension` (TypeScript, `tsc` toolchain, `extensions/librarian/` layout).
 - **New runtime deps:** none anticipated. The extension already has an MCP client (`extensions/librarian/vendor/mcp-client.js`) and a state store.
 - **Family-wide block renderer:** byte-identical to the other four plugins' renderers. Local replication (consistent with the AGENTS.md five-peer rule) rather than a shared dependency.
-- **Pi SDK:** `@earendil-works/pi-coding-agent` (whatever version this extension is pinned to). Phase A may surface that we need a newer SDK version, or an upstream change.
+- **Pi SDK:** `@earendil-works/pi-coding-agent` ^0.75.5 (the pinned version). The hook lives in a stable namespace; no SDK bump required for V1.
 
 ---
 
 ## 6. Decisions
 
-- **D1.** Investigation-first. No code until Phase A produces a workable mechanism + spike evidence.
-- **D2.** Never modify `event.text`. The block belongs in a side-channel, not the user's literal input.
-- **D3.** Conv-id convention: `pi:<session-name>`. Reuses `pi.getSessionName()` for stability across the Pi session.
-- **D4.** Privacy gate, fail-soft, sub-500ms budget — all binding.
+- **D1.** Hook surface is `before_agent_start`. Identified in Phase A; confirmed by type-level spike + five SDK-shipped canonical examples that ship with the package (`claude-rules.ts`, `pirate.ts`, `preset.ts`, `ssh.ts`, plus uses in `qna.ts` / `prompt-customizer.ts`).
+- **D2.** Mutation pattern: return `{ systemPrompt: event.systemPrompt + "\n\n" + renderConvStateBlock(state) }`. Matches the canonical `claude-rules.ts` / `pirate.ts` examples exactly. The SDK's documented chaining means our extension cooperates with any other plugin that also augments the system prompt.
+- **D3.** Never modify `event.prompt` (the user's literal text) or use `pi.on("input", ...)`'s `transform` action. Conv-state belongs in the system prompt, not in the user's message.
+- **D4.** Conv-id convention: `pi:<session-name>` via `pi.getSessionName()`. Reuses the same value the existing extension already uses for `derivePiSourceRef`. The conv-id remains brief in the rendered block; the full source_ref still goes on the Librarian session row when one is created.
+- **D5.** Privacy gate (`state.isPrivate()`), fail-soft (every error path returns silently), sub-500ms `convStateGet` budget — all binding, all from existing house rules.
+- **D6.** Local renderer (`extensions/librarian/conv-state-render.ts`) rather than a `@librarian/core` dependency. Five peer implementations, no canonical source — same as the other four plugins.
+- **D7.** `before_agent_start` is in the SDK's **stable** namespace (no `experimental.*` prefix). Unlike the opencode integration's `experimental.chat.system.transform`, we don't need the four-mechanism monitoring plan from that spec. The standard "pin the SDK + tsc in CI" hygiene covers it.
 
 ---
 
 ## 7. Migration / rollout
 
-One PR in the extension repo, contingent on Phase A:
+One PR in the extension repo. Phase A is closed (§4.1 evidence committed; §4.2 design ready).
 
-1. Land Phase A as documentation: §4.2 filled in, spike report committed alongside.
-2. PR the implementation: a new branch off the existing input / before-model hook in `extensions/librarian/index.ts`.
-3. Tests: the existing `tests/` layout has handler-level coverage; mirror it (4 cases — hit, miss, throw, off-record).
-4. CHANGELOG entry under `## [Unreleased]`.
+1. **Create the handler + supporting modules:**
+   - `extensions/librarian/handlers/system-prompt-augment.ts` — the new hook implementation.
+   - `extensions/librarian/conv-state-render.ts` — the canonical block renderer.
+   - Extend `extensions/librarian/vendor/mcp-client.ts` with `convStateGet(convId, timeoutMs)`.
+2. **Wire into the extension entry point** (`extensions/librarian/index.ts`) alongside the existing `pi.on(...)` registrations. No changes to existing handlers.
+3. **Tests** (`tests/system-prompt-augment.test.ts`): four cases mirroring the codex / hermes pattern — state hit appends the block (verified by inspecting the returned `systemPrompt` against the input plus block); no state → handler returns `undefined`; `convStateGet` throws → silent return, no thrown error; off-record → no MCP call at all.
+4. **Eyeball-test post-deploy.** In a real Pi session against a Librarian with a seeded conv_state row, ask the model "what domain are you in?" Verify the model answers correctly. (Less risk-laden than opencode's eyeball test because Pi's hook is stable namespace and the SDK ships canonical examples of this exact pattern — but worth a one-time confirmation that our wiring is right.)
+5. **CHANGELOG entry under `## [Unreleased]`.**
 
-No user-facing migration. The next extension release ships injection.
+No user-facing migration. Existing users keep running the current extension; the next release ships injection.
 
 ---
 
 ## 8. Success criteria
 
-- [ ] Phase A produces a named SDK mechanism + a 30-line spike showing the LLM reads injected text that does not appear in the visible transcript.
-- [ ] The implementation renders the canonical `<conversation-state>` block byte-identically with the other four plugins.
-- [ ] `conv_state_get` is called at most once per user turn.
-- [ ] Off-record state suppresses every Librarian call for the turn.
-- [ ] A Librarian outage produces no stack trace, no blocked turn, no visible artefact in the transcript.
-- [ ] Adding a second domain to a fresh install and seeding a `conv_state` row makes the next Pi turn carry the canonical block; clearing the row makes the following turn carry nothing.
+- [ ] `pi.on("before_agent_start", ...)` is registered and fires on every chat turn.
+- [ ] The handler returns `{ systemPrompt: event.systemPrompt + "\n\n" + block }` when conv_state exists; returns `undefined` (or doesn't return) otherwise.
+- [ ] The rendered `<conversation-state>` block is byte-identical with the other four plugins (asserted by a fixture test against a captured snapshot).
+- [ ] `conv_state_get` is called at most once per `before_agent_start` invocation.
+- [ ] Off-record state suppresses every Librarian call — `state.isPrivate()` is checked before the MCP client is touched.
+- [ ] A Librarian outage produces no stack trace, no blocked turn, no visible artefact in the user transcript.
+- [ ] Adding a second domain to a fresh Librarian install + seeding a `conv_state` row via the dashboard causes the next Pi turn to carry the canonical block in its system prompt. Clearing the row causes the following turn to carry nothing.
+- [ ] **Eyeball-test gate (pre-release):** in a real Pi session, ask the model a question that requires the conv-state context to answer; verify the model answers correctly.
 
 ---
 
 ## 9. Open questions
 
-- **Does the Pi SDK have a system-prompt augment hook?** This is the unknown that gates the whole spec. The investigation in §4.1 answers it.
-- **If not — is there an upstream PR worth opening?** The Pi SDK is `@earendil-works/pi-coding-agent`; depending on what it exposes, a small upstream PR adding a `before-model` or `system-prompt-fragment` hook may be the cleanest path. Lower-priority alternative to a workaround.
-- **Sharing Phase A findings with the opencode spec.** [`opencode-conv-state-injection-spec.md`](./opencode-conv-state-injection-spec.md) faces the same investigation against a different SDK. The two should run in the same week so any cross-SDK patterns we learn (e.g. "the augment-context pattern is increasingly common") feed back into both designs.
-- **Pi's session model and `source_ref`.** The existing extension uses `derivePiSourceRef({cwd, piSessionId, deviceId})`. Whether the conv-id should be `pi:<session-name>` or the full source_ref is a small open question — the conv-id only needs to be stable per Pi session, but using the full source_ref keeps it cross-harness-consistent. Recommendation: `pi:<session-name>` for brevity in the rendered block; the source_ref still goes on the session row when one is created.
+- **SDK version bump cadence.** The pinned version is `^0.75.5`. The pi-coding-agent's pre-1.0 versioning means semver-minor bumps can still be breaking. Standard hygiene applies: pin in package.json, run `tsc --noEmit` in CI, review the SDK CHANGELOG before merging any bump. Less risk-laden than opencode's experimental-namespace situation; doesn't need a dedicated monitoring plan.
+- **Conv-id format: name vs full source_ref.** Decision in D4 is `pi:<session-name>`. The alternative `pi:<full-source-ref>` (e.g. `pi:cwd:/Users/jim/work/foo` or `pi:device:<id>:cwd:/path`) would carry more cross-harness coordination potential but the conv-state lookup only needs to be stable per Pi session. Revisit if cross-harness handover *into* Pi proves awkward with the short name.
+- **Compaction interaction.** Pi's `session_compact` event fires after compaction; our handler fires on `before_agent_start` which is per-turn. After compaction, the next turn's `before_agent_start` fires, re-injects from conv_state, and the model sees current state again — same defeat-compaction mechanic as the other four plugins. No special handling needed.
+
+---
+
+## 10. Sources
+
+Phase A findings drew on these references — all from the locally-installed SDK at v0.75.5.
+
+- **`@earendil-works/pi-coding-agent/dist/core/extensions/types.d.ts`** — authoritative hook surface. Lines 467-478 define `BeforeAgentStartEvent`; lines 735-739 define `BeforeAgentStartEventResult` with the `systemPrompt?` field and the chained-extensions comment.
+- **`examples/extensions/claude-rules.ts`** — SDK-shipped canonical example. Appends a fixed project-rules block via the same `return { systemPrompt: event.systemPrompt + ... }` pattern we use. Closest shape to our use case.
+- **`examples/extensions/pirate.ts`** — minimal SDK-shipped example demonstrating "`systemPromptAppend`" (per the examples README).
+- **`examples/extensions/preset.ts`** — dynamic-content example; template-string interpolation with `${event.systemPrompt}\n\n${activePreset.instructions}`. Confirms dynamic per-turn payloads work fine through this hook.
+- **`examples/extensions/ssh.ts`** — uses `event.systemPrompt.replace(...)` to swap-rather-than-append. Same hook, different mutation pattern. Confirms the systemPrompt field is fully mutable.
+- **`docs/extensions.md`** — local SDK docs (under `node_modules/.../docs/`). Background reference for the extension lifecycle.

--- a/docs/specs/pi-extension-conv-state-injection-spec.md
+++ b/docs/specs/pi-extension-conv-state-injection-spec.md
@@ -1,0 +1,160 @@
+# Spec: Pi Extension — Conv-State Injection
+
+**Author:** Claude, with Jim
+**Date:** 2026-05-27
+**Status:** Draft v1 — investigation phase; design pinned to whatever the pi-coding-agent SDK surfaces
+
+---
+
+## 1. Purpose
+
+[`memory-domain-isolation-and-conv-state.md`](./memory-domain-isolation-and-conv-state.md) §4.9 defines a per-turn hook contract: every harness integration injects a `<conversation-state>` block ahead of each user message so the LLM sees the current `domain` / `session_id` / `off_record` on every turn — defeating context-compaction-driven state loss.
+
+Three of the five Librarian plugins already implement this (Claude Code, Hermes, Codex). The Pi extension was deferred because its `pi.on("input")` handler returns `{action: "continue"}` and the extension SDK doesn't visibly expose a "context-injection" pattern from the surface the plugin reaches.
+
+This spec scopes the closing-the-deferral work.
+
+---
+
+## 2. Non-goals
+
+- **Not redefining the §4.9 contract.** The rendered block is byte-identical across all five plugins; this spec adapts the *injection mechanism* to Pi's SDK, not the *payload*.
+- **Not changing the `pi.on("input")` handler's existing privacy / lifecycle behaviour.** The conv-state injection rides alongside the existing flow.
+- **Not introducing a Librarian-specific build of the Pi extension SDK.** If the SDK genuinely doesn't expose a workable surface, the answer is an upstream PR (or a "blocked on upstream" status), not a fork.
+- **Not unifying opencode + Pi.** The two specs run in parallel; they may share investigation findings but each adapts to its own SDK.
+
+---
+
+## 3. Background
+
+### 3.1 What works in the other three plugins
+
+| Plugin | Hook event | Mechanism |
+|---|---|---|
+| Claude Code | `UserPromptSubmit` | Stdout JSON envelope: `additionalContext` field |
+| Codex | `UserPromptSubmit` | Same envelope shape |
+| Hermes | `prefetch(query)` provider method | Return-string concatenation |
+
+Each lets the integration add text to the model's context without modifying the user's literal prompt.
+
+### 3.2 What the Pi extension exposes today
+
+From the existing extension at `the-librarian-pi-extension/extensions/librarian/index.ts`:
+
+```ts
+pi.on("input", async (event, ctx) => {
+  if (event.source === "extension") return { action: "continue" } as const;
+  const text = event.text.trim();
+  if (text.startsWith("/") || text.length === 0) return { action: "continue" } as const;
+  await getOrchestrator(ctx.cwd).handlePrompt(event.text);
+  refreshStatus(ctx);
+  return { action: "continue" } as const;
+});
+```
+
+The handler signature returns `{ action: "continue" }` — an enum-like response that allows the input to proceed but does not (visibly, from this code) carry additive context. The other events used (`tool_call`, `agent_end`, `session_compact`, `session_shutdown`, `session_start`) are side-effect hooks without a return-value mutation path either.
+
+The deferral note from the autonomous-build artefact reads:
+
+> Pi extension — `pi.on("input")` returns `{action: "continue"}` and doesn't expose a "context injection" pattern in the SDK surface visible from the extension. Same problem at a different layer.
+
+The right answer almost certainly exists in the `@earendil-works/pi-coding-agent` SDK — possibly a different action enum value (e.g. `{ action: "augment", text: "..." }`), possibly a different event we haven't surveyed (a "before-model" hook), or possibly a system-prompt API distinct from the input stream.
+
+---
+
+## 4. The contract
+
+### 4.1 Phase A — investigation (mandatory pre-work)
+
+Goal: identify, in `@earendil-works/pi-coding-agent`'s public TypeScript types and any extension docs the package ships, the mechanism that lets an extension add text to the model's context per turn **without** modifying the user's literal input.
+
+Tasks:
+
+1. **Read the SDK types.** Walk `node_modules/@earendil-works/pi-coding-agent/dist/`. List every event `pi.on(...)` accepts, plus the full type of each handler's return value. Look specifically for a discriminated union with a `"augment"` / `"inject"` / `"add-context"` variant.
+2. **Read the extension API surface.** Beyond `pi.on(...)`, walk every method on `ExtensionAPI`. The existing extension uses `pi.registerCommand`, `pi.getSessionName()`, `pi.ui.*`, `pi.status.*`. Look for a `pi.systemPrompt.*` / `pi.context.*` / `pi.prompt.*` surface that contributes to the model's prompt build.
+3. **Check the SDK's own example extensions** in `node_modules/@earendil-works/pi-coding-agent/examples/` if present. Real example code is the fastest disambiguator.
+4. **Spike.** A 30-line throwaway extension that emits a known string via the candidate mechanism. Verify the LLM reads it and it does not appear in the visible chat transcript.
+5. **Update this spec's §4.2 with the chosen mechanism and the spike's evidence.** No production code until §4.2 is filled in.
+
+If no such surface exists in the SDK today, the outcome is an upstream feature request to Pi and a documented "blocked on upstream" status. The fallback "modify `event.text`" is explicitly off the table — that would surface in the visible transcript.
+
+### 4.2 Phase B — design (filled in after Phase A)
+
+*Placeholder. Populated by Phase A.*
+
+Expected shape:
+
+- **Hook event / API call:** `<TBD — likely a system-prompt or before-completion surface>`.
+- **Mechanism:** call `conv_state_get` against the configured endpoint via the existing `mcp-client.ts` vendor module, parse, render the canonical block, return via the chosen mechanism.
+- **Conv-id derivation:** `pi:<session-name>` where `<session-name>` is `pi.getSessionName()`. This matches the family prefix convention from spec §4.8.
+- **Privacy gating:** the existing `state.private` flag suppresses every Librarian call; the conv-state lookup adopts the same gate.
+- **Fail-soft:** unchanged — any error returns the no-op continuation, the LLM never sees a stack trace.
+
+### 4.3 Conv-id convention
+
+`pi:<session-name>` where `<session-name>` is the value `pi.getSessionName()` returns at the moment of the input hook. The existing extension already uses `pi.getSessionName()` to derive `source_ref` — we reuse the same value so the conv-id is stable per Pi session. Documented here so it's set before Phase A picks the mechanism.
+
+### 4.4 Privacy + fail-soft contracts (binding from Phase A onward)
+
+Same set as the opencode spec — these come from `the-librarian-pi-extension/AGENTS.md` and the parent spec, and are non-negotiable in any Phase B design:
+
+- **No MCP call while off-record.** The orchestrator's existing state check gates every Librarian call.
+- **Fail-soft on every error path.** Network, parse, schema, model-unavailable, missing-token, missing-endpoint — all of them return the existing `{ action: "continue" }` response.
+- **Sub-500ms budget.** The input hook must not stall the turn for more than half a second. If `conv_state_get` exceeds the budget, the turn proceeds without injection.
+
+### 4.5 What we won't do
+
+- Modify `event.text` to inject context. Would corrupt the visible transcript.
+- Inject via the existing memory-tools surface (e.g. by treating the block as a synthetic recall result). The block is *state*, not a memory — different surface.
+- Add a static config-file injection. Stale by design.
+
+---
+
+## 5. Tech stack
+
+- **Plugin repo:** `the-librarian-pi-extension` (TypeScript, `tsc` toolchain, `extensions/librarian/` layout).
+- **New runtime deps:** none anticipated. The extension already has an MCP client (`extensions/librarian/vendor/mcp-client.js`) and a state store.
+- **Family-wide block renderer:** byte-identical to the other four plugins' renderers. Local replication (consistent with the AGENTS.md five-peer rule) rather than a shared dependency.
+- **Pi SDK:** `@earendil-works/pi-coding-agent` (whatever version this extension is pinned to). Phase A may surface that we need a newer SDK version, or an upstream change.
+
+---
+
+## 6. Decisions
+
+- **D1.** Investigation-first. No code until Phase A produces a workable mechanism + spike evidence.
+- **D2.** Never modify `event.text`. The block belongs in a side-channel, not the user's literal input.
+- **D3.** Conv-id convention: `pi:<session-name>`. Reuses `pi.getSessionName()` for stability across the Pi session.
+- **D4.** Privacy gate, fail-soft, sub-500ms budget — all binding.
+
+---
+
+## 7. Migration / rollout
+
+One PR in the extension repo, contingent on Phase A:
+
+1. Land Phase A as documentation: §4.2 filled in, spike report committed alongside.
+2. PR the implementation: a new branch off the existing input / before-model hook in `extensions/librarian/index.ts`.
+3. Tests: the existing `tests/` layout has handler-level coverage; mirror it (4 cases — hit, miss, throw, off-record).
+4. CHANGELOG entry under `## [Unreleased]`.
+
+No user-facing migration. The next extension release ships injection.
+
+---
+
+## 8. Success criteria
+
+- [ ] Phase A produces a named SDK mechanism + a 30-line spike showing the LLM reads injected text that does not appear in the visible transcript.
+- [ ] The implementation renders the canonical `<conversation-state>` block byte-identically with the other four plugins.
+- [ ] `conv_state_get` is called at most once per user turn.
+- [ ] Off-record state suppresses every Librarian call for the turn.
+- [ ] A Librarian outage produces no stack trace, no blocked turn, no visible artefact in the transcript.
+- [ ] Adding a second domain to a fresh install and seeding a `conv_state` row makes the next Pi turn carry the canonical block; clearing the row makes the following turn carry nothing.
+
+---
+
+## 9. Open questions
+
+- **Does the Pi SDK have a system-prompt augment hook?** This is the unknown that gates the whole spec. The investigation in §4.1 answers it.
+- **If not — is there an upstream PR worth opening?** The Pi SDK is `@earendil-works/pi-coding-agent`; depending on what it exposes, a small upstream PR adding a `before-model` or `system-prompt-fragment` hook may be the cleanest path. Lower-priority alternative to a workaround.
+- **Sharing Phase A findings with the opencode spec.** [`opencode-conv-state-injection-spec.md`](./opencode-conv-state-injection-spec.md) faces the same investigation against a different SDK. The two should run in the same week so any cross-SDK patterns we learn (e.g. "the augment-context pattern is increasingly common") feed back into both designs.
+- **Pi's session model and `source_ref`.** The existing extension uses `derivePiSourceRef({cwd, piSessionId, deviceId})`. Whether the conv-id should be `pi:<session-name>` or the full source_ref is a small open question — the conv-id only needs to be stable per Pi session, but using the full source_ref keeps it cross-harness-consistent. Recommendation: `pi:<session-name>` for brevity in the rendered block; the source_ref still goes on the session row when one is created.


### PR DESCRIPTION
## Summary

Closes the four spec gaps identified during the memory-domain-isolation autonomous build, with the parent spec brought along in lockstep.

Specs added under `docs/specs/`:

- **[classifier-implementation-spec.md](docs/specs/classifier-implementation-spec.md)** — closes parent §9 / plan §6 pre-work. **Departs from the parent spec in three places** (all reflected back into the parent in this PR):
  - **Async classification** instead of sync. `remember` returns instantly at conservative defaults; a background worker classifies and updates booleans/status when the verdict lands. Eliminates the 500ms latency budget and the contingency ladder for it.
  - **Configurable provider** (local default `LiquidAI/LFM2.5-1.2B-Instruct-GGUF` + curated 6-model catalog + custom HF override; or remote OpenAI-compatible). Reuses the curator's LLM client code with a separate config namespace.
  - **Dashboard-driven evaluation**, not CI quality gate. CI tests only the machinery (parser, retry, migration) against mocked classifiers; the operator runs quality eval against the synthetic fixture on demand. The 1000-item fixture is generated by multi-model consensus filter (Claude + GPT-4o + Gemini, unanimous), 60/40 straight/boundary with over-generated boundaries to survive ~50% consensus pruning. No private calibration tier — backfill + day-to-day use is the real-data signal. PR 6 + PR 7 collapse into one PR with backfill at migration.

- **[claude-plugin-lifecycle-restoration-spec.md](docs/specs/claude-plugin-lifecycle-restoration-spec.md)** — closes the broken build introduced by main-repo PR #153 (deleted `@librarian/lifecycle/src/` while the Claude plugin's `scripts/build-bundle.mjs` still references it). Vendor approach: extract source from main-repo git history into the plugin's new `src/`, rewrite the build script to read from in-repo, absorb the recently-added conv-state inject bin into the same `src/` tree (one build pipeline). `.mts` TypeScript modules per the opencode convention.

- **[opencode-conv-state-injection-spec.md](docs/specs/opencode-conv-state-injection-spec.md)** — Phase A complete; design ready for implementation. Hook surface is `experimental.chat.system.transform` (mutate `output.system: string[]` via push). Validated against opencode SDK v1.15.10 by type-level spike + real-world plugin precedent (rohitg00/agentmemory). The `experimental.*` namespace is the dominant risk — spec commits to a four-mechanism monitoring plan (§7.1) and an eyeball-test gate before first deploy.

- **[pi-extension-conv-state-injection-spec.md](docs/specs/pi-extension-conv-state-injection-spec.md)** — Phase A complete; design ready for implementation. Hook surface is `before_agent_start` (return `{ systemPrompt: event.systemPrompt + "\n\n" + block }`). Validated against `@earendil-works/pi-coding-agent` v0.75.5 by type-level spike + five canonical examples shipped with the SDK. **Stable namespace** (no `experimental.*`), so no dedicated monitoring plan needed.

Parent spec (`memory-domain-isolation-and-conv-state.md`) edited in lockstep:

- §4.4 reworded for async + configurable provider + dashboard eval; cross-links to the implementation spec for detail.
- §5 mentions both new packages (`@librarian/classifier`, `@librarian/classifier-eval`).
- §6 D19 / D20 / D21 rewritten with "originally specified X; revised when..." traceability.
- §7.3 PR 6 + PR 7 collapsed into a single PR with backfill; PR 8 renumbered to PR 7.
- §8 success criteria reworked for the async lifecycle.
- §9 closes the classifier-spec open question.
- Status header bumped to v4.

## What this does NOT do

- **No code changes.** Specs only. Implementation lands in subsequent PRs per each spec's §7 migration plan.
- **No changes outside `docs/specs/` + CHANGELOG.** Spec authoring exclusively.

## Test plan

- [x] All four new spec files are self-contained and cross-reference each other where appropriate.
- [x] Parent spec is consistent with the classifier-spec revisions (no contradictions).
- [x] Type-level spikes for the opencode and pi-extension hook surfaces compile clean against the installed SDKs (`/tmp/opencode-spike/`, `/tmp/pi-spike/` — both `tsc --noEmit` exit 0).
- [x] Phase A findings for opencode and pi-extension are evidence-backed (SDK type definitions cited, in-production plugin references for opencode, SDK-shipped canonical examples for pi).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)