### PR TITLE
feat(classifier): foundation — package, schema bump, async worker (Section 4a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,26 @@ changes from this point forward are catalogued here.
 
 ### Added
 
+- **Classifier foundation (Section 4a of the rollout-completion plan).**
+  New workspace package `@librarian/classifier` with a remote (OpenAI-
+  compatible) provider, the v1 prompt template, and the parser that
+  folds every model output failure to a conservative-defaults verdict
+  with a `fallback_used` tag (`parse` / `timeout` / `provider_unavailable`).
+  Two new `memories` columns — `classified` and
+  `classification_attempts` — both `INTEGER NOT NULL DEFAULT 0` (schema
+  bump v14 → v15). A new `memory.classified` event variant on the
+  ledger schema (spec §4.8). A new async worker scaffold at
+  `packages/mcp-server/src/classifier-worker.ts` that drains the
+  `classified = 0` queue, retries on parse / provider failures up to 3
+  attempts, then gives up with conservative defaults + an event marked
+  `fallback_used: "max_retries"`.
+
+  **No behavior change.** The worker module exists but is NOT wired
+  into mcp-server startup; no code path writes `classified = 0` yet,
+  so the worker has nothing to do in production. New memories continue
+  through the legacy `deriveLegacyMemoryFlags` path until Section 4d
+  performs the cutover (with the migration backfill).
+
 - **CLI `--conv-id` flag on `sessions start` (PR 5 of 8, T5.3 only).**
   Mirrors the new harness hook contract — when the operator pipes a
   series of CLI invocations together (e.g. `LIBRARIAN_CONV_ID=cli:work`

--- a/docker/all-in-one.Dockerfile
+++ b/docker/all-in-one.Dockerfile
@@ -16,6 +16,7 @@ RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
 # Manifests first for a cacheable install layer.
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY packages/core/package.json ./packages/core/package.json
+COPY packages/classifier/package.json ./packages/classifier/package.json
 COPY packages/mcp-server/package.json ./packages/mcp-server/package.json
 COPY packages/cli/package.json ./packages/cli/package.json
 COPY apps/dashboard/package.json ./apps/dashboard/package.json
@@ -24,11 +25,13 @@ RUN pnpm install --frozen-lockfile --ignore-scripts
 
 COPY tsconfig.base.json ./
 COPY packages/core ./packages/core
+COPY packages/classifier ./packages/classifier
 COPY packages/mcp-server ./packages/mcp-server
 COPY apps/dashboard ./apps/dashboard
 
-# core + mcp-server first (the dashboard imports mcp-server types), then dashboard.
-RUN pnpm --filter @librarian/core --filter @librarian/mcp-server run build \
+# core + classifier + mcp-server first (the dashboard imports mcp-server
+# types, mcp-server imports classifier types), then dashboard.
+RUN pnpm --filter @librarian/core --filter @librarian/classifier --filter @librarian/mcp-server run build \
   && pnpm --filter @librarian/dashboard run build
 
 # Prune the workspace to prod deps for the mcp-server runtime tree. The dashboard's

--- a/docker/dashboard.Dockerfile
+++ b/docker/dashboard.Dockerfile
@@ -9,6 +9,7 @@ RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY packages/core/package.json ./packages/core/package.json
+COPY packages/classifier/package.json ./packages/classifier/package.json
 COPY packages/mcp-server/package.json ./packages/mcp-server/package.json
 COPY packages/cli/package.json ./packages/cli/package.json
 COPY apps/dashboard/package.json ./apps/dashboard/package.json
@@ -17,12 +18,14 @@ RUN pnpm install --frozen-lockfile --ignore-scripts
 
 COPY tsconfig.base.json ./
 COPY packages/core ./packages/core
+COPY packages/classifier ./packages/classifier
 COPY packages/mcp-server ./packages/mcp-server
 COPY apps/dashboard ./apps/dashboard
 
-# The dashboard imports types from @librarian/mcp-server; both core and
-# mcp-server must build first so .d.ts files are emitted under dist/.
-RUN pnpm --filter @librarian/core --filter @librarian/mcp-server run build \
+# The dashboard imports types from @librarian/mcp-server (which imports
+# @librarian/classifier). Build the chain in order so .d.ts files are
+# emitted under dist/ before the dashboard build resolves them.
+RUN pnpm --filter @librarian/core --filter @librarian/classifier --filter @librarian/mcp-server run build \
   && pnpm --filter @librarian/dashboard run build
 
 # ---------- runtime ----------

--- a/packages/classifier/package.json
+++ b/packages/classifier/package.json
@@ -1,42 +1,31 @@
 {
-  "name": "@librarian/mcp-server",
+  "name": "@librarian/classifier",
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "description": "stdio + HTTP MCP server plus tRPC admin API for The Librarian.",
+  "description": "Async memory classifier — decides `requires_approval` + `is_global` for new memories. Provider-pluggable (remote OpenAI-compatible today; local node-llama-cpp in Section 4b).",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
-    },
-    "./formatters": {
-      "types": "./dist/mcp/formatters.d.ts",
-      "import": "./dist/mcp/formatters.js"
     }
   },
   "scripts": {
     "prepare": "tsc -p tsconfig.json",
     "build": "tsc -p tsconfig.json",
-    "start": "node --no-warnings dist/bin/stdio.js",
-    "serve": "node --no-warnings dist/bin/http.js",
     "test:vitest": "vitest run",
     "test": "pnpm run build && pnpm run test:vitest",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@librarian/classifier": "workspace:*",
     "@librarian/core": "workspace:*",
-    "@trpc/server": "^11.17.0",
-    "pino": "^10.3.1",
-    "pino-pretty": "^13.1.3",
     "zod": "^4.0.1"
   },
   "devDependencies": {
     "@types/node": "^22.10.5",
     "typescript": "catalog:",
     "vitest": "catalog:"
-  },
-  "license": "Apache-2.0"
+  }
 }

--- a/packages/classifier/src/index.ts
+++ b/packages/classifier/src/index.ts
@@ -1,0 +1,25 @@
+// @librarian/classifier — async memory classifier.
+//
+// Public surface: `classify()` decides the two booleans
+// (`requires_approval`, `is_global`) the worker writes to a memory row.
+// In Section 4a the only working provider is `remote`; `local` lands
+// in 4b and `remember`-side wiring lands in 4d.
+
+export type {
+  ClassifyInput,
+  ClassifyResult,
+  ClassifierVerdict,
+  ClassifierFallbackReason,
+} from "./types.js";
+export { ClassifierVerdictSchema, CONSERVATIVE_DEFAULTS } from "./types.js";
+export { parseVerdict } from "./parse.js";
+export { renderPrompt, loadPromptTemplate } from "./prompt.js";
+export type {
+  Classifier,
+  ProviderConfig,
+  ClassifyOptions,
+  ClassifierFactoryDeps,
+} from "./providers/index.js";
+export { createClassifier } from "./providers/index.js";
+export type { RemoteClassifierConfig, RemoteClassifierDeps } from "./providers/remote.js";
+export { createRemoteClassifier } from "./providers/remote.js";

--- a/packages/classifier/src/parse.ts
+++ b/packages/classifier/src/parse.ts
@@ -1,0 +1,86 @@
+// Output parser — extracts the verdict from the model's raw text.
+//
+// Contract (spec §4.5):
+//   1. Trim to the last `{ ... }` block in the output (the model may
+//      emit a chain-of-thought preamble; we want the last JSON object).
+//   2. `JSON.parse` and validate against `ClassifierVerdictSchema`
+//      (exactly two boolean keys, no extras).
+//   3. Either return a clean verdict or null. Callers map null to the
+//      `fallback_used: "parse"` path.
+
+import { ClassifierVerdictSchema, type ClassifierVerdict } from "./types.js";
+
+/**
+ * Parse the model's raw text into a verdict, or null on any failure.
+ *
+ * Failure modes folded to null: no `{...}` block; malformed JSON; missing
+ * keys; extra keys; wrong types. The caller has no use for the failure
+ * reason beyond "did it parse?" — the fallback flag is uniformly `"parse"`.
+ */
+export function parseVerdict(text: string): ClassifierVerdict | null {
+  const last = lastJsonObject(text);
+  if (last === null) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(last);
+  } catch {
+    return null;
+  }
+  const result = ClassifierVerdictSchema.safeParse(parsed);
+  return result.success ? result.data : null;
+}
+
+/**
+ * Slice out the last balanced `{...}` from `text`. Walks the string
+ * right-to-left tracking brace depth; ignores braces inside strings.
+ *
+ * Returns the slice (including the outermost braces) or null when
+ * there's no balanced block. The "balanced" check matters when a model
+ * emits incomplete JSON during chain-of-thought — we only want a block
+ * we can actually parse.
+ */
+function lastJsonObject(text: string): string | null {
+  // Walk left-to-right and remember the most recent BALANCED top-level
+  // object's start+end. Cheaper than reversing the string and avoids
+  // JSON-inside-strings false positives because we track string state.
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  let topStart = -1;
+  let lastStart = -1;
+  let lastEnd = -1;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text.charCodeAt(i);
+    if (inString) {
+      if (escape) {
+        escape = false;
+      } else if (ch === 0x5c /* \ */) {
+        escape = true;
+      } else if (ch === 0x22 /* " */) {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === 0x22 /* " */) {
+      inString = true;
+      continue;
+    }
+    if (ch === 0x7b /* { */) {
+      if (depth === 0) topStart = i;
+      depth++;
+      continue;
+    }
+    if (ch === 0x7d /* } */) {
+      if (depth === 0) continue;
+      depth--;
+      if (depth === 0 && topStart >= 0) {
+        lastStart = topStart;
+        lastEnd = i;
+        topStart = -1;
+      }
+      continue;
+    }
+  }
+  if (lastStart < 0 || lastEnd < 0) return null;
+  return text.slice(lastStart, lastEnd + 1);
+}

--- a/packages/classifier/src/prompt.ts
+++ b/packages/classifier/src/prompt.ts
@@ -1,0 +1,33 @@
+// Prompt rendering — fills the `{{title}}` / `{{body}}` / `{{tags}}`
+// placeholders in the inlined v<N> template.
+//
+// The version string (e.g. `"v1"`) is the spec's identity per §4.4. The
+// English source of truth lives in `src/prompts/v<N>.md` for human
+// review; `src/prompts/v<N>.ts` is what compiles into the bundle.
+
+import { PROMPT_V1 } from "./prompts/v1.js";
+import type { ClassifyInput } from "./types.js";
+
+const TEMPLATES: Record<string, string> = {
+  v1: PROMPT_V1,
+};
+
+export function loadPromptTemplate(version: string): string {
+  const template = TEMPLATES[version];
+  if (template === undefined) {
+    throw new Error(`Unknown classifier prompt version: ${version}`);
+  }
+  return template;
+}
+
+/**
+ * Render the prompt template with the memory's fields substituted in.
+ * Tags are joined by `, ` for readability; the model isn't sensitive to
+ * the exact tag formatting at this template position.
+ */
+export function renderPrompt(template: string, input: ClassifyInput): string {
+  return template
+    .replace("{{title}}", input.title)
+    .replace("{{body}}", input.body)
+    .replace("{{tags}}", input.tags.join(", "));
+}

--- a/packages/classifier/src/prompts/v1.md
+++ b/packages/classifier/src/prompts/v1.md
@@ -1,0 +1,53 @@
+You classify durable memories for a personal memory store. For each
+memory, decide two booleans:
+
+- requires_approval: true if the memory contains identity facts,
+  relationship facts, or anything an owner would want to review
+  before it becomes active. False otherwise.
+- is_global: true if the memory should bypass per-conversation domain
+  filtering and be available everywhere (identity, relationships,
+  preferences). False if it's contextual to a specific domain (tools,
+  projects, lessons, environment).
+
+Think as long as you need. When ready, output a single line:
+{"requires_approval": <bool>, "is_global": <bool>}
+
+The parser reads only the last JSON object on stdout; reasoning before
+that line is ignored.
+
+Few-shot examples:
+
+TITLE: User's name is Jim
+BODY: User goes by Jim. Pronouns he/him.
+TAGS: identity
+{"requires_approval": true, "is_global": true}
+
+TITLE: Married to Sara
+BODY: Sara is Jim's wife. They live together in London.
+TAGS: relationship
+{"requires_approval": true, "is_global": true}
+
+TITLE: Prefers dark mode
+BODY: User keeps their editor and terminal in dark mode everywhere.
+TAGS: preference
+{"requires_approval": false, "is_global": true}
+
+TITLE: Project the-librarian uses pnpm
+BODY: The-librarian monorepo uses pnpm workspaces, not npm or yarn.
+TAGS: tooling, project:the-librarian
+{"requires_approval": false, "is_global": false}
+
+TITLE: Bug in dashboard auth flow on iOS Safari
+BODY: Login redirects loop on iOS Safari when localStorage is sandboxed; needs to fall back to sessionStorage.
+TAGS: bug, dashboard, ios-safari, project:the-librarian
+{"requires_approval": false, "is_global": false}
+
+TITLE: SSH key for prod box at ~/.ssh/prod_ed25519
+BODY: Production server SSH key lives at ~/.ssh/prod_ed25519. Passphrase in 1Password under "prod ssh".
+TAGS: secret, environment
+{"requires_approval": true, "is_global": false}
+
+Now classify:
+TITLE: {{title}}
+BODY: {{body}}
+TAGS: {{tags}}

--- a/packages/classifier/src/prompts/v1.ts
+++ b/packages/classifier/src/prompts/v1.ts
@@ -1,0 +1,64 @@
+// Prompt v1 — inlined as a TS const so the package ships with no asset-
+// copy build step. The source-of-truth English text is duplicated in
+// `src/prompts/v1.md` for human review / dashboard rendering; this
+// constant is the version compiled into the bundle.
+//
+// Any edit must change BOTH files (the .md is the diffable form for
+// reviewers; this is what runs). A future asset-bundling story can
+// collapse the duplication; for now the .md stays for spec §4.4
+// "the file path is the version identifier" intent.
+
+export const PROMPT_V1 = `You classify durable memories for a personal memory store. For each
+memory, decide two booleans:
+
+- requires_approval: true if the memory contains identity facts,
+  relationship facts, or anything an owner would want to review
+  before it becomes active. False otherwise.
+- is_global: true if the memory should bypass per-conversation domain
+  filtering and be available everywhere (identity, relationships,
+  preferences). False if it's contextual to a specific domain (tools,
+  projects, lessons, environment).
+
+Think as long as you need. When ready, output a single line:
+{"requires_approval": <bool>, "is_global": <bool>}
+
+The parser reads only the last JSON object on stdout; reasoning before
+that line is ignored.
+
+Few-shot examples:
+
+TITLE: User's name is Jim
+BODY: User goes by Jim. Pronouns he/him.
+TAGS: identity
+{"requires_approval": true, "is_global": true}
+
+TITLE: Married to Sara
+BODY: Sara is Jim's wife. They live together in London.
+TAGS: relationship
+{"requires_approval": true, "is_global": true}
+
+TITLE: Prefers dark mode
+BODY: User keeps their editor and terminal in dark mode everywhere.
+TAGS: preference
+{"requires_approval": false, "is_global": true}
+
+TITLE: Project the-librarian uses pnpm
+BODY: The-librarian monorepo uses pnpm workspaces, not npm or yarn.
+TAGS: tooling, project:the-librarian
+{"requires_approval": false, "is_global": false}
+
+TITLE: Bug in dashboard auth flow on iOS Safari
+BODY: Login redirects loop on iOS Safari when localStorage is sandboxed; needs to fall back to sessionStorage.
+TAGS: bug, dashboard, ios-safari, project:the-librarian
+{"requires_approval": false, "is_global": false}
+
+TITLE: SSH key for prod box at ~/.ssh/prod_ed25519
+BODY: Production server SSH key lives at ~/.ssh/prod_ed25519. Passphrase in 1Password under "prod ssh".
+TAGS: secret, environment
+{"requires_approval": true, "is_global": false}
+
+Now classify:
+TITLE: {{title}}
+BODY: {{body}}
+TAGS: {{tags}}
+`;

--- a/packages/classifier/src/providers/index.ts
+++ b/packages/classifier/src/providers/index.ts
@@ -1,0 +1,62 @@
+// Provider router — dispatches classify() to the configured provider.
+//
+// Section 4a ships the `remote` provider only. The `local` provider
+// (node-llama-cpp) lands in Section 4b. The router lives at this seam
+// so the worker code path is provider-agnostic from day one.
+
+import { CONSERVATIVE_DEFAULTS, type ClassifyInput, type ClassifyResult } from "../types.js";
+import {
+  createRemoteClassifier,
+  type RemoteClassifierConfig,
+  type RemoteClassifierDeps,
+} from "./remote.js";
+
+/**
+ * Provider config discriminated union. `provider === "local"` is
+ * declared here so the router types stay forward-compatible with
+ * Section 4b, but local config is unimplemented until then.
+ */
+export type ProviderConfig =
+  | (RemoteClassifierConfig & { provider: "remote" })
+  | { provider: "local"; modelId: string; promptVersion?: string };
+
+export interface ClassifyOptions {
+  /** Per-attempt timeout (ms). Defaults to 30s per spec §4.1. */
+  timeoutMs?: number;
+}
+
+/**
+ * Dependency-injectable factory: callers pass an LLM client (for
+ * `remote`) and a clock (for `latency_ms` measurement). Lets tests
+ * swap both without touching the network.
+ */
+export interface ClassifierFactoryDeps extends RemoteClassifierDeps {
+  now?: () => number;
+}
+
+export interface Classifier {
+  classify(input: ClassifyInput, opts?: ClassifyOptions): Promise<ClassifyResult>;
+}
+
+export function createClassifier(config: ProviderConfig, deps: ClassifierFactoryDeps): Classifier {
+  if (config.provider === "remote") {
+    return createRemoteClassifier(config, deps);
+  }
+  // Local provider lands in Section 4b. For now return a stub that
+  // produces a conservative-defaults verdict so callers can wire the
+  // worker without crashing during the 4a→4b interregnum.
+  return {
+    async classify() {
+      const now = deps.now ?? Date.now;
+      const start = now();
+      return {
+        verdict: { ...CONSERVATIVE_DEFAULTS },
+        fallback_used: "provider_unavailable",
+        prompt_version: config.promptVersion ?? "v1",
+        provider: "none",
+        model: config.modelId,
+        latency_ms: now() - start,
+      };
+    },
+  };
+}

--- a/packages/classifier/src/providers/index.ts
+++ b/packages/classifier/src/providers/index.ts
@@ -38,13 +38,32 @@ export interface Classifier {
   classify(input: ClassifyInput, opts?: ClassifyOptions): Promise<ClassifyResult>;
 }
 
+/**
+ * Opt-in flag for the `local` provider stub. The stub returns a
+ * `fallback_used: "provider_unavailable"` verdict on every call — useful
+ * for tests and for wiring during the 4a→4b interregnum, but a footgun
+ * in production (a misconfigured `provider: "local"` would silently
+ * classify every memory with conservative defaults rather than failing
+ * loud at startup). Production wiring should leave this flag unset
+ * until Section 4b lands the real implementation.
+ */
+export const LOCAL_STUB_FLAG = "LIBRARIAN_CLASSIFIER_LOCAL_STUB";
+
 export function createClassifier(config: ProviderConfig, deps: ClassifierFactoryDeps): Classifier {
   if (config.provider === "remote") {
     return createRemoteClassifier(config, deps);
   }
-  // Local provider lands in Section 4b. For now return a stub that
-  // produces a conservative-defaults verdict so callers can wire the
-  // worker without crashing during the 4a→4b interregnum.
+  // Local provider lands in Section 4b. Guard at construction so a
+  // misconfigured production install fails fast rather than silently
+  // serving conservative-defaults forever. Tests and the future
+  // worker-wiring code path opt in via `LIBRARIAN_CLASSIFIER_LOCAL_STUB`.
+  if (process.env[LOCAL_STUB_FLAG] !== "1") {
+    throw new Error(
+      `Local classifier provider is not yet implemented (Section 4b). ` +
+        `Configure provider: "remote" or set ${LOCAL_STUB_FLAG}=1 to use ` +
+        `the conservative-defaults stub during local development.`,
+    );
+  }
   return {
     async classify() {
       const now = deps.now ?? Date.now;
@@ -56,6 +75,7 @@ export function createClassifier(config: ProviderConfig, deps: ClassifierFactory
         provider: "none",
         model: config.modelId,
         latency_ms: now() - start,
+        raw_output: "",
       };
     },
   };

--- a/packages/classifier/src/providers/remote.ts
+++ b/packages/classifier/src/providers/remote.ts
@@ -1,0 +1,112 @@
+// Remote (OpenAI-compatible chat-completions) classifier provider.
+//
+// Reuses `@librarian/core/curator-llm-client`'s transport: bearer auth
+// stays out of error messages, AbortController for timeouts, fetch
+// injectable for tests. Per spec §4.2 the config namespace is
+// `classifier.remote.*` — distinct from the curator's; admins keep
+// them independently configurable.
+
+import { LlmClientError, type LlmClient, type LlmCompletion } from "@librarian/core";
+import { parseVerdict } from "../parse.js";
+import { loadPromptTemplate, renderPrompt } from "../prompt.js";
+import {
+  CONSERVATIVE_DEFAULTS,
+  type ClassifierFallbackReason,
+  type ClassifyInput,
+  type ClassifyResult,
+} from "../types.js";
+import type { Classifier, ClassifyOptions } from "./index.js";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_PROMPT_VERSION = "v1";
+
+export interface RemoteClassifierConfig {
+  /** Model id passed to the chat-completions API. */
+  modelId: string;
+  /** Prompt template version. Defaults to `"v1"`. */
+  promptVersion?: string;
+}
+
+export interface RemoteClassifierDeps {
+  /**
+   * LLM client built by the caller (typically with the same factory
+   * the memory curator uses). Tests pass a fake; the production wiring
+   * builds one from `LlmClientConfig`.
+   */
+  llm: LlmClient;
+  now?: () => number;
+}
+
+export function createRemoteClassifier(
+  config: RemoteClassifierConfig,
+  deps: RemoteClassifierDeps,
+): Classifier {
+  const now = deps.now ?? Date.now;
+  const promptVersion = config.promptVersion ?? DEFAULT_PROMPT_VERSION;
+  const template = loadPromptTemplate(promptVersion);
+
+  return {
+    async classify(input: ClassifyInput, opts: ClassifyOptions = {}): Promise<ClassifyResult> {
+      const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+      const start = now();
+      const userMessage = renderPrompt(template, input);
+
+      let completion: LlmCompletion;
+      try {
+        completion = await deps.llm.complete({
+          messages: [{ role: "user", content: userMessage }],
+          jsonResponse: true,
+          temperature: 0,
+          timeoutMs,
+        });
+      } catch (err) {
+        return fallback(start, err, promptVersion, config.modelId);
+      }
+
+      const verdict = parseVerdict(completion.content);
+      if (verdict === null) {
+        return {
+          verdict: { ...CONSERVATIVE_DEFAULTS },
+          fallback_used: "parse",
+          prompt_version: promptVersion,
+          provider: "remote",
+          model: completion.model || config.modelId,
+          latency_ms: now() - start,
+        };
+      }
+
+      return {
+        verdict,
+        prompt_version: promptVersion,
+        provider: "remote",
+        model: completion.model || config.modelId,
+        latency_ms: now() - start,
+      };
+    },
+  };
+
+  function fallback(
+    start: number,
+    err: unknown,
+    promptVersionUsed: string,
+    modelUsed: string,
+  ): ClassifyResult {
+    const reason = mapErrorToFallback(err);
+    return {
+      verdict: { ...CONSERVATIVE_DEFAULTS },
+      fallback_used: reason,
+      prompt_version: promptVersionUsed,
+      provider: "remote",
+      model: modelUsed,
+      latency_ms: now() - start,
+    };
+  }
+}
+
+function mapErrorToFallback(err: unknown): ClassifierFallbackReason {
+  if (err instanceof LlmClientError) {
+    if (err.kind === "timeout") return "timeout";
+    return "provider_unavailable";
+  }
+  return "provider_unavailable";
+}

--- a/packages/classifier/src/providers/remote.ts
+++ b/packages/classifier/src/providers/remote.ts
@@ -72,6 +72,7 @@ export function createRemoteClassifier(
           provider: "remote",
           model: completion.model || config.modelId,
           latency_ms: now() - start,
+          raw_output: completion.content,
         };
       }
 
@@ -81,6 +82,7 @@ export function createRemoteClassifier(
         provider: "remote",
         model: completion.model || config.modelId,
         latency_ms: now() - start,
+        raw_output: completion.content,
       };
     },
   };
@@ -99,6 +101,9 @@ export function createRemoteClassifier(
       provider: "remote",
       model: modelUsed,
       latency_ms: now() - start,
+      // No model output reached us — provider error / timeout fired
+      // before any response body was buffered.
+      raw_output: "",
     };
   }
 }

--- a/packages/classifier/src/types.ts
+++ b/packages/classifier/src/types.ts
@@ -1,0 +1,71 @@
+// Classifier types — input to classify(), the verdict, and the
+// fallback taxonomy. See docs/specs/classifier-implementation-spec.md
+// §4.1 (state machine), §4.5 (output schema), §4.8 (event shape).
+
+import { z } from "zod";
+
+/** Minimal memory shape the classifier needs. Title + body + tags. */
+export interface ClassifyInput {
+  title: string;
+  body: string;
+  tags: readonly string[];
+}
+
+/**
+ * The two booleans the classifier decides for every memory.
+ *
+ * - `requires_approval` — true when the memory contains identity /
+ *   relationship facts or anything an owner would want to review
+ *   before it becomes active.
+ * - `is_global` — true when the memory should bypass per-conversation
+ *   domain filtering and be available everywhere.
+ */
+export const ClassifierVerdictSchema = z
+  .strictObject({
+    requires_approval: z.boolean(),
+    is_global: z.boolean(),
+  })
+  .strict();
+
+export type ClassifierVerdict = z.infer<typeof ClassifierVerdictSchema>;
+
+/**
+ * Why a verdict was conservative-default rather than model-driven.
+ * Recorded on the `memory.classified` event so the eval harness can
+ * exclude these from agreement scoring (§4.8).
+ */
+export type ClassifierFallbackReason =
+  | "parse" // Model output couldn't be parsed against the schema.
+  | "provider_unavailable" // Provider returned a non-2xx status or refused.
+  | "timeout" // Per-attempt timeout elapsed.
+  | "max_retries"; // Worker gave up after 3 failed attempts.
+
+/**
+ * The full result of one classify() call. `verdict` is always present
+ * (conservative defaults applied on every failure path); `fallback_used`
+ * is set only when those defaults were imposed by the classifier rather
+ * than chosen by the model.
+ */
+export interface ClassifyResult {
+  verdict: ClassifierVerdict;
+  /** Set when the verdict came from a fallback path rather than the model. */
+  fallback_used?: ClassifierFallbackReason;
+  /** Prompt version that produced the verdict (e.g. `"v1"`). */
+  prompt_version: string;
+  /** Provider that was asked. `"none"` when fallback fired before dispatch. */
+  provider: "local" | "remote" | "none";
+  /** Model id reported by the provider (or the configured id when not). */
+  model: string;
+  /** End-to-end wall-clock latency in ms. */
+  latency_ms: number;
+}
+
+/**
+ * The conservative-default verdict applied on every fallback path.
+ * Owner-safe (nothing leaks globally; everything routes through the
+ * proposal queue). See spec §4.1's "conservative defaults" definition.
+ */
+export const CONSERVATIVE_DEFAULTS: Readonly<ClassifierVerdict> = Object.freeze({
+  requires_approval: true,
+  is_global: false,
+});

--- a/packages/classifier/src/types.ts
+++ b/packages/classifier/src/types.ts
@@ -45,6 +45,11 @@ export type ClassifierFallbackReason =
  * (conservative defaults applied on every failure path); `fallback_used`
  * is set only when those defaults were imposed by the classifier rather
  * than chosen by the model.
+ *
+ * `raw_output` is the model's literal text — preserved verbatim so the
+ * eval harness (Section 4c) can replay parse failures and score prompt
+ * regressions. It's the empty string when fallback fired before any
+ * model output was produced (network error, timeout, local-stub path).
  */
 export interface ClassifyResult {
   verdict: ClassifierVerdict;
@@ -58,6 +63,12 @@ export interface ClassifyResult {
   model: string;
   /** End-to-end wall-clock latency in ms. */
   latency_ms: number;
+  /**
+   * The raw text returned by the model (`""` when no model output was
+   * produced — network error, timeout, local-stub path). Captured so
+   * the eval harness can diff parse failures and prompt regressions.
+   */
+  raw_output: string;
 }
 
 /**

--- a/packages/classifier/tests/parse.test.ts
+++ b/packages/classifier/tests/parse.test.ts
@@ -1,0 +1,69 @@
+// Parser tests — the last balanced `{...}` block, schema-validated,
+// folds every failure mode to null. Spec §4.5.
+
+import { describe, expect, it } from "vitest";
+import { parseVerdict } from "../src/parse.js";
+
+describe("parseVerdict", () => {
+  it("parses a bare JSON object", () => {
+    expect(parseVerdict('{"requires_approval": true, "is_global": false}')).toEqual({
+      requires_approval: true,
+      is_global: false,
+    });
+  });
+
+  it("ignores a chain-of-thought preamble and reads the last object", () => {
+    const text = [
+      "Let me think about this. The memory mentions a person's name, so",
+      "this is an identity fact and likely needs review.",
+      "",
+      "Actually it could just be metadata. Hmm.",
+      "",
+      '{"requires_approval": true, "is_global": true}',
+    ].join("\n");
+    expect(parseVerdict(text)).toEqual({ requires_approval: true, is_global: true });
+  });
+
+  it("when multiple JSON objects appear, the LAST balanced one wins", () => {
+    const text = [
+      '{"draft": "true", "is_global": false}', // earlier object, ignored
+      "",
+      '{"requires_approval": false, "is_global": true}',
+    ].join("\n");
+    expect(parseVerdict(text)).toEqual({ requires_approval: false, is_global: true });
+  });
+
+  it("ignores braces inside strings", () => {
+    const text = [
+      `Note that "{" is not a JSON object on its own.`,
+      `{"requires_approval": false, "is_global": false}`,
+    ].join("\n");
+    expect(parseVerdict(text)).toEqual({ requires_approval: false, is_global: false });
+  });
+
+  it("returns null on no JSON object", () => {
+    expect(parseVerdict("just prose, no braces here")).toBeNull();
+  });
+
+  it("returns null on malformed JSON", () => {
+    expect(parseVerdict("{requires_approval: true is_global: false}")).toBeNull();
+  });
+
+  it("returns null when keys are missing", () => {
+    expect(parseVerdict('{"requires_approval": true}')).toBeNull();
+  });
+
+  it("returns null when extra keys are present (strict schema)", () => {
+    expect(
+      parseVerdict('{"requires_approval": true, "is_global": false, "confidence": 0.9}'),
+    ).toBeNull();
+  });
+
+  it("returns null when types are wrong", () => {
+    expect(parseVerdict('{"requires_approval": "yes", "is_global": "no"}')).toBeNull();
+  });
+
+  it("returns null on an unbalanced brace (incomplete CoT mid-stream)", () => {
+    expect(parseVerdict('reasoning... {"requires_approval": tru')).toBeNull();
+  });
+});

--- a/packages/classifier/tests/prompt.test.ts
+++ b/packages/classifier/tests/prompt.test.ts
@@ -1,0 +1,48 @@
+// Prompt template tests — render fills the three placeholders with
+// the input fields verbatim. The template file itself is the spec's
+// version sentinel (§4.4).
+
+import { describe, expect, it } from "vitest";
+import { loadPromptTemplate, renderPrompt } from "../src/prompt.js";
+
+describe("loadPromptTemplate", () => {
+  it("loads v1 and includes the structured-output instruction", () => {
+    const template = loadPromptTemplate("v1");
+    expect(template).toContain("{{title}}");
+    expect(template).toContain("{{body}}");
+    expect(template).toContain("{{tags}}");
+    expect(template).toContain("requires_approval");
+    expect(template).toContain("is_global");
+  });
+
+  it("returns the same template across repeated reads", () => {
+    expect(loadPromptTemplate("v1")).toBe(loadPromptTemplate("v1"));
+  });
+
+  it("throws on an unknown version", () => {
+    expect(() => loadPromptTemplate("vNEVER")).toThrow(/unknown classifier prompt version/i);
+  });
+});
+
+describe("renderPrompt", () => {
+  it("substitutes all three placeholders", () => {
+    const template = loadPromptTemplate("v1");
+    const rendered = renderPrompt(template, {
+      title: "Test title",
+      body: "Test body",
+      tags: ["tag1", "tag2"],
+    });
+    expect(rendered).toContain("TITLE: Test title");
+    expect(rendered).toContain("BODY: Test body");
+    expect(rendered).toContain("TAGS: tag1, tag2");
+    expect(rendered).not.toContain("{{title}}");
+    expect(rendered).not.toContain("{{body}}");
+    expect(rendered).not.toContain("{{tags}}");
+  });
+
+  it("renders an empty tag list as the empty string", () => {
+    const template = loadPromptTemplate("v1");
+    const rendered = renderPrompt(template, { title: "x", body: "y", tags: [] });
+    expect(rendered).toContain("TAGS: \n");
+  });
+});

--- a/packages/classifier/tests/providers-remote.test.ts
+++ b/packages/classifier/tests/providers-remote.test.ts
@@ -1,0 +1,170 @@
+// Remote-provider classify() tests — every error path collapses to a
+// conservative-defaults verdict with a fallback_used flag. The LLM
+// client is mocked end-to-end; no network.
+
+import { LlmClientError, type LlmClient, type LlmCompletion } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+import { createClassifier } from "../src/providers/index.js";
+
+function fakeLlm(
+  impl: (req: {
+    messages: { role: string; content: string }[];
+    timeoutMs?: number;
+  }) => Promise<LlmCompletion>,
+): LlmClient {
+  return {
+    complete: impl as LlmClient["complete"],
+  };
+}
+
+const INPUT = {
+  title: "User's name is Jim",
+  body: "User goes by Jim.",
+  tags: ["identity"],
+};
+
+let clockMs = 1_000;
+function fakeNow(): number {
+  clockMs += 7;
+  return clockMs;
+}
+
+describe("createClassifier — remote", () => {
+  it("classifies a valid JSON-line response", async () => {
+    const classifier = createClassifier(
+      { provider: "remote", modelId: "gpt-4o-mini" },
+      {
+        llm: fakeLlm(async (req) => {
+          // The prompt sends the rendered template as a user message.
+          expect(req.messages[0]?.role).toBe("user");
+          expect(req.messages[0]?.content).toContain("TITLE: User's name is Jim");
+          return {
+            content: '{"requires_approval": true, "is_global": true}',
+            model: "gpt-4o-mini",
+            usage: null,
+          };
+        }),
+        now: fakeNow,
+      },
+    );
+    const result = await classifier.classify(INPUT);
+    expect(result.verdict).toEqual({ requires_approval: true, is_global: true });
+    expect(result.fallback_used).toBeUndefined();
+    expect(result.provider).toBe("remote");
+    expect(result.model).toBe("gpt-4o-mini");
+    expect(result.prompt_version).toBe("v1");
+    expect(result.latency_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it("strips a CoT preamble and reads the last object", async () => {
+    const classifier = createClassifier(
+      { provider: "remote", modelId: "gpt-4o-mini" },
+      {
+        llm: fakeLlm(async () => ({
+          content: 'Reasoning: this is identity.\n\n{"requires_approval": true, "is_global": true}',
+          model: "gpt-4o-mini",
+          usage: null,
+        })),
+        now: fakeNow,
+      },
+    );
+    const result = await classifier.classify(INPUT);
+    expect(result.verdict).toEqual({ requires_approval: true, is_global: true });
+    expect(result.fallback_used).toBeUndefined();
+  });
+
+  it("falls back to conservative defaults with fallback_used='parse' on malformed JSON", async () => {
+    const classifier = createClassifier(
+      { provider: "remote", modelId: "gpt-4o-mini" },
+      {
+        llm: fakeLlm(async () => ({
+          content: "I'm sorry, I cannot classify this.",
+          model: "gpt-4o-mini",
+          usage: null,
+        })),
+        now: fakeNow,
+      },
+    );
+    const result = await classifier.classify(INPUT);
+    expect(result.verdict).toEqual({ requires_approval: true, is_global: false });
+    expect(result.fallback_used).toBe("parse");
+    expect(result.provider).toBe("remote");
+  });
+
+  it("maps LlmClientError(kind=timeout) to fallback_used='timeout'", async () => {
+    const classifier = createClassifier(
+      { provider: "remote", modelId: "gpt-4o-mini" },
+      {
+        llm: fakeLlm(async () => {
+          throw new LlmClientError("timeout", "request timed out after 30000ms");
+        }),
+        now: fakeNow,
+      },
+    );
+    const result = await classifier.classify(INPUT);
+    expect(result.verdict).toEqual({ requires_approval: true, is_global: false });
+    expect(result.fallback_used).toBe("timeout");
+  });
+
+  it("maps LlmClientError(kind=http) to fallback_used='provider_unavailable'", async () => {
+    const classifier = createClassifier(
+      { provider: "remote", modelId: "gpt-4o-mini" },
+      {
+        llm: fakeLlm(async () => {
+          throw new LlmClientError("http", "HTTP 500", 500);
+        }),
+        now: fakeNow,
+      },
+    );
+    const result = await classifier.classify(INPUT);
+    expect(result.verdict).toEqual({ requires_approval: true, is_global: false });
+    expect(result.fallback_used).toBe("provider_unavailable");
+  });
+
+  it("maps an unexpected throw to fallback_used='provider_unavailable'", async () => {
+    const classifier = createClassifier(
+      { provider: "remote", modelId: "gpt-4o-mini" },
+      {
+        llm: fakeLlm(async () => {
+          throw new Error("surprise");
+        }),
+        now: fakeNow,
+      },
+    );
+    const result = await classifier.classify(INPUT);
+    expect(result.fallback_used).toBe("provider_unavailable");
+  });
+
+  it("propagates the requested timeoutMs to the LLM client", async () => {
+    let receivedTimeout: number | undefined;
+    const classifier = createClassifier(
+      { provider: "remote", modelId: "gpt-4o-mini" },
+      {
+        llm: fakeLlm(async (req) => {
+          receivedTimeout = req.timeoutMs;
+          return {
+            content: '{"requires_approval": false, "is_global": false}',
+            model: "gpt-4o-mini",
+            usage: null,
+          };
+        }),
+        now: fakeNow,
+      },
+    );
+    await classifier.classify(INPUT, { timeoutMs: 5000 });
+    expect(receivedTimeout).toBe(5000);
+  });
+});
+
+describe("createClassifier — local stub (until 4b)", () => {
+  it("returns a provider_unavailable fallback so callers don't crash", async () => {
+    const classifier = createClassifier(
+      { provider: "local", modelId: "LFM2.5-1.2B-Instruct" },
+      { llm: fakeLlm(async () => ({ content: "", model: "", usage: null })), now: fakeNow },
+    );
+    const result = await classifier.classify(INPUT);
+    expect(result.verdict).toEqual({ requires_approval: true, is_global: false });
+    expect(result.fallback_used).toBe("provider_unavailable");
+    expect(result.provider).toBe("none");
+  });
+});

--- a/packages/classifier/tests/providers-remote.test.ts
+++ b/packages/classifier/tests/providers-remote.test.ts
@@ -3,8 +3,8 @@
 // client is mocked end-to-end; no network.
 
 import { LlmClientError, type LlmClient, type LlmCompletion } from "@librarian/core";
-import { describe, expect, it } from "vitest";
-import { createClassifier } from "../src/providers/index.js";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createClassifier, LOCAL_STUB_FLAG } from "../src/providers/index.js";
 
 function fakeLlm(
   impl: (req: {
@@ -54,6 +54,7 @@ describe("createClassifier — remote", () => {
     expect(result.model).toBe("gpt-4o-mini");
     expect(result.prompt_version).toBe("v1");
     expect(result.latency_ms).toBeGreaterThanOrEqual(0);
+    expect(result.raw_output).toBe('{"requires_approval": true, "is_global": true}');
   });
 
   it("strips a CoT preamble and reads the last object", async () => {
@@ -157,6 +158,15 @@ describe("createClassifier — remote", () => {
 });
 
 describe("createClassifier — local stub (until 4b)", () => {
+  const originalFlag = process.env[LOCAL_STUB_FLAG];
+  beforeEach(() => {
+    process.env[LOCAL_STUB_FLAG] = "1";
+  });
+  afterEach(() => {
+    if (originalFlag === undefined) delete process.env[LOCAL_STUB_FLAG];
+    else process.env[LOCAL_STUB_FLAG] = originalFlag;
+  });
+
   it("returns a provider_unavailable fallback so callers don't crash", async () => {
     const classifier = createClassifier(
       { provider: "local", modelId: "LFM2.5-1.2B-Instruct" },
@@ -166,5 +176,16 @@ describe("createClassifier — local stub (until 4b)", () => {
     expect(result.verdict).toEqual({ requires_approval: true, is_global: false });
     expect(result.fallback_used).toBe("provider_unavailable");
     expect(result.provider).toBe("none");
+    expect(result.raw_output).toBe("");
+  });
+
+  it("throws at construction when LIBRARIAN_CLASSIFIER_LOCAL_STUB is not set", () => {
+    delete process.env[LOCAL_STUB_FLAG];
+    expect(() =>
+      createClassifier(
+        { provider: "local", modelId: "LFM2.5-1.2B-Instruct" },
+        { llm: fakeLlm(async () => ({ content: "", model: "", usage: null })), now: fakeNow },
+      ),
+    ).toThrow(/local classifier provider is not yet implemented/i);
   });
 });

--- a/packages/classifier/tsconfig.json
+++ b/packages/classifier/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules", "tests"]
+}

--- a/packages/classifier/vitest.config.ts
+++ b/packages/classifier/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+    passWithNoTests: true,
+    // The classifier imports `@librarian/core`, which transitively touches
+    // `node:sqlite` — Vite's SSR transformer drops the `node:` prefix when
+    // resolving Node built-ins and fails. Externalising the core package
+    // sends those imports through Node's own loader instead.
+    server: {
+      deps: {
+        external: [/\/packages\/core\/(src|dist)\//],
+      },
+    },
+  },
+});

--- a/packages/core/src/schemas/common.ts
+++ b/packages/core/src/schemas/common.ts
@@ -151,6 +151,11 @@ export enum MemoryEventType {
   BulkUpdated = "memory.bulk_updated",
   ConflictDetected = "memory.conflict_detected",
   ConflictResolved = "memory.conflict_resolved",
+  // classifier-implementation Section 4a — emitted by the classifier
+  // worker for every classification attempt (success, parse failure,
+  // provider error, or max-retries giveup). The eval harness reads
+  // these to drive agreement-rate reports. See spec §4.8.
+  Classified = "memory.classified",
 }
 export const MemoryEventTypeSchema = z.enum(MemoryEventType);
 

--- a/packages/core/src/schemas/events.ts
+++ b/packages/core/src/schemas/events.ts
@@ -166,6 +166,49 @@ export const MemoryConflictResolvedEventSchema = MemoryEventBaseSchema.extend({
   }),
 });
 
+// classifier-implementation §4.8. Emitted once per classification attempt
+// by the async worker — every success, parse failure, provider error, and
+// max-retries giveup. `raw_output` is the eval substrate (kept indefinitely);
+// `parsed` is the verdict (null on parse failure); `fallback_used` is set
+// when conservative defaults were imposed by the classifier rather than
+// chosen by the model. `attempt_number` is 1-indexed and aligns with the
+// `classification_attempts` counter on the memories row after the increment.
+export const MemoryClassifiedEventSchema = MemoryEventBaseSchema.extend({
+  event_type: z.literal(MemoryEventType.Classified),
+  payload: z.object({
+    memory_id: IdSchema,
+    agent_id: z.string(),
+    input: z.object({
+      title: z.string(),
+      body: z.string(),
+      tags: z.array(z.string()),
+    }),
+    provider: z.enum(["local", "remote", "none"]),
+    model: z.string(),
+    model_quant: z.string().nullable().optional(),
+    prompt_version: z.string(),
+    raw_output: z.string(),
+    parsed: z
+      .strictObject({
+        requires_approval: z.boolean(),
+        is_global: z.boolean(),
+      })
+      .nullable(),
+    fallback_used: z
+      .union([
+        z.literal(false),
+        z.literal("timeout"),
+        z.literal("parse"),
+        z.literal("provider_unavailable"),
+        z.literal("max_retries"),
+      ])
+      .optional(),
+    queue_wait_ms: z.number().int().nonnegative(),
+    inference_ms: z.number().int().nonnegative(),
+    attempt_number: z.number().int().positive(),
+  }),
+});
+
 export const MemoryLedgerEntrySchema = z.discriminatedUnion("event_type", [
   MemoryCreatedEventSchema,
   MemoryProposedEventSchema,
@@ -181,6 +224,7 @@ export const MemoryLedgerEntrySchema = z.discriminatedUnion("event_type", [
   MemoryBulkUpdatedEventSchema,
   MemoryConflictDetectedEventSchema,
   MemoryConflictResolvedEventSchema,
+  MemoryClassifiedEventSchema,
 ]);
 export type MemoryLedgerEntry = z.infer<typeof MemoryLedgerEntrySchema>;
 

--- a/packages/core/src/store/projection.ts
+++ b/packages/core/src/store/projection.ts
@@ -112,7 +112,17 @@ function asArray(value: unknown): string[] {
 //         time. Memories is JSONL-canonical so the bump drops + rebuilds
 //         the table from the ledger; the default 'general' still applies
 //         to writes that omit the column.
-export const PROJECTION_SCHEMA_VERSION = 14;
+//   - 15: classifier-implementation Section 4a / Task 4.4 — adds
+//         `classified` and `classification_attempts` to `memories`. Both
+//         default to 0 and are written by the future classifier worker
+//         (Section 4d wires it; 4a/4b/4c land the machinery without
+//         flipping the bit). Memories is JSONL-canonical so the bump
+//         drops + rebuilds and the defaults apply to every existing row.
+//         The INSERT in `rebuildMemoryIndex` omits both columns so the
+//         defaults take effect for existing memories on bump; new
+//         memories written through `createMemory` likewise inherit the
+//         defaults until the worker writes a verdict.
+export const PROJECTION_SCHEMA_VERSION = 15;
 
 export function getSchemaVersion(db: DatabaseSync): number {
   const row = db.prepare("PRAGMA user_version").get() as { user_version: number };
@@ -245,7 +255,9 @@ export const SCHEMA_DDL = `
       curator_note TEXT,
       domain TEXT DEFAULT 'general',
       is_global INTEGER NOT NULL DEFAULT 0,
-      requires_approval INTEGER NOT NULL DEFAULT 0
+      requires_approval INTEGER NOT NULL DEFAULT 0,
+      classified INTEGER NOT NULL DEFAULT 0,
+      classification_attempts INTEGER NOT NULL DEFAULT 0
     );
     CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
       id UNINDEXED,

--- a/packages/core/tests/store/projection.test.ts
+++ b/packages/core/tests/store/projection.test.ts
@@ -455,6 +455,37 @@ describe("Domain columns on memories + sessions (T1.2)", () => {
     }
   });
 
+  it("creates memories with classified/classification_attempts columns on first open (Section 4a)", () => {
+    const store = createLibrarianStore({ dataDir });
+    try {
+      expect(columnExists(store, "memories", "classified")).toBe(true);
+      expect(columnExists(store, "memories", "classification_attempts")).toBe(true);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("defaults a newly created memory to classified=0, classification_attempts=0", () => {
+    const store = createLibrarianStore({ dataDir });
+    try {
+      const { memory } = store.createMemory({
+        agent_id: "codex",
+        title: "Default classification test",
+        body: "A memory written before the classifier worker exists.",
+        category: "tools",
+        visibility: "common",
+        scope: "tool",
+      });
+      const row = store.db
+        .prepare("SELECT classified, classification_attempts FROM memories WHERE id = ?")
+        .get(memory.id) as { classified: number; classification_attempts: number };
+      expect(row.classified).toBe(0);
+      expect(row.classification_attempts).toBe(0);
+    } finally {
+      store.close();
+    }
+  });
+
   it("creates sessions with a domain column on first open", () => {
     const store = createLibrarianStore({ dataDir });
     try {

--- a/packages/mcp-server/src/classifier-worker.ts
+++ b/packages/mcp-server/src/classifier-worker.ts
@@ -1,0 +1,343 @@
+// Async classifier worker — drains the `classified = 0` projection
+// queue. Single instance per mcp-server process; spec §4.1 + plan
+// Task 4.5.
+//
+// Section 4a ships the worker module + tests but does NOT wire it into
+// the mcp-server startup (the runtime stays inert until 4d). Existing
+// memories continue to land via the legacy `deriveLegacyMemoryFlags`
+// path; no code path writes `classified = 0` yet, so the worker has
+// nothing to do in production until the cutover ships.
+//
+// State machine per row (spec §4.1):
+//
+//   classified=0           classifier ok?              attempts ≥ 3?
+//   attempts=0          ─ yes ──▶ classified=1     ─ yes ──▶ classified=1
+//   (row written)                  + verdict booleans          + conservative
+//                                  + memory.classified         + memory.classified
+//                       ─ no  ──▶ attempts++                   + fallback=max_retries
+//                                  classified=0
+//
+// A crash mid-classification leaves the row at `classified=0` for the
+// next iteration (no partial state to repair — the verdict is only
+// written on success, the attempt counter is only incremented on a
+// caught failure).
+
+import type { DatabaseSync } from "node:sqlite";
+import type { Classifier, ClassifyResult, ClassifierFallbackReason } from "@librarian/classifier";
+import { CONSERVATIVE_DEFAULTS } from "@librarian/classifier";
+
+/** Conservative-default attempts cap — spec §4.1. */
+export const MAX_ATTEMPTS = 3;
+
+/** Idle poll cadence in ms — spec §4.1 worker pacing. */
+export const IDLE_POLL_MS = 500;
+
+/** Result of one drain iteration. */
+export type ProcessOutcome =
+  | "processed"
+  | "max_retries_giveup"
+  | "attempt_failed"
+  | "idle"
+  | "error";
+
+interface MemoryRow {
+  id: string;
+  title: string;
+  body: string;
+  tags_json: string;
+  agent_id: string | null;
+  classification_attempts: number;
+  created_at: string;
+}
+
+export interface ClassifierWorkerDeps {
+  /** SQLite handle (the same connection the projection writes through). */
+  db: DatabaseSync;
+  classifier: Classifier;
+  /** Emit a memory ledger event (the wider store's `appendEvent`). */
+  appendEvent: (
+    eventType: string,
+    payload: Record<string, unknown>,
+    options?: { memory_id?: string; agent_id?: string },
+  ) => void;
+  /** Optional sidecar logger. Stays silent when omitted. */
+  log?: (entry: Record<string, unknown>) => void;
+  /** Optional clock seam for queue-wait measurement. Defaults to Date.now. */
+  now?: () => number;
+  /**
+   * Optional setTimeout seam — tests pass a deterministic scheduler.
+   * Defaults to the real `setTimeout`.
+   */
+  setTimeoutFn?: (handler: () => void, ms: number) => unknown;
+  clearTimeoutFn?: (handle: unknown) => void;
+}
+
+export interface ClassifierWorker {
+  /** Process at most one row; returns the outcome for that row. */
+  processOnce(): Promise<ProcessOutcome>;
+  /**
+   * Start the polling loop. Resolves immediately; the loop runs in
+   * the background until `stop()` is called.
+   */
+  start(): void;
+  /** Stop the polling loop. Resolves once any in-flight iteration ends. */
+  stop(): Promise<void>;
+  /** True while `start()` has been called and `stop()` has not yet resolved. */
+  readonly running: boolean;
+}
+
+export function createClassifierWorker(deps: ClassifierWorkerDeps): ClassifierWorker {
+  const now = deps.now ?? Date.now;
+  const setTimeoutFn = deps.setTimeoutFn ?? ((h, ms) => setTimeout(h, ms));
+  const clearTimeoutFn =
+    deps.clearTimeoutFn ?? ((h) => clearTimeout(h as ReturnType<typeof setTimeout>));
+
+  let running = false;
+  let stopping: Promise<void> | null = null;
+  let resolveStop: (() => void) | null = null;
+  let scheduledHandle: unknown = null;
+
+  const selectStmt = deps.db.prepare(
+    "SELECT id, title, body, tags_json, agent_id, classification_attempts, created_at " +
+      "FROM memories WHERE classified = 0 ORDER BY created_at LIMIT 1",
+  );
+  const incrementStmt = deps.db.prepare(
+    "UPDATE memories SET classification_attempts = classification_attempts + 1 WHERE id = ?",
+  );
+  const writeVerdictStmt = deps.db.prepare(
+    "UPDATE memories SET classified = 1, is_global = ?, requires_approval = ? WHERE id = ?",
+  );
+
+  async function processOnce(): Promise<ProcessOutcome> {
+    const row = selectStmt.get() as MemoryRow | undefined;
+    if (!row) return "idle";
+
+    const queueStart = parseTimestamp(row.created_at);
+    const beforeClassify = now();
+    const tags = parseTags(row.tags_json);
+
+    let result: ClassifyResult;
+    try {
+      result = await deps.classifier.classify({
+        title: row.title,
+        body: row.body,
+        tags,
+      });
+    } catch (err) {
+      // The classifier contract is fail-soft (every error path collapses
+      // to a `fallback_used` verdict), so we should never get here —
+      // but if a custom Classifier impl breaks the contract, do the
+      // safe thing: count as a failed attempt and let the retry cap
+      // catch it.
+      incrementStmt.run(row.id);
+      const attempts = row.classification_attempts + 1;
+      deps.log?.({
+        event: "classifier-worker",
+        outcome: "classify_threw",
+        memory_id: row.id,
+        attempts,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      if (attempts >= MAX_ATTEMPTS) {
+        giveUp(row, queueStart, beforeClassify, attempts, tags, "(threw)");
+        return "max_retries_giveup";
+      }
+      return "attempt_failed";
+    }
+
+    const inferenceMs = Math.max(0, now() - beforeClassify);
+    const queueWaitMs = isFinite(queueStart) ? Math.max(0, beforeClassify - queueStart) : 0;
+
+    if (result.fallback_used) {
+      // A fallback verdict means the model failed (parse / timeout /
+      // provider error). Count the attempt and decide whether to give up.
+      incrementStmt.run(row.id);
+      const attempts = row.classification_attempts + 1;
+      if (attempts >= MAX_ATTEMPTS) {
+        finalize(row, {
+          verdict: CONSERVATIVE_DEFAULTS,
+          fallback_used: "max_retries",
+          provider: result.provider,
+          model: result.model,
+          prompt_version: result.prompt_version,
+          rawOutput: "",
+          parsed: null,
+          inferenceMs,
+          queueWaitMs,
+          attemptNumber: attempts,
+          tags,
+        });
+        return "max_retries_giveup";
+      }
+      // Keep the row at classified=0 for the next iteration.
+      deps.log?.({
+        event: "classifier-worker",
+        outcome: "attempt_failed",
+        memory_id: row.id,
+        attempts,
+        fallback_used: result.fallback_used,
+      });
+      return "attempt_failed";
+    }
+
+    // Success: write the verdict + emit the event.
+    finalize(row, {
+      verdict: result.verdict,
+      fallback_used: false,
+      provider: result.provider,
+      model: result.model,
+      prompt_version: result.prompt_version,
+      rawOutput: "",
+      parsed: result.verdict,
+      inferenceMs,
+      queueWaitMs,
+      attemptNumber: row.classification_attempts + 1,
+      tags,
+    });
+    return "processed";
+  }
+
+  function start(): void {
+    if (running) return;
+    running = true;
+    stopping = new Promise<void>((resolve) => {
+      resolveStop = resolve;
+    });
+    void schedule(0);
+  }
+
+  async function stop(): Promise<void> {
+    if (!running) return;
+    running = false;
+    if (scheduledHandle !== null) {
+      clearTimeoutFn(scheduledHandle);
+      scheduledHandle = null;
+    }
+    if (stopping) {
+      const promise = stopping;
+      // If no iteration is in flight, resolve immediately.
+      resolveStop?.();
+      resolveStop = null;
+      stopping = null;
+      await promise;
+    }
+  }
+
+  async function tick(): Promise<void> {
+    if (!running) return;
+    let outcome: ProcessOutcome = "idle";
+    try {
+      outcome = await processOnce();
+    } catch (err) {
+      deps.log?.({
+        event: "classifier-worker",
+        outcome: "tick_threw",
+        error: err instanceof Error ? err.message : String(err),
+      });
+      outcome = "error";
+    }
+    if (!running) {
+      resolveStop?.();
+      resolveStop = null;
+      return;
+    }
+    // Busy: process the next row immediately. Idle/error: back off.
+    const delay = outcome === "idle" || outcome === "error" ? IDLE_POLL_MS : 0;
+    void schedule(delay);
+  }
+
+  function schedule(ms: number): void {
+    if (!running) return;
+    scheduledHandle = setTimeoutFn(() => {
+      scheduledHandle = null;
+      void tick();
+    }, ms);
+  }
+
+  function finalize(
+    row: MemoryRow,
+    args: {
+      verdict: { requires_approval: boolean; is_global: boolean };
+      fallback_used: false | ClassifierFallbackReason;
+      provider: "local" | "remote" | "none";
+      model: string;
+      prompt_version: string;
+      rawOutput: string;
+      parsed: { requires_approval: boolean; is_global: boolean } | null;
+      inferenceMs: number;
+      queueWaitMs: number;
+      attemptNumber: number;
+      tags: string[];
+    },
+  ): void {
+    writeVerdictStmt.run(
+      args.verdict.is_global ? 1 : 0,
+      args.verdict.requires_approval ? 1 : 0,
+      row.id,
+    );
+    const payload: Record<string, unknown> = {
+      memory_id: row.id,
+      agent_id: row.agent_id ?? "system",
+      input: { title: row.title, body: row.body, tags: args.tags },
+      provider: args.provider,
+      model: args.model,
+      prompt_version: args.prompt_version,
+      raw_output: args.rawOutput,
+      parsed: args.parsed,
+      queue_wait_ms: args.queueWaitMs,
+      inference_ms: args.inferenceMs,
+      attempt_number: args.attemptNumber,
+    };
+    if (args.fallback_used !== false) payload.fallback_used = args.fallback_used;
+    const opts: { memory_id?: string; agent_id?: string } = { memory_id: row.id };
+    if (row.agent_id !== null) opts.agent_id = row.agent_id;
+    deps.appendEvent("memory.classified", payload, opts);
+  }
+
+  function giveUp(
+    row: MemoryRow,
+    queueStart: number,
+    beforeClassify: number,
+    attempts: number,
+    tags: string[],
+    _reason: string,
+  ): void {
+    finalize(row, {
+      verdict: CONSERVATIVE_DEFAULTS,
+      fallback_used: "max_retries",
+      provider: "none",
+      model: "(none)",
+      prompt_version: "(none)",
+      rawOutput: "",
+      parsed: null,
+      inferenceMs: Math.max(0, now() - beforeClassify),
+      queueWaitMs: isFinite(queueStart) ? Math.max(0, beforeClassify - queueStart) : 0,
+      attemptNumber: attempts,
+      tags,
+    });
+  }
+
+  return {
+    processOnce,
+    start,
+    stop,
+    get running() {
+      return running;
+    },
+  };
+}
+
+function parseTags(tagsJson: string): string[] {
+  try {
+    const parsed = JSON.parse(tagsJson);
+    if (Array.isArray(parsed)) return parsed.filter((t): t is string => typeof t === "string");
+  } catch {
+    /* fall through */
+  }
+  return [];
+}
+
+function parseTimestamp(iso: string): number {
+  const t = Date.parse(iso);
+  return Number.isFinite(t) ? t : Number.NaN;
+}

--- a/packages/mcp-server/src/classifier-worker.ts
+++ b/packages/mcp-server/src/classifier-worker.ts
@@ -96,6 +96,11 @@ export function createClassifierWorker(deps: ClassifierWorkerDeps): ClassifierWo
   let stopping: Promise<void> | null = null;
   let resolveStop: (() => void) | null = null;
   let scheduledHandle: unknown = null;
+  // Tracks whether `tick()` is mid-await on `processOnce()`. `stop()`
+  // must wait for this to clear before resolving — otherwise the
+  // in-flight iteration can still `writeVerdictStmt.run(...)` /
+  // `appendEvent(...)` after the caller closed the DB / log handle.
+  let iterationInFlight = false;
 
   const selectStmt = deps.db.prepare(
     "SELECT id, title, body, tags_json, agent_id, classification_attempts, created_at " +
@@ -129,24 +134,42 @@ export function createClassifierWorker(deps: ClassifierWorkerDeps): ClassifierWo
       // but if a custom Classifier impl breaks the contract, do the
       // safe thing: count as a failed attempt and let the retry cap
       // catch it.
+      //
+      // Only log the error CLASS, never the message: a custom transport
+      // could surface a bearer token inside the thrown error. The
+      // remote provider (the only first-party impl) folds errors to
+      // a typed fallback before they reach here, so we're already
+      // belt-and-braces; redacting the message keeps that property
+      // intact for third-party impls.
       incrementStmt.run(row.id);
       const attempts = row.classification_attempts + 1;
+      const errorClass =
+        err instanceof Error
+          ? err.constructor.name
+          : typeof err === "object"
+            ? "object"
+            : typeof err;
       deps.log?.({
         event: "classifier-worker",
         outcome: "classify_threw",
         memory_id: row.id,
         attempts,
-        error: err instanceof Error ? err.message : String(err),
+        error_class: errorClass,
       });
       if (attempts >= MAX_ATTEMPTS) {
-        giveUp(row, queueStart, beforeClassify, attempts, tags, "(threw)");
+        giveUp(row, queueStart, beforeClassify, attempts, tags);
         return "max_retries_giveup";
       }
       return "attempt_failed";
     }
 
-    const inferenceMs = Math.max(0, now() - beforeClassify);
-    const queueWaitMs = isFinite(queueStart) ? Math.max(0, beforeClassify - queueStart) : 0;
+    // `now()` is `Date.now` by default (integer ms), but a custom seam
+    // could supply `performance.now()` — the event schema requires
+    // `z.number().int()`, so round at the emission boundary.
+    const inferenceMs = Math.max(0, Math.round(now() - beforeClassify));
+    const queueWaitMs = Number.isFinite(queueStart)
+      ? Math.max(0, Math.round(beforeClassify - queueStart))
+      : 0;
 
     if (result.fallback_used) {
       // A fallback verdict means the model failed (parse / timeout /
@@ -160,7 +183,7 @@ export function createClassifierWorker(deps: ClassifierWorkerDeps): ClassifierWo
           provider: result.provider,
           model: result.model,
           prompt_version: result.prompt_version,
-          rawOutput: "",
+          rawOutput: result.raw_output,
           parsed: null,
           inferenceMs,
           queueWaitMs,
@@ -181,13 +204,16 @@ export function createClassifierWorker(deps: ClassifierWorkerDeps): ClassifierWo
     }
 
     // Success: write the verdict + emit the event.
+    // `attemptNumber` is the attempt index that succeeded, 1-indexed:
+    // a first-try success is `1`, not `0`. Aligns with the spec §4.8
+    // `attempt_number` field semantics.
     finalize(row, {
       verdict: result.verdict,
       fallback_used: false,
       provider: result.provider,
       model: result.model,
       prompt_version: result.prompt_version,
-      rawOutput: "",
+      rawOutput: result.raw_output,
       parsed: result.verdict,
       inferenceMs,
       queueWaitMs,
@@ -215,16 +241,21 @@ export function createClassifierWorker(deps: ClassifierWorkerDeps): ClassifierWo
     }
     if (stopping) {
       const promise = stopping;
-      // If no iteration is in flight, resolve immediately.
-      resolveStop?.();
-      resolveStop = null;
-      stopping = null;
+      // Only resolve immediately when no iteration is mid-flight; if
+      // one is, `tick()`'s exit path will resolve via `resolveStop`
+      // when it observes `running === false`.
+      if (!iterationInFlight) {
+        resolveStop?.();
+        resolveStop = null;
+        stopping = null;
+      }
       await promise;
     }
   }
 
   async function tick(): Promise<void> {
     if (!running) return;
+    iterationInFlight = true;
     let outcome: ProcessOutcome = "idle";
     try {
       outcome = await processOnce();
@@ -235,10 +266,16 @@ export function createClassifierWorker(deps: ClassifierWorkerDeps): ClassifierWo
         error: err instanceof Error ? err.message : String(err),
       });
       outcome = "error";
+    } finally {
+      iterationInFlight = false;
     }
     if (!running) {
+      // We were asked to stop while in flight; finalise the stopping
+      // promise so the caller's `await stop()` returns only after the
+      // DB / event-append calls in this iteration have finished.
       resolveStop?.();
       resolveStop = null;
+      stopping = null;
       return;
     }
     // Busy: process the next row immediately. Idle/error: back off.
@@ -300,7 +337,6 @@ export function createClassifierWorker(deps: ClassifierWorkerDeps): ClassifierWo
     beforeClassify: number,
     attempts: number,
     tags: string[],
-    _reason: string,
   ): void {
     finalize(row, {
       verdict: CONSERVATIVE_DEFAULTS,
@@ -310,8 +346,10 @@ export function createClassifierWorker(deps: ClassifierWorkerDeps): ClassifierWo
       prompt_version: "(none)",
       rawOutput: "",
       parsed: null,
-      inferenceMs: Math.max(0, now() - beforeClassify),
-      queueWaitMs: isFinite(queueStart) ? Math.max(0, beforeClassify - queueStart) : 0,
+      inferenceMs: Math.max(0, Math.round(now() - beforeClassify)),
+      queueWaitMs: Number.isFinite(queueStart)
+        ? Math.max(0, Math.round(beforeClassify - queueStart))
+        : 0,
       attemptNumber: attempts,
       tags,
     });

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -16,3 +16,11 @@ export { createLogger, logger } from "./logging.js";
 export type { ToolContext, ToolDefinition, McpTextResult } from "./mcp/tool.js";
 export { appRouter, type AppRouter } from "./trpc/router.js";
 export { createCallerFactory } from "./trpc/trpc.js";
+export {
+  type ClassifierWorker,
+  type ClassifierWorkerDeps,
+  type ProcessOutcome,
+  IDLE_POLL_MS,
+  MAX_ATTEMPTS,
+  createClassifierWorker,
+} from "./classifier-worker.js";

--- a/packages/mcp-server/tests/classifier-worker.test.ts
+++ b/packages/mcp-server/tests/classifier-worker.test.ts
@@ -1,0 +1,357 @@
+// Classifier worker — state-machine tests against an in-memory SQLite.
+//
+// The worker is wired but inert in production (Section 4a); these
+// tests exercise it through `processOnce()` so we don't depend on the
+// runtime polling loop.
+
+import { DatabaseSync } from "node:sqlite";
+import type { Classifier, ClassifyResult } from "@librarian/classifier";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createClassifierWorker } from "../src/classifier-worker.ts";
+
+interface EventLog {
+  event_type: string;
+  memory_id: string | null;
+  agent_id: string | null;
+  payload: Record<string, unknown>;
+}
+
+function setupDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  db.exec(`
+    CREATE TABLE memories (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      body TEXT NOT NULL,
+      tags_json TEXT NOT NULL,
+      agent_id TEXT,
+      created_at TEXT NOT NULL,
+      is_global INTEGER NOT NULL DEFAULT 0,
+      requires_approval INTEGER NOT NULL DEFAULT 0,
+      classified INTEGER NOT NULL DEFAULT 0,
+      classification_attempts INTEGER NOT NULL DEFAULT 0
+    );
+  `);
+  return db;
+}
+
+function insertMemory(
+  db: DatabaseSync,
+  id: string,
+  overrides: { tags?: string[]; agent_id?: string | null; created_at?: string } = {},
+): void {
+  db.prepare(
+    "INSERT INTO memories (id, title, body, tags_json, agent_id, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+  ).run(
+    id,
+    `title-${id}`,
+    `body-${id}`,
+    JSON.stringify(overrides.tags ?? []),
+    overrides.agent_id ?? "codex",
+    overrides.created_at ?? "2026-01-01T00:00:00Z",
+  );
+}
+
+function fakeClassifier(impl: () => Promise<ClassifyResult>): {
+  classifier: Classifier;
+  calls: number;
+} {
+  let calls = 0;
+  return {
+    classifier: {
+      async classify() {
+        calls += 1;
+        return impl();
+      },
+    },
+    get calls() {
+      return calls;
+    },
+  };
+}
+
+function fakeAppendEvent(): {
+  fn: (
+    eventType: string,
+    payload: Record<string, unknown>,
+    options?: { memory_id?: string; agent_id?: string },
+  ) => void;
+  events: EventLog[];
+} {
+  const events: EventLog[] = [];
+  return {
+    events,
+    fn(eventType, payload, options = {}) {
+      events.push({
+        event_type: eventType,
+        memory_id: options.memory_id ?? null,
+        agent_id: options.agent_id ?? null,
+        payload,
+      });
+    },
+  };
+}
+
+const SUCCESS: ClassifyResult = {
+  verdict: { requires_approval: false, is_global: true },
+  prompt_version: "v1",
+  provider: "remote",
+  model: "gpt-4o-mini",
+  latency_ms: 12,
+};
+
+const PARSE_FAILURE: ClassifyResult = {
+  verdict: { requires_approval: true, is_global: false },
+  fallback_used: "parse",
+  prompt_version: "v1",
+  provider: "remote",
+  model: "gpt-4o-mini",
+  latency_ms: 5,
+};
+
+describe("classifier-worker.processOnce", () => {
+  let db: DatabaseSync;
+
+  beforeEach(() => {
+    db = setupDb();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("returns idle when no memories are pending", async () => {
+    const { fn } = fakeAppendEvent();
+    const worker = createClassifierWorker({
+      db,
+      classifier: fakeClassifier(async () => SUCCESS).classifier,
+      appendEvent: fn,
+    });
+    expect(await worker.processOnce()).toBe("idle");
+  });
+
+  it("classifies the oldest pending row first (created_at ORDER BY)", async () => {
+    insertMemory(db, "mem-new", { created_at: "2026-02-01T00:00:00Z" });
+    insertMemory(db, "mem-old", { created_at: "2026-01-01T00:00:00Z" });
+    const seen: string[] = [];
+    const classifier: Classifier = {
+      async classify(input) {
+        seen.push(input.title);
+        return SUCCESS;
+      },
+    };
+    const { fn } = fakeAppendEvent();
+    const worker = createClassifierWorker({ db, classifier, appendEvent: fn });
+    expect(await worker.processOnce()).toBe("processed");
+    expect(seen).toEqual(["title-mem-old"]);
+  });
+
+  it("on success: writes the verdict, flips classified=1, emits memory.classified", async () => {
+    insertMemory(db, "mem-1", { tags: ["identity"] });
+    const { fn, events } = fakeAppendEvent();
+    const worker = createClassifierWorker({
+      db,
+      classifier: {
+        async classify() {
+          return SUCCESS;
+        },
+      },
+      appendEvent: fn,
+    });
+    expect(await worker.processOnce()).toBe("processed");
+    const row = db
+      .prepare(
+        "SELECT classified, classification_attempts, is_global, requires_approval FROM memories WHERE id = ?",
+      )
+      .get("mem-1") as {
+      classified: number;
+      classification_attempts: number;
+      is_global: number;
+      requires_approval: number;
+    };
+    expect(row.classified).toBe(1);
+    expect(row.classification_attempts).toBe(0);
+    expect(row.is_global).toBe(1);
+    expect(row.requires_approval).toBe(0);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.event_type).toBe("memory.classified");
+    expect(events[0]?.memory_id).toBe("mem-1");
+    expect(events[0]?.payload).toMatchObject({
+      provider: "remote",
+      model: "gpt-4o-mini",
+      prompt_version: "v1",
+      parsed: { requires_approval: false, is_global: true },
+      attempt_number: 1,
+      input: { title: "title-mem-1", body: "body-mem-1", tags: ["identity"] },
+    });
+    expect(events[0]?.payload.fallback_used).toBeUndefined();
+  });
+
+  it("on a fallback verdict (parse failure) below the retry cap: increments attempts, leaves classified=0, no event", async () => {
+    insertMemory(db, "mem-1");
+    const { fn, events } = fakeAppendEvent();
+    const worker = createClassifierWorker({
+      db,
+      classifier: {
+        async classify() {
+          return PARSE_FAILURE;
+        },
+      },
+      appendEvent: fn,
+    });
+    expect(await worker.processOnce()).toBe("attempt_failed");
+    const row = db
+      .prepare("SELECT classified, classification_attempts FROM memories WHERE id = ?")
+      .get("mem-1") as { classified: number; classification_attempts: number };
+    expect(row.classified).toBe(0);
+    expect(row.classification_attempts).toBe(1);
+    expect(events).toHaveLength(0);
+  });
+
+  it("at attempt 3 (post-increment): gives up, writes conservative defaults, emits fallback_used=max_retries", async () => {
+    insertMemory(db, "mem-1");
+    db.prepare("UPDATE memories SET classification_attempts = 2 WHERE id = ?").run("mem-1");
+    const { fn, events } = fakeAppendEvent();
+    const worker = createClassifierWorker({
+      db,
+      classifier: {
+        async classify() {
+          return PARSE_FAILURE;
+        },
+      },
+      appendEvent: fn,
+    });
+    expect(await worker.processOnce()).toBe("max_retries_giveup");
+    const row = db
+      .prepare(
+        "SELECT classified, classification_attempts, is_global, requires_approval FROM memories WHERE id = ?",
+      )
+      .get("mem-1") as {
+      classified: number;
+      classification_attempts: number;
+      is_global: number;
+      requires_approval: number;
+    };
+    expect(row.classified).toBe(1);
+    expect(row.classification_attempts).toBe(3);
+    expect(row.is_global).toBe(0);
+    expect(row.requires_approval).toBe(1);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.payload).toMatchObject({
+      attempt_number: 3,
+      fallback_used: "max_retries",
+      parsed: null,
+    });
+  });
+
+  it("three sequential attempts: two retries then giveup, single max_retries event", async () => {
+    insertMemory(db, "mem-1");
+    const { fn, events } = fakeAppendEvent();
+    const worker = createClassifierWorker({
+      db,
+      classifier: {
+        async classify() {
+          return PARSE_FAILURE;
+        },
+      },
+      appendEvent: fn,
+    });
+    expect(await worker.processOnce()).toBe("attempt_failed");
+    expect(await worker.processOnce()).toBe("attempt_failed");
+    expect(await worker.processOnce()).toBe("max_retries_giveup");
+    expect(events).toHaveLength(1);
+    expect(events[0]?.payload.fallback_used).toBe("max_retries");
+    expect(events[0]?.payload.attempt_number).toBe(3);
+    const row = db
+      .prepare("SELECT classified, classification_attempts FROM memories WHERE id = ?")
+      .get("mem-1") as { classified: number; classification_attempts: number };
+    expect(row.classified).toBe(1);
+    expect(row.classification_attempts).toBe(3);
+  });
+
+  it("if classifier throws (contract violation): counts as a failed attempt and may give up", async () => {
+    insertMemory(db, "mem-1");
+    db.prepare("UPDATE memories SET classification_attempts = 2 WHERE id = ?").run("mem-1");
+    const { fn, events } = fakeAppendEvent();
+    const worker = createClassifierWorker({
+      db,
+      classifier: {
+        async classify() {
+          throw new Error("boom");
+        },
+      },
+      appendEvent: fn,
+    });
+    expect(await worker.processOnce()).toBe("max_retries_giveup");
+    const row = db
+      .prepare("SELECT classified, requires_approval FROM memories WHERE id = ?")
+      .get("mem-1") as { classified: number; requires_approval: number };
+    expect(row.classified).toBe(1);
+    expect(row.requires_approval).toBe(1);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.payload.fallback_used).toBe("max_retries");
+  });
+
+  it("on a fallback (provider_unavailable) below retry cap: stays classified=0 for the next iteration", async () => {
+    insertMemory(db, "mem-1");
+    const fail: ClassifyResult = {
+      verdict: { requires_approval: true, is_global: false },
+      fallback_used: "provider_unavailable",
+      prompt_version: "v1",
+      provider: "remote",
+      model: "gpt-4o-mini",
+      latency_ms: 3,
+    };
+    const { fn } = fakeAppendEvent();
+    const worker = createClassifierWorker({
+      db,
+      classifier: {
+        async classify() {
+          return fail;
+        },
+      },
+      appendEvent: fn,
+    });
+    expect(await worker.processOnce()).toBe("attempt_failed");
+    const row = db
+      .prepare("SELECT classified, classification_attempts FROM memories WHERE id = ?")
+      .get("mem-1") as { classified: number; classification_attempts: number };
+    expect(row.classified).toBe(0);
+    expect(row.classification_attempts).toBe(1);
+  });
+});
+
+describe("classifier-worker.start/stop polling loop", () => {
+  it("processes queued rows back-to-back, then idles, then exits on stop", async () => {
+    const db = setupDb();
+    try {
+      insertMemory(db, "mem-1");
+      insertMemory(db, "mem-2");
+      const { fn, events } = fakeAppendEvent();
+      const worker = createClassifierWorker({
+        db,
+        classifier: {
+          async classify() {
+            return SUCCESS;
+          },
+        },
+        appendEvent: fn,
+        // Deterministic scheduler: every setTimeoutFn handler runs on next microtask.
+        setTimeoutFn: (handler) => {
+          const t = setTimeout(handler, 0);
+          return t;
+        },
+        clearTimeoutFn: (h) => clearTimeout(h as ReturnType<typeof setTimeout>),
+      });
+      worker.start();
+      // Yield the event loop enough times to drain both rows.
+      vi.useRealTimers();
+      await new Promise((r) => setTimeout(r, 20));
+      await worker.stop();
+      expect(events.length).toBe(2);
+      expect(worker.running).toBe(false);
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/packages/mcp-server/tests/classifier-worker.test.ts
+++ b/packages/mcp-server/tests/classifier-worker.test.ts
@@ -12,8 +12,8 @@ import os from "node:os";
 import path from "node:path";
 import type { Classifier, ClassifyResult } from "@librarian/classifier";
 import { createLibrarianStore, type LibrarianStore } from "@librarian/core";
+import { createClassifierWorker } from "@librarian/mcp-server";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { createClassifierWorker } from "../src/classifier-worker.ts";
 
 interface EventLog {
   event_type: string;

--- a/packages/mcp-server/tests/classifier-worker.test.ts
+++ b/packages/mcp-server/tests/classifier-worker.test.ts
@@ -1,12 +1,18 @@
-// Classifier worker — state-machine tests against an in-memory SQLite.
+// Classifier worker — state-machine tests against the real
+// `@librarian/core` store. Using the production store (rather than a
+// raw `node:sqlite` handle) keeps the DDL canonical and avoids Vite's
+// `node:`-prefix-mangling on the SSR transform.
 //
 // The worker is wired but inert in production (Section 4a); these
 // tests exercise it through `processOnce()` so we don't depend on the
 // runtime polling loop.
 
-import { DatabaseSync } from "node:sqlite";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import type { Classifier, ClassifyResult } from "@librarian/classifier";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createLibrarianStore, type LibrarianStore } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createClassifierWorker } from "../src/classifier-worker.ts";
 
 interface EventLog {
@@ -16,58 +22,42 @@ interface EventLog {
   payload: Record<string, unknown>;
 }
 
-function setupDb(): DatabaseSync {
-  const db = new DatabaseSync(":memory:");
-  db.exec(`
-    CREATE TABLE memories (
-      id TEXT PRIMARY KEY,
-      title TEXT NOT NULL,
-      body TEXT NOT NULL,
-      tags_json TEXT NOT NULL,
-      agent_id TEXT,
-      created_at TEXT NOT NULL,
-      is_global INTEGER NOT NULL DEFAULT 0,
-      requires_approval INTEGER NOT NULL DEFAULT 0,
-      classified INTEGER NOT NULL DEFAULT 0,
-      classification_attempts INTEGER NOT NULL DEFAULT 0
-    );
-  `);
-  return db;
+function setupStore(): { store: LibrarianStore; dataDir: string } {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-classifier-worker-"));
+  const store = createLibrarianStore({ dataDir });
+  return { store, dataDir };
+}
+
+function cleanupStore(store: LibrarianStore, dataDir: string): void {
+  try {
+    store.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(dataDir, { recursive: true, force: true });
 }
 
 function insertMemory(
-  db: DatabaseSync,
+  store: LibrarianStore,
   id: string,
-  overrides: { tags?: string[]; agent_id?: string | null; created_at?: string } = {},
+  overrides: { tags?: string[]; agent_id?: string; created_at?: string } = {},
 ): void {
-  db.prepare(
-    "INSERT INTO memories (id, title, body, tags_json, agent_id, created_at) VALUES (?, ?, ?, ?, ?, ?)",
-  ).run(
-    id,
-    `title-${id}`,
-    `body-${id}`,
-    JSON.stringify(overrides.tags ?? []),
-    overrides.agent_id ?? "codex",
-    overrides.created_at ?? "2026-01-01T00:00:00Z",
-  );
-}
-
-function fakeClassifier(impl: () => Promise<ClassifyResult>): {
-  classifier: Classifier;
-  calls: number;
-} {
-  let calls = 0;
-  return {
-    classifier: {
-      async classify() {
-        calls += 1;
-        return impl();
-      },
-    },
-    get calls() {
-      return calls;
-    },
-  };
+  // Use the production createMemory path to get a row with all the
+  // NOT NULL columns populated correctly, then override the id +
+  // created_at + tags + classification state.
+  const { memory } = store.createMemory({
+    agent_id: overrides.agent_id ?? "codex",
+    title: `title-${id}`,
+    body: `body-${id}`,
+    category: "tools",
+    visibility: "common",
+    scope: "tool",
+    tags: overrides.tags ?? [],
+  });
+  // Pin the id + created_at so tests can pre-seed the queue order.
+  store.db
+    .prepare("UPDATE memories SET id = ?, created_at = ? WHERE id = ?")
+    .run(id, overrides.created_at ?? "2026-01-01T00:00:00Z", memory.id);
 }
 
 function fakeAppendEvent(): {
@@ -112,29 +102,34 @@ const PARSE_FAILURE: ClassifyResult = {
 };
 
 describe("classifier-worker.processOnce", () => {
-  let db: DatabaseSync;
+  let store: LibrarianStore;
+  let dataDir: string;
 
   beforeEach(() => {
-    db = setupDb();
+    ({ store, dataDir } = setupStore());
   });
 
   afterEach(() => {
-    db.close();
+    cleanupStore(store, dataDir);
   });
 
   it("returns idle when no memories are pending", async () => {
     const { fn } = fakeAppendEvent();
     const worker = createClassifierWorker({
-      db,
-      classifier: fakeClassifier(async () => SUCCESS).classifier,
+      db: store.db,
+      classifier: {
+        async classify() {
+          return SUCCESS;
+        },
+      },
       appendEvent: fn,
     });
     expect(await worker.processOnce()).toBe("idle");
   });
 
   it("classifies the oldest pending row first (created_at ORDER BY)", async () => {
-    insertMemory(db, "mem-new", { created_at: "2026-02-01T00:00:00Z" });
-    insertMemory(db, "mem-old", { created_at: "2026-01-01T00:00:00Z" });
+    insertMemory(store, "mem-new", { created_at: "2026-02-01T00:00:00Z" });
+    insertMemory(store, "mem-old", { created_at: "2026-01-01T00:00:00Z" });
     const seen: string[] = [];
     const classifier: Classifier = {
       async classify(input) {
@@ -143,16 +138,16 @@ describe("classifier-worker.processOnce", () => {
       },
     };
     const { fn } = fakeAppendEvent();
-    const worker = createClassifierWorker({ db, classifier, appendEvent: fn });
+    const worker = createClassifierWorker({ db: store.db, classifier, appendEvent: fn });
     expect(await worker.processOnce()).toBe("processed");
     expect(seen).toEqual(["title-mem-old"]);
   });
 
   it("on success: writes the verdict, flips classified=1, emits memory.classified", async () => {
-    insertMemory(db, "mem-1", { tags: ["identity"] });
+    insertMemory(store, "mem-1", { tags: ["identity"] });
     const { fn, events } = fakeAppendEvent();
     const worker = createClassifierWorker({
-      db,
+      db: store.db,
       classifier: {
         async classify() {
           return SUCCESS;
@@ -161,7 +156,7 @@ describe("classifier-worker.processOnce", () => {
       appendEvent: fn,
     });
     expect(await worker.processOnce()).toBe("processed");
-    const row = db
+    const row = store.db
       .prepare(
         "SELECT classified, classification_attempts, is_global, requires_approval FROM memories WHERE id = ?",
       )
@@ -191,10 +186,10 @@ describe("classifier-worker.processOnce", () => {
   });
 
   it("on a fallback verdict (parse failure) below the retry cap: increments attempts, leaves classified=0, no event", async () => {
-    insertMemory(db, "mem-1");
+    insertMemory(store, "mem-1");
     const { fn, events } = fakeAppendEvent();
     const worker = createClassifierWorker({
-      db,
+      db: store.db,
       classifier: {
         async classify() {
           return PARSE_FAILURE;
@@ -203,7 +198,7 @@ describe("classifier-worker.processOnce", () => {
       appendEvent: fn,
     });
     expect(await worker.processOnce()).toBe("attempt_failed");
-    const row = db
+    const row = store.db
       .prepare("SELECT classified, classification_attempts FROM memories WHERE id = ?")
       .get("mem-1") as { classified: number; classification_attempts: number };
     expect(row.classified).toBe(0);
@@ -212,11 +207,11 @@ describe("classifier-worker.processOnce", () => {
   });
 
   it("at attempt 3 (post-increment): gives up, writes conservative defaults, emits fallback_used=max_retries", async () => {
-    insertMemory(db, "mem-1");
-    db.prepare("UPDATE memories SET classification_attempts = 2 WHERE id = ?").run("mem-1");
+    insertMemory(store, "mem-1");
+    store.db.prepare("UPDATE memories SET classification_attempts = 2 WHERE id = ?").run("mem-1");
     const { fn, events } = fakeAppendEvent();
     const worker = createClassifierWorker({
-      db,
+      db: store.db,
       classifier: {
         async classify() {
           return PARSE_FAILURE;
@@ -225,7 +220,7 @@ describe("classifier-worker.processOnce", () => {
       appendEvent: fn,
     });
     expect(await worker.processOnce()).toBe("max_retries_giveup");
-    const row = db
+    const row = store.db
       .prepare(
         "SELECT classified, classification_attempts, is_global, requires_approval FROM memories WHERE id = ?",
       )
@@ -248,10 +243,10 @@ describe("classifier-worker.processOnce", () => {
   });
 
   it("three sequential attempts: two retries then giveup, single max_retries event", async () => {
-    insertMemory(db, "mem-1");
+    insertMemory(store, "mem-1");
     const { fn, events } = fakeAppendEvent();
     const worker = createClassifierWorker({
-      db,
+      db: store.db,
       classifier: {
         async classify() {
           return PARSE_FAILURE;
@@ -265,7 +260,7 @@ describe("classifier-worker.processOnce", () => {
     expect(events).toHaveLength(1);
     expect(events[0]?.payload.fallback_used).toBe("max_retries");
     expect(events[0]?.payload.attempt_number).toBe(3);
-    const row = db
+    const row = store.db
       .prepare("SELECT classified, classification_attempts FROM memories WHERE id = ?")
       .get("mem-1") as { classified: number; classification_attempts: number };
     expect(row.classified).toBe(1);
@@ -273,11 +268,11 @@ describe("classifier-worker.processOnce", () => {
   });
 
   it("if classifier throws (contract violation): counts as a failed attempt and may give up", async () => {
-    insertMemory(db, "mem-1");
-    db.prepare("UPDATE memories SET classification_attempts = 2 WHERE id = ?").run("mem-1");
+    insertMemory(store, "mem-1");
+    store.db.prepare("UPDATE memories SET classification_attempts = 2 WHERE id = ?").run("mem-1");
     const { fn, events } = fakeAppendEvent();
     const worker = createClassifierWorker({
-      db,
+      db: store.db,
       classifier: {
         async classify() {
           throw new Error("boom");
@@ -286,7 +281,7 @@ describe("classifier-worker.processOnce", () => {
       appendEvent: fn,
     });
     expect(await worker.processOnce()).toBe("max_retries_giveup");
-    const row = db
+    const row = store.db
       .prepare("SELECT classified, requires_approval FROM memories WHERE id = ?")
       .get("mem-1") as { classified: number; requires_approval: number };
     expect(row.classified).toBe(1);
@@ -296,7 +291,7 @@ describe("classifier-worker.processOnce", () => {
   });
 
   it("on a fallback (provider_unavailable) below retry cap: stays classified=0 for the next iteration", async () => {
-    insertMemory(db, "mem-1");
+    insertMemory(store, "mem-1");
     const fail: ClassifyResult = {
       verdict: { requires_approval: true, is_global: false },
       fallback_used: "provider_unavailable",
@@ -308,7 +303,7 @@ describe("classifier-worker.processOnce", () => {
     };
     const { fn } = fakeAppendEvent();
     const worker = createClassifierWorker({
-      db,
+      db: store.db,
       classifier: {
         async classify() {
           return fail;
@@ -317,7 +312,7 @@ describe("classifier-worker.processOnce", () => {
       appendEvent: fn,
     });
     expect(await worker.processOnce()).toBe("attempt_failed");
-    const row = db
+    const row = store.db
       .prepare("SELECT classified, classification_attempts FROM memories WHERE id = ?")
       .get("mem-1") as { classified: number; classification_attempts: number };
     expect(row.classified).toBe(0);
@@ -327,9 +322,9 @@ describe("classifier-worker.processOnce", () => {
 
 describe("classifier-worker.stop semantics", () => {
   it("waits for an in-flight iteration to finish before resolving", async () => {
-    const db = setupDb();
+    const { store, dataDir } = setupStore();
     try {
-      insertMemory(db, "mem-1");
+      insertMemory(store, "mem-1");
       let release: () => void = () => {};
       const inflight = new Promise<void>((resolve) => {
         release = resolve;
@@ -337,7 +332,7 @@ describe("classifier-worker.stop semantics", () => {
       let writeObserved = false;
       const { events } = fakeAppendEvent();
       const worker = createClassifierWorker({
-        db,
+        db: store.db,
         classifier: {
           async classify() {
             await inflight;
@@ -373,20 +368,20 @@ describe("classifier-worker.stop semantics", () => {
       expect(resolved).toBe(true);
       expect(writeObserved).toBe(true);
     } finally {
-      db.close();
+      cleanupStore(store, dataDir);
     }
   });
 });
 
 describe("classifier-worker.start/stop polling loop", () => {
   it("processes queued rows back-to-back, then idles, then exits on stop", async () => {
-    const db = setupDb();
+    const { store, dataDir } = setupStore();
     try {
-      insertMemory(db, "mem-1");
-      insertMemory(db, "mem-2");
+      insertMemory(store, "mem-1");
+      insertMemory(store, "mem-2", { created_at: "2026-01-02T00:00:00Z" });
       const { fn, events } = fakeAppendEvent();
       const worker = createClassifierWorker({
-        db,
+        db: store.db,
         classifier: {
           async classify() {
             return SUCCESS;
@@ -402,13 +397,12 @@ describe("classifier-worker.start/stop polling loop", () => {
       });
       worker.start();
       // Yield the event loop enough times to drain both rows.
-      vi.useRealTimers();
-      await new Promise((r) => setTimeout(r, 20));
+      await new Promise((r) => setTimeout(r, 30));
       await worker.stop();
       expect(events.length).toBe(2);
       expect(worker.running).toBe(false);
     } finally {
-      db.close();
+      cleanupStore(store, dataDir);
     }
   });
 });

--- a/packages/mcp-server/tests/classifier-worker.test.ts
+++ b/packages/mcp-server/tests/classifier-worker.test.ts
@@ -98,6 +98,7 @@ const SUCCESS: ClassifyResult = {
   provider: "remote",
   model: "gpt-4o-mini",
   latency_ms: 12,
+  raw_output: '{"requires_approval": false, "is_global": true}',
 };
 
 const PARSE_FAILURE: ClassifyResult = {
@@ -107,6 +108,7 @@ const PARSE_FAILURE: ClassifyResult = {
   provider: "remote",
   model: "gpt-4o-mini",
   latency_ms: 5,
+  raw_output: "I cannot classify this.",
 };
 
 describe("classifier-worker.processOnce", () => {
@@ -183,6 +185,7 @@ describe("classifier-worker.processOnce", () => {
       parsed: { requires_approval: false, is_global: true },
       attempt_number: 1,
       input: { title: "title-mem-1", body: "body-mem-1", tags: ["identity"] },
+      raw_output: '{"requires_approval": false, "is_global": true}',
     });
     expect(events[0]?.payload.fallback_used).toBeUndefined();
   });
@@ -301,6 +304,7 @@ describe("classifier-worker.processOnce", () => {
       provider: "remote",
       model: "gpt-4o-mini",
       latency_ms: 3,
+      raw_output: "",
     };
     const { fn } = fakeAppendEvent();
     const worker = createClassifierWorker({
@@ -318,6 +322,59 @@ describe("classifier-worker.processOnce", () => {
       .get("mem-1") as { classified: number; classification_attempts: number };
     expect(row.classified).toBe(0);
     expect(row.classification_attempts).toBe(1);
+  });
+});
+
+describe("classifier-worker.stop semantics", () => {
+  it("waits for an in-flight iteration to finish before resolving", async () => {
+    const db = setupDb();
+    try {
+      insertMemory(db, "mem-1");
+      let release: () => void = () => {};
+      const inflight = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      let writeObserved = false;
+      const { events } = fakeAppendEvent();
+      const worker = createClassifierWorker({
+        db,
+        classifier: {
+          async classify() {
+            await inflight;
+            return SUCCESS;
+          },
+        },
+        appendEvent: (eventType, payload, options) => {
+          writeObserved = true;
+          events.push({
+            event_type: eventType,
+            memory_id: options?.memory_id ?? null,
+            agent_id: options?.agent_id ?? null,
+            payload,
+          });
+        },
+      });
+      worker.start();
+      // Yield so `tick()` enters the in-flight await.
+      await new Promise((r) => setTimeout(r, 5));
+      const stopped = worker.stop();
+      let resolved = false;
+      void stopped.then(() => {
+        resolved = true;
+      });
+      // Still in flight — stop() must not have resolved yet.
+      await new Promise((r) => setTimeout(r, 5));
+      expect(resolved).toBe(false);
+      expect(writeObserved).toBe(false);
+      // Release the classify() and verify stop() resolves only after
+      // the in-flight write reached appendEvent.
+      release();
+      await stopped;
+      expect(resolved).toBe(true);
+      expect(writeObserved).toBe(true);
+    } finally {
+      db.close();
+    }
   });
 });
 

--- a/packages/mcp-server/vitest.config.ts
+++ b/packages/mcp-server/vitest.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
     // local source/dist so Node's own loader handles the import chain.
     server: {
       deps: {
-        external: [/\/packages\/core\/(src|dist)\//, /\/packages\/mcp-server\/(src|dist|tests)\//],
+        external: [/\/packages\/core\/(src|dist)\//, /\/packages\/mcp-server\/(src|dist)\//],
       },
     },
   },

--- a/packages/mcp-server/vitest.config.ts
+++ b/packages/mcp-server/vitest.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
     // local source/dist so Node's own loader handles the import chain.
     server: {
       deps: {
-        external: [/\/packages\/core\/(src|dist)\//, /\/packages\/mcp-server\/(src|dist)\//],
+        external: [/\/packages\/core\/(src|dist)\//, /\/packages\/mcp-server\/(src|dist|tests)\//],
       },
     },
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,6 +157,25 @@ importers:
         specifier: 'catalog:'
         version: 2.1.9(@types/node@22.19.19)(jsdom@25.0.1)(lightningcss@1.32.0)
 
+  packages/classifier:
+    dependencies:
+      '@librarian/core':
+        specifier: workspace:*
+        version: link:../core
+      zod:
+        specifier: ^4.0.1
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.5
+        version: 22.19.19
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@22.19.19)(jsdom@25.0.1)(lightningcss@1.32.0)
+
   packages/cli:
     dependencies:
       '@librarian/core':
@@ -194,6 +213,9 @@ importers:
 
   packages/mcp-server:
     dependencies:
+      '@librarian/classifier':
+        specifier: workspace:*
+        version: link:../classifier
       '@librarian/core':
         specifier: workspace:*
         version: link:../core

--- a/test/schema-snapshot.json
+++ b/test/schema-snapshot.json
@@ -1,4 +1,4 @@
 {
-  "version": 14,
-  "fingerprint": "8448e96dfff0726bd4b9f6222454eef8ab0f6cb1e889efbd2a94ef5aac8c4c1a"
+  "version": 15,
+  "fingerprint": "26e6b5bdd2ff70815c95729954be5ae824c34ab954435ba55a23ce3c337ce5f6"
 }


### PR DESCRIPTION
## Summary

Section 4a of the rollout-completion plan (`docs/specs/rollout-completion-plan.md`).
Foundation for the async classifier. **No agent-visible behavior change** —
the worker module exists and is fully tested but is NOT wired into
`mcp-server` startup; no code path writes `classified = 0` yet, so the
worker has nothing to do in production until Section 4d performs the
cutover. New memories continue to flow through the legacy
`deriveLegacyMemoryFlags` path.

### New workspace package — `@librarian/classifier`

- `classify(input, providerConfig)` with a fail-soft contract: every
  error path collapses to a conservative-defaults verdict
  (`requires_approval=true, is_global=false`) with a typed
  `fallback_used` flag (`parse` / `timeout` / `provider_unavailable` /
  `max_retries`).
- **Remote provider** via `@librarian/core`'s LlmClient (bearer token
  stays in the LlmClient layer, never in error messages or logs).
- **Local provider** is a stub returning `provider_unavailable`,
  guarded behind `LIBRARIAN_CLASSIFIER_LOCAL_STUB=1` so misconfigured
  production deployments fail loud at construction. Real impl lands in
  Section 4b.
- **Parser** trims to the last balanced `{...}` and zod-validates
  against a strict schema (two boolean keys, no extras). Handles
  Thinking-variant CoT preambles.
- **Prompt v1** committed (the `.md` is the diffable form for
  reviewers; the `.ts` compiles into the bundle so no asset-copy
  build step).

### Schema bump v14 → v15

- `memories` table gains `classified` and `classification_attempts`
  (both `INTEGER NOT NULL DEFAULT 0`). Memories are JSONL-canonical
  so the bump drops + rebuilds and the defaults apply to every
  existing row.
- New `MemoryEventType.Classified` + `MemoryClassifiedEventSchema` in
  `@librarian/core/schemas` (spec §4.8).
- `test/schema-snapshot.json` refreshed.

### Async worker scaffold

- `packages/mcp-server/src/classifier-worker.ts` — `createClassifierWorker`
  factory + `processOnce()` (test surface) + `start()`/`stop()` (polling
  loop). 3-retry policy with `classification_attempts`. On success:
  writes the verdict + flips `classified=1` + emits
  `memory.classified`. On a fallback verdict below the cap:
  increments attempts, leaves `classified=0`. At the cap (3): writes
  conservative defaults + emits `memory.classified` with
  `fallback_used: "max_retries"`.
- Defensive net for a contract-violating classifier impl that throws;
  the throw logs `err.constructor.name` only (never the message) so a
  bearer-bearing error from a custom transport can't leak.
- `stop()` correctly awaits any in-flight iteration before resolving —
  prevents a race against `db.close()` in shutdown handlers.

### Tests

24 new classifier-package tests + 10 new mcp-server worker tests +
2 new core projection tests. All workspace tests + `pnpm -r run typecheck`
+ schema fingerprint check + lint clean.

## Test plan

- [x] `pnpm test` — all green
- [x] `pnpm -r run typecheck` — clean
- [x] `node scripts/check-schema-version.mjs` — version=15 matches
- [x] `pnpm lint` — clean
- [x] Worker `stop()` waits for in-flight iteration before resolving
  (new test pins the contract)
- [x] `provider: "local"` throws at construction without the env flag
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)