### PR TITLE
feat(classifier-eval): generate-fixture CLI for §4.7 consensus pipeline

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"3ceefb6b-cb3c-49b5-80db-034736498927","pid":66051,"procStart":"Wed May 27 06:54:48 2026","acquiredAt":1779922271731}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ changes from this point forward are catalogued here.
 
 ## [Unreleased]
 
+### Added
+
+- **`classifier-eval generate-fixture` CLI (Task 4.10).** Implements
+  the spec §4.7 public-consensus fixture generation pipeline:
+  generate ~1500 candidate memories via one strong LLM, run each
+  through 3 frontier graders from different model families (Claude /
+  GPT / Gemini) via the classifier's own v1 prompt, keep only
+  unanimous candidates, trim to ~900 maintaining the 60/40 ratio,
+  iterate if a bucket falls short. Configurable via a JSON file
+  (`fixtures/graders.example.json` ships as a template) with tokens
+  resolved from env-var references so the config is safe to commit.
+  Hard `--max-calls` budget guard prevents runaway API spend; verbose
+  per-iteration progress logging via `--verbose`; dry-run mode
+  validates config + env without making any calls. The fixture
+  itself is NOT generated in this PR — that's an operator one-shot
+  with three API keys in hand (~$5 spend). 28 new unit tests cover
+  consensus, ratio-preserving trim, generator prompt construction,
+  CLI flag parsing, and an end-to-end pipeline test with in-memory
+  fake clients. Documented in `packages/classifier-eval/README.md`.
+
 ### Removed
 
 - **Legacy `category` / `visibility` / `scope` columns + dashboard

--- a/packages/classifier-eval/README.md
+++ b/packages/classifier-eval/README.md
@@ -1,0 +1,102 @@
+# @librarian/classifier-eval
+
+Operator-driven evaluation harness for the memory classifier (spec
+§4.6 of `classifier-implementation-spec.md`). Three surfaces:
+
+- **`runEval`** — runs a classifier against a fixture and returns a
+  structured report. Used by the dashboard's `/classifier-eval` page
+  and by the `eval run` CLI.
+- **`computeSoftAlert`** — pure helper that computes the §4.3
+  max-retries rate over a window of `memory.classified` events.
+- **`runFixtureGenerator`** — one-shot pipeline that generates the
+  public §4.7 fixture via a 3-grader unanimous-vote consensus filter.
+  Exposed via `classifier-eval generate-fixture`.
+
+## CLI
+
+```sh
+# Run an evaluation against a remote OpenAI-compatible classifier
+classifier-eval run --provider remote --model gpt-4o-mini --sample 10
+
+# Generate the §4.7 public consensus fixture (one-shot, ~$5 of API spend)
+classifier-eval generate-fixture \
+  --config fixtures/graders.example.json \
+  --output fixtures/public-v1.json
+```
+
+## `generate-fixture` operator runbook
+
+The §4.7 public fixture is built once and refreshed only when the
+classifier prompt changes materially. The pipeline:
+
+1. **Generate** ~1500 candidate memories via one strong LLM, prompted
+   for a 60/40 straight/boundary mix.
+2. **Grade** each candidate via 3 frontier models from different
+   families (Claude, GPT, Gemini). The classifier's own v1 prompt is
+   what each grader runs — the consensus filter validates that all
+   three families would have given the same verdict in production.
+3. **Filter** to unanimous-only (drop any candidate where the 3
+   graders disagree).
+4. **Trim** to the target size preserving the 60/40 ratio. Iterate
+   from step 1 if either bucket falls short.
+
+### Prereqs
+
+- Three API keys for three model families (env vars per the config).
+- A graders config JSON (see `fixtures/graders.example.json`).
+
+### Run
+
+```sh
+# 1. Copy + edit the example config to point at your endpoints
+cp packages/classifier-eval/fixtures/graders.example.json my-graders.json
+$EDITOR my-graders.json
+
+# 2. Set the token env vars referenced by `token_env`
+export ANTHROPIC_API_KEY=…
+export OPENAI_API_KEY=…
+export GEMINI_API_KEY=…
+
+# 3. Dry-run validates config + env without making API calls
+classifier-eval generate-fixture \
+  --config my-graders.json \
+  --output packages/classifier-eval/fixtures/public-v1.json \
+  --dry-run
+
+# 4. Real run — ~5500 LLM calls, ~$5 budget, several minutes wall-clock
+classifier-eval generate-fixture \
+  --config my-graders.json \
+  --output packages/classifier-eval/fixtures/public-v1.json \
+  --verbose
+
+# 5. Commit the resulting fixture + update CHANGELOG with the model
+#    versions that produced it (provenance per spec §4.7).
+```
+
+### Flag reference
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--config <path>` | (required) | Graders JSON config |
+| `--output <path>` | (required) | Where to write the fixture |
+| `--target <n>` | 900 | Total fixture size |
+| `--boundary-ratio <f>` | 0.4 | Fraction of total that's boundary |
+| `--candidates-per-batch <n>` | 100 | Per generator call |
+| `--max-iterations <n>` | 12 | Generator batches before giving up |
+| `--max-calls <n>` | 8000 | Hard cap on LLM calls (budget guard) |
+| `--dry-run` | off | Validate config + env without calls |
+| `--verbose` | off | Per-iteration progress JSON to stderr |
+
+### What can go wrong
+
+- **Boundary survival is < 50%.** Spec ballpark; if you see <30%
+  survival the boundaries probably aren't boundary enough — tighten
+  the generator prompt or lower `--boundary-ratio` to reflect what
+  the field actually produces.
+- **A grader endpoint returns malformed JSON consistently.** Any
+  parse failure counts as disagreement; check the model id supports
+  JSON-mode response_format. The pipeline doesn't retry within a
+  single grader call (one shot per candidate per grader).
+- **Budget exhausted before targets met.** Raise `--max-calls` or
+  raise `--candidates-per-batch` so each generator call goes
+  further.

--- a/packages/classifier-eval/fixtures/graders.example.json
+++ b/packages/classifier-eval/fixtures/graders.example.json
@@ -1,0 +1,28 @@
+{
+  "generator": {
+    "name": "claude-sonnet-4.6",
+    "endpoint": "https://api.anthropic.com/v1",
+    "model": "claude-sonnet-4-6",
+    "token_env": "ANTHROPIC_API_KEY"
+  },
+  "graders": [
+    {
+      "name": "claude-sonnet-4.6",
+      "endpoint": "https://api.anthropic.com/v1",
+      "model": "claude-sonnet-4-6",
+      "token_env": "ANTHROPIC_API_KEY"
+    },
+    {
+      "name": "gpt-4o",
+      "endpoint": "https://api.openai.com/v1",
+      "model": "gpt-4o",
+      "token_env": "OPENAI_API_KEY"
+    },
+    {
+      "name": "gemini-2.5-pro",
+      "endpoint": "https://generativelanguage.googleapis.com/v1beta/openai",
+      "model": "gemini-2.5-pro",
+      "token_env": "GEMINI_API_KEY"
+    }
+  ]
+}

--- a/packages/classifier-eval/src/cli/bin.ts
+++ b/packages/classifier-eval/src/cli/bin.ts
@@ -4,6 +4,7 @@
 // scripting and ad-hoc operator runs (spec §4.6).
 
 import { parseArgs } from "node:util";
+import { generateFixtureCommand } from "./generate-fixture-command.js";
 import { runEvalCommand } from "./run-command.js";
 
 async function main(): Promise<void> {
@@ -19,11 +20,14 @@ async function main(): Promise<void> {
       await runEvalCommand(process.argv.slice(3));
       return;
     }
-    case "replay":
     case "generate-fixture": {
+      await generateFixtureCommand(process.argv.slice(3));
+      return;
+    }
+    case "replay": {
       process.stderr.write(
-        `classifier-eval: subcommand "${sub}" not yet implemented — see ` +
-          `docs/specs/classifier-implementation-spec.md §4.6 + plan Task 4.10.\n`,
+        `classifier-eval: subcommand "replay" not yet implemented — see ` +
+          `docs/specs/classifier-implementation-spec.md §4.6.\n`,
       );
       process.exit(2);
       return;
@@ -49,11 +53,12 @@ function printHelp(): void {
       "",
       "Subcommands:",
       "  run                Run an evaluation against the configured classifier",
+      "  generate-fixture   Build a §4.7 public consensus fixture (one-shot)",
       "  replay             (not yet implemented)",
-      "  generate-fixture   (not yet implemented)",
       "",
       "Usage:",
       "  classifier-eval run --provider remote --model gpt-4o-mini --sample 10 --category boundary",
+      "  classifier-eval generate-fixture --config graders.json --output fixtures/public-v1.json",
       "",
       "Options for `run`:",
       "  --provider remote|local   Provider to test (required)",
@@ -62,6 +67,17 @@ function printHelp(): void {
       "  --category <all|straight|boundary>  Category filter; defaults to all",
       "  --fixture <path>          Path to fixture JSON; defaults to bundled seed-v1",
       "  --json                    Print the full report JSON to stdout (default: summary)",
+      "",
+      "Options for `generate-fixture`:",
+      "  --config <path>           JSON file declaring generator + 3 graders (required)",
+      "  --output <path>           Where to write the fixture JSON (required)",
+      "  --target <n>              Total fixture size; defaults to 900",
+      "  --boundary-ratio <f>      Fraction of total that's boundary; defaults to 0.4",
+      "  --candidates-per-batch <n>  Defaults to 100",
+      "  --max-iterations <n>      Defaults to 12",
+      "  --max-calls <n>           Hard cap on LLM calls; defaults to 8000",
+      "  --dry-run                 Validate config + token env vars without calling APIs",
+      "  --verbose                 Emit per-iteration progress JSON to stderr",
       "",
     ].join("\n"),
   );

--- a/packages/classifier-eval/src/cli/generate-fixture-command.ts
+++ b/packages/classifier-eval/src/cli/generate-fixture-command.ts
@@ -1,0 +1,221 @@
+// `classifier-eval generate-fixture` subcommand — wires the §4.7
+// pipeline to real `createCuratorLlmClient` instances driven by a
+// JSON config + environment-variable secrets.
+//
+// Single-shot operator command: never run in CI. Token references go
+// via `token_env`, not literal strings, so a config file can be
+// committed (e.g. to operator docs) without leaking secrets.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { parseArgs } from "node:util";
+import {
+  LlmClientError,
+  createCuratorLlmClient,
+  type LlmClient,
+  type LlmClientConfig,
+} from "@librarian/core";
+import { runFixtureGenerator } from "../generate/pipeline.js";
+import type { PipelineClients } from "../generate/pipeline.js";
+import { PipelineConfigSchema, type GraderConfig, type PipelineConfig } from "../generate/types.js";
+
+const DEFAULT_TARGET = 900;
+const DEFAULT_BOUNDARY_RATIO = 0.4;
+const DEFAULT_CANDIDATES_PER_BATCH = 100;
+const DEFAULT_MAX_ITERATIONS = 12;
+const DEFAULT_MAX_CALLS = 8000;
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+export interface GenerateFixtureFlags {
+  configPath: string;
+  outputPath: string;
+  target: number;
+  boundaryRatio: number;
+  candidatesPerBatch: number;
+  maxIterations: number;
+  maxCalls: number;
+  dryRun: boolean;
+  verbose: boolean;
+}
+
+export function parseGenerateFixtureFlags(args: string[]): GenerateFixtureFlags {
+  const { values } = parseArgs({
+    args,
+    options: {
+      config: { type: "string" },
+      output: { type: "string" },
+      target: { type: "string" },
+      "boundary-ratio": { type: "string" },
+      "candidates-per-batch": { type: "string" },
+      "max-iterations": { type: "string" },
+      "max-calls": { type: "string" },
+      "dry-run": { type: "boolean", default: false },
+      verbose: { type: "boolean", default: false },
+    },
+    strict: true,
+  });
+  if (typeof values.config !== "string" || values.config.length === 0) {
+    throw new Error("--config <path> is required (graders + generator JSON config)");
+  }
+  if (typeof values.output !== "string" || values.output.length === 0) {
+    throw new Error("--output <path> is required (where to write public-v1.json)");
+  }
+  return {
+    configPath: values.config,
+    outputPath: values.output,
+    target: positiveInt(values.target, DEFAULT_TARGET, "--target"),
+    boundaryRatio: fraction(values["boundary-ratio"], DEFAULT_BOUNDARY_RATIO, "--boundary-ratio"),
+    candidatesPerBatch: positiveInt(
+      values["candidates-per-batch"],
+      DEFAULT_CANDIDATES_PER_BATCH,
+      "--candidates-per-batch",
+    ),
+    maxIterations: positiveInt(
+      values["max-iterations"],
+      DEFAULT_MAX_ITERATIONS,
+      "--max-iterations",
+    ),
+    maxCalls: positiveInt(values["max-calls"], DEFAULT_MAX_CALLS, "--max-calls"),
+    dryRun: Boolean(values["dry-run"]),
+    verbose: Boolean(values.verbose),
+  };
+}
+
+export async function generateFixtureCommand(args: string[]): Promise<void> {
+  const flags = parseGenerateFixtureFlags(args);
+  const config = loadConfig(flags.configPath);
+  const tokens = resolveTokens(config);
+
+  if (flags.dryRun) {
+    process.stderr.write(
+      [
+        "generate-fixture: dry-run",
+        `  generator: ${config.generator.name} @ ${config.generator.endpoint} (model=${config.generator.model})`,
+        ...config.graders.map((g) => `  grader: ${g.name} @ ${g.endpoint} (model=${g.model})`),
+        `  target=${flags.target} boundary_ratio=${flags.boundaryRatio}`,
+        `  candidates_per_batch=${flags.candidatesPerBatch} max_iterations=${flags.maxIterations} max_calls=${flags.maxCalls}`,
+        `  output: ${flags.outputPath}`,
+        "  (token resolution OK; no API calls made)",
+        "",
+      ].join("\n"),
+    );
+    return;
+  }
+
+  const clients = buildClients(config, tokens);
+  const pipelineOpts: Parameters<typeof runFixtureGenerator>[1] = {
+    config,
+    targets: { total: flags.target, boundaryRatio: flags.boundaryRatio },
+    budget: { maxCalls: flags.maxCalls },
+    candidatesPerBatch: flags.candidatesPerBatch,
+    maxIterations: flags.maxIterations,
+  };
+  if (flags.verbose) {
+    pipelineOpts.log = (entry) => {
+      process.stderr.write(`[generate-fixture] ${JSON.stringify(entry)}\n`);
+    };
+  }
+  const result = await runFixtureGenerator(clients, pipelineOpts);
+
+  writeFileSync(flags.outputPath, `${JSON.stringify(result.fixture, null, 2)}\n`);
+  process.stderr.write(
+    `[generate-fixture] wrote ${result.fixture.length} entries to ${flags.outputPath} ` +
+      `(${result.apiCalls} API calls, ${result.iterations} iterations)\n`,
+  );
+}
+
+function loadConfig(path: string): PipelineConfig {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(path, "utf8"));
+  } catch (err) {
+    throw new Error(
+      `failed to read config at ${path}: ${err instanceof Error ? err.message : "unknown"}`,
+    );
+  }
+  return PipelineConfigSchema.parse(raw);
+}
+
+function resolveTokens(config: PipelineConfig): Map<string, string> {
+  const out = new Map<string, string>();
+  const refs = [config.generator, ...config.graders];
+  for (const ref of refs) {
+    const token = process.env[ref.token_env];
+    if (typeof token !== "string" || token.length === 0) {
+      throw new Error(
+        `env var ${ref.token_env} (for ${ref.name}) is empty or unset — refusing to start`,
+      );
+    }
+    out.set(ref.token_env, token);
+  }
+  return out;
+}
+
+function buildClients(config: PipelineConfig, tokens: Map<string, string>): PipelineClients {
+  const generatorClient = clientFor(config.generator, tokens);
+  const graderClients = config.graders.map((g) => clientFor(g, tokens));
+  return {
+    async generate(prompt) {
+      const completion = await generatorClient.complete({
+        messages: [{ role: "user", content: prompt }],
+        // The generator returns JSON in the body of its reply; we
+        // explicitly request the JSON-mode response_format so models
+        // that support it (GPT-4o, Claude) don't wrap the array in
+        // markdown fences. The parser tolerates either shape.
+        jsonResponse: true,
+        temperature: 0.7,
+        timeoutMs: DEFAULT_TIMEOUT_MS,
+      });
+      return completion.content;
+    },
+    async grade(graderIndex, prompt) {
+      const client = graderClients[graderIndex];
+      if (!client) throw new Error(`grader index out of range: ${graderIndex}`);
+      try {
+        const completion = await client.complete({
+          messages: [{ role: "user", content: prompt }],
+          jsonResponse: true,
+          temperature: 0,
+          timeoutMs: DEFAULT_TIMEOUT_MS,
+        });
+        return completion.content;
+      } catch (err) {
+        // Surface as empty text — `parseVerdict` will return null,
+        // which the consensus filter treats as `grader_failed`. We
+        // deliberately don't echo the error message (could carry a
+        // bearer token via a custom transport).
+        void (err instanceof LlmClientError);
+        return "";
+      }
+    },
+  };
+}
+
+function clientFor(spec: GraderConfig, tokens: Map<string, string>): LlmClient {
+  const token = tokens.get(spec.token_env);
+  if (!token) throw new Error(`unresolved token for ${spec.name}`);
+  const cfg: LlmClientConfig = {
+    endpoint: spec.endpoint,
+    token,
+    model: spec.model,
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+  };
+  return createCuratorLlmClient(cfg);
+}
+
+function positiveInt(value: string | undefined, fallback: number, name: string): number {
+  if (value === undefined) return fallback;
+  const n = Number(value);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0) {
+    throw new Error(`${name} must be a positive integer (got ${value})`);
+  }
+  return n;
+}
+
+function fraction(value: string | undefined, fallback: number, name: string): number {
+  if (value === undefined) return fallback;
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < 0 || n > 1) {
+    throw new Error(`${name} must be a number in [0, 1] (got ${value})`);
+  }
+  return n;
+}

--- a/packages/classifier-eval/src/generate/consensus.ts
+++ b/packages/classifier-eval/src/generate/consensus.ts
@@ -1,0 +1,39 @@
+// Consensus filter — given a candidate and N grader verdicts, return
+// the unanimous label or `null` if any grader disagreed. Pure
+// function; testable in isolation.
+//
+// The spec language is strict: "Keep only candidates where all three
+// models agree on both booleans. If a candidate has any disagreement,
+// drop it." So a null verdict from any grader (parse failure /
+// provider error) counts as disagreement and the candidate drops.
+
+import type { ClassifierVerdict } from "@librarian/classifier";
+
+export interface ConsensusResult {
+  /** The unanimous verdict, or null if the candidate must drop. */
+  verdict: ClassifierVerdict | null;
+  /** Why the candidate dropped, when verdict is null. Empty otherwise. */
+  reason: string;
+}
+
+/**
+ * Returns the unanimous verdict across `votes`, or null with a reason
+ * when any grader disagreed or failed.
+ *
+ * The minimum-graders requirement is enforced by `PipelineConfigSchema`
+ * (exactly 3 graders); this function still tolerates any non-empty
+ * count so tests can exercise edge cases.
+ */
+export function consensusVerdict(votes: ReadonlyArray<ClassifierVerdict | null>): ConsensusResult {
+  if (votes.length === 0) return { verdict: null, reason: "no votes" };
+  const first = votes[0] ?? null;
+  if (first === null) return { verdict: null, reason: "grader_failed" };
+  for (let i = 1; i < votes.length; i++) {
+    const vote = votes[i] ?? null;
+    if (vote === null) return { verdict: null, reason: "grader_failed" };
+    if (vote.requires_approval !== first.requires_approval || vote.is_global !== first.is_global) {
+      return { verdict: null, reason: "disagreement" };
+    }
+  }
+  return { verdict: first, reason: "" };
+}

--- a/packages/classifier-eval/src/generate/pipeline.ts
+++ b/packages/classifier-eval/src/generate/pipeline.ts
@@ -1,0 +1,208 @@
+// Orchestrator for the §4.7 public-fixture generation pipeline.
+//
+// Pure logic (no HTTP) — the LLM-facing dependencies arrive as injected
+// async functions so the CLI can wire them to real `createCuratorLlmClient`
+// instances, while tests pass in-memory stubs. `runFixtureGenerator`
+// returns the final `FixtureFile` or throws when budget / iteration caps
+// are exhausted before the targets are met.
+
+import { randomUUID } from "node:crypto";
+import { parseVerdict, type ClassifierVerdict } from "@librarian/classifier";
+import type { FixtureEntry } from "../fixture.js";
+import { consensusVerdict } from "./consensus.js";
+import type { GeneratorBatchSpec } from "./prompts.js";
+import { buildGeneratorPrompt, buildGraderPrompt } from "./prompts.js";
+import { targetCounts, trimToTargets } from "./trim.js";
+import type { PipelineLogEvent, PipelineOptions } from "./types.js";
+
+/** A candidate as it leaves the generator — no id, no consensus models. */
+export interface RawCandidate {
+  title: string;
+  body: string;
+  tags: string[];
+  label: ClassifierVerdict;
+  category: FixtureEntry["category"];
+}
+
+/**
+ * What the orchestrator needs from the outside world. Tests inject
+ * fakes; the CLI wires these to real HTTP-backed LLM clients.
+ */
+export interface PipelineClients {
+  /** Run one generator-prompt completion. Returns the raw model text. */
+  generate: (prompt: string) => Promise<string>;
+  /** Run one grader-prompt completion against `graderIndex`'s endpoint. */
+  grade: (graderIndex: number, prompt: string) => Promise<string>;
+}
+
+export interface PipelineResult {
+  fixture: FixtureEntry[];
+  iterations: number;
+  apiCalls: number;
+}
+
+export async function runFixtureGenerator(
+  clients: PipelineClients,
+  opts: PipelineOptions,
+): Promise<PipelineResult> {
+  const { config, targets, budget, candidatesPerBatch, maxIterations } = opts;
+  const goals = targetCounts(targets);
+  const graderNames = config.graders.map((g) => g.name);
+  const survivors: { straight: FixtureEntry[]; boundary: FixtureEntry[] } = {
+    straight: [],
+    boundary: [],
+  };
+  let apiCalls = 0;
+  let iteration = 0;
+  const log = (event: PipelineLogEvent): void => opts.log?.(event);
+
+  const checkBudget = (): void => {
+    if (apiCalls > budget.maxCalls) {
+      throw new Error(
+        `budget exhausted (max ${budget.maxCalls} API calls); have ` +
+          `${survivors.straight.length}/${goals.straight} straight + ` +
+          `${survivors.boundary.length}/${goals.boundary} boundary`,
+      );
+    }
+  };
+
+  while (
+    iteration < maxIterations &&
+    (survivors.straight.length < goals.straight || survivors.boundary.length < goals.boundary)
+  ) {
+    iteration++;
+    log({
+      event: "iteration",
+      iteration,
+      haveStraight: survivors.straight.length,
+      haveBoundary: survivors.boundary.length,
+    });
+
+    // Adapt batch composition: if one bucket is full, request only
+    // the other category from the next batch.
+    const stillNeedStraight = survivors.straight.length < goals.straight;
+    const stillNeedBoundary = survivors.boundary.length < goals.boundary;
+    let boundaryRatio: number;
+    if (stillNeedStraight && stillNeedBoundary) boundaryRatio = targets.boundaryRatio;
+    else if (stillNeedBoundary) boundaryRatio = 1;
+    else boundaryRatio = 0;
+    const spec: GeneratorBatchSpec = { totalCount: candidatesPerBatch, boundaryRatio };
+
+    const prompt = buildGeneratorPrompt(spec);
+    const raw = await clients.generate(prompt);
+    apiCalls++;
+    checkBudget();
+    const candidates = parseGeneratorOutput(raw);
+    log({
+      event: "batch_generated",
+      iteration,
+      candidates: candidates.length,
+      callCount: apiCalls,
+    });
+
+    for (const candidate of candidates) {
+      // Skip categories that are already full so we don't waste grader
+      // calls on the bucket that's done.
+      const bucketFull =
+        candidate.category === "straight"
+          ? survivors.straight.length >= goals.straight
+          : survivors.boundary.length >= goals.boundary;
+      if (bucketFull) continue;
+
+      const graderPrompt = buildGraderPrompt(candidate);
+      const votes: (ClassifierVerdict | null)[] = [];
+      for (let i = 0; i < config.graders.length; i++) {
+        const graderOutput = await clients.grade(i, graderPrompt);
+        apiCalls++;
+        votes.push(parseVerdict(graderOutput));
+        checkBudget();
+      }
+      const consensus = consensusVerdict(votes);
+      if (consensus.verdict === null) {
+        log({ event: "candidate_dropped", reason: consensus.reason, callCount: apiCalls });
+        continue;
+      }
+
+      const entry: FixtureEntry = {
+        id: `fix_${randomUUID()}`,
+        title: candidate.title,
+        body: candidate.body,
+        tags: candidate.tags,
+        // The graders' consensus IS the ground truth — overrides
+        // whatever the generator claimed.
+        label: consensus.verdict,
+        category: candidate.category,
+        consensus_models: graderNames,
+      };
+      survivors[candidate.category].push(entry);
+      log({ event: "candidate_kept", verdict: consensus.verdict, callCount: apiCalls });
+    }
+  }
+
+  const trim = trimToTargets(survivors.straight, survivors.boundary, targets);
+  if (!trim.targetsMet) {
+    throw new Error(
+      `iteration cap reached (${iteration}/${maxIterations}) before targets met; ` +
+        `have ${trim.counts.straight}/${goals.straight} straight + ` +
+        `${trim.counts.boundary}/${goals.boundary} boundary after ${apiCalls} API calls`,
+    );
+  }
+
+  log({ event: "done", iterations: iteration, calls: apiCalls });
+  return { fixture: trim.trimmed, iterations: iteration, apiCalls };
+}
+
+/**
+ * Parse the generator's raw text into structured candidates. The
+ * generator is asked to return a JSON array; in practice models
+ * sometimes wrap it in code fences or preamble. Strip both and
+ * validate against the candidate schema; malformed candidates are
+ * silently dropped (the generator will produce more next batch).
+ */
+export function parseGeneratorOutput(raw: string): RawCandidate[] {
+  const json = extractJsonArray(raw);
+  if (!json) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  const result: RawCandidate[] = [];
+  for (const item of parsed) {
+    const candidate = validateCandidate(item);
+    if (candidate) result.push(candidate);
+  }
+  return result;
+}
+
+function extractJsonArray(text: string): string | null {
+  // Find the first '[' and the last ']' — tolerant of preamble + code
+  // fences + trailing prose. Doesn't validate nesting; JSON.parse
+  // does that downstream.
+  const start = text.indexOf("[");
+  const end = text.lastIndexOf("]");
+  if (start === -1 || end === -1 || end < start) return null;
+  return text.slice(start, end + 1);
+}
+
+function validateCandidate(item: unknown): RawCandidate | null {
+  if (typeof item !== "object" || item === null) return null;
+  const obj = item as Record<string, unknown>;
+  if (typeof obj.title !== "string" || obj.title.length === 0) return null;
+  if (typeof obj.body !== "string" || obj.body.length === 0) return null;
+  if (obj.category !== "straight" && obj.category !== "boundary") return null;
+  const label = obj.label;
+  if (typeof label !== "object" || label === null) return null;
+  const l = label as Record<string, unknown>;
+  if (typeof l.requires_approval !== "boolean" || typeof l.is_global !== "boolean") return null;
+  const tags = Array.isArray(obj.tags) ? obj.tags.filter((t) => typeof t === "string") : [];
+  return {
+    title: obj.title,
+    body: obj.body,
+    tags: tags as string[],
+    label: { requires_approval: l.requires_approval, is_global: l.is_global },
+    category: obj.category,
+  };
+}

--- a/packages/classifier-eval/src/generate/prompts.ts
+++ b/packages/classifier-eval/src/generate/prompts.ts
@@ -1,0 +1,73 @@
+// Prompts used by the `eval generate-fixture` pipeline.
+//
+// `buildGeneratorPrompt` asks one strong LLM for a batch of candidate
+// memories with claimed labels. The 3 graders are then driven by the
+// existing classifier v1 prompt (re-exported here so the consensus
+// filter is byte-for-byte the same task the classifier worker faces in
+// production — that's what makes a unanimous-vote candidate
+// "ground truth").
+
+import { loadPromptTemplate, renderPrompt } from "@librarian/classifier";
+
+export interface GeneratorBatchSpec {
+  totalCount: number;
+  /** Fraction of `totalCount` that should be category=boundary. */
+  boundaryRatio: number;
+}
+
+export function buildGeneratorPrompt(spec: GeneratorBatchSpec): string {
+  const boundary = Math.round(spec.totalCount * spec.boundaryRatio);
+  const straight = spec.totalCount - boundary;
+  return [
+    "You generate synthetic test cases for a memory classifier. Each test case",
+    "is a 'memory' — a short note someone wrote to themselves — paired with",
+    "the generator's claim about two booleans:",
+    "",
+    "  - requires_approval: true if the memory contains identity facts,",
+    "    relationship facts, or anything an owner would want to review",
+    "    before it becomes active. False otherwise.",
+    "  - is_global: true if the memory should bypass per-conversation domain",
+    "    filtering and be available everywhere (identity, relationships,",
+    "    preferences). False if contextual to a domain (tools, projects,",
+    "    lessons, environment).",
+    "",
+    `Generate exactly ${spec.totalCount} memories with this mix:`,
+    `  - ${straight} STRAIGHT cases (category="straight"): clear examples`,
+    "    covering each of the four (requires_approval, is_global) quadrants.",
+    "    Vary the quadrants across straight cases — don't lopside them.",
+    `  - ${boundary} BOUNDARY cases (category="boundary"): things that LOOK`,
+    "    like one quadrant but belong in another (a tool-shaped note that",
+    "    contains a relationship fact; an identity-shaped note that's",
+    "    actually a preference; a project memory that's globally relevant).",
+    "",
+    "Each memory should be 1-3 sentences. Use realistic content. Vary",
+    "domains (work, family, coding, hobbies). Avoid generic / repetitive",
+    "phrasing.",
+    "",
+    "Return ONLY a single JSON array, no prose, no markdown fences:",
+    "[",
+    "  {",
+    '    "title": "short title (3-8 words)",',
+    '    "body": "1-3 sentence memory body",',
+    '    "tags": ["tag1", "tag2"],',
+    '    "label": { "requires_approval": false, "is_global": false },',
+    '    "category": "straight"',
+    "  },",
+    "  ...",
+    "]",
+  ].join("\n");
+}
+
+/**
+ * Render the classifier's v1 prompt with a candidate's input. This is
+ * the exact prompt the production worker uses — running each candidate
+ * through it via 3 graders is the consensus filter the spec defines.
+ */
+export function buildGraderPrompt(candidate: {
+  title: string;
+  body: string;
+  tags: readonly string[];
+}): string {
+  const template = loadPromptTemplate("v1");
+  return renderPrompt(template, candidate);
+}

--- a/packages/classifier-eval/src/generate/trim.ts
+++ b/packages/classifier-eval/src/generate/trim.ts
@@ -1,0 +1,47 @@
+// Ratio-preserving trim — given two buckets of accepted candidates
+// (`straight` + `boundary`), return a slice of the target size that
+// honours the requested boundary ratio. Drops surplus from whichever
+// bucket overshoots. Pure function.
+
+import type { FixtureEntry } from "../fixture.js";
+
+export interface TrimTargets {
+  /** Final desired total. */
+  total: number;
+  /** Fraction of total that should be category=boundary. */
+  boundaryRatio: number;
+}
+
+export interface TrimResult {
+  trimmed: FixtureEntry[];
+  /** How many of each category survived (post-trim). */
+  counts: { straight: number; boundary: number };
+  /**
+   * True when both per-category targets were met. False if either
+   * bucket was short of its target after trim — the pipeline should
+   * iterate more in that case.
+   */
+  targetsMet: boolean;
+}
+
+export function trimToTargets(
+  straight: readonly FixtureEntry[],
+  boundary: readonly FixtureEntry[],
+  targets: TrimTargets,
+): TrimResult {
+  const boundaryTarget = Math.round(targets.total * targets.boundaryRatio);
+  const straightTarget = targets.total - boundaryTarget;
+  const takenStraight = straight.slice(0, straightTarget);
+  const takenBoundary = boundary.slice(0, boundaryTarget);
+  return {
+    trimmed: [...takenStraight, ...takenBoundary],
+    counts: { straight: takenStraight.length, boundary: takenBoundary.length },
+    targetsMet: takenStraight.length === straightTarget && takenBoundary.length === boundaryTarget,
+  };
+}
+
+/** Per-category target counts derived from total + ratio. */
+export function targetCounts(targets: TrimTargets): { straight: number; boundary: number } {
+  const boundary = Math.round(targets.total * targets.boundaryRatio);
+  return { straight: targets.total - boundary, boundary };
+}

--- a/packages/classifier-eval/src/generate/types.ts
+++ b/packages/classifier-eval/src/generate/types.ts
@@ -1,0 +1,72 @@
+// Shared types for the `eval generate-fixture` pipeline (spec §4.7).
+//
+// `GraderConfig` describes a frontier-model endpoint that votes on
+// each candidate. The spec calls for three graders from three model
+// families (Claude / GPT / Gemini) so a single family's bias can't
+// shape the resulting fixture. The pipeline enforces that all
+// configured graders vote unanimously — anything less drops.
+
+import { z } from "zod";
+
+export const GraderConfigSchema = z.strictObject({
+  /** Display name for logs + the `consensus_models` field on each fixture entry. */
+  name: z.string().min(1),
+  /** OpenAI-compatible base URL. */
+  endpoint: z.string().url(),
+  /** Model id passed in chat-completions requests. */
+  model: z.string().min(1),
+  /**
+   * Environment variable name that holds the bearer token. The token
+   * itself is never written to disk via this config — the CLI reads
+   * `process.env[token_env]` at run time and refuses to start if any
+   * referenced env var is unset.
+   */
+  token_env: z.string().min(1),
+});
+export type GraderConfig = z.infer<typeof GraderConfigSchema>;
+
+export const PipelineConfigSchema = z.strictObject({
+  /** The single strong LLM that generates candidate batches. */
+  generator: GraderConfigSchema,
+  /** Exactly 3 graders from distinct families (spec §4.7). */
+  graders: z.array(GraderConfigSchema).length(3),
+});
+export type PipelineConfig = z.infer<typeof PipelineConfigSchema>;
+
+export interface PipelineTargets {
+  /** Total fixture size (straight + boundary). Default 900 per spec. */
+  total: number;
+  /** Fraction of `total` that should be boundary cases. Default 0.4. */
+  boundaryRatio: number;
+}
+
+export interface PipelineBudget {
+  /**
+   * Hard cap on total LLM calls (generator batches + grader votes).
+   * Defaults to a generous 8000 for the spec's ~5500 expected calls.
+   */
+  maxCalls: number;
+}
+
+export interface PipelineOptions {
+  config: PipelineConfig;
+  targets: PipelineTargets;
+  budget: PipelineBudget;
+  /** Candidates to generate per generator call. Default 100. */
+  candidatesPerBatch: number;
+  /** Max generator batches before giving up. Default 12. */
+  maxIterations: number;
+  /** Optional progress sink. */
+  log?: (entry: PipelineLogEvent) => void;
+}
+
+export type PipelineLogEvent =
+  | { event: "iteration"; iteration: number; haveStraight: number; haveBoundary: number }
+  | { event: "batch_generated"; iteration: number; candidates: number; callCount: number }
+  | { event: "candidate_dropped"; reason: string; callCount: number }
+  | {
+      event: "candidate_kept";
+      verdict: { requires_approval: boolean; is_global: boolean };
+      callCount: number;
+    }
+  | { event: "done"; iterations: number; calls: number };

--- a/packages/classifier-eval/src/index.ts
+++ b/packages/classifier-eval/src/index.ts
@@ -27,6 +27,24 @@ export {
 } from "./soft-alert.js";
 export type { SoftAlertInput, SoftAlertResult } from "./soft-alert.js";
 
+export { runFixtureGenerator, parseGeneratorOutput } from "./generate/pipeline.js";
+export type { PipelineClients, PipelineResult, RawCandidate } from "./generate/pipeline.js";
+export { PipelineConfigSchema, GraderConfigSchema } from "./generate/types.js";
+export type {
+  PipelineConfig,
+  PipelineOptions,
+  PipelineLogEvent,
+  PipelineTargets,
+  PipelineBudget,
+  GraderConfig,
+} from "./generate/types.js";
+export { consensusVerdict } from "./generate/consensus.js";
+export type { ConsensusResult } from "./generate/consensus.js";
+export { trimToTargets, targetCounts } from "./generate/trim.js";
+export type { TrimResult, TrimTargets } from "./generate/trim.js";
+export { buildGeneratorPrompt, buildGraderPrompt } from "./generate/prompts.js";
+export type { GeneratorBatchSpec } from "./generate/prompts.js";
+
 /**
  * Load the bundled seed fixture (~12 entries covering each verdict
  * quadrant and a few boundary cases). The public consensus-graded

--- a/packages/classifier-eval/tests/consensus.test.ts
+++ b/packages/classifier-eval/tests/consensus.test.ts
@@ -1,0 +1,39 @@
+// Consensus filter — pure function tests.
+
+import { describe, expect, it } from "vitest";
+import { consensusVerdict } from "../src/generate/consensus.js";
+
+const T = { requires_approval: true, is_global: true };
+const F = { requires_approval: false, is_global: false };
+const MIXED = { requires_approval: true, is_global: false };
+
+describe("consensusVerdict", () => {
+  it("returns the verdict when every grader agrees", () => {
+    const result = consensusVerdict([T, T, T]);
+    expect(result.verdict).toEqual(T);
+    expect(result.reason).toBe("");
+  });
+
+  it("drops the candidate when a grader returns null (parse failure / provider error)", () => {
+    const result = consensusVerdict([T, null, T]);
+    expect(result.verdict).toBeNull();
+    expect(result.reason).toBe("grader_failed");
+  });
+
+  it("drops the candidate on any disagreement, even one boolean", () => {
+    expect(consensusVerdict([T, T, MIXED]).reason).toBe("disagreement");
+    expect(consensusVerdict([T, F, T]).reason).toBe("disagreement");
+  });
+
+  it("drops on empty input", () => {
+    const result = consensusVerdict([]);
+    expect(result.verdict).toBeNull();
+    expect(result.reason).toBe("no votes");
+  });
+
+  it("works for any non-zero grader count (the production count is 3 but the filter is family-size-agnostic)", () => {
+    expect(consensusVerdict([T]).verdict).toEqual(T);
+    expect(consensusVerdict([T, T]).verdict).toEqual(T);
+    expect(consensusVerdict([T, T, T, T]).verdict).toEqual(T);
+  });
+});

--- a/packages/classifier-eval/tests/generate-fixture-command.test.ts
+++ b/packages/classifier-eval/tests/generate-fixture-command.test.ts
@@ -1,0 +1,85 @@
+// CLI flag-parsing tests for `generate-fixture`. The full command's
+// HTTP wiring is exercised manually by the operator; here we pin
+// only the pure flag-parse + validation surface.
+
+import { describe, expect, it } from "vitest";
+import { parseGenerateFixtureFlags } from "../src/cli/generate-fixture-command.js";
+
+describe("parseGenerateFixtureFlags", () => {
+  it("parses a minimal invocation with defaults", () => {
+    const flags = parseGenerateFixtureFlags([
+      "--config",
+      "graders.json",
+      "--output",
+      "fixtures/public-v1.json",
+    ]);
+    expect(flags).toMatchObject({
+      configPath: "graders.json",
+      outputPath: "fixtures/public-v1.json",
+      target: 900,
+      boundaryRatio: 0.4,
+      candidatesPerBatch: 100,
+      maxIterations: 12,
+      maxCalls: 8000,
+      dryRun: false,
+      verbose: false,
+    });
+  });
+
+  it("honours every override flag", () => {
+    const flags = parseGenerateFixtureFlags([
+      "--config",
+      "c.json",
+      "--output",
+      "out.json",
+      "--target",
+      "120",
+      "--boundary-ratio",
+      "0.5",
+      "--candidates-per-batch",
+      "30",
+      "--max-iterations",
+      "5",
+      "--max-calls",
+      "200",
+      "--dry-run",
+      "--verbose",
+    ]);
+    expect(flags.target).toBe(120);
+    expect(flags.boundaryRatio).toBe(0.5);
+    expect(flags.candidatesPerBatch).toBe(30);
+    expect(flags.maxIterations).toBe(5);
+    expect(flags.maxCalls).toBe(200);
+    expect(flags.dryRun).toBe(true);
+    expect(flags.verbose).toBe(true);
+  });
+
+  it("requires --config", () => {
+    expect(() => parseGenerateFixtureFlags(["--output", "o.json"])).toThrow(/--config/);
+  });
+
+  it("requires --output", () => {
+    expect(() => parseGenerateFixtureFlags(["--config", "c.json"])).toThrow(/--output/);
+  });
+
+  it("rejects non-positive integer arguments", () => {
+    expect(() =>
+      parseGenerateFixtureFlags(["--config", "c", "--output", "o", "--target", "0"]),
+    ).toThrow(/--target/);
+    expect(() =>
+      parseGenerateFixtureFlags(["--config", "c", "--output", "o", "--target", "-5"]),
+    ).toThrow(/--target/);
+    expect(() =>
+      parseGenerateFixtureFlags(["--config", "c", "--output", "o", "--target", "1.5"]),
+    ).toThrow(/--target/);
+  });
+
+  it("rejects boundary-ratio outside [0, 1]", () => {
+    expect(() =>
+      parseGenerateFixtureFlags(["--config", "c", "--output", "o", "--boundary-ratio", "1.5"]),
+    ).toThrow(/boundary-ratio/);
+    expect(() =>
+      parseGenerateFixtureFlags(["--config", "c", "--output", "o", "--boundary-ratio", "-0.1"]),
+    ).toThrow(/boundary-ratio/);
+  });
+});

--- a/packages/classifier-eval/tests/generate-pipeline.test.ts
+++ b/packages/classifier-eval/tests/generate-pipeline.test.ts
@@ -1,0 +1,197 @@
+// Pipeline orchestrator tests — runs against in-memory stub clients
+// so the full generate → grade → consensus → trim → iterate loop is
+// exercised without any HTTP.
+
+import { describe, expect, it } from "vitest";
+import { parseGeneratorOutput, runFixtureGenerator } from "../src/generate/pipeline.js";
+import type { PipelineClients } from "../src/generate/pipeline.js";
+import type { PipelineConfig } from "../src/generate/types.js";
+
+const CONFIG: PipelineConfig = {
+  generator: {
+    name: "claude-sonnet",
+    endpoint: "https://example/v1",
+    model: "claude-sonnet-x",
+    token_env: "_T",
+  },
+  graders: [
+    { name: "claude", endpoint: "https://a/v1", model: "claude", token_env: "_T" },
+    { name: "gpt", endpoint: "https://b/v1", model: "gpt", token_env: "_T" },
+    { name: "gemini", endpoint: "https://c/v1", model: "gemini", token_env: "_T" },
+  ],
+};
+
+function candidateJson(
+  category: "straight" | "boundary",
+  label: { requires_approval: boolean; is_global: boolean },
+  i: number,
+): string {
+  return JSON.stringify({
+    title: `title-${category}-${i}`,
+    body: `body-${category}-${i}`,
+    tags: ["x"],
+    label,
+    category,
+  });
+}
+
+function batch(items: string[]): string {
+  return `[${items.join(",")}]`;
+}
+
+function unanimousAgree(label: { requires_approval: boolean; is_global: boolean }): string {
+  return JSON.stringify(label);
+}
+
+describe("runFixtureGenerator", () => {
+  it("returns the requested ratio when graders unanimously agree", async () => {
+    const labels = [
+      { requires_approval: true, is_global: true },
+      { requires_approval: false, is_global: false },
+    ];
+    // Track per-candidate so all 3 graders of one candidate see the
+    // same verdict (unanimity is what the consensus filter accepts).
+    let candidateIdx = -1;
+    let lastGraderForCandidate = -1;
+    const clients: PipelineClients = {
+      async generate() {
+        const cands = [
+          candidateJson("straight", labels[0]!, 1),
+          candidateJson("straight", labels[1]!, 2),
+          candidateJson("straight", labels[0]!, 3),
+          candidateJson("boundary", labels[1]!, 4),
+          candidateJson("boundary", labels[0]!, 5),
+        ];
+        return batch(cands);
+      },
+      async grade(graderIndex) {
+        // The pipeline calls grader 0, then 1, then 2 in order per
+        // candidate. Roll the candidate index forward when grader 0
+        // is hit (start of a new candidate).
+        if (graderIndex <= lastGraderForCandidate) candidateIdx++;
+        else if (graderIndex === 0) candidateIdx++;
+        lastGraderForCandidate = graderIndex;
+        return unanimousAgree(labels[candidateIdx % labels.length]!);
+      },
+    };
+    const result = await runFixtureGenerator(clients, {
+      config: CONFIG,
+      targets: { total: 5, boundaryRatio: 0.4 },
+      budget: { maxCalls: 100 },
+      candidatesPerBatch: 5,
+      maxIterations: 3,
+    });
+    expect(result.fixture).toHaveLength(5);
+    const straightCount = result.fixture.filter((e) => e.category === "straight").length;
+    const boundaryCount = result.fixture.filter((e) => e.category === "boundary").length;
+    expect(straightCount).toBe(3);
+    expect(boundaryCount).toBe(2);
+    // consensus_models flows through every survivor
+    for (const e of result.fixture) {
+      expect(e.consensus_models).toEqual(["claude", "gpt", "gemini"]);
+    }
+  });
+
+  it("drops candidates when any grader disagrees", async () => {
+    const calls: string[] = [];
+    const clients: PipelineClients = {
+      async generate() {
+        return batch([
+          candidateJson("straight", { requires_approval: true, is_global: true }, 1),
+          candidateJson("straight", { requires_approval: false, is_global: false }, 2),
+        ]);
+      },
+      async grade(graderIndex) {
+        calls.push(`g${graderIndex}`);
+        // grader 0 + 1 say (T,T), grader 2 says (T,F) → disagreement
+        if (graderIndex === 2) {
+          return '{"requires_approval": true, "is_global": false}';
+        }
+        return '{"requires_approval": true, "is_global": true}';
+      },
+    };
+    await expect(
+      runFixtureGenerator(clients, {
+        config: CONFIG,
+        targets: { total: 2, boundaryRatio: 0 },
+        budget: { maxCalls: 100 },
+        candidatesPerBatch: 2,
+        maxIterations: 2,
+      }),
+    ).rejects.toThrow(/iteration cap reached/);
+    // 3 graders × 2 candidates × 2 iterations = 12 grader calls + 2 generator
+    expect(calls.length).toBeGreaterThan(0);
+  });
+
+  it("uses the graders' consensus as the ground-truth label even when the generator claimed something else", async () => {
+    const clients: PipelineClients = {
+      async generate() {
+        return batch([candidateJson("straight", { requires_approval: true, is_global: true }, 1)]);
+      },
+      async grade() {
+        // Graders unanimous on (F, F) — overrides the generator's (T, T).
+        return '{"requires_approval": false, "is_global": false}';
+      },
+    };
+    const result = await runFixtureGenerator(clients, {
+      config: CONFIG,
+      targets: { total: 1, boundaryRatio: 0 },
+      budget: { maxCalls: 100 },
+      candidatesPerBatch: 1,
+      maxIterations: 3,
+    });
+    expect(result.fixture[0]!.label).toEqual({ requires_approval: false, is_global: false });
+  });
+
+  it("throws when the call budget is exhausted before targets are met", async () => {
+    const clients: PipelineClients = {
+      async generate() {
+        return batch([candidateJson("straight", { requires_approval: true, is_global: true }, 1)]);
+      },
+      async grade() {
+        // disagreement on every candidate so nothing survives
+        return Math.random() > 0.5
+          ? '{"requires_approval": true, "is_global": true}'
+          : '{"requires_approval": false, "is_global": false}';
+      },
+    };
+    await expect(
+      runFixtureGenerator(clients, {
+        config: CONFIG,
+        targets: { total: 1, boundaryRatio: 0 },
+        budget: { maxCalls: 5 },
+        candidatesPerBatch: 1,
+        maxIterations: 10,
+      }),
+    ).rejects.toThrow(/budget exhausted/);
+  });
+});
+
+describe("parseGeneratorOutput", () => {
+  it("parses a bare JSON array", () => {
+    const out = parseGeneratorOutput(
+      batch([candidateJson("straight", { requires_approval: false, is_global: false }, 1)]),
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]?.category).toBe("straight");
+  });
+
+  it("tolerates a code-fence wrapper", () => {
+    const cand = candidateJson("boundary", { requires_approval: true, is_global: true }, 1);
+    const wrapped = `Here is the batch:\n\n\`\`\`json\n[${cand}]\n\`\`\`\n`;
+    const out = parseGeneratorOutput(wrapped);
+    expect(out).toHaveLength(1);
+  });
+
+  it("returns [] on malformed JSON", () => {
+    expect(parseGeneratorOutput("not json")).toEqual([]);
+    expect(parseGeneratorOutput("[")).toEqual([]);
+  });
+
+  it("drops malformed candidates inside an otherwise-valid array", () => {
+    const good = candidateJson("straight", { requires_approval: false, is_global: false }, 1);
+    const bad = JSON.stringify({ title: "missing body" });
+    const out = parseGeneratorOutput(`[${good}, ${bad}]`);
+    expect(out).toHaveLength(1);
+  });
+});

--- a/packages/classifier-eval/tests/generate-pipeline.test.ts
+++ b/packages/classifier-eval/tests/generate-pipeline.test.ts
@@ -144,15 +144,17 @@ describe("runFixtureGenerator", () => {
   });
 
   it("throws when the call budget is exhausted before targets are met", async () => {
+    // Deterministic disagreement: grader 2 always votes the opposite
+    // of graders 0 + 1, so no candidate ever survives the unanimous
+    // filter. The pipeline keeps iterating, the budget runs out.
     const clients: PipelineClients = {
       async generate() {
         return batch([candidateJson("straight", { requires_approval: true, is_global: true }, 1)]);
       },
-      async grade() {
-        // disagreement on every candidate so nothing survives
-        return Math.random() > 0.5
-          ? '{"requires_approval": true, "is_global": true}'
-          : '{"requires_approval": false, "is_global": false}';
+      async grade(graderIndex) {
+        return graderIndex === 2
+          ? '{"requires_approval": false, "is_global": false}'
+          : '{"requires_approval": true, "is_global": true}';
       },
     };
     await expect(

--- a/packages/classifier-eval/tests/generate-prompts.test.ts
+++ b/packages/classifier-eval/tests/generate-prompts.test.ts
@@ -1,0 +1,49 @@
+// Generator + grader prompt construction tests.
+
+import { describe, expect, it } from "vitest";
+import { buildGeneratorPrompt, buildGraderPrompt } from "../src/generate/prompts.js";
+
+describe("buildGeneratorPrompt", () => {
+  it("requests the exact total count and asks for the boundary/straight mix", () => {
+    const prompt = buildGeneratorPrompt({ totalCount: 100, boundaryRatio: 0.4 });
+    expect(prompt).toContain("Generate exactly 100 memories");
+    expect(prompt).toContain("60 STRAIGHT");
+    expect(prompt).toContain("40 BOUNDARY");
+  });
+
+  it("rounds the boundary count", () => {
+    const prompt = buildGeneratorPrompt({ totalCount: 100, boundaryRatio: 0.37 });
+    // 100 * 0.37 = 37 boundary, 63 straight
+    expect(prompt).toContain("63 STRAIGHT");
+    expect(prompt).toContain("37 BOUNDARY");
+  });
+
+  it("requests JSON-array output without prose", () => {
+    const prompt = buildGeneratorPrompt({ totalCount: 50, boundaryRatio: 0.5 });
+    expect(prompt).toContain("Return ONLY a single JSON array");
+  });
+
+  it("documents the four-key per-entry shape (title/body/tags/label/category)", () => {
+    const prompt = buildGeneratorPrompt({ totalCount: 50, boundaryRatio: 0.5 });
+    expect(prompt).toContain('"title"');
+    expect(prompt).toContain('"body"');
+    expect(prompt).toContain('"tags"');
+    expect(prompt).toContain('"label"');
+    expect(prompt).toContain('"category"');
+  });
+});
+
+describe("buildGraderPrompt", () => {
+  it("uses the classifier v1 prompt with the candidate fields substituted", () => {
+    const prompt = buildGraderPrompt({
+      title: "User identity",
+      body: "Jim is the operator.",
+      tags: ["identity"],
+    });
+    expect(prompt).toContain("User identity");
+    expect(prompt).toContain("Jim is the operator.");
+    expect(prompt).toContain("identity");
+    expect(prompt).toContain("requires_approval");
+    expect(prompt).toContain("is_global");
+  });
+});

--- a/packages/classifier-eval/tests/trim.test.ts
+++ b/packages/classifier-eval/tests/trim.test.ts
@@ -1,0 +1,58 @@
+// Ratio-preserving trim — pure function tests.
+
+import { describe, expect, it } from "vitest";
+import type { FixtureEntry } from "../src/fixture.js";
+import { targetCounts, trimToTargets } from "../src/generate/trim.js";
+
+function entry(id: string, category: FixtureEntry["category"]): FixtureEntry {
+  return {
+    id,
+    title: id,
+    body: id,
+    tags: [],
+    label: { requires_approval: false, is_global: false },
+    category,
+  };
+}
+
+describe("trimToTargets", () => {
+  it("returns a slice respecting boundary ratio when both buckets overflow", () => {
+    const straight = [entry("s1", "straight"), entry("s2", "straight"), entry("s3", "straight")];
+    const boundary = [entry("b1", "boundary"), entry("b2", "boundary"), entry("b3", "boundary")];
+    const result = trimToTargets(straight, boundary, { total: 5, boundaryRatio: 0.4 });
+    expect(result.counts).toEqual({ straight: 3, boundary: 2 });
+    expect(result.trimmed.map((e) => e.id)).toEqual(["s1", "s2", "s3", "b1", "b2"]);
+    expect(result.targetsMet).toBe(true);
+  });
+
+  it("preserves order within each bucket (FIFO from accumulated survivors)", () => {
+    const straight = [entry("s1", "straight"), entry("s2", "straight"), entry("s3", "straight")];
+    const boundary: FixtureEntry[] = [entry("b1", "boundary"), entry("b2", "boundary")];
+    const result = trimToTargets(straight, boundary, { total: 4, boundaryRatio: 0.5 });
+    expect(result.trimmed.map((e) => e.id)).toEqual(["s1", "s2", "b1", "b2"]);
+  });
+
+  it("flags targetsMet=false when one bucket is short", () => {
+    const straight: FixtureEntry[] = [entry("s1", "straight")];
+    const boundary = [entry("b1", "boundary"), entry("b2", "boundary"), entry("b3", "boundary")];
+    const result = trimToTargets(straight, boundary, { total: 5, boundaryRatio: 0.4 });
+    expect(result.counts.straight).toBe(1);
+    expect(result.counts.boundary).toBe(2);
+    expect(result.targetsMet).toBe(false);
+  });
+});
+
+describe("targetCounts", () => {
+  it("splits the total per the boundary ratio", () => {
+    expect(targetCounts({ total: 900, boundaryRatio: 0.4 })).toEqual({
+      straight: 540,
+      boundary: 360,
+    });
+    expect(targetCounts({ total: 100, boundaryRatio: 0.5 })).toEqual({
+      straight: 50,
+      boundary: 50,
+    });
+    expect(targetCounts({ total: 10, boundaryRatio: 0 })).toEqual({ straight: 10, boundary: 0 });
+    expect(targetCounts({ total: 10, boundaryRatio: 1 })).toEqual({ straight: 0, boundary: 10 });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the §4.7 multi-model consensus fixture-generation pipeline as `classifier-eval generate-fixture`. Closes the CLI half of Task 4.10 — the actual fixture remains a one-shot operator run with three API keys (~$5 spend) and intentionally is NOT generated in this PR.

## Why this PR doesn't ship `public-v1.json`

The spec's whole point at §4.7 is the **three-family unanimous-consensus filter** (Claude + GPT-4o + Gemini). A single-model fixture would defeat the bias-elimination property the design is built around — and I (Claude in this session) can't call GPT or Gemini from here. So this PR ships the pipeline + tests + docs; the actual fixture is generated by you when convenient.

## What's in this PR

### Pipeline (`packages/classifier-eval/src/generate/`)

- `prompts.ts` — generator prompt (asks for N candidates with the requested straight/boundary mix, JSON-array output) + grader prompt (re-uses the classifier's own v1 prompt so the consensus filter validates production behaviour byte-for-byte)
- `consensus.ts` — pure unanimous-vote filter. Any grader null (parse / provider error) or any disagreement → drop the candidate
- `trim.ts` — pure ratio-preserving trim. Reports `targetsMet=false` if a bucket falls short so the orchestrator iterates
- `pipeline.ts` — orchestrator with injectable LLM clients; adapts batch composition once one bucket fills; budget guard on call count

### CLI (`packages/classifier-eval/src/cli/generate-fixture-command.ts`)

\`\`\`sh
classifier-eval generate-fixture \\
  --config fixtures/graders.example.json \\
  --output fixtures/public-v1.json \\
  --target 900 --boundary-ratio 0.4 \\
  --candidates-per-batch 100 --max-iterations 12 --max-calls 8000 \\
  --verbose
\`\`\`

- Config JSON references token env vars (`token_env: \"OPENAI_API_KEY\"` etc.) rather than literal tokens — safe to commit
- `--dry-run` validates the config + env without making any API calls
- `--verbose` emits per-iteration progress JSON to stderr
- `--max-calls` hard cap prevents runaway spend
- `fixtures/graders.example.json` ships as a template

### Tests (28 new)

- Consensus filter (unanimous / disagreement / grader-null / size-agnostic)
- Trim ratios (overflow / undershoot / target-counts derivation)
- Generator prompt construction (count / ratio / output shape)
- End-to-end pipeline with fake LLM clients (happy path / disagreement / consensus-overrides-claim / budget exhaustion / generator output parsing)
- CLI flag parsing (defaults / overrides / required flags / range validation)

### Docs

- `packages/classifier-eval/README.md` — package overview + operator runbook for `generate-fixture` (prereqs, dry-run, real run, flag reference, troubleshooting)

## Test plan

- [x] \`pnpm test\` — 1046 tests pass (28 new in classifier-eval)
- [x] \`pnpm typecheck\` clean
- [x] Lint clean
- [ ] CI green