### PR TITLE
fix(docker): add classifier + classifier-eval to mcp-server.Dockerfile

### DIFF
--- a/docker/mcp-server.Dockerfile
+++ b/docker/mcp-server.Dockerfile
@@ -13,17 +13,21 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY packages/core/package.json ./packages/core/package.json
 COPY packages/mcp-server/package.json ./packages/mcp-server/package.json
 COPY packages/cli/package.json ./packages/cli/package.json
+COPY packages/classifier/package.json ./packages/classifier/package.json
+COPY packages/classifier-eval/package.json ./packages/classifier-eval/package.json
 COPY apps/dashboard/package.json ./apps/dashboard/package.json
 
-# We only need core + mcp-server for the runtime image; install everything
+# mcp-server now depends on classifier + classifier-eval at runtime; install everything
 # so workspace symlinks resolve cleanly, then prune later.
 RUN pnpm install --frozen-lockfile --ignore-scripts
 
 COPY tsconfig.base.json ./
 COPY packages/core ./packages/core
+COPY packages/classifier ./packages/classifier
+COPY packages/classifier-eval ./packages/classifier-eval
 COPY packages/mcp-server ./packages/mcp-server
 
-RUN pnpm --filter @librarian/core --filter @librarian/mcp-server run build
+RUN pnpm --filter @librarian/core --filter @librarian/classifier --filter @librarian/classifier-eval --filter @librarian/mcp-server run build
 
 # Drop dev dependencies before copying into the runtime stage. `pnpm deploy`
 # would also work but the workspace symlinks are simpler to reason about.
@@ -48,6 +52,12 @@ COPY --from=builder /app/packages/core/node_modules ./packages/core/node_modules
 COPY --from=builder /app/packages/mcp-server/package.json ./packages/mcp-server/package.json
 COPY --from=builder /app/packages/mcp-server/dist ./packages/mcp-server/dist
 COPY --from=builder /app/packages/mcp-server/node_modules ./packages/mcp-server/node_modules
+COPY --from=builder /app/packages/classifier/package.json ./packages/classifier/package.json
+COPY --from=builder /app/packages/classifier/dist ./packages/classifier/dist
+COPY --from=builder /app/packages/classifier/node_modules ./packages/classifier/node_modules
+COPY --from=builder /app/packages/classifier-eval/package.json ./packages/classifier-eval/package.json
+COPY --from=builder /app/packages/classifier-eval/dist ./packages/classifier-eval/dist
+COPY --from=builder /app/packages/classifier-eval/node_modules ./packages/classifier-eval/node_modules
 
 RUN mkdir -p /data && chown -R node:node /app /data
 


### PR DESCRIPTION
PR #177 (section 4d classifier cutover) added mcp-server imports from @librarian/classifier and @librarian/classifier-eval. Commits a5775f8 and c9302ee updated all-in-one.Dockerfile and dashboard.Dockerfile but missed the separate mcp-server.Dockerfile, so the two-container deploy broke at build time with TS2307 "Cannot find module" errors.

<!--
The Librarian PR template (introduced in T1.4 of the maintainability overhaul).
Keep the sections; trim or expand the contents as the change requires.
-->

## Spec / phase reference

<!-- e.g. "Implements T1.4 — CI workflow + enforcement guards + PR template (Phase 1 of specs/done/maintainability-overhaul.md)" -->

## Summary

<!-- 1–3 bullets on what changed and why. Lead with the why. -->

-
-

## Test plan

<!-- Bulleted checklist proving the PR works. Reference the exact commands you ran. -->

- [ ] `pnpm install --frozen-lockfile`
- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm test:vitest`
- [ ] `pnpm build`
- [ ] `pnpm run smoke`
- [ ] `pnpm run healthcheck`
- [ ] Any task-specific verification commands from the spec

## Quality gates

- [ ] **No production source file over 400 LOC introduced** (or each exception noted with rationale below — applies to `packages/*/src/` and `apps/*/src/`, not tests)
- [ ] **No new `any` or `@ts-ignore` introduced** (or each exception noted with rationale below)

<!--
If you ticked an exception above, list each here:
  - path/to/file.ts (LOC: 612) — splitting deferred to T#.# because …
  - path/to/file.ts:42 — `any` retained because the third-party type is `unknown` and `…`
-->

## Notes for the reviewer

<!-- Anything reviewer-only: known follow-ups, deliberately-deferred work, screenshots, etc. -->
