### PR TITLE
feat(handoffs): add cross-harness handoffs surface (sessions-rethink PR 1/7)

### DIFF
--- a/.claude/commands/handoff.md
+++ b/.claude/commands/handoff.md
@@ -1,0 +1,51 @@
+---
+description: Store a handoff document for cross-agent / cross-harness pickup
+---
+
+Author a five-section handoff document and persist it via the `store_handoff` MCP tool. The receiving agent (any harness) claims it with `/takeover` in the same `cwd` and same project.
+
+## Privacy gate
+
+Before doing anything else, scan the conversation for the most recent `[librarian:private=on|off]` marker. If it is `on`, ask the user to confirm explicitly that they want this conversation's content written to a handoff. Abort on "no".
+
+## Authoring
+
+Read the full transcript via the harness's native API (Claude Code: read the conversation; fall back to in-context view if no transcript API is available). Produce a Markdown document conforming to this template — **the headings are part of the contract and are validated by the MCP tool**:
+
+```markdown
+# Handoff: <title>
+
+## Start & intent
+<what the user came in wanting; why; constraints>
+
+## Journey
+<compressed timeline: decisions made (and why), alternatives considered and rejected, deferred work / parking lot, dead ends / lessons learned>
+
+## Current state
+<where we are right now — files touched, branches, open PRs, what works, what doesn't, known gotchas>
+
+## What's left
+<concrete next steps, in order, with enough context to start cold>
+
+## Open questions
+<things needing human decision before next step>
+```
+
+Pick a title that summarises the work in ≤ 80 chars.
+
+## Call
+
+Invoke `store_handoff` with:
+
+- `title` — ≤ 80 chars
+- `document_md` — the rendered template
+- `project_key` — inferred from CLAUDE.md / project root
+- `cwd` — current working directory
+- `harness` — `"claude-code"`
+- `source_ref` — `claude:session:${CLAUDE_SESSION_ID}` if available, else `cwd:<absolute path>`
+- `tags` — short tags only when they help disambiguate (e.g. `["migration", "p1"]`)
+- `conv_id` — the harness conversation id (so the server can resolve `domain` from `conv_state`)
+
+## Report back
+
+Tell the user the `handoff_id` and how to claim it (`/takeover` in any agent on the same cwd).

--- a/.claude/commands/learn.md
+++ b/.claude/commands/learn.md
@@ -1,0 +1,44 @@
+---
+description: Extract durable lessons from this conversation into memory proposals
+---
+
+Find candidate lessons in the current conversation and feed the user-approved ones into `propose_memory` (the existing proposal flow handles protected categories the usual way).
+
+## Privacy gate
+
+Before doing anything else, scan the conversation for the most recent `[librarian:private=on|off]` marker. If it is `on`, ask the user to confirm explicitly that they want lessons from this conversation written to durable memory. Abort on "no".
+
+## Read
+
+Read the full transcript via the harness's native API; fall back to the in-context view if no transcript API is available.
+
+## Extract
+
+Look for things worth keeping across future conversations:
+
+- **Durable facts** about the user, project, infra, or constraints ("user is X", "project uses Y", "we deploy on Z").
+- **Validated patterns** the user explicitly confirmed worked ("we found Z works because…", "yes, keep doing that").
+- **Explicit user corrections** ("no not that, do it this way") — quote enough surrounding context for the lesson to make sense out of session.
+
+Reject:
+
+- Ephemeral state (current task progress, transient debugging).
+- Things already captured in code (file paths, function names that grep covers).
+- Surface-level summaries that don't change future behaviour.
+
+## Present
+
+Render the candidate lessons as a numbered multi-select list. For each, show a one-line title and a 1–2 line body. Ask the user which to keep — they can pick any subset, including none.
+
+## Save
+
+For each chosen lesson, call `propose_memory` (not `remember`) with:
+
+- `title`, `body`, `tags`, `applies_to` — derived from the candidate.
+- `conv_id` — the harness conversation id (so the server can resolve `domain` from `conv_state`).
+
+Protected categories (identity, relationship) are routed through the existing proposal flow automatically by the classifier worker; nothing extra to do here.
+
+## Report
+
+Tell the user how many lessons landed as proposals and where they can review them ([dashboard /proposals](http://localhost:3838/proposals) or `/lib-session-list` etc.).

--- a/.claude/commands/takeover.md
+++ b/.claude/commands/takeover.md
@@ -1,0 +1,30 @@
+---
+description: Pick up a handoff from another agent / harness
+---
+
+Claim a handoff stored via `/handoff` and continue the work. Atomic — the row is yours once claimed; no one else can pick it up.
+
+## List
+
+Call `list_handoffs` with the caller's `project_key`, `cwd`, and `conv_id`. If empty, broaden by dropping filters in this order: drop `harness`, then `cwd`, then `project_key`. Stop at the first non-empty result. If still empty after dropping everything, tell the user "no handoffs available for this context."
+
+## Present
+
+For each candidate, render `title`, `created_in_harness`, `created_at` (age computed locally — "X minutes ago"), and `tags`. Number them and ask the user to pick one (or "none").
+
+## Claim
+
+On selection, call `claim_handoff` with:
+
+- `handoff_id`
+- `claiming_agent_id` — the current agent id
+- `claiming_harness` — `"claude-code"`
+- `claiming_source_ref` — `claude:session:${CLAUDE_SESSION_ID}` if available, else `cwd:<path>`
+- `claiming_cwd` — current working directory
+- `conv_id` — the harness conversation id
+
+On 200: inject the returned `document_md` into the conversation as system context (the user sees it once, the model now knows the full story). Echo a one-line confirmation: `claimed hdo_xyz, picking up from agent-a (claude-code, 4 minutes ago)`.
+
+On `error: "already_claimed"`: tell the user who claimed it and when, and offer to re-list.
+
+On `error: "not_found"`: tell the user the row is gone (purged or in another domain) and offer to re-list.

--- a/.claude/commands/toggle-private.md
+++ b/.claude/commands/toggle-private.md
@@ -1,0 +1,21 @@
+---
+description: Toggle in-conversation private mode (no server state, no hook)
+---
+
+Flip the in-conversation private-mode marker. **Pure in-context** — no MCP call, no server flag, no plugin hook. The contract:
+
+- `[librarian:private=on]` — agent must NOT call `remember` / `propose_memory` until told otherwise. `/handoff` and `/learn` require explicit user confirmation. Recall is still allowed (D3).
+- `[librarian:private=off]` — normal operation.
+- **Default when no marker is present:** OFF.
+
+## Behaviour
+
+1. Scan the conversation for the most recent `[librarian:private=on|off]` marker.
+2. Inject a system message announcing the inverse state. Include both the machine token and a human-readable instruction so the LLM can re-emit it on its own if context compaction drops it. Suggested wording:
+   - **ON:** "Private mode is ON. `[librarian:private=on]` — do not call `remember` or `propose_memory` until explicitly toggled off. Recall is still allowed. `/handoff` and `/learn` require explicit user confirmation. Remain in this state until told otherwise."
+   - **OFF:** "Private mode is OFF. `[librarian:private=off]` — normal operation resumed."
+3. Confirm to the user with a one-liner: `Private mode → ON` or `Private mode → OFF`.
+
+## Known limitation
+
+If the harness compacts the conversation and drops the system marker, the agent defaults to OFF and resumes writing durable memory. If a harness exposes a "context restored after compaction" signal, re-scan and re-inject the marker if it was on. Operators who need hard guarantees should run with `--no-compact` or equivalent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ changes from this point forward are catalogued here.
 
 ## [Unreleased]
 
+### Added
+
+- **Handoffs surface (sessions-rethink PR 1, additive).** Three new MCP
+  tools — `store_handoff`, `list_handoffs`, `claim_handoff` — back a new
+  `handoffs` SQLite table that records self-contained narrative handoffs
+  for cross-harness pickup. The atomic `claim_handoff` wraps an UPDATE +
+  SELECT in `BEGIN IMMEDIATE` so two concurrent claimants always pick a
+  single winner (404 vs 409 distinguish unknown rows from already-claimed
+  ones). Server-side domain isolation matches the memory tools.
+  Companion surfaces: a `the-librarian handoffs <list|show|purge>` CLI
+  family (purge is admin-only), a read-only dashboard at `/handoffs`
+  with a list view + detail view (no claim button — that's an agent
+  operation), and four new Claude Code slash commands
+  (`/handoff`, `/takeover`, `/learn`, `/toggle-private`) shipping the
+  agent-side contract from spec §6.5. Healthcheck allow-list updated.
+  **The old session surface (13 MCP tools, `lib-session-*` commands) is
+  untouched** — both surfaces live side-by-side until PR 7 removes the
+  old one. Schema bumps 17 → 18; the new table is authoritative and
+  preserved across future projection rebuilds.
+
 ### Changed
 
 - **Memory curator decouples from sessions (sessions-rethink PR 0).** The

--- a/apps/dashboard/app/handoffs/[id]/page.tsx
+++ b/apps/dashboard/app/handoffs/[id]/page.tsx
@@ -1,0 +1,12 @@
+import { HandoffDetailView } from "@/components/handoffs/detail-view";
+
+export const dynamic = "force-dynamic";
+
+export default async function HandoffDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  return (
+    <main className="flex flex-col gap-4 p-6">
+      <HandoffDetailView handoffId={id} />
+    </main>
+  );
+}

--- a/apps/dashboard/app/handoffs/page.tsx
+++ b/apps/dashboard/app/handoffs/page.tsx
@@ -1,0 +1,16 @@
+import { HandoffsListView } from "@/components/handoffs/list-view";
+
+export const dynamic = "force-dynamic";
+
+export default function HandoffsPage() {
+  return (
+    <main className="flex flex-col gap-4 p-6">
+      <h1 className="text-2xl font-semibold tracking-tight">Handoffs</h1>
+      <p className="text-sm text-muted-foreground">
+        Cross-harness narrative handoffs. Read-only — claim them from a coding agent with{" "}
+        <code>/takeover</code>.
+      </p>
+      <HandoffsListView />
+    </main>
+  );
+}

--- a/apps/dashboard/components/handoffs/detail-view.tsx
+++ b/apps/dashboard/components/handoffs/detail-view.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { trpc } from "@/lib/trpc-client";
+
+export function HandoffDetailView({ handoffId }: { handoffId: string }) {
+  const result = trpc.handoffs.byId.useQuery({ handoff_id: handoffId });
+
+  if (result.isLoading) return <p className="text-sm text-muted-foreground">Loading…</p>;
+  if (result.error) return <p className="text-sm text-destructive">{result.error.message}</p>;
+  const handoff = result.data;
+  if (!handoff) return <p className="text-sm text-muted-foreground">Handoff not found.</p>;
+
+  return (
+    <div className="grid gap-6 md:grid-cols-[2fr_1fr]">
+      <article className="prose prose-sm max-w-none rounded-md border bg-card p-6">
+        <h1 className="text-xl font-semibold">{handoff.title}</h1>
+        <pre className="whitespace-pre-wrap font-sans text-sm">{handoff.document_md}</pre>
+      </article>
+      <aside className="flex flex-col gap-2 rounded-md border bg-card p-4 text-sm">
+        <Row label="handoff_id" value={handoff.handoff_id} />
+        <Row label="created_at" value={handoff.created_at} />
+        <Row label="created_by" value={handoff.created_by_agent_id ?? "—"} />
+        <Row label="created_in" value={handoff.created_in_harness ?? "—"} />
+        <Row label="project_key" value={handoff.project_key ?? "—"} />
+        <Row label="cwd" value={handoff.cwd ?? "—"} />
+        <Row label="domain" value={handoff.domain} />
+        <Row
+          label="status"
+          value={handoff.claimed_at ? `claimed at ${handoff.claimed_at}` : "unclaimed"}
+        />
+        {handoff.tags.length > 0 ? <Row label="tags" value={handoff.tags.join(", ")} /> : null}
+      </aside>
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col">
+      <span className="text-xs uppercase text-muted-foreground">{label}</span>
+      <span className="font-mono text-xs break-all">{value}</span>
+    </div>
+  );
+}

--- a/apps/dashboard/components/handoffs/list-view.tsx
+++ b/apps/dashboard/components/handoffs/list-view.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { trpc } from "@/lib/trpc-client";
+
+const PAGE_LIMIT = 50;
+
+export function HandoffsListView() {
+  const [includeClaimed, setIncludeClaimed] = useState(false);
+  const [projectKey, setProjectKey] = useState("");
+
+  const result = trpc.handoffs.list.useQuery({
+    limit: PAGE_LIMIT,
+    include_claimed: includeClaimed,
+    ...(projectKey ? { project_key: projectKey } : {}),
+  });
+
+  const rows = result.data ?? [];
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-4 text-sm">
+        <label className="flex flex-col gap-1">
+          <span className="text-xs text-muted-foreground">Project</span>
+          <input
+            className="rounded-md border bg-background px-2 py-1 font-mono"
+            placeholder="filter project_key"
+            value={projectKey}
+            onChange={(e) => setProjectKey(e.target.value)}
+          />
+        </label>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={includeClaimed}
+            onChange={(e) => setIncludeClaimed(e.target.checked)}
+          />
+          Include claimed
+        </label>
+      </div>
+
+      {result.isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : rows.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No handoffs.</p>
+      ) : (
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b text-left text-xs uppercase text-muted-foreground">
+              <th className="py-2">Title</th>
+              <th className="py-2">Project</th>
+              <th className="py-2">From</th>
+              <th className="py-2">Created</th>
+              <th className="py-2">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.handoff_id} className="border-b hover:bg-accent/50">
+                <td className="py-2">
+                  <Link href={`/handoffs/${row.handoff_id}`} className="font-medium underline">
+                    {row.title}
+                  </Link>
+                </td>
+                <td className="py-2 font-mono text-xs">{row.project_key ?? "—"}</td>
+                <td className="py-2 font-mono text-xs">{row.created_in_harness ?? "—"}</td>
+                <td className="py-2 font-mono text-xs">{row.created_at}</td>
+                <td className="py-2 text-xs">{row.claimed_at ? "claimed" : "unclaimed"}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/apps/dashboard/tests/components/handoffs.test.tsx
+++ b/apps/dashboard/tests/components/handoffs.test.tsx
@@ -1,0 +1,81 @@
+// Dashboard handoff component tests (sessions-rethink §6.7).
+//
+// The dashboard surface is read-only — no claim button (claim is an MCP-only
+// agent operation). We mock the tRPC client so the tests stay pure.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const listMock = vi.fn();
+const byIdMock = vi.fn();
+
+vi.mock("@/lib/trpc-client", () => ({
+  trpc: {
+    handoffs: {
+      list: { useQuery: (...args: unknown[]) => listMock(...args) },
+      byId: { useQuery: (...args: unknown[]) => byIdMock(...args) },
+    },
+  },
+}));
+
+const { HandoffsListView } = await import("@/components/handoffs/list-view");
+const { HandoffDetailView } = await import("@/components/handoffs/detail-view");
+
+const sampleHandoff = {
+  handoff_id: "hdo_abc",
+  title: "Continue the migration",
+  project_key: "proj-x",
+  source_ref: null,
+  cwd: "/repo",
+  domain: "general",
+  created_by_agent_id: "agent-a",
+  created_in_harness: "claude-code",
+  tags: ["migration"],
+  created_at: "2026-05-28T12:00:00.000Z",
+  claimed_at: null,
+  claimed_by: null,
+};
+
+describe("HandoffsListView", () => {
+  it("renders empty-state when no rows arrive", () => {
+    listMock.mockReturnValue({ data: [], isLoading: false });
+    render(<HandoffsListView />);
+    expect(screen.getByText(/no handoffs/i)).toBeInTheDocument();
+  });
+
+  it("renders one row per handoff with a link to the detail view", () => {
+    listMock.mockReturnValue({
+      data: [sampleHandoff, { ...sampleHandoff, handoff_id: "hdo_xyz", title: "Another" }],
+      isLoading: false,
+    });
+    render(<HandoffsListView />);
+    expect(screen.getByText("Continue the migration").closest("a")).toHaveAttribute(
+      "href",
+      "/handoffs/hdo_abc",
+    );
+    expect(screen.getByText("Another").closest("a")).toHaveAttribute("href", "/handoffs/hdo_xyz");
+  });
+});
+
+describe("HandoffDetailView", () => {
+  it("renders the document markdown and metadata sidebar", () => {
+    byIdMock.mockReturnValue({
+      data: {
+        ...sampleHandoff,
+        document_md: "# Handoff: test\n\n## Start & intent\nstart here.",
+      },
+      isLoading: false,
+    });
+    render(<HandoffDetailView handoffId="hdo_abc" />);
+    expect(screen.getByText(/Continue the migration/)).toBeInTheDocument();
+    expect(screen.getByText(/Start & intent/)).toBeInTheDocument();
+    expect(screen.getByText("hdo_abc")).toBeInTheDocument();
+    expect(screen.getByText("unclaimed")).toBeInTheDocument();
+  });
+
+  it("renders not-found when the query has no data", () => {
+    byIdMock.mockReturnValue({ data: undefined, isLoading: false });
+    render(<HandoffDetailView handoffId="hdo_ghost" />);
+    expect(screen.getByText(/handoff not found/i)).toBeInTheDocument();
+  });
+});

--- a/packages/cli/src/commands/handoffs-list.ts
+++ b/packages/cli/src/commands/handoffs-list.ts
@@ -1,0 +1,23 @@
+import { flagString, parseNumber } from "../parse-flags.js";
+import type { Command } from "./_shared.js";
+
+const DEFAULT_DOMAIN = "general";
+
+export const handoffsList: Command = (store, _positionals, flags) => {
+  const limit = parseNumber(flags.limit);
+  const result = store.handoffs.list(
+    {
+      project_key: flagString(flags.project),
+      cwd: flagString(flags.cwd),
+      harness: flagString(flags.harness),
+      ...(limit !== undefined ? { limit } : {}),
+    },
+    { domain: flagString(flags.domain) ?? DEFAULT_DOMAIN },
+  );
+  if (flags.json) return { stdout: JSON.stringify(result, null, 2), exitCode: 0 };
+  if (result.length === 0) return { stdout: "No handoffs.", exitCode: 0 };
+  const lines = result.map(
+    (row) => `${row.handoff_id}  ${row.created_at}  ${row.created_in_harness ?? "?"}  ${row.title}`,
+  );
+  return { stdout: lines.join("\n"), exitCode: 0 };
+};

--- a/packages/cli/src/commands/handoffs-list.ts
+++ b/packages/cli/src/commands/handoffs-list.ts
@@ -12,7 +12,10 @@ export const handoffsList: Command = (store, _positionals, flags) => {
       harness: flagString(flags.harness),
       ...(limit !== undefined ? { limit } : {}),
     },
-    { domain: flagString(flags.domain) ?? DEFAULT_DOMAIN },
+    {
+      domain: flagString(flags.domain) ?? DEFAULT_DOMAIN,
+      includeClaimed: flags["include-claimed"] === true,
+    },
   );
   if (flags.json) return { stdout: JSON.stringify(result, null, 2), exitCode: 0 };
   if (result.length === 0) return { stdout: "No handoffs.", exitCode: 0 };

--- a/packages/cli/src/commands/handoffs-purge.ts
+++ b/packages/cli/src/commands/handoffs-purge.ts
@@ -1,0 +1,17 @@
+import type { Command } from "./_shared.js";
+
+export const handoffsPurge: Command = (store, positionals, flags) => {
+  if (flags.admin !== true) {
+    return {
+      stdout: "handoffs purge is admin-only. Re-run with --admin.",
+      exitCode: 1,
+    };
+  }
+  const [handoffId] = positionals;
+  if (!handoffId) {
+    return { stdout: "Usage: the-librarian handoffs purge <handoff_id> --admin", exitCode: 1 };
+  }
+  const removed = store.handoffs.purge(handoffId);
+  if (!removed) return { stdout: `No handoff for id ${handoffId}.`, exitCode: 1 };
+  return { stdout: `Purged ${handoffId}.`, exitCode: 0 };
+};

--- a/packages/cli/src/commands/handoffs-show.ts
+++ b/packages/cli/src/commands/handoffs-show.ts
@@ -1,0 +1,30 @@
+import type { Command } from "./_shared.js";
+
+export const handoffsShow: Command = (store, positionals, flags) => {
+  const [handoffId] = positionals;
+  if (!handoffId) {
+    return { stdout: "Usage: the-librarian handoffs show <handoff_id>", exitCode: 1 };
+  }
+  // The store doesn't expose a getById — `show` is rare enough that a SELECT
+  // here is the simplest path. Renaming to a method is a follow-up if a second
+  // consumer appears.
+  const row = store.db.prepare("SELECT * FROM handoffs WHERE id = ?").get(handoffId) as
+    | Record<string, unknown>
+    | undefined;
+  if (!row) return { stdout: `No handoff for id ${handoffId}.`, exitCode: 1 };
+  if (flags.json) return { stdout: JSON.stringify(row, null, 2), exitCode: 0 };
+  const lines = [
+    `handoff_id:       ${row.id}`,
+    `title:            ${row.title}`,
+    `created_at:       ${row.created_at}`,
+    `created_by:       ${row.created_by_agent_id ?? "—"}`,
+    `created_in:       ${row.created_in_harness ?? "—"}`,
+    `project_key:      ${row.project_key ?? "—"}`,
+    `cwd:              ${row.cwd ?? "—"}`,
+    `domain:           ${row.domain}`,
+    `claimed_at:       ${row.claimed_at ?? "(unclaimed)"}`,
+    "",
+    row.document_md as string,
+  ];
+  return { stdout: lines.join("\n"), exitCode: 0 };
+};

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -11,6 +11,9 @@ import { checkpoint } from "./checkpoint.js";
 import { continueCommand } from "./continue.js";
 import { end } from "./end.js";
 import { events } from "./events.js";
+import { handoffsList } from "./handoffs-list.js";
+import { handoffsPurge } from "./handoffs-purge.js";
+import { handoffsShow } from "./handoffs-show.js";
 import { list } from "./list.js";
 import { pause } from "./pause.js";
 import { search } from "./search.js";
@@ -30,6 +33,14 @@ export const sessionVerbs: Record<string, Command> = {
   continue: continueCommand,
   search,
   events,
+};
+
+// sessions-rethink PR 1 — handoffs surface (additive). The `sessions`
+// surface is removed in PR 7; until then the two live side-by-side.
+export const handoffVerbs: Record<string, Command> = {
+  list: handoffsList,
+  show: handoffsShow,
+  purge: handoffsPurge,
 };
 
 export type { Command } from "./_shared.js";

--- a/packages/cli/src/runtime.ts
+++ b/packages/cli/src/runtime.ts
@@ -14,7 +14,7 @@ import type { CliResult, Command } from "./commands/_shared.js";
 import { authUsage, authVerbs } from "./commands/auth.js";
 import { backupCommand } from "./commands/backup.js";
 import { exportCommand } from "./commands/export.js";
-import { sessionVerbs } from "./commands/index.js";
+import { handoffVerbs, sessionVerbs } from "./commands/index.js";
 import { restoreCommand } from "./commands/restore.js";
 import { parseFlags } from "./parse-flags.js";
 
@@ -54,6 +54,7 @@ export function runCli(argv: string[], store: LibrarianStore): CliResult {
     return topLevel(store, positionals, flags);
   }
   if (command === "sessions") return runSessionsCommand(rest, store);
+  if (command === "handoffs") return runHandoffsCommand(rest, store);
   if (command === "auth") return runAuthCommand(rest, store);
   return { stdout: `Unknown command: ${command}\n\n${usage()}`, exitCode: 1 };
 }
@@ -84,6 +85,24 @@ function runSessionsCommand(args: string[], store: LibrarianStore): CliResult {
   const handler = sessionVerbs[verb];
   if (!handler) {
     return { stdout: `Unknown sessions verb: ${verb}\n\n${sessionsUsage()}`, exitCode: 1 };
+  }
+
+  const { positionals, flags } = parseFlags(rest);
+  try {
+    return handler(store, positionals, flags);
+  } catch (error) {
+    return { stdout: `Error: ${(error as Error).message}`, exitCode: 1 };
+  }
+}
+
+function runHandoffsCommand(args: string[], store: LibrarianStore): CliResult {
+  const [verb, ...rest] = args;
+  if (!verb) return { stdout: handoffsUsage(), exitCode: 1 };
+  if (verb === "help" || verb === "--help") return { stdout: handoffsUsage(), exitCode: 0 };
+
+  const handler = handoffVerbs[verb];
+  if (!handler) {
+    return { stdout: `Unknown handoffs verb: ${verb}\n\n${handoffsUsage()}`, exitCode: 1 };
   }
 
   const { positionals, flags } = parseFlags(rest);
@@ -135,7 +154,28 @@ export function usage(): string {
     "  restore --from <dir> --force  Restore a snapshot bundle into the data dir (destructive)",
     "  export [--format ndjson|json] Dump memories + sessions to stdout",
     "  sessions <verb>               Manage Librarian sessions (see 'sessions help')",
+    "  handoffs <verb>               Inspect cross-harness handoffs (see 'handoffs help')",
     "  auth <verb>                   Recover dashboard auth (see 'auth help')",
+  ].join("\n");
+}
+
+export function handoffsUsage(): string {
+  return [
+    "Usage: the-librarian handoffs <verb> [args] [flags]",
+    "",
+    "Verbs:",
+    "  list                          List handoffs (default: unclaimed in the current domain)",
+    "  show <handoff_id>             Show a single handoff (including its document)",
+    "  purge <handoff_id>            Admin-only — hard-delete a handoff row",
+    "",
+    "Common flags:",
+    "  --project <key>               Filter by project_key",
+    "  --cwd <path>                  Filter by cwd",
+    "  --harness <name>              Filter by created_in_harness",
+    "  --domain <name>               Scope to a domain (default: general)",
+    "  --limit <n>                   list: max rows (default 20, max 100)",
+    "  --admin                       purge: required",
+    "  --json                        Emit JSON instead of prose",
   ].join("\n");
 }
 

--- a/packages/cli/src/runtime.ts
+++ b/packages/cli/src/runtime.ts
@@ -174,6 +174,7 @@ export function handoffsUsage(): string {
     "  --harness <name>              Filter by created_in_harness",
     "  --domain <name>               Scope to a domain (default: general)",
     "  --limit <n>                   list: max rows (default 20, max 100)",
+    "  --include-claimed             list: include already-claimed handoffs (default: hide)",
     "  --admin                       purge: required",
     "  --json                        Emit JSON instead of prose",
   ].join("\n");

--- a/packages/cli/tests/snapshots.test.ts
+++ b/packages/cli/tests/snapshots.test.ts
@@ -25,6 +25,7 @@ describe("CLI snapshots", () => {
         restore --from <dir> --force  Restore a snapshot bundle into the data dir (destructive)
         export [--format ndjson|json] Dump memories + sessions to stdout
         sessions <verb>               Manage Librarian sessions (see 'sessions help')
+        handoffs <verb>               Inspect cross-harness handoffs (see 'handoffs help')
         auth <verb>                   Recover dashboard auth (see 'auth help')"
     `);
   });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -241,3 +241,30 @@ export { type DomainRecord, type DomainsStore, createDomainsStore } from "./stor
 export type { ConversationState, ConversationStatePatch } from "./schemas/conversation-state.js";
 export { renderConvStateBlock } from "./conv-state-render.js";
 export { MemoryEventType } from "./schemas/common.js";
+export {
+  type ClaimHandoffInput,
+  type ClaimHandoffOutput,
+  type HandoffSummary,
+  type ListHandoffsInput,
+  type ListHandoffsOutput,
+  type StoreHandoffInput,
+  type StoreHandoffOutput,
+  ClaimHandoffInputSchema,
+  ClaimHandoffOutputSchema,
+  HandoffSummarySchema,
+  HANDOFF_REQUIRED_HEADINGS,
+  ListHandoffsInputSchema,
+  ListHandoffsOutputSchema,
+  StoreHandoffInputSchema,
+  StoreHandoffOutputSchema,
+} from "./schemas/handoff.js";
+export {
+  type ClaimedBy,
+  type ClaimHandoffContext,
+  type HandoffStore,
+  type ListHandoffsContext,
+  type StoreHandoffContext,
+  createHandoffStore,
+  HandoffAlreadyClaimedError,
+  HandoffNotFoundError,
+} from "./store/handoff-store.js";

--- a/packages/core/src/schemas/handoff.ts
+++ b/packages/core/src/schemas/handoff.ts
@@ -1,0 +1,106 @@
+// Handoff schemas (sessions-rethink spec §6.1).
+//
+// A handoff is a self-contained narrative the outgoing agent stores at the end
+// of `/handoff`. The incoming `/takeover` claims it in a single atomic step,
+// receives the document_md, and injects it into the new conversation. The
+// document follows the §6.3 template — five anchored headings — and that
+// template is enforced here at the Zod boundary so the store can trust input.
+
+import { z } from "zod";
+import { IdSchema, IsoTimestampSchema } from "./common.js";
+
+// The five-section template (§6.3). The refinement asserts each heading
+// appears exactly as written, anchored to the start of a line. A missing or
+// renamed heading bounces the input at the MCP boundary, before it can reach
+// the store.
+const REQUIRED_HEADINGS = [
+  "Start & intent",
+  "Journey",
+  "Current state",
+  "What's left",
+  "Open questions",
+] as const;
+
+function hasAllRequiredHeadings(document: string): boolean {
+  return REQUIRED_HEADINGS.every((heading) => {
+    // Anchored multiline regex per spec §6.1: each heading must appear as a
+    // standalone `## <heading>` line. Escape the `&`/`'` shouldn't be needed
+    // for regex (neither is a regex metachar) but we build the pattern from
+    // the literal string to keep that decision data-driven.
+    const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const pattern = new RegExp(`^## ${escaped}\\b`, "m");
+    return pattern.test(document);
+  });
+}
+
+export const StoreHandoffInputSchema = z
+  .object({
+    title: z.string().min(5).max(120),
+    document_md: z.string().min(100).max(50000),
+    project_key: z.string().nullable().optional(),
+    source_ref: z.string().nullable().optional(),
+    cwd: z.string().nullable().optional(),
+    harness: z.string().nullable().optional(),
+    tags: z.array(z.string()).max(10).optional(),
+  })
+  .refine((value) => hasAllRequiredHeadings(value.document_md), {
+    message:
+      "document_md must include each of the five required headings: " +
+      REQUIRED_HEADINGS.map((h) => `'## ${h}'`).join(", "),
+    path: ["document_md"],
+  });
+export type StoreHandoffInput = z.infer<typeof StoreHandoffInputSchema>;
+
+export const StoreHandoffOutputSchema = z.object({
+  handoff_id: IdSchema,
+  created_at: IsoTimestampSchema,
+});
+export type StoreHandoffOutput = z.infer<typeof StoreHandoffOutputSchema>;
+
+export const ListHandoffsInputSchema = z.object({
+  project_key: z.string().nullable().optional(),
+  cwd: z.string().nullable().optional(),
+  harness: z.string().nullable().optional(),
+  limit: z.number().int().min(1).max(100).optional(),
+});
+export type ListHandoffsInput = z.infer<typeof ListHandoffsInputSchema>;
+
+export const HandoffSummarySchema = z.object({
+  handoff_id: IdSchema,
+  title: z.string(),
+  project_key: z.string().nullable(),
+  source_ref: z.string().nullable(),
+  cwd: z.string().nullable(),
+  created_in_harness: z.string().nullable(),
+  created_by_agent_id: z.string().nullable(),
+  created_at: IsoTimestampSchema,
+  tags: z.array(z.string()),
+});
+export type HandoffSummary = z.infer<typeof HandoffSummarySchema>;
+
+export const ListHandoffsOutputSchema = z.object({
+  handoffs: z.array(HandoffSummarySchema),
+});
+export type ListHandoffsOutput = z.infer<typeof ListHandoffsOutputSchema>;
+
+export const ClaimHandoffInputSchema = z.object({
+  handoff_id: IdSchema,
+  claiming_agent_id: z.string().nullable().optional(),
+  claiming_harness: z.string().nullable().optional(),
+  claiming_source_ref: z.string().nullable().optional(),
+  claiming_cwd: z.string().nullable().optional(),
+});
+export type ClaimHandoffInput = z.infer<typeof ClaimHandoffInputSchema>;
+
+export const ClaimHandoffOutputSchema = z.object({
+  handoff_id: IdSchema,
+  title: z.string(),
+  document_md: z.string(),
+  created_by_agent_id: z.string().nullable(),
+  created_in_harness: z.string().nullable(),
+  created_at: IsoTimestampSchema,
+  claimed_at: IsoTimestampSchema,
+});
+export type ClaimHandoffOutput = z.infer<typeof ClaimHandoffOutputSchema>;
+
+export const HANDOFF_REQUIRED_HEADINGS: readonly string[] = REQUIRED_HEADINGS;

--- a/packages/core/src/schemas/index.ts
+++ b/packages/core/src/schemas/index.ts
@@ -3,3 +3,4 @@ export * from "./memory.js";
 export * from "./session.js";
 export * from "./events.js";
 export * from "./conversation-state.js";
+export * from "./handoff.js";

--- a/packages/core/src/store/handoff-store.ts
+++ b/packages/core/src/store/handoff-store.ts
@@ -29,14 +29,24 @@ export interface StoreHandoffContext {
   created_by_agent_id: string | null;
 }
 
-/** Listing is server-scoped by domain (non-overridable). */
+/**
+ * Listing is server-scoped by domain. A non-null `domain` is a hard filter
+ * (multi-tenant isolation, identical to memory tools); a null `domain`
+ * bypasses the filter and is reserved for admin role (mirrors `recall`'s
+ * `admin: true` path — never reachable from an agent-role caller).
+ *
+ * The MCP/agent path always sees `claimed_at IS NULL` (claim removes it from
+ * the picker). Admin paths (CLI, dashboard) can pass `includeClaimed: true`
+ * to surface already-claimed handoffs for forensic / audit use.
+ */
 export interface ListHandoffsContext {
-  domain: string;
+  domain: string | null;
+  includeClaimed?: boolean;
 }
 
-/** Claim is server-scoped by domain (non-overridable). */
+/** Claim is server-scoped by domain. Null `domain` is admin-only (see ListHandoffsContext). */
 export interface ClaimHandoffContext {
-  domain: string;
+  domain: string | null;
 }
 
 export class HandoffNotFoundError extends Error {
@@ -120,8 +130,13 @@ export function createHandoffStore(deps: { db: DatabaseSync }): HandoffStore {
   }
 
   function listHandoffs(input: ListHandoffsInput, context: ListHandoffsContext): HandoffSummary[] {
-    const where: string[] = ["domain = ?", "claimed_at IS NULL"];
-    const params: (string | number)[] = [context.domain];
+    const where: string[] = [];
+    const params: (string | number)[] = [];
+    if (!context.includeClaimed) where.push("claimed_at IS NULL");
+    if (context.domain !== null) {
+      where.push("domain = ?");
+      params.push(context.domain);
+    }
 
     // Per §6.1 D9: the picker filters by `project_key = ?` AND `cwd = ?` when
     // both are supplied; if either is null/undefined the axis is unfiltered.
@@ -140,10 +155,11 @@ export function createHandoffStore(deps: { db: DatabaseSync }): HandoffStore {
     const limit = input.limit ?? 20;
     params.push(limit);
 
+    const whereClause = where.length > 0 ? `WHERE ${where.join(" AND ")}` : "";
     const rows = db
       .prepare(
         `SELECT * FROM handoffs
-         WHERE ${where.join(" AND ")}
+         ${whereClause}
          ORDER BY created_at DESC
          LIMIT ?`,
       )
@@ -169,16 +185,20 @@ export function createHandoffStore(deps: { db: DatabaseSync }): HandoffStore {
     // racing claimant to slip between our UPDATE and SELECT under WAL.
     db.exec("BEGIN IMMEDIATE");
     try {
-      const updated = db
-        .prepare(
-          `UPDATE handoffs
-              SET claimed_at = ?, claimed_by_json = ?
-            WHERE id = ?
-              AND domain = ?
-              AND claimed_at IS NULL
-           RETURNING *`,
-        )
-        .all(claimedAt, claimedByJson, input.handoff_id, context.domain) as unknown as HandoffRow[];
+      // A non-null domain hard-filters the UPDATE (multi-tenant isolation,
+      // identical to memory tools). Admin role passes null, which broadens
+      // the predicate to "any row with this id, any domain".
+      const updateSql =
+        context.domain === null
+          ? `UPDATE handoffs SET claimed_at = ?, claimed_by_json = ?
+             WHERE id = ? AND claimed_at IS NULL RETURNING *`
+          : `UPDATE handoffs SET claimed_at = ?, claimed_by_json = ?
+             WHERE id = ? AND domain = ? AND claimed_at IS NULL RETURNING *`;
+      const updateBinds: (string | null)[] =
+        context.domain === null
+          ? [claimedAt, claimedByJson, input.handoff_id]
+          : [claimedAt, claimedByJson, input.handoff_id, context.domain];
+      const updated = db.prepare(updateSql).all(...updateBinds) as unknown as HandoffRow[];
 
       if (updated.length === 1) {
         const row = updated[0]!;
@@ -186,12 +206,16 @@ export function createHandoffStore(deps: { db: DatabaseSync }): HandoffStore {
         return rowToClaimResult(row);
       }
 
-      // The UPDATE didn't fire. Two possibilities:
+      // The UPDATE didn't fire. Two possibilities (same domain scoping):
       //   1. The row doesn't exist (or isn't in our domain) → 404.
       //   2. The row exists but is already claimed → 409 with the existing claim.
-      const existing = db
-        .prepare(`SELECT * FROM handoffs WHERE id = ? AND domain = ?`)
-        .get(input.handoff_id, context.domain) as HandoffRow | undefined;
+      const selectSql =
+        context.domain === null
+          ? `SELECT * FROM handoffs WHERE id = ?`
+          : `SELECT * FROM handoffs WHERE id = ? AND domain = ?`;
+      const selectBinds: string[] =
+        context.domain === null ? [input.handoff_id] : [input.handoff_id, context.domain];
+      const existing = db.prepare(selectSql).get(...selectBinds) as HandoffRow | undefined;
       db.exec("COMMIT");
       if (!existing) throw new HandoffNotFoundError(input.handoff_id);
       throw new HandoffAlreadyClaimedError(
@@ -200,14 +224,15 @@ export function createHandoffStore(deps: { db: DatabaseSync }): HandoffStore {
         parseClaimedBy(existing.claimed_by_json),
       );
     } catch (error) {
-      // The transaction may already have committed (the rare success path above
-      // also reaches this catch only via the throws). Roll back defensively when
-      // we're in the error branches; ignore the error if the transaction
-      // already committed.
+      // The 404/409 throws happen AFTER `COMMIT`, so the defensive ROLLBACK
+      // below is a no-op on those paths (SQLite reports "no transaction
+      // active" which we swallow). The catch also handles a thrown UPDATE
+      // or SELECT, where COMMIT hasn't run yet and ROLLBACK is the right
+      // cleanup. Either way the caller sees the original error.
       try {
         db.exec("ROLLBACK");
       } catch {
-        /* already committed */
+        /* no active transaction — happy-path COMMIT already ran */
       }
       throw error;
     }

--- a/packages/core/src/store/handoff-store.ts
+++ b/packages/core/src/store/handoff-store.ts
@@ -1,0 +1,282 @@
+// Handoff store (sessions-rethink spec §6.2).
+//
+// The `handoffs` table is SQLite-authoritative — there is no JSONL ledger
+// backing it. Each handoff is a self-contained narrative the outgoing agent
+// stored at `/handoff`; `/takeover` claims it atomically with `claim_handoff`.
+//
+// The atomic claim uses `BEGIN IMMEDIATE` so the write lock is taken up
+// front. Under multi-writer WAL the alternative — a SELECT followed by an
+// UPDATE — races between readers; `BEGIN IMMEDIATE` serializes claimants and
+// guarantees the follow-up SELECT in the 409 path reflects a consistent
+// snapshot.
+
+import type { DatabaseSync } from "node:sqlite";
+import { makeId, nowIso } from "../constants.js";
+import type {
+  ClaimHandoffInput,
+  ClaimHandoffOutput,
+  HandoffSummary,
+  ListHandoffsInput,
+  StoreHandoffInput,
+  StoreHandoffOutput,
+} from "../schemas/handoff.js";
+
+/** Server-resolved metadata the MCP layer attaches before calling the store. */
+export interface StoreHandoffContext {
+  /** Multi-tenant isolation. Resolved by domain-resolution at the MCP layer. */
+  domain: string;
+  /** The agent that ran `/handoff` (resolved from auth context). */
+  created_by_agent_id: string | null;
+}
+
+/** Listing is server-scoped by domain (non-overridable). */
+export interface ListHandoffsContext {
+  domain: string;
+}
+
+/** Claim is server-scoped by domain (non-overridable). */
+export interface ClaimHandoffContext {
+  domain: string;
+}
+
+export class HandoffNotFoundError extends Error {
+  constructor(public readonly handoffId: string) {
+    super(`No handoff found for id ${handoffId}`);
+    this.name = "HandoffNotFoundError";
+  }
+}
+
+export class HandoffAlreadyClaimedError extends Error {
+  constructor(
+    public readonly handoffId: string,
+    public readonly claimedAt: string,
+    public readonly claimedBy: ClaimedBy | null,
+  ) {
+    super(`Handoff ${handoffId} already claimed at ${claimedAt}`);
+    this.name = "HandoffAlreadyClaimedError";
+  }
+}
+
+export interface ClaimedBy {
+  agent_id?: string | null;
+  harness?: string | null;
+  source_ref?: string | null;
+  cwd?: string | null;
+}
+
+interface HandoffRow {
+  id: string;
+  title: string;
+  document_md: string;
+  project_key: string | null;
+  source_ref: string | null;
+  cwd: string | null;
+  domain: string;
+  created_by_agent_id: string | null;
+  created_in_harness: string | null;
+  tags_json: string;
+  created_at: string;
+  claimed_at: string | null;
+  claimed_by_json: string | null;
+}
+
+export interface HandoffStore {
+  store: (input: StoreHandoffInput, context: StoreHandoffContext) => StoreHandoffOutput;
+  list: (input: ListHandoffsInput, context: ListHandoffsContext) => HandoffSummary[];
+  claim: (input: ClaimHandoffInput, context: ClaimHandoffContext) => ClaimHandoffOutput;
+  /** Admin / test path — hard-delete a single row regardless of claim status. */
+  purge: (handoffId: string) => boolean;
+}
+
+export function createHandoffStore(deps: { db: DatabaseSync }): HandoffStore {
+  const { db } = deps;
+
+  function storeHandoff(
+    input: StoreHandoffInput,
+    context: StoreHandoffContext,
+  ): StoreHandoffOutput {
+    const id = makeId("hdo");
+    const createdAt = nowIso();
+    db.prepare(
+      `INSERT INTO handoffs (
+        id, title, document_md, project_key, source_ref, cwd, domain,
+        created_by_agent_id, created_in_harness, tags_json,
+        created_at, claimed_at, claimed_by_json
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL)`,
+    ).run(
+      id,
+      input.title,
+      input.document_md,
+      input.project_key ?? null,
+      input.source_ref ?? null,
+      input.cwd ?? null,
+      context.domain,
+      context.created_by_agent_id,
+      input.harness ?? null,
+      JSON.stringify(input.tags ?? []),
+      createdAt,
+    );
+    return { handoff_id: id, created_at: createdAt };
+  }
+
+  function listHandoffs(input: ListHandoffsInput, context: ListHandoffsContext): HandoffSummary[] {
+    const where: string[] = ["domain = ?", "claimed_at IS NULL"];
+    const params: (string | number)[] = [context.domain];
+
+    // Per §6.1 D9: the picker filters by `project_key = ?` AND `cwd = ?` when
+    // both are supplied; if either is null/undefined the axis is unfiltered.
+    if (input.project_key != null) {
+      where.push("project_key = ?");
+      params.push(input.project_key);
+    }
+    if (input.cwd != null) {
+      where.push("cwd = ?");
+      params.push(input.cwd);
+    }
+    if (input.harness != null) {
+      where.push("created_in_harness = ?");
+      params.push(input.harness);
+    }
+    const limit = input.limit ?? 20;
+    params.push(limit);
+
+    const rows = db
+      .prepare(
+        `SELECT * FROM handoffs
+         WHERE ${where.join(" AND ")}
+         ORDER BY created_at DESC
+         LIMIT ?`,
+      )
+      .all(...params) as unknown as HandoffRow[];
+
+    return rows.map(rowToSummary);
+  }
+
+  function claimHandoff(
+    input: ClaimHandoffInput,
+    context: ClaimHandoffContext,
+  ): ClaimHandoffOutput {
+    const claimedAt = nowIso();
+    const claimedByJson = JSON.stringify({
+      agent_id: input.claiming_agent_id ?? null,
+      harness: input.claiming_harness ?? null,
+      source_ref: input.claiming_source_ref ?? null,
+      cwd: input.claiming_cwd ?? null,
+    });
+
+    // Take the write lock up front so the UPDATE+SELECT pair is a single
+    // critical section. SQLite's deferred-transaction default would allow a
+    // racing claimant to slip between our UPDATE and SELECT under WAL.
+    db.exec("BEGIN IMMEDIATE");
+    try {
+      const updated = db
+        .prepare(
+          `UPDATE handoffs
+              SET claimed_at = ?, claimed_by_json = ?
+            WHERE id = ?
+              AND domain = ?
+              AND claimed_at IS NULL
+           RETURNING *`,
+        )
+        .all(claimedAt, claimedByJson, input.handoff_id, context.domain) as unknown as HandoffRow[];
+
+      if (updated.length === 1) {
+        const row = updated[0]!;
+        db.exec("COMMIT");
+        return rowToClaimResult(row);
+      }
+
+      // The UPDATE didn't fire. Two possibilities:
+      //   1. The row doesn't exist (or isn't in our domain) → 404.
+      //   2. The row exists but is already claimed → 409 with the existing claim.
+      const existing = db
+        .prepare(`SELECT * FROM handoffs WHERE id = ? AND domain = ?`)
+        .get(input.handoff_id, context.domain) as HandoffRow | undefined;
+      db.exec("COMMIT");
+      if (!existing) throw new HandoffNotFoundError(input.handoff_id);
+      throw new HandoffAlreadyClaimedError(
+        input.handoff_id,
+        existing.claimed_at ?? "",
+        parseClaimedBy(existing.claimed_by_json),
+      );
+    } catch (error) {
+      // The transaction may already have committed (the rare success path above
+      // also reaches this catch only via the throws). Roll back defensively when
+      // we're in the error branches; ignore the error if the transaction
+      // already committed.
+      try {
+        db.exec("ROLLBACK");
+      } catch {
+        /* already committed */
+      }
+      throw error;
+    }
+  }
+
+  function purgeHandoff(handoffId: string): boolean {
+    const stmt = db.prepare("DELETE FROM handoffs WHERE id = ?");
+    const result = stmt.run(handoffId);
+    return Number(result.changes) > 0;
+  }
+
+  return {
+    store: storeHandoff,
+    list: listHandoffs,
+    claim: claimHandoff,
+    purge: purgeHandoff,
+  };
+}
+
+function rowToSummary(row: HandoffRow): HandoffSummary {
+  return {
+    handoff_id: row.id,
+    title: row.title,
+    project_key: row.project_key,
+    source_ref: row.source_ref,
+    cwd: row.cwd,
+    created_in_harness: row.created_in_harness,
+    created_by_agent_id: row.created_by_agent_id,
+    created_at: row.created_at,
+    tags: parseTags(row.tags_json),
+  };
+}
+
+function rowToClaimResult(row: HandoffRow): ClaimHandoffOutput {
+  if (!row.claimed_at) {
+    // Unreachable — the UPDATE above sets it. Guard so the type narrows.
+    throw new Error("claim row missing claimed_at after UPDATE");
+  }
+  return {
+    handoff_id: row.id,
+    title: row.title,
+    document_md: row.document_md,
+    created_by_agent_id: row.created_by_agent_id,
+    created_in_harness: row.created_in_harness,
+    created_at: row.created_at,
+    claimed_at: row.claimed_at,
+  };
+}
+
+function parseTags(json: string): string[] {
+  try {
+    const parsed = JSON.parse(json || "[]");
+    return Array.isArray(parsed) ? (parsed as string[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function parseClaimedBy(json: string | null): ClaimedBy | null {
+  if (!json) return null;
+  try {
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+    return {
+      agent_id: typeof parsed.agent_id === "string" ? parsed.agent_id : null,
+      harness: typeof parsed.harness === "string" ? parsed.harness : null,
+      source_ref: typeof parsed.source_ref === "string" ? parsed.source_ref : null,
+      cwd: typeof parsed.cwd === "string" ? parsed.cwd : null,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -4,3 +4,4 @@ export * from "./memory-store.js";
 export * from "./session-store.js";
 export * from "./curation-store.js";
 export * from "./settings-store.js";
+export * from "./handoff-store.js";

--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -7,6 +7,7 @@ import {
 } from "./conversation-state-store.js";
 import { type CurationStore, createCurationStore } from "./curation-store.js";
 import { type DomainsStore, createDomainsStore } from "./domains-store.js";
+import { type HandoffStore, createHandoffStore } from "./handoff-store.js";
 import { readJsonl } from "./jsonl.js";
 import { type MemoryStore, createMemoryStore } from "./memory-store.js";
 import { ensureSchema, rebuildMemoryIndex, rebuildSessionIndex } from "./projection.js";
@@ -38,6 +39,7 @@ export interface LibrarianStoreOptions {
 export interface LibrarianStore extends MemoryStore, SessionStore, CurationStore, SettingsStore {
   convState: ConversationStateStore;
   domains: DomainsStore;
+  handoffs: HandoffStore;
   dataDir: string;
   eventsPath: string;
   // R3 — sessionsPath is the timeline ledger (post-R3, new file).
@@ -113,6 +115,7 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Libra
   const settingsStore = createSettingsStore({ db, secretKey: options.secretKey ?? null });
   const convState = createConversationStateStore({ db });
   const domains = createDomainsStore({ db });
+  const handoffs = createHandoffStore({ db });
 
   return {
     ...memoryStore,
@@ -121,6 +124,7 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Libra
     ...settingsStore,
     convState,
     domains,
+    handoffs,
     dataDir,
     eventsPath,
     sessionsPath,

--- a/packages/core/src/store/projection.ts
+++ b/packages/core/src/store/projection.ts
@@ -127,7 +127,13 @@ function asArray(value: unknown): string[] {
 //         via ALTER TABLE … DROP COLUMN (SQLite ≥3.35) inside
 //         `ensureAuthoritativeTableColumns`. Existing curation rows are
 //         preserved.
-export const PROJECTION_SCHEMA_VERSION = 17;
+//   - 17: sessions-rethink PR 1 / Task 1.3 — adds the `handoffs` table
+//         (the new cross-harness narrative-handover surface, spec §6.2)
+//         alongside the existing session tables. Additive; old sessions
+//         surface is untouched. The partial-unclaimed index supports the
+//         §6.1 default picker filter. Authoritative; preserved across
+//         future bumps.
+export const PROJECTION_SCHEMA_VERSION = 18;
 
 export function getSchemaVersion(db: DatabaseSync): number {
   const row = db.prepare("PRAGMA user_version").get() as { user_version: number };
@@ -145,11 +151,13 @@ function dropProjectionTables(db: DatabaseSync): void {
   // authoritative and intentionally absent here. T1.1 adds four more
   // SQLite-authoritative tables (`conversation_state`, `domains`,
   // `signal_rules`, `token_domain_bindings`) which must also survive
-  // bumps — they're intentionally absent from this drop list. Future DDL
-  // changes to authoritative tables should use ALTER TABLE rather
-  // than the drop-and-rebuild pattern below. The other tables are projections
-  // (memory side stays JSONL-canonical; session_events is rebuilt from
-  // session_events.jsonl on every bump).
+  // bumps — they're intentionally absent from this drop list. PR 1 adds
+  // `handoffs` (sessions-rethink §6.2), also SQLite-authoritative —
+  // intentionally absent here so existing handoffs survive a projection
+  // rebuild. Future DDL changes to authoritative tables should use ALTER
+  // TABLE rather than the drop-and-rebuild pattern below. The other tables
+  // are projections (memory side stays JSONL-canonical; session_events is
+  // rebuilt from session_events.jsonl on every bump).
   db.exec(`
     DROP TABLE IF EXISTS memories_fts;
     DROP TABLE IF EXISTS memories;
@@ -407,6 +415,24 @@ export const SCHEMA_DDL = `
       token_id TEXT PRIMARY KEY,
       domain TEXT NOT NULL
     );
+    CREATE TABLE IF NOT EXISTS handoffs (
+      id                      TEXT PRIMARY KEY,
+      title                   TEXT NOT NULL,
+      document_md             TEXT NOT NULL,
+      project_key             TEXT,
+      source_ref              TEXT,
+      cwd                     TEXT,
+      domain                  TEXT NOT NULL,
+      created_by_agent_id     TEXT,
+      created_in_harness      TEXT,
+      tags_json               TEXT NOT NULL DEFAULT '[]',
+      created_at              TEXT NOT NULL,
+      claimed_at              TEXT,
+      claimed_by_json         TEXT
+    );
+    CREATE INDEX IF NOT EXISTS idx_handoffs_unclaimed
+      ON handoffs(domain, project_key, cwd, created_at)
+      WHERE claimed_at IS NULL;
   `;
 
 export function initSchema(db: DatabaseSync): void {

--- a/packages/core/tests/schemas/handoff.test.ts
+++ b/packages/core/tests/schemas/handoff.test.ts
@@ -1,0 +1,118 @@
+// Handoff Zod boundary tests (sessions-rethink spec §6.1 + §6.3).
+//
+// The store layer trusts validated input, so any contract drift — a missing
+// heading, an oversize body, too many tags — must bounce here and never reach
+// the SQLite layer.
+
+import {
+  ClaimHandoffInputSchema,
+  ListHandoffsInputSchema,
+  StoreHandoffInputSchema,
+} from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+const validDoc = `# Handoff: test
+
+## Start & intent
+the user wanted to do a thing.
+
+## Journey
+we tried X then Y.
+
+## Current state
+green tests, branch is feat/foo.
+
+## What's left
+ship it; write a release note.
+
+## Open questions
+do we squash-merge or rebase?
+`;
+
+describe("StoreHandoffInputSchema", () => {
+  it("accepts a fully-formed handoff with the five required headings", () => {
+    const result = StoreHandoffInputSchema.safeParse({
+      title: "Continue the migration",
+      document_md: validDoc,
+      project_key: "proj-x",
+      cwd: "/repo",
+      harness: "claude-code",
+      tags: ["migration", "p1"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects when any required heading is missing", () => {
+    for (const heading of [
+      "## Start & intent",
+      "## Journey",
+      "## Current state",
+      "## What's left",
+      "## Open questions",
+    ]) {
+      const broken = validDoc.replace(heading, "## Renamed");
+      const result = StoreHandoffInputSchema.safeParse({
+        title: "a valid title",
+        document_md: broken,
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.path).toEqual(["document_md"]);
+      }
+    }
+  });
+
+  it("rejects a heading that is not anchored to the start of a line", () => {
+    const broken = validDoc.replace("## Journey", "blah ## Journey");
+    const result = StoreHandoffInputSchema.safeParse({
+      title: "test",
+      document_md: broken,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects when title is too short or too long", () => {
+    expect(StoreHandoffInputSchema.safeParse({ title: "abc", document_md: validDoc }).success).toBe(
+      false,
+    );
+    expect(
+      StoreHandoffInputSchema.safeParse({ title: "x".repeat(121), document_md: validDoc }).success,
+    ).toBe(false);
+  });
+
+  it("rejects when document_md is too short or too long", () => {
+    expect(
+      StoreHandoffInputSchema.safeParse({ title: "a valid title", document_md: "too short" })
+        .success,
+    ).toBe(false);
+    const oversize = `${validDoc}${"x".repeat(50_001)}`;
+    expect(
+      StoreHandoffInputSchema.safeParse({ title: "a valid title", document_md: oversize }).success,
+    ).toBe(false);
+  });
+
+  it("rejects more than ten tags", () => {
+    const result = StoreHandoffInputSchema.safeParse({
+      title: "a valid title",
+      document_md: validDoc,
+      tags: Array.from({ length: 11 }, (_, i) => `t${i}`),
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("ListHandoffsInputSchema", () => {
+  it("accepts all-optional input and clamps limit bounds", () => {
+    expect(ListHandoffsInputSchema.safeParse({}).success).toBe(true);
+    expect(ListHandoffsInputSchema.safeParse({ limit: 0 }).success).toBe(false);
+    expect(ListHandoffsInputSchema.safeParse({ limit: 101 }).success).toBe(false);
+    expect(ListHandoffsInputSchema.safeParse({ limit: 50 }).success).toBe(true);
+  });
+});
+
+describe("ClaimHandoffInputSchema", () => {
+  it("requires handoff_id; other claim metadata is optional", () => {
+    expect(ClaimHandoffInputSchema.safeParse({}).success).toBe(false);
+    expect(ClaimHandoffInputSchema.safeParse({ handoff_id: "hdo_abc" }).success).toBe(true);
+  });
+});

--- a/packages/core/tests/store/handoff-store.test.ts
+++ b/packages/core/tests/store/handoff-store.test.ts
@@ -182,6 +182,30 @@ describe("handoff store — concurrent claim", () => {
   });
 });
 
+describe("handoff store — admin / cross-domain access", () => {
+  it("lists across every domain when context.domain is null (admin bypass)", () => {
+    const { handoffs } = s!;
+    handoffs.store(defaultInput(), ctx("domain-a"));
+    handoffs.store(defaultInput(), ctx("domain-b"));
+    expect(handoffs.list({}, { domain: null })).toHaveLength(2);
+  });
+
+  it("claims across domains when context.domain is null", () => {
+    const { handoffs } = s!;
+    const stored = handoffs.store(defaultInput(), ctx("domain-a"));
+    const claimed = handoffs.claim({ handoff_id: stored.handoff_id }, { domain: null });
+    expect(claimed.handoff_id).toBe(stored.handoff_id);
+  });
+
+  it("includes already-claimed rows when context.includeClaimed is true", () => {
+    const { handoffs } = s!;
+    const stored = handoffs.store(defaultInput(), ctx());
+    handoffs.claim({ handoff_id: stored.handoff_id }, { domain: "general" });
+    expect(handoffs.list({}, { domain: "general" })).toHaveLength(0);
+    expect(handoffs.list({}, { domain: "general", includeClaimed: true })).toHaveLength(1);
+  });
+});
+
 describe("handoff store — purge (admin / test)", () => {
   it("hard-deletes a handoff and reports whether anything was removed", () => {
     const { handoffs } = s!;

--- a/packages/core/tests/store/handoff-store.test.ts
+++ b/packages/core/tests/store/handoff-store.test.ts
@@ -1,0 +1,192 @@
+// Handoff store tests (sessions-rethink spec §6.2 + §7).
+//
+// Pin the contract the MCP tools depend on:
+//   - store → list → claim → list (no longer surfaces) → claim again → 409.
+//   - server-scoped domain isolation: a handoff in domain A never lists for B.
+//   - user-facing project/cwd filtering when both are supplied.
+//   - concurrent claim: parallel attempts pick a single winner.
+//   - 404 vs 409 distinguish on the claim path.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type LibrarianStore,
+  HandoffAlreadyClaimedError,
+  HandoffNotFoundError,
+  createLibrarianStore,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+interface Scope {
+  store: LibrarianStore;
+  handoffs: LibrarianStore["handoffs"];
+  dataDir: string;
+}
+
+let s: Scope | null = null;
+
+beforeEach(() => {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-handoff-"));
+  const store = createLibrarianStore({ dataDir });
+  s = { store, handoffs: store.handoffs, dataDir };
+});
+
+afterEach(() => {
+  if (!s) return;
+  try {
+    s.store.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(s.dataDir, { recursive: true, force: true });
+  s = null;
+});
+
+const validDoc = `# Handoff: test
+
+## Start & intent
+do the thing.
+
+## Journey
+tried X then Y.
+
+## Current state
+green tests.
+
+## What's left
+ship it.
+
+## Open questions
+none.
+`;
+
+function defaultInput(
+  over: Partial<{
+    title: string;
+    document_md: string;
+    project_key: string | null;
+    cwd: string | null;
+    harness: string | null;
+    tags: string[];
+  }> = {},
+) {
+  return {
+    title: "a valid title",
+    document_md: validDoc,
+    project_key: "proj-x",
+    cwd: "/repo",
+    harness: "claude-code",
+    tags: ["migration"],
+    ...over,
+  };
+}
+
+const ctx = (domain = "general", agent = "agent-a") => ({
+  domain,
+  created_by_agent_id: agent,
+});
+
+describe("handoff store — happy path", () => {
+  it("stores, lists, and claims a handoff in a single round-trip", () => {
+    const { handoffs } = s!;
+    const stored = handoffs.store(defaultInput(), ctx());
+    expect(stored.handoff_id).toMatch(/^hdo_/);
+
+    const listed = handoffs.list({ project_key: "proj-x", cwd: "/repo" }, { domain: "general" });
+    expect(listed).toHaveLength(1);
+    expect(listed[0]!.handoff_id).toBe(stored.handoff_id);
+    expect(listed[0]!.title).toBe("a valid title");
+    expect(listed[0]!.tags).toEqual(["migration"]);
+
+    const claimed = handoffs.claim(
+      { handoff_id: stored.handoff_id, claiming_agent_id: "agent-b", claiming_harness: "codex" },
+      { domain: "general" },
+    );
+    expect(claimed.document_md).toContain("ship it");
+
+    const after = handoffs.list({ project_key: "proj-x", cwd: "/repo" }, { domain: "general" });
+    expect(after).toHaveLength(0);
+  });
+
+  it("rejects a second claim with HandoffAlreadyClaimedError", () => {
+    const { handoffs } = s!;
+    const stored = handoffs.store(defaultInput(), ctx());
+    handoffs.claim({ handoff_id: stored.handoff_id }, { domain: "general" });
+    expect(() => handoffs.claim({ handoff_id: stored.handoff_id }, { domain: "general" })).toThrow(
+      HandoffAlreadyClaimedError,
+    );
+  });
+
+  it("rejects a missing id with HandoffNotFoundError", () => {
+    const { handoffs } = s!;
+    expect(() => handoffs.claim({ handoff_id: "hdo_ghost" }, { domain: "general" })).toThrow(
+      HandoffNotFoundError,
+    );
+  });
+});
+
+describe("handoff store — domain isolation", () => {
+  it("never lists a handoff stored in another domain", () => {
+    const { handoffs } = s!;
+    handoffs.store(defaultInput({ project_key: null, cwd: null }), ctx("domain-a"));
+    expect(handoffs.list({}, { domain: "domain-b" })).toHaveLength(0);
+    expect(handoffs.list({}, { domain: "domain-a" })).toHaveLength(1);
+  });
+
+  it("treats a claim across domains as 404, not 409", () => {
+    const { handoffs } = s!;
+    const stored = handoffs.store(defaultInput(), ctx("domain-a"));
+    expect(() => handoffs.claim({ handoff_id: stored.handoff_id }, { domain: "domain-b" })).toThrow(
+      HandoffNotFoundError,
+    );
+  });
+});
+
+describe("handoff store — project + cwd filtering", () => {
+  it("returns nothing when project_key matches but cwd does not", () => {
+    const { handoffs } = s!;
+    handoffs.store(defaultInput({ project_key: "proj-x", cwd: "/a" }), ctx());
+    expect(handoffs.list({ project_key: "proj-x", cwd: "/b" }, { domain: "general" })).toHaveLength(
+      0,
+    );
+  });
+
+  it("ignores an axis when its filter is null/undefined", () => {
+    const { handoffs } = s!;
+    handoffs.store(defaultInput({ project_key: "proj-x", cwd: "/a" }), ctx());
+    // No project filter → matches.
+    expect(handoffs.list({ cwd: "/a" }, { domain: "general" })).toHaveLength(1);
+    // Project filter unrelated → no match.
+    expect(handoffs.list({ project_key: "proj-y" }, { domain: "general" })).toHaveLength(0);
+  });
+});
+
+describe("handoff store — concurrent claim", () => {
+  it("only one claim succeeds when two attempts run back-to-back", () => {
+    const { handoffs } = s!;
+    const stored = handoffs.store(defaultInput(), ctx());
+    let won = 0;
+    let lost = 0;
+    for (let i = 0; i < 2; i++) {
+      try {
+        handoffs.claim({ handoff_id: stored.handoff_id }, { domain: "general" });
+        won++;
+      } catch (error) {
+        if (error instanceof HandoffAlreadyClaimedError) lost++;
+        else throw error;
+      }
+    }
+    expect(won).toBe(1);
+    expect(lost).toBe(1);
+  });
+});
+
+describe("handoff store — purge (admin / test)", () => {
+  it("hard-deletes a handoff and reports whether anything was removed", () => {
+    const { handoffs } = s!;
+    const stored = handoffs.store(defaultInput(), ctx());
+    expect(handoffs.purge(stored.handoff_id)).toBe(true);
+    expect(handoffs.purge(stored.handoff_id)).toBe(false);
+  });
+});

--- a/packages/mcp-server/src/mcp/tools/claim-handoff.ts
+++ b/packages/mcp-server/src/mcp/tools/claim-handoff.ts
@@ -41,10 +41,22 @@ const claimHandoff: ToolDefinition = {
     }
     const convId = typeof args.conv_id === "string" ? args.conv_id : "";
     const { domain } = resolveCallerDomain(store, convId, context);
-    const effectiveDomain = domain ?? "general";
+    // Admin role: pass `domain: null` (no domain filter, cross-domain claim).
+    // Mirrors `recall`'s admin bypass. Agent role with no conv_state would
+    // resolve to null too; require a domain so a misconfigured agent can't
+    // claim across domains by accident.
+    if (domain === null && context.role !== "admin") {
+      return textResult(
+        JSON.stringify({
+          error: "no_domain",
+          message:
+            "No conv_state resolved for this caller. Set conv_state first (or invoke as admin).",
+        }),
+      );
+    }
 
     try {
-      const claimed = store.handoffs.claim(parsed.data, { domain: effectiveDomain });
+      const claimed = store.handoffs.claim(parsed.data, { domain });
       return textResult(JSON.stringify(claimed, null, 2));
     } catch (error) {
       if (error instanceof HandoffNotFoundError) {

--- a/packages/mcp-server/src/mcp/tools/claim-handoff.ts
+++ b/packages/mcp-server/src/mcp/tools/claim-handoff.ts
@@ -1,0 +1,70 @@
+// `claim_handoff` MCP tool (sessions-rethink spec §6.1).
+//
+// Atomic claim + read in a single transaction. On 404 the row was never
+// stored (or sits in another domain); on 409 someone else claimed first and
+// the error payload carries the existing claim so the caller can render
+// "claimed by X at Y."
+
+import {
+  ClaimHandoffInputSchema,
+  HandoffAlreadyClaimedError,
+  HandoffNotFoundError,
+} from "@librarian/core";
+import { resolveCallerDomain } from "../domain-resolution.js";
+import { textResult } from "../result.js";
+import type { ToolDefinition } from "../tool.js";
+
+const claimHandoff: ToolDefinition = {
+  name: "claim_handoff",
+  description:
+    "Atomically claim a handoff and return its document. Fails 404 if the id " +
+    "is unknown; 409 if already claimed (the existing claim is included so the " +
+    "caller can render it). Server-scoped by domain.",
+  inputSchema: {
+    type: "object",
+    required: ["handoff_id"],
+    properties: {
+      handoff_id: { type: "string", minLength: 1 },
+      claiming_agent_id: { type: ["string", "null"] },
+      claiming_harness: { type: ["string", "null"] },
+      claiming_source_ref: { type: ["string", "null"] },
+      claiming_cwd: { type: ["string", "null"] },
+      conv_id: { type: "string" },
+    },
+  },
+  handler(store, args, context) {
+    const parsed = ClaimHandoffInputSchema.safeParse(args);
+    if (!parsed.success) {
+      return textResult(
+        `claim_handoff rejected: ${parsed.error.issues[0]?.message ?? "invalid input"}`,
+      );
+    }
+    const convId = typeof args.conv_id === "string" ? args.conv_id : "";
+    const { domain } = resolveCallerDomain(store, convId, context);
+    const effectiveDomain = domain ?? "general";
+
+    try {
+      const claimed = store.handoffs.claim(parsed.data, { domain: effectiveDomain });
+      return textResult(JSON.stringify(claimed, null, 2));
+    } catch (error) {
+      if (error instanceof HandoffNotFoundError) {
+        return textResult(
+          JSON.stringify({ error: "not_found", handoff_id: parsed.data.handoff_id }),
+        );
+      }
+      if (error instanceof HandoffAlreadyClaimedError) {
+        return textResult(
+          JSON.stringify({
+            error: "already_claimed",
+            handoff_id: error.handoffId,
+            claimed_at: error.claimedAt,
+            claimed_by: error.claimedBy,
+          }),
+        );
+      }
+      throw error;
+    }
+  },
+};
+
+export default claimHandoff;

--- a/packages/mcp-server/src/mcp/tools/index.ts
+++ b/packages/mcp-server/src/mcp/tools/index.ts
@@ -7,12 +7,14 @@ import approveProposal from "./approve-proposal.js";
 import archiveMemory from "./archive-memory.js";
 import attachSession from "./attach-session.js";
 import checkpointSession from "./checkpoint-session.js";
+import claimHandoff from "./claim-handoff.js";
 import continueSession from "./continue-session.js";
 import convStateClear from "./conv-state-clear.js";
 import convStateGet from "./conv-state-get.js";
 import convStateUpsert from "./conv-state-upsert.js";
 import endSession from "./end-session.js";
 import getSession from "./get-session.js";
+import listHandoffs from "./list-handoffs.js";
 import listProposals from "./list-proposals.js";
 import listSessionEvents from "./list-session-events.js";
 import listSessions from "./list-sessions.js";
@@ -26,6 +28,7 @@ import remember from "./remember.js";
 import searchSessions from "./search-sessions.js";
 import startContext from "./start-context.js";
 import startSession from "./start-session.js";
+import storeHandoff from "./store-handoff.js";
 import updateMemory from "./update-memory.js";
 import verifyMemory from "./verify-memory.js";
 
@@ -55,6 +58,9 @@ export const tools: ToolDefinition[] = [
   convStateGet,
   convStateUpsert,
   convStateClear,
+  storeHandoff,
+  listHandoffs,
+  claimHandoff,
 ];
 
 export const toolsByName: Map<string, ToolDefinition> = new Map(

--- a/packages/mcp-server/src/mcp/tools/list-handoffs.ts
+++ b/packages/mcp-server/src/mcp/tools/list-handoffs.ts
@@ -1,0 +1,53 @@
+// `list_handoffs` MCP tool (sessions-rethink spec §6.1).
+//
+// Called by `/takeover` to populate the picker. Default filter is unclaimed +
+// current project_key + current cwd (per §6.1 D9); the agent broadens by
+// dropping filters when nothing matches. Domain is server-scoped from the
+// caller's conv_state.
+
+import { ListHandoffsInputSchema } from "@librarian/core";
+import { resolveCallerDomain } from "../domain-resolution.js";
+import { textResult } from "../result.js";
+import type { ToolDefinition } from "../tool.js";
+
+const listHandoffs: ToolDefinition = {
+  name: "list_handoffs",
+  description:
+    "List unclaimed handoffs visible to the calling agent. Default scope is the " +
+    "caller's current project_key + cwd when both are supplied; drop either to " +
+    "broaden. Server-scoped by domain.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      project_key: { type: ["string", "null"] },
+      cwd: { type: ["string", "null"] },
+      harness: { type: ["string", "null"] },
+      limit: { type: "integer", minimum: 1, maximum: 100 },
+      conv_id: { type: "string" },
+    },
+  },
+  handler(store, args, context) {
+    const parsed = ListHandoffsInputSchema.safeParse(args);
+    if (!parsed.success) {
+      return textResult(
+        `list_handoffs rejected: ${parsed.error.issues[0]?.message ?? "invalid input"}`,
+      );
+    }
+    const convId = typeof args.conv_id === "string" ? args.conv_id : "";
+    const { domain } = resolveCallerDomain(store, convId, context);
+    if (domain === null && context.role !== "admin") {
+      return textResult(
+        JSON.stringify({ handoffs: [] }) +
+          "\n\n(No conv_state resolved; broaden domain by attaching a session first.)",
+      );
+    }
+    const rows = store.handoffs.list(parsed.data, {
+      // Admin sees only "general" by default — handoffs are scoped by domain
+      // even for admins; broader admin views are a dashboard concern.
+      domain: domain ?? "general",
+    });
+    return textResult(JSON.stringify({ handoffs: rows }, null, 2));
+  },
+};
+
+export default listHandoffs;

--- a/packages/mcp-server/src/mcp/tools/list-handoffs.ts
+++ b/packages/mcp-server/src/mcp/tools/list-handoffs.ts
@@ -41,11 +41,9 @@ const listHandoffs: ToolDefinition = {
           "\n\n(No conv_state resolved; broaden domain by attaching a session first.)",
       );
     }
-    const rows = store.handoffs.list(parsed.data, {
-      // Admin sees only "general" by default — handoffs are scoped by domain
-      // even for admins; broader admin views are a dashboard concern.
-      domain: domain ?? "general",
-    });
+    // Admin role: pass `domain: null` to bypass the domain WHERE clause.
+    // Mirrors `recall`'s `admin: true` path (memory-domain-isolation §4.10).
+    const rows = store.handoffs.list(parsed.data, { domain });
     return textResult(JSON.stringify({ handoffs: rows }, null, 2));
   },
 };

--- a/packages/mcp-server/src/mcp/tools/store-handoff.ts
+++ b/packages/mcp-server/src/mcp/tools/store-handoff.ts
@@ -1,0 +1,57 @@
+// `store_handoff` MCP tool (sessions-rethink spec §6.1).
+//
+// Called by the outgoing agent at the end of `/handoff`. The MCP boundary
+// validates the input shape (Zod), resolves the caller's domain server-side,
+// and asks the store to persist. The store layer trusts validated input —
+// the heading/length contract is enforced here, not there.
+
+import { StoreHandoffInputSchema } from "@librarian/core";
+import { resolveCallerDomain } from "../domain-resolution.js";
+import { textResult } from "../result.js";
+import type { ToolDefinition } from "../tool.js";
+
+const storeHandoff: ToolDefinition = {
+  name: "store_handoff",
+  description:
+    "Persist a handoff document for cross-agent / cross-harness pickup. The " +
+    "document must conform to the five-section template (Start & intent, " +
+    "Journey, Current state, What's left, Open questions). Server resolves " +
+    "domain from conv_state; caller-supplied domain is ignored.",
+  inputSchema: {
+    type: "object",
+    required: ["title", "document_md"],
+    properties: {
+      title: { type: "string", minLength: 5, maxLength: 120 },
+      document_md: { type: "string", minLength: 100, maxLength: 50000 },
+      project_key: { type: ["string", "null"] },
+      source_ref: { type: ["string", "null"] },
+      cwd: { type: ["string", "null"] },
+      harness: { type: ["string", "null"] },
+      tags: { type: "array", items: { type: "string" }, maxItems: 10 },
+      conv_id: { type: "string" },
+    },
+  },
+  handler(store, args, context) {
+    const parsed = StoreHandoffInputSchema.safeParse(args);
+    if (!parsed.success) {
+      const reason = parsed.error.issues[0]?.message ?? "invalid handoff input";
+      return textResult(`Handoff rejected: ${reason}`);
+    }
+    const convId = typeof args.conv_id === "string" ? args.conv_id : "";
+    const { domain } = resolveCallerDomain(store, convId, context);
+    if (domain === null) {
+      return textResult(
+        "Cannot store handoff: no conv_state for this caller and the install is multi-domain. Run /lib-session-start (or set conv_state) first.",
+      );
+    }
+    const result = store.handoffs.store(parsed.data, {
+      domain,
+      created_by_agent_id: context.agentId ?? null,
+    });
+    return textResult(
+      `Handoff stored.\n\nhandoff_id: ${result.handoff_id}\ncreated_at:  ${result.created_at}\n\nPick it up from another agent with /takeover.`,
+    );
+  },
+};
+
+export default storeHandoff;

--- a/packages/mcp-server/src/trpc/handoffs.ts
+++ b/packages/mcp-server/src/trpc/handoffs.ts
@@ -1,0 +1,129 @@
+// Handoff tRPC procedures (sessions-rethink spec §6.7).
+//
+// Read-only dashboard surface — claim is an agent-only operation via the
+// MCP layer. The dashboard renders the markdown document + metadata; admin
+// purge belongs to a separate admin-only procedure once it's needed (not
+// in v1, per spec §6.6 "Batch purge is YAGNI for v1").
+
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+import { adminProcedure, router } from "./trpc.js";
+
+const DEFAULT_DOMAIN = "general";
+
+const ListInputSchema = z.object({
+  project_key: z.string().nullable().optional(),
+  cwd: z.string().nullable().optional(),
+  harness: z.string().nullable().optional(),
+  domain: z.string().optional(),
+  include_claimed: z.boolean().optional(),
+  limit: z.number().int().min(1).max(100).optional(),
+});
+
+const ByIdInputSchema = z.object({
+  handoff_id: z.string().min(1),
+});
+
+interface HandoffDetailRow {
+  id: string;
+  title: string;
+  document_md: string;
+  project_key: string | null;
+  source_ref: string | null;
+  cwd: string | null;
+  domain: string;
+  created_by_agent_id: string | null;
+  created_in_harness: string | null;
+  tags_json: string;
+  created_at: string;
+  claimed_at: string | null;
+  claimed_by_json: string | null;
+}
+
+function parseTags(json: string): string[] {
+  try {
+    const parsed = JSON.parse(json || "[]");
+    return Array.isArray(parsed) ? (parsed as string[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function parseClaimedBy(json: string | null) {
+  if (!json) return null;
+  try {
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
+}
+
+export const handoffsRouter = router({
+  list: adminProcedure.input(ListInputSchema.optional()).query(({ ctx, input }) => {
+    const {
+      domain = DEFAULT_DOMAIN,
+      include_claimed,
+      limit,
+      project_key,
+      cwd,
+      harness,
+    } = input ?? {};
+    const where: string[] = ["domain = ?"];
+    const params: (string | number)[] = [domain];
+    if (!include_claimed) where.push("claimed_at IS NULL");
+    if (project_key != null) {
+      where.push("project_key = ?");
+      params.push(project_key);
+    }
+    if (cwd != null) {
+      where.push("cwd = ?");
+      params.push(cwd);
+    }
+    if (harness != null) {
+      where.push("created_in_harness = ?");
+      params.push(harness);
+    }
+    params.push(limit ?? 50);
+    const rows = ctx.store.db
+      .prepare(
+        `SELECT * FROM handoffs WHERE ${where.join(" AND ")} ORDER BY created_at DESC LIMIT ?`,
+      )
+      .all(...params) as unknown as HandoffDetailRow[];
+    return rows.map((row) => ({
+      handoff_id: row.id,
+      title: row.title,
+      project_key: row.project_key,
+      source_ref: row.source_ref,
+      cwd: row.cwd,
+      domain: row.domain,
+      created_by_agent_id: row.created_by_agent_id,
+      created_in_harness: row.created_in_harness,
+      tags: parseTags(row.tags_json),
+      created_at: row.created_at,
+      claimed_at: row.claimed_at,
+      claimed_by: parseClaimedBy(row.claimed_by_json),
+    }));
+  }),
+
+  byId: adminProcedure.input(ByIdInputSchema).query(({ ctx, input }) => {
+    const row = ctx.store.db
+      .prepare("SELECT * FROM handoffs WHERE id = ?")
+      .get(input.handoff_id) as HandoffDetailRow | undefined;
+    if (!row) throw new TRPCError({ code: "NOT_FOUND", message: "Handoff not found" });
+    return {
+      handoff_id: row.id,
+      title: row.title,
+      document_md: row.document_md,
+      project_key: row.project_key,
+      source_ref: row.source_ref,
+      cwd: row.cwd,
+      domain: row.domain,
+      created_by_agent_id: row.created_by_agent_id,
+      created_in_harness: row.created_in_harness,
+      tags: parseTags(row.tags_json),
+      created_at: row.created_at,
+      claimed_at: row.claimed_at,
+      claimed_by: parseClaimedBy(row.claimed_by_json),
+    };
+  }),
+});

--- a/packages/mcp-server/src/trpc/router.ts
+++ b/packages/mcp-server/src/trpc/router.ts
@@ -10,6 +10,7 @@ import { backupRouter } from "./backup.js";
 import { classifierEvalRouter } from "./classifier-eval.js";
 import { curatorRouter } from "./curator.js";
 import { domainsRouter } from "./domains.js";
+import { handoffsRouter } from "./handoffs.js";
 import { healthRouter } from "./health.js";
 import { memoriesRouter } from "./memories.js";
 import { sessionsRouter } from "./sessions.js";
@@ -22,6 +23,7 @@ export const appRouter = router({
   classifierEval: classifierEvalRouter,
   curator: curatorRouter,
   domains: domainsRouter,
+  handoffs: handoffsRouter,
   health: healthRouter,
   memories: memoriesRouter,
   sessions: sessionsRouter,

--- a/packages/mcp-server/tests/mcp/handoffs.mcp.test.ts
+++ b/packages/mcp-server/tests/mcp/handoffs.mcp.test.ts
@@ -1,0 +1,183 @@
+// MCP tool surface for the handoffs subsystem (sessions-rethink §6.1 + §7).
+//
+// Pins dispatch wiring, the validation boundary, the domain-scoped list, and
+// the 404 / 409 split on claim. The store-level test is in
+// packages/core/tests/store/handoff-store.test.ts; this layer asserts that
+// MCP-side concerns (Zod validation, domain resolution, error envelopes)
+// behave per spec.
+
+import type { LibrarianStore } from "@librarian/core";
+import { handleMcpPayload } from "@librarian/mcp-server";
+import { describe, expect, it } from "vitest";
+import { withStore } from "../../../../test/helpers.js";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyResponse = any;
+
+function call(
+  store: LibrarianStore,
+  name: string,
+  args: Record<string, unknown>,
+  context: { role: "admin" | "agent"; agentId?: string } = { role: "agent", agentId: "agent-a" },
+): Promise<AnyResponse> {
+  return handleMcpPayload(
+    store,
+    { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name, arguments: args } },
+    context,
+  ) as Promise<AnyResponse>;
+}
+
+function extractText(response: AnyResponse): string {
+  return response.result.content[0].text as string;
+}
+
+const validDoc = `# Handoff: test
+
+## Start & intent
+do the thing.
+
+## Journey
+tried X then Y.
+
+## Current state
+green tests.
+
+## What's left
+ship it.
+
+## Open questions
+none.
+`;
+
+function defaultInput() {
+  return {
+    title: "a valid title",
+    document_md: validDoc,
+    project_key: "proj-x",
+    cwd: "/repo",
+    harness: "claude-code",
+    tags: ["migration"],
+    conv_id: "claude:abc",
+  };
+}
+
+async function seedConvState(store: LibrarianStore, domain = "general") {
+  await call(store, "conv_state_upsert", { conv_id: "claude:abc", harness: "claude-code", domain });
+}
+
+describe("MCP handoff tools", () => {
+  it("tools/list exposes store_handoff / list_handoffs / claim_handoff", async () => {
+    await withStore(async (store) => {
+      const list = await handleMcpPayload(store, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+        params: {},
+      });
+      const names = list.result.tools.map((tool: { name: string }) => tool.name);
+      expect(names).toContain("store_handoff");
+      expect(names).toContain("list_handoffs");
+      expect(names).toContain("claim_handoff");
+    });
+  });
+
+  it("store_handoff rejects a missing-heading document at the Zod boundary", async () => {
+    await withStore(async (store) => {
+      await seedConvState(store);
+      const broken = validDoc.replace("## Journey", "## Renamed");
+      const response = await call(store, "store_handoff", {
+        ...defaultInput(),
+        document_md: broken,
+      });
+      expect(extractText(response)).toMatch(/document_md must include/);
+    });
+  });
+
+  it("round-trips store → list → claim → list (no surface) → claim 409", async () => {
+    await withStore(async (store) => {
+      await seedConvState(store);
+
+      // store_handoff returns human-readable text with the handoff_id inline;
+      // a regex pulls it out so the test isn't tied to the exact wording.
+      const storedText = extractText(await call(store, "store_handoff", defaultInput()));
+      const handoffId = /handoff_id:\s*(hdo_[^\s]+)/.exec(storedText)?.[1];
+      expect(handoffId).toBeTruthy();
+
+      const listed = JSON.parse(
+        extractText(await call(store, "list_handoffs", { project_key: "proj-x", cwd: "/repo" })),
+      );
+      expect(listed.handoffs.length).toBeGreaterThanOrEqual(1);
+
+      const claimed = JSON.parse(
+        extractText(await call(store, "claim_handoff", { handoff_id: handoffId })),
+      );
+      expect(claimed.handoff_id).toBe(handoffId);
+      expect(claimed.document_md).toContain("ship it");
+
+      const afterList = JSON.parse(
+        extractText(await call(store, "list_handoffs", { project_key: "proj-x", cwd: "/repo" })),
+      );
+      expect(
+        afterList.handoffs.find((h: { handoff_id: string }) => h.handoff_id === handoffId),
+      ).toBeUndefined();
+
+      const conflict = JSON.parse(
+        extractText(await call(store, "claim_handoff", { handoff_id: handoffId })),
+      );
+      expect(conflict.error).toBe("already_claimed");
+      expect(conflict.handoff_id).toBe(handoffId);
+      expect(conflict.claimed_at).toBeTruthy();
+    });
+  });
+
+  it("claim of an unknown id returns a 'not_found' envelope", async () => {
+    await withStore(async (store) => {
+      await seedConvState(store);
+      const result = JSON.parse(
+        extractText(await call(store, "claim_handoff", { handoff_id: "hdo_ghost" })),
+      );
+      expect(result.error).toBe("not_found");
+    });
+  });
+
+  it("list scopes by domain — a handoff in domain A is invisible to a caller in domain B", async () => {
+    await withStore(async (store) => {
+      // Two conv_states pointing at different domains; the second store_handoff
+      // belongs to domain "coding", the first to "general".
+      await call(store, "conv_state_upsert", {
+        conv_id: "claude:abc",
+        harness: "claude-code",
+        domain: "general",
+      });
+      await call(store, "conv_state_upsert", {
+        conv_id: "claude:xyz",
+        harness: "claude-code",
+        domain: "coding",
+      });
+      await call(store, "store_handoff", defaultInput());
+      await call(store, "store_handoff", { ...defaultInput(), conv_id: "claude:xyz" });
+
+      const listGeneral = JSON.parse(
+        extractText(
+          await call(store, "list_handoffs", {
+            project_key: "proj-x",
+            cwd: "/repo",
+            conv_id: "claude:abc",
+          }),
+        ),
+      );
+      const listCoding = JSON.parse(
+        extractText(
+          await call(store, "list_handoffs", {
+            project_key: "proj-x",
+            cwd: "/repo",
+            conv_id: "claude:xyz",
+          }),
+        ),
+      );
+      expect(listGeneral.handoffs).toHaveLength(1);
+      expect(listCoding.handoffs).toHaveLength(1);
+      expect(listGeneral.handoffs[0].handoff_id).not.toBe(listCoding.handoffs[0].handoff_id);
+    });
+  });
+});

--- a/scripts/healthcheck.js
+++ b/scripts/healthcheck.js
@@ -52,6 +52,9 @@ const EXPECTED_TOOLS = {
     "continue_session",
     "promote_session_fact",
   ],
+  // sessions-rethink PR 1 — handoffs surface (additive). The session
+  // surface above is removed in PR 7; for now both live side-by-side.
+  handoff: ["store_handoff", "list_handoffs", "claim_handoff"],
 };
 
 const RETIRED_TOOLS = [

--- a/test/schema-snapshot.json
+++ b/test/schema-snapshot.json
@@ -1,4 +1,4 @@
 {
-  "version": 17,
-  "fingerprint": "a729b95c8998f7cef47af29c7e8c8d7eb5814012fdd6509ad1b18b9b41a5e177"
+  "version": 18,
+  "fingerprint": "c7bbff132ad6a39fdfc5c1225ef183defe6da5978983f6472a624fc399fd42ac"
 }


### PR DESCRIPTION
## Summary

PR 1 of the 8-PR sessions-rethink sequence — see `docs/specs/sessions-rethink-plan.md`. **Additive only.** Adds the new handoffs surface across the full stack (schema → store → MCP tools → tRPC → CLI → dashboard → slash commands) without touching the legacy session tools. PR 2–6 migrate each plugin, then PR 7 removes sessions.

After this PR:
- New MCP tools: `store_handoff`, `list_handoffs`, `claim_handoff`.
- New table: `handoffs` (authoritative; preserved across projection rebuilds).
- New CLI verbs: `the-librarian handoffs list|show|purge`.
- New dashboard route: `/handoffs` (read-only — claim is an agent operation).
- New slash commands: `/handoff`, `/takeover`, `/learn`, `/toggle-private`.
- Sessions tools, dashboard /sessions, CLI sessions verbs, lib-session-* commands all unchanged.

## Operator-visible notes

- **Schema bump** (17 → 18). Existing dev DBs will rebuild on next boot and the new table will appear; nothing is dropped.
- **Slash commands coexist temporarily.** `/lib-session-*` keeps working. PR 2 (Claude plugin) removes the old commands per harness; the operator deploys this PR + each plugin in any order.
- **Healthcheck allow-list** now expects the three new tools alongside the existing 13 session tools.

## Atomic claim

The `BEGIN IMMEDIATE` + `UPDATE … RETURNING *` + conditional follow-up SELECT pattern in `packages/core/src/store/handoff-store.ts` is spec §6.2. The test suite pins:
- Single-winner under back-to-back claim attempts.
- Cross-domain claim is 404 (not 409) — domain scope is enforcement, not user-facing filtering.
- 404 vs 409 distinguish unknown row from existing claim.

## Admin / cross-domain access

The MCP `list_handoffs` / `claim_handoff` tools pass `domain: null` to the store when invoked by an admin role, mirroring `recall`'s `admin: true` bypass. Agents still require a resolved domain. The CLI's `--include-claimed` flag (admin path) and the store's `includeClaimed` context flag surface claimed handoffs for audit.

## Verification

- `pnpm typecheck && pnpm lint && pnpm test && pnpm smoke` — all green (1057 tests, +31 new for handoffs).
- `node scripts/healthcheck.js` — 6/6 checks passing including the MCP tool-surface check.
- `node scripts/check-schema-version.mjs` — passes after the v17 → v18 bump.

## Test plan

- [ ] CI green (typecheck + lint + test + smoke + schema-version + test-count).
- [ ] Manual: store a handoff via the new MCP tool, list, claim from a second agent; confirm 409 on a re-claim and 404 on a bogus id.
- [ ] Manual: dashboard `/handoffs` renders alongside existing `/sessions`.
- [ ] Manual: `the-librarian handoffs list` returns the new row; `the-librarian handoffs show <id>` shows the document; `the-librarian handoffs purge <id> --admin` removes it.
- [ ] Manual: legacy `/lib-session-start` / `/lib-session-pause` / etc. still work unchanged.

## Risks

- **Existing dev DBs rebuild** on first boot post-merge because of the schema-version bump. Memory data is preserved (JSONL is canonical for memory); session data is preserved (authoritative). The new table appears clean.
- **Dashboard detail view renders the markdown body as preformatted text**, not rendered HTML — the dashboard has no markdown renderer dependency. Documented in `AUTONOMOUS-BUILD-NOTES-26-05-28.md` for a follow-up. Operators see the document content; the structure is just hash-prefixed text.
- **`HandoffStore.purge` does not filter by domain.** Currently only reachable via the admin-only CLI, but if a future caller wires it from a non-admin path it would allow cross-domain deletes. Hardening is a follow-up (add an optional `context: { domain }` arg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)