### PR TITLE
feat(dashboard): version badge + GitHub "behind latest" indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ changes from this point forward are catalogued here.
 
 ### Added
 
+- **Dashboard version badge with "behind latest" indicator.** A small
+  `v<version>` chip in the nav bar shows the running build's version
+  (read from the root `package.json` at boot, surfaced via a new public
+  `health.info` tRPC procedure). A coloured dot + native browser
+  tooltip indicates whether the local build is up to date, behind the
+  latest GitHub release, or in a "couldn't check" state (no releases
+  yet, rate-limited, or the host is offline). Clicking the badge opens
+  the matching release notes in a new tab. The GitHub lookup is cached
+  for an hour, lifts to 5000 req/h when `LIBRARIAN_GITHUB_TOKEN` is
+  set, and can be disabled entirely with
+  `LIBRARIAN_DISABLE_VERSION_CHECK=true` for air-gapped instances.
+  Downstream forks can point the check at a different repo via
+  `LIBRARIAN_GITHUB_REPO=org/repo`.
 - **Handoffs surface (sessions-rethink PR 1, additive).** Three new MCP
   tools — `store_handoff`, `list_handoffs`, `claim_handoff` — back a new
   `handoffs` SQLite table that records self-contained narrative handoffs

--- a/apps/dashboard/components/site-nav.tsx
+++ b/apps/dashboard/components/site-nav.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { SignOutButton } from "@/components/sign-out-button";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { VersionBadge } from "@/components/version-badge";
 
 // The dashboard's single persistent navigation. Mounted once in the root layout
 // (app/layout.tsx) so every surface — Memories, Sessions, Recall, the memories
@@ -58,6 +59,7 @@ export function SiteNav({ signedIn = false }: { signedIn?: boolean }) {
         );
       })}
       <span className="ml-auto flex items-center gap-1">
+        <VersionBadge />
         <ThemeToggle />
         {signedIn ? <SignOutButton /> : null}
       </span>

--- a/apps/dashboard/components/version-badge.tsx
+++ b/apps/dashboard/components/version-badge.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { trpc } from "@/lib/trpc-client";
+
+// Strip a leading `v` and split into numeric parts. Anything non-numeric
+// becomes NaN, which `compareSemver` treats as "unknown" and falls back to
+// "up to date" rather than risking a noisy false-positive.
+function parseSemver(value: string): number[] {
+  return value
+    .replace(/^v/i, "")
+    .split(/[-+.]/)
+    .slice(0, 3)
+    .map((part) => Number.parseInt(part, 10));
+}
+
+function compareSemver(a: string, b: string): -1 | 0 | 1 | null {
+  const pa = parseSemver(a);
+  const pb = parseSemver(b);
+  for (let i = 0; i < 3; i++) {
+    const av = pa[i];
+    const bv = pb[i];
+    if (av === undefined || bv === undefined || Number.isNaN(av) || Number.isNaN(bv)) {
+      return null;
+    }
+    if (av < bv) return -1;
+    if (av > bv) return 1;
+  }
+  return 0;
+}
+
+type Status = "loading" | "up_to_date" | "behind" | "unknown";
+
+function statusOf(
+  current: string,
+  latest: { kind: string; release?: { tag: string } } | undefined,
+): Status {
+  if (!latest) return "loading";
+  if (latest.kind !== "ok" || !latest.release) return "unknown";
+  const cmp = compareSemver(current, latest.release.tag);
+  if (cmp === null) return "unknown";
+  return cmp < 0 ? "behind" : "up_to_date";
+}
+
+const DOT_TONE: Record<Status, string> = {
+  loading: "bg-muted-foreground/40",
+  up_to_date: "bg-emerald-500",
+  behind: "bg-amber-500",
+  unknown: "bg-muted-foreground/40",
+};
+
+const RELEASES_URL = "https://github.com/JimJafar/the-librarian/releases";
+
+export function VersionBadge() {
+  const info = trpc.health.info.useQuery(undefined, {
+    // Refresh every 30 minutes so a long-lived dashboard tab eventually
+    // notices a new release without polling the server constantly.
+    refetchInterval: 30 * 60 * 1000,
+    staleTime: 30 * 60 * 1000,
+  });
+
+  const current = info.data?.version ?? "…";
+  const latest = info.data?.latest;
+  const status = statusOf(current, latest);
+
+  const href =
+    latest && latest.kind === "ok" && latest.release ? latest.release.htmlUrl : RELEASES_URL;
+
+  const tooltip = buildTooltip(current, latest, status);
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      title={tooltip}
+      aria-label={tooltip}
+      data-testid="version-badge"
+      data-status={status}
+      className="flex h-9 items-center gap-2 rounded-md border border-transparent px-2 font-mono text-xs text-muted-foreground hover:border-border hover:text-foreground"
+    >
+      <span
+        aria-hidden="true"
+        className={`inline-block h-2 w-2 rounded-full ${DOT_TONE[status]}`}
+      />
+      <span>v{current}</span>
+    </a>
+  );
+}
+
+function buildTooltip(
+  current: string,
+  latest: { kind: string; release?: { tag: string; publishedAt?: string } } | undefined,
+  status: Status,
+): string {
+  if (status === "loading") return `v${current} — checking for updates…`;
+  if (status === "up_to_date") return `v${current} — up to date`;
+  if (status === "behind" && latest?.release) {
+    return `v${current} — ${latest.release.tag} available (click for release notes)`;
+  }
+  if (latest?.kind === "no_release") {
+    return `v${current} — no published releases yet`;
+  }
+  if (latest?.kind === "disabled") {
+    return `v${current} — update check disabled`;
+  }
+  return `v${current} — couldn't reach github.com (click to open releases)`;
+}

--- a/apps/dashboard/tests/components/site-nav.test.tsx
+++ b/apps/dashboard/tests/components/site-nav.test.tsx
@@ -11,6 +11,20 @@ vi.mock("next-themes", () => ({
 // The sign-out control's server action imports @/auth (next-auth), an
 // integration boundary that shouldn't load in a unit test — stub it.
 vi.mock("@/auth", () => ({ signOut: vi.fn(), auth: vi.fn() }));
+// VersionBadge calls trpc.health.info.useQuery; mock the trpc client so
+// the nav test doesn't need a QueryClientProvider/TRPCProvider wrapper.
+vi.mock("@/lib/trpc-client", () => ({
+  trpc: {
+    health: {
+      info: {
+        useQuery: () => ({
+          data: { version: "0.0.0-test", latest: { kind: "no_release", cachedAt: "" } },
+          isLoading: false,
+        }),
+      },
+    },
+  },
+}));
 
 const { SiteNav } = await import("@/components/site-nav");
 

--- a/apps/dashboard/tests/components/version-badge.test.tsx
+++ b/apps/dashboard/tests/components/version-badge.test.tsx
@@ -1,0 +1,97 @@
+// VersionBadge component tests.
+//
+// Mock the tRPC `health.info` query so the component receives synthetic
+// status payloads. We assert the visible label, the dot's status data-attr
+// (drives the colour), the link href, and the title tooltip.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const infoMock = vi.fn();
+
+vi.mock("@/lib/trpc-client", () => ({
+  trpc: {
+    health: {
+      info: { useQuery: (...args: unknown[]) => infoMock(...args) },
+    },
+  },
+}));
+
+const { VersionBadge } = await import("@/components/version-badge");
+
+function setup(data: unknown) {
+  infoMock.mockReturnValue({ data, isLoading: data === undefined });
+  return render(<VersionBadge />);
+}
+
+describe("VersionBadge", () => {
+  it("shows the current version and an 'up to date' status when latest matches", () => {
+    setup({
+      version: "0.2.0",
+      latest: {
+        kind: "ok",
+        release: {
+          tag: "v0.2.0",
+          htmlUrl: "https://github.com/JimJafar/the-librarian/releases/tag/v0.2.0",
+          publishedAt: "2026-06-01T00:00:00Z",
+          bodyExcerpt: null,
+        },
+        cachedAt: "2026-06-01T00:00:00Z",
+      },
+    });
+    const badge = screen.getByTestId("version-badge");
+    expect(badge).toHaveAttribute("data-status", "up_to_date");
+    expect(badge.textContent).toContain("v0.2.0");
+    expect(badge).toHaveAttribute(
+      "href",
+      "https://github.com/JimJafar/the-librarian/releases/tag/v0.2.0",
+    );
+  });
+
+  it("shows 'behind' when the local version is older than the latest release", () => {
+    setup({
+      version: "0.1.1",
+      latest: {
+        kind: "ok",
+        release: {
+          tag: "v0.2.0",
+          htmlUrl: "https://example/releases/tag/v0.2.0",
+          publishedAt: "2026-06-01T00:00:00Z",
+          bodyExcerpt: null,
+        },
+        cachedAt: "2026-06-01T00:00:00Z",
+      },
+    });
+    const badge = screen.getByTestId("version-badge");
+    expect(badge).toHaveAttribute("data-status", "behind");
+    expect(badge.getAttribute("title")).toMatch(/v0\.2\.0 available/i);
+  });
+
+  it("links to /releases when no release is published yet", () => {
+    setup({
+      version: "0.1.1",
+      latest: { kind: "no_release", cachedAt: "2026-06-01T00:00:00Z" },
+    });
+    const badge = screen.getByTestId("version-badge");
+    expect(badge).toHaveAttribute("data-status", "unknown");
+    expect(badge.getAttribute("href")).toMatch(/\/releases$/);
+    expect(badge.getAttribute("title")).toMatch(/no published releases yet/i);
+  });
+
+  it("renders gracefully when the GitHub lookup is unavailable", () => {
+    setup({
+      version: "0.1.1",
+      latest: { kind: "unavailable", reason: "network_error" },
+    });
+    const badge = screen.getByTestId("version-badge");
+    expect(badge).toHaveAttribute("data-status", "unknown");
+    expect(badge.getAttribute("title")).toMatch(/couldn't reach github/i);
+  });
+
+  it("renders a loading state until the query returns", () => {
+    setup(undefined);
+    const badge = screen.getByTestId("version-badge");
+    expect(badge).toHaveAttribute("data-status", "loading");
+    expect(badge.textContent).toContain("v");
+  });
+});

--- a/packages/mcp-server/src/github-release.ts
+++ b/packages/mcp-server/src/github-release.ts
@@ -1,0 +1,133 @@
+// Cached lookup for the latest GitHub release of The Librarian.
+//
+// Powers the dashboard's "behind latest" indicator. Calls the GitHub
+// REST API at most once per `CACHE_TTL_MS`, swallows rate-limit and
+// network failures, and degrades gracefully when no release exists (the
+// repo is pre-tag, the operator's instance is offline, the operator
+// disabled the check via `LIBRARIAN_DISABLE_VERSION_CHECK=true`, etc.).
+
+const DEFAULT_REPO = "JimJafar/the-librarian";
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+const REQUEST_TIMEOUT_MS = 4_000;
+
+export interface LatestRelease {
+  tag: string; // e.g. "v0.2.0"
+  htmlUrl: string;
+  publishedAt: string; // ISO 8601
+  /** Truncated body (≤ 4 KB) for the dashboard popover; full notes live on the html_url. */
+  bodyExcerpt: string | null;
+}
+
+export type LatestReleaseStatus =
+  | { kind: "ok"; release: LatestRelease; cachedAt: string }
+  | { kind: "no_release"; cachedAt: string } // 404 — repo has no releases yet
+  | { kind: "disabled" }
+  | { kind: "unavailable"; reason: string }; // network / rate-limited / other
+
+interface CacheEntry {
+  fetchedAt: number; // epoch ms
+  status: LatestReleaseStatus;
+}
+
+let cache: CacheEntry | null = null;
+
+function repoSlug(): string {
+  return process.env.LIBRARIAN_GITHUB_REPO || DEFAULT_REPO;
+}
+
+function isDisabled(): boolean {
+  return process.env.LIBRARIAN_DISABLE_VERSION_CHECK === "true";
+}
+
+function fresh(entry: CacheEntry, now: number): boolean {
+  // Only successful and "no_release" responses are cached for the full TTL.
+  // Transient failures (`unavailable`) get a much shorter cache so the next
+  // request retries — but we still cache them briefly so a broken network
+  // doesn't hammer the API.
+  if (entry.status.kind === "unavailable") {
+    return now - entry.fetchedAt < 30_000;
+  }
+  return now - entry.fetchedAt < CACHE_TTL_MS;
+}
+
+async function callGithub(): Promise<LatestReleaseStatus> {
+  const slug = repoSlug();
+  const url = `https://api.github.com/repos/${slug}/releases/latest`;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const headers: Record<string, string> = {
+      accept: "application/vnd.github+json",
+      "user-agent": "the-librarian-dashboard",
+      "x-github-api-version": "2022-11-28",
+    };
+    // Optional auth lifts the unauthenticated 60 req/h limit to 5000 — useful
+    // for shared dashboards. Anonymous requests are fine for personal use.
+    if (process.env.LIBRARIAN_GITHUB_TOKEN) {
+      headers.authorization = `Bearer ${process.env.LIBRARIAN_GITHUB_TOKEN}`;
+    }
+    const response = await fetch(url, { headers, signal: controller.signal });
+    if (response.status === 404) {
+      return { kind: "no_release", cachedAt: new Date().toISOString() };
+    }
+    if (response.status === 403 || response.status === 429) {
+      return { kind: "unavailable", reason: "rate_limited" };
+    }
+    if (!response.ok) {
+      return { kind: "unavailable", reason: `http_${response.status}` };
+    }
+    const payload = (await response.json()) as {
+      tag_name?: unknown;
+      html_url?: unknown;
+      published_at?: unknown;
+      body?: unknown;
+    };
+    if (
+      typeof payload.tag_name !== "string" ||
+      typeof payload.html_url !== "string" ||
+      typeof payload.published_at !== "string"
+    ) {
+      return { kind: "unavailable", reason: "malformed_response" };
+    }
+    const bodyExcerpt =
+      typeof payload.body === "string" && payload.body.length > 0
+        ? payload.body.slice(0, 4_000)
+        : null;
+    return {
+      kind: "ok",
+      release: {
+        tag: payload.tag_name,
+        htmlUrl: payload.html_url,
+        publishedAt: payload.published_at,
+        bodyExcerpt,
+      },
+      cachedAt: new Date().toISOString(),
+    };
+  } catch (error) {
+    const reason =
+      error instanceof Error && error.name === "AbortError" ? "timeout" : "network_error";
+    return { kind: "unavailable", reason };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Returns the latest-release status, fetching from GitHub on the first call
+ * and at most once per TTL afterwards. Always resolves — no throws — so the
+ * caller can render the indicator without try/catch noise.
+ */
+export async function getLatestRelease(): Promise<LatestReleaseStatus> {
+  if (isDisabled()) return { kind: "disabled" };
+  const now = Date.now();
+  if (cache && fresh(cache, now)) return cache.status;
+  const status = await callGithub();
+  cache = { fetchedAt: now, status };
+  return status;
+}
+
+/** Test-only: forget the cache so a unit test can drive a fresh fetch. */
+export function __resetLatestReleaseCacheForTests(): void {
+  cache = null;
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -31,3 +31,10 @@ export {
   isClassifierRuntimeActive,
   __resetClassifierRuntimeForTests,
 } from "./classifier-startup.js";
+export { PACKAGE_VERSION } from "./version.js";
+export {
+  type LatestRelease,
+  type LatestReleaseStatus,
+  getLatestRelease,
+  __resetLatestReleaseCacheForTests,
+} from "./github-release.js";

--- a/packages/mcp-server/src/trpc/health.ts
+++ b/packages/mcp-server/src/trpc/health.ts
@@ -3,9 +3,24 @@
 // `health.ping` is a typed-client smoke-test procedure. It is public
 // (no admin gate) so a dashboard or external probe can verify the
 // tRPC mount is alive before configuring credentials.
+//
+// `health.info` exposes the running build's version + the latest
+// published GitHub release so the dashboard can render a "behind
+// latest" indicator. Also public — no secrets in the payload, and the
+// dashboard renders the badge in pre-auth chrome too.
 
+import { getLatestRelease } from "../github-release.js";
+import { PACKAGE_VERSION } from "../version.js";
 import { publicProcedure, router } from "./trpc.js";
 
 export const healthRouter = router({
   ping: publicProcedure.query(() => ({ ok: true as const })),
+
+  info: publicProcedure.query(async () => {
+    const latest = await getLatestRelease();
+    return {
+      version: PACKAGE_VERSION,
+      latest,
+    };
+  }),
 });

--- a/packages/mcp-server/src/version.ts
+++ b/packages/mcp-server/src/version.ts
@@ -1,0 +1,52 @@
+// Single source of truth for the running build's version string.
+//
+// We read the root `package.json` at module load — it lives one directory
+// above the workspace, so the relative walk is deterministic from the
+// installed mcp-server's `dist/` location too. The value is exposed to the
+// dashboard via the `health.info` tRPC procedure (and to anything else that
+// needs it).
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const FALLBACK_VERSION = "0.0.0+unknown";
+
+function findRootPackageJson(): string | null {
+  // From `packages/mcp-server/src/version.ts` (or `dist/version.js`) walk up
+  // to the repo root and read package.json. Stop at the filesystem root.
+  let dir = path.dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 8; i++) {
+    const candidate = path.join(dir, "package.json");
+    if (fs.existsSync(candidate)) {
+      try {
+        const parsed = JSON.parse(fs.readFileSync(candidate, "utf8")) as { name?: unknown };
+        // The root package's `name` is `the-librarian`; workspace packages
+        // are `@librarian/*`. Skip the workspace `package.json` we'd hit
+        // on the way up.
+        if (parsed.name === "the-librarian") return candidate;
+      } catch {
+        /* ignore unreadable / non-JSON */
+      }
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+function readRootVersion(): string {
+  const root = findRootPackageJson();
+  if (!root) return FALLBACK_VERSION;
+  try {
+    const parsed = JSON.parse(fs.readFileSync(root, "utf8")) as { version?: unknown };
+    return typeof parsed.version === "string" && parsed.version.length > 0
+      ? parsed.version
+      : FALLBACK_VERSION;
+  } catch {
+    return FALLBACK_VERSION;
+  }
+}
+
+export const PACKAGE_VERSION: string = readRootVersion();

--- a/packages/mcp-server/tests/github-release.test.ts
+++ b/packages/mcp-server/tests/github-release.test.ts
@@ -1,0 +1,121 @@
+// Tests for the GitHub latest-release lookup.
+//
+// Mocks `fetch` so the suite can cover all four code paths (200/404/403/
+// timeout) without touching the network, and pins the cache TTL behaviour.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { __resetLatestReleaseCacheForTests, getLatestRelease } from "../src/github-release.js";
+
+const originalFetch = globalThis.fetch;
+
+function mockFetchOnce(impl: typeof globalThis.fetch): void {
+  globalThis.fetch = impl as typeof globalThis.fetch;
+}
+
+beforeEach(() => {
+  __resetLatestReleaseCacheForTests();
+  delete process.env.LIBRARIAN_DISABLE_VERSION_CHECK;
+  delete process.env.LIBRARIAN_GITHUB_TOKEN;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("getLatestRelease", () => {
+  it("returns disabled when LIBRARIAN_DISABLE_VERSION_CHECK is set", async () => {
+    process.env.LIBRARIAN_DISABLE_VERSION_CHECK = "true";
+    let fetched = 0;
+    mockFetchOnce(async () => {
+      fetched++;
+      return jsonResponse({});
+    });
+    expect(await getLatestRelease()).toEqual({ kind: "disabled" });
+    expect(fetched).toBe(0);
+  });
+
+  it("returns ok with the parsed release on 200", async () => {
+    mockFetchOnce(async () =>
+      jsonResponse({
+        tag_name: "v0.2.0",
+        html_url: "https://github.com/JimJafar/the-librarian/releases/tag/v0.2.0",
+        published_at: "2026-06-01T00:00:00Z",
+        body: "## What's new\n\n- handoffs",
+      }),
+    );
+    const status = await getLatestRelease();
+    expect(status.kind).toBe("ok");
+    if (status.kind !== "ok") throw new Error("unreachable");
+    expect(status.release.tag).toBe("v0.2.0");
+    expect(status.release.htmlUrl).toContain("releases/tag/v0.2.0");
+    expect(status.release.bodyExcerpt).toContain("handoffs");
+  });
+
+  it("returns no_release on 404 (pre-tag repo)", async () => {
+    mockFetchOnce(async () => new Response("Not Found", { status: 404 }));
+    const status = await getLatestRelease();
+    expect(status.kind).toBe("no_release");
+  });
+
+  it("returns unavailable on rate-limit (403)", async () => {
+    mockFetchOnce(async () => new Response("", { status: 403 }));
+    const status = await getLatestRelease();
+    expect(status).toEqual({ kind: "unavailable", reason: "rate_limited" });
+  });
+
+  it("returns unavailable on network failure", async () => {
+    mockFetchOnce(async () => {
+      throw new Error("ENETUNREACH");
+    });
+    const status = await getLatestRelease();
+    expect(status.kind).toBe("unavailable");
+    if (status.kind !== "unavailable") throw new Error("unreachable");
+    expect(status.reason).toBe("network_error");
+  });
+
+  it("caches a successful response across calls", async () => {
+    let calls = 0;
+    mockFetchOnce(async () => {
+      calls++;
+      return jsonResponse({
+        tag_name: "v0.2.0",
+        html_url: "https://example/releases/tag/v0.2.0",
+        published_at: "2026-06-01T00:00:00Z",
+        body: null,
+      });
+    });
+    await getLatestRelease();
+    await getLatestRelease();
+    await getLatestRelease();
+    expect(calls).toBe(1);
+  });
+
+  it("rejects a malformed payload as unavailable", async () => {
+    mockFetchOnce(async () => jsonResponse({ tag_name: 42 }));
+    const status = await getLatestRelease();
+    expect(status).toMatchObject({ kind: "unavailable", reason: "malformed_response" });
+  });
+
+  it("sends an authorization header when LIBRARIAN_GITHUB_TOKEN is set", async () => {
+    process.env.LIBRARIAN_GITHUB_TOKEN = "ghp_fake_test_token";
+    const seen: Record<string, string> = {};
+    mockFetchOnce(async (_url, init) => {
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      for (const key of Object.keys(headers)) seen[key.toLowerCase()] = headers[key]!;
+      return jsonResponse({
+        tag_name: "v0.2.0",
+        html_url: "https://example/releases/tag/v0.2.0",
+        published_at: "2026-06-01T00:00:00Z",
+      });
+    });
+    await getLatestRelease();
+    expect(seen.authorization).toBe("Bearer ghp_fake_test_token");
+  });
+});

--- a/packages/mcp-server/tests/github-release.test.ts
+++ b/packages/mcp-server/tests/github-release.test.ts
@@ -3,8 +3,8 @@
 // Mocks `fetch` so the suite can cover all four code paths (200/404/403/
 // timeout) without touching the network, and pins the cache TTL behaviour.
 
+import { __resetLatestReleaseCacheForTests, getLatestRelease } from "@librarian/mcp-server";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { __resetLatestReleaseCacheForTests, getLatestRelease } from "../src/github-release.js";
 
 const originalFetch = globalThis.fetch;
 


### PR DESCRIPTION
## Summary

Adds a small version badge to the dashboard nav with a live GitHub-latest check:

- `v<version>` text reading from the root `package.json` (single source of truth).
- Coloured-dot status: green = up to date, amber = behind the latest GitHub release, grey = unknown (no releases yet, rate-limited, network down, or operator opted out).
- Hover tooltip shows the status sentence; click opens the matching release notes in a new tab (falls back to `/releases` when no release is known).

## Plumbing

- **`packages/mcp-server/src/version.ts`** — reads the root `package.json` at module load by walking up from the installed file. Handles the `dist/` vs `src/` ambiguity.
- **`packages/mcp-server/src/github-release.ts`** — caches the latest-release lookup for 1 hour. Discriminated `{ kind: "ok" | "no_release" | "disabled" | "unavailable" }` status so the dashboard renders every branch without try/catch noise. Network/timeout/rate-limit failures don't poison the cache for the full hour.
- **`packages/mcp-server/src/trpc/health.ts`** — new public `health.info` procedure returning `{ version, latest }`. Public (no admin gate) so the badge works pre-auth too.
- **`apps/dashboard/components/version-badge.tsx`** — the React component. Refetches every 30 minutes so a long-lived tab eventually notices a new release.
- **`apps/dashboard/components/site-nav.tsx`** — mounts the badge next to `ThemeToggle`.

## Configuration

| Env var | Default | Purpose |
|---|---|---|
| `LIBRARIAN_GITHUB_REPO` | `JimJafar/the-librarian` | Override for downstream forks |
| `LIBRARIAN_DISABLE_VERSION_CHECK` | unset | Set to `true` to silence the check on air-gapped instances |
| `LIBRARIAN_GITHUB_TOKEN` | unset | Optional PAT — lifts the unauthenticated 60 req/h limit to 5000 (irrelevant for personal use; matters for shared dashboards) |

## What this PR does NOT do

- **Does not tag a release.** Until you `git tag v0.1.1` and create a GitHub release, the badge will show grey with "no published releases yet" — that's the spec'd behaviour and the tests pin it.
- **Does not change the package version policy.** Per AGENTS.md (lines 65-82), CHANGELOG entries land per-PR, the root `package.json` version moves at release time. Unchanged.

## Verification

- `pnpm typecheck && pnpm lint && pnpm test && pnpm smoke` — all green (1070 tests, +13 new for the badge + GitHub lookup).
- `node scripts/healthcheck.js` — 6/6 passing.

## Test plan

- [ ] CI green.
- [ ] Manual: load the dashboard, confirm the badge shows `v0.1.1` with a grey dot and "no published releases yet" tooltip (current state — no tags exist).
- [ ] Manual: tag `v0.1.1` + create a GitHub release, reload the dashboard within an hour (or restart mcp-server to bust the cache), confirm the badge flips to green "up to date".
- [ ] Manual: temporarily set `LIBRARIAN_DISABLE_VERSION_CHECK=true`, restart, confirm the badge renders without polling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)