### PR TITLE
fix(core): make v18→v19 sessions-rethink migration boot on real databases

### DIFF
--- a/packages/core/src/store/projection.ts
+++ b/packages/core/src/store/projection.ts
@@ -152,22 +152,37 @@ function dropProjectionTables(db: DatabaseSync): void {
   // DDL changes to authoritative tables go through `ensureAuthoritative
   // TableColumns` (ALTER TABLE), not this drop+rebuild path. Memory
   // side is JSONL-canonical so the rebuild replays from the ledger.
-  //
-  // sessions-rethink PR 7 — `sessions`, `session_state_changes`,
-  // `session_events`, and `session_events_fts` (with its FTS5 shadow
-  // tables) are explicitly dropped so existing operator DBs migrate
-  // cleanly. The FTS shadow tables (`session_events_fts_data`,
-  // `_idx`, `_docsize`, `_config`) are dropped first because SQLite
-  // refuses to drop the virtual table if its shadows are missing.
   db.exec(`
     DROP TABLE IF EXISTS memories_fts;
     DROP TABLE IF EXISTS memories;
     DROP TABLE IF EXISTS events;
-    DROP TABLE IF EXISTS session_events_fts_data;
-    DROP TABLE IF EXISTS session_events_fts_idx;
-    DROP TABLE IF EXISTS session_events_fts_docsize;
-    DROP TABLE IF EXISTS session_events_fts_config;
-    DROP TABLE IF EXISTS session_events_fts;
+  `);
+
+  // sessions-rethink PR 7 — `sessions`, `session_state_changes`,
+  // `session_events`, and `session_events_fts` are explicitly dropped
+  // so existing operator DBs migrate cleanly. `DROP TABLE` on the FTS5
+  // virtual table cleans up its shadow tables (`_data`, `_idx`,
+  // `_content`, `_docsize`, `_config`) atomically — don't pre-drop
+  // them, SQLite refuses (`table foo_data may not be dropped`) and the
+  // whole migration aborts on the first statement (this was the
+  // crash Hermes hit at startup).
+  //
+  // The DROP is wrapped in try/catch in case an older partial
+  // migration left an orphaned `session_events_fts` row in
+  // `sqlite_master` without its shadows (the FTS5 module then
+  // refuses the DROP). We can't strip the orphan via
+  // `PRAGMA writable_schema = ON` — node:sqlite's default authorizer
+  // silently rejects the toggle. Swallowing the error still lets the
+  // rest of the migration finish + `stampSchemaVersion` run, so the
+  // orphan row stays put but never re-triggers (post-PR-7 code never
+  // references the table again).
+  try {
+    db.exec(`DROP TABLE IF EXISTS session_events_fts`);
+  } catch {
+    // Orphaned virtual table — see above. Intentionally swallowed.
+  }
+
+  db.exec(`
     DROP TABLE IF EXISTS session_events;
     DROP TABLE IF EXISTS session_state_changes;
     DROP TABLE IF EXISTS sessions;

--- a/packages/core/tests/store/projection.test.ts
+++ b/packages/core/tests/store/projection.test.ts
@@ -91,6 +91,49 @@ describe("SQLite projection rebuild parity", () => {
       store.close();
     }
   });
+
+  it("migrates a pre-PR-7 v18 DB with a populated session_events_fts cleanly", () => {
+    // Reported by the Hermes deploy: the v18 → v19 migration crashed at
+    // startup. The original PR 7 drop code tried to pre-drop the FTS5
+    // shadow tables (`session_events_fts_data` / `_idx` / `_content` /
+    // `_docsize` / `_config`) before the virtual table — but SQLite
+    // refuses (`table … may not be dropped`), so the first statement
+    // threw and the whole migration aborted. The fix: drop only the
+    // virtual table, which cleans up its own shadows atomically.
+    //
+    // We construct a v18-shaped DB by reusing the store's `db` handle
+    // (a fresh store gives us a real SQLite connection without
+    // importing `node:sqlite` directly — the vitest SSR transformer
+    // mangles the `node:` prefix), then reopen at v18.
+    {
+      const setup = createLibrarianStore({ dataDir });
+      try {
+        setup.db.exec(`
+          CREATE VIRTUAL TABLE session_events_fts USING fts5(summary);
+          INSERT INTO session_events_fts (summary) VALUES ('seed row');
+          PRAGMA user_version = 18;
+        `);
+      } finally {
+        setup.close();
+      }
+    }
+
+    // Pre-fix this throw'd `table session_events_fts_data may not be
+    // dropped` and aborted boot. Post-fix the migration runs clean.
+    const store = createLibrarianStore({ dataDir });
+    try {
+      const remaining = store.db
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE name LIKE 'session_events%' OR name = 'sessions'",
+        )
+        .all() as Array<{ name: string }>;
+      expect(remaining).toEqual([]);
+      // Memory side rebuilt from JSONL (empty in this fixture).
+      expect(store.listAll({})).toEqual([]);
+    } finally {
+      store.close();
+    }
+  });
 });
 
 describe("Schema-version sentinel (T3.6)", () => {


### PR DESCRIPTION
## Summary

Hotfix on top of #186. The drop-and-rebuild path tried to pre-drop the FTS5 shadow tables (`session_events_fts_data`, `_idx`, `_content`, `_docsize`, `_config`) before the virtual table. SQLite refuses those drops outright with `table session_events_fts_data may not be dropped` — the FTS5 contract is that shadows are only droppable via the parent virtual table's own DROP. So the first statement threw and the entire `ensureSchema` aborted. Reported by the Hermes deploy at startup.

Fix: drop only the virtual table. SQLite cleans up its shadows atomically. The DROP is wrapped in try/catch in case some exotic half-migrated DB has an orphan `session_events_fts` row in `sqlite_master` without shadows; swallowing that error still lets `stampSchemaVersion` run, so the orphan stays put but never re-triggers (post-PR-7 code never references the table again).

Side note: the `PRAGMA writable_schema = ON` + `DELETE FROM sqlite_master` recovery suggested in the Hermes debug notes won't work in this codebase — node:sqlite's default authorizer silently rejects the toggle. Verified with a probe script. The swallow-the-error fallback is the best we can do without bringing in a different SQLite binding.

## Test plan

- [x] New regression test in `packages/core/tests/store/projection.test.ts` constructs a v18-shaped DB with a populated `session_events_fts`, reopens, asserts the migration leaves no session-side tables behind. Pre-fix this test reproduces the boot crash.
- [x] `pnpm -r typecheck` green
- [x] `pnpm --filter @librarian/core test:vitest` — 436/436 pass (the new test + the existing 435)
- [x] `node scripts/check-schema-version.mjs` — unchanged fingerprint (only the migration code path moved, not SCHEMA_DDL)
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)