### PR TITLE
feat(dashboard): responsive memories page + hamburger nav on small screens

### DIFF
--- a/apps/dashboard/components/memories/view.tsx
+++ b/apps/dashboard/components/memories/view.tsx
@@ -78,8 +78,14 @@ export function MemoriesView() {
   };
 
   return (
-    <div className="grid min-h-screen grid-cols-[280px_1fr]">
-      <aside className="border-r bg-muted/30 p-4">
+    <div className="flex min-h-screen flex-col lg:grid lg:grid-cols-[280px_1fr]">
+      {/*
+        Below `lg`, the filter sidebar stacks above the list. The recall input
+        stays visible at the top because operators reach for it on every visit;
+        the rest of the filter form folds into a <details> so it doesn't
+        dominate a phone-sized viewport.
+      */}
+      <aside className="border-b bg-muted/30 p-4 lg:border-b-0 lg:border-r">
         <div className="mb-4 flex items-center gap-2">
           <Input
             placeholder="Search / recall query…"
@@ -87,20 +93,25 @@ export function MemoriesView() {
             onChange={(e) => setFilters((f) => ({ ...f, search: e.target.value }))}
           />
         </div>
-        <MemoriesFilters
-          filters={filters}
-          onChange={(next) => {
-            setFilters(next);
-            setOffset(0);
-          }}
-          onRecall={handleRecall}
-          recalling={recalling}
-        />
-        {recallError ? <p className="mt-2 text-xs text-destructive">{recallError}</p> : null}
+        <details open>
+          <summary className="mb-2 cursor-pointer select-none text-sm font-medium text-muted-foreground lg:hidden">
+            Filters & recall
+          </summary>
+          <MemoriesFilters
+            filters={filters}
+            onChange={(next) => {
+              setFilters(next);
+              setOffset(0);
+            }}
+            onRecall={handleRecall}
+            recalling={recalling}
+          />
+          {recallError ? <p className="mt-2 text-xs text-destructive">{recallError}</p> : null}
+        </details>
       </aside>
       {/* min-w-0: this is the grid's 1fr track — without it, wide content (the
           list table, long ids) forces the column past the viewport width. */}
-      <main className="flex min-w-0 flex-col gap-4 p-6">
+      <main className="flex min-w-0 flex-col gap-4 p-4 sm:p-6">
         <header className="flex items-center justify-between gap-4">
           <h1 className="text-2xl font-semibold tracking-tight">Memories</h1>
           <div className="flex items-center gap-2">

--- a/apps/dashboard/components/site-nav.tsx
+++ b/apps/dashboard/components/site-nav.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
 import { SignOutButton } from "@/components/sign-out-button";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { VersionBadge } from "@/components/version-badge";
@@ -10,6 +11,10 @@ import { VersionBadge } from "@/components/version-badge";
 // (app/layout.tsx) so every surface — Memories, Handoffs, Recall, the memories
 // sub-views, and Curator — is reachable without the command palette. "Memories"
 // matches the command-palette label for `/` (keyboard-host.tsx).
+//
+// Below the `md` breakpoint the tab list collapses behind a hamburger toggle so
+// the bar fits on a phone-sized viewport; the right-hand controls (version
+// badge, theme toggle, sign-out) stay visible at every width.
 const TABS = [
   { href: "/", label: "Memories", match: (p: string) => p === "/" },
   { href: "/handoffs", label: "Handoffs", match: (p: string) => p.startsWith("/handoffs") },
@@ -36,33 +41,109 @@ function isChromeFree(pathname: string): boolean {
   );
 }
 
+function tabClasses(active: boolean): string {
+  return `rounded-md px-3 py-1.5 transition-colors ${
+    active
+      ? "bg-background text-foreground shadow-sm"
+      : "text-muted-foreground hover:text-foreground"
+  }`;
+}
+
 export function SiteNav({ signedIn = false }: { signedIn?: boolean }) {
   const pathname = usePathname() ?? "";
+  const [open, setOpen] = useState(false);
+
+  // Auto-close the mobile menu on route change so a navigation gesture leaves
+  // the next page in its default chrome state.
+  useEffect(() => {
+    setOpen(false);
+  }, [pathname]);
+
   if (isChromeFree(pathname)) return null;
+
   return (
-    <nav className="flex flex-wrap items-center gap-1 border-b bg-muted/20 px-4 py-2 text-sm">
-      {TABS.map((tab) => {
-        const active = tab.match(pathname);
-        return (
-          <Link
-            key={tab.href}
-            href={tab.href}
-            aria-current={active ? "page" : undefined}
-            className={`rounded-md px-3 py-1.5 transition-colors ${
-              active
-                ? "bg-background text-foreground shadow-sm"
-                : "text-muted-foreground hover:text-foreground"
-            }`}
-          >
-            {tab.label}
-          </Link>
-        );
-      })}
-      <span className="ml-auto flex items-center gap-1">
-        <VersionBadge />
-        <ThemeToggle />
-        {signedIn ? <SignOutButton /> : null}
-      </span>
+    <nav className="border-b bg-muted/20 text-sm">
+      <div className="flex items-center gap-1 px-4 py-2">
+        <button
+          type="button"
+          aria-label={open ? "Close navigation menu" : "Open navigation menu"}
+          aria-expanded={open}
+          aria-controls="site-nav-mobile-menu"
+          onClick={() => setOpen((v) => !v)}
+          className="-ml-1 mr-1 rounded-md p-1.5 text-muted-foreground hover:text-foreground md:hidden"
+        >
+          {/* Plain SVG icons — no extra dep. Hamburger / close. */}
+          {open ? (
+            <svg
+              aria-hidden
+              viewBox="0 0 24 24"
+              className="h-5 w-5"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            >
+              <path d="M6 6l12 12M6 18L18 6" />
+            </svg>
+          ) : (
+            <svg
+              aria-hidden
+              viewBox="0 0 24 24"
+              className="h-5 w-5"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            >
+              <path d="M4 7h16M4 12h16M4 17h16" />
+            </svg>
+          )}
+        </button>
+        <div className="hidden flex-wrap items-center gap-1 md:flex">
+          {TABS.map((tab) => {
+            const active = tab.match(pathname);
+            return (
+              <Link
+                key={tab.href}
+                href={tab.href}
+                aria-current={active ? "page" : undefined}
+                className={tabClasses(active)}
+              >
+                {tab.label}
+              </Link>
+            );
+          })}
+        </div>
+        <span className="ml-auto flex items-center gap-1">
+          <VersionBadge />
+          <ThemeToggle />
+          {signedIn ? <SignOutButton /> : null}
+        </span>
+      </div>
+      {/*
+        Mobile drawer: rendered below the bar when `open`, hidden above `md`.
+        Each tab is a full-width target so it's tappable on a phone.
+      */}
+      {open ? (
+        <div id="site-nav-mobile-menu" className="border-t bg-muted/40 px-2 py-2 md:hidden">
+          <ul className="flex flex-col gap-1">
+            {TABS.map((tab) => {
+              const active = tab.match(pathname);
+              return (
+                <li key={tab.href}>
+                  <Link
+                    href={tab.href}
+                    aria-current={active ? "page" : undefined}
+                    className={`block ${tabClasses(active)}`}
+                  >
+                    {tab.label}
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ) : null}
     </nav>
   );
 }


### PR DESCRIPTION
## Summary

Two responsive fixes for the dashboard so it's usable on phone-sized viewports.

### Memories page

The outer grid was `grid-cols-[280px_1fr]` at every width, so on a phone the 280px filter sidebar squeezed the list into a ~30px-wide column. Switched to `flex flex-col lg:grid lg:grid-cols-[280px_1fr]` — below `lg` (1024px) the filter aside stacks above the list, above `lg` the layout is unchanged.

The filter form would dominate the viewport when stacked, so I wrapped it in a `<details>` element:

- `<details open>` so desktop users see the form expanded with no interaction.
- The `<summary>` is `lg:hidden` — appears only below `lg` as a "Filters & recall" toggle.
- The recall input above the details stays unconditional because operators reach for it on every visit.

Also dropped the main column padding from `p-6` to `p-4 sm:p-6` to give the list more horizontal room on phones.

### Site nav

`flex flex-wrap` was wrapping the eleven nav tabs onto three or four rows on a phone. Replaced with a hamburger pattern below `md`:

- Above `md`: inline tab list as before.
- Below `md`: hamburger button left, controls (VersionBadge / ThemeToggle / SignOut) right. Tap the hamburger to open a drawer below the nav bar with a full-width tap target per tab.
- Hamburger uses inline SVG (no extra dep), proper `aria-expanded` / `aria-controls` / `aria-label`.
- `useEffect` on the pathname auto-closes the drawer after navigation so the next page lands in clean chrome.

## Test plan

- [x] `pnpm -r typecheck` — green
- [x] `pnpm -r test` — 32 dashboard test files / 161 tests pass. The existing `site-nav.test.tsx` keeps passing unchanged: it does role-based queries that find the desktop tab links in the DOM regardless of Tailwind's `hidden` class (jsdom has no real viewport to enforce display: none filtering).
- [ ] Visual eyeballing of the breakpoints — not done. The local dev server needs a configured MCP backend + auth to render past the middleware gate, and the existing instance on the box is currently failing closed because the upstream is down. Worth a manual pass on the next dev rebuild before cutting the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)