### PR TITLE
feat(core): extract llm-connection helper, route curator through it

### DIFF
--- a/packages/core/src/curator-config.ts
+++ b/packages/core/src/curator-config.ts
@@ -9,15 +9,23 @@
 // render the configured state. Only the worker's `resolveCuratorToken` decrypts.
 
 import { z } from "zod";
-import type { SettingMeta } from "./store/settings-store.js";
+import {
+  type LlmConnectionPatch,
+  type LlmConnectionReader,
+  type LlmConnectionWriter,
+  LlmConnectionPatchSchema,
+  llmConnectionKeys,
+  readLlmConnection,
+  resolveLlmToken,
+  writeLlmConnection,
+} from "./llm-connection.js";
 
+// LLM-connection keys delegate to the shared helper (`curator.llm.*`);
+// curator-specific keys (enable flag, prompt addendum, auto-apply, schedule)
+// stay inline here.
+const LLM_KEYS = llmConnectionKeys("curator.llm");
 const KEYS = {
   enabled: "curator.enabled",
-  provider: "curator.llm.provider",
-  endpoint: "curator.llm.endpoint",
-  model: "curator.llm.model",
-  llmTimeoutMs: "curator.llm.timeout_ms",
-  token: "curator.llm.token",
   promptAddendum: "curator.prompt_addendum",
   defaultAutoApply: "curator.default_auto_apply",
   autoApplyConfidence: "curator.auto_apply_confidence",
@@ -43,12 +51,6 @@ const DEFAULT_CONFIDENCE = 0.9;
 const DEFAULT_INTERVAL_MINUTES = 60;
 const MIN_INTERVAL_MINUTES = 1;
 const MAX_INTERVAL_MINUTES = 7 * 24 * 60; // one week
-// Curator LLM request timeout — matches `curator-llm-client`'s DEFAULT_TIMEOUT_MS.
-// Operator-configurable so a slow provider (especially a self-hosted model on
-// modest hardware) doesn't time out mid-batch with an `llm_timeout` error.
-const DEFAULT_LLM_TIMEOUT_MS = 60_000;
-const MIN_LLM_TIMEOUT_MS = 1_000;
-const MAX_LLM_TIMEOUT_MS = 600_000;
 
 export interface CuratorConfig {
   enabled: boolean;
@@ -82,14 +84,7 @@ export interface CuratorConfigPatch {
 // enforced by writeCuratorConfig, which is the single source of truth.
 export const CuratorConfigPatchSchema = z.strictObject({
   enabled: z.boolean().optional(),
-  llm: z
-    .strictObject({
-      provider: z.string().optional(),
-      endpoint: z.string().optional(),
-      model: z.string().optional(),
-      timeoutMs: z.number().optional(),
-    })
-    .optional(),
+  llm: LlmConnectionPatchSchema.optional(),
   token: z.string().optional(),
   promptAddendum: z.string().optional(),
   defaultAutoApply: z.enum(["off", "safe_only", "high_confidence"]).optional(),
@@ -97,15 +92,11 @@ export const CuratorConfigPatchSchema = z.strictObject({
   intervalMinutes: z.number().optional(),
 });
 
-// The slices of the store this module needs.
-interface ConfigReader {
-  getSetting: (key: string) => string | null;
-  listSettings: () => SettingMeta[];
-}
-interface ConfigWriter {
-  setSetting: (key: string, value: string, options?: { secret?: boolean }) => void;
-  deleteSetting: (key: string) => void;
-}
+// The slices of the store this module needs. The LLM-connection block uses
+// the helper's reader/writer interfaces; curator-specific keys reuse the
+// same slice (it's a superset).
+type ConfigReader = LlmConnectionReader;
+type ConfigWriter = LlmConnectionWriter;
 
 function parseAutoApply(raw: string | null): AutoApplyLevel {
   return AUTO_APPLY_LEVELS.includes(raw as AutoApplyLevel)
@@ -119,18 +110,17 @@ function parseNumber(raw: string | null, fallback: number): number {
 }
 
 export function readCuratorConfig(store: ConfigReader): CuratorConfig {
-  const provider = store.getSetting(KEYS.provider) ?? "";
-  const endpoint = store.getSetting(KEYS.endpoint) ?? "";
-  const model = store.getSetting(KEYS.model) ?? "";
-  const hasToken = store.listSettings().some((setting) => setting.key === KEYS.token);
+  const llm = readLlmConnection(store, LLM_KEYS);
   const enabled = store.getSetting(KEYS.enabled) === "true";
-
-  const timeoutMs = parseNumber(store.getSetting(KEYS.llmTimeoutMs), DEFAULT_LLM_TIMEOUT_MS);
-  const isLlmComplete = Boolean(provider && endpoint && model && hasToken);
   return {
     enabled,
-    llm: { provider, endpoint, model, timeoutMs },
-    hasToken,
+    llm: {
+      provider: llm.provider,
+      endpoint: llm.endpoint,
+      model: llm.model,
+      timeoutMs: llm.timeoutMs,
+    },
+    hasToken: llm.hasToken,
     promptAddendum: store.getSetting(KEYS.promptAddendum) ?? "",
     defaultAutoApply: parseAutoApply(store.getSetting(KEYS.defaultAutoApply)),
     autoApplyConfidence: parseNumber(
@@ -138,8 +128,8 @@ export function readCuratorConfig(store: ConfigReader): CuratorConfig {
       DEFAULT_CONFIDENCE,
     ),
     intervalMinutes: parseNumber(store.getSetting(KEYS.intervalMinutes), DEFAULT_INTERVAL_MINUTES),
-    isLlmComplete,
-    isOperational: enabled && isLlmComplete,
+    isLlmComplete: llm.isComplete,
+    isOperational: enabled && llm.isComplete,
   };
 }
 
@@ -153,7 +143,8 @@ export function findLegacyScheduleKeys(store: ConfigReader): string[] {
 }
 
 export function writeCuratorConfig(store: ConfigWriter, patch: CuratorConfigPatch): void {
-  // Validate everything before writing anything (a bad patch makes no change).
+  // Validate every curator-specific field before touching the store. The
+  // LLM-connection block is validated inside `writeLlmConnection`.
   if (patch.promptAddendum !== undefined) {
     if (Buffer.byteLength(patch.promptAddendum, "utf8") > MAX_ADDENDUM_BYTES) {
       throw new Error(`prompt addendum must be ≤ ${MAX_ADDENDUM_BYTES} bytes (~2 KB)`);
@@ -176,25 +167,16 @@ export function writeCuratorConfig(store: ConfigWriter, patch: CuratorConfigPatc
       );
     }
   }
-  if (patch.llm?.timeoutMs !== undefined) {
-    const t = patch.llm.timeoutMs;
-    if (!Number.isInteger(t) || t < MIN_LLM_TIMEOUT_MS || t > MAX_LLM_TIMEOUT_MS) {
-      throw new Error(
-        `llm timeout_ms must be an integer between ${MIN_LLM_TIMEOUT_MS} and ${MAX_LLM_TIMEOUT_MS} (1s and 10min)`,
-      );
-    }
+
+  // LLM-connection block + token go through the shared helper, which validates
+  // timeoutMs bounds and encrypts the token.
+  if (patch.llm !== undefined || patch.token !== undefined) {
+    const llmPatch: LlmConnectionPatch & { token?: string } = { ...(patch.llm ?? {}) };
+    if (patch.token !== undefined) llmPatch.token = patch.token;
+    writeLlmConnection(store, LLM_KEYS, llmPatch);
   }
 
   if (patch.enabled !== undefined) store.setSetting(KEYS.enabled, patch.enabled ? "true" : "false");
-  if (patch.llm?.provider !== undefined) store.setSetting(KEYS.provider, patch.llm.provider);
-  if (patch.llm?.endpoint !== undefined) store.setSetting(KEYS.endpoint, patch.llm.endpoint);
-  if (patch.llm?.model !== undefined) store.setSetting(KEYS.model, patch.llm.model);
-  if (patch.llm?.timeoutMs !== undefined)
-    store.setSetting(KEYS.llmTimeoutMs, String(patch.llm.timeoutMs));
-  if (patch.token !== undefined) {
-    if (patch.token === "") store.deleteSetting(KEYS.token);
-    else store.setSetting(KEYS.token, patch.token, { secret: true });
-  }
   if (patch.promptAddendum !== undefined)
     store.setSetting(KEYS.promptAddendum, patch.promptAddendum);
   if (patch.defaultAutoApply !== undefined)
@@ -209,5 +191,5 @@ export function writeCuratorConfig(store: ConfigWriter, patch: CuratorConfigPatc
 export function resolveCuratorToken(store: {
   getSetting: (key: string) => string | null;
 }): string | null {
-  return store.getSetting(KEYS.token);
+  return resolveLlmToken(store, LLM_KEYS);
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -129,6 +129,18 @@ export {
   writeCuratorConfig,
 } from "./curator-config.js";
 export {
+  type LlmConnection,
+  type LlmConnectionKeys,
+  type LlmConnectionPatch,
+  type LlmConnectionReader,
+  type LlmConnectionWriter,
+  LlmConnectionPatchSchema,
+  llmConnectionKeys,
+  readLlmConnection,
+  resolveLlmToken,
+  writeLlmConnection,
+} from "./llm-connection.js";
+export {
   type BackfillChange,
   type BackfillOptions,
   type BackfillSection,

--- a/packages/core/src/llm-connection.ts
+++ b/packages/core/src/llm-connection.ts
@@ -1,0 +1,144 @@
+// Shared LLM-connection helper — the per-LLM connection block both the
+// curator (`packages/core/src/curator-config.ts`) and the classifier
+// (`packages/core/src/classifier-config.ts`) need: provider/endpoint/
+// model/timeoutMs + an encrypted bearer token. A consumer passes its
+// own keyspace prefix (e.g. `curator.llm` or `classifier.llm`) and the
+// helper composes the five settings keys under it.
+//
+// Reads NEVER include the token plaintext — only `hasToken`. The
+// settings-store metadata carries presence, so the cockpit can render
+// without the master key. Only `resolveLlmToken` decrypts.
+
+import { z } from "zod";
+import type { SettingMeta } from "./store/settings-store.js";
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+const MIN_TIMEOUT_MS = 1_000;
+const MAX_TIMEOUT_MS = 600_000;
+
+export interface LlmConnection {
+  provider: string;
+  endpoint: string;
+  model: string;
+  /** Per-request timeout in ms. Default 60s; range [1s, 10min]. */
+  timeoutMs: number;
+}
+
+export interface LlmConnectionPatch {
+  provider?: string;
+  endpoint?: string;
+  model?: string;
+  timeoutMs?: number;
+}
+
+// Zod input shape for admin patch validation at the tRPC boundary.
+// Permissive: deeper invariants (timeoutMs bounds) are enforced in
+// `writeLlmConnection`, which is the single source of truth.
+export const LlmConnectionPatchSchema = z.strictObject({
+  provider: z.string().optional(),
+  endpoint: z.string().optional(),
+  model: z.string().optional(),
+  timeoutMs: z.number().optional(),
+});
+
+export interface LlmConnectionKeys {
+  provider: string;
+  endpoint: string;
+  model: string;
+  timeoutMs: string;
+  token: string;
+}
+
+/**
+ * Derive the five settings keys for a given prefix. The prefix
+ * conventionally ends in `.llm` (e.g. `curator.llm`, `classifier.llm`)
+ * but the helper does not enforce that — any unique prefix works.
+ */
+export function llmConnectionKeys(prefix: string): LlmConnectionKeys {
+  return {
+    provider: `${prefix}.provider`,
+    endpoint: `${prefix}.endpoint`,
+    model: `${prefix}.model`,
+    timeoutMs: `${prefix}.timeout_ms`,
+    token: `${prefix}.token`,
+  };
+}
+
+// The slice of the store this module needs for reads.
+export interface LlmConnectionReader {
+  getSetting: (key: string) => string | null;
+  listSettings: () => SettingMeta[];
+}
+
+// The slice of the store this module needs for writes.
+export interface LlmConnectionWriter {
+  setSetting: (key: string, value: string, options?: { secret?: boolean }) => void;
+  deleteSetting: (key: string) => void;
+}
+
+/**
+ * Read the LLM-connection block under `keys`. Returns the four config
+ * fields plus `hasToken` (presence-only, no decryption) and
+ * `isComplete` (provider + endpoint + model + token all present).
+ */
+export function readLlmConnection(
+  store: LlmConnectionReader,
+  keys: LlmConnectionKeys,
+): LlmConnection & { hasToken: boolean; isComplete: boolean } {
+  const provider = store.getSetting(keys.provider) ?? "";
+  const endpoint = store.getSetting(keys.endpoint) ?? "";
+  const model = store.getSetting(keys.model) ?? "";
+  const timeoutMs = parseTimeoutMs(store.getSetting(keys.timeoutMs));
+  const hasToken = store.listSettings().some((s) => s.key === keys.token);
+  return {
+    provider,
+    endpoint,
+    model,
+    timeoutMs,
+    hasToken,
+    isComplete: Boolean(provider && endpoint && model && hasToken),
+  };
+}
+
+/**
+ * Write a patch. Validates bounds before touching the store (a bad
+ * patch makes no change). Token is stored encrypted; an empty-string
+ * token is treated as a clear, not a write.
+ */
+export function writeLlmConnection(
+  store: LlmConnectionWriter,
+  keys: LlmConnectionKeys,
+  patch: LlmConnectionPatch & { token?: string },
+): void {
+  if (patch.timeoutMs !== undefined) {
+    const t = patch.timeoutMs;
+    if (!Number.isInteger(t) || t < MIN_TIMEOUT_MS || t > MAX_TIMEOUT_MS) {
+      throw new Error(
+        `llm timeout_ms must be an integer between ${MIN_TIMEOUT_MS} and ${MAX_TIMEOUT_MS} (1s and 10min)`,
+      );
+    }
+  }
+
+  if (patch.provider !== undefined) store.setSetting(keys.provider, patch.provider);
+  if (patch.endpoint !== undefined) store.setSetting(keys.endpoint, patch.endpoint);
+  if (patch.model !== undefined) store.setSetting(keys.model, patch.model);
+  if (patch.timeoutMs !== undefined) store.setSetting(keys.timeoutMs, String(patch.timeoutMs));
+  if (patch.token !== undefined) {
+    if (patch.token === "") store.deleteSetting(keys.token);
+    else store.setSetting(keys.token, patch.token, { secret: true });
+  }
+}
+
+/** Decrypt the stored LLM token. Returns null when unset. Needs the master key. */
+export function resolveLlmToken(
+  store: { getSetting: (key: string) => string | null },
+  keys: LlmConnectionKeys,
+): string | null {
+  return store.getSetting(keys.token);
+}
+
+function parseTimeoutMs(raw: string | null): number {
+  if (raw === null) return DEFAULT_TIMEOUT_MS;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : DEFAULT_TIMEOUT_MS;
+}

--- a/packages/core/tests/llm-connection.test.ts
+++ b/packages/core/tests/llm-connection.test.ts
@@ -1,0 +1,217 @@
+// Shared LLM-connection helper — round-trip read/write, key-prefix isolation,
+// secret-token plumbing, timeoutMs validation. The curator and classifier both
+// compose this helper with their own keyspace prefix.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type LibrarianStore,
+  createLibrarianStore,
+  llmConnectionKeys,
+  readLlmConnection,
+  resolveLlmToken,
+  resolveSecretKey,
+  writeLlmConnection,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const KEY = resolveSecretKey("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+
+interface Scope {
+  store: LibrarianStore;
+  dataDir: string;
+}
+
+function scope(): Scope {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-llm-conn-"));
+  const store = createLibrarianStore({ dataDir, secretKey: KEY });
+  return { store, dataDir };
+}
+
+function teardown(s: Scope | null): void {
+  if (!s) return;
+  try {
+    s.store.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(s.dataDir, { recursive: true, force: true });
+}
+
+describe("llm-connection helper", () => {
+  let s: Scope | null = null;
+  beforeEach(() => {
+    s = scope();
+  });
+  afterEach(() => {
+    teardown(s);
+    s = null;
+  });
+
+  describe("llmConnectionKeys", () => {
+    it("derives the five settings keys under a prefix", () => {
+      expect(llmConnectionKeys("curator.llm")).toEqual({
+        provider: "curator.llm.provider",
+        endpoint: "curator.llm.endpoint",
+        model: "curator.llm.model",
+        timeoutMs: "curator.llm.timeout_ms",
+        token: "curator.llm.token",
+      });
+      expect(llmConnectionKeys("classifier.llm")).toEqual({
+        provider: "classifier.llm.provider",
+        endpoint: "classifier.llm.endpoint",
+        model: "classifier.llm.model",
+        timeoutMs: "classifier.llm.timeout_ms",
+        token: "classifier.llm.token",
+      });
+    });
+  });
+
+  describe("readLlmConnection", () => {
+    it("returns empty defaults when nothing is stored", () => {
+      const { store } = s!;
+      const got = readLlmConnection(store, llmConnectionKeys("test.llm"));
+      expect(got.provider).toBe("");
+      expect(got.endpoint).toBe("");
+      expect(got.model).toBe("");
+      expect(got.timeoutMs).toBe(60_000); // default
+      expect(got.hasToken).toBe(false);
+      expect(got.isComplete).toBe(false);
+    });
+
+    it("rolls timeoutMs back to default when an unparseable value is stored", () => {
+      const { store } = s!;
+      const keys = llmConnectionKeys("test.llm");
+      store.setSetting(keys.timeoutMs, "not-a-number");
+      expect(readLlmConnection(store, keys).timeoutMs).toBe(60_000);
+    });
+
+    it("never returns the token plaintext — only hasToken", () => {
+      const { store } = s!;
+      const keys = llmConnectionKeys("test.llm");
+      writeLlmConnection(store, keys, {
+        provider: "openai",
+        endpoint: "https://api.openai.com/v1",
+        model: "gpt-4o-mini",
+        timeoutMs: 30_000,
+        token: "dummy-secret-do-not-leak",
+      });
+      const got = readLlmConnection(store, keys);
+      expect(got.hasToken).toBe(true);
+      // No `token` field in the shape at all.
+      expect(Object.keys(got)).not.toContain("token");
+      // And no value shows up via any property.
+      expect(JSON.stringify(got)).not.toContain("dummy-secret");
+    });
+
+    it("flags isComplete only when provider + endpoint + model + token are all present", () => {
+      const { store } = s!;
+      const keys = llmConnectionKeys("test.llm");
+      writeLlmConnection(store, keys, {
+        provider: "openai",
+        endpoint: "https://api.openai.com/v1",
+        model: "gpt-4o-mini",
+      });
+      expect(readLlmConnection(store, keys).isComplete).toBe(false); // no token yet
+      writeLlmConnection(store, keys, { token: "dummy-token-x" });
+      expect(readLlmConnection(store, keys).isComplete).toBe(true);
+    });
+  });
+
+  describe("writeLlmConnection", () => {
+    it("round-trips every field", () => {
+      const { store } = s!;
+      const keys = llmConnectionKeys("test.llm");
+      writeLlmConnection(store, keys, {
+        provider: "openai",
+        endpoint: "https://api.openai.com/v1",
+        model: "gpt-4o-mini",
+        timeoutMs: 45_000,
+        token: "dummy-token-x",
+      });
+      const got = readLlmConnection(store, keys);
+      expect(got.provider).toBe("openai");
+      expect(got.endpoint).toBe("https://api.openai.com/v1");
+      expect(got.model).toBe("gpt-4o-mini");
+      expect(got.timeoutMs).toBe(45_000);
+      expect(got.hasToken).toBe(true);
+    });
+
+    it("treats an empty-string token as a clear, not a write", () => {
+      const { store } = s!;
+      const keys = llmConnectionKeys("test.llm");
+      writeLlmConnection(store, keys, { token: "dummy-token-x" });
+      expect(readLlmConnection(store, keys).hasToken).toBe(true);
+      writeLlmConnection(store, keys, { token: "" });
+      expect(readLlmConnection(store, keys).hasToken).toBe(false);
+    });
+
+    it("only writes the fields present in the patch", () => {
+      const { store } = s!;
+      const keys = llmConnectionKeys("test.llm");
+      writeLlmConnection(store, keys, {
+        provider: "openai",
+        endpoint: "https://api.openai.com/v1",
+        model: "gpt-4o-mini",
+      });
+      writeLlmConnection(store, keys, { model: "gpt-4o" }); // partial
+      const got = readLlmConnection(store, keys);
+      expect(got.provider).toBe("openai");
+      expect(got.endpoint).toBe("https://api.openai.com/v1");
+      expect(got.model).toBe("gpt-4o");
+    });
+
+    it("rejects an out-of-bounds timeoutMs", () => {
+      const { store } = s!;
+      const keys = llmConnectionKeys("test.llm");
+      expect(() => writeLlmConnection(store, keys, { timeoutMs: 0 })).toThrow(/timeout/i);
+      expect(() => writeLlmConnection(store, keys, { timeoutMs: 999 })).toThrow(/timeout/i);
+      expect(() => writeLlmConnection(store, keys, { timeoutMs: 600_001 })).toThrow(/timeout/i);
+      expect(() => writeLlmConnection(store, keys, { timeoutMs: 1.5 })).toThrow(/timeout/i);
+    });
+  });
+
+  describe("key-prefix isolation", () => {
+    it("writes under one prefix do not leak into another", () => {
+      const { store } = s!;
+      const curator = llmConnectionKeys("curator.llm");
+      const classifier = llmConnectionKeys("classifier.llm");
+
+      writeLlmConnection(store, curator, {
+        provider: "openai",
+        endpoint: "https://api.openai.com/v1",
+        model: "gpt-4o-mini",
+        token: "dummy-curator-token",
+      });
+
+      const curatorGot = readLlmConnection(store, curator);
+      const classifierGot = readLlmConnection(store, classifier);
+
+      expect(curatorGot.isComplete).toBe(true);
+      expect(classifierGot.provider).toBe("");
+      expect(classifierGot.endpoint).toBe("");
+      expect(classifierGot.model).toBe("");
+      expect(classifierGot.hasToken).toBe(false);
+      expect(classifierGot.isComplete).toBe(false);
+    });
+  });
+
+  describe("resolveLlmToken", () => {
+    it("returns the decrypted token plaintext when present, null when not", () => {
+      const { store } = s!;
+      const keys = llmConnectionKeys("test.llm");
+      expect(resolveLlmToken(store, keys)).toBeNull();
+      writeLlmConnection(store, keys, { token: "dummy-resolved-token" });
+      expect(resolveLlmToken(store, keys)).toBe("dummy-resolved-token");
+    });
+
+    it("returns null after the token is cleared", () => {
+      const { store } = s!;
+      const keys = llmConnectionKeys("test.llm");
+      writeLlmConnection(store, keys, { token: "dummy-token-x" });
+      writeLlmConnection(store, keys, { token: "" });
+      expect(resolveLlmToken(store, keys)).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Slice 1 of [classifier-dashboard-config-plan.md](docs/specs/classifier-dashboard-config-plan.md). Adds the shared LLM-connection helper that both the curator and the (forthcoming) classifier-config will compose.

**Commit 1 — `feat(core): extract shared llm-connection helper`** (T1.1)
- New `packages/core/src/llm-connection.ts` (~150 lines).
- Public exports: `LlmConnection`, `LlmConnectionPatch`, `LlmConnectionPatchSchema`, `llmConnectionKeys`, `readLlmConnection`, `writeLlmConnection`, `resolveLlmToken`, reader/writer slice types.
- 12 unit tests covering round-trip, secret-never-on-reads, key-prefix isolation, timeoutMs validation, empty-string-clears-token semantics.

**Commit 2 — `refactor(core): route curator-config through llm-connection helper`** (T1.2)
- `curator-config.ts` delegates the LLM-connection block to the helper under the `curator.llm` prefix.
- Curator-specific keys (`enabled`, `prompt_addendum`, `default_auto_apply`, `auto_apply_confidence`, `interval_minutes`) stay inline.
- **Public surface unchanged** — `readCuratorConfig` / `writeCuratorConfig` / `CuratorConfigPatchSchema` / `resolveCuratorToken` accept the same inputs and return the same shapes.
- The acceptance bar: `tests/curator-config.test.ts` passes **unmodified**. It does.

## Test plan

- [x] `pnpm --filter @librarian/core test:vitest tests/llm-connection.test.ts` — 12/12
- [x] `pnpm --filter @librarian/core test:vitest tests/curator-config.test.ts` — unchanged, all green
- [x] `pnpm -r typecheck` — green
- [x] `pnpm -r test` — 448 core + 161 dashboard, all green
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)