### PR TITLE
feat(mcp-server): store-driven classifier boot + restart + self-test; retire LIBRARIAN_CLASSIFIER_* env vars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Guard — projection schema version
         run: pnpm run check:schema-version
 
+      - name: Guard — classifier env retirement
+        run: pnpm run check:classifier-env-retirement
+
       - name: Validate Docker Compose config
         env:
           LIBRARIAN_ADMIN_TOKEN: ci-admin-token

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "check:test-count": "node --no-warnings scripts/check-test-count.mjs",
     "check:storage-fixture": "node --no-warnings scripts/check-storage-fixture.mjs",
     "check:schema-version": "node --no-warnings scripts/check-schema-version.mjs",
+    "check:classifier-env-retirement": "node --no-warnings scripts/check-classifier-env-retirement.mjs",
     "audit:agent-ids": "node --no-warnings scripts/audit-agent-ids.mjs",
     "backfill:agent-ids": "node --no-warnings scripts/backfill-agent-ids.mjs"
   },

--- a/packages/mcp-server/src/bin/http.ts
+++ b/packages/mcp-server/src/bin/http.ts
@@ -186,13 +186,15 @@ const backupScheduler =
       })
     : null;
 
-// Classifier worker (plan Section 4d). Opt-in via
-// `LIBRARIAN_CLASSIFIER_ENABLED=true` plus the provider-specific env
-// vars (see `classifier-startup.ts`). When the env is incomplete or
-// the flag is unset, boot returns null and mcp-server runs without
-// the classifier — `remember` continues through the legacy bridge.
+// Classifier worker — store-driven boot. Configure via the
+// `/classifier` dashboard cockpit (settings persist in the admin
+// store; see `classifier-startup.ts` for the retired
+// `LIBRARIAN_CLASSIFIER_*` env contract that the boot path now
+// only checks for the env-retired notice). When config is disabled
+// or incomplete, boot returns null and mcp-server runs without the
+// classifier — `remember` continues through the legacy bridge.
 const classifierBoot = bootClassifierWorker({
-  db: store.db,
+  store,
   appendEvent: (eventType, payload, options) => {
     store.appendEvent(eventType, payload, options);
   },

--- a/packages/mcp-server/src/classifier-startup.ts
+++ b/packages/mcp-server/src/classifier-startup.ts
@@ -22,8 +22,10 @@ import {
   type Classifier,
   type ClassifyResult,
   type LocalInferenceClient,
+  type SelfTestResult,
   createClassifier,
   createWorkerInferenceClient,
+  runSelfTest,
 } from "@librarian/classifier";
 import {
   type ClassifierConfig,
@@ -121,6 +123,9 @@ export function getRunningWorkerState(): RunningWorkerState {
 export function __resetClassifierRuntimeForTests(): void {
   currentlyRunning = null;
   runtimeActive = false;
+  // Reset the restart mutex too so a hung restart in one test doesn't
+  // leak into the next.
+  restartInFlight = null;
 }
 
 /**
@@ -206,11 +211,34 @@ interface BuiltClassifier {
   lifecycle: { terminate: () => Promise<void> };
 }
 
+/**
+ * `buildClassifier` catches build-time errors and returns null after
+ * logging them — appropriate for the boot path, where mcp-server keeps
+ * running with no classifier on failure. The restart path needs to
+ * distinguish "config not operational" from "build threw", so it calls
+ * `buildClassifierOrThrow` directly and surfaces the reason.
+ */
 function buildClassifier(
   cfg: ClassifierConfig,
   input: BootClassifierWorkerInput,
 ): BuiltClassifier | null {
   try {
+    return buildClassifierOrThrow(cfg, input);
+  } catch (err) {
+    input.log?.({
+      event: "classifier-worker",
+      outcome: "boot_failed",
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+function buildClassifierOrThrow(
+  cfg: ClassifierConfig,
+  input: BootClassifierWorkerInput,
+): BuiltClassifier | null {
+  {
     if (cfg.providerMode === "remote") {
       // resolveClassifierToken decrypts the bearer; requires the master key.
       const token = resolveClassifierToken(input.store);
@@ -257,13 +285,6 @@ function buildClassifier(
       inferenceFor: () => inferenceClient,
     });
     return { classifier, lifecycle: extractLifecycle(inferenceClient) };
-  } catch (err) {
-    input.log?.({
-      event: "classifier-worker",
-      outcome: "boot_failed",
-      error: err instanceof Error ? err.message : String(err),
-    });
-    return null;
   }
 }
 
@@ -297,3 +318,304 @@ function extractLifecycle(client: LocalInferenceClient): { terminate: () => Prom
 // this file (eliminates the dead-import warning if `Classifier` ever
 // stops re-exporting it). Imported as a type-only alias.
 type _Pinned = ClassifyResult;
+
+// ---------- T3.2: restart machinery ----------
+
+export type RestartOutcome =
+  | "started" // No prior worker; new config operational; new worker started.
+  | "stopped" // Prior worker stopped; new config not operational; registry left null.
+  | "restarted" // Prior worker stopped; new config operational; new worker started.
+  | "already_in_progress" // A restart was already in flight; this caller coalesced onto it.
+  | "failed"; // Prior worker stopped; new config operational; new build failed.
+
+export interface RestartResult {
+  outcome: RestartOutcome;
+  /** Stable digest of the running worker's config; null when no worker is running. */
+  runningConfigHash: string | null;
+  /** Human-readable error reason. Only set when `outcome === "failed"`. */
+  reason?: string;
+}
+
+export interface RestartClassifierInput {
+  store: LibrarianStore;
+  appendEvent: ClassifierWorkerDeps["appendEvent"];
+  log?: (entry: Record<string, unknown>) => void;
+  /** Test seam — same as `BootClassifierWorkerInput._inferenceFor`. */
+  _inferenceFor?: (cfg: { modelId: string; quant?: string }) => LocalInferenceClient;
+}
+
+// Single-flight mutex. A second `restartClassifierWorker` call coalesces
+// onto the in-flight one and reports `already_in_progress`.
+let restartInFlight: Promise<RestartResult> | null = null;
+
+const DRAIN_SLOW_THRESHOLD_MS = 30_000;
+
+/**
+ * The nine-step procedure documented in
+ * docs/specs/classifier-dashboard-config-plan.md (Shutdown ordering deep dive):
+ *
+ *   1. Acquire the mutex; if already-in-flight, coalesce.
+ *   2. Snapshot the prior registry slot.
+ *   3. Stop the prior worker (worker.stop() awaits in-flight tick).
+ *      Log `drain_slow` if drain exceeds 30s; do not force-kill.
+ *   4. Terminate the prior lifecycle handle (no-op for remote).
+ *   5. Clear the registry.
+ *   6. Read current stored config + compute target hash.
+ *   7. Branch on `isOperational`: not operational → stopped.
+ *   8. Build the new classifier; failure → outcome=failed,
+ *      registry stays null.
+ *   9. Start the new worker, stamp the registry, release the mutex.
+ */
+export function restartClassifierWorker(input: RestartClassifierInput): Promise<RestartResult> {
+  if (restartInFlight) {
+    return restartInFlight.then(
+      (resolved): RestartResult => ({
+        outcome: "already_in_progress",
+        runningConfigHash: resolved.runningConfigHash,
+      }),
+    );
+  }
+  restartInFlight = doRestart(input);
+  void restartInFlight.finally(() => {
+    restartInFlight = null;
+  });
+  return restartInFlight;
+}
+
+async function doRestart(input: RestartClassifierInput): Promise<RestartResult> {
+  const log = input.log;
+
+  // Step 2-5: drain + terminate + clear the prior slot.
+  const prior = __getRunningSlotForRestart();
+  if (prior) {
+    const drainStart = Date.now();
+    await prior.worker.stop();
+    const drainMs = Date.now() - drainStart;
+    if (drainMs > DRAIN_SLOW_THRESHOLD_MS) {
+      log?.({
+        event: "classifier-restart",
+        outcome: "drain_slow",
+        drainMs,
+      });
+    }
+    await prior.lifecycle.terminate();
+  }
+  __setRunningSlotForRestart(null);
+
+  // Step 6-7: read current config.
+  const cfg = readClassifierConfig(input.store);
+  if (!cfg.isOperational) {
+    log?.({
+      event: "classifier-restart",
+      outcome: "stopped",
+      had_prior: prior !== null,
+    });
+    return { outcome: "stopped", runningConfigHash: null };
+  }
+
+  // Step 8: build the new classifier. Failure leaves the registry empty
+  // and surfaces the reason to the caller.
+  let built;
+  try {
+    built = buildClassifierOrThrow(cfg, {
+      store: input.store,
+      appendEvent: input.appendEvent,
+      ...(input._inferenceFor !== undefined ? { _inferenceFor: input._inferenceFor } : {}),
+      ...(log !== undefined ? { log } : {}),
+    });
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    log?.({
+      event: "classifier-restart",
+      outcome: "boot_failed",
+      reason,
+    });
+    return { outcome: "failed", runningConfigHash: null, reason };
+  }
+  if (!built) {
+    // `buildClassifier` returned null without throwing — most often the
+    // remote token isn't set. Treat as a stop, not a failure.
+    log?.({
+      event: "classifier-restart",
+      outcome: "stopped",
+      reason: "build_returned_null",
+    });
+    return { outcome: "stopped", runningConfigHash: null };
+  }
+
+  // Step 9: start the new worker and stamp the registry.
+  const workerDeps: ClassifierWorkerDeps = {
+    db: input.store.db,
+    classifier: built.classifier,
+    appendEvent: input.appendEvent,
+  };
+  if (log) workerDeps.log = log;
+  const worker = createClassifierWorker(workerDeps);
+  worker.start();
+  const newHash = classifierConfigHash(input.store);
+  __setRunningSlotForRestart({
+    worker,
+    classifier: built.classifier,
+    lifecycle: built.lifecycle,
+    configHash: newHash,
+  });
+  log?.({
+    event: "classifier-restart",
+    outcome: prior ? "restarted" : "started",
+    provider: cfg.providerMode,
+  });
+  return {
+    outcome: prior ? "restarted" : "started",
+    runningConfigHash: newHash,
+  };
+}
+
+/**
+ * Tests-only: reset the in-flight mutex between cases so a hung restart
+ * in one test doesn't leak into the next.
+ */
+export function __resetRestartMutexForTests(): void {
+  restartInFlight = null;
+}
+
+// ---------- T3.3: classifier self-test ----------
+
+export interface ClassifierSelfTestInput {
+  store: LibrarianStore;
+  log?: (entry: Record<string, unknown>) => void;
+  _inferenceFor?: (cfg: { modelId: string; quant?: string }) => LocalInferenceClient;
+}
+
+export type ClassifierSelfTestOutcome = "ok" | "fallback" | "error";
+
+export interface ClassifierSelfTestResultRow {
+  outcome: ClassifierSelfTestOutcome;
+  /** Round-trip latency of the self-test classify call, in ms. */
+  latencyMs: number;
+  /** Provider mode the test ran against; null if it couldn't even start. */
+  providerMode: "remote" | "local" | null;
+  /** Verdict the classifier produced (ok / fallback paths). */
+  verdict?: { requires_approval: boolean; is_global: boolean };
+  /** Why the classifier fell back to defaults (fallback path). */
+  fallbackReason?: string;
+  /** Human-readable error message (error path). */
+  error?: string;
+  /** Raw model output, surfaced in the dashboard error panel. */
+  rawOutput?: string;
+}
+
+/**
+ * Build a fresh, ephemeral classifier from the current stored config,
+ * run `SELF_TEST_INPUT` through it via `runSelfTest`, and tear down. The
+ * running worker (if any) is untouched — the self-test classifier is
+ * an independent instance with its own lifecycle. Local-provider Node
+ * Worker threads are terminated in a `finally` so a thrown classify
+ * doesn't leak a worker.
+ */
+export async function runClassifierSelfTest(
+  input: ClassifierSelfTestInput,
+): Promise<ClassifierSelfTestResultRow> {
+  const cfg = readClassifierConfig(input.store);
+  if (!cfg.isOperational) {
+    return {
+      outcome: "error",
+      latencyMs: 0,
+      providerMode: null,
+      error: cfg.enabled
+        ? "classifier config is incomplete — fill in the LLM connection"
+        : "classifier is disabled",
+    };
+  }
+  let built: BuiltClassifier;
+  try {
+    const maybe = buildClassifierOrThrow(cfg, {
+      store: input.store,
+      appendEvent: () => undefined,
+      ...(input._inferenceFor !== undefined ? { _inferenceFor: input._inferenceFor } : {}),
+      ...(input.log !== undefined ? { log: input.log } : {}),
+    });
+    if (!maybe) {
+      return {
+        outcome: "error",
+        latencyMs: 0,
+        providerMode: cfg.providerMode,
+        error: "classifier build returned null (token unset?)",
+      };
+    }
+    built = maybe;
+  } catch (err) {
+    return {
+      outcome: "error",
+      latencyMs: 0,
+      providerMode: cfg.providerMode,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  let result: SelfTestResult | null = null;
+  let thrown: unknown = null;
+  try {
+    result = await runSelfTest(built.classifier);
+  } catch (err) {
+    thrown = err;
+  } finally {
+    // Always terminate the transient lifecycle, even on error.
+    await built.lifecycle.terminate().catch(() => undefined);
+  }
+
+  if (thrown) {
+    return {
+      outcome: "error",
+      latencyMs: 0,
+      providerMode: cfg.providerMode,
+      error: thrown instanceof Error ? thrown.message : String(thrown),
+    };
+  }
+  if (!result) {
+    // Defensive — shouldn't happen given the runSelfTest contract.
+    return {
+      outcome: "error",
+      latencyMs: 0,
+      providerMode: cfg.providerMode,
+      error: "self-test returned no result",
+    };
+  }
+  if (result.ok) {
+    // SELF_TEST_INPUT is a benign factual snippet; the classifier
+    // package's parser yields a structured verdict on the ok path.
+    // We surface the parsed verdict alongside the latency when it's
+    // recoverable from the raw output, omit it otherwise.
+    const verdict = parseSelfTestVerdict(result.raw_output);
+    return {
+      outcome: "ok",
+      latencyMs: result.latency_ms,
+      providerMode: cfg.providerMode,
+      ...(verdict !== undefined ? { verdict } : {}),
+      rawOutput: result.raw_output,
+    };
+  }
+  return {
+    outcome: "fallback",
+    latencyMs: result.latency_ms,
+    providerMode: cfg.providerMode,
+    ...(result.reason !== undefined ? { fallbackReason: result.reason } : {}),
+    rawOutput: result.raw_output,
+  };
+}
+
+function parseSelfTestVerdict(
+  rawOutput: string,
+): { requires_approval: boolean; is_global: boolean } | undefined {
+  try {
+    const parsed = JSON.parse(rawOutput) as Record<string, unknown>;
+    if (typeof parsed.requires_approval !== "boolean" || typeof parsed.is_global !== "boolean") {
+      return undefined;
+    }
+    return {
+      requires_approval: parsed.requires_approval,
+      is_global: parsed.is_global,
+    };
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/mcp-server/src/classifier-startup.ts
+++ b/packages/mcp-server/src/classifier-startup.ts
@@ -1,30 +1,40 @@
-// Classifier-worker startup helper — builds and starts the classifier
-// worker from environment configuration (spec §4.2 + plan Section 4d).
+// Classifier-worker startup helper — store-driven boot.
 //
-// Env contract (admin-settings persistence is a 4d.2 follow-up):
-//   LIBRARIAN_CLASSIFIER_ENABLED         "true" to opt-in. Anything else
-//                                        leaves the worker off; mcp-server
-//                                        boots with no classifier and
-//                                        `remember` continues through the
-//                                        legacy bridge.
-//   LIBRARIAN_CLASSIFIER_PROVIDER        "remote" (default) | "local"
-//   LIBRARIAN_CLASSIFIER_REMOTE_ENDPOINT OpenAI-compatible base URL
-//   LIBRARIAN_CLASSIFIER_REMOTE_TOKEN    bearer token
-//   LIBRARIAN_CLASSIFIER_REMOTE_MODEL    e.g. "gpt-4o-mini"
-//   LIBRARIAN_CLASSIFIER_LOCAL_MODEL     catalog id or HF identifier
-//   LIBRARIAN_CLASSIFIER_LOCAL_QUANT     optional, e.g. "Q4_K_M"
+// Post-rethink (see docs/specs/classifier-dashboard-config-spec.md and
+// classifier-dashboard-config-plan.md), the LIBRARIAN_CLASSIFIER_* env
+// contract is retired in favour of admin-settings persistence read from
+// `readClassifierConfig(store)`. Any retired env var still set on boot
+// triggers a one-line operator notice but does not affect behaviour.
 //
-// `boot()` returns either a started worker (with `stop` for shutdown) or
-// `null` when the env says off / is incomplete. Misconfiguration logs and
-// returns null; mcp-server keeps running without the classifier.
+// Worker registry: a module-scoped slot holds the started worker, its
+// classifier, and (for local provider) the lifecycle handle needed to
+// terminate the Node Worker thread on restart. The lifecycle is captured
+// here, BEFORE the `createClassifier` factory is called, because the
+// factory consumes the handle and doesn't expose it to its caller — so
+// keeping a reference externally is the only way the restart procedure
+// can clean up the Node Worker.
+//
+// `restartClassifierWorker` and `runClassifierSelfTest` land in T3.2 and
+// T3.3 respectively; this file ships the boot-side machinery they
+// compose with.
 
 import {
+  type Classifier,
+  type ClassifyResult,
+  type LocalInferenceClient,
   createClassifier,
   createWorkerInferenceClient,
-  type Classifier,
-  type ProviderConfig,
 } from "@librarian/classifier";
-import { createCuratorLlmClient, type LlmClientConfig } from "@librarian/core";
+import {
+  type ClassifierConfig,
+  type LibrarianStore,
+  type LlmClient,
+  classifierConfigHash,
+  createCuratorLlmClient,
+  findLegacyClassifierEnvKeys,
+  readClassifierConfig,
+  resolveClassifierToken,
+} from "@librarian/core";
 import {
   createClassifierWorker,
   type ClassifierWorker,
@@ -32,14 +42,36 @@ import {
 } from "./classifier-worker.js";
 
 export interface BootClassifierWorkerInput {
-  /** SQLite handle (the projection's connection). */
-  db: ClassifierWorkerDeps["db"];
+  /**
+   * Store handle — the boot path reads classifier config + resolves the
+   * encrypted token via the same connection the worker will use.
+   */
+  store: LibrarianStore;
   /** Event appender — the wider store's `appendEvent`. */
   appendEvent: ClassifierWorkerDeps["appendEvent"];
   /** Optional sidecar logger. */
   log?: (entry: Record<string, unknown>) => void;
-  /** Env source — defaults to `process.env`. Tests inject. */
+  /**
+   * Env source — defaults to `process.env`. Boot reads it only to detect
+   * retired `LIBRARIAN_CLASSIFIER_*` keys and emit a notice. Configuration
+   * itself comes from the store.
+   */
   env?: NodeJS.ProcessEnv;
+  /**
+   * Test-only injection seam for the local provider's inference factory.
+   * Production callers omit this; the boot path calls
+   * `createWorkerInferenceClient` directly.
+   */
+  _inferenceFor?: (cfg: { modelId: string; quant?: string }) => LocalInferenceClient;
+}
+
+interface RunningWorkerSlot {
+  worker: ClassifierWorker;
+  classifier: Classifier;
+  /** Idempotent terminate for the local Node Worker thread; no-op for remote. */
+  lifecycle: { terminate: () => Promise<void> };
+  /** Stable digest of the config the worker booted with (drift detection). */
+  configHash: string;
 }
 
 export interface BootedClassifierWorker {
@@ -48,12 +80,21 @@ export interface BootedClassifierWorker {
   enabled: true;
 }
 
-/**
- * Module-scoped flag the MCP tool layer reads at handler time so
- * `remember` knows whether the classifier worker is active and writes
- * should land at conservative defaults. Set by `bootClassifierWorker`
- * on successful boot; never read outside this module after that.
- */
+export interface RunningWorkerState {
+  /**
+   * Whether a worker is currently running. `false` even when the store
+   * config says `enabled=true` if the boot path returned null
+   * (incomplete config, build failure).
+   */
+  enabled: boolean;
+  /** Stable digest of the config the running worker booted with; null when not running. */
+  runningConfigHash: string | null;
+}
+
+// Module-scoped registry. The wider mcp-server process treats this as
+// the single source of truth for "is the classifier running, and with
+// what config".
+let currentlyRunning: RunningWorkerSlot | null = null;
 let runtimeActive = false;
 
 /** Read by `mcp/tools/remember.ts` to decide the write-path policy. */
@@ -62,81 +103,162 @@ export function isClassifierRuntimeActive(): boolean {
 }
 
 /**
- * Tests-only: reset the runtime flag between cases so tests don't
- * leak state across `bootClassifierWorker()` calls. Not part of the
- * production API.
+ * Snapshot of the running worker's state for the dashboard's drift
+ * banner. The hash is compared against `classifierConfigHash(store)` on
+ * each `workerState` query; mismatch → drift → operator restarts.
+ */
+export function getRunningWorkerState(): RunningWorkerState {
+  return {
+    enabled: runtimeActive,
+    runningConfigHash: currentlyRunning?.configHash ?? null,
+  };
+}
+
+/**
+ * Tests-only: reset the registry between cases so tests don't leak state
+ * across `bootClassifierWorker()` calls. Not part of the production API.
  */
 export function __resetClassifierRuntimeForTests(): void {
+  currentlyRunning = null;
   runtimeActive = false;
+}
+
+/**
+ * Internal: registry getter for the restart procedure (T3.2). Exposed so
+ * `restartClassifierWorker` can `worker.stop()` + `lifecycle.terminate()`
+ * the prior slot before booting again.
+ */
+export function __getRunningSlotForRestart(): RunningWorkerSlot | null {
+  return currentlyRunning;
+}
+
+/**
+ * Internal: registry setter for the restart procedure. Returns the prior
+ * slot so the caller can compare or fall back.
+ */
+export function __setRunningSlotForRestart(
+  next: RunningWorkerSlot | null,
+): RunningWorkerSlot | null {
+  const prior = currentlyRunning;
+  currentlyRunning = next;
+  runtimeActive = next !== null;
+  return prior;
 }
 
 export function bootClassifierWorker(
   input: BootClassifierWorkerInput,
 ): BootedClassifierWorker | null {
   const env = input.env ?? process.env;
-  if (env.LIBRARIAN_CLASSIFIER_ENABLED !== "true") return null;
 
-  const provider = (env.LIBRARIAN_CLASSIFIER_PROVIDER ?? "remote") as "remote" | "local";
-  const classifier = tryBuildClassifier(env, provider, input.log);
-  if (!classifier) return null;
+  // Step 1: env-retirement notice. Emits once per boot when any retired
+  // key is set, regardless of store state. Does not affect behaviour.
+  const legacyKeys = findLegacyClassifierEnvKeys(env);
+  if (legacyKeys.length > 0 && input.log) {
+    input.log({
+      event: "classifier_env_retired",
+      level: "warn",
+      keys: legacyKeys,
+      hint: "Classifier env vars are retired; configure via the /classifier dashboard cockpit.",
+    });
+  }
 
+  // Step 2: read the stored config. Disabled or incomplete → no worker.
+  const cfg = readClassifierConfig(input.store);
+  if (!cfg.isOperational) {
+    return null;
+  }
+
+  // Step 3: build the classifier (provider-mode branch).
+  const built = buildClassifier(cfg, input);
+  if (!built) {
+    return null;
+  }
+
+  // Step 4: start the worker and stamp the registry.
   const workerDeps: ClassifierWorkerDeps = {
-    db: input.db,
-    classifier,
+    db: input.store.db,
+    classifier: built.classifier,
     appendEvent: input.appendEvent,
   };
   if (input.log) workerDeps.log = input.log;
   const worker = createClassifierWorker(workerDeps);
   worker.start();
+
+  currentlyRunning = {
+    worker,
+    classifier: built.classifier,
+    lifecycle: built.lifecycle,
+    configHash: classifierConfigHash(input.store),
+  };
   runtimeActive = true;
+
   input.log?.({
     event: "classifier-worker",
     outcome: "started",
-    provider,
+    provider: cfg.providerMode,
   });
   return { worker, enabled: true };
 }
 
-function tryBuildClassifier(
-  env: NodeJS.ProcessEnv,
-  provider: "remote" | "local",
-  log?: (entry: Record<string, unknown>) => void,
-): Classifier | null {
+interface BuiltClassifier {
+  classifier: Classifier;
+  /** Idempotent. No-op for remote provider; terminates the Node Worker thread for local. */
+  lifecycle: { terminate: () => Promise<void> };
+}
+
+function buildClassifier(
+  cfg: ClassifierConfig,
+  input: BootClassifierWorkerInput,
+): BuiltClassifier | null {
   try {
-    if (provider === "remote") {
-      const endpoint = env.LIBRARIAN_CLASSIFIER_REMOTE_ENDPOINT;
-      const token = env.LIBRARIAN_CLASSIFIER_REMOTE_TOKEN;
-      const model = env.LIBRARIAN_CLASSIFIER_REMOTE_MODEL;
-      if (!endpoint || !token || !model) {
-        log?.({
+    if (cfg.providerMode === "remote") {
+      // resolveClassifierToken decrypts the bearer; requires the master key.
+      const token = resolveClassifierToken(input.store);
+      if (!token) {
+        input.log?.({
           event: "classifier-worker",
           outcome: "boot_skipped",
-          reason: "remote_env_incomplete",
+          reason: "remote_token_unset",
         });
         return null;
       }
-      const llmConfig: LlmClientConfig = { endpoint, token, model };
-      const llm = createCuratorLlmClient(llmConfig);
-      const cfg: ProviderConfig = { provider: "remote", modelId: model };
-      return createClassifier(cfg, { llm });
+      const llmConfig: Parameters<typeof createCuratorLlmClient>[0] = {
+        endpoint: cfg.llm.endpoint,
+        token,
+        model: cfg.llm.model,
+        timeoutMs: cfg.llm.timeoutMs,
+      };
+      const llm: LlmClient = createCuratorLlmClient(llmConfig);
+      const providerCfg: Parameters<typeof createClassifier>[0] = {
+        provider: "remote",
+        modelId: cfg.llm.model,
+      };
+      if (cfg.promptVersion !== null) providerCfg.promptVersion = cfg.promptVersion;
+      const classifier = createClassifier(providerCfg, { llm });
+      return { classifier, lifecycle: noopLifecycle() };
     }
-    const modelId = env.LIBRARIAN_CLASSIFIER_LOCAL_MODEL;
-    if (!modelId) {
-      log?.({
-        event: "classifier-worker",
-        outcome: "boot_skipped",
-        reason: "local_model_unset",
-      });
-      return null;
-    }
-    const localCfg: ProviderConfig = { provider: "local", modelId };
-    const quant = env.LIBRARIAN_CLASSIFIER_LOCAL_QUANT;
-    if (quant !== undefined) localCfg.quant = quant;
-    return createClassifier(localCfg, {
-      inferenceFor: (cfg) => createWorkerInferenceClient(cfg),
+
+    // local provider: capture the lifecycle handle BEFORE handing the
+    // bare client to createClassifier (the factory consumes it and
+    // doesn't expose the lifecycle externally).
+    const inferenceFor =
+      input._inferenceFor ??
+      ((c: { modelId: string; quant?: string }) => createWorkerInferenceClient(c));
+    const inferenceCfg: { modelId: string; quant?: string } = { modelId: cfg.local.modelId };
+    if (cfg.local.quant !== null) inferenceCfg.quant = cfg.local.quant;
+    const inferenceClient = inferenceFor(inferenceCfg);
+    const providerCfg: Parameters<typeof createClassifier>[0] = {
+      provider: "local",
+      modelId: cfg.local.modelId,
+    };
+    if (cfg.local.quant !== null) providerCfg.quant = cfg.local.quant;
+    if (cfg.promptVersion !== null) providerCfg.promptVersion = cfg.promptVersion;
+    const classifier = createClassifier(providerCfg, {
+      inferenceFor: () => inferenceClient,
     });
+    return { classifier, lifecycle: extractLifecycle(inferenceClient) };
   } catch (err) {
-    log?.({
+    input.log?.({
       event: "classifier-worker",
       outcome: "boot_failed",
       error: err instanceof Error ? err.message : String(err),
@@ -144,3 +266,34 @@ function tryBuildClassifier(
     return null;
   }
 }
+
+function noopLifecycle(): { terminate: () => Promise<void> } {
+  return { terminate: async () => undefined };
+}
+
+/**
+ * The production `createWorkerInferenceClient` returns a
+ * `LocalInferenceClientWithLifecycle` (extends `LocalInferenceClient`
+ * with `terminate`/`alive`). Tests inject a plain `LocalInferenceClient`
+ * with no lifecycle — extract the terminator defensively.
+ */
+function extractLifecycle(client: LocalInferenceClient): { terminate: () => Promise<void> } {
+  const maybeWithLifecycle = client as LocalInferenceClient & {
+    terminate?: () => Promise<void> | void;
+  };
+  if (typeof maybeWithLifecycle.terminate !== "function") {
+    return noopLifecycle();
+  }
+  const terminate = maybeWithLifecycle.terminate;
+  return {
+    terminate: async () => {
+      await terminate.call(maybeWithLifecycle);
+    },
+  };
+}
+
+// Surface unused for the production code today but kept so the
+// classifier worker's `ClassifyResult` type stays referenced through
+// this file (eliminates the dead-import warning if `Classifier` ever
+// stops re-exporting it). Imported as a type-only alias.
+type _Pinned = ClassifyResult;

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -21,7 +21,9 @@ export {
 export {
   type BootClassifierWorkerInput,
   type BootedClassifierWorker,
+  type RunningWorkerState,
   bootClassifierWorker,
+  getRunningWorkerState,
   isClassifierRuntimeActive,
   __resetClassifierRuntimeForTests,
 } from "./classifier-startup.js";

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -21,11 +21,20 @@ export {
 export {
   type BootClassifierWorkerInput,
   type BootedClassifierWorker,
+  type ClassifierSelfTestInput,
+  type ClassifierSelfTestOutcome,
+  type ClassifierSelfTestResultRow,
+  type RestartClassifierInput,
+  type RestartOutcome,
+  type RestartResult,
   type RunningWorkerState,
   bootClassifierWorker,
   getRunningWorkerState,
   isClassifierRuntimeActive,
+  restartClassifierWorker,
+  runClassifierSelfTest,
   __resetClassifierRuntimeForTests,
+  __resetRestartMutexForTests,
 } from "./classifier-startup.js";
 export { PACKAGE_VERSION } from "./version.js";
 export {

--- a/packages/mcp-server/tests/classifier-restart.test.ts
+++ b/packages/mcp-server/tests/classifier-restart.test.ts
@@ -1,0 +1,212 @@
+// restartClassifierWorker — the nine-step procedure from
+// docs/specs/classifier-dashboard-config-plan.md (shutdown deep-dive).
+//
+// Covered:
+//   - disabled → enabled: outcome=started
+//   - enabled → disabled: outcome=stopped
+//   - enabled config change: outcome=restarted, lifecycle terminate called
+//   - concurrent restart: second call returns already_in_progress
+//   - boot failure during step 8: outcome=failed, registry left null,
+//     prior worker is already stopped + lifecycle terminated
+//   - local provider: lifecycle.terminate called exactly once per restart
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { LocalInferenceClient } from "@librarian/classifier";
+import {
+  createLibrarianStore,
+  type LibrarianStore,
+  resolveSecretKey,
+  writeClassifierConfig,
+} from "@librarian/core";
+import {
+  __resetClassifierRuntimeForTests,
+  bootClassifierWorker,
+  getRunningWorkerState,
+  isClassifierRuntimeActive,
+  restartClassifierWorker,
+} from "@librarian/mcp-server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const KEY = resolveSecretKey("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+
+let store: LibrarianStore | null = null;
+let dataDir = "";
+
+function seedRemoteComplete(s: LibrarianStore): void {
+  writeClassifierConfig(s, {
+    enabled: true,
+    providerMode: "remote",
+    llm: {
+      provider: "openai",
+      endpoint: "https://api.example.com/v1",
+      model: "gpt-4o-mini",
+    },
+    token: "dummy-classifier-token",
+  });
+}
+
+function seedLocalComplete(s: LibrarianStore): void {
+  writeClassifierConfig(s, {
+    enabled: true,
+    providerMode: "local",
+    local: { modelId: "test-local-model" },
+  });
+}
+
+beforeEach(() => {
+  __resetClassifierRuntimeForTests();
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-classifier-restart-"));
+  store = createLibrarianStore({ dataDir, secretKey: KEY });
+});
+
+afterEach(async () => {
+  try {
+    store?.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  store = null;
+  __resetClassifierRuntimeForTests();
+});
+
+describe("restartClassifierWorker — shutdown ordering", () => {
+  it("disabled config → no-op stopped outcome with null hash", async () => {
+    const result = await restartClassifierWorker({
+      store: store!,
+      appendEvent: () => undefined,
+    });
+    expect(result.outcome).toBe("stopped");
+    expect(result.runningConfigHash).toBeNull();
+    expect(isClassifierRuntimeActive()).toBe(false);
+  });
+
+  it("disabled → enabled: outcome=started, registry populated", async () => {
+    seedRemoteComplete(store!);
+    const result = await restartClassifierWorker({
+      store: store!,
+      appendEvent: () => undefined,
+    });
+    expect(result.outcome).toBe("started");
+    expect(result.runningConfigHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(isClassifierRuntimeActive()).toBe(true);
+    expect(getRunningWorkerState().runningConfigHash).toBe(result.runningConfigHash);
+  });
+
+  it("enabled → enabled with config change: outcome=restarted, new hash", async () => {
+    seedRemoteComplete(store!);
+    const first = bootClassifierWorker({ store: store!, appendEvent: () => undefined });
+    expect(first).not.toBeNull();
+    const firstHash = getRunningWorkerState().runningConfigHash;
+
+    // Change the model — this should flip the hash.
+    writeClassifierConfig(store!, { llm: { model: "gpt-4o" } });
+
+    const result = await restartClassifierWorker({
+      store: store!,
+      appendEvent: () => undefined,
+    });
+    expect(result.outcome).toBe("restarted");
+    expect(result.runningConfigHash).not.toBe(firstHash);
+    expect(isClassifierRuntimeActive()).toBe(true);
+  });
+
+  it("enabled → disabled: outcome=stopped, registry cleared", async () => {
+    seedRemoteComplete(store!);
+    bootClassifierWorker({ store: store!, appendEvent: () => undefined });
+    expect(isClassifierRuntimeActive()).toBe(true);
+
+    writeClassifierConfig(store!, { enabled: false });
+
+    const result = await restartClassifierWorker({
+      store: store!,
+      appendEvent: () => undefined,
+    });
+    expect(result.outcome).toBe("stopped");
+    expect(result.runningConfigHash).toBeNull();
+    expect(isClassifierRuntimeActive()).toBe(false);
+  });
+
+  it("concurrent restart: second caller coalesces onto already_in_progress", async () => {
+    seedRemoteComplete(store!);
+    const a = restartClassifierWorker({
+      store: store!,
+      appendEvent: () => undefined,
+    });
+    const b = restartClassifierWorker({
+      store: store!,
+      appendEvent: () => undefined,
+    });
+    const [resA, resB] = await Promise.all([a, b]);
+    // Exactly one of the two reports a real outcome; the other reports
+    // already_in_progress. We don't pin which one because the
+    // scheduling is implementation-defined.
+    const outcomes = [resA.outcome, resB.outcome].sort();
+    expect(outcomes).toEqual(["already_in_progress", "started"].sort());
+  });
+
+  it("local provider: lifecycle.terminate called between stop and rebuild", async () => {
+    seedLocalComplete(store!);
+    const terminate = vi.fn(async () => undefined);
+    const inferenceFor = vi.fn((_cfg: { modelId: string; quant?: string }) => {
+      const client: LocalInferenceClient & { terminate?: () => Promise<void> } = {
+        infer: async () => JSON.stringify({ requires_approval: false, is_global: false }),
+        terminate,
+      };
+      return client;
+    });
+
+    // Initial boot.
+    bootClassifierWorker({
+      store: store!,
+      appendEvent: () => undefined,
+      _inferenceFor: inferenceFor as never,
+    });
+    expect(isClassifierRuntimeActive()).toBe(true);
+    expect(terminate).not.toHaveBeenCalled();
+
+    // Trigger restart with a config change. The prior lifecycle must
+    // be terminated exactly once.
+    writeClassifierConfig(store!, { local: { modelId: "different-model" } });
+    const result = await restartClassifierWorker({
+      store: store!,
+      appendEvent: () => undefined,
+      _inferenceFor: inferenceFor as never,
+    });
+    expect(result.outcome).toBe("restarted");
+    expect(terminate).toHaveBeenCalledTimes(1);
+  });
+
+  it("boot failure during the swap: outcome=failed, registry left null", async () => {
+    seedRemoteComplete(store!);
+    bootClassifierWorker({ store: store!, appendEvent: () => undefined });
+    expect(isClassifierRuntimeActive()).toBe(true);
+
+    // Now break the config by clearing the token; remote config is
+    // incomplete → buildClassifier returns null → outcome=failed.
+    // Actually it returns the well-known "stopped" outcome because the
+    // post-swap cfg is not operational. The "failed" outcome is for an
+    // operational config whose build throws. To simulate, switch to
+    // local mode and throw from the inference factory.
+    writeClassifierConfig(store!, {
+      providerMode: "local",
+      local: { modelId: "throws" },
+    });
+    const inferenceFor = vi.fn(() => {
+      throw new Error("simulated boot failure");
+    });
+
+    const result = await restartClassifierWorker({
+      store: store!,
+      appendEvent: () => undefined,
+      _inferenceFor: inferenceFor as never,
+    });
+    expect(result.outcome).toBe("failed");
+    expect(result.reason).toMatch(/simulated boot failure/);
+    expect(result.runningConfigHash).toBeNull();
+    // Prior worker is gone; registry is empty.
+    expect(isClassifierRuntimeActive()).toBe(false);
+  });
+});

--- a/packages/mcp-server/tests/classifier-self-test.test.ts
+++ b/packages/mcp-server/tests/classifier-self-test.test.ts
@@ -1,0 +1,96 @@
+// runClassifierSelfTest — builds a transient classifier from the
+// current store config, runs SELF_TEST_INPUT through it, and tears
+// down. The running worker (if any) is untouched.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { LocalInferenceClient } from "@librarian/classifier";
+import {
+  createLibrarianStore,
+  type LibrarianStore,
+  resolveSecretKey,
+  writeClassifierConfig,
+} from "@librarian/core";
+import { __resetClassifierRuntimeForTests, runClassifierSelfTest } from "@librarian/mcp-server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const KEY = resolveSecretKey("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+
+let store: LibrarianStore | null = null;
+let dataDir = "";
+
+beforeEach(() => {
+  __resetClassifierRuntimeForTests();
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-classifier-selftest-"));
+  store = createLibrarianStore({ dataDir, secretKey: KEY });
+});
+
+afterEach(() => {
+  try {
+    store?.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  store = null;
+  __resetClassifierRuntimeForTests();
+});
+
+describe("runClassifierSelfTest", () => {
+  it("reports outcome=error when no config is set (not operational)", async () => {
+    const result = await runClassifierSelfTest({ store: store! });
+    expect(result.outcome).toBe("error");
+    expect(result.error).toMatch(/not operational|disabled|incomplete/i);
+  });
+
+  it("reports outcome=ok when local classifier infers a parseable verdict", async () => {
+    writeClassifierConfig(store!, {
+      enabled: true,
+      providerMode: "local",
+      local: { modelId: "test-local-model" },
+    });
+    const inferenceFor = vi.fn(() => {
+      const client: LocalInferenceClient = {
+        infer: async () => JSON.stringify({ requires_approval: false, is_global: false }),
+      };
+      return client;
+    });
+    const result = await runClassifierSelfTest({
+      store: store!,
+      _inferenceFor: inferenceFor as never,
+    });
+    expect(result.outcome).toBe("ok");
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+    expect(result.verdict).toEqual({ requires_approval: false, is_global: false });
+  });
+
+  it("terminates the transient lifecycle even when infer throws", async () => {
+    writeClassifierConfig(store!, {
+      enabled: true,
+      providerMode: "local",
+      local: { modelId: "test-local-model" },
+    });
+    const terminate = vi.fn(async () => undefined);
+    const inferenceFor = vi.fn(() => {
+      const client: LocalInferenceClient & { terminate?: () => Promise<void> } = {
+        infer: async () => {
+          throw new Error("simulated inference failure");
+        },
+        terminate,
+      };
+      return client;
+    });
+
+    const result = await runClassifierSelfTest({
+      store: store!,
+      _inferenceFor: inferenceFor as never,
+    });
+    // The classifier's local provider catches inference errors and
+    // returns a fallback verdict rather than throwing; the self-test
+    // sees a fallback outcome, not an error.
+    expect(["fallback", "error"]).toContain(result.outcome);
+    // The transient lifecycle was terminated cleanly regardless.
+    expect(terminate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/mcp-server/tests/classifier-startup.test.ts
+++ b/packages/mcp-server/tests/classifier-startup.test.ts
@@ -127,13 +127,7 @@ describe("bootClassifierWorker — store-driven", () => {
     });
     // Inject a fake inference client so the test doesn't load a real model.
     const stubInferenceFor = vi.fn(() => ({
-      classify: async () => ({
-        outcome: "ok" as const,
-        verdict: { requires_approval: false, is_global: false },
-        provider: "local" as const,
-        attempts: 1,
-        latencyMs: 1,
-      }),
+      infer: async () => JSON.stringify({ requires_approval: false, is_global: false }),
     }));
     const result = bootClassifierWorker({
       store: store!,

--- a/packages/mcp-server/tests/classifier-startup.test.ts
+++ b/packages/mcp-server/tests/classifier-startup.test.ts
@@ -1,16 +1,34 @@
-// Classifier-worker startup helper — verifies env-flag opt-in and
-// missing-config skip semantics (plan Section 4d).
+// Classifier-worker startup helper — store-driven boot (post-rethink, the
+// env contract is retired). Cases:
+//
+//   1. boot returns null when stored config is disabled
+//   2. boot returns null when remote config is incomplete
+//   3. boot returns a started worker when remote is complete
+//   4. boot returns null when local is missing modelId
+//   5. boot returns a started worker when local is complete (injected
+//      inferenceFor — no real model load)
+//   6. legacy env detector emits a notice when any LIBRARIAN_CLASSIFIER_*
+//      env is set, regardless of store state
+//   7. getRunningWorkerState reflects the registry
 
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { createLibrarianStore, type LibrarianStore } from "@librarian/core";
+import {
+  createLibrarianStore,
+  type LibrarianStore,
+  resolveSecretKey,
+  writeClassifierConfig,
+} from "@librarian/core";
 import {
   __resetClassifierRuntimeForTests,
   bootClassifierWorker,
+  getRunningWorkerState,
   isClassifierRuntimeActive,
 } from "@librarian/mcp-server";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const KEY = resolveSecretKey("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
 
 let store: LibrarianStore | null = null;
 let dataDir = "";
@@ -18,7 +36,7 @@ let dataDir = "";
 beforeEach(() => {
   __resetClassifierRuntimeForTests();
   dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-classifier-startup-"));
-  store = createLibrarianStore({ dataDir });
+  store = createLibrarianStore({ dataDir, secretKey: KEY });
 });
 
 afterEach(async () => {
@@ -32,67 +50,135 @@ afterEach(async () => {
   __resetClassifierRuntimeForTests();
 });
 
-describe("bootClassifierWorker", () => {
-  it("returns null when LIBRARIAN_CLASSIFIER_ENABLED is unset", () => {
+describe("bootClassifierWorker — store-driven", () => {
+  it("returns null when stored config is disabled (the default)", () => {
     const result = bootClassifierWorker({
-      db: store!.db,
+      store: store!,
+      appendEvent: () => undefined,
+      env: {},
+    });
+    expect(result).toBeNull();
+    expect(isClassifierRuntimeActive()).toBe(false);
+    expect(getRunningWorkerState().enabled).toBe(false);
+    expect(getRunningWorkerState().runningConfigHash).toBeNull();
+  });
+
+  it("returns null when remote config is enabled but incomplete", () => {
+    writeClassifierConfig(store!, {
+      enabled: true,
+      providerMode: "remote",
+      llm: { provider: "openai" }, // missing endpoint/model/token
+    });
+    const result = bootClassifierWorker({
+      store: store!,
+      appendEvent: () => undefined,
+      env: {},
+    });
+    expect(result).toBeNull();
+    expect(isClassifierRuntimeActive()).toBe(false);
+  });
+
+  it("starts a worker when remote config is complete and stamps the registry", async () => {
+    writeClassifierConfig(store!, {
+      enabled: true,
+      providerMode: "remote",
+      llm: {
+        provider: "openai",
+        endpoint: "https://api.example.com/v1",
+        model: "gpt-4o-mini",
+      },
+      token: "dummy-classifier-token",
+    });
+    const result = bootClassifierWorker({
+      store: store!,
+      appendEvent: () => undefined,
+      env: {},
+    });
+    expect(result).not.toBeNull();
+    expect(result!.enabled).toBe(true);
+    expect(result!.worker.running).toBe(true);
+    expect(isClassifierRuntimeActive()).toBe(true);
+
+    const state = getRunningWorkerState();
+    expect(state.enabled).toBe(true);
+    expect(state.runningConfigHash).toMatch(/^[0-9a-f]{64}$/);
+
+    await result!.worker.stop();
+  });
+
+  it("returns null when local config is enabled but local.modelId is unset", () => {
+    writeClassifierConfig(store!, {
+      enabled: true,
+      providerMode: "local",
+    });
+    const result = bootClassifierWorker({
+      store: store!,
       appendEvent: () => undefined,
       env: {},
     });
     expect(result).toBeNull();
   });
 
-  it("returns null when remote provider env is incomplete", () => {
-    const result = bootClassifierWorker({
-      db: store!.db,
-      appendEvent: () => undefined,
-      env: {
-        LIBRARIAN_CLASSIFIER_ENABLED: "true",
-        LIBRARIAN_CLASSIFIER_PROVIDER: "remote",
-        // missing endpoint/token/model
-      },
+  it("starts a worker when local config is complete (injected inferenceFor)", async () => {
+    writeClassifierConfig(store!, {
+      enabled: true,
+      providerMode: "local",
+      local: { modelId: "test-local-model" },
     });
-    expect(result).toBeNull();
-  });
-
-  it("returns null when local model id is unset", () => {
+    // Inject a fake inference client so the test doesn't load a real model.
+    const stubInferenceFor = vi.fn(() => ({
+      classify: async () => ({
+        outcome: "ok" as const,
+        verdict: { requires_approval: false, is_global: false },
+        provider: "local" as const,
+        attempts: 1,
+        latencyMs: 1,
+      }),
+    }));
     const result = bootClassifierWorker({
-      db: store!.db,
+      store: store!,
       appendEvent: () => undefined,
-      env: {
-        LIBRARIAN_CLASSIFIER_ENABLED: "true",
-        LIBRARIAN_CLASSIFIER_PROVIDER: "local",
-      },
-    });
-    expect(result).toBeNull();
-  });
-
-  it("starts a worker when remote env is complete and flips the runtime flag", async () => {
-    expect(isClassifierRuntimeActive()).toBe(false);
-    const result = bootClassifierWorker({
-      db: store!.db,
-      appendEvent: () => undefined,
-      env: {
-        LIBRARIAN_CLASSIFIER_ENABLED: "true",
-        LIBRARIAN_CLASSIFIER_PROVIDER: "remote",
-        LIBRARIAN_CLASSIFIER_REMOTE_ENDPOINT: "https://api.example.com/v1",
-        LIBRARIAN_CLASSIFIER_REMOTE_TOKEN: "test-token",
-        LIBRARIAN_CLASSIFIER_REMOTE_MODEL: "gpt-4o-mini",
-      },
+      env: {},
+      // Test-only seam — see bootClassifierWorker input shape for the rationale.
+      _inferenceFor: stubInferenceFor as never,
     });
     expect(result).not.toBeNull();
-    expect(result!.enabled).toBe(true);
     expect(result!.worker.running).toBe(true);
     expect(isClassifierRuntimeActive()).toBe(true);
     await result!.worker.stop();
   });
 
-  it("leaves the runtime flag off when env is incomplete", () => {
+  it("emits the env-retired notice when any LIBRARIAN_CLASSIFIER_* env is set", () => {
+    const log = vi.fn();
     bootClassifierWorker({
-      db: store!.db,
+      store: store!,
       appendEvent: () => undefined,
-      env: { LIBRARIAN_CLASSIFIER_ENABLED: "true" },
+      env: {
+        LIBRARIAN_CLASSIFIER_ENABLED: "true",
+        LIBRARIAN_CLASSIFIER_REMOTE_MODEL: "gpt-4o-mini",
+      },
+      log,
     });
-    expect(isClassifierRuntimeActive()).toBe(false);
+    const calls = log.mock.calls.map((c) => c[0] as Record<string, unknown>);
+    const retirement = calls.find((c) => c.event === "classifier_env_retired");
+    expect(retirement).toBeDefined();
+    expect(retirement!.level).toBe("warn");
+    expect(retirement!.keys).toEqual([
+      "LIBRARIAN_CLASSIFIER_ENABLED",
+      "LIBRARIAN_CLASSIFIER_REMOTE_MODEL",
+    ]);
+    expect(retirement!.hint).toMatch(/classifier/i);
+  });
+
+  it("does NOT emit the env-retired notice when no LIBRARIAN_CLASSIFIER_* is set", () => {
+    const log = vi.fn();
+    bootClassifierWorker({
+      store: store!,
+      appendEvent: () => undefined,
+      env: {},
+      log,
+    });
+    const calls = log.mock.calls.map((c) => c[0] as Record<string, unknown>);
+    expect(calls.find((c) => c.event === "classifier_env_retired")).toBeUndefined();
   });
 });

--- a/packages/mcp-server/tests/mcp/remember-domain.mcp.test.ts
+++ b/packages/mcp-server/tests/mcp/remember-domain.mcp.test.ts
@@ -167,9 +167,9 @@ describe("MCP remember + conv_state (T3.1)", () => {
       // Section 4d.3 — agents no longer get protected routing for
       // free via `category=identity`. With the classifier worker
       // unwired, the memory lands at active with conservative-default
-      // booleans. The classifier-cutover path (Section 4d.1 — set
-      // LIBRARIAN_CLASSIFIER_ENABLED=true) routes via
-      // pendingClassification instead.
+      // booleans. The classifier-cutover path (Section 4d.1 — enable
+      // the classifier from the /classifier dashboard cockpit) routes
+      // via pendingClassification instead.
       expect(row.status).toBe("active");
       expect(row.requires_approval).toBe(0);
     });

--- a/scripts/check-classifier-env-retirement.mjs
+++ b/scripts/check-classifier-env-retirement.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+// Guard against re-introduction of the retired `LIBRARIAN_CLASSIFIER_*`
+// env contract (see docs/specs/classifier-dashboard-config-spec.md). The
+// env vars were replaced by admin-settings persistence read from the
+// `/classifier` dashboard cockpit; any new occurrence in source, tests,
+// scripts, docker config, or env templates is a regression.
+//
+// An explicit allowlist of files is permitted to retain the strings:
+// the CHANGELOG retroactive note, the classifier-config module that
+// owns the `LEGACY_CLASSIFIER_ENV_KEYS` constant, the startup helper
+// that emits the env-retired notice, the spec / plan docs the change
+// itself referenced, and this script.
+//
+// Exits 1 with a diff-style report on any unallowed occurrence.
+
+import { execSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+
+const ALLOWED = new Set([
+  // CHANGELOG entry naming the retired keys is permanent.
+  "CHANGELOG.md",
+  // classifier-config owns the `LEGACY_CLASSIFIER_ENV_KEYS` constant.
+  "packages/core/src/classifier-config.ts",
+  "packages/core/dist/classifier-config.d.ts",
+  "packages/core/dist/classifier-config.js",
+  "packages/core/dist/index.d.ts",
+  "packages/core/dist/index.js",
+  // classifier-startup emits the env-retired notice.
+  "packages/mcp-server/src/classifier-startup.ts",
+  "packages/mcp-server/dist/classifier-startup.d.ts",
+  "packages/mcp-server/dist/classifier-startup.js",
+  // Tests exercise the env-retirement notice + legacy key detector.
+  "packages/core/tests/classifier-config.test.ts",
+  "packages/mcp-server/tests/classifier-startup.test.ts",
+  // Comment in the boot wiring refers to the retired contract.
+  "packages/mcp-server/src/bin/http.ts",
+  // classifier-eval is an offline evaluation harness, separate from the
+  // production runtime. It keeps its own env contract for endpoint /
+  // token because admins drive it from a shell. Migrating it to the
+  // settings store is a future independent decision.
+  "packages/classifier-eval/src/cli/run-command.ts",
+  // local.worker / providers-local: LIBRARIAN_CLASSIFIER_LOCAL_E2E is an
+  // integration-test gate, NOT a config knob. Out of scope for the
+  // settings-store migration.
+  "packages/classifier/src/providers/local.worker.ts",
+  "packages/classifier/tests/providers-local.test.ts",
+  // Spec / plan docs that describe the retirement itself.
+  "docs/specs/classifier-implementation-spec.md",
+  "docs/specs/done/classifier-implementation-spec.md",
+  "docs/specs/classifier-dashboard-config-spec.md",
+  "docs/specs/done/classifier-dashboard-config-spec.md",
+  "docs/specs/classifier-dashboard-config-plan.md",
+  "docs/specs/done/classifier-dashboard-config-plan.md",
+  // The guard itself names the keys it forbids.
+  "scripts/check-classifier-env-retirement.mjs",
+]);
+
+let stdout = "";
+try {
+  // Use git grep so the search respects .gitignore (no node_modules, etc.).
+  stdout = execSync("git grep -lI 'LIBRARIAN_CLASSIFIER'", {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+} catch (err) {
+  if (err && typeof err === "object" && "status" in err && err.status === 1) {
+    // git grep returns 1 when nothing matches — the all-clear path.
+    console.log(
+      "[check-classifier-env-retirement] OK: no LIBRARIAN_CLASSIFIER_* references found.",
+    );
+    process.exit(0);
+  }
+  console.error("[check-classifier-env-retirement] git grep failed:", err);
+  process.exit(2);
+}
+
+const files = stdout
+  .split("\n")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+const offenders = files.filter((file) => !ALLOWED.has(file));
+
+if (offenders.length === 0) {
+  console.log(
+    `[check-classifier-env-retirement] OK: ${files.length} reference(s) found, all in allowlisted files.`,
+  );
+  process.exit(0);
+}
+
+console.error("[check-classifier-env-retirement] FAIL:");
+console.error(
+  "  LIBRARIAN_CLASSIFIER_* env vars are retired " +
+    "(see docs/specs/classifier-dashboard-config-spec.md).",
+);
+console.error("  The following files contain references and are NOT on the allowlist:");
+for (const file of offenders) {
+  console.error(`    - ${file}`);
+}
+console.error("");
+console.error("  Either remove the references, or add the file to the ALLOWED set in");
+console.error("  scripts/check-classifier-env-retirement.mjs with a comment explaining why.");
+process.exit(1);


### PR DESCRIPTION
## Summary

Slice 3 of [classifier-dashboard-config-plan.md](docs/specs/classifier-dashboard-config-plan.md). Two commits, T3.1–T3.4 from the plan.

### Commit 1 — `feat(mcp-server): store-driven classifier boot + worker registry` (T3.1)

- `bootClassifierWorker({ store, … })` replaces `{ db, env, … }`. Configuration reads from `readClassifierConfig(store)`; the env contract is only consulted to detect retired keys and emit a one-line operator notice.
- Module-scoped registry slot `{ worker, classifier, lifecycle, configHash }`. The local-provider lifecycle handle is captured **before** `createClassifier` consumes the inference client (A4 in the plan) so the restart procedure can terminate the Node Worker thread.
- New exports: `getRunningWorkerState()` returning `{ enabled, runningConfigHash | null }` for the dashboard drift banner; `__get/__setRunningSlotForRestart` for the restart machinery.
- `http.ts` passes `{ store, appendEvent, log }`.
- 7 new test cases (disabled / remote complete / local complete / env notice firing & not firing).

### Commit 2 — `feat(mcp-server): restartClassifierWorker + self-test + env-retired CI guard` (T3.2 + T3.3 + T3.4)

- **`restartClassifierWorker(input)`** implements the nine-step procedure from the spec's shutdown deep-dive. Single-flight mutex coalesces concurrent calls to `already_in_progress`. `worker.stop()` waits for the in-flight tick (logs `drain_slow` if drain >30s, no force-kill); `lifecycle.terminate()` releases the Node Worker thread; registry cleared; new config read; build threw → outcome=`failed`; build returned null → outcome=`stopped`; otherwise → outcome=`started`/`restarted`. 7 test cases including the local-provider termination invariant and the boot-failure path.
- **`runClassifierSelfTest(input)`** builds a transient classifier from the current store config, runs `runSelfTest(SELF_TEST_INPUT)` via the classifier package, and tears down. Local-provider Node Worker terminated in `finally` so a thrown infer doesn't leak a worker. Returns `{ outcome, latencyMs, providerMode, verdict?, fallbackReason?, error?, rawOutput? }`. 3 test cases.
- **`scripts/check-classifier-env-retirement.mjs`** — new CI guard. `git grep` for `LIBRARIAN_CLASSIFIER_*` across the repo; fail on any occurrence outside the explicit allowlist (CHANGELOG, the `LEGACY_CLASSIFIER_ENV_KEYS` source + tests, the boot-notice emitter, classifier-eval's separate CLI env contract, the `_LOCAL_E2E` integration-test flag, the spec/plan docs, and this script). Wired into the guards CI job.

## Test plan

- [x] `pnpm --filter @librarian/mcp-server test:vitest` — 144 mcp-server tests pass (137 prior + 7 startup-rewrite + 7 restart + 3 self-test, minus the 10 env-driven tests that were rewritten)
- [x] `pnpm --filter @librarian/core test:vitest` — 470 core tests pass, unchanged
- [x] `pnpm -r typecheck` green
- [x] `node scripts/check-classifier-env-retirement.mjs` — OK (12 references found, all allowlisted)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)