### PR TITLE
feat(mcp-server): tRPC classifierConfig admin surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Guard — projection schema version
         run: pnpm run check:schema-version
 
+      - name: Guard — classifier env retirement
+        run: pnpm run check:classifier-env-retirement
+
       - name: Validate Docker Compose config
         env:
           LIBRARIAN_ADMIN_TOKEN: ci-admin-token

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "check:test-count": "node --no-warnings scripts/check-test-count.mjs",
     "check:storage-fixture": "node --no-warnings scripts/check-storage-fixture.mjs",
     "check:schema-version": "node --no-warnings scripts/check-schema-version.mjs",
+    "check:classifier-env-retirement": "node --no-warnings scripts/check-classifier-env-retirement.mjs",
     "audit:agent-ids": "node --no-warnings scripts/audit-agent-ids.mjs",
     "backfill:agent-ids": "node --no-warnings scripts/backfill-agent-ids.mjs"
   },

--- a/packages/mcp-server/src/classifier-startup.ts
+++ b/packages/mcp-server/src/classifier-startup.ts
@@ -22,8 +22,10 @@ import {
   type Classifier,
   type ClassifyResult,
   type LocalInferenceClient,
+  type SelfTestResult,
   createClassifier,
   createWorkerInferenceClient,
+  runSelfTest,
 } from "@librarian/classifier";
 import {
   type ClassifierConfig,
@@ -121,6 +123,9 @@ export function getRunningWorkerState(): RunningWorkerState {
 export function __resetClassifierRuntimeForTests(): void {
   currentlyRunning = null;
   runtimeActive = false;
+  // Reset the restart mutex too so a hung restart in one test doesn't
+  // leak into the next.
+  restartInFlight = null;
 }
 
 /**
@@ -206,11 +211,34 @@ interface BuiltClassifier {
   lifecycle: { terminate: () => Promise<void> };
 }
 
+/**
+ * `buildClassifier` catches build-time errors and returns null after
+ * logging them — appropriate for the boot path, where mcp-server keeps
+ * running with no classifier on failure. The restart path needs to
+ * distinguish "config not operational" from "build threw", so it calls
+ * `buildClassifierOrThrow` directly and surfaces the reason.
+ */
 function buildClassifier(
   cfg: ClassifierConfig,
   input: BootClassifierWorkerInput,
 ): BuiltClassifier | null {
   try {
+    return buildClassifierOrThrow(cfg, input);
+  } catch (err) {
+    input.log?.({
+      event: "classifier-worker",
+      outcome: "boot_failed",
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+function buildClassifierOrThrow(
+  cfg: ClassifierConfig,
+  input: BootClassifierWorkerInput,
+): BuiltClassifier | null {
+  {
     if (cfg.providerMode === "remote") {
       // resolveClassifierToken decrypts the bearer; requires the master key.
       const token = resolveClassifierToken(input.store);
@@ -257,13 +285,6 @@ function buildClassifier(
       inferenceFor: () => inferenceClient,
     });
     return { classifier, lifecycle: extractLifecycle(inferenceClient) };
-  } catch (err) {
-    input.log?.({
-      event: "classifier-worker",
-      outcome: "boot_failed",
-      error: err instanceof Error ? err.message : String(err),
-    });
-    return null;
   }
 }
 
@@ -297,3 +318,304 @@ function extractLifecycle(client: LocalInferenceClient): { terminate: () => Prom
 // this file (eliminates the dead-import warning if `Classifier` ever
 // stops re-exporting it). Imported as a type-only alias.
 type _Pinned = ClassifyResult;
+
+// ---------- T3.2: restart machinery ----------
+
+export type RestartOutcome =
+  | "started" // No prior worker; new config operational; new worker started.
+  | "stopped" // Prior worker stopped; new config not operational; registry left null.
+  | "restarted" // Prior worker stopped; new config operational; new worker started.
+  | "already_in_progress" // A restart was already in flight; this caller coalesced onto it.
+  | "failed"; // Prior worker stopped; new config operational; new build failed.
+
+export interface RestartResult {
+  outcome: RestartOutcome;
+  /** Stable digest of the running worker's config; null when no worker is running. */
+  runningConfigHash: string | null;
+  /** Human-readable error reason. Only set when `outcome === "failed"`. */
+  reason?: string;
+}
+
+export interface RestartClassifierInput {
+  store: LibrarianStore;
+  appendEvent: ClassifierWorkerDeps["appendEvent"];
+  log?: (entry: Record<string, unknown>) => void;
+  /** Test seam — same as `BootClassifierWorkerInput._inferenceFor`. */
+  _inferenceFor?: (cfg: { modelId: string; quant?: string }) => LocalInferenceClient;
+}
+
+// Single-flight mutex. A second `restartClassifierWorker` call coalesces
+// onto the in-flight one and reports `already_in_progress`.
+let restartInFlight: Promise<RestartResult> | null = null;
+
+const DRAIN_SLOW_THRESHOLD_MS = 30_000;
+
+/**
+ * The nine-step procedure documented in
+ * docs/specs/classifier-dashboard-config-plan.md (Shutdown ordering deep dive):
+ *
+ *   1. Acquire the mutex; if already-in-flight, coalesce.
+ *   2. Snapshot the prior registry slot.
+ *   3. Stop the prior worker (worker.stop() awaits in-flight tick).
+ *      Log `drain_slow` if drain exceeds 30s; do not force-kill.
+ *   4. Terminate the prior lifecycle handle (no-op for remote).
+ *   5. Clear the registry.
+ *   6. Read current stored config + compute target hash.
+ *   7. Branch on `isOperational`: not operational → stopped.
+ *   8. Build the new classifier; failure → outcome=failed,
+ *      registry stays null.
+ *   9. Start the new worker, stamp the registry, release the mutex.
+ */
+export function restartClassifierWorker(input: RestartClassifierInput): Promise<RestartResult> {
+  if (restartInFlight) {
+    return restartInFlight.then(
+      (resolved): RestartResult => ({
+        outcome: "already_in_progress",
+        runningConfigHash: resolved.runningConfigHash,
+      }),
+    );
+  }
+  restartInFlight = doRestart(input);
+  void restartInFlight.finally(() => {
+    restartInFlight = null;
+  });
+  return restartInFlight;
+}
+
+async function doRestart(input: RestartClassifierInput): Promise<RestartResult> {
+  const log = input.log;
+
+  // Step 2-5: drain + terminate + clear the prior slot.
+  const prior = __getRunningSlotForRestart();
+  if (prior) {
+    const drainStart = Date.now();
+    await prior.worker.stop();
+    const drainMs = Date.now() - drainStart;
+    if (drainMs > DRAIN_SLOW_THRESHOLD_MS) {
+      log?.({
+        event: "classifier-restart",
+        outcome: "drain_slow",
+        drainMs,
+      });
+    }
+    await prior.lifecycle.terminate();
+  }
+  __setRunningSlotForRestart(null);
+
+  // Step 6-7: read current config.
+  const cfg = readClassifierConfig(input.store);
+  if (!cfg.isOperational) {
+    log?.({
+      event: "classifier-restart",
+      outcome: "stopped",
+      had_prior: prior !== null,
+    });
+    return { outcome: "stopped", runningConfigHash: null };
+  }
+
+  // Step 8: build the new classifier. Failure leaves the registry empty
+  // and surfaces the reason to the caller.
+  let built;
+  try {
+    built = buildClassifierOrThrow(cfg, {
+      store: input.store,
+      appendEvent: input.appendEvent,
+      ...(input._inferenceFor !== undefined ? { _inferenceFor: input._inferenceFor } : {}),
+      ...(log !== undefined ? { log } : {}),
+    });
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    log?.({
+      event: "classifier-restart",
+      outcome: "boot_failed",
+      reason,
+    });
+    return { outcome: "failed", runningConfigHash: null, reason };
+  }
+  if (!built) {
+    // `buildClassifier` returned null without throwing — most often the
+    // remote token isn't set. Treat as a stop, not a failure.
+    log?.({
+      event: "classifier-restart",
+      outcome: "stopped",
+      reason: "build_returned_null",
+    });
+    return { outcome: "stopped", runningConfigHash: null };
+  }
+
+  // Step 9: start the new worker and stamp the registry.
+  const workerDeps: ClassifierWorkerDeps = {
+    db: input.store.db,
+    classifier: built.classifier,
+    appendEvent: input.appendEvent,
+  };
+  if (log) workerDeps.log = log;
+  const worker = createClassifierWorker(workerDeps);
+  worker.start();
+  const newHash = classifierConfigHash(input.store);
+  __setRunningSlotForRestart({
+    worker,
+    classifier: built.classifier,
+    lifecycle: built.lifecycle,
+    configHash: newHash,
+  });
+  log?.({
+    event: "classifier-restart",
+    outcome: prior ? "restarted" : "started",
+    provider: cfg.providerMode,
+  });
+  return {
+    outcome: prior ? "restarted" : "started",
+    runningConfigHash: newHash,
+  };
+}
+
+/**
+ * Tests-only: reset the in-flight mutex between cases so a hung restart
+ * in one test doesn't leak into the next.
+ */
+export function __resetRestartMutexForTests(): void {
+  restartInFlight = null;
+}
+
+// ---------- T3.3: classifier self-test ----------
+
+export interface ClassifierSelfTestInput {
+  store: LibrarianStore;
+  log?: (entry: Record<string, unknown>) => void;
+  _inferenceFor?: (cfg: { modelId: string; quant?: string }) => LocalInferenceClient;
+}
+
+export type ClassifierSelfTestOutcome = "ok" | "fallback" | "error";
+
+export interface ClassifierSelfTestResultRow {
+  outcome: ClassifierSelfTestOutcome;
+  /** Round-trip latency of the self-test classify call, in ms. */
+  latencyMs: number;
+  /** Provider mode the test ran against; null if it couldn't even start. */
+  providerMode: "remote" | "local" | null;
+  /** Verdict the classifier produced (ok / fallback paths). */
+  verdict?: { requires_approval: boolean; is_global: boolean };
+  /** Why the classifier fell back to defaults (fallback path). */
+  fallbackReason?: string;
+  /** Human-readable error message (error path). */
+  error?: string;
+  /** Raw model output, surfaced in the dashboard error panel. */
+  rawOutput?: string;
+}
+
+/**
+ * Build a fresh, ephemeral classifier from the current stored config,
+ * run `SELF_TEST_INPUT` through it via `runSelfTest`, and tear down. The
+ * running worker (if any) is untouched — the self-test classifier is
+ * an independent instance with its own lifecycle. Local-provider Node
+ * Worker threads are terminated in a `finally` so a thrown classify
+ * doesn't leak a worker.
+ */
+export async function runClassifierSelfTest(
+  input: ClassifierSelfTestInput,
+): Promise<ClassifierSelfTestResultRow> {
+  const cfg = readClassifierConfig(input.store);
+  if (!cfg.isOperational) {
+    return {
+      outcome: "error",
+      latencyMs: 0,
+      providerMode: null,
+      error: cfg.enabled
+        ? "classifier config is incomplete — fill in the LLM connection"
+        : "classifier is disabled",
+    };
+  }
+  let built: BuiltClassifier;
+  try {
+    const maybe = buildClassifierOrThrow(cfg, {
+      store: input.store,
+      appendEvent: () => undefined,
+      ...(input._inferenceFor !== undefined ? { _inferenceFor: input._inferenceFor } : {}),
+      ...(input.log !== undefined ? { log: input.log } : {}),
+    });
+    if (!maybe) {
+      return {
+        outcome: "error",
+        latencyMs: 0,
+        providerMode: cfg.providerMode,
+        error: "classifier build returned null (token unset?)",
+      };
+    }
+    built = maybe;
+  } catch (err) {
+    return {
+      outcome: "error",
+      latencyMs: 0,
+      providerMode: cfg.providerMode,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  let result: SelfTestResult | null = null;
+  let thrown: unknown = null;
+  try {
+    result = await runSelfTest(built.classifier);
+  } catch (err) {
+    thrown = err;
+  } finally {
+    // Always terminate the transient lifecycle, even on error.
+    await built.lifecycle.terminate().catch(() => undefined);
+  }
+
+  if (thrown) {
+    return {
+      outcome: "error",
+      latencyMs: 0,
+      providerMode: cfg.providerMode,
+      error: thrown instanceof Error ? thrown.message : String(thrown),
+    };
+  }
+  if (!result) {
+    // Defensive — shouldn't happen given the runSelfTest contract.
+    return {
+      outcome: "error",
+      latencyMs: 0,
+      providerMode: cfg.providerMode,
+      error: "self-test returned no result",
+    };
+  }
+  if (result.ok) {
+    // SELF_TEST_INPUT is a benign factual snippet; the classifier
+    // package's parser yields a structured verdict on the ok path.
+    // We surface the parsed verdict alongside the latency when it's
+    // recoverable from the raw output, omit it otherwise.
+    const verdict = parseSelfTestVerdict(result.raw_output);
+    return {
+      outcome: "ok",
+      latencyMs: result.latency_ms,
+      providerMode: cfg.providerMode,
+      ...(verdict !== undefined ? { verdict } : {}),
+      rawOutput: result.raw_output,
+    };
+  }
+  return {
+    outcome: "fallback",
+    latencyMs: result.latency_ms,
+    providerMode: cfg.providerMode,
+    ...(result.reason !== undefined ? { fallbackReason: result.reason } : {}),
+    rawOutput: result.raw_output,
+  };
+}
+
+function parseSelfTestVerdict(
+  rawOutput: string,
+): { requires_approval: boolean; is_global: boolean } | undefined {
+  try {
+    const parsed = JSON.parse(rawOutput) as Record<string, unknown>;
+    if (typeof parsed.requires_approval !== "boolean" || typeof parsed.is_global !== "boolean") {
+      return undefined;
+    }
+    return {
+      requires_approval: parsed.requires_approval,
+      is_global: parsed.is_global,
+    };
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -21,11 +21,20 @@ export {
 export {
   type BootClassifierWorkerInput,
   type BootedClassifierWorker,
+  type ClassifierSelfTestInput,
+  type ClassifierSelfTestOutcome,
+  type ClassifierSelfTestResultRow,
+  type RestartClassifierInput,
+  type RestartOutcome,
+  type RestartResult,
   type RunningWorkerState,
   bootClassifierWorker,
   getRunningWorkerState,
   isClassifierRuntimeActive,
+  restartClassifierWorker,
+  runClassifierSelfTest,
   __resetClassifierRuntimeForTests,
+  __resetRestartMutexForTests,
 } from "./classifier-startup.js";
 export { PACKAGE_VERSION } from "./version.js";
 export {

--- a/packages/mcp-server/src/trpc/classifier-config.ts
+++ b/packages/mcp-server/src/trpc/classifier-config.ts
@@ -1,0 +1,81 @@
+// Classifier admin tRPC procedures — cockpit surface for the
+// classifier worker's config, drift detection, restart, and self-test
+// (see docs/specs/classifier-dashboard-config-spec.md).
+//
+// Five admin-gated procedures:
+//
+//   config         — read the current stored config (no token, only hasToken)
+//   setConfig      — validated update; returns the fresh readable config
+//   workerState    — running vs stored config hash + drift boolean for
+//                    the dashboard's "Restart classifier worker" banner
+//   restartWorker  — invoke restartClassifierWorker; coalesces concurrent
+//                    callers via the single-flight mutex
+//   selfTest       — runSelfTest against a transient classifier; doesn't
+//                    touch the running worker
+//
+// There is deliberately NO consumer-agent surface — the classifier
+// worker runs in-process and writes the verdict directly to the memory
+// row via the queue; agents never call into this from MCP tools.
+
+import {
+  type ClassifierConfigPatch,
+  ClassifierConfigPatchSchema,
+  classifierConfigHash,
+  readClassifierConfig,
+  writeClassifierConfig,
+} from "@librarian/core";
+import {
+  getRunningWorkerState,
+  restartClassifierWorker,
+  runClassifierSelfTest,
+} from "../classifier-startup.js";
+import { adminProcedure, router } from "./trpc.js";
+
+export const classifierConfigRouter = router({
+  // Current config (never includes the token — only `hasToken`).
+  config: adminProcedure.query(({ ctx }) => readClassifierConfig(ctx.store)),
+
+  // Update config; returns the fresh readable config. `writeClassifierConfig`
+  // validates classifier-specific invariants (provider-mode enum,
+  // promptVersion regex) and the shared LLM helper validates timeoutMs;
+  // tokens are stored encrypted.
+  setConfig: adminProcedure.input(ClassifierConfigPatchSchema).mutation(({ ctx, input }) => {
+    // Cast at the validated boundary — Zod `.optional()` infers `T | undefined`,
+    // which the patch type (optional-key, not undefined-value) rejects under
+    // exactOptionalPropertyTypes.
+    writeClassifierConfig(ctx.store, input as ClassifierConfigPatch);
+    return readClassifierConfig(ctx.store);
+  }),
+
+  // Drift signal for the dashboard banner. Drift is meaningful when
+  // the stored hash differs from what's running AND there's something
+  // to do about it — either a running worker that needs to pick up new
+  // config, or an operational stored config that should be started.
+  workerState: adminProcedure.query(({ ctx }) => {
+    const state = getRunningWorkerState();
+    const storedConfigHash = classifierConfigHash(ctx.store);
+    const cfg = readClassifierConfig(ctx.store);
+    const hashesDiffer = state.runningConfigHash !== storedConfigHash;
+    const actionable = state.runningConfigHash !== null || cfg.isOperational;
+    return {
+      runningConfigHash: state.runningConfigHash,
+      storedConfigHash,
+      hasDrift: hashesDiffer && actionable,
+    };
+  }),
+
+  // Apply the current stored config. Concurrent calls coalesce onto
+  // already_in_progress; see classifier-startup.ts shutdown deep-dive.
+  restartWorker: adminProcedure.mutation(async ({ ctx }) =>
+    restartClassifierWorker({
+      store: ctx.store,
+      appendEvent: (eventType, payload, options) => {
+        ctx.store.appendEvent(eventType, payload, options);
+      },
+    }),
+  ),
+
+  // Run `runSelfTest(SELF_TEST_INPUT)` against a transient classifier.
+  // Does not touch the running worker.
+  selfTest: adminProcedure.mutation(async ({ ctx }) => runClassifierSelfTest({ store: ctx.store })),
+});

--- a/packages/mcp-server/src/trpc/router.ts
+++ b/packages/mcp-server/src/trpc/router.ts
@@ -9,6 +9,7 @@
 
 import { authRouter } from "./auth.js";
 import { backupRouter } from "./backup.js";
+import { classifierConfigRouter } from "./classifier-config.js";
 import { classifierEvalRouter } from "./classifier-eval.js";
 import { curatorRouter } from "./curator.js";
 import { domainsRouter } from "./domains.js";
@@ -21,6 +22,7 @@ import { router } from "./trpc.js";
 export const appRouter = router({
   auth: authRouter,
   backup: backupRouter,
+  classifierConfig: classifierConfigRouter,
   classifierEval: classifierEvalRouter,
   curator: curatorRouter,
   domains: domainsRouter,

--- a/packages/mcp-server/tests/classifier-restart.test.ts
+++ b/packages/mcp-server/tests/classifier-restart.test.ts
@@ -1,0 +1,212 @@
+// restartClassifierWorker — the nine-step procedure from
+// docs/specs/classifier-dashboard-config-plan.md (shutdown deep-dive).
+//
+// Covered:
+//   - disabled → enabled: outcome=started
+//   - enabled → disabled: outcome=stopped
+//   - enabled config change: outcome=restarted, lifecycle terminate called
+//   - concurrent restart: second call returns already_in_progress
+//   - boot failure during step 8: outcome=failed, registry left null,
+//     prior worker is already stopped + lifecycle terminated
+//   - local provider: lifecycle.terminate called exactly once per restart
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { LocalInferenceClient } from "@librarian/classifier";
+import {
+  createLibrarianStore,
+  type LibrarianStore,
+  resolveSecretKey,
+  writeClassifierConfig,
+} from "@librarian/core";
+import {
+  __resetClassifierRuntimeForTests,
+  bootClassifierWorker,
+  getRunningWorkerState,
+  isClassifierRuntimeActive,
+  restartClassifierWorker,
+} from "@librarian/mcp-server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const KEY = resolveSecretKey("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+
+let store: LibrarianStore | null = null;
+let dataDir = "";
+
+function seedRemoteComplete(s: LibrarianStore): void {
+  writeClassifierConfig(s, {
+    enabled: true,
+    providerMode: "remote",
+    llm: {
+      provider: "openai",
+      endpoint: "https://api.example.com/v1",
+      model: "gpt-4o-mini",
+    },
+    token: "dummy-classifier-token",
+  });
+}
+
+function seedLocalComplete(s: LibrarianStore): void {
+  writeClassifierConfig(s, {
+    enabled: true,
+    providerMode: "local",
+    local: { modelId: "test-local-model" },
+  });
+}
+
+beforeEach(() => {
+  __resetClassifierRuntimeForTests();
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-classifier-restart-"));
+  store = createLibrarianStore({ dataDir, secretKey: KEY });
+});
+
+afterEach(async () => {
+  try {
+    store?.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  store = null;
+  __resetClassifierRuntimeForTests();
+});
+
+describe("restartClassifierWorker — shutdown ordering", () => {
+  it("disabled config → no-op stopped outcome with null hash", async () => {
+    const result = await restartClassifierWorker({
+      store: store!,
+      appendEvent: () => undefined,
+    });
+    expect(result.outcome).toBe("stopped");
+    expect(result.runningConfigHash).toBeNull();
+    expect(isClassifierRuntimeActive()).toBe(false);
+  });
+
+  it("disabled → enabled: outcome=started, registry populated", async () => {
+    seedRemoteComplete(store!);
+    const result = await restartClassifierWorker({
+      store: store!,
+      appendEvent: () => undefined,
+    });
+    expect(result.outcome).toBe("started");
+    expect(result.runningConfigHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(isClassifierRuntimeActive()).toBe(true);
+    expect(getRunningWorkerState().runningConfigHash).toBe(result.runningConfigHash);
+  });
+
+  it("enabled → enabled with config change: outcome=restarted, new hash", async () => {
+    seedRemoteComplete(store!);
+    const first = bootClassifierWorker({ store: store!, appendEvent: () => undefined });
+    expect(first).not.toBeNull();
+    const firstHash = getRunningWorkerState().runningConfigHash;
+
+    // Change the model — this should flip the hash.
+    writeClassifierConfig(store!, { llm: { model: "gpt-4o" } });
+
+    const result = await restartClassifierWorker({
+      store: store!,
+      appendEvent: () => undefined,
+    });
+    expect(result.outcome).toBe("restarted");
+    expect(result.runningConfigHash).not.toBe(firstHash);
+    expect(isClassifierRuntimeActive()).toBe(true);
+  });
+
+  it("enabled → disabled: outcome=stopped, registry cleared", async () => {
+    seedRemoteComplete(store!);
+    bootClassifierWorker({ store: store!, appendEvent: () => undefined });
+    expect(isClassifierRuntimeActive()).toBe(true);
+
+    writeClassifierConfig(store!, { enabled: false });
+
+    const result = await restartClassifierWorker({
+      store: store!,
+      appendEvent: () => undefined,
+    });
+    expect(result.outcome).toBe("stopped");
+    expect(result.runningConfigHash).toBeNull();
+    expect(isClassifierRuntimeActive()).toBe(false);
+  });
+
+  it("concurrent restart: second caller coalesces onto already_in_progress", async () => {
+    seedRemoteComplete(store!);
+    const a = restartClassifierWorker({
+      store: store!,
+      appendEvent: () => undefined,
+    });
+    const b = restartClassifierWorker({
+      store: store!,
+      appendEvent: () => undefined,
+    });
+    const [resA, resB] = await Promise.all([a, b]);
+    // Exactly one of the two reports a real outcome; the other reports
+    // already_in_progress. We don't pin which one because the
+    // scheduling is implementation-defined.
+    const outcomes = [resA.outcome, resB.outcome].sort();
+    expect(outcomes).toEqual(["already_in_progress", "started"].sort());
+  });
+
+  it("local provider: lifecycle.terminate called between stop and rebuild", async () => {
+    seedLocalComplete(store!);
+    const terminate = vi.fn(async () => undefined);
+    const inferenceFor = vi.fn((_cfg: { modelId: string; quant?: string }) => {
+      const client: LocalInferenceClient & { terminate?: () => Promise<void> } = {
+        infer: async () => JSON.stringify({ requires_approval: false, is_global: false }),
+        terminate,
+      };
+      return client;
+    });
+
+    // Initial boot.
+    bootClassifierWorker({
+      store: store!,
+      appendEvent: () => undefined,
+      _inferenceFor: inferenceFor as never,
+    });
+    expect(isClassifierRuntimeActive()).toBe(true);
+    expect(terminate).not.toHaveBeenCalled();
+
+    // Trigger restart with a config change. The prior lifecycle must
+    // be terminated exactly once.
+    writeClassifierConfig(store!, { local: { modelId: "different-model" } });
+    const result = await restartClassifierWorker({
+      store: store!,
+      appendEvent: () => undefined,
+      _inferenceFor: inferenceFor as never,
+    });
+    expect(result.outcome).toBe("restarted");
+    expect(terminate).toHaveBeenCalledTimes(1);
+  });
+
+  it("boot failure during the swap: outcome=failed, registry left null", async () => {
+    seedRemoteComplete(store!);
+    bootClassifierWorker({ store: store!, appendEvent: () => undefined });
+    expect(isClassifierRuntimeActive()).toBe(true);
+
+    // Now break the config by clearing the token; remote config is
+    // incomplete → buildClassifier returns null → outcome=failed.
+    // Actually it returns the well-known "stopped" outcome because the
+    // post-swap cfg is not operational. The "failed" outcome is for an
+    // operational config whose build throws. To simulate, switch to
+    // local mode and throw from the inference factory.
+    writeClassifierConfig(store!, {
+      providerMode: "local",
+      local: { modelId: "throws" },
+    });
+    const inferenceFor = vi.fn(() => {
+      throw new Error("simulated boot failure");
+    });
+
+    const result = await restartClassifierWorker({
+      store: store!,
+      appendEvent: () => undefined,
+      _inferenceFor: inferenceFor as never,
+    });
+    expect(result.outcome).toBe("failed");
+    expect(result.reason).toMatch(/simulated boot failure/);
+    expect(result.runningConfigHash).toBeNull();
+    // Prior worker is gone; registry is empty.
+    expect(isClassifierRuntimeActive()).toBe(false);
+  });
+});

--- a/packages/mcp-server/tests/classifier-self-test.test.ts
+++ b/packages/mcp-server/tests/classifier-self-test.test.ts
@@ -1,0 +1,96 @@
+// runClassifierSelfTest — builds a transient classifier from the
+// current store config, runs SELF_TEST_INPUT through it, and tears
+// down. The running worker (if any) is untouched.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { LocalInferenceClient } from "@librarian/classifier";
+import {
+  createLibrarianStore,
+  type LibrarianStore,
+  resolveSecretKey,
+  writeClassifierConfig,
+} from "@librarian/core";
+import { __resetClassifierRuntimeForTests, runClassifierSelfTest } from "@librarian/mcp-server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const KEY = resolveSecretKey("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+
+let store: LibrarianStore | null = null;
+let dataDir = "";
+
+beforeEach(() => {
+  __resetClassifierRuntimeForTests();
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-classifier-selftest-"));
+  store = createLibrarianStore({ dataDir, secretKey: KEY });
+});
+
+afterEach(() => {
+  try {
+    store?.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  store = null;
+  __resetClassifierRuntimeForTests();
+});
+
+describe("runClassifierSelfTest", () => {
+  it("reports outcome=error when no config is set (not operational)", async () => {
+    const result = await runClassifierSelfTest({ store: store! });
+    expect(result.outcome).toBe("error");
+    expect(result.error).toMatch(/not operational|disabled|incomplete/i);
+  });
+
+  it("reports outcome=ok when local classifier infers a parseable verdict", async () => {
+    writeClassifierConfig(store!, {
+      enabled: true,
+      providerMode: "local",
+      local: { modelId: "test-local-model" },
+    });
+    const inferenceFor = vi.fn(() => {
+      const client: LocalInferenceClient = {
+        infer: async () => JSON.stringify({ requires_approval: false, is_global: false }),
+      };
+      return client;
+    });
+    const result = await runClassifierSelfTest({
+      store: store!,
+      _inferenceFor: inferenceFor as never,
+    });
+    expect(result.outcome).toBe("ok");
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+    expect(result.verdict).toEqual({ requires_approval: false, is_global: false });
+  });
+
+  it("terminates the transient lifecycle even when infer throws", async () => {
+    writeClassifierConfig(store!, {
+      enabled: true,
+      providerMode: "local",
+      local: { modelId: "test-local-model" },
+    });
+    const terminate = vi.fn(async () => undefined);
+    const inferenceFor = vi.fn(() => {
+      const client: LocalInferenceClient & { terminate?: () => Promise<void> } = {
+        infer: async () => {
+          throw new Error("simulated inference failure");
+        },
+        terminate,
+      };
+      return client;
+    });
+
+    const result = await runClassifierSelfTest({
+      store: store!,
+      _inferenceFor: inferenceFor as never,
+    });
+    // The classifier's local provider catches inference errors and
+    // returns a fallback verdict rather than throwing; the self-test
+    // sees a fallback outcome, not an error.
+    expect(["fallback", "error"]).toContain(result.outcome);
+    // The transient lifecycle was terminated cleanly regardless.
+    expect(terminate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/mcp-server/tests/classifier-startup.test.ts
+++ b/packages/mcp-server/tests/classifier-startup.test.ts
@@ -127,13 +127,7 @@ describe("bootClassifierWorker — store-driven", () => {
     });
     // Inject a fake inference client so the test doesn't load a real model.
     const stubInferenceFor = vi.fn(() => ({
-      classify: async () => ({
-        outcome: "ok" as const,
-        verdict: { requires_approval: false, is_global: false },
-        provider: "local" as const,
-        attempts: 1,
-        latencyMs: 1,
-      }),
+      infer: async () => JSON.stringify({ requires_approval: false, is_global: false }),
     }));
     const result = bootClassifierWorker({
       store: store!,

--- a/packages/mcp-server/tests/mcp/remember-domain.mcp.test.ts
+++ b/packages/mcp-server/tests/mcp/remember-domain.mcp.test.ts
@@ -167,9 +167,9 @@ describe("MCP remember + conv_state (T3.1)", () => {
       // Section 4d.3 — agents no longer get protected routing for
       // free via `category=identity`. With the classifier worker
       // unwired, the memory lands at active with conservative-default
-      // booleans. The classifier-cutover path (Section 4d.1 — set
-      // LIBRARIAN_CLASSIFIER_ENABLED=true) routes via
-      // pendingClassification instead.
+      // booleans. The classifier-cutover path (Section 4d.1 — enable
+      // the classifier from the /classifier dashboard cockpit) routes
+      // via pendingClassification instead.
       expect(row.status).toBe("active");
       expect(row.requires_approval).toBe(0);
     });

--- a/packages/mcp-server/tests/trpc/classifier-config.test.ts
+++ b/packages/mcp-server/tests/trpc/classifier-config.test.ts
@@ -1,0 +1,195 @@
+// classifierConfig tRPC procedure tests — exercises the cockpit surface
+// end to end: admin gating, config read/update round-trip with no token
+// leak, workerState drift detection, restartWorker outcome, and selfTest
+// outcomes via a fresh HTTP bin.
+
+import { describe, expect, it } from "vitest";
+import { cleanupTempDir, makeTempDir, startHttpServer } from "../../../../test/helpers.js";
+
+interface TrpcOk<T> {
+  result: { data: T };
+}
+interface TrpcErr {
+  error: unknown;
+}
+interface ServerHandle {
+  url: string;
+  token: string;
+  stop: () => Promise<void>;
+}
+
+async function trpcGet<T>(server: ServerHandle, path: string, input?: unknown): Promise<T> {
+  const url = new URL(`${server.url}/trpc/${path}`);
+  if (input !== undefined) url.searchParams.set("input", JSON.stringify(input));
+  const response = await fetch(url, { headers: { authorization: `Bearer ${server.token}` } });
+  const json = (await response.json()) as TrpcOk<T> | TrpcErr;
+  if (response.status >= 400 || "error" in json) {
+    throw new Error(`trpc GET ${path} failed: ${JSON.stringify(json)}`);
+  }
+  return (json as TrpcOk<T>).result.data;
+}
+
+async function trpcPost<T>(server: ServerHandle, path: string, input?: unknown): Promise<T> {
+  const response = await fetch(`${server.url}/trpc/${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${server.token}` },
+    body: input === undefined ? undefined : JSON.stringify(input),
+  });
+  const json = (await response.json()) as TrpcOk<T> | TrpcErr;
+  if (response.status >= 400 || "error" in json) {
+    throw new Error(`trpc POST ${path} failed: ${JSON.stringify(json)}`);
+  }
+  return (json as TrpcOk<T>).result.data;
+}
+
+interface ClassifierConfigResponse {
+  enabled: boolean;
+  providerMode: "remote" | "local";
+  llm: { provider: string; endpoint: string; model: string; timeoutMs: number };
+  hasToken: boolean;
+  isLlmComplete: boolean;
+  local: { modelId: string; quant: string | null };
+  promptVersion: string | null;
+  isOperational: boolean;
+}
+
+interface WorkerStateResponse {
+  runningConfigHash: string | null;
+  storedConfigHash: string;
+  hasDrift: boolean;
+}
+
+interface RestartResponse {
+  outcome: string;
+  runningConfigHash: string | null;
+  reason?: string;
+}
+
+interface SelfTestResponse {
+  outcome: "ok" | "fallback" | "error";
+  latencyMs: number;
+  providerMode: "remote" | "local" | null;
+  verdict?: { requires_approval: boolean; is_global: boolean };
+  fallbackReason?: string;
+  error?: string;
+  rawOutput?: string;
+}
+
+describe("tRPC classifierConfig surface", () => {
+  it("requires admin auth on every procedure", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const calls = ["classifierConfig.config", "classifierConfig.workerState"];
+      for (const call of calls) {
+        const response = await fetch(`${server.url}/trpc/${call}`); // no Authorization
+        expect(response.status, `expected 401 for ${call}`).toBeGreaterThanOrEqual(400);
+      }
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("returns sensible defaults on a fresh data dir", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const cfg = await trpcGet<ClassifierConfigResponse>(server, "classifierConfig.config");
+      expect(cfg.enabled).toBe(false);
+      expect(cfg.providerMode).toBe("remote");
+      expect(cfg.hasToken).toBe(false);
+      expect(cfg.isOperational).toBe(false);
+      expect(cfg.local.modelId).toBe("");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("round-trips a config update and never returns the token on the wire", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const after = await trpcPost<ClassifierConfigResponse>(server, "classifierConfig.setConfig", {
+        enabled: true,
+        providerMode: "remote",
+        llm: {
+          provider: "openai",
+          endpoint: "https://api.example.com/v1",
+          model: "gpt-4o-mini",
+        },
+        token: "dummy-trpc-classifier-token",
+        promptVersion: "v1",
+      });
+      expect(after.enabled).toBe(true);
+      expect(after.llm.model).toBe("gpt-4o-mini");
+      expect(after.hasToken).toBe(true);
+      expect(after.isOperational).toBe(true);
+      expect(after.promptVersion).toBe("v1");
+      // Token plaintext must not be visible anywhere in the response.
+      expect(JSON.stringify(after)).not.toContain("dummy-trpc-classifier-token");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("workerState reports drift after a setConfig without a restart", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      // No config stored yet — runningConfigHash and storedConfigHash both
+      // reflect the empty config; hasDrift is false.
+      const initial = await trpcGet<WorkerStateResponse>(server, "classifierConfig.workerState");
+      expect(initial.runningConfigHash).toBeNull(); // nothing running
+      expect(initial.storedConfigHash).toMatch(/^[0-9a-f]{64}$/);
+      expect(initial.hasDrift).toBe(false);
+
+      // Write a complete config — the running hash is still null (no
+      // restart yet), the stored hash flips, so hasDrift goes true.
+      await trpcPost(server, "classifierConfig.setConfig", {
+        enabled: true,
+        providerMode: "remote",
+        llm: {
+          provider: "openai",
+          endpoint: "https://api.example.com/v1",
+          model: "gpt-4o-mini",
+        },
+        token: "dummy-trpc-classifier-token",
+      });
+      const drifted = await trpcGet<WorkerStateResponse>(server, "classifierConfig.workerState");
+      expect(drifted.runningConfigHash).toBeNull();
+      expect(drifted.hasDrift).toBe(true);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("restartWorker on a disabled config reports stopped", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const result = await trpcPost<RestartResponse>(server, "classifierConfig.restartWorker");
+      expect(result.outcome).toBe("stopped");
+      expect(result.runningConfigHash).toBeNull();
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("selfTest on a non-operational config reports an error outcome", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const result = await trpcPost<SelfTestResponse>(server, "classifierConfig.selfTest");
+      expect(result.outcome).toBe("error");
+      expect(result.error).toMatch(/disabled|incomplete|operational/i);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+});

--- a/scripts/check-classifier-env-retirement.mjs
+++ b/scripts/check-classifier-env-retirement.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+// Guard against re-introduction of the retired `LIBRARIAN_CLASSIFIER_*`
+// env contract (see docs/specs/classifier-dashboard-config-spec.md). The
+// env vars were replaced by admin-settings persistence read from the
+// `/classifier` dashboard cockpit; any new occurrence in source, tests,
+// scripts, docker config, or env templates is a regression.
+//
+// An explicit allowlist of files is permitted to retain the strings:
+// the CHANGELOG retroactive note, the classifier-config module that
+// owns the `LEGACY_CLASSIFIER_ENV_KEYS` constant, the startup helper
+// that emits the env-retired notice, the spec / plan docs the change
+// itself referenced, and this script.
+//
+// Exits 1 with a diff-style report on any unallowed occurrence.
+
+import { execSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+
+const ALLOWED = new Set([
+  // CHANGELOG entry naming the retired keys is permanent.
+  "CHANGELOG.md",
+  // classifier-config owns the `LEGACY_CLASSIFIER_ENV_KEYS` constant.
+  "packages/core/src/classifier-config.ts",
+  "packages/core/dist/classifier-config.d.ts",
+  "packages/core/dist/classifier-config.js",
+  "packages/core/dist/index.d.ts",
+  "packages/core/dist/index.js",
+  // classifier-startup emits the env-retired notice.
+  "packages/mcp-server/src/classifier-startup.ts",
+  "packages/mcp-server/dist/classifier-startup.d.ts",
+  "packages/mcp-server/dist/classifier-startup.js",
+  // Tests exercise the env-retirement notice + legacy key detector.
+  "packages/core/tests/classifier-config.test.ts",
+  "packages/mcp-server/tests/classifier-startup.test.ts",
+  // Comment in the boot wiring refers to the retired contract.
+  "packages/mcp-server/src/bin/http.ts",
+  // classifier-eval is an offline evaluation harness, separate from the
+  // production runtime. It keeps its own env contract for endpoint /
+  // token because admins drive it from a shell. Migrating it to the
+  // settings store is a future independent decision.
+  "packages/classifier-eval/src/cli/run-command.ts",
+  // local.worker / providers-local: LIBRARIAN_CLASSIFIER_LOCAL_E2E is an
+  // integration-test gate, NOT a config knob. Out of scope for the
+  // settings-store migration.
+  "packages/classifier/src/providers/local.worker.ts",
+  "packages/classifier/tests/providers-local.test.ts",
+  // Spec / plan docs that describe the retirement itself.
+  "docs/specs/classifier-implementation-spec.md",
+  "docs/specs/done/classifier-implementation-spec.md",
+  "docs/specs/classifier-dashboard-config-spec.md",
+  "docs/specs/done/classifier-dashboard-config-spec.md",
+  "docs/specs/classifier-dashboard-config-plan.md",
+  "docs/specs/done/classifier-dashboard-config-plan.md",
+  // The guard itself names the keys it forbids.
+  "scripts/check-classifier-env-retirement.mjs",
+]);
+
+let stdout = "";
+try {
+  // Use git grep so the search respects .gitignore (no node_modules, etc.).
+  stdout = execSync("git grep -lI 'LIBRARIAN_CLASSIFIER'", {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+} catch (err) {
+  if (err && typeof err === "object" && "status" in err && err.status === 1) {
+    // git grep returns 1 when nothing matches — the all-clear path.
+    console.log(
+      "[check-classifier-env-retirement] OK: no LIBRARIAN_CLASSIFIER_* references found.",
+    );
+    process.exit(0);
+  }
+  console.error("[check-classifier-env-retirement] git grep failed:", err);
+  process.exit(2);
+}
+
+const files = stdout
+  .split("\n")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+const offenders = files.filter((file) => !ALLOWED.has(file));
+
+if (offenders.length === 0) {
+  console.log(
+    `[check-classifier-env-retirement] OK: ${files.length} reference(s) found, all in allowlisted files.`,
+  );
+  process.exit(0);
+}
+
+console.error("[check-classifier-env-retirement] FAIL:");
+console.error(
+  "  LIBRARIAN_CLASSIFIER_* env vars are retired " +
+    "(see docs/specs/classifier-dashboard-config-spec.md).",
+);
+console.error("  The following files contain references and are NOT on the allowlist:");
+for (const file of offenders) {
+  console.error(`    - ${file}`);
+}
+console.error("");
+console.error("  Either remove the references, or add the file to the ALLOWED set in");
+console.error("  scripts/check-classifier-env-retirement.mjs with a comment explaining why.");
+process.exit(1);


### PR DESCRIPTION
## Summary

Slice 4 of [classifier-dashboard-config-plan.md](docs/specs/classifier-dashboard-config-plan.md). T4.1 — five admin-gated procedures mounted as `appRouter.classifierConfig`:

- **`config`** (query) — returns `readClassifierConfig(ctx.store)`. Token never on the wire; only `hasToken` boolean.
- **`setConfig`** (mutation, validated by `ClassifierConfigPatchSchema`) — writes via `writeClassifierConfig`, returns fresh config. Token still never echoed.
- **`workerState`** (query) — returns `{ runningConfigHash, storedConfigHash, hasDrift }` for the dashboard's "Restart classifier worker" banner. Drift is meaningful only when actionable: hashes differ AND (something is running OR the stored config is operational). An empty store + no worker is no-drift, not "drifted from null".
- **`restartWorker`** (mutation) — calls `restartClassifierWorker`. Concurrent callers coalesce onto `already_in_progress` via the single-flight mutex.
- **`selfTest`** (mutation) — calls `runClassifierSelfTest`. Runs against a transient classifier; doesn't touch the running worker.

### TS2742 watch

The plan flagged a risk that adding `classifierConfig` to `appRouter` could trigger the inferred-type-portability error that bit sessions-rethink PR 7. **Dashboard typecheck stays green** — the new procedures don't embed `Memory` in their inferred outputs, so the chain doesn't reach `memory-store.js`.

## Test plan

- [x] `pnpm --filter @librarian/mcp-server test:vitest tests/trpc/classifier-config.test.ts` — 6 new tests pass
- [x] `pnpm --filter @librarian/mcp-server test:vitest` — 146 mcp-server tests pass
- [x] `pnpm -r typecheck` — green (dashboard's `AppRouter` inference clean)
- [x] `node scripts/check-classifier-env-retirement.mjs` — OK
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)