### PR TITLE
feat(dashboard): /classifier cockpit + form + worker controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,68 @@ changes from this point forward are catalogued here.
 
 ## [Unreleased]
 
+### Added
+
+- **Classifier admin cockpit at `/classifier`.** Operators configure
+  the classifier worker (provider mode, remote LLM connection, local
+  GGUF model picker backed by `@librarian/classifier`'s `CATALOG`,
+  prompt version, enable flag) from the dashboard the same way they
+  configure the curator. The page shows a configuration summary with
+  a "Config has changed since the worker started" drift banner; a
+  full form with a provider-mode toggle, masked token input that
+  preserves the stored value on empty submit, and a collapsible
+  custom-id field for HF identifiers outside the catalog; a restart
+  button that calls the new
+  `classifierConfig.restartWorker` mutation (coalesces concurrent
+  callers via the single-flight mutex documented in the spec); and a
+  self-test button that runs the classifier package's
+  `runSelfTest(SELF_TEST_INPUT)` against a transient classifier
+  instance, returning verdict + latency + fallback reason. Worker
+  drift detection uses a sha256 of the encrypted token blob so token
+  rotation flips the hash without ever touching plaintext.
+- **`@librarian/core` shared `llm-connection` helper.** The
+  per-LLM-connection block (provider/endpoint/model/timeoutMs +
+  encrypted token) used by both the curator and the new classifier
+  config is now a single tested module. Curator-config delegates to
+  it; classifier-config layers provider-mode + local-model knobs +
+  prompt version on top. Public surface:
+  `LlmConnection`, `LlmConnectionPatch`, `LlmConnectionPatchSchema`,
+  `llmConnectionKeys`, `readLlmConnection`, `writeLlmConnection`,
+  `resolveLlmToken`.
+- **`@librarian/core/classifier-config`.** Settings-store-backed
+  config for the classifier worker.
+  `readClassifierConfig` / `writeClassifierConfig` /
+  `resolveClassifierToken` / `classifierConfigHash` /
+  `findLegacyClassifierEnvKeys` / `ClassifierConfigPatchSchema`. The
+  hash includes a sha256 fingerprint of the encrypted token blob, so
+  rotation triggers drift without exposing plaintext.
+- **`@librarian/mcp-server` store-driven classifier boot + restart +
+  self-test.** `bootClassifierWorker({ store, … })` reads the stored
+  config; `restartClassifierWorker(input)` implements the nine-step
+  shutdown procedure with a single-flight mutex
+  (outcomes: `started | stopped | restarted | already_in_progress |
+  failed`); `runClassifierSelfTest(input)` builds a transient
+  classifier and tears down with a `finally`-terminated lifecycle so
+  a thrown classify doesn't leak the local-provider Node Worker.
+- **`classifierConfig` tRPC router** mounted on `appRouter`:
+  `config` / `setConfig` / `workerState` / `restartWorker` /
+  `selfTest`. All admin-gated; token never on the wire.
+
+### Removed
+
+- **`LIBRARIAN_CLASSIFIER_*` env vars retired** in favour of admin-
+  settings persistence (see the cockpit above). Boot logs a one-line
+  `classifier_env_retired` notice if any of the seven retired keys
+  (`_ENABLED`, `_PROVIDER`, `_REMOTE_ENDPOINT`, `_REMOTE_TOKEN`,
+  `_REMOTE_MODEL`, `_LOCAL_MODEL`, `_LOCAL_QUANT`) are still set, with
+  a hint to migrate to the cockpit. A new CI guard
+  (`scripts/check-classifier-env-retirement.mjs`, wired into the
+  guards job) `git grep`s the repo for new references and fails the
+  build on any occurrence outside the explicit allowlist (the
+  retirement-related source / tests / docs + classifier-eval's
+  separate CLI env contract + the `_LOCAL_E2E` integration-test
+  flag).
+
 ## [0.2.0] — 2026-05-28
 
 ### Fixed

--- a/apps/dashboard/app/classifier/actions.ts
+++ b/apps/dashboard/app/classifier/actions.ts
@@ -1,0 +1,81 @@
+"use server";
+
+import type { ClassifierConfigPatch, ClassifierConfig } from "@librarian/core";
+import { revalidatePath } from "next/cache";
+import { serverTRPC } from "@/lib/trpc-server";
+
+export type SaveConfigResult =
+  | { ok: true; config: ClassifierConfig }
+  | { ok: false; error: string };
+export type RestartResult =
+  | {
+      ok: true;
+      outcome: "started" | "stopped" | "restarted" | "already_in_progress" | "failed";
+      runningConfigHash: string | null;
+      reason?: string;
+    }
+  | { ok: false; error: string };
+export type SelfTestResult =
+  | {
+      ok: true;
+      outcome: "ok" | "fallback" | "error";
+      latencyMs: number;
+      providerMode: "remote" | "local" | null;
+      verdict?: { requires_approval: boolean; is_global: boolean };
+      fallbackReason?: string;
+      error?: string;
+      rawOutput?: string;
+    }
+  | { ok: false; error: string };
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+// Save the classifier config. An empty token field leaves the stored
+// token unchanged (the form never round-trips the secret); send "" to
+// clear.
+export async function saveClassifierConfigAction(
+  patch: ClassifierConfigPatch,
+): Promise<SaveConfigResult> {
+  try {
+    const config = await serverTRPC.classifierConfig.setConfig.mutate(patch);
+    revalidatePath("/classifier");
+    return { ok: true, config: config as ClassifierConfig };
+  } catch (error) {
+    return { ok: false, error: message(error) };
+  }
+}
+
+export async function restartClassifierWorkerAction(): Promise<RestartResult> {
+  try {
+    const result = await serverTRPC.classifierConfig.restartWorker.mutate();
+    revalidatePath("/classifier");
+    return {
+      ok: true,
+      outcome: result.outcome as RestartResult extends { ok: true; outcome: infer O } ? O : never,
+      runningConfigHash: result.runningConfigHash,
+      ...(result.reason !== undefined ? { reason: result.reason } : {}),
+    };
+  } catch (error) {
+    return { ok: false, error: message(error) };
+  }
+}
+
+export async function runClassifierSelfTestAction(): Promise<SelfTestResult> {
+  try {
+    const result = await serverTRPC.classifierConfig.selfTest.mutate();
+    return {
+      ok: true,
+      outcome: result.outcome,
+      latencyMs: result.latencyMs,
+      providerMode: result.providerMode,
+      ...(result.verdict !== undefined ? { verdict: result.verdict } : {}),
+      ...(result.fallbackReason !== undefined ? { fallbackReason: result.fallbackReason } : {}),
+      ...(result.error !== undefined ? { error: result.error } : {}),
+      ...(result.rawOutput !== undefined ? { rawOutput: result.rawOutput } : {}),
+    };
+  } catch (error) {
+    return { ok: false, error: message(error) };
+  }
+}

--- a/apps/dashboard/app/classifier/page.tsx
+++ b/apps/dashboard/app/classifier/page.tsx
@@ -1,0 +1,59 @@
+// Classifier admin cockpit (spec: classifier-dashboard-config) — config
+// summary + form + worker controls (restart + self-test).
+
+import {
+  restartClassifierWorkerAction,
+  runClassifierSelfTestAction,
+  saveClassifierConfigAction,
+} from "@/app/classifier/actions";
+import { ClassifierConfigForm } from "@/components/classifier/config-form";
+import { ClassifierConfigSummary } from "@/components/classifier/config-summary";
+import { RestartWorkerButton } from "@/components/classifier/restart-worker-button";
+import { SelfTestButton } from "@/components/classifier/self-test-button";
+import { serverTRPC } from "@/lib/trpc-server";
+
+export const dynamic = "force-dynamic";
+
+export default async function ClassifierPage() {
+  let config: Awaited<ReturnType<typeof serverTRPC.classifierConfig.config.query>> | null = null;
+  let workerState: Awaited<
+    ReturnType<typeof serverTRPC.classifierConfig.workerState.query>
+  > | null = null;
+  let error: string | null = null;
+  try {
+    [config, workerState] = await Promise.all([
+      serverTRPC.classifierConfig.config.query(),
+      serverTRPC.classifierConfig.workerState.query(),
+    ]);
+  } catch (err) {
+    error = err instanceof Error ? err.message : String(err);
+  }
+
+  return (
+    <main className="flex flex-col gap-6 p-4 sm:p-6">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <h1 className="text-2xl font-semibold tracking-tight">Classifier</h1>
+        <div className="flex flex-wrap items-center gap-2">
+          <SelfTestButton onRun={runClassifierSelfTestAction} />
+          <RestartWorkerButton onRestart={restartClassifierWorkerAction} />
+        </div>
+      </header>
+
+      {error ? (
+        <p
+          role="alert"
+          className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive"
+        >
+          Failed to load classifier config: {error}
+        </p>
+      ) : null}
+
+      {config && workerState ? (
+        <div className="grid gap-6 lg:grid-cols-[1fr_1fr]">
+          <ClassifierConfigSummary config={config} hasDrift={workerState.hasDrift} />
+          <ClassifierConfigForm config={config} onSave={saveClassifierConfigAction} />
+        </div>
+      ) : null}
+    </main>
+  );
+}

--- a/apps/dashboard/components/classifier/config-form.tsx
+++ b/apps/dashboard/components/classifier/config-form.tsx
@@ -1,0 +1,403 @@
+"use client";
+
+// Classifier configuration form. Provider-mode radio toggles between
+// two field groups; the remote group is the standard LLM connection
+// surface (provider/endpoint/model/timeoutMs/token), the local group
+// is a CATALOG-backed picker plus a collapsible custom-id escape hatch
+// for HF identifiers not in the catalog, plus an optional quant input.
+//
+// Cross-mode state is preserved in component state so flipping the
+// radio back and forth doesn't lose what the admin typed. The patch
+// posted to `setConfig` only includes the active mode's fields plus
+// the mode itself.
+//
+// The token input is masked (`type=password`) and never pre-filled.
+// Submitting an empty token leaves the stored token unchanged; submit
+// the literal empty string only when the admin types it explicitly
+// (the form sends `token: undefined` when the box is untouched).
+
+import { CATALOG, DEFAULT_MODEL_ID } from "@librarian/classifier";
+import type { ClassifierConfig, ClassifierConfigPatch } from "@librarian/core";
+import { useState, useTransition } from "react";
+import { Button } from "@/components/ui-v2/button";
+
+type SaveAction = (
+  patch: ClassifierConfigPatch,
+) => Promise<{ ok: true; config: ClassifierConfig } | { ok: false; error: string }>;
+
+interface FormState {
+  enabled: boolean;
+  providerMode: "remote" | "local";
+  // remote
+  remoteProvider: string;
+  remoteEndpoint: string;
+  remoteModel: string;
+  remoteTimeoutMs: string;
+  remoteToken: string; // never pre-filled; "" means "leave unchanged"
+  // local
+  localCatalogId: string; // "" means use custom id
+  localCustomId: string;
+  localQuant: string;
+  // shared
+  promptVersion: string; // "" means use classifier default (null)
+}
+
+function initialFormState(config: ClassifierConfig): FormState {
+  // Pre-fill the catalog dropdown when the stored modelId matches a
+  // catalog entry; otherwise drop into the custom-id escape hatch so
+  // the admin sees the value they had.
+  const inCatalog = CATALOG.find((c) => c.id === config.local.modelId);
+  return {
+    enabled: config.enabled,
+    providerMode: config.providerMode,
+    remoteProvider: config.llm.provider,
+    remoteEndpoint: config.llm.endpoint,
+    remoteModel: config.llm.model,
+    remoteTimeoutMs: String(config.llm.timeoutMs),
+    remoteToken: "",
+    localCatalogId: inCatalog ? inCatalog.id : config.local.modelId === "" ? DEFAULT_MODEL_ID : "",
+    localCustomId: inCatalog || config.local.modelId === "" ? "" : config.local.modelId,
+    localQuant: config.local.quant ?? "",
+    promptVersion: config.promptVersion ?? "",
+  };
+}
+
+export function ClassifierConfigForm({
+  config,
+  onSave,
+}: {
+  config: ClassifierConfig;
+  onSave: SaveAction;
+}) {
+  const [state, setState] = useState<FormState>(() => initialFormState(config));
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [showCustomLocal, setShowCustomLocal] = useState(state.localCatalogId === "");
+  const [tokenTouched, setTokenTouched] = useState(false);
+
+  function patch<K extends keyof FormState>(key: K, value: FormState[K]): void {
+    setState((s) => ({ ...s, [key]: value }));
+  }
+
+  function buildPatch(): ClassifierConfigPatch {
+    const out: ClassifierConfigPatch = {
+      enabled: state.enabled,
+      providerMode: state.providerMode,
+    };
+    if (state.providerMode === "remote") {
+      const timeoutMs = Number.parseInt(state.remoteTimeoutMs, 10);
+      out.llm = {
+        provider: state.remoteProvider.trim(),
+        endpoint: state.remoteEndpoint.trim(),
+        model: state.remoteModel.trim(),
+        ...(Number.isFinite(timeoutMs) ? { timeoutMs } : {}),
+      };
+      if (tokenTouched) out.token = state.remoteToken;
+    } else {
+      const modelId = (showCustomLocal ? state.localCustomId : state.localCatalogId).trim();
+      out.local = {
+        modelId,
+        quant: state.localQuant.trim() === "" ? null : state.localQuant.trim(),
+      };
+    }
+    out.promptVersion = state.promptVersion.trim() === "" ? null : state.promptVersion.trim();
+    return out;
+  }
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>): void {
+    e.preventDefault();
+    setError(null);
+    startTransition(async () => {
+      const result = await onSave(buildPatch());
+      if (!result.ok) {
+        setError(result.error);
+        return;
+      }
+      // Clear the password field on success so a future submit doesn't
+      // re-send the same plaintext.
+      patch("remoteToken", "");
+      setTokenTouched(false);
+    });
+  }
+
+  return (
+    <section className="rounded-md border bg-card p-4" aria-label="Classifier configuration form">
+      <header className="mb-3">
+        <h2 className="font-semibold">Edit configuration</h2>
+      </header>
+      <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={state.enabled}
+            disabled={pending}
+            onChange={(e) => patch("enabled", e.target.checked)}
+          />
+          Enable classifier worker
+        </label>
+
+        <fieldset className="flex flex-col gap-2">
+          <legend className="text-xs font-medium text-muted-foreground">Provider mode</legend>
+          <div className="flex gap-4 text-sm">
+            <label className="flex items-center gap-1">
+              <input
+                type="radio"
+                name="providerMode"
+                value="remote"
+                checked={state.providerMode === "remote"}
+                disabled={pending}
+                onChange={() => patch("providerMode", "remote")}
+              />
+              Remote (OpenAI-compatible API)
+            </label>
+            <label className="flex items-center gap-1">
+              <input
+                type="radio"
+                name="providerMode"
+                value="local"
+                checked={state.providerMode === "local"}
+                disabled={pending}
+                onChange={() => patch("providerMode", "local")}
+              />
+              Local (GGUF model)
+            </label>
+          </div>
+        </fieldset>
+
+        {state.providerMode === "remote" ? (
+          <RemoteFields
+            state={state}
+            disabled={pending}
+            onChange={patch}
+            tokenTouched={tokenTouched}
+            onTokenTouched={setTokenTouched}
+          />
+        ) : (
+          <LocalFields
+            state={state}
+            disabled={pending}
+            onChange={patch}
+            showCustom={showCustomLocal}
+            onShowCustomToggle={setShowCustomLocal}
+          />
+        )}
+
+        <FieldRow
+          id="classifier-prompt-version"
+          label="Prompt version"
+          hint="Optional. e.g. v1 / v2. Empty uses the classifier package default."
+        >
+          <input
+            id="classifier-prompt-version"
+            type="text"
+            inputMode="text"
+            disabled={pending}
+            value={state.promptVersion}
+            onChange={(e) => patch("promptVersion", e.target.value)}
+            placeholder="(default)"
+            className="rounded-md border bg-background px-2 py-1 text-sm"
+          />
+        </FieldRow>
+
+        {error ? (
+          <p role="alert" className="text-sm text-destructive">
+            {error}
+          </p>
+        ) : null}
+
+        <div className="flex justify-end">
+          <Button type="submit" disabled={pending}>
+            {pending ? "Saving…" : "Save"}
+          </Button>
+        </div>
+      </form>
+    </section>
+  );
+}
+
+function RemoteFields({
+  state,
+  disabled,
+  onChange,
+  tokenTouched,
+  onTokenTouched,
+}: {
+  state: FormState;
+  disabled: boolean;
+  onChange: <K extends keyof FormState>(key: K, value: FormState[K]) => void;
+  tokenTouched: boolean;
+  onTokenTouched: (v: boolean) => void;
+}) {
+  return (
+    <div className="grid gap-2 sm:grid-cols-2">
+      <FieldRow id="classifier-remote-provider" label="Provider">
+        <input
+          id="classifier-remote-provider"
+          type="text"
+          disabled={disabled}
+          value={state.remoteProvider}
+          onChange={(e) => onChange("remoteProvider", e.target.value)}
+          placeholder="openai / azure / …"
+          className="rounded-md border bg-background px-2 py-1 text-sm"
+        />
+      </FieldRow>
+      <FieldRow id="classifier-remote-endpoint" label="Endpoint">
+        <input
+          id="classifier-remote-endpoint"
+          type="url"
+          disabled={disabled}
+          value={state.remoteEndpoint}
+          onChange={(e) => onChange("remoteEndpoint", e.target.value)}
+          placeholder="https://api.openai.com/v1"
+          className="rounded-md border bg-background px-2 py-1 text-sm"
+        />
+      </FieldRow>
+      <FieldRow id="classifier-remote-model" label="Model">
+        <input
+          id="classifier-remote-model"
+          type="text"
+          disabled={disabled}
+          value={state.remoteModel}
+          onChange={(e) => onChange("remoteModel", e.target.value)}
+          placeholder="gpt-4o-mini"
+          className="rounded-md border bg-background px-2 py-1 text-sm"
+        />
+      </FieldRow>
+      <FieldRow id="classifier-remote-timeout" label="Timeout (ms)">
+        <input
+          id="classifier-remote-timeout"
+          type="number"
+          inputMode="numeric"
+          min={1000}
+          max={600000}
+          disabled={disabled}
+          value={state.remoteTimeoutMs}
+          onChange={(e) => onChange("remoteTimeoutMs", e.target.value)}
+          className="rounded-md border bg-background px-2 py-1 text-sm"
+        />
+      </FieldRow>
+      <FieldRow
+        id="classifier-remote-token"
+        label="API token"
+        hint={
+          tokenTouched
+            ? "Will replace the stored token on save."
+            : "Leave empty to keep the stored token unchanged."
+        }
+      >
+        <input
+          id="classifier-remote-token"
+          type="password"
+          autoComplete="off"
+          disabled={disabled}
+          value={state.remoteToken}
+          onChange={(e) => {
+            onChange("remoteToken", e.target.value);
+            onTokenTouched(true);
+          }}
+          placeholder="(unchanged)"
+          className="rounded-md border bg-background px-2 py-1 text-sm"
+        />
+      </FieldRow>
+    </div>
+  );
+}
+
+function LocalFields({
+  state,
+  disabled,
+  onChange,
+  showCustom,
+  onShowCustomToggle,
+}: {
+  state: FormState;
+  disabled: boolean;
+  onChange: <K extends keyof FormState>(key: K, value: FormState[K]) => void;
+  showCustom: boolean;
+  onShowCustomToggle: (v: boolean) => void;
+}) {
+  return (
+    <div className="grid gap-2 sm:grid-cols-2">
+      <FieldRow
+        id="classifier-local-model"
+        label="Local model"
+        hint="Picked from the curated catalog by default."
+      >
+        <select
+          id="classifier-local-model"
+          disabled={disabled || showCustom}
+          value={state.localCatalogId}
+          onChange={(e) => onChange("localCatalogId", e.target.value)}
+          className="rounded-md border bg-background px-2 py-1 text-sm"
+        >
+          <option value="">(choose a catalog entry)</option>
+          {CATALOG.map((entry) => (
+            <option key={entry.id} value={entry.id}>
+              {entry.label} — {entry.parameters}, {entry.ramGb} GB
+            </option>
+          ))}
+        </select>
+      </FieldRow>
+      <FieldRow id="classifier-local-quant" label="Quantisation" hint="e.g. Q4_K_M. Optional.">
+        <input
+          id="classifier-local-quant"
+          type="text"
+          disabled={disabled}
+          value={state.localQuant}
+          onChange={(e) => onChange("localQuant", e.target.value)}
+          placeholder="Q4_K_M"
+          className="rounded-md border bg-background px-2 py-1 text-sm"
+        />
+      </FieldRow>
+      <div className="sm:col-span-2">
+        <details
+          open={showCustom}
+          onToggle={(e) => onShowCustomToggle((e.target as HTMLDetailsElement).open)}
+        >
+          <summary className="cursor-pointer text-xs text-muted-foreground">
+            Use a custom model identifier
+          </summary>
+          <div className="mt-2">
+            <FieldRow
+              id="classifier-local-custom-id"
+              label="Custom model id"
+              hint="HuggingFace identifier or local path; overrides the catalog pick."
+            >
+              <input
+                id="classifier-local-custom-id"
+                type="text"
+                disabled={disabled || !showCustom}
+                value={state.localCustomId}
+                onChange={(e) => onChange("localCustomId", e.target.value)}
+                placeholder="org/model-gguf"
+                className="rounded-md border bg-background px-2 py-1 text-sm"
+              />
+            </FieldRow>
+          </div>
+        </details>
+      </div>
+    </div>
+  );
+}
+
+function FieldRow({
+  id,
+  label,
+  hint,
+  children,
+}: {
+  id: string;
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label htmlFor={id} className="text-xs font-medium text-muted-foreground">
+        {label}
+      </label>
+      {children}
+      {hint ? <span className="text-xs text-muted-foreground">{hint}</span> : null}
+    </div>
+  );
+}

--- a/apps/dashboard/components/classifier/config-form.tsx
+++ b/apps/dashboard/components/classifier/config-form.tsx
@@ -16,7 +16,7 @@
 // the literal empty string only when the admin types it explicitly
 // (the form sends `token: undefined` when the box is untouched).
 
-import { CATALOG, DEFAULT_MODEL_ID } from "@librarian/classifier";
+import { CATALOG, DEFAULT_MODEL_ID } from "@librarian/classifier/catalog";
 import type { ClassifierConfig, ClassifierConfigPatch } from "@librarian/core";
 import { useState, useTransition } from "react";
 import { Button } from "@/components/ui-v2/button";

--- a/apps/dashboard/components/classifier/config-summary.tsx
+++ b/apps/dashboard/components/classifier/config-summary.tsx
@@ -1,0 +1,65 @@
+// Read-only summary of the classifier config (spec:
+// classifier-dashboard-config). The token is never shown — only
+// whether one is configured (config.hasToken). Drift banner is
+// rendered when the running worker's config diverges from the stored
+// config; the restart button itself lives in restart-worker-button.tsx.
+
+import type { ClassifierConfig } from "@librarian/core";
+
+function statusOf(config: ClassifierConfig): { label: string; tone: string } {
+  if (config.isOperational) return { label: "Operational", tone: "text-green-600" };
+  if (config.enabled) return { label: "Enabled — config incomplete", tone: "text-amber-600" };
+  return { label: "Disabled", tone: "text-muted-foreground" };
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-4 py-1">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      <span className="font-mono text-sm">{value}</span>
+    </div>
+  );
+}
+
+export function ClassifierConfigSummary({
+  config,
+  hasDrift,
+}: {
+  config: ClassifierConfig;
+  hasDrift: boolean;
+}) {
+  const status = statusOf(config);
+  return (
+    <section className="rounded-md border bg-card p-4" aria-label="Classifier configuration">
+      <header className="mb-3 flex items-baseline justify-between">
+        <h2 className="font-semibold">Configuration</h2>
+        <span className={`text-sm font-medium ${status.tone}`}>{status.label}</span>
+      </header>
+      {hasDrift ? (
+        <div
+          role="status"
+          aria-live="polite"
+          className="mb-3 rounded border border-amber-500/30 bg-amber-500/10 p-2 text-sm text-amber-900 dark:text-amber-100"
+        >
+          Config has changed since the worker started. Restart to apply.
+        </div>
+      ) : null}
+      <Row label="Provider mode" value={config.providerMode} />
+      {config.providerMode === "remote" ? (
+        <>
+          <Row label="Provider" value={config.llm.provider || "—"} />
+          <Row label="Endpoint" value={config.llm.endpoint || "—"} />
+          <Row label="Model" value={config.llm.model || "—"} />
+          <Row label="Timeout (ms)" value={String(config.llm.timeoutMs)} />
+          <Row label="API token" value={config.hasToken ? "configured" : "not set"} />
+        </>
+      ) : (
+        <>
+          <Row label="Local model" value={config.local.modelId || "—"} />
+          <Row label="Quantisation" value={config.local.quant ?? "—"} />
+        </>
+      )}
+      <Row label="Prompt version" value={config.promptVersion ?? "(default)"} />
+    </section>
+  );
+}

--- a/apps/dashboard/components/classifier/restart-worker-button.tsx
+++ b/apps/dashboard/components/classifier/restart-worker-button.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Button } from "@/components/ui-v2/button";
+
+type RestartOutcome = "started" | "stopped" | "restarted" | "already_in_progress" | "failed";
+
+type RestartAction = () => Promise<
+  | { ok: true; outcome: RestartOutcome; runningConfigHash: string | null; reason?: string }
+  | { ok: false; error: string }
+>;
+
+function formatOutcome(outcome: RestartOutcome, reason?: string): string {
+  switch (outcome) {
+    case "started":
+      return "Classifier worker started.";
+    case "stopped":
+      return "Classifier worker stopped (config disabled or incomplete).";
+    case "restarted":
+      return "Classifier worker restarted.";
+    case "already_in_progress":
+      return "A restart was already in progress — coalesced.";
+    case "failed":
+      return `Restart failed${reason ? `: ${reason}` : "."}`;
+  }
+}
+
+export function RestartWorkerButton({ onRestart }: { onRestart: RestartAction }) {
+  const [pending, startTransition] = useTransition();
+  const [toast, setToast] = useState<{ tone: "ok" | "fail"; text: string } | null>(null);
+
+  function handle(): void {
+    startTransition(async () => {
+      const result = await onRestart();
+      if (!result.ok) {
+        setToast({ tone: "fail", text: result.error });
+        return;
+      }
+      const tone = result.outcome === "failed" ? "fail" : "ok";
+      setToast({ tone, text: formatOutcome(result.outcome, result.reason) });
+    });
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <Button variant="outline" disabled={pending} onClick={handle}>
+        {pending ? "Restarting…" : "Restart classifier worker"}
+      </Button>
+      {toast ? (
+        <p
+          role="status"
+          className={`text-xs ${toast.tone === "ok" ? "text-muted-foreground" : "text-destructive"}`}
+        >
+          {toast.text}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/dashboard/components/classifier/self-test-button.tsx
+++ b/apps/dashboard/components/classifier/self-test-button.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Button } from "@/components/ui-v2/button";
+
+type SelfTestOutcome = "ok" | "fallback" | "error";
+
+type SelfTestAction = () => Promise<
+  | {
+      ok: true;
+      outcome: SelfTestOutcome;
+      latencyMs: number;
+      providerMode: "remote" | "local" | null;
+      verdict?: { requires_approval: boolean; is_global: boolean };
+      fallbackReason?: string;
+      error?: string;
+      rawOutput?: string;
+    }
+  | { ok: false; error: string }
+>;
+
+interface ResultRow {
+  outcome: SelfTestOutcome | "transport_error";
+  latencyMs?: number;
+  providerMode?: "remote" | "local" | null;
+  verdict?: { requires_approval: boolean; is_global: boolean };
+  fallbackReason?: string;
+  error?: string;
+  rawOutput?: string;
+}
+
+export function SelfTestButton({ onRun }: { onRun: SelfTestAction }) {
+  const [pending, startTransition] = useTransition();
+  const [result, setResult] = useState<ResultRow | null>(null);
+
+  function handle(): void {
+    startTransition(async () => {
+      const res = await onRun();
+      if (!res.ok) {
+        setResult({ outcome: "transport_error", error: res.error });
+        return;
+      }
+      setResult({
+        outcome: res.outcome,
+        latencyMs: res.latencyMs,
+        providerMode: res.providerMode,
+        ...(res.verdict !== undefined ? { verdict: res.verdict } : {}),
+        ...(res.fallbackReason !== undefined ? { fallbackReason: res.fallbackReason } : {}),
+        ...(res.error !== undefined ? { error: res.error } : {}),
+        ...(res.rawOutput !== undefined ? { rawOutput: res.rawOutput } : {}),
+      });
+    });
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <Button
+        variant="outline"
+        disabled={pending}
+        onClick={handle}
+        title="Loads a transient classifier (a second model load on local mode) and runs the self-test fixture."
+      >
+        {pending ? "Testing…" : "Test classifier"}
+      </Button>
+      {result ? <SelfTestPanel result={result} /> : null}
+    </div>
+  );
+}
+
+function SelfTestPanel({ result }: { result: ResultRow }) {
+  if (result.outcome === "transport_error") {
+    return (
+      <p role="status" className="text-xs text-destructive">
+        Self-test request failed: {result.error}
+      </p>
+    );
+  }
+  if (result.outcome === "error") {
+    return (
+      <p role="status" className="text-xs text-destructive">
+        {result.error ?? "self-test errored"}
+      </p>
+    );
+  }
+  return (
+    <div className="rounded-md border bg-card p-2 text-xs">
+      <div>
+        <span className="font-medium">Outcome:</span> {result.outcome}
+      </div>
+      {result.latencyMs !== undefined ? (
+        <div>
+          <span className="font-medium">Latency:</span> {result.latencyMs} ms
+        </div>
+      ) : null}
+      {result.verdict ? (
+        <div>
+          <span className="font-medium">Verdict:</span> requires_approval=
+          {String(result.verdict.requires_approval)}, is_global=
+          {String(result.verdict.is_global)}
+        </div>
+      ) : null}
+      {result.fallbackReason ? (
+        <div>
+          <span className="font-medium">Fallback reason:</span> {result.fallbackReason}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/dashboard/components/keyboard-host.tsx
+++ b/apps/dashboard/components/keyboard-host.tsx
@@ -21,6 +21,7 @@ const NAV_ITEMS = [
   { id: "nav-archive", label: "Go to Archive", href: "/archive", hint: "" },
   { id: "nav-logs", label: "Go to Logs", href: "/logs", hint: "" },
   { id: "nav-curator", label: "Go to Curator", href: "/curator", hint: "" },
+  { id: "nav-classifier", label: "Go to Classifier", href: "/classifier", hint: "" },
   { id: "nav-backups", label: "Go to Backups", href: "/backups", hint: "" },
 ];
 

--- a/apps/dashboard/components/site-nav.tsx
+++ b/apps/dashboard/components/site-nav.tsx
@@ -24,6 +24,11 @@ const TABS = [
   { href: "/archive", label: "Archive", match: (p: string) => p === "/archive" },
   { href: "/logs", label: "Logs", match: (p: string) => p === "/logs" },
   { href: "/curator", label: "Curator", match: (p: string) => p.startsWith("/curator") },
+  {
+    href: "/classifier",
+    label: "Classifier",
+    match: (p: string) => p.startsWith("/classifier"),
+  },
   { href: "/backups", label: "Backups", match: (p: string) => p.startsWith("/backups") },
   { href: "/tokens", label: "Tokens", match: (p: string) => p.startsWith("/tokens") },
   { href: "/settings/auth", label: "Auth", match: (p: string) => p.startsWith("/settings/auth") },

--- a/apps/dashboard/e2e/classifier-cockpit.spec.ts
+++ b/apps/dashboard/e2e/classifier-cockpit.spec.ts
@@ -17,18 +17,22 @@ test.describe("classifier cockpit", () => {
     // includes "Classifier" too, so we match the h1 specifically.
     await expect(page.getByRole("heading", { name: "Classifier", level: 1 })).toBeVisible();
 
-    // Configuration summary shows the disabled state.
-    await expect(page.getByText("Disabled", { exact: false })).toBeVisible();
+    // Configuration summary shows the disabled state. Match the
+    // summary panel's status pill specifically (the e2e suite's site
+    // nav also surfaces "Classifier" but not "Disabled").
+    await expect(page.getByText("Disabled", { exact: true })).toBeVisible();
 
-    // Restart on a disabled worker reports the "stopped" outcome.
+    // Restart on a disabled worker reports the "stopped" outcome via
+    // a tone-coloured paragraph that includes a recognisable phrase.
     await page.getByRole("button", { name: /restart classifier worker/i }).click();
-    await expect(page.getByText(/stopped|already in progress/i, { exact: false })).toBeVisible({
+    await expect(page.getByText(/classifier worker stopped/i)).toBeVisible({
       timeout: 15_000,
     });
 
-    // Self-test on a non-operational config reports the disabled error.
+    // Self-test on a non-operational config surfaces a backend error
+    // string from `runClassifierSelfTest` ("classifier is disabled").
     await page.getByRole("button", { name: /test classifier/i }).click();
-    await expect(page.getByText(/disabled|operational/i, { exact: false })).toBeVisible({
+    await expect(page.getByText(/classifier is disabled/i)).toBeVisible({
       timeout: 15_000,
     });
   });

--- a/apps/dashboard/e2e/classifier-cockpit.spec.ts
+++ b/apps/dashboard/e2e/classifier-cockpit.spec.ts
@@ -1,0 +1,35 @@
+// /classifier cockpit smoke — admin can open the page, see the
+// configuration summary, restart the worker on a disabled config (gets
+// the "stopped" outcome), and run a self-test (gets the not-operational
+// error outcome). The happy path (configure remote provider with a stub
+// LLM end to end) is left as a follow-up because mcp-server doesn't yet
+// have an LLM stub on the http path.
+
+import { expect, test } from "@playwright/test";
+
+test.describe("classifier cockpit", () => {
+  test("admin sees the page, can restart the disabled worker, and run self-test", async ({
+    page,
+  }) => {
+    await page.goto("/classifier");
+
+    // The page header is the disambiguating element — the site nav
+    // includes "Classifier" too, so we match the h1 specifically.
+    await expect(page.getByRole("heading", { name: "Classifier", level: 1 })).toBeVisible();
+
+    // Configuration summary shows the disabled state.
+    await expect(page.getByText("Disabled", { exact: false })).toBeVisible();
+
+    // Restart on a disabled worker reports the "stopped" outcome.
+    await page.getByRole("button", { name: /restart classifier worker/i }).click();
+    await expect(page.getByText(/stopped|already in progress/i, { exact: false })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Self-test on a non-operational config reports the disabled error.
+    await page.getByRole("button", { name: /test classifier/i }).click();
+    await expect(page.getByText(/disabled|operational/i, { exact: false })).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+});

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -33,6 +33,7 @@
     "tailwind-merge": "^2.6.0"
   },
   "devDependencies": {
+    "@librarian/classifier": "workspace:*",
     "@librarian/mcp-server": "workspace:*",
     "@next/eslint-plugin-next": "^15.1.4",
     "@playwright/test": "^1.49.1",

--- a/apps/dashboard/tests/components/site-nav.test.tsx
+++ b/apps/dashboard/tests/components/site-nav.test.tsx
@@ -37,6 +37,7 @@ const SECTIONS = [
   ["Archive", "/archive"],
   ["Logs", "/logs"],
   ["Curator", "/curator"],
+  ["Classifier", "/classifier"],
   ["Backups", "/backups"],
   ["Tokens", "/tokens"],
 ] as const;

--- a/packages/classifier/package.json
+++ b/packages/classifier/package.json
@@ -10,6 +10,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./catalog": {
+      "types": "./dist/catalog.d.ts",
+      "import": "./dist/catalog.js"
     }
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
         specifier: ^2.6.0
         version: 2.6.1
     devDependencies:
+      '@librarian/classifier':
+        specifier: workspace:*
+        version: link:../../packages/classifier
       '@librarian/mcp-server':
         specifier: workspace:*
         version: link:../../packages/mcp-server


### PR DESCRIPTION
## Summary

Slice 5 — final slice of [classifier-dashboard-config-plan.md](docs/specs/classifier-dashboard-config-plan.md). Tasks T5.1–T5.5 in one commit.

### Cockpit at `/classifier`

Mirrors `/curator`'s ergonomics:

- **`page.tsx`** — server-side fetch via `serverTRPC.classifierConfig.{config,workerState}`; renders summary + form + restart/self-test buttons in a responsive 2-column grid stacking below `lg`.
- **`ConfigSummary`** — disabled / enabled-incomplete / operational status, active provider-mode fields, yellow drift banner when `workerState.hasDrift` is true.
- **`ConfigForm`** — provider-mode radio toggles two field groups:
  - Remote: provider, endpoint, model, timeoutMs, masked token (`type=password`, empty submit preserves the stored token — form sends `token: undefined` when the box is untouched, sends `""` only when the admin explicitly clears it).
  - Local: `<select>` populated from `@librarian/classifier`'s `CATALOG` (model id, parameters, RAM), collapsible "Use a custom model identifier" `<details>` for HF identifiers outside the catalog, optional quant.
  - Shared `promptVersion` input (empty → null → classifier package default).
  - Cross-mode state preserved in component state.
- **`RestartWorkerButton`** — disabled while pending; renders a tone-coloured outcome message (Started / Stopped / Restarted / Already in progress / Failed: <reason>).
- **`SelfTestButton`** — tooltip warns about second-model-load on local mode. Result panel shows outcome / latency / parsed verdict / fallback reason.
- **Server actions** wrap the three tRPC mutations and `revalidatePath('/classifier')` after state-changing calls.

### Nav + palette

`Classifier` tab between Curator and Backups; "Go to Classifier" palette entry. Existing `site-nav.test.tsx` extended to assert the new entry.

### Playwright smoke

`e2e/classifier-cockpit.spec.ts` covers the disabled-state happy path (page loads → "Disabled" visible → restart → stopped outcome → self-test → not-operational error). Full LLM-stubbed happy path is a follow-up.

### Misc

- `@librarian/classifier` added to `apps/dashboard/package.json` (workspace dep) so CATALOG/DEFAULT_MODEL_ID resolve at compile time.
- CHANGELOG `[Unreleased]` updated under Added (cockpit, llm-connection helper, classifier-config, boot/restart/self-test, tRPC router) and Removed (`LIBRARIAN_CLASSIFIER_*` env vars).

## Test plan

- [x] `pnpm -r typecheck` — green
- [x] `pnpm -r test` — 470 core + 146 mcp-server + 161 dashboard, all green
- [x] `node scripts/check-classifier-env-retirement.mjs` — OK
- [x] Site-nav test extended for the new entry
- [ ] CI (incl. Playwright e2e)

Closes the classifier-dashboard-config plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)