### PR TITLE
fix(classifier): forward catalog hfRepo + clearer error when node-llama-cpp is missing

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -65,6 +65,22 @@ These are deployment-specific exercises against the canonical instance, not code
   isn't recorded; toggle back via `/lib-toggle-private` and confirm recording
   resumes.
 
+## Classifier — local mode lifecycle
+
+- **Surface installed local models on the cockpit + let operators delete
+  them.** `node-llama-cpp` caches downloaded GGUF files under its own
+  models dir; today there's no surface in the dashboard showing which
+  ones are present, how big they are, or which one the running worker
+  is using, and no way to evict an unwanted one short of shelling into
+  the container. Add a panel under `/classifier` that lists installed
+  models (path, size, last-used, whether currently loaded) and an
+  admin-only delete control. Probably wants a new tRPC procedure
+  `classifierConfig.localModels` returning the list and a `deleteLocalModel`
+  mutation, plus a `du`-style scan of the node-llama-cpp cache dir.
+  Block: deleting the currently-loaded model needs to either refuse, or
+  stop the worker first (probably the latter — feels right that the UI
+  flow is "switch to a different model → restart → delete the old one").
+
 ## Dashboard / UI polish
 
 Deliberate carve-outs from the dashboard redesign (D1.x) that needed a more careful
@@ -82,6 +98,20 @@ landing than the autonomous run had room for.
 
 ## Spec open questions (deferred)
 
+- **Collapse `is_global` into `domain` by renaming `general` → `global`.**
+  Drop the boolean entirely; let `domain="global"` carry "visible everywhere"
+  and leave every other domain isolated. Easier to reason about (1D pick
+  instead of a 2×2 truth table) and removes the existing trap where
+  `domain="general" & is_global=false` is invisible from work-area domains
+  despite "general" reading as "everywhere" to a human. Costs: lossy
+  migration for the `domain=X & is_global=true` combo (proposal: copy the
+  prior domain into an `origin-domain:<x>` tag), classifier output schema
+  change (`is_global` boolean → `domain` string), and prompt/eval-fixture
+  refresh. Pick up when operators repeatedly hit the
+  `domain=general & is_global=false` trap, when classifier-eval shows low
+  agreement on `is_global` verdicts, or when a new feature would compound
+  the two-axis complexity rather than collapse it.
+  _(raised 2026-05-29; parked pending real-usage evidence)_
 - **`harness_private` visibility.** Add later if sandbox/test traffic patterns
   demand it.
 - **Physical purge of soft-deleted sessions** — retention policy + admin UI (the

--- a/packages/mcp-server/src/classifier-startup.ts
+++ b/packages/mcp-server/src/classifier-startup.ts
@@ -18,11 +18,13 @@
 // T3.3 respectively; this file ships the boot-side machinery they
 // compose with.
 
+import { createRequire } from "node:module";
 import {
   type Classifier,
   type ClassifyResult,
   type LocalInferenceClient,
   type SelfTestResult,
+  catalogEntry,
   createClassifier,
   createWorkerInferenceClient,
   runSelfTest,
@@ -63,8 +65,17 @@ export interface BootClassifierWorkerInput {
    * Test-only injection seam for the local provider's inference factory.
    * Production callers omit this; the boot path calls
    * `createWorkerInferenceClient` directly.
+   *
+   * `hfRepo` is the HuggingFace repo identifier the catalog provides
+   * (e.g. `unsloth/Qwen3.5-0.8B-GGUF`) — the worker uses it to build
+   * the `hf:…` download URI. When the stored modelId is a catalog
+   * entry, the boot path looks up its `hfRepo` and forwards it here.
    */
-  _inferenceFor?: (cfg: { modelId: string; quant?: string }) => LocalInferenceClient;
+  _inferenceFor?: (cfg: {
+    modelId: string;
+    hfRepo?: string;
+    quant?: string;
+  }) => LocalInferenceClient;
 }
 
 interface RunningWorkerSlot {
@@ -269,10 +280,31 @@ function buildClassifierOrThrow(
     // local provider: capture the lifecycle handle BEFORE handing the
     // bare client to createClassifier (the factory consumes it and
     // doesn't expose the lifecycle externally).
+    //
+    // Probe `node-llama-cpp` first when we'd actually load the real
+    // worker. It's an optional dependency (~300MB native binary) and
+    // may not be installed on every deploy — surface a clear error here
+    // instead of letting the worker spawn and emit a generic
+    // `provider_unavailable`. Tests inject `_inferenceFor` and never
+    // touch the real worker, so the probe is skipped in that path.
+    if (input._inferenceFor === undefined) {
+      ensureNodeLlamaCppInstalled();
+    }
+
     const inferenceFor =
       input._inferenceFor ??
-      ((c: { modelId: string; quant?: string }) => createWorkerInferenceClient(c));
-    const inferenceCfg: { modelId: string; quant?: string } = { modelId: cfg.local.modelId };
+      ((c: { modelId: string; hfRepo?: string; quant?: string }) => createWorkerInferenceClient(c));
+
+    // If the stored modelId matches a catalog entry, forward its
+    // `hfRepo` so the worker can build the right `hf:<org>/<repo>`
+    // URI for node-llama-cpp's auto-download. A custom modelId
+    // (HF identifier supplied via the dashboard's escape hatch) is
+    // forwarded as-is; the worker falls back to `hf:${modelId}`.
+    const inferenceCfg: { modelId: string; hfRepo?: string; quant?: string } = {
+      modelId: cfg.local.modelId,
+    };
+    const entry = catalogEntry(cfg.local.modelId);
+    if (entry?.hfRepo) inferenceCfg.hfRepo = entry.hfRepo;
     if (cfg.local.quant !== null) inferenceCfg.quant = cfg.local.quant;
     const inferenceClient = inferenceFor(inferenceCfg);
     const providerCfg: Parameters<typeof createClassifier>[0] = {
@@ -290,6 +322,66 @@ function buildClassifierOrThrow(
 
 function noopLifecycle(): { terminate: () => Promise<void> } {
   return { terminate: async () => undefined };
+}
+
+// `node-llama-cpp` is an optional dependency (~300MB native binary kept
+// off cloud-only installs). We probe via `createRequire(...).resolve`
+// so the boundary error is clear ("install node-llama-cpp") rather than
+// the generic provider_unavailable the worker would emit when its
+// dynamic `import("node-llama-cpp")` throws inside a worker thread.
+//
+// `createRequire` is used rather than `import.meta.resolve` because the
+// latter isn't reliably exposed by every test runner. Both end up
+// hitting the same node-resolution algorithm.
+type Resolver = (specifier: string) => string;
+const defaultResolver: Resolver = (() => {
+  const require = createRequire(import.meta.url);
+  return (specifier) => require.resolve(specifier);
+})();
+
+let resolverOverride: Resolver | null = null;
+let nodeLlamaCppProbeCache: { ok: true } | { ok: false; error: string } | null = null;
+
+function ensureNodeLlamaCppInstalled(): void {
+  if (nodeLlamaCppProbeCache === null) {
+    const resolver = resolverOverride ?? defaultResolver;
+    try {
+      resolver("node-llama-cpp");
+      nodeLlamaCppProbeCache = { ok: true };
+    } catch {
+      nodeLlamaCppProbeCache = {
+        ok: false,
+        error:
+          "Local classifier mode requires the `node-llama-cpp` package " +
+          "(an optional dependency, ~300MB native binary). Install it on " +
+          "the server and redeploy: `pnpm add -w node-llama-cpp` from the " +
+          "monorepo root, or switch the classifier to remote mode in the " +
+          "/classifier cockpit.",
+      };
+    }
+  }
+  if (!nodeLlamaCppProbeCache.ok) {
+    throw new Error(nodeLlamaCppProbeCache.error);
+  }
+}
+
+/**
+ * Tests-only: clear the probe cache so a test override isn't pinned by
+ * a previous run's outcome. Not part of the production API.
+ */
+export function __resetNodeLlamaCppProbeForTests(): void {
+  nodeLlamaCppProbeCache = null;
+  resolverOverride = null;
+}
+
+/**
+ * Tests-only: install a fake module resolver so the probe can verify
+ * the "node-llama-cpp not installed" error path without uninstalling
+ * the real dependency.
+ */
+export function __setNodeLlamaCppResolverForTests(resolver: Resolver | null): void {
+  resolverOverride = resolver;
+  nodeLlamaCppProbeCache = null;
 }
 
 /**

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -34,7 +34,9 @@ export {
   restartClassifierWorker,
   runClassifierSelfTest,
   __resetClassifierRuntimeForTests,
+  __resetNodeLlamaCppProbeForTests,
   __resetRestartMutexForTests,
+  __setNodeLlamaCppResolverForTests,
 } from "./classifier-startup.js";
 export { PACKAGE_VERSION } from "./version.js";
 export {

--- a/packages/mcp-server/tests/classifier-self-test.test.ts
+++ b/packages/mcp-server/tests/classifier-self-test.test.ts
@@ -44,6 +44,34 @@ describe("runClassifierSelfTest", () => {
     expect(result.error).toMatch(/not operational|disabled|incomplete/i);
   });
 
+  it("surfaces an actionable error when local mode is selected but node-llama-cpp is missing", async () => {
+    // Drive the probe path by omitting `_inferenceFor`; install a stub
+    // resolver that pretends node-llama-cpp can't be found. The
+    // self-test should propagate the friendly install message instead
+    // of a bare `provider_unavailable`.
+    writeClassifierConfig(store!, {
+      enabled: true,
+      providerMode: "local",
+      local: { modelId: "qwen3.5-0.8b-instruct" },
+    });
+
+    const { __setNodeLlamaCppResolverForTests, __resetNodeLlamaCppProbeForTests } =
+      await import("@librarian/mcp-server");
+    __setNodeLlamaCppResolverForTests((specifier: string) => {
+      if (specifier === "node-llama-cpp") throw new Error("ERR_MODULE_NOT_FOUND");
+      return specifier;
+    });
+
+    try {
+      const result = await runClassifierSelfTest({ store: store! });
+      expect(result.outcome).toBe("error");
+      expect(result.error).toMatch(/node-llama-cpp/i);
+      expect(result.error).toMatch(/install/i);
+    } finally {
+      __resetNodeLlamaCppProbeForTests();
+    }
+  });
+
   it("reports outcome=ok when local classifier infers a parseable verdict", async () => {
     writeClassifierConfig(store!, {
       enabled: true,

--- a/packages/mcp-server/tests/classifier-startup.test.ts
+++ b/packages/mcp-server/tests/classifier-startup.test.ts
@@ -142,6 +142,65 @@ describe("bootClassifierWorker — store-driven", () => {
     await result!.worker.stop();
   });
 
+  it("forwards hfRepo from the catalog when modelId matches a catalog entry", async () => {
+    // Pick a known catalog entry — the boot path should look it up and
+    // forward `hfRepo` to the inference factory so node-llama-cpp can
+    // actually fetch from HuggingFace.
+    writeClassifierConfig(store!, {
+      enabled: true,
+      providerMode: "local",
+      local: { modelId: "qwen3.5-0.8b-instruct", quant: "Q4_K_M" },
+    });
+    const stubInferenceFor = vi.fn(() => ({
+      infer: async () => JSON.stringify({ requires_approval: false, is_global: false }),
+    }));
+    const result = bootClassifierWorker({
+      store: store!,
+      appendEvent: () => undefined,
+      env: {},
+      _inferenceFor: stubInferenceFor as never,
+    });
+    expect(result).not.toBeNull();
+    expect(stubInferenceFor).toHaveBeenCalledTimes(1);
+    const cfg = stubInferenceFor.mock.calls[0]![0] as {
+      modelId: string;
+      hfRepo?: string;
+      quant?: string;
+    };
+    expect(cfg.modelId).toBe("qwen3.5-0.8b-instruct");
+    expect(cfg.hfRepo).toBe("unsloth/Qwen3.5-0.8B-GGUF");
+    expect(cfg.quant).toBe("Q4_K_M");
+    await result!.worker.stop();
+  });
+
+  it("does NOT forward hfRepo for a custom (non-catalog) modelId", async () => {
+    // A custom HF identifier supplied via the dashboard's escape hatch:
+    // the boot path can't look it up in the catalog, so it forwards the
+    // modelId as-is and the worker falls back to `hf:${modelId}`.
+    writeClassifierConfig(store!, {
+      enabled: true,
+      providerMode: "local",
+      local: { modelId: "custom-org/custom-model-GGUF" },
+    });
+    const stubInferenceFor = vi.fn(() => ({
+      infer: async () => JSON.stringify({ requires_approval: false, is_global: false }),
+    }));
+    const result = bootClassifierWorker({
+      store: store!,
+      appendEvent: () => undefined,
+      env: {},
+      _inferenceFor: stubInferenceFor as never,
+    });
+    expect(result).not.toBeNull();
+    const cfg = stubInferenceFor.mock.calls[0]![0] as {
+      modelId: string;
+      hfRepo?: string;
+    };
+    expect(cfg.modelId).toBe("custom-org/custom-model-GGUF");
+    expect(cfg.hfRepo).toBeUndefined();
+    await result!.worker.stop();
+  });
+
   it("emits the env-retired notice when any LIBRARIAN_CLASSIFIER_* env is set", () => {
     const log = vi.fn();
     bootClassifierWorker({


### PR DESCRIPTION
## Summary

Two related bugs surfaced when a user picked a catalog model from the dashboard cockpit and got `provider_unavailable` from the self-test.

### Bug 1 — boot path dropped `hfRepo`

The local-worker host accepts `{ modelId, hfRepo?, quant? }` and resolves the model URI as `hf:\${hfRepo}` (e.g. `unsloth/Qwen3.5-0.8B-GGUF`) when present, falling back to `hf:\${modelId}` otherwise. Storage stores the catalog's **stable id** (e.g. `qwen3.5-0.8b-instruct`) which is NOT a real HF identifier, so `node-llama-cpp`'s auto-download was looking up a non-existent repo and failing.

**Fix:** `catalogEntry(modelId)` in classifier-startup's local branch, forward `entry.hfRepo` when found. Custom HF ids supplied via the dashboard's escape hatch pass through as-is — the worker falls back to `hf:\${modelId}` for those.

### Bug 2 — `node-llama-cpp` missing surfaced as generic `provider_unavailable`

`node-llama-cpp` is an `optionalDependencies` entry (~300MB native binary kept off cloud-only installs). When it's not present, the worker's dynamic `import("node-llama-cpp")` throws inside a worker thread and the self-test reports the unhelpful fallback reason.

**Fix:** probe via `createRequire(...).resolve("node-llama-cpp")` at boot time when we'd actually load the real worker (skipped when tests inject `_inferenceFor`). Throws an actionable error pointing the operator at `pnpm add -w node-llama-cpp` or switching to remote mode in the cockpit. Result panel shows the friendly message.

Probe is cached; `__resetNodeLlamaCppProbeForTests` / `__setNodeLlamaCppResolverForTests` seams let tests verify both the success and failure paths without uninstalling the real dep.

### Bonus

`docs/TODO.md` gets a new "Classifier — local mode lifecycle" section with the related operator request: a dashboard surface for listing / deleting installed local models from the node-llama-cpp cache.

## Test plan

- [x] Three new tests pin: catalog → hfRepo forwarding, custom-id pass-through, friendly install message.
- [x] All 149 mcp-server + 470 core + 161 dashboard tests pass.
- [x] Full repo typecheck green.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)