### PR TITLE
feat(backup): GitHub Releases sync target (A2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ changes from this point forward are catalogued here.
 
 ## [Unreleased]
 
+### Added
+
+- **GitHub Releases as a backup target.** Alongside S3-compatible storage, a
+  backup can now sync to a (private) GitHub repo: each bundle becomes a Release
+  (tag = bundle name) with the bundle's files attached as release assets. No new
+  dependency — it uses Node's built-in `fetch`; the fine-grained token is stored
+  encrypted and never appears in URLs, logs, or errors. Configure via
+  `backup.github.repo` / `backup.github.token` (dashboard or the
+  `LIBRARIAN_BACKUP_GITHUB_REPO` / `LIBRARIAN_BACKUP_GITHUB_TOKEN` env vars).
+
 ### Changed
 
 - **Backup bundles are now gzipped (`format_version` 2).** Each file in a

--- a/packages/core/src/backup/run.ts
+++ b/packages/core/src/backup/run.ts
@@ -7,13 +7,32 @@ import type { LibrarianStore } from "../store/librarian-store.js";
 import { type BackupManifest, createBackup } from "./backup.js";
 import { syncBundle } from "./sync/bundle.js";
 import { resolveS3SyncConfig } from "./sync/config.js";
+import { resolveGithubSyncConfig } from "./sync/github-config.js";
+import { createGithubTarget } from "./sync/github.js";
 import { createS3Target } from "./sync/s3.js";
+import type { BackupTarget } from "./sync/types.js";
+
+export type BackupTargetKind = "s3" | "github";
 
 export interface RunBackupResult {
   dir: string;
   manifest: BackupManifest;
   synced: boolean;
+  /** Which cloud target the bundle was synced to (omitted when not synced). */
+  target?: BackupTargetKind;
   syncedKeys?: string[];
+}
+
+// Resolve the single configured cloud target. S3 takes precedence over GitHub when
+// both are configured (one cloud target per run — see spec non-goals).
+async function resolveBackupTarget(
+  store: LibrarianStore,
+): Promise<{ kind: BackupTargetKind; target: BackupTarget } | null> {
+  const s3 = resolveS3SyncConfig(store);
+  if (s3) return { kind: "s3", target: await createS3Target(s3) };
+  const github = resolveGithubSyncConfig(store);
+  if (github) return { kind: "github", target: createGithubTarget(github) };
+  return null;
 }
 
 export async function runBackup(
@@ -23,10 +42,9 @@ export async function runBackup(
   const { dir, manifest } = createBackup(store, { destDir: options.destDir });
 
   if (options.sync === false) return { dir, manifest, synced: false };
-  const config = resolveS3SyncConfig(store);
-  if (!config) return { dir, manifest, synced: false };
+  const resolved = await resolveBackupTarget(store);
+  if (!resolved) return { dir, manifest, synced: false };
 
-  const target = await createS3Target(config);
-  const syncedKeys = await syncBundle(target, dir);
-  return { dir, manifest, synced: true, syncedKeys };
+  const syncedKeys = await syncBundle(resolved.target, dir);
+  return { dir, manifest, synced: true, target: resolved.kind, syncedKeys };
 }

--- a/packages/core/src/backup/sync/github-config.ts
+++ b/packages/core/src/backup/sync/github-config.ts
@@ -1,0 +1,38 @@
+// Resolve the GitHub Releases sync config from the settings store
+// (dashboard-configured, automated-backups A2/A6) with an env fallback (headless).
+// Returns null when not configured. Mirrors resolveS3SyncConfig.
+//
+// The token is a secret setting (encrypted at rest); reading it needs
+// LIBRARIAN_SECRET_KEY, so getSetting may throw — we fall back to env in that case.
+
+import type { LibrarianStore } from "../../store/librarian-store.js";
+
+export interface GithubSyncConfig {
+  /** "owner/repo" of a (private) repo whose Releases hold the backup bundles. */
+  repo: string;
+  /** A fine-grained PAT with contents read/write on the repo. */
+  token: string;
+}
+
+type SettingsReader = Pick<LibrarianStore, "getSetting">;
+
+function readSetting(store: SettingsReader, key: string): string {
+  try {
+    return store.getSetting(key) ?? "";
+  } catch {
+    return ""; // secret setting without a master key, or store error → fall back to env
+  }
+}
+
+export function resolveGithubSyncConfig(
+  store: SettingsReader,
+  env: NodeJS.ProcessEnv = process.env,
+): GithubSyncConfig | null {
+  const pick = (settingKey: string, envKey: string): string =>
+    readSetting(store, settingKey) || env[envKey] || "";
+
+  const repo = pick("backup.github.repo", "LIBRARIAN_BACKUP_GITHUB_REPO");
+  const token = pick("backup.github.token", "LIBRARIAN_BACKUP_GITHUB_TOKEN");
+  if (!repo || !token) return null;
+  return { repo, token };
+}

--- a/packages/core/src/backup/sync/github.ts
+++ b/packages/core/src/backup/sync/github.ts
@@ -40,6 +40,16 @@ function splitKey(name: string): [bundle: string, file: string] {
   return [name.slice(0, i), name.slice(i + 1)];
 }
 
+/** The `rel="next"` URL from a GitHub `Link` pagination header, or null. */
+function parseNextLink(linkHeader: string | null): string | null {
+  if (!linkHeader) return null;
+  for (const part of linkHeader.split(",")) {
+    const match = part.match(/<([^>]+)>\s*;\s*rel="next"/);
+    if (match?.[1]) return match[1];
+  }
+  return null;
+}
+
 export function createGithubTarget(config: GithubSyncConfig): BackupTarget {
   const slash = config.repo.indexOf("/");
   if (slash <= 0 || slash !== config.repo.lastIndexOf("/") || slash === config.repo.length - 1) {
@@ -108,7 +118,11 @@ export function createGithubTarget(config: GithubSyncConfig): BackupTarget {
     async put(name, data) {
       const [bundle, file] = splitKey(name);
       const release = await ensureRelease(bundle);
-      // Assets are immutable, so overwriting means delete-then-upload.
+      // Assets are immutable and names unique, so overwriting means delete-then-
+      // upload. If the upload then fails the bundle is left short a file — but each
+      // backup run writes a FRESH timestamped tag, so true overwrite only happens on
+      // a re-sync of the same bundle, and a torn bundle is caught at restore (its
+      // manifest checksum/presence check rejects the missing file).
       const existing = (release.assets ?? []).find((a) => a.name === file);
       if (existing) {
         await apiOk(
@@ -134,10 +148,14 @@ export function createGithubTarget(config: GithubSyncConfig): BackupTarget {
       const release = await getRelease(bundle);
       const asset = release && (release.assets ?? []).find((a) => a.name === file);
       if (!asset) throw new Error(`no asset ${JSON.stringify(file)} in backup ${bundle}`);
-      // The asset endpoint 302-redirects to a presigned storage URL. We follow it
-      // (redirect:"follow"): per the fetch spec the Authorization header is dropped
-      // on the cross-origin hop, so the token never reaches the storage host, and
-      // the presigned URL needs no auth. This is the one call that follows redirects.
+      // The asset endpoint 302-redirects to a presigned storage URL. This is the one
+      // call that follows redirects. Token safety relies on a runtime guarantee, NOT
+      // on us: Node's fetch (undici) strips `authorization` on a cross-origin redirect
+      // (per the WHATWG fetch redirect handling), so the PAT never reaches the storage
+      // host; the presigned URL needs no auth. We can't self-enforce a manual two-step
+      // here — undici's `redirect:"manual"` returns an opaque response with no readable
+      // `Location` — so this depends on the pinned Node runtime (package.json engines).
+      // The real download path is exercised by the A2 live smoke (see the plan).
       const res = await fetch(`${repoPath}/releases/assets/${asset.id}`, {
         redirect: "follow",
         headers: { ...authHeaders, accept: "application/octet-stream" },
@@ -147,21 +165,28 @@ export function createGithubTarget(config: GithubSyncConfig): BackupTarget {
     },
 
     async list(prefix = "") {
-      // Retention keeps a small number of bundles, so one page (100) is ample;
-      // assets are returned inline with each release.
-      const res = await apiOk(`${repoPath}/releases?per_page=100`, {}, "release list");
-      const releases = (await res.json()) as GithubRelease[];
+      // Page through EVERY backup Release (assets are returned inline). Following
+      // the `Link: rel="next"` header rather than reading a single page avoids
+      // silently truncating the listing once a repo accumulates >100 releases — a
+      // silent cap is the worst failure mode for a backup list (retention built on
+      // it would never see, and so never prune, the oldest bundles).
       const keys: string[] = [];
-      for (const release of releases) {
-        if (
-          typeof release.tag_name !== "string" ||
-          !release.tag_name.startsWith(BACKUP_TAG_PREFIX)
-        ) {
-          continue; // not one of ours
+      let url: string | null = `${repoPath}/releases?per_page=100`;
+      while (url) {
+        const res = await apiOk(url, {}, "release list");
+        const releases = (await res.json()) as GithubRelease[];
+        for (const release of releases) {
+          if (
+            typeof release.tag_name !== "string" ||
+            !release.tag_name.startsWith(BACKUP_TAG_PREFIX)
+          ) {
+            continue; // not one of ours
+          }
+          for (const asset of release.assets ?? []) {
+            keys.push(`${release.tag_name}/${asset.name}`);
+          }
         }
-        for (const asset of release.assets ?? []) {
-          keys.push(`${release.tag_name}/${asset.name}`);
-        }
+        url = parseNextLink(res.headers.get("link"));
       }
       return keys.filter((k) => k.startsWith(prefix)).sort();
     },

--- a/packages/core/src/backup/sync/github.ts
+++ b/packages/core/src/backup/sync/github.ts
@@ -77,6 +77,11 @@ export function createGithubTarget(config: GithubSyncConfig): BackupTarget {
     throw new Error(`GitHub ${action} failed (HTTP ${res.status})${detail ? `: ${detail}` : ""}`);
   }
 
+  // The common path: call and throw a teaching error on any non-2xx.
+  async function apiOk(url: string, init: RequestInit, action: string): Promise<Response> {
+    return ensureOk(await api(url, init), action);
+  }
+
   async function getRelease(tag: string): Promise<GithubRelease | null> {
     const res = await api(`${repoPath}/releases/tags/${encodeURIComponent(tag)}`);
     if (res.status === 404) return null;
@@ -87,12 +92,15 @@ export function createGithubTarget(config: GithubSyncConfig): BackupTarget {
   async function ensureRelease(tag: string): Promise<GithubRelease> {
     const existing = await getRelease(tag);
     if (existing) return existing;
-    const res = await api(`${repoPath}/releases`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ tag_name: tag, name: tag }),
-    });
-    await ensureOk(res, "release create");
+    const res = await apiOk(
+      `${repoPath}/releases`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ tag_name: tag, name: tag }),
+      },
+      "release create",
+    );
     return (await res.json()) as GithubRelease;
   }
 
@@ -103,18 +111,20 @@ export function createGithubTarget(config: GithubSyncConfig): BackupTarget {
       // Assets are immutable, so overwriting means delete-then-upload.
       const existing = (release.assets ?? []).find((a) => a.name === file);
       if (existing) {
-        await ensureOk(
-          await api(`${repoPath}/releases/assets/${existing.id}`, { method: "DELETE" }),
+        await apiOk(
+          `${repoPath}/releases/assets/${existing.id}`,
+          { method: "DELETE" },
           "asset delete (overwrite)",
         );
       }
       const url = `${uploadPath}/releases/${release.id}/assets?name=${encodeURIComponent(file)}`;
-      await ensureOk(
-        await api(url, {
+      await apiOk(
+        url,
+        {
           method: "POST",
           headers: { "content-type": "application/octet-stream" },
           body: data,
-        }),
+        },
         "asset upload",
       );
     },
@@ -139,8 +149,7 @@ export function createGithubTarget(config: GithubSyncConfig): BackupTarget {
     async list(prefix = "") {
       // Retention keeps a small number of bundles, so one page (100) is ample;
       // assets are returned inline with each release.
-      const res = await api(`${repoPath}/releases?per_page=100`);
-      await ensureOk(res, "release list");
+      const res = await apiOk(`${repoPath}/releases?per_page=100`, {}, "release list");
       const releases = (await res.json()) as GithubRelease[];
       const keys: string[] = [];
       for (const release of releases) {
@@ -160,10 +169,7 @@ export function createGithubTarget(config: GithubSyncConfig): BackupTarget {
     async deleteBundle(bundleName) {
       const release = await getRelease(bundleName);
       if (release) {
-        await ensureOk(
-          await api(`${repoPath}/releases/${release.id}`, { method: "DELETE" }),
-          "release delete",
-        );
+        await apiOk(`${repoPath}/releases/${release.id}`, { method: "DELETE" }, "release delete");
       }
       // Deleting a Release leaves its tag ref behind — remove it too, or retention
       // would prune Releases while orphan tags accumulate. 404/422 = already gone.

--- a/packages/core/src/backup/sync/github.ts
+++ b/packages/core/src/backup/sync/github.ts
@@ -1,0 +1,178 @@
+// GitHub Releases BackupTarget (automated-backups A2). A backup bundle is a
+// GitHub Release (tag = bundle name) with the bundle's files attached as release
+// ASSETS — assets live in GitHub's blob storage, not the git object database, so
+// each backup is an independent, deletable snapshot (no history rewrite, no bloat).
+//
+// Uses Node's global `fetch` — no SDK dependency. The bearer token lives only in
+// request headers; it never appears in URLs, logs, or error messages, and every
+// token-bearing call to api.github.com uses `redirect: "error"` so a 3xx can't
+// carry it cross-origin. (The one exception — asset download — is documented at
+// its call site.)
+//
+// Object keys follow the bundle convention `<bundleName>/<file>` used by
+// syncBundle/fetchBundle: the bundle is the tag, the file is the asset name.
+
+import type { GithubSyncConfig } from "./github-config.js";
+import type { BackupTarget } from "./types.js";
+
+const API = "https://api.github.com";
+const UPLOADS = "https://uploads.github.com";
+// Only Releases whose tag carries this prefix are treated as Librarian backups, so
+// the target never lists or deletes unrelated Releases in a shared repo.
+const BACKUP_TAG_PREFIX = "librarian-backup-";
+
+interface GithubAsset {
+  id: number;
+  name: string;
+}
+interface GithubRelease {
+  id: number;
+  tag_name: string;
+  assets?: GithubAsset[];
+}
+
+/** Split a `<bundleName>/<file>` key into its two parts. */
+function splitKey(name: string): [bundle: string, file: string] {
+  const i = name.indexOf("/");
+  if (i <= 0 || i === name.length - 1) {
+    throw new Error(`expected a "<bundle>/<file>" key, got ${JSON.stringify(name)}`);
+  }
+  return [name.slice(0, i), name.slice(i + 1)];
+}
+
+export function createGithubTarget(config: GithubSyncConfig): BackupTarget {
+  const slash = config.repo.indexOf("/");
+  if (slash <= 0 || slash !== config.repo.lastIndexOf("/") || slash === config.repo.length - 1) {
+    throw new Error(`invalid GitHub repo ${JSON.stringify(config.repo)} — expected "owner/repo"`);
+  }
+  const repoPath = `${API}/repos/${config.repo}`;
+  const uploadPath = `${UPLOADS}/repos/${config.repo}`;
+  const authHeaders: Record<string, string> = {
+    authorization: `Bearer ${config.token}`,
+    accept: "application/vnd.github+json",
+    "x-github-api-version": "2022-11-28",
+    "user-agent": "the-librarian-backup",
+  };
+
+  // A token-bearing api.github.com request. redirect:"error" keeps a 3xx from
+  // carrying the bearer token to another origin.
+  function api(url: string, init: RequestInit = {}): Promise<Response> {
+    return fetch(url, {
+      ...init,
+      redirect: "error",
+      headers: { ...authHeaders, ...(init.headers as Record<string, string> | undefined) },
+    });
+  }
+
+  // Throw a teaching error WITHOUT the token. GitHub never echoes the
+  // Authorization header, so a short slice of the body is safe and informative.
+  async function ensureOk(res: Response, action: string): Promise<Response> {
+    if (res.ok) return res;
+    let detail = "";
+    try {
+      detail = (await res.text()).slice(0, 300).replace(/\s+/g, " ").trim();
+    } catch {
+      // body already consumed / unreadable — status alone teaches enough
+    }
+    throw new Error(`GitHub ${action} failed (HTTP ${res.status})${detail ? `: ${detail}` : ""}`);
+  }
+
+  async function getRelease(tag: string): Promise<GithubRelease | null> {
+    const res = await api(`${repoPath}/releases/tags/${encodeURIComponent(tag)}`);
+    if (res.status === 404) return null;
+    await ensureOk(res, "release lookup");
+    return (await res.json()) as GithubRelease;
+  }
+
+  async function ensureRelease(tag: string): Promise<GithubRelease> {
+    const existing = await getRelease(tag);
+    if (existing) return existing;
+    const res = await api(`${repoPath}/releases`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ tag_name: tag, name: tag }),
+    });
+    await ensureOk(res, "release create");
+    return (await res.json()) as GithubRelease;
+  }
+
+  return {
+    async put(name, data) {
+      const [bundle, file] = splitKey(name);
+      const release = await ensureRelease(bundle);
+      // Assets are immutable, so overwriting means delete-then-upload.
+      const existing = (release.assets ?? []).find((a) => a.name === file);
+      if (existing) {
+        await ensureOk(
+          await api(`${repoPath}/releases/assets/${existing.id}`, { method: "DELETE" }),
+          "asset delete (overwrite)",
+        );
+      }
+      const url = `${uploadPath}/releases/${release.id}/assets?name=${encodeURIComponent(file)}`;
+      await ensureOk(
+        await api(url, {
+          method: "POST",
+          headers: { "content-type": "application/octet-stream" },
+          body: data,
+        }),
+        "asset upload",
+      );
+    },
+
+    async get(name) {
+      const [bundle, file] = splitKey(name);
+      const release = await getRelease(bundle);
+      const asset = release && (release.assets ?? []).find((a) => a.name === file);
+      if (!asset) throw new Error(`no asset ${JSON.stringify(file)} in backup ${bundle}`);
+      // The asset endpoint 302-redirects to a presigned storage URL. We follow it
+      // (redirect:"follow"): per the fetch spec the Authorization header is dropped
+      // on the cross-origin hop, so the token never reaches the storage host, and
+      // the presigned URL needs no auth. This is the one call that follows redirects.
+      const res = await fetch(`${repoPath}/releases/assets/${asset.id}`, {
+        redirect: "follow",
+        headers: { ...authHeaders, accept: "application/octet-stream" },
+      });
+      await ensureOk(res, "asset download");
+      return Buffer.from(await res.arrayBuffer());
+    },
+
+    async list(prefix = "") {
+      // Retention keeps a small number of bundles, so one page (100) is ample;
+      // assets are returned inline with each release.
+      const res = await api(`${repoPath}/releases?per_page=100`);
+      await ensureOk(res, "release list");
+      const releases = (await res.json()) as GithubRelease[];
+      const keys: string[] = [];
+      for (const release of releases) {
+        if (
+          typeof release.tag_name !== "string" ||
+          !release.tag_name.startsWith(BACKUP_TAG_PREFIX)
+        ) {
+          continue; // not one of ours
+        }
+        for (const asset of release.assets ?? []) {
+          keys.push(`${release.tag_name}/${asset.name}`);
+        }
+      }
+      return keys.filter((k) => k.startsWith(prefix)).sort();
+    },
+
+    async deleteBundle(bundleName) {
+      const release = await getRelease(bundleName);
+      if (release) {
+        await ensureOk(
+          await api(`${repoPath}/releases/${release.id}`, { method: "DELETE" }),
+          "release delete",
+        );
+      }
+      // Deleting a Release leaves its tag ref behind — remove it too, or retention
+      // would prune Releases while orphan tags accumulate. 404/422 = already gone.
+      const tagRes = await api(`${repoPath}/git/refs/tags/${encodeURIComponent(bundleName)}`, {
+        method: "DELETE",
+      });
+      if (!tagRes.ok && tagRes.status !== 404 && tagRes.status !== 422) {
+        await ensureOk(tagRes, "tag delete");
+      }
+    },
+  };
+}

--- a/packages/core/src/backup/sync/memory.ts
+++ b/packages/core/src/backup/sync/memory.ts
@@ -22,5 +22,11 @@ export function createMemoryBackupTarget(): MemoryBackupTarget {
     async list(prefix = "") {
       return [...objects.keys()].filter((key) => key.startsWith(prefix)).sort();
     },
+    async deleteBundle(bundleName) {
+      const prefix = `${bundleName}/`;
+      for (const key of [...objects.keys()]) {
+        if (key.startsWith(prefix)) objects.delete(key);
+      }
+    },
   };
 }

--- a/packages/core/src/backup/sync/s3.ts
+++ b/packages/core/src/backup/sync/s3.ts
@@ -15,6 +15,7 @@ interface AwsS3Module {
   PutObjectCommand: new (input: unknown) => unknown;
   GetObjectCommand: new (input: unknown) => unknown;
   ListObjectsV2Command: new (input: unknown) => unknown;
+  DeleteObjectCommand: new (input: unknown) => unknown;
 }
 
 export async function createS3Target(config: S3SyncConfig): Promise<BackupTarget> {
@@ -26,7 +27,13 @@ export async function createS3Target(config: S3SyncConfig): Promise<BackupTarget
       "@aws-sdk/client-s3 is not installed — run `npm i @aws-sdk/client-s3` to enable S3 backup sync",
     );
   }
-  const { S3Client, PutObjectCommand, GetObjectCommand, ListObjectsV2Command } = aws;
+  const {
+    S3Client,
+    PutObjectCommand,
+    GetObjectCommand,
+    ListObjectsV2Command,
+    DeleteObjectCommand,
+  } = aws;
 
   const client = new S3Client({
     region: config.region ?? "us-east-1",
@@ -34,6 +41,17 @@ export async function createS3Target(config: S3SyncConfig): Promise<BackupTarget
     credentials: { accessKeyId: config.accessKeyId, secretAccessKey: config.secretAccessKey },
   });
   const prefix = config.prefix ? `${config.prefix.replace(/\/+$/, "")}/` : "";
+
+  // Object names (relative to the configured prefix) under a list prefix.
+  async function listNames(p: string): Promise<string[]> {
+    const res = (await client.send(
+      new ListObjectsV2Command({ Bucket: config.bucket, Prefix: prefix + p }),
+    )) as { Contents?: { Key?: string }[] };
+    return (res.Contents ?? [])
+      .map((o) => o.Key ?? "")
+      .filter((k) => k.startsWith(prefix))
+      .map((k) => k.slice(prefix.length));
+  }
 
   return {
     async put(name, data) {
@@ -48,14 +66,12 @@ export async function createS3Target(config: S3SyncConfig): Promise<BackupTarget
       if (!res.Body) throw new Error(`empty object: ${name}`);
       return Buffer.from(await res.Body.transformToByteArray());
     },
-    async list(p = "") {
-      const res = (await client.send(
-        new ListObjectsV2Command({ Bucket: config.bucket, Prefix: prefix + p }),
-      )) as { Contents?: { Key?: string }[] };
-      return (res.Contents ?? [])
-        .map((o) => o.Key ?? "")
-        .filter((k) => k.startsWith(prefix))
-        .map((k) => k.slice(prefix.length));
+    list: listNames,
+    async deleteBundle(bundleName) {
+      const names = await listNames(`${bundleName}/`);
+      for (const name of names) {
+        await client.send(new DeleteObjectCommand({ Bucket: config.bucket, Key: prefix + name }));
+      }
     },
   };
 }

--- a/packages/core/src/backup/sync/types.ts
+++ b/packages/core/src/backup/sync/types.ts
@@ -10,4 +10,11 @@ export interface BackupTarget {
   get(name: string): Promise<Buffer>;
   /** List object names, optionally filtered by a `prefix`. */
   list(prefix?: string): Promise<string[]>;
+  /**
+   * Delete a whole bundle/snapshot — every object keyed `<bundleName>/<file>`.
+   * Retention's unit is the snapshot, not a single file; on object stores this is
+   * "delete the prefix's objects", on GitHub it's "delete the Release + its tag".
+   * Idempotent: deleting an absent bundle is a no-op.
+   */
+  deleteBundle(bundleName: string): Promise<void>;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -181,7 +181,9 @@ export { type MemoryBackupTarget, createMemoryBackupTarget } from "./backup/sync
 export { fetchBundle, syncBundle } from "./backup/sync/bundle.js";
 export { type S3SyncConfig, resolveS3SyncConfig } from "./backup/sync/config.js";
 export { createS3Target } from "./backup/sync/s3.js";
-export { type RunBackupResult, runBackup } from "./backup/run.js";
+export { type GithubSyncConfig, resolveGithubSyncConfig } from "./backup/sync/github-config.js";
+export { createGithubTarget } from "./backup/sync/github.js";
+export { type BackupTargetKind, type RunBackupResult, runBackup } from "./backup/run.js";
 export {
   type AgentTokenMeta,
   type CreatedAgentToken,

--- a/packages/core/tests/backup-github.test.ts
+++ b/packages/core/tests/backup-github.test.ts
@@ -1,0 +1,201 @@
+import { createGithubTarget, resolveGithubSyncConfig } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const REPO = "owner/backups";
+const TOKEN = "ghp_secret_token_value_do_not_leak";
+
+// A small stateful GitHub fake: Releases keyed by tag, each with named assets, plus
+// the set of tag refs. Enough of the REST surface for the target's put/get/list/
+// deleteBundle to round-trip without a network.
+function makeFakeGithub() {
+  let nextId = 1;
+  const releases = new Map<
+    string,
+    { id: number; tag_name: string; assets: Map<string, { id: number; data: Buffer }> }
+  >();
+  const tags = new Set<string>();
+  const apiRepo = `https://api.github.com/repos/${REPO}`;
+  const uploadsRepo = `https://uploads.github.com/repos/${REPO}`;
+
+  const esc = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const json = (status: number, body: unknown) =>
+    new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+  const serialize = (r: { id: number; tag_name: string; assets: Map<string, { id: number }> }) => ({
+    id: r.id,
+    tag_name: r.tag_name,
+    assets: [...r.assets].map(([name, a]) => ({ id: a.id, name })),
+  });
+
+  async function fakeFetch(input: RequestInfo | URL, init: RequestInit = {}): Promise<Response> {
+    const url = String(input);
+    const method = (init.method ?? "GET").toUpperCase();
+    const headers = (init.headers ?? {}) as Record<string, string>;
+    if (url.startsWith("https://api.github.com") && headers.authorization !== `Bearer ${TOKEN}`) {
+      return json(401, { message: "Bad credentials" });
+    }
+
+    let m: RegExpMatchArray | null;
+    if (method === "GET" && (m = url.match(new RegExp(`^${esc(apiRepo)}/releases/tags/(.+)$`)))) {
+      const rel = releases.get(decodeURIComponent(m[1]));
+      return rel ? json(200, serialize(rel)) : json(404, { message: "Not Found" });
+    }
+    if (method === "POST" && url === `${apiRepo}/releases`) {
+      const body = JSON.parse(String(init.body));
+      const rel = { id: nextId++, tag_name: body.tag_name as string, assets: new Map() };
+      releases.set(rel.tag_name, rel);
+      tags.add(rel.tag_name);
+      return json(201, serialize(rel));
+    }
+    if (
+      method === "POST" &&
+      (m = url.match(new RegExp(`^${esc(uploadsRepo)}/releases/(\\d+)/assets\\?name=(.+)$`)))
+    ) {
+      const rel = [...releases.values()].find((r) => r.id === Number(m![1]));
+      if (!rel) return json(404, { message: "Not Found" });
+      const name = decodeURIComponent(m[2]);
+      rel.assets.set(name, { id: nextId++, data: Buffer.from(init.body as Uint8Array) });
+      return json(201, { id: nextId, name });
+    }
+    if (
+      method === "DELETE" &&
+      (m = url.match(new RegExp(`^${esc(apiRepo)}/releases/assets/(\\d+)$`)))
+    ) {
+      for (const rel of releases.values())
+        for (const [name, a] of rel.assets) if (a.id === Number(m![1])) rel.assets.delete(name);
+      return new Response(null, { status: 204 });
+    }
+    if (
+      method === "GET" &&
+      (m = url.match(new RegExp(`^${esc(apiRepo)}/releases/assets/(\\d+)$`)))
+    ) {
+      for (const rel of releases.values())
+        for (const a of rel.assets.values())
+          if (a.id === Number(m![1])) return new Response(a.data, { status: 200 });
+      return json(404, { message: "Not Found" });
+    }
+    if (method === "GET" && url.startsWith(`${apiRepo}/releases?`)) {
+      return json(200, [...releases.values()].map(serialize));
+    }
+    if (method === "DELETE" && (m = url.match(new RegExp(`^${esc(apiRepo)}/releases/(\\d+)$`)))) {
+      for (const [tag, rel] of releases) if (rel.id === Number(m![1])) releases.delete(tag);
+      return new Response(null, { status: 204 });
+    }
+    if (
+      method === "DELETE" &&
+      (m = url.match(new RegExp(`^${esc(apiRepo)}/git/refs/tags/(.+)$`)))
+    ) {
+      const tag = decodeURIComponent(m[1]);
+      if (!tags.has(tag)) return json(404, { message: "Not Found" });
+      tags.delete(tag);
+      return new Response(null, { status: 204 });
+    }
+    return json(404, { message: `unhandled ${method} ${url}` });
+  }
+
+  return { fakeFetch, releases, tags, json };
+}
+
+describe("createGithubTarget (Releases)", () => {
+  let fake: ReturnType<typeof makeFakeGithub>;
+
+  beforeEach(() => {
+    fake = makeFakeGithub();
+    vi.stubGlobal("fetch", fake.fakeFetch);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  const target = () => createGithubTarget({ repo: REPO, token: TOKEN });
+
+  it("put creates a release with the file attached, and get returns the bytes", async () => {
+    const t = target();
+    await t.put("librarian-backup-A/events.jsonl", Buffer.from("hello"));
+    expect(fake.releases.has("librarian-backup-A")).toBe(true);
+    expect((await t.get("librarian-backup-A/events.jsonl")).toString()).toBe("hello");
+  });
+
+  it("put overwrites an existing asset", async () => {
+    const t = target();
+    await t.put("librarian-backup-A/f", Buffer.from("one"));
+    await t.put("librarian-backup-A/f", Buffer.from("two"));
+    expect((await t.get("librarian-backup-A/f")).toString()).toBe("two");
+    expect(fake.releases.get("librarian-backup-A")!.assets.size).toBe(1);
+  });
+
+  it("list returns <bundle>/<file> keys for backup releases only", async () => {
+    const t = target();
+    await t.put("librarian-backup-A/librarian.sqlite.gz", Buffer.from("x"));
+    await t.put("librarian-backup-B/events.jsonl.gz", Buffer.from("y"));
+    // A non-backup release must be ignored.
+    fake.releases.set("v1.0.0", {
+      id: 999,
+      tag_name: "v1.0.0",
+      assets: new Map([["app.zip", { id: 998, data: Buffer.from("z") }]]),
+    });
+
+    expect(await t.list()).toEqual([
+      "librarian-backup-A/librarian.sqlite.gz",
+      "librarian-backup-B/events.jsonl.gz",
+    ]);
+    expect(await t.list("librarian-backup-B/")).toEqual(["librarian-backup-B/events.jsonl.gz"]);
+  });
+
+  it("deleteBundle removes the release AND its tag (no orphan tag)", async () => {
+    const t = target();
+    await t.put("librarian-backup-A/f", Buffer.from("x"));
+    expect(fake.tags.has("librarian-backup-A")).toBe(true);
+
+    await t.deleteBundle("librarian-backup-A");
+    expect(fake.releases.has("librarian-backup-A")).toBe(false);
+    expect(fake.tags.has("librarian-backup-A")).toBe(false);
+    expect(await t.list()).toEqual([]);
+    await t.deleteBundle("librarian-backup-A"); // idempotent
+  });
+
+  it("never leaks the token in an error message", async () => {
+    vi.stubGlobal(
+      "fetch",
+      async () => new Response(JSON.stringify({ message: "forbidden" }), { status: 403 }),
+    );
+    const t = target();
+    const err = await t.put("librarian-backup-A/f", Buffer.from("x")).catch((e) => e as Error);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).not.toContain(TOKEN);
+    expect(err.message).toContain("403");
+  });
+
+  it("rejects a malformed repo", () => {
+    expect(() => createGithubTarget({ repo: "no-slash", token: TOKEN })).toThrow(/owner\/repo/);
+  });
+});
+
+describe("resolveGithubSyncConfig", () => {
+  const noSettings = { getSetting: () => null };
+
+  it("returns null when not configured", () => {
+    expect(resolveGithubSyncConfig(noSettings, {})).toBeNull();
+  });
+
+  it("resolves from env", () => {
+    expect(
+      resolveGithubSyncConfig(noSettings, {
+        LIBRARIAN_BACKUP_GITHUB_REPO: "o/r",
+        LIBRARIAN_BACKUP_GITHUB_TOKEN: "tok",
+      }),
+    ).toEqual({ repo: "o/r", token: "tok" });
+  });
+
+  it("prefers settings over env and tolerates a secret read that throws", () => {
+    const store = {
+      getSetting: (key: string) => {
+        if (key === "backup.github.token") throw new Error("no master key");
+        if (key === "backup.github.repo") return "from/settings";
+        return null;
+      },
+    };
+    const config = resolveGithubSyncConfig(store, {
+      LIBRARIAN_BACKUP_GITHUB_REPO: "from/env",
+      LIBRARIAN_BACKUP_GITHUB_TOKEN: "env-token", // settings read threw → env used
+    });
+    expect(config).toEqual({ repo: "from/settings", token: "env-token" });
+  });
+});

--- a/packages/core/tests/backup-github.test.ts
+++ b/packages/core/tests/backup-github.test.ts
@@ -151,6 +151,48 @@ describe("createGithubTarget (Releases)", () => {
     await t.deleteBundle("librarian-backup-A"); // idempotent
   });
 
+  it("list pages through every release via the Link: rel=next header", async () => {
+    const page = (id: number, tag: string, asset: string) => [
+      { id, tag_name: tag, assets: [{ id: id * 10, name: asset }] },
+    ];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("page=2")) {
+        return new Response(JSON.stringify(page(2, "librarian-backup-2", "b")), {
+          status: 200,
+          headers: { "content-type": "application/json" }, // no next → last page
+        });
+      }
+      return new Response(JSON.stringify(page(1, "librarian-backup-1", "a")), {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          link: `<https://api.github.com/repos/${REPO}/releases?per_page=100&page=2>; rel="next"`,
+        },
+      });
+    });
+    const t = target();
+    expect(await t.list()).toEqual(["librarian-backup-1/a", "librarian-backup-2/b"]);
+  });
+
+  it("ignores a release with no assets; get on a missing asset throws", async () => {
+    const t = target();
+    fake.releases.set("librarian-backup-empty", {
+      id: 50,
+      tag_name: "librarian-backup-empty",
+      assets: new Map(),
+    });
+    expect(await t.list()).toEqual([]);
+    await expect(t.get("librarian-backup-empty/events.jsonl")).rejects.toThrow(/no asset/);
+  });
+
+  it("deleteBundle removes a leftover tag even when the release is already gone", async () => {
+    const t = target();
+    fake.tags.add("librarian-backup-orphan"); // a tag with no Release (orphan)
+    await t.deleteBundle("librarian-backup-orphan");
+    expect(fake.tags.has("librarian-backup-orphan")).toBe(false);
+  });
+
   it("never leaks the token in an error message", async () => {
     vi.stubGlobal(
       "fetch",

--- a/packages/core/tests/backup-sync.test.ts
+++ b/packages/core/tests/backup-sync.test.ts
@@ -30,6 +30,17 @@ describe("BackupTarget contract (memory)", () => {
     expect(await t.list("a/")).toEqual(["a/x.txt", "a/y.txt"]);
     await expect(t.get("missing")).rejects.toThrow();
   });
+
+  it("deleteBundle removes only that bundle's objects", async () => {
+    const t = createMemoryBackupTarget();
+    await t.put("bundleA/x", Buffer.from("1"));
+    await t.put("bundleA/y", Buffer.from("2"));
+    await t.put("bundleB/z", Buffer.from("3"));
+    await t.deleteBundle("bundleA");
+    expect(await t.list()).toEqual(["bundleB/z"]);
+    await t.deleteBundle("nope"); // idempotent — absent bundle is a no-op
+    expect(await t.list()).toEqual(["bundleB/z"]);
+  });
 });
 
 describe("syncBundle / fetchBundle", () => {


### PR DESCRIPTION
## What (A2 of automated-backups, plan 034)

Adds a **GitHub Releases** cloud backup target alongside S3. A backup bundle becomes a GitHub **Release** (tag = bundle name) with the bundle's files attached as release **assets** — assets live in GitHub's blob storage, not the git object DB, so each backup is an independent, deletable snapshot (no history rewrite/bloat).

- Implemented over Node's global `fetch` — **no SDK dependency**.
- Bearer token lives only in request headers — never in URLs, logs, or errors. Token-bearing `api.github.com` calls use `redirect:"error"`; the one asset-download `GET` follows the presigned cross-origin redirect, where undici strips `Authorization`.
- New `deleteBundle(bundleName)` on the `BackupTarget` contract (retention's unit is the whole snapshot): memory (test double), S3 (delete the prefix's objects), GitHub (delete the Release **and** its tag — no orphan tags).
- `list()` paginates via the `Link: rel="next"` header (no silent 100-release truncation).
- `runBackup` resolves a single cloud target (S3 preferred, else GitHub).

Config: `backup.github.repo` (plain) + `backup.github.token` (secret), env fallback `LIBRARIAN_BACKUP_GITHUB_{REPO,TOKEN}`.

## Tests

Full GitHub target contract against a stateful mocked `fetch`: put creates release+asset, get returns bytes, overwrite, list (backup-releases-only + pagination), deleteBundle removes release+tag, orphan-tag cleanup, no-assets release, token-never-in-errors, malformed repo. Plus `deleteBundle` on the memory target and `resolveGithubSyncConfig` (env/settings/throw). Full suite green.

## Note

The A2 plan's **live smoke against a real private repo + PAT** was not run autonomously (no creds in this run) — it's logged as a deferred operator step. The mock-based contract tests are CI-runnable and cover the surface.

Implements A2 of `docs/specs/034-automated-backups-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)