### PR TITLE
feat(backup): dashboard-managed schedule + run health (A3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ changes from this point forward are catalogued here.
   encrypted and never appears in URLs, logs, or errors. Configure via
   `backup.github.repo` / `backup.github.token` (dashboard or the
   `LIBRARIAN_BACKUP_GITHUB_REPO` / `LIBRARIAN_BACKUP_GITHUB_TOKEN` env vars).
+- **Dashboard-managed backup schedule + run health.** The backup cadence,
+  target, retention count, and an optional failure-alert webhook now live in
+  admin settings (no redeploy to change). Each scheduled or manual backup
+  records a `backup_runs` row (status, target, bytes, error, timestamps); the
+  server runs a backup once the configured interval has elapsed, recovers a run
+  left in-flight by a crash, and POSTs a generic-JSON alert to the webhook on
+  failure. The schedule ships disabled by default; the legacy
+  `LIBRARIAN_BACKUP_INTERVAL_MS` still enables backups for headless installs.
 
 ### Changed
 

--- a/packages/core/src/backup/config.ts
+++ b/packages/core/src/backup/config.ts
@@ -1,0 +1,133 @@
+// Backup schedule + retention + alert config (automated-backups A3), stored in
+// the admin settings table so the dashboard can change it without a redeploy.
+// The scheduler tick self-gates on `enabled`; `target` selects the cloud sync
+// destination; `retentionKeep` bounds how many bundles are kept (pruned in A4);
+// `webhookUrl` (optional) is POSTed on a failed run.
+//
+// Back-compat: a headless install that set the legacy `LIBRARIAN_BACKUP_INTERVAL_MS`
+// env var (016 B4) and never touched the dashboard keeps working — when no
+// `backup.schedule.*` setting exists, the env var supplies enabled + interval.
+
+import { z } from "zod";
+import type { LibrarianStore } from "../store/librarian-store.js";
+import { resolveS3SyncConfig } from "./sync/config.js";
+import { resolveGithubSyncConfig } from "./sync/github-config.js";
+
+const KEYS = {
+  enabled: "backup.schedule.enabled",
+  intervalMinutes: "backup.schedule.interval_minutes",
+  target: "backup.target",
+  retentionKeep: "backup.retention.keep",
+  webhookUrl: "backup.alert.webhook_url",
+} as const;
+
+const DEFAULT_INTERVAL_MINUTES = 1440; // daily
+const MIN_INTERVAL_MINUTES = 1;
+const DEFAULT_RETENTION_KEEP = 14;
+const MIN_RETENTION_KEEP = 1;
+
+export type BackupTargetSelection = "local" | "s3" | "github";
+const TARGET_SELECTIONS: readonly BackupTargetSelection[] = ["local", "s3", "github"];
+
+export interface BackupConfig {
+  /** Whether the scheduler runs backups on a cadence. */
+  enabled: boolean;
+  /** Whole minutes between scheduled backups (>= 1). */
+  intervalMinutes: number;
+  /** Cloud sync destination ('local' = no cloud sync). */
+  target: BackupTargetSelection;
+  /** How many bundles to keep per target before pruning (A4). */
+  retentionKeep: number;
+  /** Failure-alert webhook URL ('' = disabled). */
+  webhookUrl: string;
+}
+
+type SettingsReader = Pick<LibrarianStore, "getSetting">;
+type SettingsWriter = Pick<LibrarianStore, "setSetting">;
+
+function readSetting(store: SettingsReader, key: string): string | null {
+  try {
+    return store.getSetting(key);
+  } catch {
+    return null; // plain setting read failures degrade to "unset"
+  }
+}
+
+function parsePositiveInt(value: string | null, fallback: number, min: number): number {
+  if (value === null) return fallback;
+  const n = Number(value);
+  return Number.isFinite(n) && Number.isInteger(n) && n >= min ? n : fallback;
+}
+
+// 'local'|'s3'|'github' when explicitly set; otherwise inferred from which cloud
+// credentials are present (back-compat for env-only S3/GitHub setups).
+function resolveTargetSelection(
+  store: SettingsReader,
+  explicit: string | null,
+  env: NodeJS.ProcessEnv,
+): BackupTargetSelection {
+  if (explicit && (TARGET_SELECTIONS as readonly string[]).includes(explicit)) {
+    return explicit as BackupTargetSelection;
+  }
+  if (resolveS3SyncConfig(store, env)) return "s3";
+  if (resolveGithubSyncConfig(store, env)) return "github";
+  return "local";
+}
+
+export function readBackupConfig(
+  store: SettingsReader,
+  env: NodeJS.ProcessEnv = process.env,
+): BackupConfig {
+  const enabledSetting = readSetting(store, KEYS.enabled);
+  const intervalSetting = readSetting(store, KEYS.intervalMinutes);
+
+  // Legacy fallback: env interval drives enabled + cadence only when the dashboard
+  // has never configured a schedule.
+  const legacyMs = Number(env.LIBRARIAN_BACKUP_INTERVAL_MS ?? 0);
+  const legacyEnabled = enabledSetting === null && Number.isFinite(legacyMs) && legacyMs > 0;
+
+  const enabled = enabledSetting === null ? legacyEnabled : enabledSetting === "true";
+  const intervalMinutes =
+    intervalSetting !== null
+      ? parsePositiveInt(intervalSetting, DEFAULT_INTERVAL_MINUTES, MIN_INTERVAL_MINUTES)
+      : legacyEnabled
+        ? Math.max(MIN_INTERVAL_MINUTES, Math.round(legacyMs / 60_000))
+        : DEFAULT_INTERVAL_MINUTES;
+
+  return {
+    enabled,
+    intervalMinutes,
+    target: resolveTargetSelection(store, readSetting(store, KEYS.target), env),
+    retentionKeep: parsePositiveInt(
+      readSetting(store, KEYS.retentionKeep),
+      DEFAULT_RETENTION_KEEP,
+      MIN_RETENTION_KEEP,
+    ),
+    webhookUrl: readSetting(store, KEYS.webhookUrl) ?? "",
+  };
+}
+
+export const BackupConfigPatchSchema = z.strictObject({
+  enabled: z.boolean().optional(),
+  intervalMinutes: z.number().int().min(MIN_INTERVAL_MINUTES).optional(),
+  target: z.enum(["local", "s3", "github"]).optional(),
+  retentionKeep: z.number().int().min(MIN_RETENTION_KEEP).optional(),
+  webhookUrl: z.string().optional(),
+});
+export type BackupConfigPatch = z.infer<typeof BackupConfigPatchSchema>;
+
+export function writeBackupConfig(store: SettingsWriter, patch: BackupConfigPatch): void {
+  const p = BackupConfigPatchSchema.parse(patch);
+  if (p.webhookUrl && !/^https?:\/\//i.test(p.webhookUrl)) {
+    throw new Error(
+      `webhook URL must start with http:// or https://, got ${JSON.stringify(p.webhookUrl)}`,
+    );
+  }
+  if (p.enabled !== undefined) store.setSetting(KEYS.enabled, p.enabled ? "true" : "false");
+  if (p.intervalMinutes !== undefined) {
+    store.setSetting(KEYS.intervalMinutes, String(p.intervalMinutes));
+  }
+  if (p.target !== undefined) store.setSetting(KEYS.target, p.target);
+  if (p.retentionKeep !== undefined) store.setSetting(KEYS.retentionKeep, String(p.retentionKeep));
+  if (p.webhookUrl !== undefined) store.setSetting(KEYS.webhookUrl, p.webhookUrl);
+}

--- a/packages/core/src/backup/config.ts
+++ b/packages/core/src/backup/config.ts
@@ -59,6 +59,20 @@ function parsePositiveInt(value: string | null, fallback: number, min: number): 
   return Number.isFinite(n) && Number.isInteger(n) && n >= min ? n : fallback;
 }
 
+// The schedule setting wins; otherwise the legacy env interval (when it's driving
+// `enabled`); otherwise the default cadence.
+function resolveIntervalMinutes(
+  intervalSetting: string | null,
+  legacyEnabled: boolean,
+  legacyMs: number,
+): number {
+  if (intervalSetting !== null) {
+    return parsePositiveInt(intervalSetting, DEFAULT_INTERVAL_MINUTES, MIN_INTERVAL_MINUTES);
+  }
+  if (legacyEnabled) return Math.max(MIN_INTERVAL_MINUTES, Math.round(legacyMs / 60_000));
+  return DEFAULT_INTERVAL_MINUTES;
+}
+
 // 'local'|'s3'|'github' when explicitly set; otherwise inferred from which cloud
 // credentials are present (back-compat for env-only S3/GitHub setups).
 function resolveTargetSelection(
@@ -87,16 +101,10 @@ export function readBackupConfig(
   const legacyEnabled = enabledSetting === null && Number.isFinite(legacyMs) && legacyMs > 0;
 
   const enabled = enabledSetting === null ? legacyEnabled : enabledSetting === "true";
-  const intervalMinutes =
-    intervalSetting !== null
-      ? parsePositiveInt(intervalSetting, DEFAULT_INTERVAL_MINUTES, MIN_INTERVAL_MINUTES)
-      : legacyEnabled
-        ? Math.max(MIN_INTERVAL_MINUTES, Math.round(legacyMs / 60_000))
-        : DEFAULT_INTERVAL_MINUTES;
 
   return {
     enabled,
-    intervalMinutes,
+    intervalMinutes: resolveIntervalMinutes(intervalSetting, legacyEnabled, legacyMs),
     target: resolveTargetSelection(store, readSetting(store, KEYS.target), env),
     retentionKeep: parsePositiveInt(
       readSetting(store, KEYS.retentionKeep),

--- a/packages/core/src/backup/run.ts
+++ b/packages/core/src/backup/run.ts
@@ -1,10 +1,14 @@
-// Orchestrate a backup: create the local bundle, then (if cloud sync is
-// configured) upload it. Async, so it runs from the server scheduler + the admin
-// tRPC surface (not the synchronous CLI). Sync failures do not lose the local
-// backup — the bundle is already on disk before the upload is attempted.
+// Orchestrate a backup: create the local bundle, then (if a cloud target is
+// configured) upload it — recording run health (automated-backups A3) and, on
+// failure, firing the optional alert webhook. Async, so it runs from the server
+// scheduler + the admin tRPC surface (not the synchronous CLI). Sync failures do
+// not lose the local backup — the bundle is already on disk before the upload.
 
+import path from "node:path";
 import type { LibrarianStore } from "../store/librarian-store.js";
 import { type BackupManifest, createBackup } from "./backup.js";
+import { type BackupConfig, readBackupConfig } from "./config.js";
+import { type BackupRunTrigger, finishBackupRun, latestBackupRun, startBackupRun } from "./runs.js";
 import { syncBundle } from "./sync/bundle.js";
 import { resolveS3SyncConfig } from "./sync/config.js";
 import { resolveGithubSyncConfig } from "./sync/github-config.js";
@@ -23,28 +27,98 @@ export interface RunBackupResult {
   syncedKeys?: string[];
 }
 
-// Resolve the single configured cloud target. S3 takes precedence over GitHub when
-// both are configured (one cloud target per run — see spec non-goals).
+// Resolve the cloud target the config selects ('local' → no sync). A selected
+// target whose credentials are missing resolves to null (the run records
+// synced=false rather than failing).
 async function resolveBackupTarget(
   store: LibrarianStore,
+  config: BackupConfig,
 ): Promise<{ kind: BackupTargetKind; target: BackupTarget } | null> {
-  const s3 = resolveS3SyncConfig(store);
-  if (s3) return { kind: "s3", target: await createS3Target(s3) };
-  const github = resolveGithubSyncConfig(store);
-  if (github) return { kind: "github", target: createGithubTarget(github) };
+  if (config.target === "s3") {
+    const s3 = resolveS3SyncConfig(store);
+    return s3 ? { kind: "s3", target: await createS3Target(s3) } : null;
+  }
+  if (config.target === "github") {
+    const github = resolveGithubSyncConfig(store);
+    return github ? { kind: "github", target: createGithubTarget(github) } : null;
+  }
   return null;
+}
+
+// Best-effort failure alert. Generic JSON, failure-only, no secrets (backup error
+// messages are already token-scrubbed). A webhook failure must never mask — or be
+// masked by — the backup failure, so it is fully swallowed.
+async function fireFailureWebhook(config: BackupConfig, error: string): Promise<void> {
+  if (!config.webhookUrl) return;
+  try {
+    await fetch(config.webhookUrl, {
+      method: "POST",
+      redirect: "error",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        event: "backup.failed",
+        at: new Date().toISOString(),
+        target: config.target,
+        error,
+      }),
+    });
+  } catch {
+    // best-effort
+  }
 }
 
 export async function runBackup(
   store: LibrarianStore,
-  options: { destDir: string; sync?: boolean },
+  options: { destDir: string; sync?: boolean; trigger?: BackupRunTrigger },
 ): Promise<RunBackupResult> {
-  const { dir, manifest } = createBackup(store, { destDir: options.destDir });
+  const config = readBackupConfig(store);
+  const runId = startBackupRun(store, options.trigger ?? "scheduled");
+  try {
+    const { dir, manifest } = createBackup(store, { destDir: options.destDir });
+    const bytes = manifest.files.reduce((sum, file) => sum + file.bytes, 0);
+    const bundle = path.basename(dir);
 
-  if (options.sync === false) return { dir, manifest, synced: false };
-  const resolved = await resolveBackupTarget(store);
-  if (!resolved) return { dir, manifest, synced: false };
+    const result: RunBackupResult = { dir, manifest, synced: false };
+    if (options.sync !== false) {
+      const resolved = await resolveBackupTarget(store, config);
+      if (resolved) {
+        result.syncedKeys = await syncBundle(resolved.target, dir);
+        result.synced = true;
+        result.target = resolved.kind;
+      }
+    }
 
-  const syncedKeys = await syncBundle(resolved.target, dir);
-  return { dir, manifest, synced: true, target: resolved.kind, syncedKeys };
+    finishBackupRun(store, runId, {
+      status: "ok",
+      target: result.target ?? "local",
+      bundle,
+      bytes,
+      synced: result.synced,
+    });
+    return result;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    finishBackupRun(store, runId, { status: "error", error: message });
+    await fireFailureWebhook(config, message);
+    throw err;
+  }
+}
+
+// Scheduler tick: self-gates on the stored config (disabled → cheap no-op) and
+// only runs when `intervalMinutes` has elapsed since the LAST run (any status, so
+// a failing backup backs off to the cadence instead of hammering). Mirrors the
+// curator tick — safe to always start.
+export async function runBackupTick(
+  store: LibrarianStore,
+  options: { destDir: string },
+): Promise<void> {
+  const config = readBackupConfig(store);
+  if (!config.enabled) return;
+
+  const last = latestBackupRun(store);
+  if (last) {
+    const elapsedMinutes = (Date.now() - new Date(last.created_at).getTime()) / 60_000;
+    if (elapsedMinutes < config.intervalMinutes) return;
+  }
+  await runBackup(store, { destDir: options.destDir, trigger: "scheduled" });
 }

--- a/packages/core/src/backup/run.ts
+++ b/packages/core/src/backup/run.ts
@@ -8,7 +8,13 @@ import path from "node:path";
 import type { LibrarianStore } from "../store/librarian-store.js";
 import { type BackupManifest, createBackup } from "./backup.js";
 import { type BackupConfig, readBackupConfig } from "./config.js";
-import { type BackupRunTrigger, finishBackupRun, latestBackupRun, startBackupRun } from "./runs.js";
+import {
+  type BackupRunTrigger,
+  finishBackupRun,
+  latestTerminalBackupRun,
+  reconcileStaleBackupRuns,
+  startBackupRun,
+} from "./runs.js";
 import { syncBundle } from "./sync/bundle.js";
 import { resolveS3SyncConfig } from "./sync/config.js";
 import { resolveGithubSyncConfig } from "./sync/github-config.js";
@@ -105,9 +111,10 @@ export async function runBackup(
 }
 
 // Scheduler tick: self-gates on the stored config (disabled → cheap no-op) and
-// only runs when `intervalMinutes` has elapsed since the LAST run (any status, so
-// a failing backup backs off to the cadence instead of hammering). Mirrors the
-// curator tick — safe to always start.
+// only runs when `intervalMinutes` has elapsed since the last COMPLETED run — so a
+// long-running backup doesn't shrink the next interval, and a failed run backs off
+// to the cadence instead of hammering. First reconciles any run left `running` by a
+// crash. Mirrors the curator tick — safe to always start.
 export async function runBackupTick(
   store: LibrarianStore,
   options: { destDir: string },
@@ -115,9 +122,11 @@ export async function runBackupTick(
   const config = readBackupConfig(store);
   if (!config.enabled) return;
 
-  const last = latestBackupRun(store);
-  if (last) {
-    const elapsedMinutes = (Date.now() - new Date(last.created_at).getTime()) / 60_000;
+  reconcileStaleBackupRuns(store);
+
+  const last = latestTerminalBackupRun(store);
+  if (last?.completed_at) {
+    const elapsedMinutes = (Date.now() - new Date(last.completed_at).getTime()) / 60_000;
     if (elapsedMinutes < config.intervalMinutes) return;
   }
   await runBackup(store, { destDir: options.destDir, trigger: "scheduled" });

--- a/packages/core/src/backup/runs.ts
+++ b/packages/core/src/backup/runs.ts
@@ -94,10 +94,35 @@ export function listBackupRuns(store: RunsStore, limit = 10): BackupRun[] {
   return rows.map(rowToRun);
 }
 
-/** The latest run of any status (used by the scheduler to decide if one is due). */
-export function latestBackupRun(store: RunsStore): BackupRun | null {
+// A backup running longer than this was almost certainly killed mid-run (process
+// crash / container restart). The scheduler is serial, so the only other in-flight
+// run is a manual "Backup now", which completes in seconds/minutes — well under
+// this — so a `running` row older than the TTL is safe to reclaim.
+const STALE_RUN_TTL_MS = 60 * 60_000;
+
+/**
+ * Reconcile any run left `running` past the stale TTL (a crash between
+ * start/finish) to `error`, so it stops showing as a phantom in-flight run and the
+ * dashboard's failure surface is accurate. `completed_at` is set to the run's own
+ * `created_at` so the scheduler's interval gate measures from the crash, not now.
+ */
+export function reconcileStaleBackupRuns(store: RunsStore): void {
+  const cutoff = new Date(Date.now() - STALE_RUN_TTL_MS).toISOString();
+  store.db
+    .prepare(
+      `UPDATE backup_runs
+         SET status = 'error', error = 'stale_run_reclaimed', completed_at = created_at
+       WHERE status = 'running' AND created_at < ?`,
+    )
+    .run(cutoff);
+}
+
+/** The most recent terminal (ok/error) run — what the scheduler gates the cadence on. */
+export function latestTerminalBackupRun(store: RunsStore): BackupRun | null {
   const row = store.db
-    .prepare(`SELECT * FROM backup_runs ORDER BY created_at DESC LIMIT 1`)
+    .prepare(
+      `SELECT * FROM backup_runs WHERE status IN ('ok', 'error') ORDER BY created_at DESC LIMIT 1`,
+    )
     .get() as unknown as BackupRunRow | undefined;
   return row ? rowToRun(row) : null;
 }

--- a/packages/core/src/backup/runs.ts
+++ b/packages/core/src/backup/runs.ts
@@ -1,0 +1,111 @@
+// Backup run health (automated-backups A3). Every scheduled or manual backup
+// records a row in the SQLite-authoritative `backup_runs` table (mirrors
+// `memory_curation_runs`): a `running` row at start, updated to `ok`/`error` at
+// the end. The dashboard reads these to show the last successful backup and to
+// alert on the most recent failure.
+
+import { randomUUID } from "node:crypto";
+import type { LibrarianStore } from "../store/librarian-store.js";
+
+export type BackupRunStatus = "running" | "ok" | "error";
+export type BackupRunTrigger = "scheduled" | "manual";
+
+export interface BackupRun {
+  id: string;
+  status: BackupRunStatus;
+  trigger: BackupRunTrigger;
+  target: string | null;
+  bundle: string | null;
+  bytes: number;
+  synced: boolean;
+  error: string | null;
+  created_at: string;
+  started_at: string | null;
+  completed_at: string | null;
+}
+
+export interface FinishBackupRun {
+  status: "ok" | "error";
+  target?: string | null;
+  bundle?: string | null;
+  bytes?: number;
+  synced?: boolean;
+  error?: string | null;
+}
+
+type RunsStore = Pick<LibrarianStore, "db">;
+
+interface BackupRunRow {
+  id: string;
+  status: BackupRunStatus;
+  trigger: BackupRunTrigger;
+  target: string | null;
+  bundle: string | null;
+  bytes: number;
+  synced: number;
+  error: string | null;
+  created_at: string;
+  started_at: string | null;
+  completed_at: string | null;
+}
+
+function rowToRun(row: BackupRunRow): BackupRun {
+  return { ...row, synced: row.synced !== 0 };
+}
+
+/** Insert a `running` row and return its id. */
+export function startBackupRun(store: RunsStore, trigger: BackupRunTrigger): string {
+  const id = `bkp_${randomUUID()}`;
+  const now = new Date().toISOString();
+  store.db
+    .prepare(
+      `INSERT INTO backup_runs (id, status, trigger, bytes, synced, created_at, started_at)
+       VALUES (?, 'running', ?, 0, 0, ?, ?)`,
+    )
+    .run(id, trigger, now, now);
+  return id;
+}
+
+/** Update a run to its terminal `ok`/`error` state. */
+export function finishBackupRun(store: RunsStore, id: string, result: FinishBackupRun): void {
+  store.db
+    .prepare(
+      `UPDATE backup_runs
+         SET status = ?, target = ?, bundle = ?, bytes = ?, synced = ?, error = ?, completed_at = ?
+       WHERE id = ?`,
+    )
+    .run(
+      result.status,
+      result.target ?? null,
+      result.bundle ?? null,
+      result.bytes ?? 0,
+      result.synced ? 1 : 0,
+      result.error ?? null,
+      new Date().toISOString(),
+      id,
+    );
+}
+
+/** Most-recent runs first, capped at `limit` (default 10). */
+export function listBackupRuns(store: RunsStore, limit = 10): BackupRun[] {
+  const rows = store.db
+    .prepare(`SELECT * FROM backup_runs ORDER BY created_at DESC LIMIT ?`)
+    .all(limit) as unknown as BackupRunRow[];
+  return rows.map(rowToRun);
+}
+
+/** The latest run of any status (used by the scheduler to decide if one is due). */
+export function latestBackupRun(store: RunsStore): BackupRun | null {
+  const row = store.db
+    .prepare(`SELECT * FROM backup_runs ORDER BY created_at DESC LIMIT 1`)
+    .get() as unknown as BackupRunRow | undefined;
+  return row ? rowToRun(row) : null;
+}
+
+/** The most recent successful run, or null. */
+export function lastSuccessfulBackupRun(store: RunsStore): BackupRun | null {
+  const row = store.db
+    .prepare(`SELECT * FROM backup_runs WHERE status = 'ok' ORDER BY created_at DESC LIMIT 1`)
+    .get() as unknown as BackupRunRow | undefined;
+  return row ? rowToRun(row) : null;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -183,7 +183,27 @@ export { type S3SyncConfig, resolveS3SyncConfig } from "./backup/sync/config.js"
 export { createS3Target } from "./backup/sync/s3.js";
 export { type GithubSyncConfig, resolveGithubSyncConfig } from "./backup/sync/github-config.js";
 export { createGithubTarget } from "./backup/sync/github.js";
-export { type BackupTargetKind, type RunBackupResult, runBackup } from "./backup/run.js";
+export {
+  type BackupTargetKind,
+  type RunBackupResult,
+  runBackup,
+  runBackupTick,
+} from "./backup/run.js";
+export {
+  type BackupConfig,
+  type BackupConfigPatch,
+  type BackupTargetSelection,
+  BackupConfigPatchSchema,
+  readBackupConfig,
+  writeBackupConfig,
+} from "./backup/config.js";
+export {
+  type BackupRun,
+  type BackupRunStatus,
+  type BackupRunTrigger,
+  listBackupRuns,
+  lastSuccessfulBackupRun,
+} from "./backup/runs.js";
 export {
   type AgentTokenMeta,
   type CreatedAgentToken,

--- a/packages/core/src/store/projection.ts
+++ b/packages/core/src/store/projection.ts
@@ -133,7 +133,12 @@ function asArray(value: unknown): string[] {
 //         (settings, curation_*, conv_state, domains, handoffs, …) are
 //         preserved. The on-disk JSONL ledgers for sessions are renamed
 //         to `.predeprecation.bak` by `createLibrarianStore`.
-export const PROJECTION_SCHEMA_VERSION = 19;
+//   - 20: automated-backups A3 — adds the `backup_runs` table (scheduled/
+//         manual backup health: status, trigger, target, bytes, error,
+//         timestamps). SQLite-authoritative (not a ledger projection), so it
+//         is preserved across future bumps; the bump just CREATEs it on
+//         existing installs and the projection rebuild does not touch it.
+export const PROJECTION_SCHEMA_VERSION = 20;
 
 export function getSchemaVersion(db: DatabaseSync): number {
   const row = db.prepare("PRAGMA user_version").get() as { user_version: number };
@@ -311,6 +316,19 @@ export const SCHEMA_DDL = `
     );
     CREATE INDEX IF NOT EXISTS idx_memory_curation_operations_run
       ON memory_curation_operations(run_id, id);
+    CREATE TABLE IF NOT EXISTS backup_runs (
+      id TEXT PRIMARY KEY,
+      status TEXT NOT NULL,
+      trigger TEXT NOT NULL,
+      target TEXT,
+      bundle TEXT,
+      bytes INTEGER NOT NULL DEFAULT 0,
+      synced INTEGER NOT NULL DEFAULT 0,
+      error TEXT,
+      created_at TEXT NOT NULL,
+      started_at TEXT,
+      completed_at TEXT
+    );
     CREATE TABLE IF NOT EXISTS settings (
       key TEXT PRIMARY KEY,
       value TEXT NOT NULL,

--- a/packages/core/tests/backup-schedule.test.ts
+++ b/packages/core/tests/backup-schedule.test.ts
@@ -136,4 +136,26 @@ describe("runBackupTick self-gating", () => {
     await runBackupTick(store, { destDir });
     expect(listBackupRuns(store)).toHaveLength(1);
   });
+
+  it("reconciles a stale 'running' row left by a crash, then runs", async () => {
+    writeBackupConfig(store, { enabled: true, intervalMinutes: 60, target: "local" });
+    // A crashed run: 'running' from 2 hours ago (older than the stale TTL).
+    const old = new Date(Date.now() - 2 * 60 * 60_000).toISOString();
+    store.db
+      .prepare(
+        `INSERT INTO backup_runs (id, status, trigger, bytes, synced, created_at, started_at)
+         VALUES ('bkp_stale', 'running', 'scheduled', 0, 0, ?, ?)`,
+      )
+      .run(old, old);
+
+    await runBackupTick(store, { destDir });
+
+    const runs = listBackupRuns(store);
+    const stale = runs.find((r) => r.id === "bkp_stale");
+    expect(stale?.status).toBe("error");
+    expect(stale?.error).toBe("stale_run_reclaimed");
+    // and a fresh backup was made (the reclaimed run's completed_at = its old
+    // created_at, so the interval has long since elapsed).
+    expect(runs.some((r) => r.status === "ok")).toBe(true);
+  });
 });

--- a/packages/core/tests/backup-schedule.test.ts
+++ b/packages/core/tests/backup-schedule.test.ts
@@ -1,0 +1,139 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type LibrarianStore,
+  listBackupRuns,
+  readBackupConfig,
+  runBackup,
+  runBackupTick,
+  writeBackupConfig,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let dataDir: string;
+let destDir: string;
+let store: LibrarianStore;
+
+beforeEach(async () => {
+  const { createLibrarianStore } = await import("@librarian/core");
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "lib-sched-data-"));
+  destDir = fs.mkdtempSync(path.join(os.tmpdir(), "lib-sched-dest-"));
+  store = createLibrarianStore({ dataDir });
+});
+
+afterEach(() => {
+  try {
+    store.close();
+  } catch {
+    /* already closed */
+  }
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  fs.rmSync(destDir, { recursive: true, force: true });
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe("backup config", () => {
+  it("defaults to disabled, daily, local, keep 14, no webhook", () => {
+    const cfg = readBackupConfig(store, {});
+    expect(cfg).toEqual({
+      enabled: false,
+      intervalMinutes: 1440,
+      target: "local",
+      retentionKeep: 14,
+      webhookUrl: "",
+    });
+  });
+
+  it("round-trips a written config", () => {
+    writeBackupConfig(store, {
+      enabled: true,
+      intervalMinutes: 60,
+      target: "github",
+      retentionKeep: 7,
+      webhookUrl: "https://hooks.example/backup",
+    });
+    expect(readBackupConfig(store, {})).toEqual({
+      enabled: true,
+      intervalMinutes: 60,
+      target: "github",
+      retentionKeep: 7,
+      webhookUrl: "https://hooks.example/backup",
+    });
+  });
+
+  it("rejects a non-http webhook URL and a sub-minute interval", () => {
+    expect(() => writeBackupConfig(store, { webhookUrl: "ftp://nope" })).toThrow(/http/);
+    expect(() => writeBackupConfig(store, { intervalMinutes: 0 })).toThrow();
+  });
+
+  it("falls back to the legacy LIBRARIAN_BACKUP_INTERVAL_MS when unconfigured", () => {
+    const cfg = readBackupConfig(store, { LIBRARIAN_BACKUP_INTERVAL_MS: "120000" });
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.intervalMinutes).toBe(2); // 120000ms → 2 min
+  });
+
+  it("auto-detects the target from env cloud creds when not explicitly set", () => {
+    const cfg = readBackupConfig(store, {
+      LIBRARIAN_BACKUP_GITHUB_REPO: "o/r",
+      LIBRARIAN_BACKUP_GITHUB_TOKEN: "tok",
+    });
+    expect(cfg.target).toBe("github");
+  });
+});
+
+describe("runBackup run-health", () => {
+  it("records an ok run (target local) for a local-only backup", async () => {
+    await runBackup(store, { destDir, sync: false, trigger: "manual" });
+    const runs = listBackupRuns(store);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]).toMatchObject({
+      status: "ok",
+      trigger: "manual",
+      target: "local",
+      synced: false,
+    });
+    expect(runs[0].bytes).toBeGreaterThan(0);
+  });
+
+  it("records an error run and POSTs the failure webhook", async () => {
+    // target=s3 with creds present (env) but no @aws-sdk installed → the S3 target
+    // construction throws, which is a deterministic, network-free failure.
+    vi.stubEnv("LIBRARIAN_BACKUP_S3_BUCKET", "b");
+    vi.stubEnv("LIBRARIAN_BACKUP_S3_ACCESS_KEY", "ak");
+    vi.stubEnv("LIBRARIAN_BACKUP_S3_SECRET_KEY", "sk");
+    writeBackupConfig(store, { target: "s3", webhookUrl: "https://hooks.example/x" });
+    const posts: { url: string; body: unknown }[] = [];
+    vi.stubGlobal("fetch", async (url: RequestInfo | URL, init: RequestInit) => {
+      posts.push({ url: String(url), body: JSON.parse(String(init.body)) });
+      return new Response(null, { status: 204 });
+    });
+
+    await expect(runBackup(store, { destDir, trigger: "scheduled" })).rejects.toThrow();
+
+    const runs = listBackupRuns(store);
+    expect(runs[0]).toMatchObject({ status: "error" });
+    expect(runs[0].error).toBeTruthy();
+    expect(posts).toHaveLength(1);
+    expect(posts[0].url).toBe("https://hooks.example/x");
+    expect(posts[0].body).toMatchObject({ event: "backup.failed", target: "s3" });
+  });
+});
+
+describe("runBackupTick self-gating", () => {
+  it("is a no-op when disabled", async () => {
+    writeBackupConfig(store, { enabled: false });
+    await runBackupTick(store, { destDir });
+    expect(listBackupRuns(store)).toHaveLength(0);
+  });
+
+  it("runs once when enabled with no prior run, then skips within the interval", async () => {
+    writeBackupConfig(store, { enabled: true, intervalMinutes: 60, target: "local" });
+    await runBackupTick(store, { destDir });
+    expect(listBackupRuns(store)).toHaveLength(1);
+    // A second tick within the interval must not run again.
+    await runBackupTick(store, { destDir });
+    expect(listBackupRuns(store)).toHaveLength(1);
+  });
+});

--- a/packages/mcp-server/src/bin/http.ts
+++ b/packages/mcp-server/src/bin/http.ts
@@ -13,7 +13,7 @@ import {
   findLegacyScheduleKeys,
   resolveBootCredentials,
   resolveDataDir,
-  runBackup,
+  runBackupTick,
   runCuratorTick,
   verifyAgentToken,
 } from "@librarian/core";
@@ -173,16 +173,20 @@ const curatorScheduler =
       })
     : null;
 
-// Scheduled backups (opt-in): set LIBRARIAN_BACKUP_INTERVAL_MS > 0 to enable. Each
-// tick writes a local bundle and, if cloud sync is configured, uploads it.
-const backupIntervalMs = Number(process.env.LIBRARIAN_BACKUP_INTERVAL_MS ?? 0);
+// Scheduled backups: the tick self-gates on the dashboard-managed config
+// (`backup.schedule.*`) — disabled → cheap no-op — and runs a backup once the
+// configured interval has elapsed. LIBRARIAN_BACKUP_TICK_MS sets the poll cadence
+// (default 5 min); 0 disables the scheduler entirely. The legacy
+// LIBRARIAN_BACKUP_INTERVAL_MS still enables backups for headless installs that
+// never configured a schedule (handled in readBackupConfig).
+const backupTickMs = Number(process.env.LIBRARIAN_BACKUP_TICK_MS ?? 5 * 60_000);
 const backupDir = process.env.LIBRARIAN_BACKUP_DIR || path.join(store.dataDir, "backups");
 const backupScheduler =
-  backupIntervalMs > 0
+  backupTickMs > 0
     ? createSerialScheduler({
-        task: () => runBackup(store, { destDir: backupDir }),
-        intervalMs: backupIntervalMs,
-        onError: (error) => logger.error({ err: error }, "scheduled backup failed"),
+        task: () => runBackupTick(store, { destDir: backupDir }),
+        intervalMs: backupTickMs,
+        onError: (error) => logger.error({ err: error }, "scheduled backup tick failed"),
       })
     : null;
 

--- a/packages/mcp-server/src/trpc/backup.ts
+++ b/packages/mcp-server/src/trpc/backup.ts
@@ -24,7 +24,10 @@ const SetConfigSchema = z.strictObject({
 
 export const backupRouter = router({
   createNow: adminProcedure.mutation(async ({ ctx }) => {
-    const result = await runBackup(ctx.store, { destDir: backupDestDir(ctx.store) });
+    const result = await runBackup(ctx.store, {
+      destDir: backupDestDir(ctx.store),
+      trigger: "manual",
+    });
     return {
       dir: result.dir,
       files: result.manifest.files.length,

--- a/test/schema-snapshot.json
+++ b/test/schema-snapshot.json
@@ -1,4 +1,4 @@
 {
-  "version": 19,
-  "fingerprint": "7ab598e52868f851f7e248793da31f0251bdfd36827bfa8d6efb0a6b16b68f68"
+  "version": 20,
+  "fingerprint": "f378a164d171b8b24ef79eb0f5989c828bfdbc9550c184953e4c316d8fe400f2"
 }


### PR DESCRIPTION
## What (A3 of automated-backups, plan 034)

Moves the backup schedule out of env vars into **dashboard-managed settings** and records **run health** for the cockpit (A6 will surface it).

- **`backup_runs` table** (schema **v20**, SQLite-authoritative — preserved across rebuilds like `memory_curation_runs`) + `runs.ts`: start/finish a run, list recent, last-successful, plus crash reconciliation.
- **`config.ts`** — validated read/write of `enabled`, `interval_minutes`, `target` (local|s3|github), `retention.keep` (default 14), `alert.webhook_url`. Target is explicit or auto-detected from configured cloud creds; the legacy `LIBRARIAN_BACKUP_INTERVAL_MS` still enables backups for headless installs that never touched the dashboard.
- **`runBackup`** records each run (running → ok/error), resolves the target from config, and on failure POSTs a generic-JSON failure webhook (best-effort, `redirect:"error"`, no secrets).
- **`runBackupTick`** self-gates on config + the elapsed interval (measured from the last *completed* run), and reconciles a run left `running` by a crash. `bin/http.ts` polls it every `LIBRARIAN_BACKUP_TICK_MS` (default 5 min) — replacing the old fixed-interval scheduler.

**Ships dark:** the schedule is disabled by default, so nothing runs until an operator enables it.

## Tests

Config defaults / round-trip / validation / legacy-fallback / target auto-detect; run-health ok + error; failure-webhook POST; tick self-gating (disabled no-op, runs-then-skips); crashed-`running`-row reconciliation. Full suite green.

Implements A3 of `docs/specs/034-automated-backups-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)