### PR TITLE
feat(backup): retention — keep last N (A4)

### DIFF
--- a/packages/cli/src/commands/backup.ts
+++ b/packages/cli/src/commands/backup.ts
@@ -1,6 +1,8 @@
-// `the-librarian backup [--out <dir>]` — write a restorable snapshot bundle.
+// `the-librarian backup [--out <dir>] [--keep <n>]` — write a restorable snapshot
+// bundle, then prune the local bundle dir to the newest `--keep` (default: the
+// configured retention, or 14).
 
-import { type LibrarianStore, createBackup } from "@librarian/core";
+import { type LibrarianStore, createBackup, pruneLocal, readBackupConfig } from "@librarian/core";
 import type { FlagMap } from "../parse-flags.js";
 import type { CliResult } from "./_shared.js";
 
@@ -10,9 +12,17 @@ export function backupCommand(
   flags: FlagMap,
 ): CliResult {
   const destDir = typeof flags.out === "string" && flags.out ? flags.out : process.cwd();
+
+  const keepFlag = typeof flags.keep === "string" ? Number(flags.keep) : NaN;
+  const keep =
+    Number.isInteger(keepFlag) && keepFlag >= 1 ? keepFlag : readBackupConfig(store).retentionKeep;
+
   const { dir, manifest } = createBackup(store, { destDir });
+  const pruned = pruneLocal(destDir, keep);
+
+  const prunedNote = pruned.length ? ` Pruned ${pruned.length} old bundle(s) (keep ${keep}).` : "";
   return {
-    stdout: `Backup written to ${dir} (${manifest.files.length} files, schema v${manifest.schema_version}).`,
+    stdout: `Backup written to ${dir} (${manifest.files.length} files, schema v${manifest.schema_version}).${prunedNote}`,
     exitCode: 0,
   };
 }

--- a/packages/core/src/backup/backup.ts
+++ b/packages/core/src/backup/backup.ts
@@ -67,10 +67,14 @@ function sha256(buf: Buffer): string {
 
 export function createBackup(store: LibrarianStore, options: { destDir: string }): BackupResult {
   const now = new Date();
-  const dir = path.join(
-    options.destDir,
-    `librarian-backup-${now.toISOString().replace(/[:.]/g, "-")}`,
-  );
+  // A fresh dir per backup. Two backups in the same millisecond would otherwise
+  // collide on the timestamped name (the second silently overwriting the first);
+  // an incrementing suffix guarantees uniqueness and still sorts chronologically.
+  const base = `librarian-backup-${now.toISOString().replace(/[:.]/g, "-")}`;
+  let dir = path.join(options.destDir, base);
+  for (let suffix = 1; fs.existsSync(dir); suffix++) {
+    dir = path.join(options.destDir, `${base}-${suffix}`);
+  }
   fs.mkdirSync(dir, { recursive: true });
 
   try {

--- a/packages/core/src/backup/retention.ts
+++ b/packages/core/src/backup/retention.ts
@@ -12,7 +12,8 @@ const BACKUP_DIR_PREFIX = "librarian-backup-";
 
 function bundlesToRemove(sortedNames: string[], keep: number): string[] {
   // sortedNames is chronological (oldest first); drop all but the newest `keep`.
-  return sortedNames.slice(0, Math.max(0, sortedNames.length - Math.max(0, keep)));
+  const overflow = Math.max(0, sortedNames.length - Math.max(0, keep));
+  return sortedNames.slice(0, overflow);
 }
 
 /** Remove all but the newest `keep` local bundle dirs. Returns the removed names. */

--- a/packages/core/src/backup/retention.ts
+++ b/packages/core/src/backup/retention.ts
@@ -1,0 +1,46 @@
+// Backup retention (automated-backups A4): keep the newest `keep` bundles, prune
+// the rest. The unit is the whole bundle/snapshot. `librarian-backup-<iso>` names
+// sort lexically == chronologically, so the oldest are the lowest-sorted; the
+// newest (including an in-progress bundle being written) are kept. Each function
+// returns the names it removed (never silent).
+
+import fs from "node:fs";
+import path from "node:path";
+import type { BackupTarget } from "./sync/types.js";
+
+const BACKUP_DIR_PREFIX = "librarian-backup-";
+
+function bundlesToRemove(sortedNames: string[], keep: number): string[] {
+  // sortedNames is chronological (oldest first); drop all but the newest `keep`.
+  return sortedNames.slice(0, Math.max(0, sortedNames.length - Math.max(0, keep)));
+}
+
+/** Remove all but the newest `keep` local bundle dirs. Returns the removed names. */
+export function pruneLocal(dir: string, keep: number): string[] {
+  if (!fs.existsSync(dir)) return [];
+  const bundles = fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name.startsWith(BACKUP_DIR_PREFIX))
+    .map((entry) => entry.name)
+    .sort();
+  const removable = bundlesToRemove(bundles, keep);
+  for (const name of removable) {
+    fs.rmSync(path.join(dir, name), { recursive: true, force: true });
+  }
+  return removable;
+}
+
+/** Delete all but the newest `keep` bundles on a cloud target. Returns removed names. */
+export async function pruneTarget(target: BackupTarget, keep: number): Promise<string[]> {
+  const keys = await target.list();
+  const bundleNames = new Set<string>();
+  for (const key of keys) {
+    const slash = key.indexOf("/");
+    bundleNames.add(slash > 0 ? key.slice(0, slash) : key);
+  }
+  const removable = bundlesToRemove([...bundleNames].sort(), keep);
+  for (const name of removable) {
+    await target.deleteBundle(name);
+  }
+  return removable;
+}

--- a/packages/core/src/backup/run.ts
+++ b/packages/core/src/backup/run.ts
@@ -78,7 +78,28 @@ async function fireFailureWebhook(config: BackupConfig, error: string): Promise<
   }
 }
 
-export async function runBackup(
+// Serialize every backup run in this process. The scheduler tick and a manual
+// "Backup now" both call runBackup; serializing them ensures a prune in one never
+// races a write/upload in the other (which could delete a bundle mid-flight), and
+// closes the pre-existing two-runs-at-once double-write. A FIFO promise chain.
+let backupQueue: Promise<unknown> = Promise.resolve();
+function runExclusive<T>(task: () => Promise<T>): Promise<T> {
+  const next = backupQueue.then(task, task);
+  backupQueue = next.then(
+    () => undefined,
+    () => undefined,
+  );
+  return next;
+}
+
+export function runBackup(
+  store: LibrarianStore,
+  options: { destDir: string; sync?: boolean; trigger?: BackupRunTrigger },
+): Promise<RunBackupResult> {
+  return runExclusive(() => runBackupOnce(store, options));
+}
+
+async function runBackupOnce(
   store: LibrarianStore,
   options: { destDir: string; sync?: boolean; trigger?: BackupRunTrigger },
 ): Promise<RunBackupResult> {
@@ -104,9 +125,15 @@ export async function runBackup(
     // backup already succeeded, so a prune failure must NOT fail the run (it
     // retries next time); it's surfaced via `pruneError`, never swallowed silently.
     try {
-      const prunedLocal = pruneLocal(options.destDir, config.retentionKeep);
-      const prunedCloud = resolved ? await pruneTarget(resolved.target, config.retentionKeep) : [];
-      result.pruned = [...prunedLocal, ...prunedCloud];
+      // Assign local prunes first so they're still reported if the cloud prune
+      // throws — a real deletion must never go unrecorded.
+      result.pruned = pruneLocal(options.destDir, config.retentionKeep);
+      if (resolved) {
+        result.pruned = [
+          ...result.pruned,
+          ...(await pruneTarget(resolved.target, config.retentionKeep)),
+        ];
+      }
     } catch (err) {
       result.pruneError = err instanceof Error ? err.message : String(err);
     }

--- a/packages/core/src/backup/run.ts
+++ b/packages/core/src/backup/run.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import type { LibrarianStore } from "../store/librarian-store.js";
 import { type BackupManifest, createBackup } from "./backup.js";
 import { type BackupConfig, readBackupConfig } from "./config.js";
+import { pruneLocal, pruneTarget } from "./retention.js";
 import {
   type BackupRunTrigger,
   finishBackupRun,
@@ -31,6 +32,10 @@ export interface RunBackupResult {
   /** Which cloud target the bundle was synced to (omitted when not synced). */
   target?: BackupTargetKind;
   syncedKeys?: string[];
+  /** Bundle names pruned by retention (local + cloud), newest-`keep` kept. */
+  pruned?: string[];
+  /** A best-effort prune failure message (the backup itself still succeeded). */
+  pruneError?: string;
 }
 
 // Resolve the cloud target the config selects ('local' → no sync). A selected
@@ -85,13 +90,25 @@ export async function runBackup(
     const bundle = path.basename(dir);
 
     const result: RunBackupResult = { dir, manifest, synced: false };
+    let resolved: { kind: BackupTargetKind; target: BackupTarget } | null = null;
     if (options.sync !== false) {
-      const resolved = await resolveBackupTarget(store, config);
+      resolved = await resolveBackupTarget(store, config);
       if (resolved) {
         result.syncedKeys = await syncBundle(resolved.target, dir);
         result.synced = true;
         result.target = resolved.kind;
       }
+    }
+
+    // Retention: keep the newest N bundles, prune the rest. Best-effort — the
+    // backup already succeeded, so a prune failure must NOT fail the run (it
+    // retries next time); it's surfaced via `pruneError`, never swallowed silently.
+    try {
+      const prunedLocal = pruneLocal(options.destDir, config.retentionKeep);
+      const prunedCloud = resolved ? await pruneTarget(resolved.target, config.retentionKeep) : [];
+      result.pruned = [...prunedLocal, ...prunedCloud];
+    } catch (err) {
+      result.pruneError = err instanceof Error ? err.message : String(err);
     }
 
     finishBackupRun(store, runId, {
@@ -118,16 +135,16 @@ export async function runBackup(
 export async function runBackupTick(
   store: LibrarianStore,
   options: { destDir: string },
-): Promise<void> {
+): Promise<RunBackupResult | null> {
   const config = readBackupConfig(store);
-  if (!config.enabled) return;
+  if (!config.enabled) return null;
 
   reconcileStaleBackupRuns(store);
 
   const last = latestTerminalBackupRun(store);
   if (last?.completed_at) {
     const elapsedMinutes = (Date.now() - new Date(last.completed_at).getTime()) / 60_000;
-    if (elapsedMinutes < config.intervalMinutes) return;
+    if (elapsedMinutes < config.intervalMinutes) return null;
   }
-  await runBackup(store, { destDir: options.destDir, trigger: "scheduled" });
+  return runBackup(store, { destDir: options.destDir, trigger: "scheduled" });
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -183,6 +183,7 @@ export { type S3SyncConfig, resolveS3SyncConfig } from "./backup/sync/config.js"
 export { createS3Target } from "./backup/sync/s3.js";
 export { type GithubSyncConfig, resolveGithubSyncConfig } from "./backup/sync/github-config.js";
 export { createGithubTarget } from "./backup/sync/github.js";
+export { pruneLocal, pruneTarget } from "./backup/retention.js";
 export {
   type BackupTargetKind,
   type RunBackupResult,

--- a/packages/core/tests/backup-retention.test.ts
+++ b/packages/core/tests/backup-retention.test.ts
@@ -49,6 +49,22 @@ describe("pruneLocal", () => {
     expect(fs.existsSync(path.join(dir, bundleName(0)))).toBe(false);
   });
 
+  it("sorts real createBackup-style timestamp names chronologically", () => {
+    // Names exactly as createBackup produces them: librarian-backup-<ISO with :/. → ->.
+    // This guards the load-bearing "lexical == chronological" invariant against a
+    // future change to the bundle-naming format.
+    const names = Array.from({ length: 5 }, (_, i) => {
+      const iso = new Date(Date.UTC(2026, 4, 30, 0, 0, i)).toISOString().replace(/[:.]/g, "-");
+      return `librarian-backup-${iso}`;
+    });
+    for (const name of names) makeBundle(name);
+
+    const removed = pruneLocal(dir, 3);
+    expect(removed).toEqual([names[0], names[1]]); // the two oldest, in order
+    expect(fs.existsSync(path.join(dir, names[0]))).toBe(false);
+    expect(fs.existsSync(path.join(dir, names[4]))).toBe(true);
+  });
+
   it("ignores non-bundle dirs and a missing dir", () => {
     fs.mkdirSync(path.join(dir, "not-a-backup"));
     for (let i = 0; i < 16; i++) makeBundle(bundleName(i));

--- a/packages/core/tests/backup-retention.test.ts
+++ b/packages/core/tests/backup-retention.test.ts
@@ -1,0 +1,83 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createMemoryBackupTarget, pruneLocal, pruneTarget } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "lib-retention-"));
+});
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function makeBundle(name: string, withManifest = true) {
+  const bundleDir = path.join(dir, name);
+  fs.mkdirSync(bundleDir);
+  fs.writeFileSync(path.join(bundleDir, "librarian.sqlite.gz"), "x");
+  if (withManifest) fs.writeFileSync(path.join(bundleDir, "manifest.json"), "{}");
+}
+
+const bundleName = (i: number) => `librarian-backup-${String(i).padStart(2, "0")}`;
+
+describe("pruneLocal", () => {
+  it("keeps the newest N bundles and removes the rest (16 → keep 14)", () => {
+    for (let i = 0; i < 16; i++) makeBundle(bundleName(i));
+    const removed = pruneLocal(dir, 14);
+
+    expect(removed.sort()).toEqual([bundleName(0), bundleName(1)]); // the two oldest
+    const remaining = fs.readdirSync(dir).sort();
+    expect(remaining).toHaveLength(14);
+    expect(remaining[0]).toBe(bundleName(2));
+    expect(remaining.at(-1)).toBe(bundleName(15));
+  });
+
+  it("is a no-op when keep >= the bundle count", () => {
+    for (let i = 0; i < 5; i++) makeBundle(bundleName(i));
+    expect(pruneLocal(dir, 14)).toEqual([]);
+    expect(fs.readdirSync(dir)).toHaveLength(5);
+  });
+
+  it("never prunes the newest (possibly in-progress) bundle", () => {
+    for (let i = 0; i < 14; i++) makeBundle(bundleName(i));
+    makeBundle(bundleName(99), /* withManifest */ false); // newest, still being written
+    pruneLocal(dir, 14);
+    // 15 bundles, keep 14 → only the single oldest goes; the manifest-less newest stays.
+    expect(fs.existsSync(path.join(dir, bundleName(99)))).toBe(true);
+    expect(fs.existsSync(path.join(dir, bundleName(0)))).toBe(false);
+  });
+
+  it("ignores non-bundle dirs and a missing dir", () => {
+    fs.mkdirSync(path.join(dir, "not-a-backup"));
+    for (let i = 0; i < 16; i++) makeBundle(bundleName(i));
+    pruneLocal(dir, 14);
+    expect(fs.existsSync(path.join(dir, "not-a-backup"))).toBe(true);
+    expect(pruneLocal(path.join(dir, "does-not-exist"), 14)).toEqual([]);
+  });
+});
+
+describe("pruneTarget", () => {
+  it("keeps the newest N bundles on a cloud target (16 → keep 14)", async () => {
+    const target = createMemoryBackupTarget();
+    for (let i = 0; i < 16; i++) {
+      await target.put(`${bundleName(i)}/librarian.sqlite.gz`, Buffer.from("x"));
+      await target.put(`${bundleName(i)}/manifest.json`, Buffer.from("{}"));
+    }
+
+    const removed = await pruneTarget(target, 14);
+    expect(removed.sort()).toEqual([bundleName(0), bundleName(1)]);
+
+    const remainingBundles = new Set((await target.list()).map((k) => k.split("/")[0]));
+    expect(remainingBundles.size).toBe(14);
+    expect(remainingBundles.has(bundleName(0))).toBe(false);
+    expect(remainingBundles.has(bundleName(15))).toBe(true);
+  });
+
+  it("is a no-op when keep >= the bundle count", async () => {
+    const target = createMemoryBackupTarget();
+    await target.put(`${bundleName(0)}/f`, Buffer.from("x"));
+    expect(await pruneTarget(target, 14)).toEqual([]);
+  });
+});

--- a/packages/core/tests/backup-schedule.test.ts
+++ b/packages/core/tests/backup-schedule.test.ts
@@ -119,6 +119,18 @@ describe("runBackup run-health", () => {
     expect(posts[0].url).toBe("https://hooks.example/x");
     expect(posts[0].body).toMatchObject({ event: "backup.failed", target: "s3" });
   });
+
+  it("serializes concurrent runs — all succeed with distinct bundles", async () => {
+    const results = await Promise.all([
+      runBackup(store, { destDir, sync: false, trigger: "manual" }),
+      runBackup(store, { destDir, sync: false, trigger: "manual" }),
+      runBackup(store, { destDir, sync: false, trigger: "scheduled" }),
+    ]);
+    expect(new Set(results.map((r) => r.dir)).size).toBe(3); // distinct dirs, no collision
+    const runs = listBackupRuns(store, 10);
+    expect(runs).toHaveLength(3);
+    expect(runs.every((r) => r.status === "ok")).toBe(true);
+  });
 });
 
 describe("runBackupTick self-gating", () => {

--- a/packages/mcp-server/src/bin/http.ts
+++ b/packages/mcp-server/src/bin/http.ts
@@ -190,7 +190,7 @@ const backupScheduler =
             logger.info({ pruned: result.pruned }, "backup retention pruned old bundles");
           }
           if (result?.pruneError) {
-            logger.warn({ err: result.pruneError }, "backup retention prune failed");
+            logger.warn({ reason: result.pruneError }, "backup retention prune failed");
           }
         },
         intervalMs: backupTickMs,

--- a/packages/mcp-server/src/bin/http.ts
+++ b/packages/mcp-server/src/bin/http.ts
@@ -184,7 +184,15 @@ const backupDir = process.env.LIBRARIAN_BACKUP_DIR || path.join(store.dataDir, "
 const backupScheduler =
   backupTickMs > 0
     ? createSerialScheduler({
-        task: () => runBackupTick(store, { destDir: backupDir }),
+        task: async () => {
+          const result = await runBackupTick(store, { destDir: backupDir });
+          if (result?.pruned?.length) {
+            logger.info({ pruned: result.pruned }, "backup retention pruned old bundles");
+          }
+          if (result?.pruneError) {
+            logger.warn({ err: result.pruneError }, "backup retention prune failed");
+          }
+        },
         intervalMs: backupTickMs,
         onError: (error) => logger.error({ err: error }, "scheduled backup tick failed"),
       })


### PR DESCRIPTION
## What (A4 of automated-backups, plan 034)

Adds **retention/pruning** — keep the newest N bundles, prune the rest.

- **`retention.ts`** — `pruneLocal(dir, keep)` removes all but the newest `keep` `librarian-backup-*` dirs; `pruneTarget(target, keep)` does the same on a cloud target via `deleteBundle` (GitHub drops the Release **and** tag; S3 the prefix's objects). Bundle names sort chronologically, so the oldest go and the newest — including an in-progress bundle still being written — are always kept. Both return the removed names.
- **`runBackup`** prunes local + the active cloud target to `config.retention.keep` after a successful backup. Best-effort: a prune failure does **not** fail the run — it's surfaced via `result.pruneError` (logged by the scheduler), and any prunes already done are still reported.
- **CLI `backup`** gains `--keep <n>` (defaults to the configured retention, or 14).

## Review fixes (included)

- **Serialized all backup runs in-process** (FIFO promise chain) — the scheduler tick and a manual "Backup now" no longer overlap, so a prune can't race a concurrent write/upload (also closes a pre-existing double-write).
- **Collision-proof bundle dir names** — two same-millisecond backups no longer collide (incrementing suffix).
- Partial-prune reporting fixed; pino log key corrected.

## Tests

16 bundles + keep 14 → 2 oldest removed / newest 14 kept (local + memory target); keep ≥ count is a no-op; in-progress newest never pruned; real `toISOString`-style names sort chronologically; concurrent runs all succeed with distinct bundles. Full suite green.

Implements A4 of `docs/specs/034-automated-backups-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)