### PR TITLE
feat(backup): restart-staged restore (A5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ changes from this point forward are catalogued here.
 
 ### Added
 
+- **Restore a backup from the dashboard (restart-staged).** Staging a restore
+  validates the chosen bundle (pulling it from the cloud target if it isn't
+  local) and queues it; it's applied on the next server boot — before the SQLite
+  file is opened, never under a live connection. A failed restore leaves the live
+  data untouched and keeps the marker for the operator. The admin API gains
+  `backup.stageRestore` and a `backup.restart` control.
+
 - **GitHub Releases as a backup target.** Alongside S3-compatible storage, a
   backup can now sync to a (private) GitHub repo: each bundle becomes a Release
   (tag = bundle name) with the bundle's files attached as release assets. No new

--- a/packages/core/src/backup/restore-staging.ts
+++ b/packages/core/src/backup/restore-staging.ts
@@ -19,6 +19,7 @@ import { fetchBundle } from "./sync/bundle.js";
 import { resolveCloudTarget } from "./target.js";
 
 export const RESTORE_MARKER = "restore.pending.json";
+export const RESTORE_FAILED_MARKER = "restore.failed.json";
 const STAGING_SUBDIR = "restore-staging";
 
 export interface StageRestoreResult {
@@ -106,14 +107,25 @@ export function applyPendingRestore(dataDir: string): ApplyRestoreResult {
   try {
     restoreBackup(marker.dir, { dataDir });
   } catch (err) {
-    // Live data is untouched (restoreBackup validates before writing). Keep the
-    // marker so the operator can see the failure and retry / clear it.
-    return { applied: false, bundle: marker.bundle, error: (err as Error).message };
+    // Live data is untouched (restoreBackup validates before writing). Quarantine
+    // the marker as `restore.failed.json` — kept for the operator (with the error),
+    // but NOT retried on every boot. They can inspect it and re-stage.
+    const error = (err as Error).message;
+    try {
+      fs.writeFileSync(
+        path.join(dataDir, RESTORE_FAILED_MARKER),
+        `${JSON.stringify({ ...marker, error, failed_at: new Date().toISOString() }, null, 2)}\n`,
+      );
+      fs.rmSync(markerPath, { force: true });
+    } catch {
+      // couldn't quarantine — leave the pending marker for a retry rather than lose it
+    }
+    return { applied: false, bundle: marker.bundle, error };
   }
 
+  // Success: clear the marker and sweep the cloud-staging area (orphaned dirs from
+  // earlier re-stages, plus this bundle's).
   fs.rmSync(markerPath, { force: true });
-  if (marker.staged_from_cloud) {
-    fs.rmSync(marker.dir, { recursive: true, force: true });
-  }
+  fs.rmSync(path.join(dataDir, STAGING_SUBDIR), { recursive: true, force: true });
   return { applied: true, bundle: marker.bundle };
 }

--- a/packages/core/src/backup/restore-staging.ts
+++ b/packages/core/src/backup/restore-staging.ts
@@ -1,0 +1,119 @@
+// Restart-staged restore (automated-backups A5). The dashboard can't swap
+// `librarian.sqlite` under a live DB connection, so a restore is split in two:
+//
+//   stageRestore()       — runs in the live server (tRPC): resolve the bundle
+//                          (local, else pull from the cloud target), VALIDATE it
+//                          without applying, and drop a `restore.pending.json`
+//                          marker in the data dir. Refuses a corrupt bundle.
+//   applyPendingRestore() — runs at BOOT, before the store opens (no live
+//                          connection): swap the validated bundle into the data
+//                          dir, then clear the marker. On failure the live data is
+//                          untouched (restoreBackup validates before writing) and
+//                          the marker is kept for the operator.
+
+import fs from "node:fs";
+import path from "node:path";
+import type { LibrarianStore } from "../store/librarian-store.js";
+import { restoreBackup, validateBundle } from "./restore.js";
+import { fetchBundle } from "./sync/bundle.js";
+import { resolveCloudTarget } from "./target.js";
+
+export const RESTORE_MARKER = "restore.pending.json";
+const STAGING_SUBDIR = "restore-staging";
+
+export interface StageRestoreResult {
+  staged: string;
+  restartRequired: true;
+}
+
+export interface ApplyRestoreResult {
+  applied: boolean;
+  bundle?: string;
+  error?: string;
+}
+
+interface RestoreMarker {
+  bundle: string;
+  dir: string;
+  staged_from_cloud: boolean;
+  staged_at: string;
+  schema_version: number;
+}
+
+export async function stageRestore(
+  store: LibrarianStore,
+  options: { bundleName: string; backupDir: string },
+): Promise<StageRestoreResult> {
+  const { bundleName, backupDir } = options;
+  // A bundle name is a plain basename (it becomes a path segment below).
+  if (
+    !bundleName ||
+    bundleName.includes("/") ||
+    bundleName.includes("\\") ||
+    bundleName.includes("\0") ||
+    bundleName.split(/[\\/]/).includes("..")
+  ) {
+    throw new Error(`invalid bundle name: ${JSON.stringify(bundleName)}`);
+  }
+
+  // Prefer a local bundle; otherwise pull it from the configured cloud target.
+  const localDir = path.join(backupDir, bundleName);
+  let bundleDir: string;
+  let stagedFromCloud = false;
+  if (fs.existsSync(path.join(localDir, "manifest.json"))) {
+    bundleDir = localDir;
+  } else {
+    const resolved = await resolveCloudTarget(store);
+    if (!resolved) {
+      throw new Error(
+        `backup ${bundleName} is not present locally and no cloud target is configured to pull it from`,
+      );
+    }
+    const stagingRoot = path.join(store.dataDir, STAGING_SUBDIR);
+    fs.rmSync(path.join(stagingRoot, bundleName), { recursive: true, force: true });
+    bundleDir = await fetchBundle(resolved.target, bundleName, stagingRoot);
+    stagedFromCloud = true;
+  }
+
+  // Refuse to stage a corrupt bundle — validate fully without applying.
+  const manifest = validateBundle(bundleDir);
+
+  const marker: RestoreMarker = {
+    bundle: bundleName,
+    dir: bundleDir,
+    staged_from_cloud: stagedFromCloud,
+    staged_at: new Date().toISOString(),
+    schema_version: manifest.schema_version,
+  };
+  fs.writeFileSync(
+    path.join(store.dataDir, RESTORE_MARKER),
+    `${JSON.stringify(marker, null, 2)}\n`,
+  );
+  return { staged: bundleName, restartRequired: true };
+}
+
+export function applyPendingRestore(dataDir: string): ApplyRestoreResult {
+  const markerPath = path.join(dataDir, RESTORE_MARKER);
+  if (!fs.existsSync(markerPath)) return { applied: false };
+
+  let marker: RestoreMarker;
+  try {
+    marker = JSON.parse(fs.readFileSync(markerPath, "utf8")) as RestoreMarker;
+  } catch (err) {
+    return { applied: false, error: `unreadable ${RESTORE_MARKER}: ${(err as Error).message}` };
+  }
+
+  try {
+    restoreBackup(marker.dir, { dataDir });
+  } catch (err) {
+    // Live data is untouched (restoreBackup validates before writing). Keep the
+    // marker so the operator can see the failure and retry / clear it.
+    return { applied: false, bundle: marker.bundle, error: (err as Error).message };
+  }
+
+  fs.rmSync(markerPath, { force: true });
+  if (marker.staged_from_cloud) {
+    fs.rmSync(marker.dir, { recursive: true, force: true });
+  }
+  return { applied: true, bundle: marker.bundle };
+}

--- a/packages/core/src/backup/restore.ts
+++ b/packages/core/src/backup/restore.ts
@@ -77,7 +77,14 @@ function assertSafeName(name: string): void {
   }
 }
 
-export function restoreBackup(backupDir: string, options: { dataDir: string }): RestoreResult {
+// Phase 1 — read the manifest and validate + decode EVERY file into memory before
+// the data dir is touched, so a corrupt or hostile bundle never half-overwrites (or
+// escapes) it. Throws BackupRestoreError on any problem; returns the manifest + the
+// decoded file buffers ready to write.
+function prepareRestore(backupDir: string): {
+  manifest: BackupManifest;
+  entries: { name: string; data: Buffer }[];
+} {
   const manifestPath = path.join(backupDir, BACKUP_MANIFEST);
   if (!fs.existsSync(manifestPath)) {
     throw new BackupRestoreError(`no ${BACKUP_MANIFEST} in ${backupDir}`);
@@ -99,10 +106,7 @@ export function restoreBackup(backupDir: string, options: { dataDir: string }): 
     );
   }
 
-  // Phase 1 — validate + decode EVERYTHING before touching the data dir, so a
-  // corrupt or hostile bundle never half-overwrites (or escapes) it: safe names,
-  // the stored (compressed) checksum, then the decompressed content checksum.
-  const prepared: { name: string; data: Buffer }[] = [];
+  const entries: { name: string; data: Buffer }[] = [];
   for (const file of manifest.files) {
     assertSafeName(file.name);
     const gzipped = file.compression === "gzip";
@@ -139,13 +143,28 @@ export function restoreBackup(backupDir: string, options: { dataDir: string }): 
         throw new BackupRestoreError(`decompressed checksum mismatch for ${file.name}`);
       }
     }
-    prepared.push({ name: file.name, data });
+    entries.push({ name: file.name, data });
   }
+
+  return { manifest, entries };
+}
+
+/**
+ * Validate a bundle (manifest + every checksum, decompressing to verify content)
+ * WITHOUT touching any data dir. Used by restore-staging to refuse a corrupt bundle
+ * before it's queued. Throws BackupRestoreError on any problem; returns the manifest.
+ */
+export function validateBundle(backupDir: string): BackupManifest {
+  return prepareRestore(backupDir).manifest;
+}
+
+export function restoreBackup(backupDir: string, options: { dataDir: string }): RestoreResult {
+  const { manifest, entries } = prepareRestore(backupDir);
 
   // Phase 2 — swap each decoded file in atomically (temp + rename).
   fs.mkdirSync(options.dataDir, { recursive: true });
   const restored: string[] = [];
-  for (const { name, data } of prepared) {
+  for (const { name, data } of entries) {
     const dest = path.join(options.dataDir, name);
     const tmp = `${dest}.restore-${process.pid}-${Date.now()}.tmp`;
     fs.writeFileSync(tmp, data);

--- a/packages/core/src/backup/run.ts
+++ b/packages/core/src/backup/run.ts
@@ -17,13 +17,9 @@ import {
   startBackupRun,
 } from "./runs.js";
 import { syncBundle } from "./sync/bundle.js";
-import { resolveS3SyncConfig } from "./sync/config.js";
-import { resolveGithubSyncConfig } from "./sync/github-config.js";
-import { createGithubTarget } from "./sync/github.js";
-import { createS3Target } from "./sync/s3.js";
-import type { BackupTarget } from "./sync/types.js";
+import { type BackupTargetKind, type ResolvedTarget, resolveCloudTarget } from "./target.js";
 
-export type BackupTargetKind = "s3" | "github";
+export type { BackupTargetKind };
 
 export interface RunBackupResult {
   dir: string;
@@ -36,24 +32,6 @@ export interface RunBackupResult {
   pruned?: string[];
   /** A best-effort prune failure message (the backup itself still succeeded). */
   pruneError?: string;
-}
-
-// Resolve the cloud target the config selects ('local' → no sync). A selected
-// target whose credentials are missing resolves to null (the run records
-// synced=false rather than failing).
-async function resolveBackupTarget(
-  store: LibrarianStore,
-  config: BackupConfig,
-): Promise<{ kind: BackupTargetKind; target: BackupTarget } | null> {
-  if (config.target === "s3") {
-    const s3 = resolveS3SyncConfig(store);
-    return s3 ? { kind: "s3", target: await createS3Target(s3) } : null;
-  }
-  if (config.target === "github") {
-    const github = resolveGithubSyncConfig(store);
-    return github ? { kind: "github", target: createGithubTarget(github) } : null;
-  }
-  return null;
 }
 
 // Best-effort failure alert. Generic JSON, failure-only, no secrets (backup error
@@ -111,9 +89,9 @@ async function runBackupOnce(
     const bundle = path.basename(dir);
 
     const result: RunBackupResult = { dir, manifest, synced: false };
-    let resolved: { kind: BackupTargetKind; target: BackupTarget } | null = null;
+    let resolved: ResolvedTarget | null = null;
     if (options.sync !== false) {
-      resolved = await resolveBackupTarget(store, config);
+      resolved = await resolveCloudTarget(store, config);
       if (resolved) {
         result.syncedKeys = await syncBundle(resolved.target, dir);
         result.synced = true;

--- a/packages/core/src/backup/target.ts
+++ b/packages/core/src/backup/target.ts
@@ -1,0 +1,34 @@
+// Resolve the configured cloud backup target (automated-backups A3/A5). Shared by
+// runBackup (to sync a fresh bundle) and restore-staging (to pull a bundle that may
+// only exist in the cloud). 'local' → no target; a selected target whose
+// credentials are missing also resolves to null.
+
+import type { LibrarianStore } from "../store/librarian-store.js";
+import { type BackupConfig, readBackupConfig } from "./config.js";
+import { resolveS3SyncConfig } from "./sync/config.js";
+import { resolveGithubSyncConfig } from "./sync/github-config.js";
+import { createGithubTarget } from "./sync/github.js";
+import { createS3Target } from "./sync/s3.js";
+import type { BackupTarget } from "./sync/types.js";
+
+export type BackupTargetKind = "s3" | "github";
+
+export interface ResolvedTarget {
+  kind: BackupTargetKind;
+  target: BackupTarget;
+}
+
+export async function resolveCloudTarget(
+  store: LibrarianStore,
+  config: BackupConfig = readBackupConfig(store),
+): Promise<ResolvedTarget | null> {
+  if (config.target === "s3") {
+    const s3 = resolveS3SyncConfig(store);
+    return s3 ? { kind: "s3", target: await createS3Target(s3) } : null;
+  }
+  if (config.target === "github") {
+    const github = resolveGithubSyncConfig(store);
+    return github ? { kind: "github", target: createGithubTarget(github) } : null;
+  }
+  return null;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -183,6 +183,7 @@ export {
 export {
   type ApplyRestoreResult,
   type StageRestoreResult,
+  RESTORE_FAILED_MARKER,
   RESTORE_MARKER,
   applyPendingRestore,
   stageRestore,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -174,7 +174,19 @@ export {
   BACKUP_MANIFEST,
   createBackup,
 } from "./backup/backup.js";
-export { type RestoreResult, BackupRestoreError, restoreBackup } from "./backup/restore.js";
+export {
+  type RestoreResult,
+  BackupRestoreError,
+  restoreBackup,
+  validateBundle,
+} from "./backup/restore.js";
+export {
+  type ApplyRestoreResult,
+  type StageRestoreResult,
+  RESTORE_MARKER,
+  applyPendingRestore,
+  stageRestore,
+} from "./backup/restore-staging.js";
 export { type ExportFormat, exportData } from "./backup/export.js";
 export { type BackupTarget } from "./backup/sync/types.js";
 export { type MemoryBackupTarget, createMemoryBackupTarget } from "./backup/sync/memory.js";

--- a/packages/core/tests/backup-restore-staging.test.ts
+++ b/packages/core/tests/backup-restore-staging.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import {
   type LibrarianStore,
+  RESTORE_FAILED_MARKER,
   RESTORE_MARKER,
   applyPendingRestore,
   createBackup,
@@ -80,7 +81,7 @@ describe("restart-staged restore", () => {
     expect(store.listAll({}).length).toBe(1); // untouched
   });
 
-  it("keeps the marker and leaves data untouched when the boot-restore fails", async () => {
+  it("quarantines the marker and leaves data untouched when the boot-restore fails", async () => {
     seed(store, "one");
     const { dir } = createBackup(store, { destDir: backupDir });
     const bundle = path.basename(dir);
@@ -95,7 +96,9 @@ describe("restart-staged restore", () => {
     const applied = applyPendingRestore(dataDir);
     expect(applied.applied).toBe(false);
     expect(applied.error).toBeTruthy();
-    expect(fs.existsSync(markerPath())).toBe(true); // marker kept for the operator
+    // Pending marker is quarantined to restore.failed.json (kept, but not retried).
+    expect(fs.existsSync(markerPath())).toBe(false);
+    expect(fs.existsSync(path.join(dataDir, RESTORE_FAILED_MARKER))).toBe(true);
 
     store = createLibrarianStore({ dataDir });
     expect(store.listAll({}).length).toBe(2); // live data untouched (still has "two")

--- a/packages/core/tests/backup-restore-staging.test.ts
+++ b/packages/core/tests/backup-restore-staging.test.ts
@@ -1,0 +1,113 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type LibrarianStore,
+  RESTORE_MARKER,
+  applyPendingRestore,
+  createBackup,
+  createLibrarianStore,
+  stageRestore,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let dataDir: string;
+let backupDir: string;
+let store: LibrarianStore;
+
+function seed(s: LibrarianStore, title: string) {
+  s.createMemory({
+    agent_id: "claude",
+    title,
+    body: "body",
+    category: "projects",
+    visibility: "common",
+    scope: "project",
+    project_key: "the-librarian",
+    priority: "normal",
+    confidence: "working",
+  });
+}
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "lib-restore-data-"));
+  backupDir = path.join(dataDir, "backups");
+  store = createLibrarianStore({ dataDir });
+});
+
+afterEach(() => {
+  try {
+    store.close();
+  } catch {
+    /* already closed */
+  }
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+const markerPath = () => path.join(dataDir, RESTORE_MARKER);
+
+describe("restart-staged restore", () => {
+  it("stages a local bundle and applies it on the next boot", async () => {
+    seed(store, "one");
+    const { dir } = createBackup(store, { destDir: backupDir });
+    const bundle = path.basename(dir);
+
+    seed(store, "two"); // mutate AFTER the backup → 2 memories live
+    expect(store.listAll({}).length).toBe(2);
+
+    const result = await stageRestore(store, { bundleName: bundle, backupDir });
+    expect(result).toEqual({ staged: bundle, restartRequired: true });
+    expect(fs.existsSync(markerPath())).toBe(true);
+
+    store.close(); // simulate shutdown
+    const applied = applyPendingRestore(dataDir);
+    expect(applied).toMatchObject({ applied: true, bundle });
+    expect(fs.existsSync(markerPath())).toBe(false); // marker cleared
+
+    store = createLibrarianStore({ dataDir });
+    expect(store.listAll({}).length).toBe(1); // reverted to the backed-up state
+  });
+
+  it("refuses to stage a corrupt bundle — no marker, live data untouched", async () => {
+    seed(store, "one");
+    const { dir } = createBackup(store, { destDir: backupDir });
+    const bundle = path.basename(dir);
+    // Corrupt the stored ledger so its checksum no longer matches.
+    fs.appendFileSync(path.join(dir, "events.jsonl.gz"), Buffer.from([0, 1, 2]));
+
+    await expect(stageRestore(store, { bundleName: bundle, backupDir })).rejects.toThrow();
+    expect(fs.existsSync(markerPath())).toBe(false);
+    expect(store.listAll({}).length).toBe(1); // untouched
+  });
+
+  it("keeps the marker and leaves data untouched when the boot-restore fails", async () => {
+    seed(store, "one");
+    const { dir } = createBackup(store, { destDir: backupDir });
+    const bundle = path.basename(dir);
+    await stageRestore(store, { bundleName: bundle, backupDir });
+    expect(fs.existsSync(markerPath())).toBe(true);
+
+    // Corrupt the staged bundle AFTER staging (passes stage validation, fails at boot).
+    fs.appendFileSync(path.join(dir, "librarian.sqlite.gz"), Buffer.from([9, 9, 9]));
+    seed(store, "two");
+    store.close();
+
+    const applied = applyPendingRestore(dataDir);
+    expect(applied.applied).toBe(false);
+    expect(applied.error).toBeTruthy();
+    expect(fs.existsSync(markerPath())).toBe(true); // marker kept for the operator
+
+    store = createLibrarianStore({ dataDir });
+    expect(store.listAll({}).length).toBe(2); // live data untouched (still has "two")
+  });
+
+  it("rejects an unsafe bundle name", async () => {
+    await expect(stageRestore(store, { bundleName: "../escape", backupDir })).rejects.toThrow(
+      /invalid bundle name/,
+    );
+  });
+
+  it("applyPendingRestore is a no-op with no marker", () => {
+    expect(applyPendingRestore(dataDir)).toEqual({ applied: false });
+  });
+});

--- a/packages/mcp-server/src/bin/http.ts
+++ b/packages/mcp-server/src/bin/http.ts
@@ -8,6 +8,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import {
+  applyPendingRestore,
   createLibrarianStore,
   createSerialScheduler,
   findLegacyScheduleKeys,
@@ -71,6 +72,21 @@ try {
 } catch (error) {
   logger.fatal(`Invalid boot credentials: ${(error as Error).message}`);
   process.exit(1);
+}
+
+// Apply a dashboard-staged restore BEFORE the store opens — the SQLite file is
+// swapped while no connection holds it (automated-backups A5). A failed restore
+// leaves the live data untouched and keeps the marker for the operator.
+{
+  const restore = applyPendingRestore(dataDir);
+  if (restore.applied) {
+    logger.warn({ bundle: restore.bundle }, "applied a staged restore on boot");
+  } else if (restore.error) {
+    logger.error(
+      { bundle: restore.bundle, reason: restore.error },
+      "staged restore failed on boot; live data left untouched, marker kept",
+    );
+  }
 }
 
 const store = createLibrarianStore({ secretKey, dataDir });

--- a/packages/mcp-server/src/bin/http.ts
+++ b/packages/mcp-server/src/bin/http.ts
@@ -84,7 +84,8 @@ try {
   } else if (restore.error) {
     logger.error(
       { bundle: restore.bundle, reason: restore.error },
-      "staged restore failed on boot; live data left untouched, marker kept",
+      "staged restore failed on boot; live data left untouched. The pending marker " +
+        "was quarantined to restore.failed.json (not retried) — inspect it and re-stage to retry.",
     );
   }
 }

--- a/packages/mcp-server/src/trpc/backup.ts
+++ b/packages/mcp-server/src/trpc/backup.ts
@@ -92,10 +92,11 @@ export const backupRouter = router({
 
   // Exit the server so the supervisor/orchestrator restarts it (applying any staged
   // restore on boot). The cockpit's "Restart now" button warns that this only
-  // recovers under an auto-restart supervisor. Exit is deferred so the response
-  // flushes first.
+  // recovers under an auto-restart supervisor. The exit is deferred so the
+  // { restarting: true } ack flushes first — best-effort: a dropped ack is harmless
+  // here (the caller asked to restart; the server going down IS the outcome).
   restart: adminProcedure.mutation(() => {
-    setTimeout(() => process.exit(0), 100);
+    setTimeout(() => process.exit(0), 250);
     return { restarting: true as const };
   }),
 });

--- a/packages/mcp-server/src/trpc/backup.ts
+++ b/packages/mcp-server/src/trpc/backup.ts
@@ -5,7 +5,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import type { LibrarianStore } from "@librarian/core";
-import { runBackup } from "@librarian/core";
+import { runBackup, stageRestore } from "@librarian/core";
 import { z } from "zod";
 import { adminProcedure, router } from "./trpc.js";
 
@@ -42,7 +42,11 @@ export const backupRouter = router({
     return fs
       .readdirSync(dir)
       .filter((name) => name.startsWith("librarian-backup-"))
-      .map((name) => ({ name, created_at: fs.statSync(path.join(dir, name)).mtime.toISOString() }))
+      .map((name) => ({
+        name,
+        created_at: fs.statSync(path.join(dir, name)).mtime.toISOString(),
+        restorable: true,
+      }))
       .sort((a, b) => b.created_at.localeCompare(a.created_at));
   }),
 
@@ -75,5 +79,23 @@ export const backupRouter = router({
     if (input.secretKey)
       ctx.store.setSetting("backup.s3.secret_key", input.secretKey, { secret: true });
     return { ok: true };
+  }),
+
+  // Stage a restore: validate the chosen bundle (pulling from the cloud target if
+  // it's not local) and write the pending-restore marker. It is APPLIED on the next
+  // boot — never under the live DB connection. The cockpit then prompts a restart.
+  stageRestore: adminProcedure
+    .input(z.strictObject({ bundle: z.string().min(1) }))
+    .mutation(({ ctx, input }) =>
+      stageRestore(ctx.store, { bundleName: input.bundle, backupDir: backupDestDir(ctx.store) }),
+    ),
+
+  // Exit the server so the supervisor/orchestrator restarts it (applying any staged
+  // restore on boot). The cockpit's "Restart now" button warns that this only
+  // recovers under an auto-restart supervisor. Exit is deferred so the response
+  // flushes first.
+  restart: adminProcedure.mutation(() => {
+    setTimeout(() => process.exit(0), 100);
+    return { restarting: true as const };
   }),
 });

--- a/packages/mcp-server/tests/trpc/backup.test.ts
+++ b/packages/mcp-server/tests/trpc/backup.test.ts
@@ -2,6 +2,8 @@
 // createNow → list, and a plain config round-trip. (The secret-credential path is
 // covered by core's settings-store; it needs LIBRARIAN_SECRET_KEY in the server env.)
 
+import fs from "node:fs";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { cleanupTempDir, makeTempDir, startHttpServer } from "../../../../test/helpers.js";
 
@@ -64,6 +66,27 @@ describe("tRPC backup surface", () => {
       const list = await trpcGet<{ name: string }[]>(server, "backup.list");
       expect(list.length).toBe(1);
       expect(list[0]?.name).toMatch(/^librarian-backup-/);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("stageRestore validates a bundle and writes the pending-restore marker", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      await trpcPost(server, "backup.createNow");
+      const list = await trpcGet<{ name: string }[]>(server, "backup.list");
+      const bundle = list[0]?.name as string;
+
+      const staged = await trpcPost<{ staged: string; restartRequired: boolean }>(
+        server,
+        "backup.stageRestore",
+        { bundle },
+      );
+      expect(staged).toEqual({ staged: bundle, restartRequired: true });
+      expect(fs.existsSync(path.join(dataDir, "restore.pending.json"))).toBe(true);
     } finally {
       await server.stop();
       cleanupTempDir(dataDir);


### PR DESCRIPTION
## What (A5 of automated-backups, plan 034)

Restore a backup **from the dashboard**, safely — without swapping `librarian.sqlite` under a live DB connection. Split into stage + apply:

- **`stageRestore`** (live server, tRPC `backup.stageRestore`): resolve the bundle (local, else pull from the configured cloud target), **validate it fully without applying** (refuses a corrupt bundle), and write a `restore.pending.json` marker.
- **`applyPendingRestore`** (boot, `bin/http.ts` before `createLibrarianStore`): swap the validated bundle in while no connection holds the DB, then clear the marker. On failure the live data is **untouched** (validate-before-write) and the marker is **quarantined** to `restore.failed.json` (visible but not retried).
- tRPC `backup.restart` exits the server (deferred, so the ack flushes) → the supervisor restarts → the restore applies on boot. `backup.list` entries gain `restorable`.

## Safety

- Boot restore runs strictly **before** the store opens; a failed restore never half-applies (two-phase: validate-all-then-swap, atomic per-file rename).
- Path traversal is doubly guarded: `stageRestore` validates the bundle name, and the written file names are guarded by `assertSafeName` regardless of the marker's source dir.
- `restart` and `stageRestore` are admin-gated; no secrets logged.

## Refactors

Extracted the cloud-target resolver to `backup/target.ts` (shared by `runBackup` + staging) and `prepareRestore`/`validateBundle` from `restore.ts` (phase-1 validation reused by staging) — behaviour preserved.

## Tests

Stage local → apply on boot → data reverts; corrupt bundle refused at stage; corrupt-after-stage → boot-restore quarantines the marker + leaves data intact; unsafe bundle name rejected; no-marker no-op; tRPC `stageRestore` writes the marker. Full suite green.

Implements A5 of `docs/specs/034-automated-backups-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)