### PR TITLE
feat(backup): dashboard cockpit + docs (A6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ changes from this point forward are catalogued here.
 
 ### Added
 
+- **Backups cockpit on the dashboard.** The `/backups` page now manages the whole
+  backup lifecycle: a config form (cloud target — S3 or GitHub — with write-only
+  credentials, schedule, retention, and an optional failure webhook), a health
+  banner (last successful backup / last failure), the recent bundles with one-click
+  **restore** (restart-staged, with the supervisor warning), and a run-history
+  table. No redeploy needed to change any of it.
+
 - **Restore a backup from the dashboard (restart-staged).** Staging a restore
   validates the chosen bundle (pulling it from the cloud target if it isn't
   local) and queues it; it's applied on the next server boot — before the SQLite

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -233,16 +233,32 @@ Inside the single-container image, run via `docker exec <container> the-libraria
 
 **Restoring onto a new host (master key).** Backups are deliberately **key-free** — `secret.key` never travels in a bundle, so a leaked backup is not a leaked key. If the bundle contains encrypted secrets (e.g. the curator token), `restore` needs the original master key to unlock them on a host that lacks it: pass `--secret-key <key>` or let it **prompt** on a TTY. A correct key is verified against the restored data and saved to `<data>/secret.key` so the next boot can read it; a wrong key fails with a clear error and is never persisted. If the new host already has the key (its own `secret.key` or `LIBRARIAN_SECRET_KEY` in the env), no prompt appears.
 
-### Scheduled backups + cloud sync
+### Automated backups + cloud sync (dashboard **Backups** page)
 
-- **Schedule**: set `LIBRARIAN_BACKUP_INTERVAL_MS` (>0) to have the server write a bundle on a
-  cadence (to `LIBRARIAN_BACKUP_DIR`, default `<data>/backups`). Trigger one anytime from the
-  dashboard's **Backups** page (admin).
-- **Cloud sync** (optional): configure S3-compatible storage (AWS / Cloudflare R2 / MinIO /
-  Backblaze) via the dashboard, or env: `LIBRARIAN_BACKUP_S3_BUCKET`, `…_ACCESS_KEY`,
-  `…_SECRET_KEY`, and optionally `…_REGION` / `…_ENDPOINT` / `…_PREFIX`. Each scheduled or
-  dashboard backup is then uploaded after it's written locally. (Requires `@aws-sdk/client-s3`
-  installed in the runtime; the credentials are encrypted at rest with `LIBRARIAN_SECRET_KEY`.)
+The dashboard's **Backups** cockpit (admin) drives the whole lifecycle — no redeploy
+to change the schedule. Bundles are gzipped (`format_version` 2, ~70% smaller; older
+uncompressed bundles still restore).
+
+- **Schedule**: enable scheduled backups and set the frequency (minutes) + retention
+  (how many bundles to keep — the rest are pruned per target). The server runs a
+  backup once the interval elapses. Bundles land in `LIBRARIAN_BACKUP_DIR` (default
+  `<data>/backups`); trigger one anytime with **Backup now**. (Legacy: a headless
+  install can still enable backups via `LIBRARIAN_BACKUP_INTERVAL_MS` until the
+  dashboard configures a schedule.)
+- **Cloud target** (optional, pick one): **S3-compatible** (AWS / Cloudflare R2 /
+  MinIO / Backblaze — requires `@aws-sdk/client-s3` in the runtime) or **GitHub
+  Releases** (a private repo; each backup is a Release with the bundle files as
+  assets — no SDK, uses built-in `fetch`). For GitHub, save `owner/repo` + a
+  fine-grained **PAT** with **Contents: read/write** on that repo. Credentials are
+  encrypted at rest with `LIBRARIAN_SECRET_KEY` and never leave the dashboard server.
+  Env fallback: `LIBRARIAN_BACKUP_S3_*` / `LIBRARIAN_BACKUP_GITHUB_{REPO,TOKEN}`.
+- **Failure alerts**: the cockpit shows the last successful backup and a banner on
+  the most recent failure; set a webhook URL to also POST a generic-JSON alert.
+- **Restore**: pick a recent bundle → **Restore**. The restore is *staged* and
+  applied on the next **boot** (the SQLite file is never swapped under a live
+  connection). The cockpit prompts a restart; **Restart now** only recovers under an
+  auto-restart supervisor (Docker `restart:` / systemd `Restart=` / Fly) — otherwise
+  restart the server yourself. A failed restore leaves the live data untouched.
 
 ### Volume snapshot (alternative)
 

--- a/apps/dashboard/app/backups/actions.ts
+++ b/apps/dashboard/app/backups/actions.ts
@@ -3,16 +3,76 @@
 import { revalidatePath } from "next/cache";
 import { serverTRPC } from "@/lib/trpc-server";
 
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 export type BackupNowResult =
-  | { ok: true; dir: string; files: number; synced: boolean }
+  | { ok: true; files: number; synced: boolean; pruned: number }
   | { ok: false; error: string };
 
 export async function backupNowAction(): Promise<BackupNowResult> {
   try {
     const r = await serverTRPC.backup.createNow.mutate();
     revalidatePath("/backups");
-    return { ok: true, dir: r.dir, files: r.files, synced: r.synced };
+    return { ok: true, files: r.files, synced: r.synced, pruned: r.pruned };
   } catch (error) {
-    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+    return { ok: false, error: message(error) };
+  }
+}
+
+// The setConfig input shape (mirrors the backup tRPC SetConfigSchema). Secrets are
+// write-only: an empty/absent field leaves the stored value unchanged.
+export interface SaveBackupConfigInput {
+  enabled?: boolean;
+  intervalMinutes?: number;
+  target?: "local" | "s3" | "github";
+  retentionKeep?: number;
+  webhookUrl?: string;
+  s3?: {
+    bucket?: string;
+    region?: string;
+    endpoint?: string;
+    prefix?: string;
+    accessKey?: string;
+    secretKey?: string;
+  };
+  github?: { repo?: string; token?: string };
+}
+
+export type SaveConfigResult = { ok: true } | { ok: false; error: string };
+
+export async function saveBackupConfigAction(
+  input: SaveBackupConfigInput,
+): Promise<SaveConfigResult> {
+  try {
+    await serverTRPC.backup.setConfig.mutate(input);
+    revalidatePath("/backups");
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: message(error) };
+  }
+}
+
+export type StageRestoreResult = { ok: true; staged: string } | { ok: false; error: string };
+
+export async function stageRestoreAction(bundle: string): Promise<StageRestoreResult> {
+  try {
+    const r = await serverTRPC.backup.stageRestore.mutate({ bundle });
+    revalidatePath("/backups");
+    return { ok: true, staged: r.staged };
+  } catch (error) {
+    return { ok: false, error: message(error) };
+  }
+}
+
+export type RestartResult = { ok: true } | { ok: false; error: string };
+
+export async function restartAction(): Promise<RestartResult> {
+  try {
+    await serverTRPC.backup.restart.mutate();
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: message(error) };
   }
 }

--- a/apps/dashboard/app/backups/page.tsx
+++ b/apps/dashboard/app/backups/page.tsx
@@ -1,26 +1,61 @@
-// Backups cockpit — recent backups + a "Backup now" trigger + cloud-sync status.
-// The backend (tRPC backup router) handles the actual snapshot + optional upload.
+// Backups cockpit (automated-backups A6) — health banner, config (target + schedule
+// + retention + webhook), recent bundles with one-click restore, and run history.
 
-import { backupNowAction } from "./actions";
+import {
+  backupNowAction,
+  restartAction,
+  saveBackupConfigAction,
+  stageRestoreAction,
+} from "./actions";
 import { BackupNowButton } from "@/components/backups/backup-now-button";
+import { BackupConfigForm } from "@/components/backups/config-form";
+import { type BackupCockpitConfig, BackupConfigSummary } from "@/components/backups/config-summary";
+import { RestoreButton } from "@/components/backups/restore-button";
+import { BackupRunsTable } from "@/components/backups/runs-table";
 import { serverTRPC } from "@/lib/trpc-server";
 
 export const dynamic = "force-dynamic";
 
+function HealthBanner({
+  config,
+}: {
+  config: Awaited<ReturnType<typeof serverTRPC.backup.config.query>>;
+}) {
+  if (config.lastRun?.status === "error") {
+    return (
+      <p
+        role="alert"
+        className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm"
+      >
+        ⚠️ Last backup failed: {config.lastRun.error ?? "unknown error"}
+      </p>
+    );
+  }
+  if (config.lastSuccess) {
+    return (
+      <p className="rounded-md border border-green-600/40 bg-green-50 p-3 text-sm dark:bg-green-950/20">
+        ✓ Last successful backup {new Date(config.lastSuccess.created_at).toLocaleString()}
+        {config.lastSuccess.synced ? " (synced to cloud)" : ""}.
+      </p>
+    );
+  }
+  return <p className="text-sm text-muted-foreground">No backups yet.</p>;
+}
+
 export default async function BackupsPage() {
   let backups: Awaited<ReturnType<typeof serverTRPC.backup.list.query>> = [];
+  let runs: Awaited<ReturnType<typeof serverTRPC.backup.runs.query>> = [];
   let config: Awaited<ReturnType<typeof serverTRPC.backup.config.query>> | null = null;
   let error: string | null = null;
   try {
-    [backups, config] = await Promise.all([
+    [backups, runs, config] = await Promise.all([
       serverTRPC.backup.list.query(),
+      serverTRPC.backup.runs.query({ limit: 10 }),
       serverTRPC.backup.config.query(),
     ]);
   } catch (err) {
     error = err instanceof Error ? err.message : String(err);
   }
-
-  const syncOn = Boolean(config?.bucket && config.hasAccessKey && config.hasSecretKey);
 
   return (
     <main className="flex flex-col gap-6 p-6">
@@ -29,23 +64,38 @@ export default async function BackupsPage() {
         <BackupNowButton onRun={backupNowAction} />
       </header>
       {error ? <p className="text-sm text-destructive">{error}</p> : null}
-      <p className="text-sm text-muted-foreground">
-        Cloud sync: {syncOn ? `enabled → ${config?.bucket}` : "not configured"}.
-      </p>
+      {config ? <HealthBanner config={config} /> : null}
+      {config ? <BackupConfigSummary config={config as BackupCockpitConfig} /> : null}
+      {config ? (
+        <BackupConfigForm initial={config as BackupCockpitConfig} onSave={saveBackupConfigAction} />
+      ) : null}
+
       <section className="rounded-md border bg-card p-4" aria-label="Recent backups">
         <h2 className="mb-3 font-semibold">Recent backups</h2>
         {backups.length === 0 ? (
           <p className="text-sm text-muted-foreground">No backups yet.</p>
         ) : (
-          <ul className="flex flex-col gap-1 text-sm">
+          <ul className="flex flex-col gap-2 text-sm">
             {backups.map((b) => (
-              <li key={b.name} className="flex justify-between gap-4">
+              <li key={b.name} className="flex flex-wrap items-center justify-between gap-3">
                 <span className="font-mono">{b.name}</span>
-                <span className="text-muted-foreground">{b.created_at}</span>
+                <span className="text-muted-foreground">
+                  {new Date(b.created_at).toLocaleString()}
+                </span>
+                <RestoreButton
+                  bundle={b.name}
+                  onStage={stageRestoreAction}
+                  onRestart={restartAction}
+                />
               </li>
             ))}
           </ul>
         )}
+      </section>
+
+      <section className="rounded-md border bg-card p-4" aria-label="Run history">
+        <h2 className="mb-3 font-semibold">Run history</h2>
+        <BackupRunsTable runs={runs} />
       </section>
     </main>
   );

--- a/apps/dashboard/components/backups/config-form.tsx
+++ b/apps/dashboard/components/backups/config-form.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import type { BackupCockpitConfig } from "./config-summary";
+import type { SaveBackupConfigInput, SaveConfigResult } from "@/app/backups/actions";
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="flex flex-col gap-1 text-sm">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      {children}
+    </label>
+  );
+}
+
+const inputClass = "rounded-md border bg-background px-2 py-1 font-mono text-sm";
+
+export function BackupConfigForm({
+  initial,
+  onSave,
+}: {
+  initial: BackupCockpitConfig;
+  onSave: (input: SaveBackupConfigInput) => Promise<SaveConfigResult>;
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [status, setStatus] = useState<string | null>(null);
+
+  const [enabled, setEnabled] = useState(initial.enabled);
+  const [target, setTarget] = useState(initial.target);
+  const [intervalMinutes, setIntervalMinutes] = useState(String(initial.intervalMinutes));
+  const [retentionKeep, setRetentionKeep] = useState(String(initial.retentionKeep));
+  const [webhookUrl, setWebhookUrl] = useState(initial.webhookUrl);
+
+  const [bucket, setBucket] = useState(initial.s3.bucket);
+  const [region, setRegion] = useState(initial.s3.region);
+  const [endpoint, setEndpoint] = useState(initial.s3.endpoint);
+  const [prefix, setPrefix] = useState(initial.s3.prefix);
+  const [accessKey, setAccessKey] = useState("");
+  const [secretKey, setSecretKey] = useState("");
+
+  const [repo, setRepo] = useState(initial.github.repo);
+  const [token, setToken] = useState("");
+
+  const submit = (event: React.FormEvent) => {
+    event.preventDefault();
+    startTransition(async () => {
+      const input: SaveBackupConfigInput = {
+        enabled,
+        target,
+        intervalMinutes: Number(intervalMinutes),
+        retentionKeep: Number(retentionKeep),
+        webhookUrl,
+        s3: { bucket, region, endpoint, prefix },
+        github: { repo },
+      };
+      // Secrets are write-only — only send a non-empty field; blank keeps the stored value.
+      if (accessKey) input.s3!.accessKey = accessKey;
+      if (secretKey) input.s3!.secretKey = secretKey;
+      if (token) input.github!.token = token;
+
+      const result = await onSave(input);
+      setStatus(result.ok ? "Saved." : `Error: ${result.error}`);
+      if (result.ok) {
+        setAccessKey("");
+        setSecretKey("");
+        setToken("");
+        router.refresh();
+      }
+    });
+  };
+
+  return (
+    <form
+      onSubmit={submit}
+      className="flex flex-col gap-4 rounded-md border bg-card p-4"
+      aria-label="Backup configuration form"
+    >
+      <h2 className="font-semibold">Edit configuration</h2>
+
+      <label className="flex items-center gap-2 text-sm">
+        <input type="checkbox" checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />
+        Enable scheduled backups
+      </label>
+
+      <div className="grid gap-3 sm:grid-cols-3">
+        <Field label="Cloud target">
+          <select
+            className={inputClass}
+            value={target}
+            onChange={(e) => setTarget(e.target.value as BackupCockpitConfig["target"])}
+          >
+            <option value="local">local only</option>
+            <option value="s3">S3-compatible</option>
+            <option value="github">GitHub Releases</option>
+          </select>
+        </Field>
+        <Field label="Run every N minutes">
+          <input
+            className={inputClass}
+            type="number"
+            min="1"
+            value={intervalMinutes}
+            onChange={(e) => setIntervalMinutes(e.target.value)}
+          />
+        </Field>
+        <Field label="Keep N bundles">
+          <input
+            className={inputClass}
+            type="number"
+            min="1"
+            value={retentionKeep}
+            onChange={(e) => setRetentionKeep(e.target.value)}
+          />
+        </Field>
+      </div>
+
+      <Field label="Failure webhook URL (blank = off)">
+        <input
+          className={inputClass}
+          type="url"
+          placeholder="https://hooks.example/backup"
+          value={webhookUrl}
+          onChange={(e) => setWebhookUrl(e.target.value)}
+        />
+      </Field>
+
+      {target === "s3" ? (
+        <fieldset className="grid gap-3 rounded-md border p-3 sm:grid-cols-2">
+          <legend className="px-1 text-xs text-muted-foreground">S3-compatible storage</legend>
+          <Field label="Bucket">
+            <input
+              className={inputClass}
+              value={bucket}
+              onChange={(e) => setBucket(e.target.value)}
+            />
+          </Field>
+          <Field label="Region">
+            <input
+              className={inputClass}
+              value={region}
+              onChange={(e) => setRegion(e.target.value)}
+            />
+          </Field>
+          <Field label="Endpoint (R2/MinIO/Backblaze)">
+            <input
+              className={inputClass}
+              value={endpoint}
+              onChange={(e) => setEndpoint(e.target.value)}
+            />
+          </Field>
+          <Field label="Prefix">
+            <input
+              className={inputClass}
+              value={prefix}
+              onChange={(e) => setPrefix(e.target.value)}
+            />
+          </Field>
+          <Field label="Access key (blank = keep)">
+            <input
+              className={inputClass}
+              type="password"
+              placeholder={initial.s3.hasAccessKey ? "•••••• (configured)" : "not set"}
+              value={accessKey}
+              onChange={(e) => setAccessKey(e.target.value)}
+            />
+          </Field>
+          <Field label="Secret key (blank = keep)">
+            <input
+              className={inputClass}
+              type="password"
+              placeholder={initial.s3.hasSecretKey ? "•••••• (configured)" : "not set"}
+              value={secretKey}
+              onChange={(e) => setSecretKey(e.target.value)}
+            />
+          </Field>
+        </fieldset>
+      ) : null}
+
+      {target === "github" ? (
+        <fieldset className="grid gap-3 rounded-md border p-3 sm:grid-cols-2">
+          <legend className="px-1 text-xs text-muted-foreground">GitHub Releases</legend>
+          <Field label="Repository (owner/repo)">
+            <input
+              className={inputClass}
+              placeholder="me/librarian-backups"
+              value={repo}
+              onChange={(e) => setRepo(e.target.value)}
+            />
+          </Field>
+          <Field label="Fine-grained token (blank = keep)">
+            <input
+              className={inputClass}
+              type="password"
+              placeholder={initial.github.hasToken ? "•••••• (configured)" : "not set"}
+              value={token}
+              onChange={(e) => setToken(e.target.value)}
+            />
+          </Field>
+        </fieldset>
+      ) : null}
+
+      <div className="flex items-center gap-3">
+        <button
+          type="submit"
+          disabled={pending}
+          className="rounded-md border bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground disabled:opacity-50"
+        >
+          {pending ? "Saving…" : "Save"}
+        </button>
+        {status ? <span className="text-sm text-muted-foreground">{status}</span> : null}
+      </div>
+    </form>
+  );
+}

--- a/apps/dashboard/components/backups/config-summary.tsx
+++ b/apps/dashboard/components/backups/config-summary.tsx
@@ -1,0 +1,53 @@
+// Read-only summary of the backup config (automated-backups A6). No secret values
+// are shown — only whether each credential is set.
+
+export interface BackupCockpitConfig {
+  enabled: boolean;
+  intervalMinutes: number;
+  target: "local" | "s3" | "github";
+  retentionKeep: number;
+  webhookUrl: string;
+  s3: {
+    bucket: string;
+    region: string;
+    endpoint: string;
+    prefix: string;
+    hasAccessKey: boolean;
+    hasSecretKey: boolean;
+  };
+  github: { repo: string; hasToken: boolean };
+}
+
+function targetLabel(config: BackupCockpitConfig): string {
+  if (config.target === "s3") return `S3 → ${config.s3.bucket || "(no bucket)"}`;
+  if (config.target === "github") return `GitHub → ${config.github.repo || "(no repo)"}`;
+  return "local only";
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-4 py-1">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      <span className="font-mono text-sm">{value}</span>
+    </div>
+  );
+}
+
+export function BackupConfigSummary({ config }: { config: BackupCockpitConfig }) {
+  return (
+    <section className="rounded-md border bg-card p-4" aria-label="Backup configuration">
+      <header className="mb-3 flex items-baseline justify-between">
+        <h2 className="font-semibold">Configuration</h2>
+        <span
+          className={`text-sm font-medium ${config.enabled ? "text-green-600" : "text-muted-foreground"}`}
+        >
+          {config.enabled ? "Schedule enabled" : "Schedule disabled"}
+        </span>
+      </header>
+      <Row label="Cloud target" value={targetLabel(config)} />
+      <Row label="Frequency" value={`every ${config.intervalMinutes} minute(s)`} />
+      <Row label="Retention" value={`keep ${config.retentionKeep} bundle(s)`} />
+      <Row label="Failure webhook" value={config.webhookUrl ? "configured" : "off"} />
+    </section>
+  );
+}

--- a/apps/dashboard/components/backups/restart-prompt.tsx
+++ b/apps/dashboard/components/backups/restart-prompt.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import type { RestartResult } from "@/app/backups/actions";
+
+// Shown after a restore is staged: a restart applies it on the next boot. The
+// warning is load-bearing (Decision 10) — a bare process won't come back.
+export function RestartPrompt({ onRestart }: { onRestart: () => Promise<RestartResult> }) {
+  const [pending, startTransition] = useTransition();
+  const [message, setMessage] = useState<string | null>(null);
+
+  const restart = () =>
+    startTransition(async () => {
+      const res = await onRestart();
+      setMessage(res.ok ? "Restarting… reconnect in a moment." : `Error: ${res.error}`);
+    });
+
+  return (
+    <div
+      role="alert"
+      className="flex flex-col gap-2 rounded-md border border-amber-500/50 bg-amber-50 p-3 text-sm dark:bg-amber-950/30"
+    >
+      <p className="font-medium">Restart required to apply this restore.</p>
+      <p className="text-xs text-muted-foreground">
+        Only use “Restart now” if The Librarian runs under an auto-restart supervisor (Docker{" "}
+        <code>restart:</code> policy, systemd <code>Restart=</code>, Fly, …). On a bare process it
+        will shut down and <strong>not come back</strong> — restart it yourself instead.
+      </p>
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={restart}
+          disabled={pending}
+          className="rounded-md border bg-destructive px-3 py-1.5 text-sm font-medium text-destructive-foreground disabled:opacity-50"
+        >
+          {pending ? "Restarting…" : "Restart now"}
+        </button>
+        {message ? <span className="text-sm text-muted-foreground">{message}</span> : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/components/backups/restore-button.tsx
+++ b/apps/dashboard/components/backups/restore-button.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { RestartPrompt } from "./restart-prompt";
+import type { RestartResult, StageRestoreResult } from "@/app/backups/actions";
+
+// Per-bundle restore. Restoring is destructive (it replaces current data on the
+// next restart), so it's two-step: Restore → Confirm. On a successful stage it
+// reveals the warned restart prompt.
+export function RestoreButton({
+  bundle,
+  onStage,
+  onRestart,
+}: {
+  bundle: string;
+  onStage: (bundle: string) => Promise<StageRestoreResult>;
+  onRestart: () => Promise<RestartResult>;
+}) {
+  const [pending, startTransition] = useTransition();
+  const [confirming, setConfirming] = useState(false);
+  const [staged, setStaged] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const stage = () =>
+    startTransition(async () => {
+      const res = await onStage(bundle);
+      if (res.ok) {
+        setStaged(true);
+        setConfirming(false);
+      } else {
+        setError(res.error);
+        setConfirming(false);
+      }
+    });
+
+  if (staged) return <RestartPrompt onRestart={onRestart} />;
+
+  return (
+    <div className="flex items-center gap-2">
+      {confirming ? (
+        <>
+          <span className="text-xs text-muted-foreground">Replace current data on restart?</span>
+          <button
+            type="button"
+            onClick={stage}
+            disabled={pending}
+            className="rounded-md border bg-destructive px-2 py-1 text-xs font-medium text-destructive-foreground disabled:opacity-50"
+          >
+            {pending ? "Staging…" : "Confirm restore"}
+          </button>
+          <button
+            type="button"
+            onClick={() => setConfirming(false)}
+            className="rounded-md border px-2 py-1 text-xs"
+          >
+            Cancel
+          </button>
+        </>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setConfirming(true)}
+          className="rounded-md border px-2 py-1 text-xs font-medium"
+        >
+          Restore
+        </button>
+      )}
+      {error ? <span className="text-xs text-destructive">{error}</span> : null}
+    </div>
+  );
+}

--- a/apps/dashboard/components/backups/runs-table.tsx
+++ b/apps/dashboard/components/backups/runs-table.tsx
@@ -1,0 +1,51 @@
+// Read-only backup run health (automated-backups A6): trigger, status, target,
+// size, when, and the error / sync detail.
+
+import type { BackupRun } from "@librarian/core";
+
+function fmt(ts: string | null): string {
+  return ts ? new Date(ts).toLocaleString() : "—";
+}
+
+function fmtBytes(n: number): string {
+  if (n <= 0) return "—";
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(0)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function BackupRunsTable({ runs }: { runs: BackupRun[] }) {
+  if (runs.length === 0) {
+    return <p className="text-sm text-muted-foreground">No backup runs yet.</p>;
+  }
+  return (
+    <table className="w-full text-left text-sm" aria-label="Backup runs">
+      <thead className="text-xs text-muted-foreground">
+        <tr>
+          <th className="py-2 pr-4 font-medium">Trigger</th>
+          <th className="py-2 pr-4 font-medium">Status</th>
+          <th className="py-2 pr-4 font-medium">Target</th>
+          <th className="py-2 pr-4 font-medium">Size</th>
+          <th className="py-2 pr-4 font-medium">When</th>
+          <th className="py-2 font-medium">Detail</th>
+        </tr>
+      </thead>
+      <tbody>
+        {runs.map((run) => (
+          <tr key={run.id} className="border-t align-top">
+            <td className="py-2 pr-4">{run.trigger}</td>
+            <td
+              className={`py-2 pr-4 ${run.status === "error" ? "text-destructive" : run.status === "ok" ? "text-green-600" : ""}`}
+            >
+              {run.status}
+            </td>
+            <td className="py-2 pr-4">{run.target ?? "—"}</td>
+            <td className="py-2 pr-4 font-mono text-xs">{fmtBytes(run.bytes)}</td>
+            <td className="py-2 pr-4 font-mono text-xs">{fmt(run.created_at)}</td>
+            <td className="py-2">{run.error ?? (run.synced ? "synced" : "local")}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/apps/dashboard/components/backups/runs-table.tsx
+++ b/apps/dashboard/components/backups/runs-table.tsx
@@ -1,5 +1,7 @@
 // Read-only backup run health (automated-backups A6): trigger, status, target,
-// size, when, and the error / sync detail.
+// size, when, and the error / sync detail. `run.error` is rendered verbatim — it's
+// safe because backup error messages are token-scrubbed upstream (S3/GitHub clients
+// never put credentials in errors), and React escapes the text.
 
 import type { BackupRun } from "@librarian/core";
 

--- a/apps/dashboard/tests/components/backup-now-button.test.tsx
+++ b/apps/dashboard/tests/components/backup-now-button.test.tsx
@@ -7,7 +7,7 @@ const { BackupNowButton } = await import("@/components/backups/backup-now-button
 
 describe("BackupNowButton", () => {
   it("reports success after a backup", async () => {
-    const onRun = vi.fn().mockResolvedValue({ ok: true, dir: "/d", files: 4, synced: false });
+    const onRun = vi.fn().mockResolvedValue({ ok: true, files: 4, synced: false, pruned: 0 });
     render(<BackupNowButton onRun={onRun} />);
     fireEvent.click(screen.getByRole("button", { name: "Backup now" }));
     await waitFor(() => expect(screen.getByText(/Backed up 4 file/)).toBeInTheDocument());
@@ -15,7 +15,7 @@ describe("BackupNowButton", () => {
   });
 
   it("reports the cloud-sync state when synced", async () => {
-    const onRun = vi.fn().mockResolvedValue({ ok: true, dir: "/d", files: 4, synced: true });
+    const onRun = vi.fn().mockResolvedValue({ ok: true, files: 4, synced: true, pruned: 0 });
     render(<BackupNowButton onRun={onRun} />);
     fireEvent.click(screen.getByRole("button", { name: "Backup now" }));
     await waitFor(() => expect(screen.getByText(/synced to cloud/)).toBeInTheDocument());

--- a/apps/dashboard/tests/components/backups/cockpit.test.tsx
+++ b/apps/dashboard/tests/components/backups/cockpit.test.tsx
@@ -1,0 +1,134 @@
+import type { BackupRun } from "@librarian/core";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
+
+const { BackupConfigSummary } = await import("@/components/backups/config-summary");
+const { BackupConfigForm } = await import("@/components/backups/config-form");
+const { BackupRunsTable } = await import("@/components/backups/runs-table");
+const { RestoreButton } = await import("@/components/backups/restore-button");
+const { RestartPrompt } = await import("@/components/backups/restart-prompt");
+
+type Config = Parameters<typeof BackupConfigSummary>[0]["config"];
+
+function cfg(over: Partial<Config> = {}): Config {
+  return {
+    enabled: false,
+    intervalMinutes: 1440,
+    target: "local",
+    retentionKeep: 14,
+    webhookUrl: "",
+    s3: {
+      bucket: "",
+      region: "",
+      endpoint: "",
+      prefix: "",
+      hasAccessKey: false,
+      hasSecretKey: false,
+    },
+    github: { repo: "", hasToken: false },
+    ...over,
+  };
+}
+
+function run(over: Partial<BackupRun> = {}): BackupRun {
+  return {
+    id: "bkp_1",
+    status: "ok",
+    trigger: "manual",
+    target: "local",
+    bundle: "librarian-backup-x",
+    bytes: 1234,
+    synced: false,
+    error: null,
+    created_at: "2026-05-30T00:00:00.000Z",
+    started_at: "2026-05-30T00:00:00.000Z",
+    completed_at: "2026-05-30T00:00:01.000Z",
+    ...over,
+  };
+}
+
+describe("BackupConfigSummary", () => {
+  it("shows the schedule state, target, retention and webhook", () => {
+    render(
+      <BackupConfigSummary
+        config={cfg({ enabled: true, target: "github", github: { repo: "me/bk", hasToken: true } })}
+      />,
+    );
+    expect(screen.getByText("Schedule enabled")).toBeTruthy();
+    expect(screen.getByText(/GitHub → me\/bk/)).toBeTruthy();
+    expect(screen.getByText(/keep 14 bundle/)).toBeTruthy();
+  });
+});
+
+describe("BackupConfigForm", () => {
+  it("shows GitHub fields for the github target and keeps the token write-only", async () => {
+    const onSave = vi.fn().mockResolvedValue({ ok: true });
+    render(
+      <BackupConfigForm
+        initial={cfg({ target: "github", github: { repo: "me/bk", hasToken: true } })}
+        onSave={onSave}
+      />,
+    );
+
+    expect(screen.getByPlaceholderText("me/librarian-backups")).toBeTruthy();
+    fireEvent.submit(screen.getByLabelText("Backup configuration form"));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    const input = onSave.mock.calls[0][0];
+    expect(input.target).toBe("github");
+    expect(input.github.repo).toBe("me/bk");
+    expect(input.github.token).toBeUndefined(); // blank token not round-tripped
+    expect(input.s3.accessKey).toBeUndefined();
+  });
+
+  it("sends a newly typed secret but not the placeholder", async () => {
+    const onSave = vi.fn().mockResolvedValue({ ok: true });
+    render(<BackupConfigForm initial={cfg({ target: "s3" })} onSave={onSave} />);
+    fireEvent.change(screen.getByLabelText("Access key (blank = keep)"), {
+      target: { value: "AKIA123" },
+    });
+    fireEvent.submit(screen.getByLabelText("Backup configuration form"));
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    expect(onSave.mock.calls[0][0].s3.accessKey).toBe("AKIA123");
+  });
+});
+
+describe("BackupRunsTable", () => {
+  it("renders runs and an empty state", () => {
+    const { rerender } = render(<BackupRunsTable runs={[]} />);
+    expect(screen.getByText("No backup runs yet.")).toBeTruthy();
+    rerender(<BackupRunsTable runs={[run({ status: "error", error: "boom" })]} />);
+    expect(screen.getByText("error")).toBeTruthy();
+    expect(screen.getByText("boom")).toBeTruthy();
+  });
+});
+
+describe("RestoreButton → RestartPrompt", () => {
+  it("two-step restore then reveals the warned restart prompt", async () => {
+    const onStage = vi.fn().mockResolvedValue({ ok: true, staged: "librarian-backup-x" });
+    const onRestart = vi.fn().mockResolvedValue({ ok: true });
+    render(<RestoreButton bundle="librarian-backup-x" onStage={onStage} onRestart={onRestart} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Restore" }));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm restore" }));
+
+    await waitFor(() => expect(screen.getByText(/Restart required to apply/)).toBeTruthy());
+    expect(onStage).toHaveBeenCalledWith("librarian-backup-x");
+    // The load-bearing warning is present.
+    expect(screen.getByText(/not come back/)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Restart now" }));
+    await waitFor(() => expect(onRestart).toHaveBeenCalledTimes(1));
+  });
+});
+
+describe("RestartPrompt", () => {
+  it("surfaces a restart error", async () => {
+    const onRestart = vi.fn().mockResolvedValue({ ok: false, error: "nope" });
+    render(<RestartPrompt onRestart={onRestart} />);
+    fireEvent.click(screen.getByRole("button", { name: "Restart now" }));
+    await waitFor(() => expect(screen.getByText(/Error: nope/)).toBeTruthy());
+  });
+});

--- a/apps/dashboard/tests/components/backups/cockpit.test.tsx
+++ b/apps/dashboard/tests/components/backups/cockpit.test.tsx
@@ -76,7 +76,7 @@ describe("BackupConfigForm", () => {
     fireEvent.submit(screen.getByLabelText("Backup configuration form"));
 
     await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
-    const input = onSave.mock.calls[0][0];
+    const input = onSave.mock.calls[0]![0];
     expect(input.target).toBe("github");
     expect(input.github.repo).toBe("me/bk");
     expect(input.github.token).toBeUndefined(); // blank token not round-tripped
@@ -91,7 +91,7 @@ describe("BackupConfigForm", () => {
     });
     fireEvent.submit(screen.getByLabelText("Backup configuration form"));
     await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
-    expect(onSave.mock.calls[0][0].s3.accessKey).toBe("AKIA123");
+    expect(onSave.mock.calls[0]![0].s3.accessKey).toBe("AKIA123");
   });
 });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -215,6 +215,7 @@ export {
   type BackupRun,
   type BackupRunStatus,
   type BackupRunTrigger,
+  latestTerminalBackupRun,
   listBackupRuns,
   lastSuccessfulBackupRun,
 } from "./backup/runs.js";

--- a/packages/mcp-server/src/trpc/backup.ts
+++ b/packages/mcp-server/src/trpc/backup.ts
@@ -1,25 +1,51 @@
-// Backup admin tRPC procedures: trigger a backup now, list recent backups, and
-// read/update the cloud-sync config. All admin-gated. The config read never
-// returns the secret credentials — only whether they are set.
+// Backup admin tRPC procedures: trigger a backup, list recent bundles + run
+// health, read/update the schedule + both cloud targets' config, and stage a
+// restore / restart. All admin-gated. Config reads never return secret values —
+// only whether each is set.
 
 import fs from "node:fs";
 import path from "node:path";
-import type { LibrarianStore } from "@librarian/core";
-import { runBackup, stageRestore } from "@librarian/core";
+import type { BackupConfigPatch, LibrarianStore } from "@librarian/core";
+import {
+  listBackupRuns,
+  readBackupConfig,
+  runBackup,
+  stageRestore,
+  writeBackupConfig,
+} from "@librarian/core";
 import { z } from "zod";
 import { adminProcedure, router } from "./trpc.js";
+
+const LIST_LIMIT = 10;
 
 function backupDestDir(store: LibrarianStore): string {
   return process.env.LIBRARIAN_BACKUP_DIR || path.join(store.dataDir, "backups");
 }
 
 const SetConfigSchema = z.strictObject({
-  bucket: z.string().optional(),
-  region: z.string().optional(),
-  endpoint: z.string().optional(),
-  prefix: z.string().optional(),
-  accessKey: z.string().optional(),
-  secretKey: z.string().optional(),
+  // Schedule / retention / alerting (validated by writeBackupConfig).
+  enabled: z.boolean().optional(),
+  intervalMinutes: z.number().int().min(1).optional(),
+  target: z.enum(["local", "s3", "github"]).optional(),
+  retentionKeep: z.number().int().min(1).optional(),
+  webhookUrl: z.string().optional(),
+  // Cloud-target credentials (secrets write-only — empty/absent leaves them).
+  s3: z
+    .strictObject({
+      bucket: z.string().optional(),
+      region: z.string().optional(),
+      endpoint: z.string().optional(),
+      prefix: z.string().optional(),
+      accessKey: z.string().optional(),
+      secretKey: z.string().optional(),
+    })
+    .optional(),
+  github: z
+    .strictObject({
+      repo: z.string().optional(),
+      token: z.string().optional(),
+    })
+    .optional(),
 });
 
 export const backupRouter = router({
@@ -33,9 +59,11 @@ export const backupRouter = router({
       files: result.manifest.files.length,
       schema_version: result.manifest.schema_version,
       synced: result.synced,
+      pruned: result.pruned?.length ?? 0,
     };
   }),
 
+  // The most-recent bundles on disk (capped), newest first.
   list: adminProcedure.query(({ ctx }) => {
     const dir = backupDestDir(ctx.store);
     if (!fs.existsSync(dir)) return [];
@@ -47,37 +75,76 @@ export const backupRouter = router({
         created_at: fs.statSync(path.join(dir, name)).mtime.toISOString(),
         restorable: true,
       }))
-      .sort((a, b) => b.created_at.localeCompare(a.created_at));
+      .sort((a, b) => b.created_at.localeCompare(a.created_at))
+      .slice(0, LIST_LIMIT);
   }),
 
-  // Non-secret view + whether credentials are configured (never the values).
+  // Recent backup run health (status, target, bytes, error, timestamps).
+  runs: adminProcedure
+    .input(z.strictObject({ limit: z.number().int().positive().max(100).optional() }).optional())
+    .query(({ ctx, input }) => listBackupRuns(ctx.store, input?.limit ?? LIST_LIMIT)),
+
+  // Non-secret config view + health summary. Never returns a secret value.
   config: adminProcedure.query(({ ctx }) => {
+    const cfg = readBackupConfig(ctx.store);
     const settingKeys = new Set(ctx.store.listSettings().map((s) => s.key));
+    const recent = listBackupRuns(ctx.store, 50);
     return {
-      bucket: ctx.store.getSetting("backup.s3.bucket") ?? "",
-      region: ctx.store.getSetting("backup.s3.region") ?? "",
-      endpoint: ctx.store.getSetting("backup.s3.endpoint") ?? "",
-      prefix: ctx.store.getSetting("backup.s3.prefix") ?? "",
-      hasAccessKey: settingKeys.has("backup.s3.access_key"),
-      hasSecretKey: settingKeys.has("backup.s3.secret_key"),
+      enabled: cfg.enabled,
+      intervalMinutes: cfg.intervalMinutes,
+      target: cfg.target,
+      retentionKeep: cfg.retentionKeep,
+      webhookUrl: cfg.webhookUrl,
+      s3: {
+        bucket: ctx.store.getSetting("backup.s3.bucket") ?? "",
+        region: ctx.store.getSetting("backup.s3.region") ?? "",
+        endpoint: ctx.store.getSetting("backup.s3.endpoint") ?? "",
+        prefix: ctx.store.getSetting("backup.s3.prefix") ?? "",
+        hasAccessKey: settingKeys.has("backup.s3.access_key"),
+        hasSecretKey: settingKeys.has("backup.s3.secret_key"),
+      },
+      github: {
+        repo: ctx.store.getSetting("backup.github.repo") ?? "",
+        hasToken: settingKeys.has("backup.github.token"),
+      },
+      lastRun: recent[0] ?? null,
+      lastSuccess: recent.find((r) => r.status === "ok") ?? null,
     };
   }),
 
   setConfig: adminProcedure.input(SetConfigSchema).mutation(({ ctx, input }) => {
-    const plain: Record<string, string | undefined> = {
-      "backup.s3.bucket": input.bucket,
-      "backup.s3.region": input.region,
-      "backup.s3.endpoint": input.endpoint,
-      "backup.s3.prefix": input.prefix,
-    };
-    for (const [key, value] of Object.entries(plain)) {
-      if (value !== undefined) ctx.store.setSetting(key, value);
+    const patch: BackupConfigPatch = {};
+    if (input.enabled !== undefined) patch.enabled = input.enabled;
+    if (input.intervalMinutes !== undefined) patch.intervalMinutes = input.intervalMinutes;
+    if (input.target !== undefined) patch.target = input.target;
+    if (input.retentionKeep !== undefined) patch.retentionKeep = input.retentionKeep;
+    if (input.webhookUrl !== undefined) patch.webhookUrl = input.webhookUrl;
+    writeBackupConfig(ctx.store, patch);
+
+    if (input.s3) {
+      const plain: Record<string, string | undefined> = {
+        "backup.s3.bucket": input.s3.bucket,
+        "backup.s3.region": input.s3.region,
+        "backup.s3.endpoint": input.s3.endpoint,
+        "backup.s3.prefix": input.s3.prefix,
+      };
+      for (const [key, value] of Object.entries(plain)) {
+        if (value !== undefined) ctx.store.setSetting(key, value);
+      }
+      // Empty string leaves a secret unchanged (the form never round-trips it).
+      if (input.s3.accessKey)
+        ctx.store.setSetting("backup.s3.access_key", input.s3.accessKey, { secret: true });
+      if (input.s3.secretKey)
+        ctx.store.setSetting("backup.s3.secret_key", input.s3.secretKey, { secret: true });
     }
-    // Empty string leaves a secret unchanged (the form never round-trips it).
-    if (input.accessKey)
-      ctx.store.setSetting("backup.s3.access_key", input.accessKey, { secret: true });
-    if (input.secretKey)
-      ctx.store.setSetting("backup.s3.secret_key", input.secretKey, { secret: true });
+
+    if (input.github) {
+      if (input.github.repo !== undefined)
+        ctx.store.setSetting("backup.github.repo", input.github.repo);
+      if (input.github.token)
+        ctx.store.setSetting("backup.github.token", input.github.token, { secret: true });
+    }
+
     return { ok: true };
   }),
 

--- a/packages/mcp-server/src/trpc/backup.ts
+++ b/packages/mcp-server/src/trpc/backup.ts
@@ -7,6 +7,8 @@ import fs from "node:fs";
 import path from "node:path";
 import type { BackupConfigPatch, LibrarianStore } from "@librarian/core";
 import {
+  lastSuccessfulBackupRun,
+  latestTerminalBackupRun,
   listBackupRuns,
   readBackupConfig,
   runBackup,
@@ -88,7 +90,6 @@ export const backupRouter = router({
   config: adminProcedure.query(({ ctx }) => {
     const cfg = readBackupConfig(ctx.store);
     const settingKeys = new Set(ctx.store.listSettings().map((s) => s.key));
-    const recent = listBackupRuns(ctx.store, 50);
     return {
       enabled: cfg.enabled,
       intervalMinutes: cfg.intervalMinutes,
@@ -107,8 +108,10 @@ export const backupRouter = router({
         repo: ctx.store.getSetting("backup.github.repo") ?? "",
         hasToken: settingKeys.has("backup.github.token"),
       },
-      lastRun: recent[0] ?? null,
-      lastSuccess: recent.find((r) => r.status === "ok") ?? null,
+      // The last *terminal* run drives the failure banner (an in-flight run isn't a
+      // failure); lastSuccess drives the green "last backup" line.
+      lastRun: latestTerminalBackupRun(ctx.store),
+      lastSuccess: lastSuccessfulBackupRun(ctx.store),
     };
   }),
 

--- a/packages/mcp-server/tests/trpc/backup.test.ts
+++ b/packages/mcp-server/tests/trpc/backup.test.ts
@@ -135,6 +135,44 @@ describe("tRPC backup surface", () => {
     }
   });
 
+  it("stores cloud secrets write-only — config exposes presence, never the value", async () => {
+    const dataDir = makeTempDir();
+    // A master key is required to store {secret:true} settings.
+    const secretKey = "a".repeat(63) + "b"; // 64 hex chars, non-constant
+    const server = await startHttpServer({ dataDir, secretKey });
+    try {
+      await trpcPost(server, "backup.setConfig", {
+        s3: { bucket: "b", accessKey: "AKIA_SECRET_VALUE", secretKey: "SHHH_SECRET_VALUE" },
+        github: { repo: "me/bk", token: "ghp_SECRET_TOKEN" },
+      });
+
+      // The raw config response must contain the presence flags but none of the values.
+      const url = new URL(`${server.url}/trpc/backup.config`);
+      const raw = await (
+        await fetch(url, { headers: { authorization: `Bearer ${server.token}` } })
+      ).text();
+      expect(raw).not.toContain("AKIA_SECRET_VALUE");
+      expect(raw).not.toContain("SHHH_SECRET_VALUE");
+      expect(raw).not.toContain("ghp_SECRET_TOKEN");
+
+      const after = await trpcGet<{
+        s3: { hasAccessKey: boolean; hasSecretKey: boolean };
+        github: { hasToken: boolean };
+      }>(server, "backup.config");
+      expect(after.s3.hasAccessKey).toBe(true);
+      expect(after.s3.hasSecretKey).toBe(true);
+      expect(after.github.hasToken).toBe(true);
+
+      // A blank secret on a later save leaves the stored value intact.
+      await trpcPost(server, "backup.setConfig", { s3: { region: "eu-west-1" } });
+      const reread = await trpcGet<{ s3: { hasAccessKey: boolean } }>(server, "backup.config");
+      expect(reread.s3.hasAccessKey).toBe(true);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
   it("records a run that backup.runs returns", async () => {
     const dataDir = makeTempDir();
     const server = await startHttpServer({ dataDir });

--- a/packages/mcp-server/tests/trpc/backup.test.ts
+++ b/packages/mcp-server/tests/trpc/backup.test.ts
@@ -93,22 +93,57 @@ describe("tRPC backup surface", () => {
     }
   });
 
-  it("round-trips a plain (non-secret) sync config", async () => {
+  it("round-trips the schedule + both targets' non-secret config", async () => {
     const dataDir = makeTempDir();
     const server = await startHttpServer({ dataDir });
     try {
-      const before = await trpcGet<{ bucket: string; hasSecretKey: boolean }>(
-        server,
-        "backup.config",
-      );
-      expect(before.bucket).toBe("");
-      expect(before.hasSecretKey).toBe(false);
+      type Config = {
+        enabled: boolean;
+        intervalMinutes: number;
+        target: string;
+        retentionKeep: number;
+        webhookUrl: string;
+        s3: { bucket: string; hasSecretKey: boolean };
+        github: { repo: string; hasToken: boolean };
+      };
+      const before = await trpcGet<Config>(server, "backup.config");
+      expect(before.enabled).toBe(false);
+      expect(before.s3.bucket).toBe("");
+      expect(before.github.hasToken).toBe(false);
 
-      await trpcPost(server, "backup.setConfig", { bucket: "my-bucket", region: "eu-west-1" });
+      await trpcPost(server, "backup.setConfig", {
+        enabled: true,
+        intervalMinutes: 30,
+        target: "github",
+        retentionKeep: 7,
+        webhookUrl: "https://hooks.example/x",
+        s3: { bucket: "my-bucket", region: "eu-west-1" },
+        github: { repo: "me/backups" },
+      });
 
-      const after = await trpcGet<{ bucket: string; region: string }>(server, "backup.config");
-      expect(after.bucket).toBe("my-bucket");
-      expect(after.region).toBe("eu-west-1");
+      const after = await trpcGet<Config>(server, "backup.config");
+      expect(after.enabled).toBe(true);
+      expect(after.intervalMinutes).toBe(30);
+      expect(after.target).toBe("github");
+      expect(after.retentionKeep).toBe(7);
+      expect(after.webhookUrl).toBe("https://hooks.example/x");
+      expect(after.s3.bucket).toBe("my-bucket");
+      expect(after.github.repo).toBe("me/backups");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("records a run that backup.runs returns", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      await trpcPost(server, "backup.createNow");
+      const runs = await trpcGet<{ status: string; trigger: string }[]>(server, "backup.runs");
+      expect(runs.length).toBe(1);
+      expect(runs[0]?.status).toBe("ok");
+      expect(runs[0]?.trigger).toBe("manual");
     } finally {
       await server.stop();
       cleanupTempDir(dataDir);

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -49,12 +49,14 @@ export async function startHttpServer({
   agentToken = "agent-token",
   agentTokens = "",
   allowedOrigins = "",
+  secretKey = "",
 } = {}) {
   const port = await getFreePort();
   const child = spawn(process.execPath, ["--no-warnings", HTTP_BIN], {
     cwd: REPO_ROOT,
     env: {
       ...process.env,
+      ...(secretKey ? { LIBRARIAN_SECRET_KEY: secretKey } : {}),
       LIBRARIAN_DATA_DIR: dataDir,
       LIBRARIAN_HOST: "0.0.0.0",
       LIBRARIAN_PORT: String(port),


### PR DESCRIPTION
## What (A6 of automated-backups, plan 034 — final PR)

The `/backups` page now manages the whole backup lifecycle (cloning the curator cockpit):

- **tRPC** `config`/`setConfig` cover the schedule, retention, failure webhook, target selection, and **both** cloud targets' non-secret fields + **write-only** credentials (S3 + GitHub). `runs` returns recent `backup_runs`; `list` is capped at 10 + `restorable`. Secrets are never returned — only `hasAccessKey`/`hasSecretKey`/`hasToken` presence flags.
- **UI** (`components/backups/*`): config form (target picker reveals S3 or GitHub fields; secrets write-only, blank = keep), config summary, a **health banner** (last success / last failure), the recent bundles with a two-step **Restore** that stages and reveals the **warned restart prompt** (Decision 10 — "only under an auto-restart supervisor"), and a run-history table.
- **DEPLOYMENT.md**: replaced the env-only schedule section with the cockpit flow — GitHub Releases target (fine-grained PAT scopes), retention, restart-staged restore, gzipped `format_version` 2 bundles.

## Security

The config response is verified (tRPC test) to expose credential **presence** only — the raw body never contains the S3 keys or GitHub token; a blank secret on re-save leaves the stored value intact.

## Tests

tRPC: config/setConfig round-trip (both targets), **secret write-only round-trip**, runs. Dashboard: config summary, form (both targets + write-only secrets), runs table, restore→restart prompt (with the warning), restart error. Full suite green.

Implements **A6** of `docs/specs/034-automated-backups-plan.md` — **completes the plan (A1–A6).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)