### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ changes from this point forward are catalogued here.
 
 ## [Unreleased]
 
+## [0.4.0] — 2026-05-30
+
 ### Added
 
 - **Backups cockpit on the dashboard.** The `/backups` page now manages the whole

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Release **v0.4.0** — automated backups (plan 034, PRs #199–#204).

Bumps the root version to 0.4.0 and moves the `[Unreleased]` CHANGELOG entries under `## [0.4.0]`.

**MINOR** per `docs/release.md`: new dashboard surface (Backups cockpit), additive schema bump (`backup_runs`, v20 — non-breaking), new env vars with defaults, new admin tRPC procedures. No breaking changes. Monorepo-only (no plugin-repo coordination).

Highlights:
- Gzipped bundles (`format_version` 2, ~70% smaller; v1 bundles still restore)
- GitHub Releases backup target alongside S3
- Dashboard-managed schedule + retention + failure-alert webhook + run health
- Restart-staged restore (validate → apply on boot, never under a live DB connection)
- Backups cockpit (config, health banner, one-click restore, warned restart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)