### PR TITLE
F0 (PR-1): route handoffs.list through HandoffStore.listDetails

### DIFF
--- a/packages/core/src/store/handoff-store.ts
+++ b/packages/core/src/store/handoff-store.ts
@@ -115,6 +115,12 @@ export interface HandoffDetail {
 export interface HandoffStore {
   store: (input: StoreHandoffInput, context: StoreHandoffContext) => StoreHandoffOutput;
   list: (input: ListHandoffsInput, context: ListHandoffsContext) => HandoffSummary[];
+  /**
+   * Like `list`, but returns full `HandoffDetail` rows (incl. `domain`, claim
+   * status, and the document body) for the admin dashboard list view, which
+   * renders fields `HandoffSummary` omits. Same filtering semantics as `list`.
+   */
+  listDetails: (input: ListHandoffsInput, context: ListHandoffsContext) => HandoffDetail[];
   claim: (input: ClaimHandoffInput, context: ClaimHandoffContext) => ClaimHandoffOutput;
   /** Admin / dashboard / CLI detail lookup by id; not domain-scoped. Null when absent. */
   getById: (handoffId: string) => HandoffDetail | null;
@@ -153,7 +159,7 @@ export function createHandoffStore(deps: { db: DatabaseSync }): HandoffStore {
     return { handoff_id: id, created_at: createdAt };
   }
 
-  function listHandoffs(input: ListHandoffsInput, context: ListHandoffsContext): HandoffSummary[] {
+  function queryHandoffRows(input: ListHandoffsInput, context: ListHandoffsContext): HandoffRow[] {
     const where: string[] = [];
     const params: (string | number)[] = [];
     if (!context.includeClaimed) where.push("claimed_at IS NULL");
@@ -180,7 +186,7 @@ export function createHandoffStore(deps: { db: DatabaseSync }): HandoffStore {
     params.push(limit);
 
     const whereClause = where.length > 0 ? `WHERE ${where.join(" AND ")}` : "";
-    const rows = db
+    return db
       .prepare(
         `SELECT * FROM handoffs
          ${whereClause}
@@ -188,8 +194,17 @@ export function createHandoffStore(deps: { db: DatabaseSync }): HandoffStore {
          LIMIT ?`,
       )
       .all(...params) as unknown as HandoffRow[];
+  }
 
-    return rows.map(rowToSummary);
+  function listHandoffs(input: ListHandoffsInput, context: ListHandoffsContext): HandoffSummary[] {
+    return queryHandoffRows(input, context).map(rowToSummary);
+  }
+
+  function listDetailsHandoffs(
+    input: ListHandoffsInput,
+    context: ListHandoffsContext,
+  ): HandoffDetail[] {
+    return queryHandoffRows(input, context).map(rowToDetail);
   }
 
   function claimHandoff(
@@ -278,6 +293,7 @@ export function createHandoffStore(deps: { db: DatabaseSync }): HandoffStore {
   return {
     store: storeHandoff,
     list: listHandoffs,
+    listDetails: listDetailsHandoffs,
     claim: claimHandoff,
     getById: getByIdHandoff,
     purge: purgeHandoff,

--- a/packages/core/tests/store/handoff-store.test.ts
+++ b/packages/core/tests/store/handoff-store.test.ts
@@ -269,3 +269,43 @@ describe("handoff store — getById (admin / dashboard detail)", () => {
     expect(detail!.domain).toBe("domain-a");
   });
 });
+
+describe("handoff store — listDetails (admin / dashboard list with full detail)", () => {
+  it("returns full detail incl. domain, document body, and claim status", () => {
+    const { handoffs } = s!;
+    const stored = handoffs.store(defaultInput(), ctx("general", "agent-a"));
+    handoffs.claim(
+      { handoff_id: stored.handoff_id, claiming_agent_id: "agent-b", claiming_harness: "codex" },
+      { domain: "general" },
+    );
+
+    const items = handoffs.listDetails({}, { domain: "general", includeClaimed: true });
+    expect(items).toHaveLength(1);
+    const item = items[0]!;
+    expect(item.handoff_id).toBe(stored.handoff_id);
+    expect(item.domain).toBe("general");
+    expect(item.document_md).toContain("ship it");
+    expect(item.claimed_at).not.toBeNull();
+    expect(item.claimed_by).toEqual({
+      agent_id: "agent-b",
+      harness: "codex",
+      source_ref: null,
+      cwd: null,
+    });
+  });
+
+  it("applies the same domain, claim, and project/cwd filtering as list", () => {
+    const { handoffs } = s!;
+    handoffs.store(defaultInput({ project_key: null, cwd: null }), ctx("domain-a"));
+    handoffs.store(defaultInput({ project_key: null, cwd: null }), ctx("domain-b"));
+    // A non-null domain is a hard filter; null domain is the admin bypass.
+    expect(handoffs.listDetails({}, { domain: "domain-a" })).toHaveLength(1);
+    expect(handoffs.listDetails({}, { domain: null })).toHaveLength(2);
+
+    // Claimed handoffs drop out unless includeClaimed is set.
+    const claimed = handoffs.store(defaultInput({ project_key: null, cwd: null }), ctx("general"));
+    handoffs.claim({ handoff_id: claimed.handoff_id }, { domain: "general" });
+    expect(handoffs.listDetails({}, { domain: "general" })).toHaveLength(0);
+    expect(handoffs.listDetails({}, { domain: "general", includeClaimed: true })).toHaveLength(1);
+  });
+});

--- a/packages/mcp-server/src/trpc/handoffs.ts
+++ b/packages/mcp-server/src/trpc/handoffs.ts
@@ -24,40 +24,6 @@ const ByIdInputSchema = z.object({
   handoff_id: z.string().min(1),
 });
 
-interface HandoffDetailRow {
-  id: string;
-  title: string;
-  document_md: string;
-  project_key: string | null;
-  source_ref: string | null;
-  cwd: string | null;
-  domain: string;
-  created_by_agent_id: string | null;
-  created_in_harness: string | null;
-  tags_json: string;
-  created_at: string;
-  claimed_at: string | null;
-  claimed_by_json: string | null;
-}
-
-function parseTags(json: string): string[] {
-  try {
-    const parsed = JSON.parse(json || "[]");
-    return Array.isArray(parsed) ? (parsed as string[]) : [];
-  } catch {
-    return [];
-  }
-}
-
-function parseClaimedBy(json: string | null) {
-  if (!json) return null;
-  try {
-    return JSON.parse(json);
-  } catch {
-    return null;
-  }
-}
-
 export const handoffsRouter = router({
   list: adminProcedure.input(ListInputSchema.optional()).query(({ ctx, input }) => {
     const {
@@ -68,40 +34,23 @@ export const handoffsRouter = router({
       cwd,
       harness,
     } = input ?? {};
-    const where: string[] = ["domain = ?"];
-    const params: (string | number)[] = [domain];
-    if (!include_claimed) where.push("claimed_at IS NULL");
-    if (project_key != null) {
-      where.push("project_key = ?");
-      params.push(project_key);
-    }
-    if (cwd != null) {
-      where.push("cwd = ?");
-      params.push(cwd);
-    }
-    if (harness != null) {
-      where.push("created_in_harness = ?");
-      params.push(harness);
-    }
-    params.push(limit ?? 50);
-    const rows = ctx.store.db
-      .prepare(
-        `SELECT * FROM handoffs WHERE ${where.join(" AND ")} ORDER BY created_at DESC LIMIT ?`,
-      )
-      .all(...params) as unknown as HandoffDetailRow[];
-    return rows.map((row) => ({
-      handoff_id: row.id,
-      title: row.title,
-      project_key: row.project_key,
-      source_ref: row.source_ref,
-      cwd: row.cwd,
-      domain: row.domain,
-      created_by_agent_id: row.created_by_agent_id,
-      created_in_harness: row.created_in_harness,
-      tags: parseTags(row.tags_json),
-      created_at: row.created_at,
-      claimed_at: row.claimed_at,
-      claimed_by: parseClaimedBy(row.claimed_by_json),
+    const details = ctx.store.handoffs.listDetails(
+      { project_key, cwd, harness, limit: limit ?? 50 },
+      { domain, includeClaimed: include_claimed ?? false },
+    );
+    return details.map((d) => ({
+      handoff_id: d.handoff_id,
+      title: d.title,
+      project_key: d.project_key,
+      source_ref: d.source_ref,
+      cwd: d.cwd,
+      domain: d.domain,
+      created_by_agent_id: d.created_by_agent_id,
+      created_in_harness: d.created_in_harness,
+      tags: d.tags,
+      created_at: d.created_at,
+      claimed_at: d.claimed_at,
+      claimed_by: d.claimed_by,
     }));
   }),
 


### PR DESCRIPTION
## What
Second F0 ("seal the seam") increment, following the merged handoffs detail-read PR (#208). Routes the dashboard `handoffs.list` tRPC procedure off raw `ctx.store.db` SQL and through the store interface.

- Adds `HandoffStore.listDetails(input, context): HandoffDetail[]` — a sibling of `list()` returning full detail rows (`domain`, claim status, document body) the dashboard list renders but `HandoffSummary` omits. Shares the WHERE/query with `list()` via a new private `queryHandoffRows`.
- Reroutes `trpc/handoffs.ts#list` onto it and deletes the now-dead duplicate `HandoffDetailRow` / `parseTags` / `parseClaimedBy`.

## Behaviour
Behaviour-preserving: identical response shape, filtering (domain default `general`, `include_claimed`, project/cwd/harness), and limit default (50). `claimed_by` is now the normalized `{agent_id, harness, source_ref, cwd}` shape, matching `handoffs.byId`.

## Tests
New `listDetails` cases (full detail incl. domain/claim/document; domain + claim + admin-bypass filtering). Green: lint, `pnpm -r typecheck` (0 errors), `pnpm test` (core 513, mcp-server 147, cli 52, dashboard 167, classifier 26, classifier-eval 50, root 23).

## Context
Part of the F0 bypass-sealing sequence. Remaining: curator read-side, caller-backfill, CLI `reindex`, then the `LibrarianStore` narrowing (Option A — public/internal split).

🤖 Generated with [Claude Code](https://claude.com/claude-code)