### PR TITLE
F0 (PR-2): route curator read-side through CurationStore

### DIFF
--- a/packages/core/src/curator-enqueue.ts
+++ b/packages/core/src/curator-enqueue.ts
@@ -25,7 +25,6 @@
 import { type ApplyPolicy } from "./curator-apply-policy.js";
 import type { LlmClient } from "./curator-llm-client.js";
 import type { ScheduleConfig } from "./curator-schedule.js";
-import { findRunningRun, selectDueSlices } from "./curator-scheduler.js";
 import type { RunCurationCaps } from "./curator-worker.js";
 import { runCuration } from "./curator-worker.js";
 import type { LibrarianStore } from "./store/librarian-store.js";
@@ -82,13 +81,13 @@ export async function runDueCuration(
     errored: 0,
   };
 
-  const due = selectDueSlices(store.db, options.schedule, now);
+  const due = store.selectDueSlices(options.schedule, now);
   summary.due = due.length;
 
   for (const { slice } of due) {
     // One slice's failure (store error etc.) must not abort the whole batch.
     try {
-      const lock = findRunningRun(store.db, slice);
+      const lock = store.findRunningRun(slice);
       if (lock) {
         if (now.getTime() - lock.startedAt.getTime() < lockTtlMs) {
           summary.skippedLocked++;

--- a/packages/core/src/curator-worker.ts
+++ b/packages/core/src/curator-worker.ts
@@ -58,7 +58,7 @@ export async function runCuration(
 ): Promise<CurationRun | null> {
   const { store, caps = {} } = options;
 
-  const memory = gatherMemoryEvidence(store.db, slice, {
+  const memory = store.gatherMemoryEvidence(slice, {
     maxMemories: caps.maxMemories ?? DEFAULT_MAX_MEMORIES,
     ...(caps.maxBodyChars !== undefined ? { maxBodyChars: caps.maxBodyChars } : {}),
   });

--- a/packages/core/src/store/curation-store.ts
+++ b/packages/core/src/store/curation-store.ts
@@ -12,6 +12,19 @@
 
 import type { DatabaseSync } from "node:sqlite";
 import { makeId, nowIso } from "../constants.js";
+import {
+  type EvidenceSlice,
+  type MemoryEvidenceBundle,
+  type MemoryEvidenceCaps,
+  gatherMemoryEvidence as gatherMemoryEvidenceImpl,
+  listCuratorSlices as listCuratorSlicesImpl,
+} from "../curator-evidence.js";
+import type { ScheduleConfig } from "../curator-schedule.js";
+import {
+  type DueSlice,
+  findRunningRun as findRunningRunImpl,
+  selectDueSlices as selectDueSlicesImpl,
+} from "../curator-scheduler.js";
 
 export interface CreateCurationRunInput {
   trigger: string; // schedule | manual | maintenance
@@ -106,6 +119,12 @@ export interface CurationStore {
   startCurationRun: (id: string) => CurationRun;
   completeCurationRun: (id: string, input?: CompleteCurationRunInput) => CurationRun;
   failCurationRun: (id: string, input: FailCurationRunInput) => CurationRun;
+  // Curator read-side (F0): thin wrappers binding the store db to the pure
+  // curator functions so curator-worker/enqueue never touch `store.db`.
+  gatherMemoryEvidence: (slice: EvidenceSlice, caps: MemoryEvidenceCaps) => MemoryEvidenceBundle;
+  listCuratorSlices: () => EvidenceSlice[];
+  selectDueSlices: (config: ScheduleConfig, now: Date) => DueSlice[];
+  findRunningRun: (slice: EvidenceSlice) => { id: string; startedAt: Date } | null;
 }
 
 interface CurationRunRow {
@@ -332,6 +351,25 @@ export function createCurationStore(deps: { db: DatabaseSync }): CurationStore {
     return requireRun(id);
   }
 
+  function gatherMemoryEvidence(
+    slice: EvidenceSlice,
+    caps: MemoryEvidenceCaps,
+  ): MemoryEvidenceBundle {
+    return gatherMemoryEvidenceImpl(db, slice, caps);
+  }
+
+  function listCuratorSlices(): EvidenceSlice[] {
+    return listCuratorSlicesImpl(db);
+  }
+
+  function selectDueSlices(config: ScheduleConfig, now: Date): DueSlice[] {
+    return selectDueSlicesImpl(db, config, now);
+  }
+
+  function findRunningRun(slice: EvidenceSlice): { id: string; startedAt: Date } | null {
+    return findRunningRunImpl(db, slice);
+  }
+
   return {
     createCurationRun,
     getCurationRun,
@@ -342,5 +380,9 @@ export function createCurationStore(deps: { db: DatabaseSync }): CurationStore {
     startCurationRun,
     completeCurationRun,
     failCurationRun,
+    gatherMemoryEvidence,
+    listCuratorSlices,
+    selectDueSlices,
+    findRunningRun,
   };
 }

--- a/packages/core/tests/store/curation-reads.test.ts
+++ b/packages/core/tests/store/curation-reads.test.ts
@@ -1,0 +1,56 @@
+// CurationStore curator-read methods (F0 — seal the seam).
+//
+// The curator read functions (gatherMemoryEvidence / listCuratorSlices /
+// selectDueSlices / findRunningRun) are pure functions over the SQLite db.
+// To stop non-storage code (curator-worker, curator-enqueue) from reaching
+// `store.db`, the store exposes thin wrappers that bind its own db. This pins
+// that the wrappers delegate to exactly those functions with the store's db.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type EvidenceSlice,
+  createLibrarianStore,
+  findRunningRun,
+  gatherMemoryEvidence,
+  listCuratorSlices,
+  selectDueSlices,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// Inferred (not the public `LibrarianStore`) so this storage-layer test keeps
+// access to `db` after the F0 public/internal interface split (PR-6).
+let store: ReturnType<typeof createLibrarianStore> | null = null;
+let dataDir = "";
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-curation-reads-"));
+  store = createLibrarianStore({ dataDir });
+});
+
+afterEach(() => {
+  try {
+    store?.close();
+  } catch {
+    /* ignore */
+  }
+  if (dataDir) fs.rmSync(dataDir, { recursive: true, force: true });
+  store = null;
+});
+
+describe("CurationStore — curator read methods bind the store db", () => {
+  it("delegates the curator read functions to the underlying store db", () => {
+    const s = store!;
+    const slice: EvidenceSlice = { kind: "common_global" };
+    const schedule = { intervalMinutes: 60 };
+    const now = new Date("2026-06-01T00:00:00.000Z");
+
+    expect(s.listCuratorSlices()).toEqual(listCuratorSlices(s.db));
+    expect(s.gatherMemoryEvidence(slice, { maxMemories: 5 })).toEqual(
+      gatherMemoryEvidence(s.db, slice, { maxMemories: 5 }),
+    );
+    expect(s.selectDueSlices(schedule, now)).toEqual(selectDueSlices(s.db, schedule, now));
+    expect(s.findRunningRun(slice)).toEqual(findRunningRun(s.db, slice));
+  });
+});


### PR DESCRIPTION
## What
Third F0 ("seal the seam") increment. Routes the **curator read-side** off raw `store.db` and through the store interface.

- Adds four thin `CurationStore` methods that bind the store's `db` to the existing pure curator functions: `gatherMemoryEvidence`, `listCuratorSlices`, `selectDueSlices`, `findRunningRun`.
- Reroutes `curator-worker.ts` (`gatherMemoryEvidence`) and `curator-enqueue.ts` (`selectDueSlices`, `findRunningRun`) onto them; drops the now-dead `curator-scheduler` import in `curator-enqueue.ts`.

## Behaviour
Behaviour-preserving — the wrappers just bind `db`; the pure functions (already covered by `curator-evidence`/`curator-scheduler` tests) are unchanged. The curator pipeline is explicitly KEPT in the rearchitecture.

## Tests
New `curation-reads.test.ts` pins that each store method delegates to its pure counterpart with the store's `db` (typed via `ReturnType<typeof createLibrarianStore>` so it survives the PR-6 public/internal split). Green: lint, `pnpm -r typecheck` (0 errors), `pnpm test` (core 514, mcp-server 147, cli 52, dashboard 167, classifier 26, classifier-eval 50, root 23).

## Context
Remaining F0: caller-backfill reads (PR-4), CLI `reindex` (PR-5), then the `LibrarianStore` narrowing — Option A, public/internal split (PR-6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)