### PR TITLE
F0 (PR-4): route caller-backfill agent-id reads through MemoryStore

### DIFF
--- a/packages/core/src/caller-backfill.ts
+++ b/packages/core/src/caller-backfill.ts
@@ -83,28 +83,19 @@ function backfillMemories(
   actorId: string,
   apply: boolean,
 ): BackfillSection {
-  const rows = store.db
-    .prepare(
-      "SELECT agent_id AS id, COUNT(*) AS n FROM memories " +
-        "WHERE agent_id IS NOT NULL AND agent_id != '' GROUP BY agent_id",
-    )
-    .all() as Array<{ id: string; n: number }>;
+  const rows = store.countMemoriesByAgentId();
 
   const changes: BackfillChange[] = [];
   const skipped: string[] = [];
-  for (const { id, n } of rows) {
-    const target = plannedTarget(id, aliases);
+  for (const { agent_id, count } of rows) {
+    const target = plannedTarget(agent_id, aliases);
     if (target === null) {
-      skipped.push(id);
+      skipped.push(agent_id);
       continue;
     }
-    changes.push({ from: id, to: target, count: n });
+    changes.push({ from: agent_id, to: target, count });
     if (apply) {
-      const ids = (
-        store.db.prepare("SELECT id FROM memories WHERE agent_id = ?").all(id) as Array<{
-          id: string;
-        }>
-      ).map((row) => row.id);
+      const ids = store.listMemoryIdsByAgentId(agent_id);
       // Append-event path: durable through the JSONL → SQLite projection rebuild.
       store.bulkUpdateMemory({ ids, patch: { agent_id: target }, agent_id: actorId });
     }

--- a/packages/core/src/store/memory-store.ts
+++ b/packages/core/src/store/memory-store.ts
@@ -132,6 +132,10 @@ export interface MemoryStore {
     agent_id?: string;
   }) => { transaction_id: string; updated: number };
   distinctValues: (input: { field: string; include_archived?: boolean }) => string[];
+  // Caller-backfill read seam (F0): group memory counts per stored agent id, and
+  // list the memory ids owned by one agent — so backfill never touches store.db.
+  countMemoriesByAgentId: () => { agent_id: string; count: number }[];
+  listMemoryIdsByAgentId: (agentId: string) => string[];
   archiveMemory: (id: string, agent_id?: string) => Memory | null;
   verifyMemory: (id: string, result: string, note?: string, agent_id?: string) => Memory | null;
   recordRecall: (memories: Memory[], agent_id?: string, query?: string) => void;
@@ -871,6 +875,23 @@ export function createMemoryStore(deps: MemoryStoreDeps): MemoryStore {
     };
   }
 
+  function countMemoriesByAgentId(): { agent_id: string; count: number }[] {
+    return db
+      .prepare(
+        "SELECT agent_id, COUNT(*) AS count FROM memories " +
+          "WHERE agent_id IS NOT NULL AND agent_id != '' GROUP BY agent_id",
+      )
+      .all() as Array<{ agent_id: string; count: number }>;
+  }
+
+  function listMemoryIdsByAgentId(agentId: string): string[] {
+    return (
+      db.prepare("SELECT id FROM memories WHERE agent_id = ?").all(agentId) as Array<{
+        id: string;
+      }>
+    ).map((row) => row.id);
+  }
+
   return {
     appendEvent,
     listAll,
@@ -885,6 +906,8 @@ export function createMemoryStore(deps: MemoryStoreDeps): MemoryStore {
     updateMemory,
     bulkUpdateMemory,
     distinctValues,
+    countMemoriesByAgentId,
+    listMemoryIdsByAgentId,
     archiveMemory,
     verifyMemory,
     recordRecall,

--- a/packages/core/tests/store/memory-agent-id-queries.test.ts
+++ b/packages/core/tests/store/memory-agent-id-queries.test.ts
@@ -1,0 +1,68 @@
+// MemoryStore agent-id query methods (F0 — seal the seam).
+//
+// caller-backfill reattributes stored caller ids; it needs to (a) count
+// memories per agent and (b) list the memory ids for one agent. These were raw
+// SELECTs against `store.db`; the store now owns them so backfill never reaches
+// past the interface. Pins the grouping/listing contract directly.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createLibrarianStore } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// Inferred type keeps `db`-free public API parity while this storage-layer test
+// constructs the store directly (survives the PR-6 public/internal split).
+let store: ReturnType<typeof createLibrarianStore> | null = null;
+let dataDir = "";
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-agentid-"));
+  store = createLibrarianStore({ dataDir });
+});
+
+afterEach(() => {
+  try {
+    store?.close();
+  } catch {
+    /* ignore */
+  }
+  if (dataDir) fs.rmSync(dataDir, { recursive: true, force: true });
+  store = null;
+});
+
+function seed(agent_id: string, title: string): string {
+  return store!.createMemory({
+    agent_id,
+    title,
+    body: "body text",
+    category: "projects",
+    visibility: "common",
+    scope: "project",
+    project_key: "the-librarian",
+    priority: "normal",
+    confidence: "working",
+  }).memory.id;
+}
+
+describe("MemoryStore — agent-id queries (caller-backfill seam)", () => {
+  it("countMemoriesByAgentId groups counts per agent", () => {
+    seed("claude-code", "a");
+    seed("claude-code", "b");
+    seed("codex", "c");
+
+    const counts = store!.countMemoriesByAgentId();
+    expect(counts.find((c) => c.agent_id === "claude-code")?.count).toBe(2);
+    expect(counts.find((c) => c.agent_id === "codex")?.count).toBe(1);
+  });
+
+  it("listMemoryIdsByAgentId returns exactly the ids for one agent", () => {
+    const a1 = seed("claude-code", "a");
+    const a2 = seed("claude-code", "b");
+    seed("codex", "c");
+
+    expect(store!.listMemoryIdsByAgentId("claude-code").sort()).toEqual([a1, a2].sort());
+    expect(store!.listMemoryIdsByAgentId("codex")).toHaveLength(1);
+    expect(store!.listMemoryIdsByAgentId("nobody")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What
Fourth F0 ("seal the seam") increment. Routes the caller-id backfill's two raw `store.db` reads through the store interface.

- Adds `MemoryStore.countMemoriesByAgentId(): { agent_id, count }[]` and `MemoryStore.listMemoryIdsByAgentId(agentId): string[]`.
- Reroutes `caller-backfill.ts#backfillMemories` onto them (the write path already used `bulkUpdateMemory`).

## Behaviour
Behaviour-preserving — same grouping, counts, ids, and append-event write path. Covered end-to-end by the existing `caller-backfill.test.ts` (dry-run/apply/idempotency/collision/audit), plus a new focused unit test pinning the two methods.

## Tests
Green: lint, `pnpm -r typecheck` (0 errors), `pnpm test` (core 516, mcp-server 147, cli 52, dashboard 167, classifier 26, classifier-eval 50, root 23).

## Context
Remaining F0: CLI `reindex` (PR-5), then the `LibrarianStore` narrowing — Option A, public/internal split (PR-6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)