### PR TITLE
F0 (PR-5): CLI rebuild via reindex(), drop raw-internals wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ changes from this point forward are catalogued here.
   `claimed_by_json`). This falls out of routing the dashboard `handoffs.byId` view
   and the CLI through a new `HandoffStore.getById` rather than raw SQL — the first
   step of sealing the storage seam (F0) for the markdown rearchitecture.
+- **`the-librarian rebuild` output is backend-neutral.** The command now reports
+  "Rebuilt the memory index in &lt;data-dir&gt;" (was "Rebuilt projection from
+  &lt;events.jsonl path&gt;"), and its help line reads "Rebuild the memory index from
+  stored data". Same behaviour; the wording no longer names the SQLite/events-ledger
+  internals, via a new backend-neutral `reindex()` store verb (F0).
 
 ## [0.4.0] — 2026-05-30
 

--- a/packages/cli/src/runtime.ts
+++ b/packages/cli/src/runtime.ts
@@ -35,9 +35,9 @@ export function runCli(argv: string[], store: LibrarianStore): CliResult {
     return { stdout: usage(), exitCode: 0 };
   }
   if (command === "rebuild") {
-    store.rebuildIndex();
+    store.reindex();
     return {
-      stdout: `Rebuilt projection from ${store.eventsPath}`,
+      stdout: `Rebuilt the memory index in ${store.dataDir}`,
       exitCode: 0,
     };
   }
@@ -129,7 +129,7 @@ export function usage(): string {
     "Usage: the-librarian <command>",
     "",
     "Commands:",
-    "  rebuild                       Replay events.jsonl into the SQLite projection",
+    "  rebuild                       Rebuild the memory index from stored data",
     "  seed                          Seed sample memories (no-op if any exist)",
     "  backup [--out <dir>]          Write a restorable snapshot bundle",
     "  restore --from <dir> --force  Restore a snapshot bundle into the data dir (destructive)",

--- a/packages/cli/tests/snapshots.test.ts
+++ b/packages/cli/tests/snapshots.test.ts
@@ -13,7 +13,7 @@ describe("CLI snapshots", () => {
       "Usage: the-librarian <command>
 
       Commands:
-        rebuild                       Replay events.jsonl into the SQLite projection
+        rebuild                       Rebuild the memory index from stored data
         seed                          Seed sample memories (no-op if any exist)
         backup [--out <dir>]          Write a restorable snapshot bundle
         restore --from <dir> --force  Restore a snapshot bundle into the data dir (destructive)

--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -47,6 +47,8 @@ export interface LibrarianStore extends MemoryStore, CurationStore, SettingsStor
   close(): void;
   readEvents(): Record<string, unknown>[];
   rebuildIndex(): void;
+  /** Backend-neutral maintenance verb: rebuild the disposable memory index. */
+  reindex(): void;
 }
 
 export function createLibrarianStore(options: LibrarianStoreOptions = {}): LibrarianStore {
@@ -106,5 +108,6 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Libra
     close: () => db.close(),
     readEvents: () => readJsonl(eventsPath),
     rebuildIndex,
+    reindex: rebuildIndex,
   };
 }


### PR DESCRIPTION
## What
Fifth F0 ("seal the seam") increment — the last pure reroute before the `LibrarianStore` narrowing.

- Adds `LibrarianStore.reindex()` — a backend-neutral maintenance verb (currently aliases the SQLite `rebuildIndex`; the markdown backend will implement the same verb).
- The CLI `rebuild` command now calls `store.reindex()` instead of `store.rebuildIndex()`, and reports `Rebuilt the memory index in <data-dir>` (public `dataDir`) instead of interpolating `store.eventsPath`. Help text reworded off `events.jsonl`/SQLite; help **snapshot** updated in lockstep.

## Behaviour
Behaviour-preserving (same rebuild action, exit code). Only user-facing change is CLI wording — documented in CHANGELOG. The `rebuild` command name is unchanged.

## Tests
Green: lint, `pnpm -r typecheck` (0 errors), `pnpm test` (core 516, mcp-server 147, cli 52, dashboard 167, classifier 26, classifier-eval 50, root 23). The existing `cli.test.ts` rebuild test and the help snapshot both pass.

## Context
This clears all the **production** raw-`store.db`/`eventsPath`/`rebuildIndex` reroutes. Next and last: **PR-6** — narrow the public `LibrarianStore` (drop `db`/`eventsPath`/`readEvents`/`rebuildIndex`) via the approved Option A public/internal split, with the F0 grep guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)