### PR TITLE
F0 (PR-6): narrow public LibrarianStore (Option A) + seam guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Guard — classifier env retirement
         run: pnpm run check:classifier-env-retirement
 
+      - name: Guard — no store-handle bypass
+        run: pnpm run check:no-store-bypass
+
       - name: Validate Docker Compose config
         env:
           LIBRARIAN_ADMIN_TOKEN: ci-admin-token

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "check:storage-fixture": "node --no-warnings scripts/check-storage-fixture.mjs",
     "check:schema-version": "node --no-warnings scripts/check-schema-version.mjs",
     "check:classifier-env-retirement": "node --no-warnings scripts/check-classifier-env-retirement.mjs",
+    "check:no-store-bypass": "node --no-warnings scripts/check-no-store-bypass.mjs",
     "audit:agent-ids": "node --no-warnings scripts/audit-agent-ids.mjs",
     "backfill:agent-ids": "node --no-warnings scripts/backfill-agent-ids.mjs"
   },

--- a/packages/cli/src/commands/_shared.ts
+++ b/packages/cli/src/commands/_shared.ts
@@ -1,7 +1,7 @@
 // Shared command-shape types kept after sessions-rethink PR 7 (the
 // session-lifecycle helpers that used to live here are gone).
 
-import type { LibrarianStore } from "@librarian/core";
+import type { InternalLibrarianStore } from "@librarian/core";
 import type { FlagMap } from "../parse-flags.js";
 
 export interface CliResult {
@@ -9,4 +9,8 @@ export interface CliResult {
   exitCode: number;
 }
 
-export type Command = (store: LibrarianStore, positionals: string[], flags: FlagMap) => CliResult;
+export type Command = (
+  store: InternalLibrarianStore,
+  positionals: string[],
+  flags: FlagMap,
+) => CliResult;

--- a/packages/cli/src/commands/backup.ts
+++ b/packages/cli/src/commands/backup.ts
@@ -2,12 +2,17 @@
 // bundle, then prune the local bundle dir to the newest `--keep` (default: the
 // configured retention, or 14).
 
-import { type LibrarianStore, createBackup, pruneLocal, readBackupConfig } from "@librarian/core";
+import {
+  type InternalLibrarianStore,
+  createBackup,
+  pruneLocal,
+  readBackupConfig,
+} from "@librarian/core";
 import type { FlagMap } from "../parse-flags.js";
 import type { CliResult } from "./_shared.js";
 
 export function backupCommand(
-  store: LibrarianStore,
+  store: InternalLibrarianStore,
   _positionals: string[],
   flags: FlagMap,
 ): CliResult {

--- a/packages/cli/src/runtime.ts
+++ b/packages/cli/src/runtime.ts
@@ -9,7 +9,7 @@
 // Per-verb logic for the surviving surfaces (handoffs, auth) lives
 // under `commands/` and is dispatched here.
 
-import { SYSTEM_ACTOR_IDS, type LibrarianStore } from "@librarian/core";
+import { SYSTEM_ACTOR_IDS, type InternalLibrarianStore } from "@librarian/core";
 import type { CliResult, Command } from "./commands/_shared.js";
 import { authUsage, authVerbs } from "./commands/auth.js";
 import { backupCommand } from "./commands/backup.js";
@@ -27,7 +27,7 @@ const topLevelCommands: Record<string, Command> = {
   export: exportCommand,
 };
 
-export function runCli(argv: string[], store: LibrarianStore): CliResult {
+export function runCli(argv: string[], store: InternalLibrarianStore): CliResult {
   const [command, ...rest] = argv;
 
   if (!command) return { stdout: usage(), exitCode: 1 };
@@ -58,7 +58,7 @@ export function runCli(argv: string[], store: LibrarianStore): CliResult {
   return { stdout: `Unknown command: ${command}\n\n${usage()}`, exitCode: 1 };
 }
 
-function runAuthCommand(args: string[], store: LibrarianStore): CliResult {
+function runAuthCommand(args: string[], store: InternalLibrarianStore): CliResult {
   const [verb, ...rest] = args;
   if (!verb) return { stdout: authUsage(), exitCode: 1 };
   if (verb === "help" || verb === "--help") return { stdout: authUsage(), exitCode: 0 };
@@ -76,7 +76,7 @@ function runAuthCommand(args: string[], store: LibrarianStore): CliResult {
   }
 }
 
-function runHandoffsCommand(args: string[], store: LibrarianStore): CliResult {
+function runHandoffsCommand(args: string[], store: InternalLibrarianStore): CliResult {
   const [verb, ...rest] = args;
   if (!verb) return { stdout: handoffsUsage(), exitCode: 1 };
   if (verb === "help" || verb === "--help") return { stdout: handoffsUsage(), exitCode: 0 };
@@ -94,7 +94,7 @@ function runHandoffsCommand(args: string[], store: LibrarianStore): CliResult {
   }
 }
 
-function seed(store: LibrarianStore): void {
+function seed(store: InternalLibrarianStore): void {
   const existing = store.listAll({});
   if (existing.length) return;
   // Bootstrap memories are placed by a system process, not an interactive

--- a/packages/core/src/backup/backup.ts
+++ b/packages/core/src/backup/backup.ts
@@ -28,7 +28,7 @@ import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { gzipSync } from "node:zlib";
-import type { LibrarianStore } from "../store/librarian-store.js";
+import type { InternalLibrarianStore } from "../store/librarian-store.js";
 import { getSchemaVersion } from "../store/projection.js";
 
 export const BACKUP_FORMAT_VERSION = 2;
@@ -65,7 +65,10 @@ function sha256(buf: Buffer): string {
   return createHash("sha256").update(buf).digest("hex");
 }
 
-export function createBackup(store: LibrarianStore, options: { destDir: string }): BackupResult {
+export function createBackup(
+  store: InternalLibrarianStore,
+  options: { destDir: string },
+): BackupResult {
   const now = new Date();
   // A fresh dir per backup. Two backups in the same millisecond would otherwise
   // collide on the timestamped name (the second silently overwriting the first);

--- a/packages/core/src/backup/run.ts
+++ b/packages/core/src/backup/run.ts
@@ -5,7 +5,7 @@
 // not lose the local backup — the bundle is already on disk before the upload.
 
 import path from "node:path";
-import type { LibrarianStore } from "../store/librarian-store.js";
+import type { InternalLibrarianStore } from "../store/librarian-store.js";
 import { type BackupManifest, createBackup } from "./backup.js";
 import { type BackupConfig, readBackupConfig } from "./config.js";
 import { pruneLocal, pruneTarget } from "./retention.js";
@@ -71,14 +71,14 @@ function runExclusive<T>(task: () => Promise<T>): Promise<T> {
 }
 
 export function runBackup(
-  store: LibrarianStore,
+  store: InternalLibrarianStore,
   options: { destDir: string; sync?: boolean; trigger?: BackupRunTrigger },
 ): Promise<RunBackupResult> {
   return runExclusive(() => runBackupOnce(store, options));
 }
 
 async function runBackupOnce(
-  store: LibrarianStore,
+  store: InternalLibrarianStore,
   options: { destDir: string; sync?: boolean; trigger?: BackupRunTrigger },
 ): Promise<RunBackupResult> {
   const config = readBackupConfig(store);
@@ -138,7 +138,7 @@ async function runBackupOnce(
 // to the cadence instead of hammering. First reconciles any run left `running` by a
 // crash. Mirrors the curator tick — safe to always start.
 export async function runBackupTick(
-  store: LibrarianStore,
+  store: InternalLibrarianStore,
   options: { destDir: string },
 ): Promise<RunBackupResult | null> {
   const config = readBackupConfig(store);

--- a/packages/core/src/backup/runs.ts
+++ b/packages/core/src/backup/runs.ts
@@ -5,7 +5,7 @@
 // alert on the most recent failure.
 
 import { randomUUID } from "node:crypto";
-import type { LibrarianStore } from "../store/librarian-store.js";
+import type { InternalLibrarianStore } from "../store/librarian-store.js";
 
 export type BackupRunStatus = "running" | "ok" | "error";
 export type BackupRunTrigger = "scheduled" | "manual";
@@ -33,7 +33,7 @@ export interface FinishBackupRun {
   error?: string | null;
 }
 
-type RunsStore = Pick<LibrarianStore, "db">;
+type RunsStore = Pick<InternalLibrarianStore, "db">;
 
 interface BackupRunRow {
   id: string;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -161,6 +161,7 @@ export {
 export { formatRecall } from "./formatters/index.js";
 export type { Memory, MemoryStore, MemoryStoreDeps } from "./store/memory-store.js";
 export {
+  type InternalLibrarianStore,
   type LibrarianStore,
   type LibrarianStoreOptions,
   createLibrarianStore,

--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -40,18 +40,29 @@ export interface LibrarianStore extends MemoryStore, CurationStore, SettingsStor
   domains: DomainsStore;
   handoffs: HandoffStore;
   dataDir: string;
-  eventsPath: string;
-  dbPath: string;
-  snapshotPath: string;
-  db: DatabaseSync;
   close(): void;
-  readEvents(): Record<string, unknown>[];
-  rebuildIndex(): void;
   /** Backend-neutral maintenance verb: rebuild the disposable memory index. */
   reindex(): void;
 }
 
-export function createLibrarianStore(options: LibrarianStoreOptions = {}): LibrarianStore {
+/**
+ * The concrete store, which also exposes the raw SQLite handle and event-ledger
+ * paths — the storage seam (F0). Only the storage layer itself and the
+ * not-yet-migrated classifier (Phase 4) and backup (Phase 7) machinery may use
+ * these; all other code receives the narrow `LibrarianStore`. Reach for this
+ * type only when you genuinely must bypass the seam — it collapses back into
+ * `LibrarianStore` once those subsystems are retired.
+ */
+export interface InternalLibrarianStore extends LibrarianStore {
+  eventsPath: string;
+  dbPath: string;
+  snapshotPath: string;
+  db: DatabaseSync;
+  readEvents(): Record<string, unknown>[];
+  rebuildIndex(): void;
+}
+
+export function createLibrarianStore(options: LibrarianStoreOptions = {}): InternalLibrarianStore {
   const dataDir = resolveDataDir(options.dataDir);
   const eventsPath = path.join(dataDir, "events.jsonl");
   const dbPath = path.join(dataDir, "librarian.sqlite");

--- a/packages/mcp-server/src/classifier-startup.ts
+++ b/packages/mcp-server/src/classifier-startup.ts
@@ -22,7 +22,7 @@ import {
 } from "@librarian/classifier";
 import {
   type ClassifierConfig,
-  type LibrarianStore,
+  type InternalLibrarianStore,
   type LlmClient,
   classifierConfigHash,
   createCuratorLlmClient,
@@ -41,7 +41,7 @@ export interface BootClassifierWorkerInput {
    * Store handle — the boot path reads classifier config + resolves the
    * encrypted token via the same connection the worker will use.
    */
-  store: LibrarianStore;
+  store: InternalLibrarianStore;
   /** Event appender — the wider store's `appendEvent`. */
   appendEvent: ClassifierWorkerDeps["appendEvent"];
   /** Optional sidecar logger. */
@@ -277,7 +277,7 @@ export interface RestartResult {
 }
 
 export interface RestartClassifierInput {
-  store: LibrarianStore;
+  store: InternalLibrarianStore;
   appendEvent: ClassifierWorkerDeps["appendEvent"];
   log?: (entry: Record<string, unknown>) => void;
   /** Test seam — same as `BootClassifierWorkerInput._llm`. */
@@ -417,7 +417,7 @@ export function __resetRestartMutexForTests(): void {
 // ---------- T3.3: classifier self-test ----------
 
 export interface ClassifierSelfTestInput {
-  store: LibrarianStore;
+  store: InternalLibrarianStore;
   log?: (entry: Record<string, unknown>) => void;
   /** Test seam — same as `BootClassifierWorkerInput._llm`. */
   _llm?: () => LlmClient;

--- a/packages/mcp-server/src/http/routes.ts
+++ b/packages/mcp-server/src/http/routes.ts
@@ -11,7 +11,7 @@
 // tRPC. Anything else 404s.
 
 import type { IncomingMessage, ServerResponse } from "node:http";
-import type { LibrarianStore } from "@librarian/core";
+import type { InternalLibrarianStore } from "@librarian/core";
 import { createHTTPHandler } from "@trpc/server/adapters/standalone";
 import { handleMcpPayload } from "../mcp/rpc.js";
 import { createContextFactory } from "../trpc/context.js";
@@ -19,7 +19,7 @@ import { appRouter } from "../trpc/router.js";
 import { type AuthConfig, authenticateMcp, isAllowedOrigin } from "./auth.js";
 
 export interface RouteDeps {
-  store: LibrarianStore;
+  store: InternalLibrarianStore;
   auth: AuthConfig;
   maxBodyBytes: number;
   secretKey: Buffer | null;

--- a/packages/mcp-server/src/http/server.ts
+++ b/packages/mcp-server/src/http/server.ts
@@ -7,12 +7,12 @@
 // from tests without spawning a subprocess.
 
 import http from "node:http";
-import type { LibrarianStore } from "@librarian/core";
+import type { InternalLibrarianStore } from "@librarian/core";
 import type { AuthConfig } from "./auth.js";
 import { createRouteHandler } from "./routes.js";
 
 export interface HttpServerOptions {
-  store: LibrarianStore;
+  store: InternalLibrarianStore;
   auth: AuthConfig;
   maxBodyBytes?: number;
   /** Master key — threaded to the tRPC auth router for AUTH_SECRET / OAuth secrets. */

--- a/packages/mcp-server/src/mcp/domain-resolution.ts
+++ b/packages/mcp-server/src/mcp/domain-resolution.ts
@@ -32,11 +32,9 @@ export function resolveCallerDomain(
     const state = store.convState.get(convId);
     if (state) return { domain: state.domain, source: "conv_state" };
   }
-  const rows = store.db.prepare("SELECT name FROM domains LIMIT 2").all() as Array<{
-    name: string;
-  }>;
-  if (rows.length === 1) {
-    return { domain: rows[0]?.name ?? null, source: "single_domain" };
+  const domains = store.domains.list();
+  if (domains.length === 1) {
+    return { domain: domains[0]?.name ?? null, source: "single_domain" };
   }
   return { domain: null, source: "none" };
 }

--- a/packages/mcp-server/src/trpc/context.ts
+++ b/packages/mcp-server/src/trpc/context.ts
@@ -5,7 +5,7 @@
 // in one place. The `store` is threaded through so future routers
 // (memories, sessions) can call it without reaching for globals.
 
-import type { LibrarianStore } from "@librarian/core";
+import type { InternalLibrarianStore } from "@librarian/core";
 import type { CreateHTTPContextOptions } from "@trpc/server/adapters/standalone";
 import { type AuthConfig, authenticateMcp } from "../http/auth.js";
 
@@ -13,7 +13,7 @@ export type TrpcRole = "admin" | "anonymous";
 
 export interface TrpcContext {
   role: TrpcRole;
-  store: LibrarianStore;
+  store: InternalLibrarianStore;
   /** Master key for deriving AUTH_SECRET / decrypting OAuth secrets (null when unset). */
   secretKey: Buffer | null;
   /** The configured admin token — the auth router compares it timing-safe in `enable`. */
@@ -21,7 +21,7 @@ export interface TrpcContext {
 }
 
 export interface TrpcContextDeps {
-  store: LibrarianStore;
+  store: InternalLibrarianStore;
   auth: AuthConfig;
   secretKey: Buffer | null;
 }

--- a/scripts/check-no-store-bypass.mjs
+++ b/scripts/check-no-store-bypass.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+// Storage-seam guard (F0 — "seal the seam").
+//
+// The public `LibrarianStore` no longer exposes the raw SQLite handle or the
+// event-ledger paths (`db` / `dbPath` / `snapshotPath` / `eventsPath` /
+// `readEvents` / `rebuildIndex`). Only the storage layer itself and the
+// not-yet-migrated backup (Phase 7) and classifier (Phase 4) subsystems may
+// reach them, via the `InternalLibrarianStore` escape hatch.
+//
+// This guard fails if raw store-handle access appears anywhere else in
+// production source, so the seam can't silently re-open between the type-level
+// narrowing and the markdown-backend cutover. It tightens automatically: as the
+// allowlisted subsystems are retired, their entries should be removed here too.
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+
+// Production (non-test) source roots to scan.
+const ROOTS = [
+  "packages/core/src",
+  "packages/mcp-server/src",
+  "packages/cli/src",
+  "apps/dashboard",
+];
+
+// The storage layer owns the handles; backup + classifier are the deferred
+// internal-tier consumers (typed `InternalLibrarianStore`) pending their
+// Phase 7 / Phase 4 retirement.
+function isAllowlisted(rel) {
+  return (
+    rel.includes("/store/") ||
+    rel.includes("/backup/") ||
+    /classifier-(startup|worker)\.ts$/.test(rel)
+  );
+}
+
+function isScannable(rel) {
+  if (!/\.tsx?$/.test(rel)) return false;
+  if (/\.test\.tsx?$/.test(rel)) return false;
+  return true;
+}
+
+// Raw store-handle access that must stay behind the seam.
+const PATTERNS = [
+  /\bstore\.db\b/,
+  /\.db\.(prepare|exec)\b/,
+  /\bstore\.eventsPath\b/,
+  /\bstore\.dbPath\b/,
+  /\bstore\.snapshotPath\b/,
+  /\.readEvents\(/,
+  /\.rebuildIndex\(/,
+];
+
+const SKIP_DIRS = new Set(["node_modules", "dist", ".next"]);
+
+function walk(dir, out) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (!SKIP_DIRS.has(entry.name)) walk(full, out);
+    } else {
+      out.push(full);
+    }
+  }
+}
+
+const violations = [];
+for (const root of ROOTS) {
+  const files = [];
+  walk(path.join(repoRoot, root), files);
+  for (const file of files) {
+    const rel = path.relative(repoRoot, file).split(path.sep).join("/");
+    if (!isScannable(rel) || isAllowlisted(rel)) continue;
+    const lines = fs.readFileSync(file, "utf8").split("\n");
+    lines.forEach((line, i) => {
+      if (PATTERNS.some((pattern) => pattern.test(line))) {
+        violations.push(`${rel}:${i + 1}: ${line.trim()}`);
+      }
+    });
+  }
+}
+
+if (violations.length > 0) {
+  console.error(
+    "[check-no-store-bypass] Raw store-handle access found outside the storage seam.\n" +
+      "The public LibrarianStore must not expose db/eventsPath/readEvents/rebuildIndex; route\n" +
+      "through a store interface method, or (only for store/**, backup/**, classifier-startup|worker)\n" +
+      "use InternalLibrarianStore. Offending lines:",
+  );
+  for (const violation of violations) console.error(`  ${violation}`);
+  process.exit(1);
+}
+
+console.log("[check-no-store-bypass] OK — no raw store-handle access outside the storage seam.");


### PR DESCRIPTION
## What
Final F0 ("seal the seam") increment — narrows the public store type so non-storage code can't reach raw SQLite/ledger internals, enabling the markdown-backend swap behind a stable interface. Uses **Option A** (public/internal split).

- **`LibrarianStore` (public)** drops `db` / `dbPath` / `snapshotPath` / `eventsPath` / `readEvents()` / `rebuildIndex()`. It keeps the store sub-interfaces, `dataDir`, `close()`, and `reindex()`.
- **`InternalLibrarianStore extends LibrarianStore`** carries the raw handles; `createLibrarianStore()` returns it.
- Only the **storage layer** and the deferred **backup** (Phase 7) + **classifier** (Phase 4) subsystems use the internal type. The mcp-server contexts and the CLI thread it as the store's owner; library pipeline functions (curator, caller-backfill) receive the narrow type.
- `domain-resolution`'s lone `store.db` read is rerouted to the public `store.domains.list()`, keeping the whole MCP tool layer on the narrow type.

## Why it's safe
The compiler now enforces the seam: you cannot touch `db` on a `LibrarianStore`. Tests construct stores via `createLibrarianStore()` and get the internal type by inference, so **no test changes were needed**. The `InternalLibrarianStore` escape hatch is a self-documenting "delete as backup/classifier retire" list.

## Guard
Adds `check:no-store-bypass` (wired into the CI guards job): fails if raw `store.db`/`eventsPath`/`readEvents`/`rebuildIndex` access appears in production source outside the storage layer + allowlisted `backup/**` / `classifier-startup|worker`. Verified clean today.

## Tests
Green: lint, `pnpm -r typecheck` (0 errors, **with the narrowed type**), `pnpm test` (core 516, mcp-server 147, cli 52, dashboard 167, classifier 26, classifier-eval 50, root 23), and the new guard.

## F0 status
This completes the F0 seam-sealing series (handoffs detail-read + list, curator reads, caller-backfill, CLI reindex, and now the type narrowing). Remaining storage-layer raw-handle use is confined to the storage layer and the explicitly-deferred backup/classifier subsystems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)