### PR TITLE
feat(corpus): markdown frontmatter parse/serialize (F1, Phase 1)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,6 +36,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "gray-matter": "^4.0.3",
     "zod": "^4.0.1"
   },
   "devDependencies": {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -159,6 +159,13 @@ export {
   backfillCallerIds,
 } from "./caller-backfill.js";
 export { formatRecall } from "./formatters/index.js";
+export {
+  type CorpusDocument,
+  type CorpusFrontmatter,
+  CorpusFrontmatterSchema,
+  parseDocument,
+  serializeDocument,
+} from "./store/corpus/index.js";
 export type { Memory, MemoryStore, MemoryStoreDeps } from "./store/memory-store.js";
 export {
   type InternalLibrarianStore,

--- a/packages/core/src/store/corpus/frontmatter.ts
+++ b/packages/core/src/store/corpus/frontmatter.ts
@@ -1,0 +1,96 @@
+// Corpus frontmatter — the minimal document metadata for the markdown
+// rearchitecture (spec 035 §F1). A corpus document is Obsidian-flavoured
+// markdown: a YAML frontmatter block followed by a markdown body. D16
+// reduced the metadata to identity + filing hints only — no
+// agent/source/confidence/scope/domain.
+//
+// The markdown is the source of truth, so serialization is deterministic
+// and byte-stable: a fixed key order, double-quoted scalars, and
+// block-style arrays. Double-quoting matters — js-yaml (via gray-matter)
+// otherwise re-parses an unquoted ISO timestamp as a `Date`, which would
+// break the round-trip and bloat git diffs. `parseDocument` is tolerant of
+// hand edits (Obsidian / the dashboard): it coerces any YAML `Date` back to
+// an ISO string before validating.
+
+import matter from "gray-matter";
+import { z } from "zod";
+import { IsoTimestampSchema } from "../../schemas/common.js";
+
+export const CorpusFrontmatterSchema = z.object({
+  /** Stable slug identity for the document (also its filename stem). */
+  id: z.string().min(1),
+  /** Alternate names the document is known by — used for wikilink resolution. */
+  aliases: z.array(z.string()).default([]),
+  tags: z.array(z.string()).default([]),
+  /** Topic-folder filing hint (people / projects / preferences / lessons / …). */
+  category: z.string().min(1),
+  created: IsoTimestampSchema,
+  updated: IsoTimestampSchema,
+});
+export type CorpusFrontmatter = z.infer<typeof CorpusFrontmatterSchema>;
+
+/** A parsed corpus document: validated frontmatter + the trimmed markdown body. */
+export interface CorpusDocument {
+  frontmatter: CorpusFrontmatter;
+  body: string;
+}
+
+/**
+ * Parse raw markdown (frontmatter + body) into a validated `CorpusDocument`.
+ * Throws a teaching error naming the offending field when the frontmatter
+ * doesn't satisfy the minimal schema.
+ */
+export function parseDocument(raw: string): CorpusDocument {
+  const { data, content } = matter(raw);
+  const result = CorpusFrontmatterSchema.safeParse(coerceDates(data));
+  if (!result.success) {
+    const detail = result.error.issues
+      .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+      .join("; ");
+    throw new Error(`Invalid corpus frontmatter: ${detail}`);
+  }
+  return { frontmatter: result.data, body: content.trim() };
+}
+
+/**
+ * Serialize a `CorpusDocument` to its canonical on-disk form: deterministic
+ * frontmatter (fixed key order, double-quoted scalars, block arrays) and a
+ * trimmed body. `parseDocument(serializeDocument(doc))` deep-equals `doc`,
+ * and `serializeDocument(parseDocument(x)) === x` for any canonical `x`.
+ */
+export function serializeDocument(doc: CorpusDocument): string {
+  const fm = doc.frontmatter;
+  const head = `---\n${[
+    `id: ${quoteScalar(fm.id)}`,
+    arrayLines("aliases", fm.aliases),
+    arrayLines("tags", fm.tags),
+    `category: ${quoteScalar(fm.category)}`,
+    `created: ${quoteScalar(fm.created)}`,
+    `updated: ${quoteScalar(fm.updated)}`,
+  ].join("\n")}\n---\n`;
+  const body = doc.body.trim();
+  return body ? `${head}\n${body}\n` : head;
+}
+
+function quoteScalar(value: string): string {
+  const escaped = value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\t/g, "\\t")
+    .replace(/\r/g, "\\r");
+  return `"${escaped}"`;
+}
+
+function arrayLines(key: string, items: string[]): string {
+  if (items.length === 0) return `${key}: []`;
+  return [`${key}:`, ...items.map((item) => `  - ${quoteScalar(item)}`)].join("\n");
+}
+
+function coerceDates(data: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(data)) {
+    out[key] = value instanceof Date ? value.toISOString() : value;
+  }
+  return out;
+}

--- a/packages/core/src/store/corpus/index.ts
+++ b/packages/core/src/store/corpus/index.ts
@@ -1,0 +1,11 @@
+// Corpus module — markdown vault I/O for the markdown rearchitecture
+// (spec 035 §F1 / Phase 1). Frontmatter today; wikilink parsing and vault
+// file I/O land in follow-on increments.
+
+export {
+  type CorpusDocument,
+  type CorpusFrontmatter,
+  CorpusFrontmatterSchema,
+  parseDocument,
+  serializeDocument,
+} from "./frontmatter.js";

--- a/packages/core/tests/store/corpus/frontmatter.test.ts
+++ b/packages/core/tests/store/corpus/frontmatter.test.ts
@@ -1,0 +1,141 @@
+// Corpus frontmatter round-trip tests (spec 035 §F1 — Phase 1 checkpoint).
+//
+// The markdown is the source of truth, so frontmatter parse/serialize must
+// round-trip byte-for-byte (minimal git diffs) and survive hand edits in
+// Obsidian/the dashboard. These tests pin:
+//   - the minimal D16 schema (id, aliases, tags, category, created, updated),
+//   - byte-stable serialize(parse(x)) === x,
+//   - value-stable parse(serialize(doc)) deep-equals doc,
+//   - timestamps stay strings even when YAML would coerce them to Date,
+//   - teaching errors that name the offending field.
+
+import { type CorpusDocument, parseDocument, serializeDocument } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+const sampleDoc: CorpusDocument = {
+  frontmatter: {
+    id: "anna-sangwine",
+    aliases: ["Anna", "Anna S."],
+    tags: ["family", "people"],
+    category: "people",
+    created: "2026-05-31T09:00:00.000Z",
+    updated: "2026-06-01T10:30:00.000Z",
+  },
+  body: "# Anna\n\nAnna is Jim's wife. See also [[sophie-sangwine]].",
+};
+
+// The canonical on-disk form `serializeDocument` is expected to emit.
+const canonical = `---
+id: "anna-sangwine"
+aliases:
+  - "Anna"
+  - "Anna S."
+tags:
+  - "family"
+  - "people"
+category: "people"
+created: "2026-05-31T09:00:00.000Z"
+updated: "2026-06-01T10:30:00.000Z"
+---
+
+# Anna
+
+Anna is Jim's wife. See also [[sophie-sangwine]].
+`;
+
+describe("corpus frontmatter", () => {
+  it("serializes a document to the canonical, deterministic form", () => {
+    expect(serializeDocument(sampleDoc)).toBe(canonical);
+  });
+
+  it("parses the canonical form back into the document", () => {
+    expect(parseDocument(canonical)).toEqual(sampleDoc);
+  });
+
+  it("round-trips byte-for-byte: serialize(parse(x)) === x", () => {
+    expect(serializeDocument(parseDocument(canonical))).toBe(canonical);
+  });
+
+  it("round-trips by value: parse(serialize(doc)) deep-equals doc", () => {
+    expect(parseDocument(serializeDocument(sampleDoc))).toEqual(sampleDoc);
+  });
+
+  it("defaults aliases and tags to empty arrays when absent", () => {
+    const raw = `---
+id: "pnpm-usage"
+category: "preferences"
+created: "2026-05-31T09:00:00.000Z"
+updated: "2026-05-31T09:00:00.000Z"
+---
+
+Always use pnpm, never npm.
+`;
+    const doc = parseDocument(raw);
+    expect(doc.frontmatter.aliases).toEqual([]);
+    expect(doc.frontmatter.tags).toEqual([]);
+    expect(doc.body).toBe("Always use pnpm, never npm.");
+  });
+
+  it("keeps timestamps as strings even when YAML leaves them unquoted (Obsidian edits)", () => {
+    const raw = `---
+id: "x"
+category: "lessons"
+created: 2026-05-31T09:00:00.000Z
+updated: 2026-05-31T09:00:00.000Z
+---
+
+body
+`;
+    const doc = parseDocument(raw);
+    expect(typeof doc.frontmatter.created).toBe("string");
+    expect(doc.frontmatter.created).toBe("2026-05-31T09:00:00.000Z");
+  });
+
+  it("preserves a body that contains every wikilink form untouched", () => {
+    const body = "See [[x]], [[y|Why]], [[z#Heading]], and ![[embed]].";
+    const doc: CorpusDocument = { ...sampleDoc, body };
+    expect(parseDocument(serializeDocument(doc)).body).toBe(body);
+  });
+
+  it("round-trips an empty body", () => {
+    const doc: CorpusDocument = { ...sampleDoc, body: "" };
+    expect(parseDocument(serializeDocument(doc))).toEqual(doc);
+  });
+
+  it("rejects a missing id with a teaching error that names the field", () => {
+    const raw = `---
+category: "people"
+created: "2026-05-31T09:00:00.000Z"
+updated: "2026-05-31T09:00:00.000Z"
+---
+
+body
+`;
+    expect(() => parseDocument(raw)).toThrow(/id/);
+  });
+
+  it("rejects a missing category with a teaching error that names the field", () => {
+    const raw = `---
+id: "x"
+created: "2026-05-31T09:00:00.000Z"
+updated: "2026-05-31T09:00:00.000Z"
+---
+
+body
+`;
+    expect(() => parseDocument(raw)).toThrow(/category/);
+  });
+
+  it("rejects a non-ISO timestamp with a teaching error", () => {
+    const raw = `---
+id: "x"
+category: "people"
+created: "2026-13-99"
+updated: "2026-05-31T09:00:00.000Z"
+---
+
+body
+`;
+    expect(() => parseDocument(raw)).toThrow(/created/);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,6 +222,9 @@ importers:
 
   packages/core:
     dependencies:
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
       zod:
         specifier: ^4.0.1
         version: 4.4.3
@@ -1529,6 +1532,9 @@ packages:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
 
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -1923,6 +1929,11 @@ packages:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
@@ -1945,6 +1956,10 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
 
   fast-copy@4.0.3:
     resolution: {integrity: sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==}
@@ -2079,6 +2094,10 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+    engines: {node: '>=6.0'}
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -2197,6 +2216,10 @@ packages:
     resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
     engines: {node: '>= 0.4'}
 
+  is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -2288,6 +2311,10 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+    hasBin: true
+
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
@@ -2331,6 +2358,10 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
 
   lefthook-darwin-arm64@1.13.6:
     resolution: {integrity: sha512-m6Lb77VGc84/Qo21Lhq576pEvcgFCnvloEiP02HbAHcIXD0RTLy9u2yAInrixqZeaz13HYtdDaI7OBYAAdVt8A==}
@@ -2895,6 +2926,10 @@ packages:
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
+  section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
+    engines: {node: '>=4'}
+
   secure-json-parse@4.1.0:
     resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
@@ -2976,6 +3011,9 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -2997,6 +3035,10 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
+
+  strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
+    engines: {node: '>=0.10.0'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -4424,6 +4466,10 @@ snapshots:
 
   ansi-styles@5.2.0: {}
 
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
   argparse@2.0.1: {}
 
   aria-hidden@1.2.6:
@@ -4941,6 +4987,8 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 4.2.1
 
+  esprima@4.0.1: {}
+
   esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
@@ -4958,6 +5006,10 @@ snapshots:
   esutils@2.0.3: {}
 
   expect-type@1.3.0: {}
+
+  extend-shallow@2.0.1:
+    dependencies:
+      is-extendable: 0.1.1
 
   fast-copy@4.0.3: {}
 
@@ -5089,6 +5141,13 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  gray-matter@4.0.3:
+    dependencies:
+      js-yaml: 3.14.2
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
+
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -5206,6 +5265,8 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
+  is-extendable@0.1.1: {}
+
   is-extglob@2.1.1: {}
 
   is-finalizationregistry@1.1.1:
@@ -5288,6 +5349,11 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-yaml@3.14.2:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
@@ -5339,6 +5405,8 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  kind-of@6.0.3: {}
 
   lefthook-darwin-arm64@1.13.6:
     optional: true
@@ -5904,6 +5972,11 @@ snapshots:
 
   scheduler@0.27.0: {}
 
+  section-matter@1.0.0:
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
+
   secure-json-parse@4.1.0: {}
 
   semver@6.3.1: {}
@@ -6024,6 +6097,8 @@ snapshots:
 
   split2@4.2.0: {}
 
+  sprintf-js@1.0.3: {}
+
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
@@ -6055,6 +6130,8 @@ snapshots:
       call-bind: 1.0.9
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  strip-bom-string@1.0.0: {}
 
   strip-bom@3.0.0: {}
 


### PR DESCRIPTION
## What

First increment of the markdown rearchitecture (plan 036 **Phase 1 — Corpus + git foundation**; spec 035 §F1). Adds `packages/core/src/store/corpus/` with the corpus document model and frontmatter I/O.

- **Minimal D16 frontmatter schema** (`id, aliases, tags, category, created, updated`) — no agent/source/confidence/scope/domain.
- `parseDocument(raw)` / `serializeDocument(doc)`:
  - Deterministic, **byte-stable** serialization (fixed key order, double-quoted scalars, block-style arrays) so the markdown source-of-truth produces minimal git diffs.
  - Scalars are double-quoted deliberately: js-yaml (via `gray-matter`) otherwise re-parses an unquoted ISO timestamp as a `Date` and breaks the round-trip. `parseDocument` coerces any YAML `Date` back to an ISO string, so hand edits in Obsidian / the dashboard survive.
  - Teaching errors that name the offending field.
- Adds the `gray-matter` dependency (pre-approved — spec 035 tech stack / resolved Open Question 1).

## Scope

Internal scaffolding only — the module is **not yet wired into any store**, so there is **no user-visible change** (hence no CHANGELOG entry). Wikilink parsing, vault file I/O, and the git-ops / link-integrity service (F12) follow in subsequent Phase 1 increments.

## Verification

- New `corpus/frontmatter` unit suite (11 tests): canonical serialization, byte-stable `serialize(parse(x)) === x`, value-stable `parse(serialize(doc))`, default empty arrays, unquoted-timestamp tolerance, every wikilink form preserved in the body, empty-body round-trip, teaching errors.
- `pnpm -r typecheck`, `pnpm run lint`, full `pnpm test` green (the one transient failure seen locally was a 5s healthcheck timeout under concurrent load — passes in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)