### PR TITLE
feat(corpus): wikilink parse + surgical rename (F1/F12, Phase 1)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -162,8 +162,11 @@ export { formatRecall } from "./formatters/index.js";
 export {
   type CorpusDocument,
   type CorpusFrontmatter,
+  type Wikilink,
   CorpusFrontmatterSchema,
   parseDocument,
+  parseWikilinks,
+  renameWikilinkTarget,
   serializeDocument,
 } from "./store/corpus/index.js";
 export type { Memory, MemoryStore, MemoryStoreDeps } from "./store/memory-store.js";

--- a/packages/core/src/store/corpus/index.ts
+++ b/packages/core/src/store/corpus/index.ts
@@ -9,3 +9,4 @@ export {
   parseDocument,
   serializeDocument,
 } from "./frontmatter.js";
+export { type Wikilink, parseWikilinks, renameWikilinkTarget } from "./wikilink.js";

--- a/packages/core/src/store/corpus/wikilink.ts
+++ b/packages/core/src/store/corpus/wikilink.ts
@@ -1,0 +1,77 @@
+// Wikilink parsing + surgical link-integrity rewrites for the markdown
+// corpus (spec 035 §F1 / §F12). Obsidian wikilink forms:
+//   [[target]] · [[target|alias]] · [[target#heading]] · ![[embed]]
+// (plus the heading+alias combo). The parser yields each link's exact
+// source span so renames are surgical string edits — only the matched
+// link tokens change, the rest of the file stays byte-identical (minimal
+// git diffs; no full markdown re-stringify, which is why this is a focused
+// scanner rather than a remark round-trip — remark/rehype rendering is a
+// Phase-6 dashboard concern).
+//
+// Known simplification (MVP): matches occur anywhere, including inside
+// inline-code / fenced blocks. The consolidator authors prose and ids are
+// unique slugs, so this is low-risk; code-fence-aware skipping is a
+// documented follow-up.
+
+// (!?) embed flag · target (no [ ] | #) · optional #heading · optional |alias
+const WIKILINK = /(!?)\[\[([^[\]|#]+)(#[^[\]|]+)?(\|[^[\]]+)?\]\]/g;
+
+export interface Wikilink {
+  /** The exact matched text, e.g. "![[doc#H|Alias]]". */
+  raw: string;
+  /** True for an embed / transclusion (`![[...]]`). */
+  embed: boolean;
+  /** The link target (note id / path), trimmed. */
+  target: string;
+  /** Heading anchor without the leading `#`, or null. */
+  heading: string | null;
+  /** Display alias without the leading `|`, or null. */
+  alias: string | null;
+  /** Start offset in the source string (inclusive). */
+  start: number;
+  /** End offset in the source string (exclusive). */
+  end: number;
+}
+
+/** Extract every wikilink (with its source span) from a markdown string. */
+export function parseWikilinks(markdown: string): Wikilink[] {
+  const links: Wikilink[] = [];
+  for (const match of markdown.matchAll(WIKILINK)) {
+    const raw = match[0]!;
+    const start = match.index!;
+    const heading = match[3];
+    const alias = match[4];
+    links.push({
+      raw,
+      embed: match[1] === "!",
+      target: (match[2] ?? "").trim(),
+      heading: heading ? heading.slice(1).trim() : null,
+      alias: alias ? alias.slice(1).trim() : null,
+      start,
+      end: start + raw.length,
+    });
+  }
+  return links;
+}
+
+/**
+ * Rewrite every wikilink whose target exactly equals `from` to point at
+ * `to`, preserving its embed flag, heading anchor, and alias. Non-matching
+ * links and all surrounding content are copied verbatim.
+ */
+export function renameWikilinkTarget(markdown: string, from: string, to: string): string {
+  let out = "";
+  let cursor = 0;
+  for (const link of parseWikilinks(markdown)) {
+    if (link.target !== from) continue;
+    out += markdown.slice(cursor, link.start) + renderWikilink({ ...link, target: to });
+    cursor = link.end;
+  }
+  return out + markdown.slice(cursor);
+}
+
+function renderWikilink(link: Wikilink): string {
+  const heading = link.heading ? `#${link.heading}` : "";
+  const alias = link.alias ? `|${link.alias}` : "";
+  return `${link.embed ? "!" : ""}[[${link.target}${heading}${alias}]]`;
+}

--- a/packages/core/tests/store/corpus/wikilink.test.ts
+++ b/packages/core/tests/store/corpus/wikilink.test.ts
@@ -1,0 +1,75 @@
+// Wikilink parse + surgical-rename tests (spec 035 §F1/§F12 — Phase 1).
+//
+// Link integrity is a Phase-1 checkpoint: a rename must rewrite *every*
+// wikilink form and leave the rest of the document byte-identical (minimal
+// git diffs — no full re-stringify). These tests pin the four Obsidian
+// forms — [[x]] / [[x|alias]] / [[x#heading]] / ![[embed]] — plus the
+// heading+alias combo, and that a rename touches only the matching targets.
+
+import { parseWikilinks, renameWikilinkTarget } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+describe("parseWikilinks", () => {
+  it("extracts a plain link with its source span", () => {
+    const md = "see [[anna]] now";
+    const links = parseWikilinks(md);
+    expect(links).toHaveLength(1);
+    expect(links[0]).toMatchObject({
+      embed: false,
+      target: "anna",
+      heading: null,
+      alias: null,
+      raw: "[[anna]]",
+    });
+    expect(md.slice(links[0]!.start, links[0]!.end)).toBe("[[anna]]");
+  });
+
+  it("parses every wikilink form", () => {
+    const md = "[[plain]] [[t|Display]] [[doc#Heading]] ![[embedded]] [[d#H|A]]";
+    const links = parseWikilinks(md);
+    expect(
+      links.map((l) => ({ embed: l.embed, target: l.target, heading: l.heading, alias: l.alias })),
+    ).toEqual([
+      { embed: false, target: "plain", heading: null, alias: null },
+      { embed: false, target: "t", heading: null, alias: "Display" },
+      { embed: false, target: "doc", heading: "Heading", alias: null },
+      { embed: true, target: "embedded", heading: null, alias: null },
+      { embed: false, target: "d", heading: "H", alias: "A" },
+    ]);
+  });
+
+  it("ignores non-wikilink brackets and markdown links", () => {
+    expect(parseWikilinks("a [single] b [text](http://x) c [[]] d")).toEqual([]);
+  });
+
+  it("tolerates targets containing spaces and slashes", () => {
+    const links = parseWikilinks("[[people/Anna Sangwine]]");
+    expect(links[0]).toMatchObject({ target: "people/Anna Sangwine" });
+  });
+});
+
+describe("renameWikilinkTarget", () => {
+  it("rewrites every form that points at the renamed target, preserving alias/heading/embed", () => {
+    const md = "[[anna]] [[anna|Anna]] [[anna#Bio]] ![[anna]] [[anna#Bio|Anna]]";
+    expect(renameWikilinkTarget(md, "anna", "anna-sangwine")).toBe(
+      "[[anna-sangwine]] [[anna-sangwine|Anna]] [[anna-sangwine#Bio]] ![[anna-sangwine]] [[anna-sangwine#Bio|Anna]]",
+    );
+  });
+
+  it("leaves non-matching links and surrounding prose byte-identical", () => {
+    const md = "# Notes\n\n[[anna]] knows [[bob]]. Code: `[[anna]]` stays prose.\n";
+    const out = renameWikilinkTarget(md, "anna", "anna-2");
+    // bob untouched; the prose/structure unchanged except the two `anna` targets.
+    expect(out).toBe("# Notes\n\n[[anna-2]] knows [[bob]]. Code: `[[anna-2]]` stays prose.\n");
+  });
+
+  it("is a no-op when the target does not occur", () => {
+    const md = "[[bob]] and [[carol|C]]";
+    expect(renameWikilinkTarget(md, "anna", "anna-2")).toBe(md);
+  });
+
+  it("matches the target exactly (not a substring or prefix)", () => {
+    const md = "[[anna]] [[annabel]] [[anna-lee]]";
+    expect(renameWikilinkTarget(md, "anna", "ZZ")).toBe("[[ZZ]] [[annabel]] [[anna-lee]]");
+  });
+});


### PR DESCRIPTION
## What

Second increment of plan 036 **Phase 1** (spec 035 §F1 / §F12 link integrity). Adds `packages/core/src/store/corpus/wikilink.ts`.

- **`parseWikilinks(md)`** extracts every Obsidian wikilink form — `[[x]]` / `[[x|alias]]` / `[[x#heading]]` / `![[embed]]` (+ the heading+alias combo) — with each link's exact **source span**. This feeds the backlink graph (Phase 3) and the link-integrity service (F12).
- **`renameWikilinkTarget(md, from, to)`** rewrites only the matching link tokens via **surgical string edits** (preserving the embed flag, heading anchor, and alias) and copies everything else verbatim — so git diffs stay minimal. No full markdown re-stringify.

## Design note

The spec lists `remark`/`unified` for parse/render. For *position-accurate surgical rewrites* a focused scanner is the better tool (exact offsets, zero new deps, and it already serves the Phase-3 backlink graph). `remark`/`rehype` is genuinely only needed for dashboard **rendering** (Phase 6), so that dependency is deferred to where it's actually used.

**Known MVP simplification:** matches occur anywhere, including inside inline-code / fenced blocks (the consolidator authors prose and ids are unique slugs, so this is low-risk). Code-fence-aware skipping is a documented follow-up.

## Scope

Internal scaffolding — **no user-visible change** (no CHANGELOG entry). Vault file I/O and the `simple-git` git-ops/link-integrity service that drives renames end-to-end follow in the next Phase-1 increments.

## Verification

- New `corpus/wikilink` unit suite (8 tests): all four forms parsed with spans; non-links ignored; targets with spaces/slashes; rename rewrites every form preserving alias/heading/embed; non-matching links + prose byte-identical; no-op when absent; exact-target match (not prefix/substring).
- `pnpm -r typecheck` + `pnpm run lint` green; core suite 519 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)