### PR TITLE
feat(corpus): vault file I/O — read/write/list/move (F1, Phase 1)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -162,11 +162,15 @@ export { formatRecall } from "./formatters/index.js";
 export {
   type CorpusDocument,
   type CorpusFrontmatter,
+  type Vault,
+  type VaultOptions,
   type Wikilink,
   CorpusFrontmatterSchema,
+  createVault,
   parseDocument,
   parseWikilinks,
   renameWikilinkTarget,
+  resolveVaultPath,
   serializeDocument,
 } from "./store/corpus/index.js";
 export type { Memory, MemoryStore, MemoryStoreDeps } from "./store/memory-store.js";

--- a/packages/core/src/store/corpus/index.ts
+++ b/packages/core/src/store/corpus/index.ts
@@ -10,3 +10,4 @@ export {
   serializeDocument,
 } from "./frontmatter.js";
 export { type Wikilink, parseWikilinks, renameWikilinkTarget } from "./wikilink.js";
+export { type Vault, type VaultOptions, createVault, resolveVaultPath } from "./vault.js";

--- a/packages/core/src/store/corpus/vault.ts
+++ b/packages/core/src/store/corpus/vault.ts
@@ -1,0 +1,111 @@
+// Vault file I/O for the markdown corpus (spec 035 §F1 / Project
+// Structure). The vault is a folder of Obsidian-flavoured markdown at
+// `<data-dir>/vault` (or `LIBRARIAN_VAULT_PATH`), laid out as `inbox/`,
+// topic folders, `skills/`, `references/`, `handoffs/`, `archive/`. This
+// module is the read/write/list/move primitive the git-ops +
+// link-integrity service (next increment) commits on top of.
+//
+// The corpus layer stays free of the store graph (component map:
+// corpus → no deps), so the tiny data-dir resolution is inlined here
+// rather than imported from `librarian-store`.
+
+import fs from "node:fs";
+import path from "node:path";
+import { type CorpusDocument, parseDocument, serializeDocument } from "./frontmatter.js";
+
+export interface VaultOptions {
+  /** Explicit vault directory; wins over env + dataDir. */
+  vaultPath?: string;
+  /** Data dir to derive `<dataDir>/vault` from when no explicit/env path. */
+  dataDir?: string;
+}
+
+/**
+ * Resolve the vault directory: an explicit `vaultPath` wins, then
+ * `LIBRARIAN_VAULT_PATH`, then `<dataDir>/vault` (dataDir itself resolving
+ * via `LIBRARIAN_DATA_DIR` / `<cwd>/data`).
+ */
+export function resolveVaultPath(options: VaultOptions = {}): string {
+  if (options.vaultPath) return options.vaultPath;
+  if (process.env.LIBRARIAN_VAULT_PATH) return process.env.LIBRARIAN_VAULT_PATH;
+  const dataDir =
+    options.dataDir || process.env.LIBRARIAN_DATA_DIR || path.join(process.cwd(), "data");
+  return path.join(dataDir, "vault");
+}
+
+export interface Vault {
+  /** Absolute path of the vault root. */
+  readonly root: string;
+  writeDocument(relPath: string, doc: CorpusDocument): void;
+  /** Read + parse a document; throws a teaching error when absent. */
+  readDocument(relPath: string): CorpusDocument;
+  tryReadDocument(relPath: string): CorpusDocument | null;
+  /** Recursive list of `.md` files (posix-relative to the root, sorted). */
+  listMarkdown(subdir?: string): string[];
+  /** Move a file within the vault — the archive=move (reversible) primitive. */
+  moveFile(fromRel: string, toRel: string): void;
+  exists(relPath: string): boolean;
+}
+
+export function createVault(options: VaultOptions = {}): Vault {
+  const root = resolveVaultPath(options);
+  fs.mkdirSync(root, { recursive: true });
+
+  // Resolve a vault-relative path to an absolute one, refusing anything
+  // that escapes the root — the vault is `git push`ed, so a stray `..`
+  // write must never land outside it.
+  function within(relPath: string): string {
+    const abs = path.resolve(root, relPath);
+    if (abs !== root && !abs.startsWith(root + path.sep)) {
+      throw new Error(`vault: path '${relPath}' escapes the vault root`);
+    }
+    return abs;
+  }
+
+  function exists(relPath: string): boolean {
+    return fs.existsSync(within(relPath));
+  }
+
+  function writeDocument(relPath: string, doc: CorpusDocument): void {
+    const abs = within(relPath);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, serializeDocument(doc), "utf8");
+  }
+
+  function readDocument(relPath: string): CorpusDocument {
+    const abs = within(relPath);
+    if (!fs.existsSync(abs)) throw new Error(`vault: no document at '${relPath}'`);
+    return parseDocument(fs.readFileSync(abs, "utf8"));
+  }
+
+  function tryReadDocument(relPath: string): CorpusDocument | null {
+    return exists(relPath) ? readDocument(relPath) : null;
+  }
+
+  function listMarkdown(subdir?: string): string[] {
+    const base = subdir ? within(subdir) : root;
+    if (!fs.existsSync(base)) return [];
+    const out: string[] = [];
+    const walk = (dir: string): void => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const abs = path.join(dir, entry.name);
+        if (entry.isDirectory()) walk(abs);
+        else if (entry.isFile() && entry.name.endsWith(".md")) {
+          out.push(path.relative(root, abs).split(path.sep).join("/"));
+        }
+      }
+    };
+    walk(base);
+    return out.sort();
+  }
+
+  function moveFile(fromRel: string, toRel: string): void {
+    const absFrom = within(fromRel);
+    const absTo = within(toRel);
+    if (!fs.existsSync(absFrom)) throw new Error(`vault: no file to move at '${fromRel}'`);
+    fs.mkdirSync(path.dirname(absTo), { recursive: true });
+    fs.renameSync(absFrom, absTo);
+  }
+
+  return { root, writeDocument, readDocument, tryReadDocument, listMarkdown, moveFile, exists };
+}

--- a/packages/core/tests/store/corpus/vault.test.ts
+++ b/packages/core/tests/store/corpus/vault.test.ts
@@ -1,0 +1,108 @@
+// Vault file-I/O tests (spec 035 §F1 / Project Structure — Phase 1).
+//
+// The vault is a folder of markdown at `<data-dir>/vault` (or
+// LIBRARIAN_VAULT_PATH). This module is the read/write/list/move primitive
+// the git-ops + link-integrity service (next increment) commits on top of.
+// Pins: path resolution, document round-trip through the corpus
+// serializer, recursive listing (stable, posix-relative), move (the
+// archive=move primitive), and the path-escape guard (the vault is
+// `git push`ed — writes must not escape its root).
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { type CorpusDocument, createVault, resolveVaultPath } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-vault-"));
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+const doc = (id: string): CorpusDocument => ({
+  frontmatter: {
+    id,
+    aliases: [],
+    tags: ["t"],
+    category: "people",
+    created: "2026-06-01T00:00:00.000Z",
+    updated: "2026-06-01T00:00:00.000Z",
+  },
+  body: `# ${id}\n\nbody for ${id}.`,
+});
+
+describe("resolveVaultPath", () => {
+  it("prefers an explicit vaultPath", () => {
+    expect(resolveVaultPath({ vaultPath: "/tmp/custom-vault", dataDir })).toBe("/tmp/custom-vault");
+  });
+
+  it("falls back to <dataDir>/vault", () => {
+    expect(resolveVaultPath({ dataDir })).toBe(path.join(dataDir, "vault"));
+  });
+
+  it("honours LIBRARIAN_VAULT_PATH", () => {
+    const prev = process.env.LIBRARIAN_VAULT_PATH;
+    process.env.LIBRARIAN_VAULT_PATH = "/tmp/env-vault";
+    try {
+      expect(resolveVaultPath({ dataDir })).toBe("/tmp/env-vault");
+    } finally {
+      if (prev === undefined) delete process.env.LIBRARIAN_VAULT_PATH;
+      else process.env.LIBRARIAN_VAULT_PATH = prev;
+    }
+  });
+});
+
+describe("vault file I/O", () => {
+  it("round-trips a document through write → read", () => {
+    const vault = createVault({ dataDir });
+    vault.writeDocument("people/anna.md", doc("anna"));
+    expect(vault.readDocument("people/anna.md")).toEqual(doc("anna"));
+  });
+
+  it("creates nested parent folders on write", () => {
+    const vault = createVault({ dataDir });
+    vault.writeDocument("skills/deploy/notes.md", doc("notes"));
+    expect(fs.existsSync(path.join(vault.root, "skills/deploy/notes.md"))).toBe(true);
+  });
+
+  it("lists markdown recursively as sorted, posix-relative paths and ignores non-markdown", () => {
+    const vault = createVault({ dataDir });
+    vault.writeDocument("people/anna.md", doc("anna"));
+    vault.writeDocument("projects/x.md", doc("x"));
+    fs.writeFileSync(path.join(vault.root, "people", "notes.txt"), "ignored");
+    expect(vault.listMarkdown()).toEqual(["people/anna.md", "projects/x.md"]);
+  });
+
+  it("scopes listMarkdown to a subdirectory and returns [] for a missing one", () => {
+    const vault = createVault({ dataDir });
+    vault.writeDocument("people/anna.md", doc("anna"));
+    vault.writeDocument("projects/x.md", doc("x"));
+    expect(vault.listMarkdown("people")).toEqual(["people/anna.md"]);
+    expect(vault.listMarkdown("nope")).toEqual([]);
+  });
+
+  it("moves a file (the archive=move primitive)", () => {
+    const vault = createVault({ dataDir });
+    vault.writeDocument("people/anna.md", doc("anna"));
+    vault.moveFile("people/anna.md", "archive/anna.md");
+    expect(vault.exists("people/anna.md")).toBe(false);
+    expect(vault.readDocument("archive/anna.md").frontmatter.id).toBe("anna");
+  });
+
+  it("tryReadDocument returns null for a missing file; readDocument throws a teaching error", () => {
+    const vault = createVault({ dataDir });
+    expect(vault.tryReadDocument("ghost.md")).toBeNull();
+    expect(() => vault.readDocument("ghost.md")).toThrow(/ghost\.md/);
+  });
+
+  it("refuses a path that escapes the vault root", () => {
+    const vault = createVault({ dataDir });
+    expect(() => vault.writeDocument("../escape.md", doc("x"))).toThrow(/escape/i);
+    expect(() => vault.readDocument("../../etc/passwd")).toThrow(/escape/i);
+  });
+});


### PR DESCRIPTION
## What

Third increment of plan 036 **Phase 1** (spec 035 §F1 / Project Structure). Adds `packages/core/src/store/corpus/vault.ts` — the read/write/list/move primitive for the markdown vault.

- **`resolveVaultPath`** — explicit `vaultPath` › `LIBRARIAN_VAULT_PATH` › `<data-dir>/vault`.
- **`createVault()`** — `writeDocument` / `readDocument` / `tryReadDocument` (through the corpus frontmatter serializer), recursive **`listMarkdown`** (sorted, posix-relative), **`moveFile`** (the archive=move / reversible primitive), `exists`.
- Every path is resolved through a `within()` guard that **refuses anything escaping the vault root** — the vault is `git push`ed, so a stray `..` write must never land outside it.

The corpus layer stays dependency-free (component map: *corpus → no deps*), so the small data-dir resolution is inlined rather than imported from `librarian-store`.

## Scope

Internal scaffolding — **no user-visible change** (no CHANGELOG entry). This is the file-I/O layer the next increment — the `simple-git` git-ops + link-integrity service (commit-per-op; `renameWikilinkTarget` across the vault; auto `git init`) — commits on top of.

## Verification

- New `corpus/vault` unit suite (10 tests): path resolution (explicit / env / `<dataDir>/vault`), write→read round-trip, nested-dir creation, recursive sorted listing (ignoring non-markdown), subdir scoping + missing-dir `[]`, move, `tryRead` null vs `read` teaching error, and the path-escape guard.
- `pnpm -r typecheck` + `pnpm run lint` green; core suite 529 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)