### PR TITLE
feat(git): vault git-ops service — auto-init + commit-per-op (F12, Phase 1)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "gray-matter": "^4.0.3",
+    "simple-git": "^3.36.0",
     "zod": "^4.0.1"
   },
   "devDependencies": {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -173,6 +173,7 @@ export {
   resolveVaultPath,
   serializeDocument,
 } from "./store/corpus/index.js";
+export { type GitOps, createGitOps } from "./store/git/index.js";
 export type { Memory, MemoryStore, MemoryStoreDeps } from "./store/memory-store.js";
 export {
   type InternalLibrarianStore,

--- a/packages/core/src/store/git/git-ops.ts
+++ b/packages/core/src/store/git/git-ops.ts
@@ -1,0 +1,82 @@
+// Git-ops service for the markdown vault (spec 035 §F12). The vault is a
+// real git repo — history/audit for free (retiring the events ledger) and
+// `git push` backup in Phase 7. This service auto-inits the repo
+// (idempotent) and commits every file op; it is shared by the consolidator
+// (F5) and manual dashboard ops (F10).
+//
+// A fallback commit identity is configured (locally, only when none is
+// set) so headless / CI commits never fail with "Please tell me who you
+// are". Promise API throughout (simple-git over the git CLI).
+
+import fs from "node:fs";
+import { type SimpleGit, simpleGit } from "simple-git";
+
+export interface GitOps {
+  /** Idempotently `git init` the repo + ensure a commit identity exists. */
+  init(): Promise<void>;
+  /**
+   * Stage everything (incl. deletions) and commit. Returns the new HEAD
+   * hash, or `null` when there was nothing to commit (no empty commits).
+   */
+  commitAll(message: string): Promise<string | null>;
+  /** Current HEAD hash, or `null` on a repo with no commits yet. */
+  head(): Promise<string | null>;
+  /** Commit subjects, newest first (empty on a repo with no commits). */
+  log(): Promise<string[]>;
+  isRepo(): Promise<boolean>;
+}
+
+export function createGitOps(opts: { cwd: string }): GitOps {
+  fs.mkdirSync(opts.cwd, { recursive: true });
+  const git: SimpleGit = simpleGit({ baseDir: opts.cwd });
+
+  async function readConfig(key: string): Promise<string> {
+    try {
+      return (await git.raw(["config", key])).trim();
+    } catch {
+      return ""; // `git config <unset key>` exits non-zero
+    }
+  }
+
+  async function ensureIdentity(): Promise<void> {
+    if (await readConfig("user.email")) return;
+    await git.addConfig("user.email", "librarian@localhost", false, "local");
+    await git.addConfig("user.name", "The Librarian", false, "local");
+  }
+
+  async function init(): Promise<void> {
+    if (!(await git.checkIsRepo())) await git.init();
+    await ensureIdentity();
+  }
+
+  async function commitAll(message: string): Promise<string | null> {
+    await git.raw(["add", "-A"]);
+    if ((await git.status()).isClean()) return null;
+    await git.commit(message);
+    return head();
+  }
+
+  async function head(): Promise<string | null> {
+    try {
+      return (await git.revparse(["HEAD"])).trim();
+    } catch {
+      return null; // no commits yet
+    }
+  }
+
+  async function log(): Promise<string[]> {
+    try {
+      return (await git.log()).all.map((entry) => entry.message);
+    } catch {
+      return []; // no commits yet
+    }
+  }
+
+  return {
+    init,
+    commitAll,
+    head,
+    log,
+    isRepo: () => git.checkIsRepo(),
+  };
+}

--- a/packages/core/src/store/git/index.ts
+++ b/packages/core/src/store/git/index.ts
@@ -1,0 +1,4 @@
+// Git-ops module — the vault's git layer (commit-per-op; `git push` backup
+// in Phase 7). Spec 035 §F12.
+
+export { type GitOps, createGitOps } from "./git-ops.js";

--- a/packages/core/tests/store/git/git-ops.test.ts
+++ b/packages/core/tests/store/git/git-ops.test.ts
@@ -1,0 +1,89 @@
+// Git-ops service tests (spec 035 §F12 — Phase 1).
+//
+// The vault is a real git repo (history/audit for free; `git push` backup
+// in Phase 7). This service auto-inits the repo (idempotent, with a
+// fallback commit identity so headless/CI commits never fail) and commits
+// every file op. Pins: init idempotency, commit-per-op, no empty commits,
+// deletions staged, and log/head reads. Runs real `git` via simple-git.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createGitOps } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let cwd: string;
+
+beforeEach(() => {
+  cwd = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-gitops-"));
+});
+
+afterEach(() => {
+  fs.rmSync(cwd, { recursive: true, force: true });
+});
+
+const write = (rel: string, content: string): void => {
+  const abs = path.join(cwd, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content, "utf8");
+};
+
+describe("git-ops service", () => {
+  it("init creates a git repo and is idempotent", async () => {
+    const git = createGitOps({ cwd });
+    expect(await git.isRepo()).toBe(false);
+    await git.init();
+    expect(await git.isRepo()).toBe(true);
+    await git.init(); // second call must not throw
+    expect(await git.isRepo()).toBe(true);
+  });
+
+  it("head is null on a fresh repo with no commits", async () => {
+    const git = createGitOps({ cwd });
+    await git.init();
+    expect(await git.head()).toBeNull();
+    expect(await git.log()).toEqual([]);
+  });
+
+  it("commitAll commits new files and records the message", async () => {
+    const git = createGitOps({ cwd });
+    await git.init();
+    write("people/anna.md", "# Anna\n");
+    const hash = await git.commitAll("memory: inbox anna");
+    expect(hash).toMatch(/^[0-9a-f]{7,40}$/);
+    expect(await git.head()).toBe(hash);
+    expect(await git.log()).toEqual(["memory: inbox anna"]);
+  });
+
+  it("commitAll is a no-op (returns null) when nothing changed", async () => {
+    const git = createGitOps({ cwd });
+    await git.init();
+    write("a.md", "x\n");
+    await git.commitAll("first");
+    expect(await git.commitAll("second")).toBeNull();
+    expect(await git.log()).toEqual(["first"]);
+  });
+
+  it("records successive changes as separate commits, newest first", async () => {
+    const git = createGitOps({ cwd });
+    await git.init();
+    write("a.md", "one\n");
+    await git.commitAll("add a");
+    write("a.md", "two\n");
+    await git.commitAll("edit a");
+    expect(await git.log()).toEqual(["edit a", "add a"]);
+  });
+
+  it("stages deletions (the archive/move path)", async () => {
+    const git = createGitOps({ cwd });
+    await git.init();
+    write("gone.md", "bye\n");
+    await git.commitAll("add gone");
+    fs.rmSync(path.join(cwd, "gone.md"));
+    const hash = await git.commitAll("remove gone");
+    expect(hash).not.toBeNull();
+    // The deletion is committed: the file is absent from the working tree.
+    expect(fs.existsSync(path.join(cwd, "gone.md"))).toBe(false);
+    expect(await git.log()).toEqual(["remove gone", "add gone"]);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,6 +225,9 @@ importers:
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
+      simple-git:
+        specifier: ^3.36.0
+        version: 3.36.0
       zod:
         specifier: ^4.0.1
         version: 4.4.3
@@ -766,6 +769,12 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@kwsites/file-exists@1.1.1':
+    resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
+
+  '@kwsites/promise-deferred@1.1.1':
+    resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
+
   '@next/env@15.5.18':
     resolution: {integrity: sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==}
 
@@ -1201,6 +1210,12 @@ packages:
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@simple-git/args-pathspec@1.0.3':
+    resolution: {integrity: sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==}
+
+  '@simple-git/argv-parser@1.1.1':
+    resolution: {integrity: sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -2988,6 +3003,9 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  simple-git@3.36.0:
+    resolution: {integrity: sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==}
+
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
@@ -3782,6 +3800,14 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@kwsites/file-exists@1.1.1':
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@kwsites/promise-deferred@1.1.1': {}
+
   '@next/env@15.5.18': {}
 
   '@next/eslint-plugin-next@15.5.18':
@@ -4111,6 +4137,12 @@ snapshots:
     optional: true
 
   '@rtsao/scc@1.1.0': {}
+
+  '@simple-git/args-pathspec@1.0.3': {}
+
+  '@simple-git/argv-parser@1.1.1':
+    dependencies:
+      '@simple-git/args-pathspec': 1.0.3
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -6074,6 +6106,16 @@ snapshots:
       side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
+
+  simple-git@3.36.0:
+    dependencies:
+      '@kwsites/file-exists': 1.1.1
+      '@kwsites/promise-deferred': 1.1.1
+      '@simple-git/args-pathspec': 1.0.3
+      '@simple-git/argv-parser': 1.1.1
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   sonic-boom@4.2.1:
     dependencies:


### PR DESCRIPTION
## What

Fourth increment of plan 036 **Phase 1** (spec 035 §F12). Adds `packages/core/src/store/git/git-ops.ts` (`simple-git`) — the vault's git layer.

- **`init()`** — idempotent `git init` of the vault repo **+ a fallback local commit identity** (set only when none is configured) so headless / CI commits never fail with "Please tell me who you are". The vault becomes a real git repo automatically — **no manual setup required**.
- **`commitAll(message)`** — stage everything (incl. deletions), commit; returns the new HEAD hash, or `null` when nothing changed (no empty commits).
- **`head()` / `log()` / `isRepo()`** reads (`null` / `[]` on a repo with no commits yet).

This is the commit-per-write layer the consolidator (F5) and dashboard ops (F10) share. Adds the `simple-git` dependency (pre-approved — spec 035 tech stack).

## Scope

Internal scaffolding — **no user-visible change** (no CHANGELOG entry). The cross-vault **link-integrity rename** (compose `vault.moveFile` + `renameWikilinkTarget` across docs + a commit) and the `check:no-secrets-in-vault` guard follow in the next Phase-1 increments.

## Verification

- New `git/git-ops` unit suite (6 tests, real `git` via simple-git): init creates a repo + is idempotent; `head`/`log` null/empty on a fresh repo; commit-per-op with message; no-op (`null`) when nothing changed; successive commits newest-first; deletions staged (the archive/move path).
- `pnpm -r typecheck` + `pnpm run lint` green; core suite 535 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)