### PR TITLE
feat(corpus): vault-wide link integrity — relink on rename (F12, Phase 1)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -169,6 +169,7 @@ export {
   createVault,
   parseDocument,
   parseWikilinks,
+  relinkVault,
   renameWikilinkTarget,
   resolveVaultPath,
   serializeDocument,

--- a/packages/core/src/store/corpus/index.ts
+++ b/packages/core/src/store/corpus/index.ts
@@ -11,3 +11,4 @@ export {
 } from "./frontmatter.js";
 export { type Wikilink, parseWikilinks, renameWikilinkTarget } from "./wikilink.js";
 export { type Vault, type VaultOptions, createVault, resolveVaultPath } from "./vault.js";
+export { relinkVault } from "./link-integrity.js";

--- a/packages/core/src/store/corpus/link-integrity.ts
+++ b/packages/core/src/store/corpus/link-integrity.ts
@@ -1,0 +1,29 @@
+// Vault-wide link integrity (spec 035 §F12). When a document is renamed,
+// every wikilink that points at it — in any form, in any document — must be
+// rewritten so no link dangles. This is the link-integrity half of F12; the
+// move of the document's own file is the caller's `vault.moveFile`, and
+// persisting the result is the caller's `git.commitAll` (commit-per-op).
+//
+// Link targets are bare ids (the consolidator's convention — slugs unique
+// across the vault, matching Obsidian's shortest-unique-path default), so
+// relinking matches `[[id]]` rather than path-form links.
+
+import type { Vault } from "./vault.js";
+import { renameWikilinkTarget } from "./wikilink.js";
+
+/**
+ * Rewrite every wikilink whose target equals `from` to `to` across the
+ * whole vault (all forms), writing back only the documents that changed.
+ * Returns the changed file paths (posix-relative to the vault root, sorted).
+ */
+export function relinkVault(vault: Vault, from: string, to: string): string[] {
+  const changed: string[] = [];
+  for (const relPath of vault.listMarkdown()) {
+    const document = vault.readDocument(relPath);
+    const body = renameWikilinkTarget(document.body, from, to);
+    if (body === document.body) continue;
+    vault.writeDocument(relPath, { ...document, body });
+    changed.push(relPath);
+  }
+  return changed;
+}

--- a/packages/core/tests/store/corpus/link-integrity.test.ts
+++ b/packages/core/tests/store/corpus/link-integrity.test.ts
@@ -1,0 +1,72 @@
+// Vault-wide link-integrity tests (spec 035 §F12 — Phase 1 checkpoint:
+// "rename rewrites every wikilink form").
+//
+// relinkVault rewrites a renamed target across *every* document in the
+// vault (all wikilink forms), writes back only the docs that changed, and
+// returns those paths — leaving non-referencing docs untouched. The file
+// move (vault.moveFile) and the commit (git.commitAll) are the caller's
+// separate steps.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { type CorpusDocument, createVault, relinkVault } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-relink-"));
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+const doc = (id: string, body: string): CorpusDocument => ({
+  frontmatter: {
+    id,
+    aliases: [],
+    tags: [],
+    category: "people",
+    created: "2026-06-01T00:00:00.000Z",
+    updated: "2026-06-01T00:00:00.000Z",
+  },
+  body,
+});
+
+describe("relinkVault", () => {
+  it("rewrites every wikilink form pointing at the renamed target, across docs", () => {
+    const vault = createVault({ dataDir });
+    vault.writeDocument("people/anna.md", doc("anna", "I am [[anna]] (self)."));
+    vault.writeDocument(
+      "people/sophie.md",
+      doc("sophie", "[[anna|Mum]] and [[anna#Bio]] and ![[anna]]."),
+    );
+    vault.writeDocument("people/bob.md", doc("bob", "knows [[carol]] only."));
+
+    const changed = relinkVault(vault, "anna", "anna-sangwine");
+
+    expect(changed).toEqual(["people/anna.md", "people/sophie.md"]);
+    expect(vault.readDocument("people/anna.md").body).toBe("I am [[anna-sangwine]] (self).");
+    expect(vault.readDocument("people/sophie.md").body).toBe(
+      "[[anna-sangwine|Mum]] and [[anna-sangwine#Bio]] and ![[anna-sangwine]].",
+    );
+    // The doc that didn't reference `anna` is untouched.
+    expect(vault.readDocument("people/bob.md").body).toBe("knows [[carol]] only.");
+  });
+
+  it("is a no-op (returns []) when no document references the target", () => {
+    const vault = createVault({ dataDir });
+    vault.writeDocument("a.md", doc("a", "[[b]] and [[c]]"));
+    expect(relinkVault(vault, "anna", "anna-2")).toEqual([]);
+    expect(vault.readDocument("a.md").body).toBe("[[b]] and [[c]]");
+  });
+
+  it("relinks documents anywhere in the vault tree, including archive/", () => {
+    const vault = createVault({ dataDir });
+    vault.writeDocument("archive/old.md", doc("old", "still mentions [[anna]]."));
+    expect(relinkVault(vault, "anna", "anna-sangwine")).toEqual(["archive/old.md"]);
+    expect(vault.readDocument("archive/old.md").body).toBe("still mentions [[anna-sangwine]].");
+  });
+});


### PR DESCRIPTION
## What

Fifth increment of plan 036 **Phase 1** (spec 035 §F12; checkpoint *"rename rewrites every wikilink form"*). Adds `packages/core/src/store/corpus/link-integrity.ts`.

- **`relinkVault(vault, from, to)`** rewrites every wikilink whose target equals the old id to the new id **across the whole vault** — all forms (`[[x]]` / `[[x|alias]]` / `[[x#heading]]` / `![[embed]]`, plus a doc's self-references) — writing back only the documents that changed and returning their (sorted, posix-relative) paths.

This is the link-integrity half of F12. The move of the document's own file is `vault.moveFile` (the archive=move / reversible primitive, already shipped in #219) and persisting is `git.commitAll` (commit-per-op, #220); a Phase-2 store composes the three into a full rename. Link targets are bare ids (the consolidator's slug convention — unique across the vault, matching Obsidian's shortest-unique-path default).

## Scope

Internal scaffolding — **no user-visible change** (no CHANGELOG entry). Remaining Phase-1 item: the `check:no-secrets-in-vault` guard.

## Verification

- New `corpus/link-integrity` unit suite (3 tests): rewrites every form across multiple docs (incl. self-reference) while leaving non-referencing docs byte-identical and returning the changed paths; no-op `[]` when the target is absent; relinks anywhere in the tree incl. `archive/`.
- `pnpm -r typecheck` + `pnpm run lint` green; core suite 538 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)