### PR TITLE
feat(markdown): Memory ↔ document mapping (F1, Phase 2 — parity-first)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -175,6 +175,7 @@ export {
   serializeDocument,
 } from "./store/corpus/index.js";
 export { type GitOps, createGitOps } from "./store/git/index.js";
+export { parseMemoryDocument, serializeMemoryDocument } from "./store/markdown/index.js";
 export type { Memory, MemoryStore, MemoryStoreDeps } from "./store/memory-store.js";
 export {
   type InternalLibrarianStore,

--- a/packages/core/src/store/markdown/index.ts
+++ b/packages/core/src/store/markdown/index.ts
@@ -1,0 +1,5 @@
+// Markdown-backed store implementation (plan 036 Phase 2). Built behind
+// the existing `LibrarianStore` interfaces, parity-first; replaces the
+// SQLite `memory-store.ts` at the Phase-7 cutover.
+
+export { parseMemoryDocument, serializeMemoryDocument } from "./memory-doc.js";

--- a/packages/core/src/store/markdown/memory-doc.ts
+++ b/packages/core/src/store/markdown/memory-doc.ts
@@ -1,0 +1,87 @@
+// Memory <-> markdown-document mapping (plan 036 Phase 2 / spec 035 §F1).
+//
+// The markdown backend stores each memory as a markdown file — a YAML
+// frontmatter block + the memory body. This is the parity-first mapping:
+// it is lossless for the full current `Memory` shape so the markdown
+// backend can pass the existing (storage-agnostic) verb tests while it's
+// built behind `LibrarianStore`. The D16 frontmatter minimisation (drop
+// agent/priority/confidence/usefulness/…) happens later, at cutover; until
+// then the raw memory docs carry the whole shape.
+//
+// Frontmatter is built in a fixed key order so serialization is
+// deterministic (minimal git diffs). `parseMemoryDocument` coerces any
+// YAML `Date` back to an ISO string, so the timestamp fields survive hand
+// edits and js-yaml's implicit timestamp typing.
+
+import matter from "gray-matter";
+import { z } from "zod";
+import { IsoTimestampSchema } from "../../schemas/common.js";
+import type { Memory } from "../memory-store.js";
+
+const MemoryFrontmatterSchema = z.object({
+  id: z.string().min(1),
+  title: z.string(),
+  agent_id: z.string(),
+  status: z.string(),
+  project_key: z.string().nullable(),
+  priority: z.string(),
+  confidence: z.string(),
+  tags: z.array(z.string()),
+  applies_to: z.array(z.string()),
+  supersedes: z.array(z.string()),
+  conflicts_with: z.array(z.string()),
+  recall_count: z.number(),
+  usefulness_score: z.number(),
+  is_global: z.boolean(),
+  requires_approval: z.boolean(),
+  created_at: IsoTimestampSchema,
+  updated_at: IsoTimestampSchema,
+  curator_note: z.record(z.string(), z.unknown()).nullable(),
+});
+
+/** Serialize a memory to its markdown document form (frontmatter + body). */
+export function serializeMemoryDocument(memory: Memory): string {
+  // Fixed key order → deterministic output → minimal git diffs.
+  const frontmatter = {
+    id: memory.id,
+    title: memory.title,
+    agent_id: memory.agent_id,
+    status: memory.status,
+    project_key: memory.project_key ?? null,
+    priority: memory.priority,
+    confidence: memory.confidence,
+    tags: memory.tags ?? [],
+    applies_to: memory.applies_to ?? [],
+    supersedes: memory.supersedes ?? [],
+    conflicts_with: memory.conflicts_with ?? [],
+    recall_count: memory.recall_count ?? 0,
+    usefulness_score: memory.usefulness_score ?? 0,
+    is_global: memory.is_global ?? false,
+    requires_approval: memory.requires_approval ?? false,
+    created_at: (memory.created_at as string | undefined) ?? memory.updated_at,
+    updated_at: memory.updated_at,
+    curator_note: memory.curator_note ?? null,
+  };
+  return matter.stringify(memory.body.trim(), frontmatter);
+}
+
+/** Parse a markdown document back into a `Memory`; teaching error on a bad shape. */
+export function parseMemoryDocument(raw: string): Memory {
+  const { data, content } = matter(raw);
+  const result = MemoryFrontmatterSchema.safeParse(coerceDates(data));
+  if (!result.success) {
+    const detail = result.error.issues
+      .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+      .join("; ");
+    throw new Error(`Invalid memory document frontmatter: ${detail}`);
+  }
+  return { ...result.data, body: content.trim() };
+}
+
+function coerceDates(data: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(data)) {
+    out[key] = value instanceof Date ? value.toISOString() : value;
+  }
+  return out;
+}

--- a/packages/core/tests/store/markdown/memory-doc.test.ts
+++ b/packages/core/tests/store/markdown/memory-doc.test.ts
@@ -1,0 +1,80 @@
+// Memory <-> markdown-document mapping tests (plan 036 Phase 2, spec 035
+// §F1). The markdown backend stores each memory as a markdown file: a
+// frontmatter block + the memory body. Phase 2 is parity-first — the
+// mapping is lossless for the full current Memory shape (the D16
+// frontmatter minimisation happens later, at cutover) — so these pin a
+// value-stable and byte-stable round-trip across all field types
+// (strings, string arrays, numbers, booleans, null, nested object).
+
+import type { Memory } from "@librarian/core";
+import { parseMemoryDocument, serializeMemoryDocument } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+const memory: Memory = {
+  id: "mem_abc",
+  agent_id: "codex",
+  status: "active",
+  tags: ["pnpm", "tooling"],
+  applies_to: ["the-librarian"],
+  supersedes: [],
+  conflicts_with: [],
+  recall_count: 3,
+  usefulness_score: 2,
+  title: "Use pnpm",
+  body: "Always use pnpm, never npm. See [[tooling]].",
+  priority: "high",
+  confidence: "working",
+  project_key: "the-librarian",
+  created_at: "2026-06-01T09:00:00.000Z",
+  updated_at: "2026-06-01T10:00:00.000Z",
+  curator_note: null,
+  is_global: false,
+  requires_approval: false,
+};
+
+describe("memory <-> document mapping", () => {
+  it("round-trips by value: parse(serialize(memory)) deep-equals memory", () => {
+    expect(parseMemoryDocument(serializeMemoryDocument(memory))).toEqual(memory);
+  });
+
+  it("round-trips byte-for-byte: serialize(parse(x)) === x", () => {
+    const x = serializeMemoryDocument(memory);
+    expect(serializeMemoryDocument(parseMemoryDocument(x))).toBe(x);
+  });
+
+  it("preserves the body verbatim (wikilinks untouched)", () => {
+    const parsed = parseMemoryDocument(serializeMemoryDocument(memory));
+    expect(parsed.body).toBe("Always use pnpm, never npm. See [[tooling]].");
+  });
+
+  it("preserves field types: numbers, booleans, null, and arrays", () => {
+    const p = parseMemoryDocument(serializeMemoryDocument(memory));
+    expect(typeof p.recall_count).toBe("number");
+    expect(typeof p.usefulness_score).toBe("number");
+    expect(typeof p.is_global).toBe("boolean");
+    expect(typeof p.created_at).toBe("string");
+    expect(p.project_key).toBe("the-librarian");
+    expect(p.conflicts_with).toEqual([]);
+  });
+
+  it("preserves a null project_key and a nested curator_note object", () => {
+    const m: Memory = {
+      ...memory,
+      project_key: null,
+      curator_note: { source: "curator", run_id: "run_1", confidence: 0.9 },
+    };
+    const p = parseMemoryDocument(serializeMemoryDocument(m));
+    expect(p.project_key).toBeNull();
+    expect(p.curator_note).toEqual({ source: "curator", run_id: "run_1", confidence: 0.9 });
+  });
+
+  it("round-trips an empty body", () => {
+    const p = parseMemoryDocument(serializeMemoryDocument({ ...memory, body: "" }));
+    expect(p.body).toBe("");
+  });
+
+  it("rejects a document whose frontmatter is missing a required field, naming it", () => {
+    const raw = serializeMemoryDocument(memory).replace(/^id:.*\n/m, "");
+    expect(() => parseMemoryDocument(raw)).toThrow(/id/);
+  });
+});


### PR DESCRIPTION
## What

First increment of plan 036 **Phase 2** (markdown-backed stores). Adds `packages/core/src/store/markdown/memory-doc.ts` — the lossless mapping between a `Memory` and its markdown file.

- **`serializeMemoryDocument(memory)`** / **`parseMemoryDocument(raw)`** — a memory ↔ (frontmatter + body) markdown document.
- **Parity-first:** lossless for the *full current* `Memory` shape, per the plan's strategy — *"build the new backend behind the existing interfaces, reach parity on the current verb test-suite, then cut over and migrate."* The D16 frontmatter minimisation (dropping agent/priority/confidence/usefulness/…) happens later, at cutover; until then raw memory docs carry the whole shape.
- Frontmatter is built in a **fixed key order** (deterministic → minimal git diffs); `parseMemoryDocument` coerces any YAML `Date` back to an ISO string, so timestamps survive js-yaml's implicit timestamp typing and hand edits.

This is the foundation of the markdown `MemoryStore`. The new `store/markdown/` module is the parallel implementation built behind `LibrarianStore`; it replaces the SQLite `memory-store.ts` at the Phase-7 cutover.

## Scope

Not wired into `createLibrarianStore` — the SQLite store remains the live backend, so **no user-visible change** (no CHANGELOG entry). Subsequent increments add the vault-backed `createMemory`/`getMemory`/`search` toward the Phase-2 parity gate.

## Verification

- New `markdown/memory-doc` unit suite (7 tests): value-stable `parse(serialize(m))`, byte-stable `serialize(parse(x)) === x`, body verbatim (wikilinks untouched), field-type preservation (number/boolean/null/array), null `project_key` + nested `curator_note` object, empty body, teaching error on a missing required field.
- `pnpm -r typecheck` + `pnpm run lint` green; core suite 545 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)