### PR TITLE
refactor(core): extract memory write-routing into a shared module (Phase 2)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -176,6 +176,7 @@ export {
 } from "./store/corpus/index.js";
 export { type GitOps, createGitOps } from "./store/git/index.js";
 export { parseMemoryDocument, serializeMemoryDocument } from "./store/markdown/index.js";
+export { type MemoryWriteVerdict, routeMemoryWrite } from "./store/memory-routing.js";
 export type { Memory, MemoryStore, MemoryStoreDeps } from "./store/memory-store.js";
 export {
   type InternalLibrarianStore,

--- a/packages/core/src/store/memory-routing.ts
+++ b/packages/core/src/store/memory-routing.ts
@@ -1,0 +1,60 @@
+// Memory write-routing — the storage-agnostic decision of whether a write
+// lands `active` or `proposed`, plus the classifier-verdict booleans.
+// Extracted from memory-store.ts (plan 036 Phase 2) so the SQLite and
+// markdown backends share one implementation and can't drift.
+//
+// Section 4d.3 — the protected-routing decision reads explicit signals
+// only: `pendingClassification` (classifier-cutover path), `outsideSession`
+// (no conv_state context), and an explicit `options.requires_approval` from
+// trusted internal callers (e.g. the curator apply layer). Agent-supplied
+// `input.requires_approval` is ignored upstream (spec §4.1/§4.4).
+
+import { MemoryStatus } from "../schemas/common.js";
+
+export interface MemoryWriteVerdict {
+  status: MemoryStatus;
+  isGlobal: boolean;
+  requiresApproval: boolean;
+  curatorNote: Record<string, unknown> | null;
+}
+
+/**
+ * Decide a memory write's landing status + verdict booleans from its
+ * `options`. `normalizedStatus` is the status from `normalizeMemoryInput`
+ * (the default landing when no protection signal applies).
+ */
+export function routeMemoryWrite(
+  normalizedStatus: string,
+  options: Record<string, unknown> = {},
+): MemoryWriteVerdict {
+  const outsideSession = options.outsideSession === true;
+  const pendingClassification = options.pendingClassification === true;
+  const explicitRequiresApproval =
+    typeof options.requires_approval === "boolean" ? options.requires_approval : null;
+  const explicitIsGlobal = typeof options.is_global === "boolean" ? options.is_global : null;
+
+  const requiresApproval = pendingClassification
+    ? true
+    : outsideSession
+      ? true
+      : (explicitRequiresApproval ?? false);
+  const isGlobal = pendingClassification ? false : (explicitIsGlobal ?? false);
+
+  // forceActive overrides the landing status only — a write can require
+  // approval yet still be activated by a trusted caller.
+  const protectedWrite = (requiresApproval || outsideSession) && options.forceActive !== true;
+  const status =
+    (options.status as MemoryStatus | undefined) ||
+    (pendingClassification || protectedWrite
+      ? MemoryStatus.Proposed
+      : (normalizedStatus as MemoryStatus));
+
+  // curator_note is curator-only provenance — accepted ONLY via the trusted
+  // options channel, never from free-form input.
+  const curatorNote =
+    options.curator_note && typeof options.curator_note === "object"
+      ? (options.curator_note as Record<string, unknown>)
+      : null;
+
+  return { status, isGlobal, requiresApproval, curatorNote };
+}

--- a/packages/core/src/store/memory-store.ts
+++ b/packages/core/src/store/memory-store.ts
@@ -20,6 +20,7 @@ import {
 } from "../constants.js";
 import { MemoryEventType, MemoryStatus } from "../schemas/common.js";
 import { appendJsonl, readJsonl } from "./jsonl.js";
+import { routeMemoryWrite } from "./memory-routing.js";
 
 // ---------- Public types ----------
 
@@ -524,60 +525,15 @@ export function createMemoryStore(deps: MemoryStoreDeps): MemoryStore {
     // informational — the agent can decide whether to consolidate via
     // update + verify(outdated). No more refused writes.
     const normalized = normalizeMemoryInput(input);
-    // memory-domain-isolation §4.14 — writes that arrive without a
-    // conv_state context route through the proposal queue with
-    // `domain = NULL` and `requires_approval = true`. The MCP layer
-    // sets `outsideSession: true` for the curator / direct CLI / API
-    // entry points and for in-conversation calls that find no
-    // matching conv_state row.
-    const outsideSession = options.outsideSession === true;
-    // Classifier-cutover (plan Section 4d) — when the caller marks the
-    // write as awaiting classification, override the legacy-bridge
-    // booleans with conservative defaults so the worker decides them.
-    // The async worker reads `classified = 0` rows from the projection,
-    // emits a `memory.classified` event, and updates is_global +
-    // requires_approval (and promotes proposed→active when its verdict
-    // says no review is needed). `category` / `visibility` / `scope`
-    // are still populated from the normalized input for read-back; the
-    // §7.3 parent-spec column drop lands in 4d.2.
+    // The active/proposed landing + verdict booleans + curator-note gating
+    // are storage-agnostic, shared with the markdown backend via
+    // `routeMemoryWrite` (plan 036 Phase 2). `pendingClassification` also
+    // drives the SQLite-only `classified` snapshot flag below.
     const pendingClassification = options.pendingClassification === true;
-    // Section 4d.3 — the legacy category-based protection gate is
-    // retired. The protected-routing decision now reads three
-    // explicit signals only: pendingClassification (classifier-cutover
-    // path), outsideSession (no conv_state context), and an explicit
-    // `options.requires_approval` from trusted internal callers like
-    // the curator's apply layer. Agent-supplied values via
-    // `input.requires_approval` are still ignored (per §4.1/§4.4 of
-    // the parent spec).
-    const explicitRequiresApproval =
-      typeof options.requires_approval === "boolean"
-        ? (options.requires_approval as boolean)
-        : null;
-    const explicitIsGlobal =
-      typeof options.is_global === "boolean" ? (options.is_global as boolean) : null;
-    const requiresApproval = pendingClassification
-      ? true
-      : outsideSession
-        ? true
-        : (explicitRequiresApproval ?? false);
-    const isGlobal = pendingClassification ? false : (explicitIsGlobal ?? false);
-
-    const protectedWrite = (requiresApproval || outsideSession) && !options.forceActive;
-    const status =
-      (options.status as MemoryStatus | undefined) ||
-      (pendingClassification
-        ? MemoryStatus.Proposed
-        : protectedWrite
-          ? MemoryStatus.Proposed
-          : normalized.status);
-    // curator_note is curator-only provenance (memory-curator spec §8). It is
-    // accepted ONLY via the trusted `options` channel used by the internal
-    // apply layer / proposal path — never from the free-form `input`, so an
-    // MCP agent can't smuggle a forged `supersedes` through normalizeMemoryInput.
-    const curatorNote =
-      options.curator_note && typeof options.curator_note === "object"
-        ? (options.curator_note as Record<string, unknown>)
-        : null;
+    const { status, isGlobal, requiresApproval, curatorNote } = routeMemoryWrite(
+      normalized.status,
+      options,
+    );
     const memory: Memory = {
       id: makeId("mem"),
       ...normalized,

--- a/packages/core/tests/store/memory-routing.test.ts
+++ b/packages/core/tests/store/memory-routing.test.ts
@@ -1,0 +1,76 @@
+// Memory write-routing truth table (extracted from memory-store.ts so the
+// SQLite and markdown backends share one implementation — plan 036 Phase 2).
+//
+// The routing decides, from a write's options, whether a memory lands
+// `active` or `proposed` and the classifier-verdict booleans. Pinning the
+// matrix here keeps both stores honest. Section 4d.3 — the protected-routing
+// decision reads explicit signals only (pendingClassification / outsideSession
+// / options.requires_approval); agent-supplied input values are ignored
+// upstream.
+
+import { routeMemoryWrite } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+describe("routeMemoryWrite", () => {
+  it("defaults to the normalized status with no protection signals", () => {
+    expect(routeMemoryWrite("active", {})).toEqual({
+      status: "active",
+      isGlobal: false,
+      requiresApproval: false,
+      curatorNote: null,
+    });
+  });
+
+  it("pendingClassification → proposed + requiresApproval, isGlobal forced false", () => {
+    expect(routeMemoryWrite("active", { pendingClassification: true, is_global: true })).toEqual({
+      status: "proposed",
+      isGlobal: false,
+      requiresApproval: true,
+      curatorNote: null,
+    });
+  });
+
+  it("outsideSession → proposed + requiresApproval; explicit is_global honoured", () => {
+    expect(routeMemoryWrite("active", { outsideSession: true, is_global: true })).toEqual({
+      status: "proposed",
+      isGlobal: true,
+      requiresApproval: true,
+      curatorNote: null,
+    });
+  });
+
+  it("explicit requires_approval → proposed", () => {
+    expect(routeMemoryWrite("active", { requires_approval: true })).toEqual({
+      status: "proposed",
+      isGlobal: false,
+      requiresApproval: true,
+      curatorNote: null,
+    });
+  });
+
+  it("forceActive keeps status active even though requiresApproval stays true", () => {
+    expect(routeMemoryWrite("active", { requires_approval: true, forceActive: true })).toEqual({
+      status: "active",
+      isGlobal: false,
+      requiresApproval: true,
+      curatorNote: null,
+    });
+  });
+
+  it("an explicit options.status overrides the routing", () => {
+    expect(
+      routeMemoryWrite("active", { pendingClassification: true, status: "active" }),
+    ).toMatchObject({
+      status: "active",
+    });
+  });
+
+  it("accepts a curator_note object via the trusted options channel only", () => {
+    expect(routeMemoryWrite("active", { curator_note: { source: "curator" } }).curatorNote).toEqual(
+      {
+        source: "curator",
+      },
+    );
+    expect(routeMemoryWrite("active", { curator_note: "nope" }).curatorNote).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Behaviour-preserving extraction (plan 036 Phase 2). The active/proposed landing decision + classifier-verdict booleans (`is_global`/`requires_approval`) + curator-note gating that were inline in `createMemory` are storage-agnostic, so they move into a shared `packages/core/src/store/memory-routing.ts` (`routeMemoryWrite`). The SQLite store and the incoming markdown backend now share **one** routing implementation and can't drift.

- `memory-store.ts` `createMemory`: ~62 lines of inline routing → a single `routeMemoryWrite(normalized.status, options)` call (the SQLite-only `classified` snapshot flag stays local).
- New routing truth-table unit test pins the matrix.

## Why this PR (process)

This is the first step of the next Phase-2 increment (the markdown-backed `createMemory`): sharing the routing rather than duplicating it guarantees parity between the two backends.

## Verification

- New `memory-routing` truth-table suite (7 tests): no-signal default, pendingClassification, outsideSession, explicit requires_approval, forceActive (status active, requiresApproval still true), `options.status` override, curator_note trusted-channel gating.
- Existing `memory-store` (19) + `verify-scoring` (9) suites still green ⇒ **behaviour unchanged**.
- A review sub-agent verified the extraction case-by-case against the original inline logic and confirmed it is behaviour-identical (the `forceActive` strict-vs-truthy nuance is unreachable — every caller passes `true`).
- `pnpm -r typecheck` + `pnpm run lint` green; core suite 552.

🤖 Generated with [Claude Code](https://claude.com/claude-code)