### PR TITLE
feat(markdown): vault-backed createMemory + getMemory (Phase 2)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -175,7 +175,12 @@ export {
   serializeDocument,
 } from "./store/corpus/index.js";
 export { type GitOps, createGitOps } from "./store/git/index.js";
-export { parseMemoryDocument, serializeMemoryDocument } from "./store/markdown/index.js";
+export {
+  type MarkdownMemoryStoreDeps,
+  createMarkdownMemoryStore,
+  parseMemoryDocument,
+  serializeMemoryDocument,
+} from "./store/markdown/index.js";
 export { type MemoryWriteVerdict, routeMemoryWrite } from "./store/memory-routing.js";
 export type { Memory, MemoryStore, MemoryStoreDeps } from "./store/memory-store.js";
 export {

--- a/packages/core/src/store/corpus/vault.ts
+++ b/packages/core/src/store/corpus/vault.ts
@@ -36,8 +36,13 @@ export function resolveVaultPath(options: VaultOptions = {}): string {
 export interface Vault {
   /** Absolute path of the vault root. */
   readonly root: string;
+  /** Write raw markdown text (creating parent folders). */
+  writeText(relPath: string, content: string): void;
+  /** Read raw markdown text; throws a teaching error when absent. */
+  readText(relPath: string): string;
+  tryReadText(relPath: string): string | null;
   writeDocument(relPath: string, doc: CorpusDocument): void;
-  /** Read + parse a document; throws a teaching error when absent. */
+  /** Read + parse a corpus-minimal document; throws a teaching error when absent. */
   readDocument(relPath: string): CorpusDocument;
   tryReadDocument(relPath: string): CorpusDocument | null;
   /** Recursive list of `.md` files (posix-relative to the root, sorted). */
@@ -66,16 +71,28 @@ export function createVault(options: VaultOptions = {}): Vault {
     return fs.existsSync(within(relPath));
   }
 
-  function writeDocument(relPath: string, doc: CorpusDocument): void {
+  function writeText(relPath: string, content: string): void {
     const abs = within(relPath);
     fs.mkdirSync(path.dirname(abs), { recursive: true });
-    fs.writeFileSync(abs, serializeDocument(doc), "utf8");
+    fs.writeFileSync(abs, content, "utf8");
+  }
+
+  function readText(relPath: string): string {
+    const abs = within(relPath);
+    if (!fs.existsSync(abs)) throw new Error(`vault: no document at '${relPath}'`);
+    return fs.readFileSync(abs, "utf8");
+  }
+
+  function tryReadText(relPath: string): string | null {
+    return exists(relPath) ? readText(relPath) : null;
+  }
+
+  function writeDocument(relPath: string, doc: CorpusDocument): void {
+    writeText(relPath, serializeDocument(doc));
   }
 
   function readDocument(relPath: string): CorpusDocument {
-    const abs = within(relPath);
-    if (!fs.existsSync(abs)) throw new Error(`vault: no document at '${relPath}'`);
-    return parseDocument(fs.readFileSync(abs, "utf8"));
+    return parseDocument(readText(relPath));
   }
 
   function tryReadDocument(relPath: string): CorpusDocument | null {
@@ -107,5 +124,16 @@ export function createVault(options: VaultOptions = {}): Vault {
     fs.renameSync(absFrom, absTo);
   }
 
-  return { root, writeDocument, readDocument, tryReadDocument, listMarkdown, moveFile, exists };
+  return {
+    root,
+    writeText,
+    readText,
+    tryReadText,
+    writeDocument,
+    readDocument,
+    tryReadDocument,
+    listMarkdown,
+    moveFile,
+    exists,
+  };
 }

--- a/packages/core/src/store/markdown/index.ts
+++ b/packages/core/src/store/markdown/index.ts
@@ -3,3 +3,7 @@
 // SQLite `memory-store.ts` at the Phase-7 cutover.
 
 export { parseMemoryDocument, serializeMemoryDocument } from "./memory-doc.js";
+export {
+  type MarkdownMemoryStoreDeps,
+  createMarkdownMemoryStore,
+} from "./markdown-memory-store.js";

--- a/packages/core/src/store/markdown/markdown-memory-store.ts
+++ b/packages/core/src/store/markdown/markdown-memory-store.ts
@@ -1,0 +1,83 @@
+// Markdown-backed MemoryStore (plan 036 Phase 2) — built behind the
+// existing interfaces, parity-first. This increment lands the write/read
+// core (createMemory + getMemory); subsequent increments add list/search/
+// update/archive/verify/approve toward the parity gate, after which it's
+// wired behind `createLibrarianStore` (SQLite stays the default until the
+// Phase-7 cutover).
+//
+// The store is SYNC (the storage-agnostic verb tests are sync): vault I/O
+// is sync, and the git commit-per-op is an injected sync committer
+// (`commit`) — most unit tests inject none (fast); production wires a
+// synchronous git commit. Each memory is `memories/<id>.md`; status lives
+// in frontmatter (folder-based inbox/consolidation filing is Phase 4).
+
+import { makeId, normalizeMemoryInput, nowIso } from "../../constants.js";
+import { MemoryStatus } from "../../schemas/common.js";
+import type { Vault } from "../corpus/vault.js";
+import { routeMemoryWrite } from "../memory-routing.js";
+import type { Memory } from "../memory-store.js";
+import { parseMemoryDocument, serializeMemoryDocument } from "./memory-doc.js";
+
+export interface MarkdownMemoryStoreDeps {
+  vault: Vault;
+  /** Sync commit-per-op (e.g. a synchronous git commit). Omit to skip committing. */
+  commit?: (message: string) => void;
+  /** Clock injection (defaults to `nowIso`). */
+  now?: () => string;
+  /** Id generator injection (defaults to `makeId("mem")`). */
+  generateId?: () => string;
+}
+
+function memoryPath(id: string): string {
+  return `memories/${id}.md`;
+}
+
+export function createMarkdownMemoryStore(deps: MarkdownMemoryStoreDeps) {
+  const { vault } = deps;
+  const now = deps.now ?? nowIso;
+  const generateId = deps.generateId ?? (() => makeId("mem"));
+  const commit = deps.commit ?? (() => {});
+
+  function createMemory(input: Record<string, unknown>, options: Record<string, unknown> = {}) {
+    const normalized = normalizeMemoryInput(input);
+    const { status, isGlobal, requiresApproval, curatorNote } = routeMemoryWrite(
+      normalized.status,
+      options,
+    );
+    const ts = now();
+    // Only the fields the markdown model persists (D16 retired
+    // category/visibility/scope) — keeps createMemory's returned memory
+    // identical to a getMemory read-back.
+    const memory: Memory = {
+      id: generateId(),
+      title: normalized.title,
+      body: normalized.body,
+      agent_id: normalized.agent_id,
+      project_key: normalized.project_key || null,
+      priority: normalized.priority,
+      confidence: normalized.confidence,
+      tags: normalized.tags,
+      applies_to: normalized.applies_to,
+      supersedes: [],
+      conflicts_with: [],
+      recall_count: 0,
+      usefulness_score: 0,
+      status,
+      is_global: isGlobal,
+      requires_approval: requiresApproval,
+      created_at: ts,
+      updated_at: ts,
+      curator_note: curatorNote,
+    };
+    vault.writeText(memoryPath(memory.id), serializeMemoryDocument(memory));
+    commit(`memory: ${status === MemoryStatus.Proposed ? "propose" : "store"} ${memory.id}`);
+    return { status, memory, duplicates: [] as Memory[] };
+  }
+
+  function getMemory(id: string): Memory | null {
+    const raw = vault.tryReadText(memoryPath(id));
+    return raw ? parseMemoryDocument(raw) : null;
+  }
+
+  return { createMemory, getMemory };
+}

--- a/packages/core/tests/store/corpus/vault.test.ts
+++ b/packages/core/tests/store/corpus/vault.test.ts
@@ -106,3 +106,24 @@ describe("vault file I/O", () => {
     expect(() => vault.readDocument("../../etc/passwd")).toThrow(/escape/i);
   });
 });
+
+describe("vault raw text I/O", () => {
+  it("round-trips raw markdown verbatim through writeText → readText", () => {
+    const vault = createVault({ dataDir });
+    const content = "---\nid: x\n---\n\nbody with [[wikilink]].\n";
+    vault.writeText("notes/x.md", content);
+    expect(vault.readText("notes/x.md")).toBe(content);
+  });
+
+  it("tryReadText returns null for a missing file; readText throws a teaching error", () => {
+    const vault = createVault({ dataDir });
+    expect(vault.tryReadText("ghost.md")).toBeNull();
+    expect(() => vault.readText("ghost.md")).toThrow(/no document at 'ghost\.md'/);
+  });
+
+  it("applies the path-escape guard to the raw methods", () => {
+    const vault = createVault({ dataDir });
+    expect(() => vault.writeText("../escape.md", "x")).toThrow(/escape/i);
+    expect(() => vault.readText("../../etc/passwd")).toThrow(/escape/i);
+  });
+});

--- a/packages/core/tests/store/markdown/markdown-memory-store.test.ts
+++ b/packages/core/tests/store/markdown/markdown-memory-store.test.ts
@@ -1,0 +1,116 @@
+// Markdown-backed MemoryStore — createMemory + getMemory (plan 036 Phase 2).
+//
+// The inbox/write path: createMemory writes a markdown file (memories/<id>.md)
+// via the shared normalize + routeMemoryWrite logic and the memory-doc
+// mapping, optionally committing; getMemory reads it back by id. Parity-first
+// (full Memory shape), sync, with an injected sync committer. These pin the
+// write→read round-trip and the status routing on the new backend.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createMarkdownMemoryStore, createVault } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-md-store-"));
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+function makeStore() {
+  const vault = createVault({ dataDir });
+  const commits: string[] = [];
+  let counter = 0;
+  const store = createMarkdownMemoryStore({
+    vault,
+    commit: (message) => commits.push(message),
+    now: () => "2026-06-01T00:00:00.000Z",
+    generateId: () => `mem_test${++counter}`,
+  });
+  return { store, vault, commits };
+}
+
+describe("markdown MemoryStore — createMemory + getMemory", () => {
+  it("createMemory writes a markdown file and returns an active memory", () => {
+    const { store, vault } = makeStore();
+    const result = store.createMemory({
+      agent_id: "codex",
+      title: "Use pnpm",
+      body: "Always use pnpm.",
+      tags: ["tooling"],
+      project_key: "the-librarian",
+    });
+    expect(result.status).toBe("active");
+    expect(result.memory.id).toBe("mem_test1");
+    expect(result.duplicates).toEqual([]);
+    expect(vault.exists("memories/mem_test1.md")).toBe(true);
+    expect(vault.readText("memories/mem_test1.md")).toContain("Always use pnpm.");
+  });
+
+  it("getMemory round-trips the stored memory exactly", () => {
+    const { store } = makeStore();
+    const { memory } = store.createMemory({
+      agent_id: "codex",
+      title: "Use pnpm",
+      body: "Always use pnpm.",
+      tags: ["tooling"],
+    });
+    expect(store.getMemory(memory.id)).toEqual(memory);
+  });
+
+  it("getMemory returns null for an unknown id", () => {
+    const { store } = makeStore();
+    expect(store.getMemory("mem_ghost")).toBeNull();
+  });
+
+  it("routes a requires_approval write to proposed", () => {
+    const { store } = makeStore();
+    const result = store.createMemory(
+      { agent_id: "codex", title: "Owner identity", body: "Jim is the owner." },
+      { requires_approval: true },
+    );
+    expect(result.status).toBe("proposed");
+    expect(result.memory.status).toBe("proposed");
+    expect(result.memory.requires_approval).toBe(true);
+  });
+
+  it("routes a pendingClassification write to proposed with conservative defaults", () => {
+    const { store } = makeStore();
+    const result = store.createMemory(
+      { agent_id: "codex", title: "x", body: "y" },
+      { pendingClassification: true },
+    );
+    expect(result.status).toBe("proposed");
+    expect(result.memory.requires_approval).toBe(true);
+    expect(result.memory.is_global).toBe(false);
+  });
+
+  it("normalizes missing input fields (defaults title/body/agent_id)", () => {
+    const { store } = makeStore();
+    const { memory } = store.createMemory({});
+    expect(memory.title).toBe("Untitled memory");
+    expect(memory.priority).toBe("normal");
+    expect(memory.confidence).toBe("working");
+    expect(memory.usefulness_score).toBe(0);
+    expect(memory.recall_count).toBe(0);
+  });
+
+  it("commits per write with the memory id in the message", () => {
+    const { store, commits } = makeStore();
+    store.createMemory({ agent_id: "codex", title: "a", body: "b" });
+    expect(commits).toHaveLength(1);
+    expect(commits[0]).toContain("mem_test1");
+  });
+
+  it("works without a commit callback (commit is optional)", () => {
+    const vault = createVault({ dataDir });
+    const store = createMarkdownMemoryStore({ vault });
+    const { memory } = store.createMemory({ agent_id: "codex", title: "a", body: "b" });
+    expect(store.getMemory(memory.id)).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Plan 036 **Phase 2** — the markdown `MemoryStore`'s write/read core, built behind the existing interface (parity-first). Adds `packages/core/src/store/markdown/markdown-memory-store.ts`.

- **`createMemory(input, options)`** — `normalizeMemoryInput` + the shared `routeMemoryWrite` (#223) + the `memory-doc` mapping (#222) → writes `memories/<id>.md`, then an optional **sync** commit; returns `{status, memory, duplicates: []}`.
- **`getMemory(id)`** — reads `memories/<id>.md` back (O(1) by id), or `null`.
- **Sync** throughout (the storage-agnostic verb tests are sync): sync vault I/O + an **injected sync committer** (`commit?`, omit to skip — most unit tests do). Status lives in frontmatter; folder-based inbox/consolidation filing is Phase 4. Duplicate detection + `list`/`search`/`update`/`archive`/`verify`/`approve` land in following increments.

Also adds raw text I/O to the vault (`writeText`/`readText`/`tryReadText`) — memory docs use the richer memory frontmatter, not the corpus-minimal serializer — and routes the existing `writeDocument`/`readDocument` through it (behaviour preserved).

## Review

A review sub-agent verified the vault refactor is behaviour-preserving and the create↔read round-trip is robust (no field-set drift). Findings actioned: the commit-status check now uses the `MemoryStatus` enum (not a string literal), and direct unit tests were added for the new raw-text methods. It also confirmed (and I verified) that **no storage-agnostic parity test asserts the D16-dropped fields** (`category`/`visibility`/`scope`/`last_recalled_at`), so the simplified markdown shape is safe for the parity gate.

## Scope

Not wired into `createLibrarianStore` — SQLite stays the live backend, **no user-visible change** (no CHANGELOG entry).

## Verification

- New `markdown-memory-store` suite (8 tests) + 3 new vault raw-text tests; `memory-doc` round-trip + existing vault suite still green.
- `pnpm -r typecheck` + `pnpm run lint` green; core suite 563.

🤖 Generated with [Claude Code](https://claude.com/claude-code)