### PR TITLE
feat(markdown): listAll + listMemories + getAggregates (Phase 2)

### DIFF
--- a/packages/core/src/store/markdown/markdown-memory-store.ts
+++ b/packages/core/src/store/markdown/markdown-memory-store.ts
@@ -32,6 +32,14 @@ function memoryPath(id: string): string {
   return `memories/${id}.md`;
 }
 
+const PRIORITY_RANK: Record<string, number> = { core: 0, high: 1, normal: 2 };
+function priorityRank(memory: Memory): number {
+  return PRIORITY_RANK[memory.priority] ?? 3;
+}
+function cmpStr(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
 export function createMarkdownMemoryStore(deps: MarkdownMemoryStoreDeps) {
   const { vault } = deps;
   const now = deps.now ?? nowIso;
@@ -79,5 +87,91 @@ export function createMarkdownMemoryStore(deps: MarkdownMemoryStoreDeps) {
     return raw ? parseMemoryDocument(raw) : null;
   }
 
-  return { createMemory, getMemory };
+  function readAllMemories(): Memory[] {
+    return vault.listMarkdown("memories").map((rel) => parseMemoryDocument(vault.readText(rel)));
+  }
+
+  function listAll(filters: Record<string, unknown> = {}): Memory[] {
+    let out = readAllMemories();
+    if (filters.status) out = out.filter((m) => m.status === filters.status);
+    if (filters.agent_id) out = out.filter((m) => m.agent_id === filters.agent_id);
+    if (filters.project_key) {
+      // Parity with SQLite `(project_key IS NULL OR project_key = ?)`.
+      out = out.filter((m) => m.project_key == null || m.project_key === filters.project_key);
+    }
+    return out.sort(
+      (a, b) => priorityRank(a) - priorityRank(b) || cmpStr(b.updated_at, a.updated_at),
+    );
+  }
+
+  function listMemories(filters: Record<string, unknown> = {}) {
+    let out = readAllMemories();
+    if (filters.status) out = out.filter((m) => m.status === filters.status);
+    if (filters.agent_id) out = out.filter((m) => m.agent_id === filters.agent_id);
+    if (filters.project_key) {
+      out = out.filter((m) => m.project_key == null || m.project_key === filters.project_key);
+    }
+    if (filters.is_global !== undefined) {
+      out = out.filter((m) => m.is_global === Boolean(filters.is_global));
+    }
+    if (filters.requires_approval !== undefined) {
+      out = out.filter((m) => m.requires_approval === Boolean(filters.requires_approval));
+    }
+    if (Array.isArray(filters.tags) && filters.tags.length > 0) {
+      const wanted = filters.tags as string[];
+      out = out.filter((m) => wanted.some((tag) => m.tags.includes(tag)));
+    }
+    if (filters.from) out = out.filter((m) => String(m.created_at) >= String(filters.from));
+    if (filters.to) {
+      // `to` is a date; SQLite compares against end-of-day.
+      const ceiling = `${String(filters.to)}T23:59:59.999Z`;
+      out = out.filter((m) => String(m.created_at) <= ceiling);
+    }
+
+    const total = out.length;
+    const sortField = ["created_at", "updated_at", "title", "priority"].includes(
+      filters.sort as string,
+    )
+      ? (filters.sort as string)
+      : "updated_at";
+    const asc = filters.order === "asc";
+    out.sort((a, b) => {
+      const cmp =
+        sortField === "priority"
+          ? priorityRank(a) - priorityRank(b)
+          : cmpStr(String(a[sortField]), String(b[sortField]));
+      return asc ? cmp : -cmp;
+    });
+
+    const limit = Math.min(Math.max(Number(filters.limit ?? 100), 1), 200);
+    const offset = Math.max(Number(filters.offset ?? 0), 0);
+    return { memories: out.slice(offset, offset + limit), total, limit, offset };
+  }
+
+  function getAggregates() {
+    const active = listAll({}).filter((m) => m.status !== MemoryStatus.Archived);
+    const tally = (field: string) => {
+      const counts = new Map<unknown, number>();
+      for (const memory of active) {
+        const value = (memory as Record<string, unknown>)[field];
+        if (!value) continue;
+        counts.set(value, (counts.get(value) ?? 0) + 1);
+      }
+      return [...counts.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .map(([value, count]) => ({ value, count }));
+    };
+    return {
+      agents: tally("agent_id"),
+      projects: tally("project_key"),
+      // D16 / Section 4d.3 — category + scope columns retired.
+      categories: [] as { value: unknown; count: number }[],
+      statuses: tally("status"),
+      scopes: [] as { value: unknown; count: number }[],
+      priorities: tally("priority"),
+      total: active.length,
+    };
+  }
+
+  return { createMemory, getMemory, listAll, listMemories, getAggregates };
 }

--- a/packages/core/tests/store/markdown/markdown-memory-reads.test.ts
+++ b/packages/core/tests/store/markdown/markdown-memory-reads.test.ts
@@ -1,0 +1,197 @@
+// Markdown MemoryStore — listAll / listMemories / getAggregates (Phase 2).
+//
+// Read-surface parity with the SQLite store: status/agent/project filtering
+// (project = NULL-or-match), priority-then-recency ordering, paginated
+// listMemories with tag-OR + boolean + date filters and sort/order, and the
+// aggregates tallies (categories/scopes retired → empty). Memory docs are
+// seeded directly into the vault so field values are controlled.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type Memory,
+  createMarkdownMemoryStore,
+  createVault,
+  serializeMemoryDocument,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-md-reads-"));
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+function setup() {
+  const vault = createVault({ dataDir });
+  const store = createMarkdownMemoryStore({ vault });
+  const seed = (over: Partial<Memory> & { id: string }): Memory => {
+    const memory: Memory = {
+      id: over.id,
+      title: over.title ?? over.id,
+      body: over.body ?? "body",
+      agent_id: over.agent_id ?? "codex",
+      project_key: over.project_key ?? null,
+      priority: over.priority ?? "normal",
+      confidence: over.confidence ?? "working",
+      tags: over.tags ?? [],
+      applies_to: over.applies_to ?? [],
+      supersedes: [],
+      conflicts_with: [],
+      recall_count: 0,
+      usefulness_score: 0,
+      status: over.status ?? "active",
+      is_global: over.is_global ?? false,
+      requires_approval: over.requires_approval ?? false,
+      created_at: over.created_at ?? "2026-06-01T00:00:00.000Z",
+      updated_at: over.updated_at ?? "2026-06-01T00:00:00.000Z",
+      curator_note: over.curator_note ?? null,
+    };
+    vault.writeText(`memories/${memory.id}.md`, serializeMemoryDocument(memory));
+    return memory;
+  };
+  return { vault, store, seed };
+}
+
+describe("markdown MemoryStore — listAll", () => {
+  it("orders by priority (core→high→normal→low) then updated_at DESC", () => {
+    const { store, seed } = setup();
+    seed({ id: "a", priority: "normal", updated_at: "2026-06-03T00:00:00.000Z" });
+    seed({ id: "b", priority: "core", updated_at: "2026-06-01T00:00:00.000Z" });
+    seed({ id: "c", priority: "normal", updated_at: "2026-06-05T00:00:00.000Z" });
+    expect(store.listAll().map((m) => m.id)).toEqual(["b", "c", "a"]);
+  });
+
+  it("filters by status and agent_id", () => {
+    const { store, seed } = setup();
+    seed({ id: "a", agent_id: "codex", status: "active" });
+    seed({ id: "b", agent_id: "claude", status: "active" });
+    seed({ id: "c", agent_id: "codex", status: "archived" });
+    expect(
+      store
+        .listAll({ status: "active" })
+        .map((m) => m.id)
+        .sort(),
+    ).toEqual(["a", "b"]);
+    expect(
+      store
+        .listAll({ agent_id: "codex" })
+        .map((m) => m.id)
+        .sort(),
+    ).toEqual(["a", "c"]);
+  });
+
+  it("project_key filter matches that project OR a null-project memory", () => {
+    const { store, seed } = setup();
+    seed({ id: "shared", project_key: null });
+    seed({ id: "alpha", project_key: "alpha" });
+    seed({ id: "beta", project_key: "beta" });
+    expect(
+      store
+        .listAll({ project_key: "alpha" })
+        .map((m) => m.id)
+        .sort(),
+    ).toEqual(["alpha", "shared"]);
+  });
+});
+
+describe("markdown MemoryStore — listMemories", () => {
+  it("paginates with total/limit/offset", () => {
+    const { store, seed } = setup();
+    for (let i = 0; i < 5; i++) {
+      seed({ id: `m${i}`, updated_at: `2026-06-0${i + 1}T00:00:00.000Z` });
+    }
+    const page = store.listMemories({ limit: 2, offset: 1 });
+    expect(page.total).toBe(5);
+    expect(page.limit).toBe(2);
+    expect(page.offset).toBe(1);
+    expect(page.memories).toHaveLength(2);
+  });
+
+  it("filters by tags (OR), is_global, and requires_approval", () => {
+    const { store, seed } = setup();
+    seed({ id: "a", tags: ["x"] });
+    seed({ id: "b", tags: ["y"], is_global: true });
+    seed({ id: "c", tags: ["z"], requires_approval: true });
+    expect(
+      store
+        .listMemories({ tags: ["x", "z"] })
+        .memories.map((m) => m.id)
+        .sort(),
+    ).toEqual(["a", "c"]);
+    expect(store.listMemories({ is_global: true }).memories.map((m) => m.id)).toEqual(["b"]);
+    expect(store.listMemories({ requires_approval: true }).memories.map((m) => m.id)).toEqual([
+      "c",
+    ]);
+  });
+
+  it("filters by created_at from/to (to is end-of-day inclusive)", () => {
+    const { store, seed } = setup();
+    seed({ id: "old", created_at: "2026-05-20T12:00:00.000Z" });
+    seed({ id: "mid", created_at: "2026-06-01T12:00:00.000Z" });
+    seed({ id: "new", created_at: "2026-06-10T12:00:00.000Z" });
+    const r = store.listMemories({ from: "2026-06-01", to: "2026-06-01" });
+    expect(r.memories.map((m) => m.id)).toEqual(["mid"]);
+  });
+
+  it("sorts by title ascending when asked", () => {
+    const { store, seed } = setup();
+    seed({ id: "a", title: "banana" });
+    seed({ id: "b", title: "apple" });
+    seed({ id: "c", title: "cherry" });
+    expect(
+      store.listMemories({ sort: "title", order: "asc" }).memories.map((m) => m.title),
+    ).toEqual(["apple", "banana", "cherry"]);
+  });
+
+  it("sorts titles by BINARY collation, not locale-aware (uppercase before lowercase)", () => {
+    // Pins parity with SQLite's default BINARY collation: 'Z' (0x5A) < 'a'
+    // (0x61). localeCompare would instead order 'apple' before 'Zebra' —
+    // this guards against a future cmpStr → localeCompare regression.
+    const { store, seed } = setup();
+    seed({ id: "a", title: "Zebra" });
+    seed({ id: "b", title: "apple" });
+    expect(
+      store.listMemories({ sort: "title", order: "asc" }).memories.map((m) => m.title),
+    ).toEqual(["Zebra", "apple"]);
+  });
+
+  it("defaults to updated_at DESC and supports a priority sort", () => {
+    const { store, seed } = setup();
+    seed({ id: "old", updated_at: "2026-06-01T00:00:00.000Z", priority: "low" });
+    seed({ id: "new", updated_at: "2026-06-09T00:00:00.000Z", priority: "core" });
+    expect(store.listMemories().memories.map((m) => m.id)).toEqual(["new", "old"]);
+    // priority asc → core (rank 0) before low (rank 3).
+    expect(
+      store.listMemories({ sort: "priority", order: "asc" }).memories.map((m) => m.id),
+    ).toEqual(["new", "old"]);
+  });
+
+  it("clamps limit to 1..200 and offset to >= 0", () => {
+    const { store, seed } = setup();
+    for (let i = 0; i < 3; i++) seed({ id: `m${i}` });
+    expect(store.listMemories({ limit: 0 }).limit).toBe(1);
+    expect(store.listMemories({ limit: 500 }).limit).toBe(200);
+    expect(store.listMemories({ offset: -5 }).offset).toBe(0);
+  });
+});
+
+describe("markdown MemoryStore — getAggregates", () => {
+  it("tallies active memories and retires categories/scopes", () => {
+    const { store, seed } = setup();
+    seed({ id: "a", agent_id: "codex", priority: "core", status: "active" });
+    seed({ id: "b", agent_id: "codex", priority: "normal", status: "active" });
+    seed({ id: "c", agent_id: "claude", priority: "normal", status: "archived" });
+    const agg = store.getAggregates();
+    expect(agg.total).toBe(2); // archived excluded
+    expect(agg.agents).toEqual([{ value: "codex", count: 2 }]);
+    expect(agg.categories).toEqual([]);
+    expect(agg.scopes).toEqual([]);
+    expect(agg.priorities.map((p) => p.value).sort()).toEqual(["core", "normal"]);
+  });
+});


### PR DESCRIPTION
## What

Plan 036 **Phase 2** — the markdown `MemoryStore`'s read surface, faithful to the SQLite filter/sort/pagination semantics.

- **`listAll(filters)`** — `status` / `agent_id` / `project_key` (NULL-or-match) filters; ordered by priority (core→high→normal→low) then `updated_at` DESC.
- **`listMemories(filters)`** — the above plus `is_global` / `requires_approval` / `tags` (OR) / `created_at` `from..to` (`to` = end-of-day inclusive); sort by `created_at|updated_at|title|priority` + asc/desc; paginated `{memories, total, limit (clamped 1..200), offset}`.
- **`getAggregates()`** — agent/project/status/priority tallies over active memories; `categories` + `scopes` retired (empty) per D16.

Reads via `vault.listMarkdown("memories")` + `parseMemoryDocument`.

## Review

A review sub-agent verified **behavioural parity is exact** against the SQLite read surface, line by line — including the collation-sensitive sorts (the code uses codepoint `cmpStr`, matching SQLite's default BINARY on the `title`/`created_at`/`updated_at` TEXT columns — *not* `localeCompare`) and all clamp/edge cases. Actioned its test-coverage suggestions: added guards pinning **BINARY collation** (uppercase-before-lowercase, so a future `localeCompare` regression is caught), default/`priority` sort, and the limit/offset clamps. Noted (deferred to the Phase-7 cutover, per the parity-first stance): `readAllMemories` parses every doc per call — fine at MVP scale.

## Scope

Not wired into `createLibrarianStore` — SQLite stays the live backend, **no user-visible change**. `searchMemories`/`detectRelated` (needs a shared `tokenize`) + the mutation methods follow next.

## Verification

- New `markdown-memory-reads` suite (11 tests); rest of the markdown + core suites green.
- `pnpm -r typecheck` + `pnpm run lint` green; core suite 574.

🤖 Generated with [Claude Code](https://claude.com/claude-code)