### PR TITLE
feat(markdown): searchMemories + detectRelated/getRelated (Phase 2)

### DIFF
--- a/packages/core/src/store/markdown/markdown-memory-store.ts
+++ b/packages/core/src/store/markdown/markdown-memory-store.ts
@@ -11,11 +11,12 @@
 // synchronous git commit. Each memory is `memories/<id>.md`; status lives
 // in frontmatter (folder-based inbox/consolidation filing is Phase 4).
 
-import { makeId, normalizeMemoryInput, nowIso } from "../../constants.js";
+import { asArray, makeId, normalizeMemoryInput, normalizeString, nowIso } from "../../constants.js";
 import { MemoryStatus } from "../../schemas/common.js";
 import type { Vault } from "../corpus/vault.js";
 import { routeMemoryWrite } from "../memory-routing.js";
 import type { Memory } from "../memory-store.js";
+import { tokenize } from "../memory-tokenize.js";
 import { parseMemoryDocument, serializeMemoryDocument } from "./memory-doc.js";
 
 export interface MarkdownMemoryStoreDeps {
@@ -77,9 +78,10 @@ export function createMarkdownMemoryStore(deps: MarkdownMemoryStoreDeps) {
       updated_at: ts,
       curator_note: curatorNote,
     };
+    const related = detectRelated(memory);
     vault.writeText(memoryPath(memory.id), serializeMemoryDocument(memory));
     commit(`memory: ${status === MemoryStatus.Proposed ? "propose" : "store"} ${memory.id}`);
-    return { status, memory, duplicates: [] as Memory[] };
+    return { status, memory, duplicates: related.duplicates };
   }
 
   function getMemory(id: string): Memory | null {
@@ -148,6 +150,86 @@ export function createMarkdownMemoryStore(deps: MarkdownMemoryStoreDeps) {
     return { memories: out.slice(offset, offset + limit), total, limit, offset };
   }
 
+  function searchMemories(input: Record<string, unknown> = {}): Memory[] {
+    const query = typeof input.query === "string" ? input.query : "";
+    const projectKey = typeof input.project_key === "string" ? input.project_key : "";
+    const limit = typeof input.limit === "number" ? input.limit : 8;
+    const status = (input.status as string | undefined) ?? MemoryStatus.Active;
+    const cleaned = normalizeString(query);
+    const tagSet = new Set(asArray(input.tags));
+
+    const allowed = listAll({ status, project_key: projectKey }).filter((memory) => {
+      if (!tagSet.size) return true;
+      return (memory.tags || []).some((tag) => tagSet.has(tag));
+    });
+    if (!cleaned) return allowed.slice(0, limit);
+
+    const terms = tokenize(cleaned);
+    const scored = allowed
+      .map((memory) => {
+        const haystack =
+          `${memory.title} ${memory.body} ${memory.tags.join(" ")} ${memory.project_key || ""}`.toLowerCase();
+        let score = 0;
+        for (const term of terms) if (haystack.includes(term)) score += term.length > 4 ? 3 : 1;
+        if (memory.priority === "core") score += 3;
+        if (memory.priority === "high") score += 1;
+        if (memory.project_key && memory.project_key === projectKey) score += 3;
+        score += Math.max(-3, Math.min(3, Number(memory.usefulness_score || 0)));
+        return { memory, score };
+      })
+      .filter((item) => item.score > 0);
+
+    scored.sort(
+      (a, b) => b.score - a.score || b.memory.updated_at.localeCompare(a.memory.updated_at),
+    );
+    return scored.slice(0, limit).map((item) => item.memory);
+  }
+
+  function detectRelated(candidate: Memory, options: { threshold?: number } = {}) {
+    const terms = new Set(
+      tokenize(`${candidate.title} ${candidate.body} ${candidate.tags.join(" ")}`),
+    );
+    if (!terms.size) return { duplicates: [] as Memory[] };
+    const pool = listAll({
+      status: MemoryStatus.Active,
+      agent_id: candidate.agent_id,
+      project_key: candidate.project_key ?? undefined,
+    }).filter((memory) => memory.id !== candidate.id);
+    const duplicates = pool
+      .map((memory) => {
+        const other = new Set(tokenize(`${memory.title} ${memory.body} ${memory.tags.join(" ")}`));
+        const overlap = [...terms].filter((term) => other.has(term)).length;
+        return { memory, ratio: overlap / Math.max(terms.size, other.size, 1) };
+      })
+      .filter((item) => item.ratio >= (options.threshold ?? 0.55))
+      .map((item) => item.memory);
+    return { duplicates };
+  }
+
+  function getRelated(id: string) {
+    const memory = getMemory(id);
+    if (!memory) return null;
+    const terms = new Set(tokenize(`${memory.title} ${memory.body} ${memory.tags.join(" ")}`));
+    if (!terms.size) return { memory, related: [] };
+    const pool = listAll({
+      status: MemoryStatus.Active,
+      agent_id: memory.agent_id,
+      project_key: memory.project_key ?? undefined,
+    }).filter((other) => other.id !== id);
+    const related = pool
+      .map((other) => {
+        const otherTerms = new Set(
+          tokenize(`${other.title} ${other.body} ${other.tags.join(" ")}`),
+        );
+        const overlap = [...terms].filter((term) => otherTerms.has(term)).length;
+        const ratio = overlap / Math.max(terms.size, otherTerms.size, 1);
+        return { memory: other, ratio, isDuplicate: ratio >= 0.55 };
+      })
+      .filter((item) => item.ratio >= 0.32)
+      .sort((a, b) => b.ratio - a.ratio);
+    return { memory, related };
+  }
+
   function getAggregates() {
     const active = listAll({}).filter((m) => m.status !== MemoryStatus.Archived);
     const tally = (field: string) => {
@@ -173,5 +255,14 @@ export function createMarkdownMemoryStore(deps: MarkdownMemoryStoreDeps) {
     };
   }
 
-  return { createMemory, getMemory, listAll, listMemories, getAggregates };
+  return {
+    createMemory,
+    getMemory,
+    listAll,
+    listMemories,
+    getAggregates,
+    searchMemories,
+    detectRelated,
+    getRelated,
+  };
 }

--- a/packages/core/src/store/memory-store.ts
+++ b/packages/core/src/store/memory-store.ts
@@ -21,6 +21,7 @@ import {
 import { MemoryEventType, MemoryStatus } from "../schemas/common.js";
 import { appendJsonl, readJsonl } from "./jsonl.js";
 import { routeMemoryWrite } from "./memory-routing.js";
+import { tokenize } from "./memory-tokenize.js";
 
 // ---------- Public types ----------
 
@@ -875,20 +876,6 @@ function safeJsonParseObject(
     );
     return null;
   }
-}
-
-function tokenize(text: string): string[] {
-  return normalizeString(text)
-    .toLowerCase()
-    .replace(/[^a-z0-9_./-]+/g, " ")
-    .split(/\s+/)
-    .filter((term) => term.length > 2)
-    .filter(
-      (term) =>
-        !["the", "and", "for", "with", "that", "this", "from", "into", "agent", "memory"].includes(
-          term,
-        ),
-    );
 }
 
 function cleanPatch(patch: Record<string, unknown> = {}): Record<string, unknown> {

--- a/packages/core/src/store/memory-tokenize.ts
+++ b/packages/core/src/store/memory-tokenize.ts
@@ -1,0 +1,18 @@
+// Recall/similarity tokenizer — storage-agnostic, shared by the SQLite and
+// markdown backends (plan 036 Phase 2). Lowercase, strip to a
+// word/path-char alphabet, drop tokens ≤ 2 chars and a small stopword set.
+// Extracted from memory-store.ts so search + duplicate-detection score
+// identically on both backends.
+
+import { normalizeString } from "../constants.js";
+
+const STOPWORDS = ["the", "and", "for", "with", "that", "this", "from", "into", "agent", "memory"];
+
+export function tokenize(text: string): string[] {
+  return normalizeString(text)
+    .toLowerCase()
+    .replace(/[^a-z0-9_./-]+/g, " ")
+    .split(/\s+/)
+    .filter((term) => term.length > 2)
+    .filter((term) => !STOPWORDS.includes(term));
+}

--- a/packages/core/tests/store/markdown/markdown-memory-search.test.ts
+++ b/packages/core/tests/store/markdown/markdown-memory-search.test.ts
@@ -1,0 +1,159 @@
+// Markdown MemoryStore — searchMemories / detectRelated / getRelated (Phase 2).
+//
+// Keyword-scoring recall + token-overlap similarity, parity with the SQLite
+// store's JS-side scoring (term length 3/1, priority + project bonuses,
+// usefulness band; archived excluded; duplicate ratio ≥ 0.55; related ≥ 0.32).
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type Memory,
+  createMarkdownMemoryStore,
+  createVault,
+  serializeMemoryDocument,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-md-search-"));
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+function setup() {
+  const vault = createVault({ dataDir });
+  let counter = 0;
+  const store = createMarkdownMemoryStore({ vault, generateId: () => `mem_t${++counter}` });
+  const seed = (over: Partial<Memory> & { id: string }): Memory => {
+    const memory: Memory = {
+      id: over.id,
+      title: over.title ?? over.id,
+      body: over.body ?? "body",
+      agent_id: over.agent_id ?? "codex",
+      project_key: over.project_key ?? null,
+      priority: over.priority ?? "normal",
+      confidence: "working",
+      tags: over.tags ?? [],
+      applies_to: [],
+      supersedes: [],
+      conflicts_with: [],
+      recall_count: 0,
+      usefulness_score: over.usefulness_score ?? 0,
+      status: over.status ?? "active",
+      is_global: false,
+      requires_approval: false,
+      created_at: "2026-06-01T00:00:00.000Z",
+      updated_at: over.updated_at ?? "2026-06-01T00:00:00.000Z",
+      curator_note: null,
+    };
+    vault.writeText(`memories/${memory.id}.md`, serializeMemoryDocument(memory));
+    return memory;
+  };
+  return { vault, store, seed };
+}
+
+describe("markdown MemoryStore — searchMemories", () => {
+  it("scores keyword matches and drops non-matches", () => {
+    const { store, seed } = setup();
+    seed({ id: "pnpm", title: "pnpm workspace setup", body: "use pnpm for the monorepo" });
+    seed({ id: "cal", title: "calendar", body: "tuesdays only" });
+    const hits = store.searchMemories({ query: "pnpm monorepo" });
+    expect(hits.map((m) => m.id)).toEqual(["pnpm"]);
+  });
+
+  it("returns up to limit (recent-first) when the query is empty", () => {
+    const { store, seed } = setup();
+    seed({ id: "a", updated_at: "2026-06-01T00:00:00.000Z" });
+    seed({ id: "b", updated_at: "2026-06-09T00:00:00.000Z" });
+    expect(store.searchMemories({ limit: 1 })).toHaveLength(1);
+    expect(store.searchMemories({}).map((m) => m.id)).toContain("a");
+  });
+
+  it("excludes archived memories", () => {
+    const { store, seed } = setup();
+    seed({ id: "live", title: "deploy command", body: "run deploy" });
+    seed({ id: "dead", title: "deploy command", body: "run deploy", status: "archived" });
+    expect(store.searchMemories({ query: "deploy" }).map((m) => m.id)).toEqual(["live"]);
+  });
+
+  it("filters by tag (OR) before scoring", () => {
+    const { store, seed } = setup();
+    seed({ id: "x", title: "deploy alpha", body: "deploy", tags: ["ops"] });
+    seed({ id: "y", title: "deploy beta", body: "deploy", tags: ["docs"] });
+    expect(store.searchMemories({ query: "deploy", tags: ["ops"] }).map((m) => m.id)).toEqual([
+      "x",
+    ]);
+  });
+
+  it("ranks a higher-usefulness memory above an equal keyword match", () => {
+    const { store, seed } = setup();
+    seed({ id: "low", title: "deploy notes", body: "deploy", usefulness_score: 0 });
+    seed({ id: "high", title: "deploy notes", body: "deploy", usefulness_score: 3 });
+    expect(store.searchMemories({ query: "deploy" }).map((m) => m.id)).toEqual(["high", "low"]);
+  });
+
+  it("applies the priority bonus (core outranks an equal keyword match)", () => {
+    const { store, seed } = setup();
+    seed({ id: "plain", title: "deploy notes", body: "deploy", priority: "normal" });
+    seed({ id: "core", title: "deploy notes", body: "deploy", priority: "core" });
+    expect(store.searchMemories({ query: "deploy" }).map((m) => m.id)).toEqual(["core", "plain"]);
+  });
+});
+
+describe("markdown MemoryStore — detectRelated + getRelated", () => {
+  it("flags a high-overlap memory as a duplicate and ignores a low-overlap one", () => {
+    const { store, seed } = setup();
+    seed({ id: "dup", title: "alpha beta gamma delta", body: "alpha beta gamma delta" });
+    seed({ id: "far", title: "unrelated subject matter", body: "nothing alike here" });
+    const candidate: Memory = {
+      ...seed({ id: "cand", title: "alpha beta gamma delta", body: "alpha beta gamma delta" }),
+    };
+    const { duplicates } = store.detectRelated(candidate);
+    expect(duplicates.map((m) => m.id)).toEqual(["dup"]);
+  });
+
+  it("getRelated ranks by ratio, flags isDuplicate (≥0.55), and filters below 0.32", () => {
+    const { store, seed } = setup();
+    const base = seed({
+      id: "base",
+      title: "alpha beta gamma delta",
+      body: "alpha beta gamma delta",
+    });
+    // near shares 3/4 terms → 0.75 (duplicate); mid shares 2/4 → 0.5 (related,
+    // not a duplicate); far shares 0 → excluded (< 0.32).
+    seed({ id: "near", title: "alpha beta gamma epsilon", body: "alpha beta gamma epsilon" });
+    seed({ id: "mid", title: "alpha beta epsilon zeta", body: "alpha beta epsilon zeta" });
+    seed({ id: "far", title: "totally different words", body: "nothing in common at all" });
+    const result = store.getRelated(base.id);
+    expect(result).not.toBeNull();
+    expect(result!.related.map((r) => ({ id: r.memory.id, dup: r.isDuplicate }))).toEqual([
+      { id: "near", dup: true },
+      { id: "mid", dup: false },
+    ]);
+  });
+
+  it("getRelated returns null for an unknown id", () => {
+    const { store } = setup();
+    expect(store.getRelated("mem_ghost")).toBeNull();
+  });
+
+  it("createMemory surfaces duplicates of an existing similar memory", () => {
+    const { store } = setup();
+    store.createMemory({
+      agent_id: "codex",
+      title: "alpha beta gamma delta",
+      body: "alpha beta gamma delta",
+    });
+    const result = store.createMemory({
+      agent_id: "codex",
+      title: "alpha beta gamma delta",
+      body: "alpha beta gamma delta",
+    });
+    expect(result.duplicates).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## What

Plan 036 **Phase 2** — the markdown `MemoryStore`'s recall + similarity surface, parity with the SQLite store's JS-side scoring.

- **`searchMemories`** — tag-OR pre-filter, then keyword scoring (term length >4 → 3 else 1; +3 core / +1 high priority; +3 project match; usefulness clamped ±3), `score > 0`, sorted by score DESC then `updated_at.localeCompare`; empty query → the recent slice; archived excluded.
- **`detectRelated` / `getRelated`** — token-overlap ratio over same-agent/project actives; duplicates ≥ 0.55; related ≥ 0.32 with `isDuplicate` ≥ 0.55.
- **`createMemory`** now surfaces real `duplicates` (was a placeholder `[]`).

Extracts the shared tokenizer into `store/memory-tokenize.ts` so both backends score identically; the SQLite `memory-store.ts` imports it (behaviour-preserving — its search + verify-scoring suites still pass).

## Review

A review sub-agent verified **parity holds across the board** — the `tokenize` extraction is behaviour-identical, and `searchMemories`/`detectRelated`/`getRelated` match the SQLite scoring term-by-term (including the `localeCompare` tie-break, the `?? undefined` project-filter equivalence, and detect-before-write). Actioned its top coverage suggestions: added tests pinning the **priority bonus** and the **`isDuplicate` flag** (≥0.55 vs the 0.32 related floor). Noted (deferred): `readAllMemories` re-reads/re-tokenizes the whole pool per call — acceptable at MVP scale, same algorithmic cost as the SQLite JS scoring.

## Scope

Not wired into `createLibrarianStore` — SQLite stays the live backend, **no user-visible change**. Mutation methods (update/archive/verify/approve/recordRecall/startContext) follow next, then the parity-gate wiring.

## Verification

- New `markdown-memory-search` suite (10 tests); `memory-store` (19) + `verify-scoring` (9) still green.
- `pnpm -r typecheck` + `pnpm run lint` green; core suite 584.

🤖 Generated with [Claude Code](https://claude.com/claude-code)