### PR TITLE
feat(markdown): update/archive/verify/approveProposal (Phase 2)

### DIFF
--- a/packages/core/src/store/markdown/markdown-memory-store.ts
+++ b/packages/core/src/store/markdown/markdown-memory-store.ts
@@ -11,9 +11,17 @@
 // synchronous git commit. Each memory is `memories/<id>.md`; status lives
 // in frontmatter (folder-based inbox/consolidation filing is Phase 4).
 
-import { asArray, makeId, normalizeMemoryInput, normalizeString, nowIso } from "../../constants.js";
-import { MemoryStatus } from "../../schemas/common.js";
+import {
+  DEFAULT_AGENT_ID,
+  asArray,
+  makeId,
+  normalizeMemoryInput,
+  normalizeString,
+  nowIso,
+} from "../../constants.js";
+import { MemoryStatus, VerifyResult } from "../../schemas/common.js";
 import type { Vault } from "../corpus/vault.js";
+import { cleanPatch } from "../memory-patch.js";
 import { routeMemoryWrite } from "../memory-routing.js";
 import type { Memory } from "../memory-store.js";
 import { tokenize } from "../memory-tokenize.js";
@@ -87,6 +95,105 @@ export function createMarkdownMemoryStore(deps: MarkdownMemoryStoreDeps) {
   function getMemory(id: string): Memory | null {
     const raw = vault.tryReadText(memoryPath(id));
     return raw ? parseMemoryDocument(raw) : null;
+  }
+
+  // Write a mutated memory back + commit. The state-transition logic below
+  // mirrors the SQLite projection's reduceMemoryLog handlers (which the
+  // SQLite store reaches via events); the markdown store applies them
+  // directly to the document.
+  function persist(memory: Memory, message: string): Memory {
+    vault.writeText(memoryPath(memory.id), serializeMemoryDocument(memory));
+    commit(message);
+    return memory;
+  }
+
+  function updateMemory(
+    id: string,
+    patch: Record<string, unknown> = {},
+    agent_id: string = DEFAULT_AGENT_ID,
+    options: { allowProtected?: boolean } = {},
+  ): Memory | null {
+    void agent_id;
+    const existing = getMemory(id);
+    if (!existing) throw new Error(`No memory found for id ${id}`);
+    if (
+      existing.requires_approval === true &&
+      existing.status === MemoryStatus.Active &&
+      !options.allowProtected
+    ) {
+      throw new Error("Protected memories must be changed through a proposal workflow.");
+    }
+    const normalizedPatch = cleanPatch(patch);
+    if (normalizedPatch.status !== undefined && normalizedPatch.status !== existing.status) {
+      throw new Error("Memory status changes must use the dedicated approval or archive workflow.");
+    }
+    return persist(
+      { ...existing, ...normalizedPatch, id, updated_at: now() },
+      `memory: update ${id}`,
+    );
+  }
+
+  function archiveMemory(id: string, agent_id: string = DEFAULT_AGENT_ID): Memory | null {
+    void agent_id;
+    const existing = getMemory(id);
+    if (!existing) throw new Error(`No memory found for id ${id}`);
+    if (existing.status === MemoryStatus.Archived) return existing; // idempotent
+    return persist(
+      { ...existing, status: MemoryStatus.Archived, updated_at: now() },
+      `memory: archive ${id}`,
+    );
+  }
+
+  function verifyMemory(
+    id: string,
+    result: string,
+    note: string = "",
+    agent_id: string = DEFAULT_AGENT_ID,
+  ): Memory | null {
+    void note;
+    void agent_id;
+    const existing = getMemory(id);
+    if (!existing) throw new Error(`No memory found for id ${id}`);
+    // useful → +1, not_useful / legacy "wrong" → −1, outdated → 0 (clamped ±3).
+    const delta =
+      result === VerifyResult.Useful
+        ? 1
+        : result === VerifyResult.NotUseful || result === "wrong"
+          ? -1
+          : 0;
+    const usefulness_score = Math.max(
+      -3,
+      Math.min(3, Number(existing.usefulness_score || 0) + delta),
+    );
+    // outdated is load-bearing — it also archives the memory out of recall.
+    const status =
+      result === VerifyResult.Outdated ? MemoryStatus.Archived : (existing.status as MemoryStatus);
+    return persist(
+      { ...existing, usefulness_score, status, updated_at: now() },
+      `memory: verify ${id}`,
+    );
+  }
+
+  function approveProposal(
+    id: string,
+    action: string = "approve",
+    patch: Record<string, unknown> = {},
+    agent_id: string = DEFAULT_AGENT_ID,
+  ): Memory | null {
+    void agent_id;
+    const existing = getMemory(id);
+    if (!existing) throw new Error(`No memory found for id ${id}`);
+    if (existing.status !== MemoryStatus.Proposed) throw new Error(`Memory ${id} is not proposed`);
+    if (action === "reject") {
+      return persist(
+        { ...existing, status: MemoryStatus.Archived, updated_at: now() },
+        `memory: reject ${id}`,
+      );
+    }
+    return persist(
+      { ...existing, ...cleanPatch(patch), status: MemoryStatus.Active, updated_at: now() },
+      `memory: approve ${id}`,
+    );
   }
 
   function readAllMemories(): Memory[] {
@@ -264,5 +371,9 @@ export function createMarkdownMemoryStore(deps: MarkdownMemoryStoreDeps) {
     searchMemories,
     detectRelated,
     getRelated,
+    updateMemory,
+    archiveMemory,
+    verifyMemory,
+    approveProposal,
   };
 }

--- a/packages/core/src/store/memory-patch.ts
+++ b/packages/core/src/store/memory-patch.ts
@@ -1,0 +1,31 @@
+// Memory update-patch whitelist — storage-agnostic, shared by the SQLite
+// and markdown backends (plan 036 Phase 2). Restricts a free-form patch to
+// the fields a caller may set on update/approve, so an agent can't smuggle
+// protected fields (e.g. is_global / requires_approval / curator_note)
+// through the update path. Array fields are normalized via `asArray`.
+
+import { asArray } from "../constants.js";
+
+const ALLOWED_PATCH_FIELDS = [
+  "title",
+  "body",
+  "agent_id",
+  "project_key",
+  "applies_to",
+  "status",
+  "priority",
+  "confidence",
+  "supersedes",
+  "conflicts_with",
+  "tags",
+];
+
+export function cleanPatch(patch: Record<string, unknown> = {}): Record<string, unknown> {
+  const output: Record<string, unknown> = {};
+  for (const key of ALLOWED_PATCH_FIELDS) {
+    if (patch[key] !== undefined) {
+      output[key] = Array.isArray(patch[key]) ? asArray(patch[key]) : patch[key];
+    }
+  }
+  return output;
+}

--- a/packages/core/src/store/memory-store.ts
+++ b/packages/core/src/store/memory-store.ts
@@ -20,6 +20,7 @@ import {
 } from "../constants.js";
 import { MemoryEventType, MemoryStatus } from "../schemas/common.js";
 import { appendJsonl, readJsonl } from "./jsonl.js";
+import { cleanPatch } from "./memory-patch.js";
 import { routeMemoryWrite } from "./memory-routing.js";
 import { tokenize } from "./memory-tokenize.js";
 
@@ -876,28 +877,6 @@ function safeJsonParseObject(
     );
     return null;
   }
-}
-
-function cleanPatch(patch: Record<string, unknown> = {}): Record<string, unknown> {
-  const allowed = [
-    "title",
-    "body",
-    "agent_id",
-    "project_key",
-    "applies_to",
-    "status",
-    "priority",
-    "confidence",
-    "supersedes",
-    "conflicts_with",
-    "tags",
-  ];
-  const output: Record<string, unknown> = {};
-  for (const key of allowed) {
-    if (patch[key] !== undefined)
-      output[key] = Array.isArray(patch[key]) ? asArray(patch[key]) : patch[key];
-  }
-  return output;
 }
 
 function uniqueById(memories: Memory[]): Memory[] {

--- a/packages/core/tests/store/markdown/markdown-memory-mutations.test.ts
+++ b/packages/core/tests/store/markdown/markdown-memory-mutations.test.ts
@@ -1,0 +1,179 @@
+// Markdown MemoryStore — updateMemory / archiveMemory / verifyMemory /
+// approveProposal (plan 036 Phase 2). The SQLite store reaches these via
+// events + the projection; the markdown store applies the transitions
+// directly. Parity: the protection gate + status-patch guard on update, the
+// idempotent archive, the verify usefulness delta (±1, clamp ±3, outdated →
+// archived), and the proposal approve/reject transitions.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type Memory,
+  createMarkdownMemoryStore,
+  createVault,
+  serializeMemoryDocument,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-md-mut-"));
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+const NOW = "2026-07-01T00:00:00.000Z";
+
+function setup() {
+  const vault = createVault({ dataDir });
+  const store = createMarkdownMemoryStore({ vault, now: () => NOW });
+  const seed = (over: Partial<Memory> & { id: string }): Memory => {
+    const memory: Memory = {
+      id: over.id,
+      title: over.title ?? over.id,
+      body: over.body ?? "body",
+      agent_id: over.agent_id ?? "codex",
+      project_key: over.project_key ?? null,
+      priority: over.priority ?? "normal",
+      confidence: "working",
+      tags: over.tags ?? [],
+      applies_to: [],
+      supersedes: [],
+      conflicts_with: [],
+      recall_count: 0,
+      usefulness_score: over.usefulness_score ?? 0,
+      status: over.status ?? "active",
+      is_global: false,
+      requires_approval: over.requires_approval ?? false,
+      created_at: "2026-06-01T00:00:00.000Z",
+      updated_at: "2026-06-01T00:00:00.000Z",
+      curator_note: null,
+    };
+    vault.writeText(`memories/${memory.id}.md`, serializeMemoryDocument(memory));
+    return memory;
+  };
+  return { vault, store, seed };
+}
+
+describe("markdown MemoryStore — updateMemory", () => {
+  it("applies a whitelisted patch and bumps updated_at", () => {
+    const { store, seed } = setup();
+    seed({ id: "m", title: "old", body: "old body" });
+    const updated = store.updateMemory("m", { title: "new", body: "new body" });
+    expect(updated!.title).toBe("new");
+    expect(updated!.body).toBe("new body");
+    expect(updated!.updated_at).toBe(NOW);
+  });
+
+  it("throws for an unknown id", () => {
+    const { store } = setup();
+    expect(() => store.updateMemory("ghost", { title: "x" })).toThrow(/No memory found/);
+  });
+
+  it("rejects a status change via updateMemory", () => {
+    const { store, seed } = setup();
+    seed({ id: "m", status: "active" });
+    expect(() => store.updateMemory("m", { status: "archived" })).toThrow(/status changes/);
+  });
+
+  it("blocks edits to a protected active memory unless allowProtected is set", () => {
+    const { store, seed } = setup();
+    seed({ id: "p", status: "active", requires_approval: true });
+    expect(() => store.updateMemory("p", { body: "edit" })).toThrow(/Protected memories/);
+    const ok = store.updateMemory("p", { body: "edit" }, "codex", { allowProtected: true });
+    expect(ok!.body).toBe("edit");
+  });
+
+  it("strips protected fields smuggled through a patch (cleanPatch allow-list)", () => {
+    const { store, seed } = setup();
+    seed({ id: "m", status: "active", requires_approval: false });
+    const updated = store.updateMemory("m", {
+      body: "ok",
+      is_global: true,
+      requires_approval: true,
+      curator_note: { forged: true },
+    });
+    expect(updated!.body).toBe("ok");
+    expect(updated!.is_global).toBe(false);
+    expect(updated!.requires_approval).toBe(false);
+    expect(updated!.curator_note).toBeNull();
+  });
+});
+
+describe("markdown MemoryStore — archiveMemory", () => {
+  it("archives a memory and is idempotent", () => {
+    const { store, seed } = setup();
+    seed({ id: "m", status: "active" });
+    expect(store.archiveMemory("m")!.status).toBe("archived");
+    expect(store.archiveMemory("m")!.status).toBe("archived"); // no-op second call
+  });
+
+  it("throws for an unknown id", () => {
+    const { store } = setup();
+    expect(() => store.archiveMemory("ghost")).toThrow(/No memory found/);
+  });
+});
+
+describe("markdown MemoryStore — verifyMemory", () => {
+  it("nudges usefulness +1 / -1 and clamps to ±3", () => {
+    const { store, seed } = setup();
+    seed({ id: "m", usefulness_score: 0 });
+    expect(store.verifyMemory("m", "useful")!.usefulness_score).toBe(1);
+    expect(store.verifyMemory("m", "not_useful")!.usefulness_score).toBe(0);
+    for (let i = 0; i < 5; i++) store.verifyMemory("m", "useful");
+    expect(store.getMemory("m")!.usefulness_score).toBe(3); // clamped
+  });
+
+  it("outdated archives the memory and leaves the score unchanged", () => {
+    const { store, seed } = setup();
+    seed({ id: "m", usefulness_score: 2, status: "active" });
+    const result = store.verifyMemory("m", "outdated");
+    expect(result!.status).toBe("archived");
+    expect(result!.usefulness_score).toBe(2);
+  });
+});
+
+describe("markdown MemoryStore — approveProposal", () => {
+  it("approves a proposed memory to active, applying a patch", () => {
+    const { store, seed } = setup();
+    seed({ id: "m", status: "proposed", body: "draft" });
+    const approved = store.approveProposal("m", "approve", { body: "reviewed" });
+    expect(approved!.status).toBe("active");
+    expect(approved!.body).toBe("reviewed");
+  });
+
+  it("rejects a proposed memory to archived", () => {
+    const { store, seed } = setup();
+    seed({ id: "m", status: "proposed" });
+    expect(store.approveProposal("m", "reject")!.status).toBe("archived");
+  });
+
+  it("strips protected fields smuggled through an approve patch", () => {
+    const { store, seed } = setup();
+    seed({ id: "m", status: "proposed", requires_approval: true });
+    const approved = store.approveProposal("m", "approve", {
+      body: "reviewed",
+      is_global: true,
+      requires_approval: false,
+    });
+    expect(approved!.status).toBe("active");
+    expect(approved!.body).toBe("reviewed");
+    expect(approved!.is_global).toBe(false); // smuggled value dropped
+    expect(approved!.requires_approval).toBe(true); // unchanged by the patch
+  });
+
+  it("throws when the memory is not proposed", () => {
+    const { store, seed } = setup();
+    seed({ id: "m", status: "active" });
+    expect(() => store.approveProposal("m")).toThrow(/not proposed/);
+  });
+
+  it("throws for an unknown id", () => {
+    const { store } = setup();
+    expect(() => store.approveProposal("ghost")).toThrow(/No memory found/);
+  });
+});


### PR DESCRIPTION
## What

Plan 036 **Phase 2** — the markdown `MemoryStore`'s state-transition surface. The SQLite store reaches these by appending an event + letting the projection's `reduceMemoryLog` apply the transition; the markdown store has no projection, so it applies the transition directly (read → mutate → write → commit).

- **`updateMemory`** — protection gate (`requires_approval && active && !allowProtected` → throw), status-patch guard (→ throw), `cleanPatch` whitelist, bump `updated_at`.
- **`archiveMemory`** — `status → archived`, idempotent (already-archived no-op).
- **`verifyMemory`** — usefulness ±1 (`useful` +1, `not_useful`/legacy `wrong` −1, `outdated` 0), clamped ±3; `outdated` also archives.
- **`approveProposal`** — `proposed → active` (+ patch) or `reject → archived`; throws if not proposed.

Extracts the shared `cleanPatch` whitelist into `store/memory-patch.ts`; the SQLite store imports it (its suites still green → behaviour preserved).

## Review

A review sub-agent verified **parity holds** against both halves — the SQLite orchestration guards *and* the projection transitions — for all four verbs, plus the `cleanPatch` extraction is byte-identical and the `void agent_id`/`void note` omissions are correct (those are event-author/audit-only in SQLite, never on the memory). Actioned its security-coverage suggestion: added tests proving smuggled `is_global`/`requires_approval`/`curator_note` are **stripped** through both the update and approve patch paths. (Its body-trim note is *not* a parity defect — SQLite has the same in-memory-vs-readback behavior — so left as-is.)

## Scope

Not wired into `createLibrarianStore` — SQLite stays the live backend, **no user-visible change**. Remaining for the parity gate: `recordRecall`, `startContext`, `bulkUpdateMemory`, `distinctValues` (and `listEvents` is ledger-specific → out of markdown parity), then the `LibrarianStore` wiring.

## Verification

- New `markdown-memory-mutations` suite (14 tests); `memory-store` (19) + `verify-scoring` (9) still green.
- `pnpm -r typecheck` + `pnpm run lint` green; core suite 598.

🤖 Generated with [Claude Code](https://claude.com/claude-code)