### PR TITLE
feat(markdown): recordRecall/bulkUpdate/distinctValues/agent-id queries (Phase 2)

### DIFF
--- a/packages/core/src/store/markdown/markdown-memory-store.ts
+++ b/packages/core/src/store/markdown/markdown-memory-store.ts
@@ -362,6 +362,64 @@ export function createMarkdownMemoryStore(deps: MarkdownMemoryStoreDeps) {
     };
   }
 
+  function recordRecall(_memories: Memory[], _agentId?: string, _query?: string): void {
+    // No-op in the markdown model: recall-count tracking + the recall event
+    // ledger are retired (D16 — relevance comes from the index, not usage
+    // counters; git history replaces the ledger). Kept for interface parity.
+  }
+
+  function bulkUpdateMemory(input: {
+    ids: string[];
+    patch: { agent_id?: string; project_key?: string };
+    agent_id?: string;
+  }): { transaction_id: string; updated: number } {
+    const patch: Record<string, unknown> = {};
+    if (input.patch.agent_id !== undefined) patch.agent_id = input.patch.agent_id;
+    if (input.patch.project_key !== undefined) patch.project_key = input.patch.project_key;
+    if (Object.keys(patch).length === 0) {
+      throw new Error("bulkUpdateMemory requires at least one of agent_id / project_key in patch");
+    }
+    const transaction_id = makeId("txn");
+    let updated = 0;
+    for (const id of input.ids) {
+      const existing = getMemory(id);
+      if (!existing) continue;
+      persist({ ...existing, ...patch, updated_at: now() }, `memory: bulk-update ${id}`);
+      updated++;
+    }
+    return { transaction_id, updated };
+  }
+
+  function distinctValues(input: { field: string; include_archived?: boolean }): string[] {
+    if (input.field !== "agent_id" && input.field !== "project_key") {
+      throw new Error(`distinctValues field not allowed: ${input.field}`);
+    }
+    const includeArchived = input.include_archived === true;
+    const values = new Set<string>();
+    for (const memory of readAllMemories()) {
+      if (!includeArchived && memory.status === MemoryStatus.Archived) continue;
+      const value = (memory as Record<string, unknown>)[input.field];
+      if (typeof value === "string" && value.length > 0) values.add(value);
+    }
+    // Parity with SQLite `ORDER BY value COLLATE NOCASE`.
+    return [...values].sort((a, b) => cmpStr(a.toLowerCase(), b.toLowerCase()));
+  }
+
+  function countMemoriesByAgentId(): { agent_id: string; count: number }[] {
+    const counts = new Map<string, number>();
+    for (const memory of readAllMemories()) {
+      if (!memory.agent_id) continue;
+      counts.set(memory.agent_id, (counts.get(memory.agent_id) ?? 0) + 1);
+    }
+    return [...counts.entries()].map(([agent_id, count]) => ({ agent_id, count }));
+  }
+
+  function listMemoryIdsByAgentId(agentId: string): string[] {
+    return readAllMemories()
+      .filter((memory) => memory.agent_id === agentId)
+      .map((memory) => memory.id);
+  }
+
   return {
     createMemory,
     getMemory,
@@ -375,5 +433,10 @@ export function createMarkdownMemoryStore(deps: MarkdownMemoryStoreDeps) {
     archiveMemory,
     verifyMemory,
     approveProposal,
+    recordRecall,
+    bulkUpdateMemory,
+    distinctValues,
+    countMemoriesByAgentId,
+    listMemoryIdsByAgentId,
   };
 }

--- a/packages/core/tests/store/markdown/markdown-memory-utils.test.ts
+++ b/packages/core/tests/store/markdown/markdown-memory-utils.test.ts
@@ -1,0 +1,129 @@
+// Markdown MemoryStore — recordRecall / bulkUpdateMemory / distinctValues /
+// countMemoriesByAgentId / listMemoryIdsByAgentId (plan 036 Phase 2). The
+// remaining domain methods before the parity-gate wiring; the ledger
+// appendEvent/listEvents are out of markdown parity (git history replaces them).
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type Memory,
+  createMarkdownMemoryStore,
+  createVault,
+  serializeMemoryDocument,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-md-utils-"));
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+function setup() {
+  const vault = createVault({ dataDir });
+  const store = createMarkdownMemoryStore({ vault, now: () => "2026-07-01T00:00:00.000Z" });
+  const seed = (over: Partial<Memory> & { id: string }): Memory => {
+    const memory: Memory = {
+      id: over.id,
+      title: over.title ?? over.id,
+      body: "body",
+      agent_id: over.agent_id ?? "codex",
+      project_key: over.project_key ?? null,
+      priority: "normal",
+      confidence: "working",
+      tags: [],
+      applies_to: [],
+      supersedes: [],
+      conflicts_with: [],
+      recall_count: 0,
+      usefulness_score: 0,
+      status: over.status ?? "active",
+      is_global: false,
+      requires_approval: false,
+      created_at: "2026-06-01T00:00:00.000Z",
+      updated_at: "2026-06-01T00:00:00.000Z",
+      curator_note: null,
+    };
+    vault.writeText(`memories/${memory.id}.md`, serializeMemoryDocument(memory));
+    return memory;
+  };
+  return { vault, store, seed };
+}
+
+describe("markdown MemoryStore — agent-id queries", () => {
+  it("countMemoriesByAgentId groups counts per agent", () => {
+    const { store, seed } = setup();
+    seed({ id: "a", agent_id: "claude" });
+    seed({ id: "b", agent_id: "claude" });
+    seed({ id: "c", agent_id: "codex" });
+    const counts = store.countMemoriesByAgentId();
+    expect(counts.find((c) => c.agent_id === "claude")!.count).toBe(2);
+    expect(counts.find((c) => c.agent_id === "codex")!.count).toBe(1);
+  });
+
+  it("listMemoryIdsByAgentId returns exactly the ids for one agent", () => {
+    const { store, seed } = setup();
+    seed({ id: "a", agent_id: "claude" });
+    seed({ id: "b", agent_id: "claude" });
+    seed({ id: "c", agent_id: "codex" });
+    expect(store.listMemoryIdsByAgentId("claude").sort()).toEqual(["a", "b"]);
+    expect(store.listMemoryIdsByAgentId("codex")).toEqual(["c"]);
+    expect(store.listMemoryIdsByAgentId("nobody")).toEqual([]);
+  });
+});
+
+describe("markdown MemoryStore — bulkUpdateMemory", () => {
+  it("re-homes agent_id/project_key across a set and reports the count", () => {
+    const { store, seed } = setup();
+    seed({ id: "a", agent_id: "codex", project_key: "old" });
+    seed({ id: "b", agent_id: "codex", project_key: "old" });
+    const result = store.bulkUpdateMemory({
+      ids: ["a", "b", "ghost"],
+      patch: { project_key: "new" },
+    });
+    expect(result.transaction_id).toMatch(/^txn_/);
+    expect(result.updated).toBe(2); // ghost skipped
+    expect(store.getMemory("a")!.project_key).toBe("new");
+    expect(store.getMemory("b")!.project_key).toBe("new");
+  });
+
+  it("throws on an empty patch", () => {
+    const { store } = setup();
+    expect(() => store.bulkUpdateMemory({ ids: ["a"], patch: {} })).toThrow(/at least one/);
+  });
+});
+
+describe("markdown MemoryStore — distinctValues", () => {
+  it("returns deduped, case-insensitively-sorted values, excluding archived", () => {
+    const { store, seed } = setup();
+    seed({ id: "a", agent_id: "Bob" });
+    seed({ id: "b", agent_id: "alice" });
+    seed({ id: "c", agent_id: "alice" });
+    seed({ id: "d", agent_id: "zed", status: "archived" });
+    expect(store.distinctValues({ field: "agent_id" })).toEqual(["alice", "Bob"]);
+    expect(store.distinctValues({ field: "agent_id", include_archived: true })).toEqual([
+      "alice",
+      "Bob",
+      "zed",
+    ]);
+  });
+
+  it("rejects a field outside the whitelist", () => {
+    const { store } = setup();
+    expect(() => store.distinctValues({ field: "title" })).toThrow(/not allowed/);
+  });
+});
+
+describe("markdown MemoryStore — recordRecall", () => {
+  it("is a no-op (recall tracking is retired in the markdown model)", () => {
+    const { store, seed } = setup();
+    const memory = seed({ id: "a" });
+    expect(() => store.recordRecall([memory], "codex", "q")).not.toThrow();
+    expect(store.recordRecall([], "codex", "q")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Plan 036 **Phase 2** — the remaining markdown `MemoryStore` domain methods. This completes the store's domain surface (everything except the ledger `appendEvent`/`listEvents`, which are out of markdown parity — git history replaces the ledger).

- **`recordRecall`** — no-op (D16 retires recall-count tracking + the recall event ledger; relevance comes from the index).
- **`bulkUpdateMemory`** — patch whitelisted to `agent_id`/`project_key`, applied per id (unknown skipped), bumps `updated_at`, returns `{transaction_id, updated}`; throws on empty patch.
- **`distinctValues`** — whitelisted `agent_id`/`project_key`, excludes archived, case-insensitively sorted (SQLite `COLLATE NOCASE` parity).
- **`countMemoriesByAgentId` / `listMemoryIdsByAgentId`** — the caller-backfill read seam (F0).

## Review

A review sub-agent confirmed **parity holds** for all five against the SQLite implementations + the projection `BulkUpdated` case (whitelist tightness, NOCASE sort, archived exclusion, order-independence vs the shared tests). It surfaced one **forward-looking** item (tracked in notes, not this PR): when the markdown store is wired in at the parity gate, the `memories.events` `recall_empty` assertion in `trpc/memories.test.ts` will need rewriting, since `recordRecall` is a no-op and there's no `listEvents` — expected, as the ledger is retired.

## Scope

Not wired into `createLibrarianStore` — SQLite stays the live backend, **no user-visible change**. Next: `startContext`, then the `LibrarianStore` wiring (the parity gate).

## Verification

- New `markdown-memory-utils` suite (7 tests); whole core suite green (605).
- `pnpm -r typecheck` + `pnpm run lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)