### PR TITLE
feat(markdown): startContext + extract context-package helpers (Phase 2)

### DIFF
--- a/packages/core/src/store/markdown/markdown-memory-store.ts
+++ b/packages/core/src/store/markdown/markdown-memory-store.ts
@@ -21,6 +21,7 @@ import {
 } from "../../constants.js";
 import { MemoryStatus, VerifyResult } from "../../schemas/common.js";
 import type { Vault } from "../corpus/vault.js";
+import { formatContextPackage, uniqueById } from "../memory-context.js";
 import { cleanPatch } from "../memory-patch.js";
 import { routeMemoryWrite } from "../memory-routing.js";
 import type { Memory } from "../memory-store.js";
@@ -420,6 +421,41 @@ export function createMarkdownMemoryStore(deps: MarkdownMemoryStoreDeps) {
       .map((memory) => memory.id);
   }
 
+  function startContext(
+    input: { agent_id?: string; project_key?: string; task_summary?: string } = {},
+  ) {
+    const { agent_id = DEFAULT_AGENT_ID, project_key = "", task_summary = "" } = input;
+    const globals = listAll({ status: MemoryStatus.Active, is_global: true });
+    const privateMemories = searchMemories({
+      agent_id,
+      query: task_summary || project_key || agent_id,
+      project_key,
+      include_private: true,
+      limit: 6,
+    }).filter((memory) => memory.agent_id === agent_id);
+    const relevant =
+      task_summary || project_key
+        ? searchMemories({
+            agent_id,
+            query: `${task_summary} ${project_key}`,
+            project_key,
+            include_private: true,
+            limit: 8,
+          })
+        : [];
+    const memories = uniqueById([...globals, ...privateMemories, ...relevant]);
+    recordRecall(memories, agent_id, task_summary || "start_context");
+    return {
+      memories,
+      text: formatContextPackage({
+        identity: globals,
+        relationship: [],
+        privateMemories,
+        relevant,
+      }),
+    };
+  }
+
   return {
     createMemory,
     getMemory,
@@ -438,5 +474,6 @@ export function createMarkdownMemoryStore(deps: MarkdownMemoryStoreDeps) {
     distinctValues,
     countMemoriesByAgentId,
     listMemoryIdsByAgentId,
+    startContext,
   };
 }

--- a/packages/core/src/store/memory-context.ts
+++ b/packages/core/src/store/memory-context.ts
@@ -1,0 +1,49 @@
+// start_context presentation helpers — storage-agnostic, shared by the
+// SQLite and markdown backends (plan 036 Phase 2). Dedup-by-id and the
+// prose context package the `start_context` verb returns. Extracted from
+// memory-store.ts so both backends render identical output.
+
+import type { Memory } from "./memory-store.js";
+
+/** Dedup a memory list by id, preserving first-seen order. */
+export function uniqueById(memories: Memory[]): Memory[] {
+  const seen = new Set<string>();
+  const output: Memory[] = [];
+  for (const memory of memories) {
+    if (!memory || seen.has(memory.id)) continue;
+    seen.add(memory.id);
+    output.push(memory);
+  }
+  return output;
+}
+
+/** Render the start_context prose package (Identity / Relationship / notes / relevant). */
+export function formatContextPackage({
+  identity,
+  relationship,
+  privateMemories,
+  relevant,
+}: {
+  identity: Memory[];
+  relationship: Memory[];
+  privateMemories: Memory[];
+  relevant: Memory[];
+}): string {
+  const sections: string[] = [];
+  sections.push("Memory Context");
+  sections.push("");
+  sections.push(formatSection("Identity", identity));
+  sections.push(formatSection("Relationship", relationship));
+  if (privateMemories.length)
+    sections.push(formatSection("Agent Operating Notes", privateMemories));
+  if (relevant.length) sections.push(formatSection("Relevant Working Context", relevant));
+  return (
+    sections.filter(Boolean).join("\n\n").trim() ||
+    "Memory Context\n\nNo active memories found yet."
+  );
+}
+
+function formatSection(title: string, memories: Memory[]): string {
+  if (!memories.length) return `${title}\nNo active memories found.`;
+  return `${title}\n${memories.map((memory) => `- ${memory.title}: ${memory.body}`).join("\n")}`;
+}

--- a/packages/core/src/store/memory-store.ts
+++ b/packages/core/src/store/memory-store.ts
@@ -20,6 +20,7 @@ import {
 } from "../constants.js";
 import { MemoryEventType, MemoryStatus } from "../schemas/common.js";
 import { appendJsonl, readJsonl } from "./jsonl.js";
+import { formatContextPackage, uniqueById } from "./memory-context.js";
 import { cleanPatch } from "./memory-patch.js";
 import { routeMemoryWrite } from "./memory-routing.js";
 import { tokenize } from "./memory-tokenize.js";
@@ -877,45 +878,4 @@ function safeJsonParseObject(
     );
     return null;
   }
-}
-
-function uniqueById(memories: Memory[]): Memory[] {
-  const seen = new Set<string>();
-  const output: Memory[] = [];
-  for (const memory of memories) {
-    if (!memory || seen.has(memory.id)) continue;
-    seen.add(memory.id);
-    output.push(memory);
-  }
-  return output;
-}
-
-function formatContextPackage({
-  identity,
-  relationship,
-  privateMemories,
-  relevant,
-}: {
-  identity: Memory[];
-  relationship: Memory[];
-  privateMemories: Memory[];
-  relevant: Memory[];
-}): string {
-  const sections: string[] = [];
-  sections.push("Memory Context");
-  sections.push("");
-  sections.push(formatSection("Identity", identity));
-  sections.push(formatSection("Relationship", relationship));
-  if (privateMemories.length)
-    sections.push(formatSection("Agent Operating Notes", privateMemories));
-  if (relevant.length) sections.push(formatSection("Relevant Working Context", relevant));
-  return (
-    sections.filter(Boolean).join("\n\n").trim() ||
-    "Memory Context\n\nNo active memories found yet."
-  );
-}
-
-function formatSection(title: string, memories: Memory[]): string {
-  if (!memories.length) return `${title}\nNo active memories found.`;
-  return `${title}\n${memories.map((memory) => `- ${memory.title}: ${memory.body}`).join("\n")}`;
 }

--- a/packages/core/tests/store/markdown/markdown-memory-context.test.ts
+++ b/packages/core/tests/store/markdown/markdown-memory-context.test.ts
@@ -1,0 +1,89 @@
+// Markdown MemoryStore — startContext (plan 036 Phase 2). Composes
+// is_global "Identity" memories + the agent's private + a query-relevant
+// slice into the shared context-package prose, parity with the SQLite store.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type Memory,
+  createMarkdownMemoryStore,
+  createVault,
+  serializeMemoryDocument,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-md-ctx-"));
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+function setup() {
+  const vault = createVault({ dataDir });
+  const store = createMarkdownMemoryStore({ vault });
+  const seed = (over: Partial<Memory> & { id: string }): Memory => {
+    const memory: Memory = {
+      id: over.id,
+      title: over.title ?? over.id,
+      body: over.body ?? "body",
+      agent_id: over.agent_id ?? "codex",
+      project_key: over.project_key ?? null,
+      priority: "normal",
+      confidence: "working",
+      tags: [],
+      applies_to: [],
+      supersedes: [],
+      conflicts_with: [],
+      recall_count: 0,
+      usefulness_score: 0,
+      status: over.status ?? "active",
+      is_global: over.is_global ?? false,
+      requires_approval: false,
+      created_at: "2026-06-01T00:00:00.000Z",
+      updated_at: "2026-06-01T00:00:00.000Z",
+      curator_note: null,
+    };
+    vault.writeText(`memories/${memory.id}.md`, serializeMemoryDocument(memory));
+    return memory;
+  };
+  return { vault, store, seed };
+}
+
+describe("markdown MemoryStore — startContext", () => {
+  it("surfaces the Identity section (all active memories — listAll's is_global filter is a no-op)", () => {
+    // Parity quirk faithfully replicated from the SQLite store: startContext
+    // calls listAll({ is_global: true }), but listAll only filters
+    // status/agent_id/project_key — the is_global axis is ignored — so the
+    // "Identity" section is really every active memory, not just globals.
+    const { store, seed } = setup();
+    seed({ id: "g", title: "Owner is Jim", body: "Jim owns this.", is_global: true });
+    seed({ id: "n", title: "non-global", body: "ordinary", is_global: false });
+    const result = store.startContext({ agent_id: "codex" });
+    expect(result.memories.map((m) => m.id).sort()).toEqual(["g", "n"]);
+    expect(result.text).toContain("Identity");
+    expect(result.text).toContain("Owner is Jim: Jim owns this.");
+  });
+
+  it("includes a query-relevant slice for a task summary", () => {
+    const { store, seed } = setup();
+    seed({ id: "dep", title: "deploy command", body: "run pnpm deploy", agent_id: "codex" });
+    const result = store.startContext({ agent_id: "codex", task_summary: "deploy" });
+    expect(result.memories.map((m) => m.id)).toContain("dep");
+    expect(result.text).toContain("Relevant Working Context");
+  });
+
+  it("returns the empty package when there are no memories", () => {
+    const { store } = setup();
+    const result = store.startContext({ agent_id: "codex" });
+    expect(result.memories).toEqual([]);
+    // Parity with SQLite: the Identity/Relationship sections always render,
+    // each with the per-section "No active memories found." line.
+    expect(result.text).toContain("Identity");
+    expect(result.text).toContain("No active memories found.");
+  });
+});


### PR DESCRIPTION
## What

Plan 036 **Phase 2** — the last markdown `MemoryStore` domain method. `startContext` composes the is_global "Identity" memories + the agent's private slice + a query-relevant slice (via `listAll` + `searchMemories`), dedups, and renders the shared context-package prose — parity with the SQLite store.

Extracts the storage-agnostic presentation helpers (`uniqueById`, `formatContextPackage` + `formatSection`) into `store/memory-context.ts` so both backends render byte-identical `start_context` output; `memory-store.ts` imports them.

**This completes the markdown store's domain method surface** — every `MemoryStore` method except the ledger `appendEvent`/`listEvents` (retired in the markdown model; git history replaces them).

## Review

A review sub-agent confirmed: the helper extraction is byte-identical (SQLite suite + the mcp `start_context` test still green → behaviour preserved), `startContext` matches the SQLite composition exactly, the no-op `recordRecall` is transparent here, and the type-only `Memory` import avoids a runtime cycle (`memory-context.js` emits zero imports). It flagged that `listAll({is_global:true})` **silently ignores** the `is_global` filter in *both* stores (listAll only filters status/agent_id/project_key), so the "Identity" section is really all active memories — a pre-existing SQLite quirk faithfully replicated. Fixed the test to document and assert that honestly (worth revisiting when `is_global` semantics are reworked in Phase 4).

## Scope

Not wired into `createLibrarianStore` — SQLite stays the live backend, **no user-visible change**. Next: wire the markdown store behind `createLibrarianStore` for the parity gate (the ledger/`memories.events` recall tests get rewritten there).

## Verification

- New `markdown-memory-context` suite (3 tests); core 608 + mcp-server 131 green.
- `pnpm -r typecheck` + `pnpm run lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)