### PR TITLE
feat(git): synchronous git-ops for the markdown store's commit-per-write (Phase 2)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -174,7 +174,7 @@ export {
   resolveVaultPath,
   serializeDocument,
 } from "./store/corpus/index.js";
-export { type GitOps, createGitOps } from "./store/git/index.js";
+export { type GitOps, type SyncGitOps, createGitOps, createSyncGitOps } from "./store/git/index.js";
 export {
   type MarkdownMemoryStoreDeps,
   createMarkdownMemoryStore,

--- a/packages/core/src/store/git/index.ts
+++ b/packages/core/src/store/git/index.ts
@@ -2,3 +2,4 @@
 // in Phase 7). Spec 035 §F12.
 
 export { type GitOps, createGitOps } from "./git-ops.js";
+export { type SyncGitOps, createSyncGitOps } from "./sync-git-ops.js";

--- a/packages/core/src/store/git/sync-git-ops.ts
+++ b/packages/core/src/store/git/sync-git-ops.ts
@@ -1,0 +1,82 @@
+// Synchronous git-ops for the markdown MemoryStore's commit-per-write path
+// (spec 035 §F12). The store is sync (the storage-agnostic verb tests are
+// sync), so it can't await the simple-git service (#220, which serves the
+// async consolidator / dashboard / backup). This is the same contract,
+// shelling out to `git` synchronously via child_process.
+//
+// A fallback commit identity is configured locally (only when none is set)
+// so headless / CI commits never fail.
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+
+export interface SyncGitOps {
+  /** Idempotently `git init` the repo + ensure a commit identity exists. */
+  init(): void;
+  /**
+   * Stage everything (incl. deletions) and commit. Returns the new HEAD
+   * hash, or `null` when there was nothing to commit (no empty commits).
+   */
+  commitAll(message: string): string | null;
+  /** Current HEAD hash, or `null` on a repo with no commits yet. */
+  head(): string | null;
+  /** Commit subjects, newest first (empty on a repo with no commits). */
+  log(): string[];
+  isRepo(): boolean;
+}
+
+export function createSyncGitOps(opts: { cwd: string }): SyncGitOps {
+  fs.mkdirSync(opts.cwd, { recursive: true });
+
+  const git = (args: string[]): string =>
+    // stderr piped (not inherited) so routine git noise — `init` branch
+    // hints, the pre-init `rev-parse` "fatal: not a git repository" probe —
+    // stays off the console; on failure it's still attached to the thrown
+    // error's `.stderr`.
+    execFileSync("git", args, {
+      cwd: opts.cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  const tryGit = (args: string[]): string | null => {
+    try {
+      return git(args);
+    } catch {
+      return null;
+    }
+  };
+
+  function isRepo(): boolean {
+    return tryGit(["rev-parse", "--is-inside-work-tree"])?.trim() === "true";
+  }
+
+  function ensureIdentity(): void {
+    if (tryGit(["config", "user.email"])?.trim()) return;
+    git(["config", "user.email", "librarian@localhost"]);
+    git(["config", "user.name", "The Librarian"]);
+  }
+
+  function init(): void {
+    if (!isRepo()) git(["init"]);
+    ensureIdentity();
+  }
+
+  function commitAll(message: string): string | null {
+    git(["add", "-A"]);
+    if (!(tryGit(["status", "--porcelain"]) ?? "").trim()) return null;
+    git(["commit", "-m", message]);
+    return head();
+  }
+
+  function head(): string | null {
+    return tryGit(["rev-parse", "HEAD"])?.trim() ?? null;
+  }
+
+  function log(): string[] {
+    const out = tryGit(["log", "--format=%s"]);
+    if (out === null) return []; // no commits yet
+    return out.split("\n").filter((line) => line.length > 0);
+  }
+
+  return { init, commitAll, head, log, isRepo };
+}

--- a/packages/core/tests/store/git/sync-git-ops.test.ts
+++ b/packages/core/tests/store/git/sync-git-ops.test.ts
@@ -1,0 +1,75 @@
+// Sync git-ops tests (spec 035 §F12 — Phase 2). The markdown MemoryStore is
+// SYNC (the storage-agnostic verb tests are sync), so its commit-per-write
+// path needs a SYNCHRONOUS git committer (the simple-git service #220 is
+// async, for the consolidator/dashboard/backup). Same contract as the async
+// one — idempotent init, commit-per-op, no empty commits, deletions staged.
+// Runs real `git` via child_process.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createSyncGitOps } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let cwd: string;
+
+beforeEach(() => {
+  cwd = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-syncgit-"));
+});
+
+afterEach(() => {
+  fs.rmSync(cwd, { recursive: true, force: true });
+});
+
+const write = (rel: string, content: string): void => {
+  const abs = path.join(cwd, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content, "utf8");
+};
+
+describe("sync git-ops", () => {
+  it("init creates a repo and is idempotent", () => {
+    const git = createSyncGitOps({ cwd });
+    expect(git.isRepo()).toBe(false);
+    git.init();
+    expect(git.isRepo()).toBe(true);
+    git.init();
+    expect(git.isRepo()).toBe(true);
+  });
+
+  it("head is null and log empty on a fresh repo", () => {
+    const git = createSyncGitOps({ cwd });
+    git.init();
+    expect(git.head()).toBeNull();
+    expect(git.log()).toEqual([]);
+  });
+
+  it("commitAll commits new files and records the message", () => {
+    const git = createSyncGitOps({ cwd });
+    git.init();
+    write("memories/anna.md", "# Anna\n");
+    const hash = git.commitAll("memory: store anna");
+    expect(hash).toMatch(/^[0-9a-f]{7,40}$/);
+    expect(git.head()).toBe(hash);
+    expect(git.log()).toEqual(["memory: store anna"]);
+  });
+
+  it("commitAll is a no-op (null) when nothing changed", () => {
+    const git = createSyncGitOps({ cwd });
+    git.init();
+    write("a.md", "x\n");
+    git.commitAll("first");
+    expect(git.commitAll("second")).toBeNull();
+    expect(git.log()).toEqual(["first"]);
+  });
+
+  it("records successive changes newest-first and stages deletions", () => {
+    const git = createSyncGitOps({ cwd });
+    git.init();
+    write("a.md", "one\n");
+    git.commitAll("add a");
+    fs.rmSync(path.join(cwd, "a.md"));
+    git.commitAll("remove a");
+    expect(git.log()).toEqual(["remove a", "add a"]);
+  });
+});

--- a/packages/core/tests/store/markdown/markdown-store-git.test.ts
+++ b/packages/core/tests/store/markdown/markdown-store-git.test.ts
@@ -1,0 +1,68 @@
+// Integration: the markdown MemoryStore commits per write (spec 035 §F1 /
+// plan 036 Phase 2 — "a remember produces a markdown file + a commit").
+// Wires the store to the sync git committer over the vault repo and asserts
+// each write lands a file AND a git commit.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createMarkdownMemoryStore, createSyncGitOps, createVault } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-md-git-"));
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+function setup() {
+  const vault = createVault({ dataDir });
+  const git = createSyncGitOps({ cwd: vault.root });
+  git.init();
+  let counter = 0;
+  const store = createMarkdownMemoryStore({
+    vault,
+    commit: (message) => git.commitAll(message),
+    generateId: () => `mem_g${++counter}`,
+  });
+  return { vault, git, store };
+}
+
+describe("markdown store + git — commit per write", () => {
+  it("createMemory writes a markdown file AND records a commit", () => {
+    const { vault, git, store } = setup();
+    const { memory } = store.createMemory({
+      agent_id: "codex",
+      title: "Use pnpm",
+      body: "Always pnpm.",
+    });
+    expect(fs.existsSync(path.join(vault.root, `memories/${memory.id}.md`))).toBe(true);
+    expect(git.head()).toMatch(/^[0-9a-f]{7,40}$/);
+    expect(git.log()).toEqual([`memory: store ${memory.id}`]);
+  });
+
+  it("a proposed write commits with the propose verb", () => {
+    const { git, store } = setup();
+    const { memory } = store.createMemory(
+      { agent_id: "codex", title: "Owner", body: "Jim owns this." },
+      { requires_approval: true },
+    );
+    expect(git.log()).toEqual([`memory: propose ${memory.id}`]);
+  });
+
+  it("each mutation lands its own commit, newest first", () => {
+    const { git, store } = setup();
+    const { memory } = store.createMemory({ agent_id: "codex", title: "t", body: "b" });
+    store.updateMemory(memory.id, { body: "edited" });
+    store.archiveMemory(memory.id);
+    expect(git.log()).toEqual([
+      `memory: archive ${memory.id}`,
+      `memory: update ${memory.id}`,
+      `memory: store ${memory.id}`,
+    ]);
+  });
+});


### PR DESCRIPTION
## What

Plan 036 **Phase 2** — proves the *"`remember` produces a markdown file **+ a commit**"* parity criterion. Adds `packages/core/src/store/git/sync-git-ops.ts` (`createSyncGitOps`): a **synchronous** git committer (`execFileSync`) mirroring the async `simple-git` service (#220) — `init` (idempotent + fallback identity), `commitAll` (stage incl. deletions; `null` on no-op), `head`/`log`/`isRepo`.

The markdown `MemoryStore` is sync (the storage-agnostic verb tests are sync), so its commit-per-write path needs a sync committer; the async service stays for the consolidator / dashboard / backup.

An integration test wires the markdown store to the sync committer over the vault repo and asserts each write lands a **file AND a commit** (store / propose / update / archive each produce their own commit, newest-first).

## Review

A review sub-agent confirmed: **behavioural parity with the async service is exact**; command/option injection is genuinely prevented (array-arg `execFileSync`, `message` only ever the value of `-m`, no shell, and the message is app-constructed from verb+id, not memory content); commit failures propagate (the `add`/`commit` calls throw, only the expected `isRepo`/`head`/`log`/status probes swallow). Actioned its noise suggestion: stderr is now piped (captured, not inherited), so routine `git init` hints and the pre-init `rev-parse` "fatal" probe no longer leak to the console, while remaining attached to the thrown error on failure (verified: 0 git stderr lines in the test run after the fix).

## Scope

Not wired into `createLibrarianStore` — **no user-visible change**. Next: the `createLibrarianStore` markdown-backend wiring (the parity gate).

## Verification

- New `sync-git-ops` (5) + `markdown-store-git` integration (3) suites; core 616 green.
- `pnpm -r typecheck` + `pnpm run lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)