### PR TITLE
feat(markdown): markdown store conforms to MemoryStore (Phase 2 parity gate)

### DIFF
--- a/packages/core/src/store/markdown/markdown-memory-store.ts
+++ b/packages/core/src/store/markdown/markdown-memory-store.ts
@@ -24,7 +24,7 @@ import type { Vault } from "../corpus/vault.js";
 import { formatContextPackage, uniqueById } from "../memory-context.js";
 import { cleanPatch } from "../memory-patch.js";
 import { routeMemoryWrite } from "../memory-routing.js";
-import type { Memory } from "../memory-store.js";
+import type { Memory, MemoryEvent, MemoryStore } from "../memory-store.js";
 import { tokenize } from "../memory-tokenize.js";
 import { parseMemoryDocument, serializeMemoryDocument } from "./memory-doc.js";
 
@@ -50,11 +50,27 @@ function cmpStr(a: string, b: string): number {
   return a < b ? -1 : a > b ? 1 : 0;
 }
 
-export function createMarkdownMemoryStore(deps: MarkdownMemoryStoreDeps) {
+const LEDGER_RETIRED =
+  "event ledger is retired in the markdown backend — git history is the audit trail";
+
+export function createMarkdownMemoryStore(deps: MarkdownMemoryStoreDeps): MemoryStore {
   const { vault } = deps;
   const now = deps.now ?? nowIso;
   const generateId = deps.generateId ?? (() => makeId("mem"));
   const commit = deps.commit ?? (() => {});
+
+  // The append-only event ledger is retired in the markdown model — every
+  // write is a git commit, so git history is the audit trail. These two
+  // members exist only to satisfy the `MemoryStore` interface; nothing on
+  // the markdown write path calls them, and the SQLite-era ledger consumers
+  // (dashboard logs view, etc.) are rewired to git history at the Phase-7
+  // cutover. They fail loudly so a stray ledger dependency surfaces.
+  function appendEvent(): MemoryEvent {
+    throw new Error(LEDGER_RETIRED);
+  }
+  function listEvents(): { events: MemoryEvent[]; total: number; limit: number; offset: number } {
+    throw new Error(LEDGER_RETIRED);
+  }
 
   function createMemory(input: Record<string, unknown>, options: Record<string, unknown> = {}) {
     const normalized = normalizeMemoryInput(input);
@@ -90,7 +106,15 @@ export function createMarkdownMemoryStore(deps: MarkdownMemoryStoreDeps) {
     const related = detectRelated(memory);
     vault.writeText(memoryPath(memory.id), serializeMemoryDocument(memory));
     commit(`memory: ${status === MemoryStatus.Proposed ? "propose" : "store"} ${memory.id}`);
-    return { status, memory, duplicates: related.duplicates };
+    // Narrow to the interface's active|proposed return shape — the same cast
+    // the SQLite createMemory makes over the identical normalize+route
+    // pipeline. (A caller force-passing options.status: "archived" is the lone
+    // edge, shared with SQLite; real callers pass nothing or "proposed".)
+    return {
+      status: status as MemoryStatus.Active | MemoryStatus.Proposed,
+      memory,
+      duplicates: related.duplicates,
+    };
   }
 
   function getMemory(id: string): Memory | null {
@@ -475,5 +499,7 @@ export function createMarkdownMemoryStore(deps: MarkdownMemoryStoreDeps) {
     countMemoriesByAgentId,
     listMemoryIdsByAgentId,
     startContext,
+    appendEvent,
+    listEvents,
   };
 }

--- a/packages/core/tests/store/markdown/markdown-memory-parity.test.ts
+++ b/packages/core/tests/store/markdown/markdown-memory-parity.test.ts
@@ -1,0 +1,64 @@
+// Parity gate (plan 036 Phase 2): the markdown backend IS a MemoryStore.
+//
+// `createMarkdownMemoryStore` is typed `: MemoryStore`, so the compiler
+// already enforces full interface conformance (all 20 methods, exact
+// signatures). This test exercises the core verb contract through a
+// `MemoryStore`-typed reference (no markdown-specific surface) and pins the
+// retired-ledger boundary — git history replaces appendEvent/listEvents.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createMarkdownMemoryStore, createVault } from "@librarian/core";
+import type { MemoryStore } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-md-parity-"));
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("markdown backend — MemoryStore parity", () => {
+  it("runs the create → recall → verify → archive verb contract via the MemoryStore surface", () => {
+    // Typed as the interface — only MemoryStore methods are in scope here.
+    const store: MemoryStore = createMarkdownMemoryStore({ vault: createVault({ dataDir }) });
+
+    const { status, memory } = store.createMemory({
+      agent_id: "codex",
+      title: "Use pnpm",
+      body: "Always pnpm, never npm.",
+      tags: ["tooling"],
+    });
+    expect(status).toBe("active");
+
+    expect(store.getMemory(memory.id)?.title).toBe("Use pnpm");
+    expect(store.searchMemories({ query: "pnpm" }).map((m) => m.id)).toContain(memory.id);
+
+    expect(store.verifyMemory(memory.id, "useful")?.usefulness_score).toBe(1);
+
+    store.archiveMemory(memory.id);
+    expect(store.searchMemories({ query: "pnpm" })).toEqual([]);
+    expect(store.getMemory(memory.id)?.status).toBe("archived");
+  });
+
+  it("routes a protected write to the proposal flow and back to active on approve", () => {
+    const store: MemoryStore = createMarkdownMemoryStore({ vault: createVault({ dataDir }) });
+    const { status, memory } = store.createMemory(
+      { agent_id: "codex", title: "Owner", body: "Jim owns this." },
+      { requires_approval: true },
+    );
+    expect(status).toBe("proposed");
+    expect(store.approveProposal(memory.id)?.status).toBe("active");
+  });
+
+  it("exposes the retired event-ledger methods but they throw (git history is the audit trail)", () => {
+    const store: MemoryStore = createMarkdownMemoryStore({ vault: createVault({ dataDir }) });
+    expect(() => store.appendEvent("memory.created", {})).toThrow(/retired/);
+    expect(() => store.listEvents()).toThrow(/retired/);
+  });
+});


### PR DESCRIPTION
## What

Plan 036 **Phase 2 — the MemoryStore parity-gate capstone.** Types `createMarkdownMemoryStore` as `: MemoryStore`, so the **compiler now enforces full interface conformance** (all 20 methods, exact signatures). Adds the retired event-ledger members (`appendEvent`/`listEvents`) as **throwing stubs** — every write is a git commit, so git history is the audit trail; the SQLite-era ledger consumers (dashboard logs view, etc.) get rewired to git history at the Phase-7 cutover, and the stubs fail loudly so any stray ledger dependency surfaces.

A parity test runs the `create → recall → verify → archive` + protected-proposal verb contract through a **`MemoryStore`-typed reference** (only interface methods reachable), proving the markdown backend satisfies the storage-agnostic contract, and pins the retired-ledger boundary.

**The markdown `MemoryStore` is now feature-complete and interface-conformant.**

## Review

A review sub-agent confirmed the `: MemoryStore` conformance is **genuine** (`tsc` clean, no `any`, no loosened signatures); the one new cast (`status as Active|Proposed`) is byte-identical to the SQLite `createMemory` cast over the same normalize+route pipeline (pre-existing parity, not a new lie — tightened the comment to say so); nothing on the markdown write paths calls the throwing stubs; and the parity test genuinely exercises the interface surface.

## Scope

Not wired as the `createLibrarianStore` default — SQLite stays the live backend until the Phase-7 cutover — so **no user-visible change**.

## Verification

- New `markdown-memory-parity` suite (3 tests); whole markdown suite + core green (619).
- `pnpm -r typecheck` (`: MemoryStore` conformance) + `pnpm run lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)