### PR TITLE
feat(markdown): handoff ↔ document mapping (F9, Phase 2)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -178,7 +178,9 @@ export { type GitOps, type SyncGitOps, createGitOps, createSyncGitOps } from "./
 export {
   type MarkdownMemoryStoreDeps,
   createMarkdownMemoryStore,
+  parseHandoffDocument,
   parseMemoryDocument,
+  serializeHandoffDocument,
   serializeMemoryDocument,
 } from "./store/markdown/index.js";
 export { type MemoryWriteVerdict, routeMemoryWrite } from "./store/memory-routing.js";

--- a/packages/core/src/store/markdown/handoff-doc.ts
+++ b/packages/core/src/store/markdown/handoff-doc.ts
@@ -1,0 +1,77 @@
+// Handoff <-> markdown-document mapping (plan 036 Phase 2 / spec 035 §F9).
+// A handoff is stored as `handoffs/<id>.md`: frontmatter metadata + the
+// 5-heading narrative body (the document_md). The cross-repo 5-heading
+// contract is preserved in the body verbatim; Zod heading validation stays
+// at the MCP boundary (schemas/handoff.ts), so this mapping is lossless and
+// doesn't re-validate structure.
+//
+// Deterministic frontmatter (fixed key order); parse coerces any YAML Date
+// back to an ISO string (js-yaml's implicit timestamp typing / hand edits).
+
+import matter from "gray-matter";
+import { z } from "zod";
+import { IsoTimestampSchema } from "../../schemas/common.js";
+import type { HandoffDetail } from "../handoff-store.js";
+
+const ClaimedBySchema = z
+  .object({
+    agent_id: z.string().nullable(),
+    harness: z.string().nullable(),
+    source_ref: z.string().nullable(),
+    cwd: z.string().nullable(),
+  })
+  .nullable();
+
+const HandoffFrontmatterSchema = z.object({
+  handoff_id: z.string().min(1),
+  title: z.string(),
+  project_key: z.string().nullable(),
+  source_ref: z.string().nullable(),
+  cwd: z.string().nullable(),
+  created_by_agent_id: z.string().nullable(),
+  created_in_harness: z.string().nullable(),
+  tags: z.array(z.string()),
+  created_at: IsoTimestampSchema,
+  claimed_at: IsoTimestampSchema.nullable(),
+  claimed_by: ClaimedBySchema,
+});
+
+/** Serialize a handoff to its markdown document form (frontmatter + body). */
+export function serializeHandoffDocument(handoff: HandoffDetail): string {
+  // Fixed key order → deterministic output → minimal git diffs.
+  const frontmatter = {
+    handoff_id: handoff.handoff_id,
+    title: handoff.title,
+    project_key: handoff.project_key,
+    source_ref: handoff.source_ref,
+    cwd: handoff.cwd,
+    created_by_agent_id: handoff.created_by_agent_id,
+    created_in_harness: handoff.created_in_harness,
+    tags: handoff.tags ?? [],
+    created_at: handoff.created_at,
+    claimed_at: handoff.claimed_at,
+    claimed_by: handoff.claimed_by ?? null,
+  };
+  return matter.stringify(handoff.document_md.trim(), frontmatter);
+}
+
+/** Parse a markdown document back into a `HandoffDetail`; teaching error on a bad shape. */
+export function parseHandoffDocument(raw: string): HandoffDetail {
+  const { data, content } = matter(raw);
+  const result = HandoffFrontmatterSchema.safeParse(coerceDates(data));
+  if (!result.success) {
+    const detail = result.error.issues
+      .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+      .join("; ");
+    throw new Error(`Invalid handoff document frontmatter: ${detail}`);
+  }
+  return { ...result.data, document_md: content.trim() };
+}
+
+function coerceDates(data: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(data)) {
+    out[key] = value instanceof Date ? value.toISOString() : value;
+  }
+  return out;
+}

--- a/packages/core/src/store/markdown/index.ts
+++ b/packages/core/src/store/markdown/index.ts
@@ -3,6 +3,7 @@
 // SQLite `memory-store.ts` at the Phase-7 cutover.
 
 export { parseMemoryDocument, serializeMemoryDocument } from "./memory-doc.js";
+export { parseHandoffDocument, serializeHandoffDocument } from "./handoff-doc.js";
 export {
   type MarkdownMemoryStoreDeps,
   createMarkdownMemoryStore,

--- a/packages/core/tests/store/markdown/handoff-doc.test.ts
+++ b/packages/core/tests/store/markdown/handoff-doc.test.ts
@@ -1,0 +1,85 @@
+// Handoff <-> markdown-document mapping tests (plan 036 Phase 2 / F9). A
+// handoff is stored as a markdown file: frontmatter metadata + the 5-heading
+// narrative body (the document_md, preserved verbatim — the cross-repo
+// 5-heading contract lives in that body). Lossless, deterministic round-trip
+// across all field types incl. the nested claimed_by object and nullables.
+
+import {
+  type HandoffDetail,
+  parseHandoffDocument,
+  serializeHandoffDocument,
+} from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+const handoff: HandoffDetail = {
+  handoff_id: "hdo_abc",
+  title: "Continue the migration",
+  document_md: [
+    "## Start & intent",
+    "do the thing.",
+    "",
+    "## Journey",
+    "tried X then Y. See [[the-librarian]].",
+    "",
+    "## Current state",
+    "green tests.",
+    "",
+    "## What's left",
+    "ship it.",
+    "",
+    "## Open questions",
+    "none.",
+  ].join("\n"),
+  project_key: "the-librarian",
+  source_ref: null,
+  cwd: "/repo",
+  created_by_agent_id: "agent-a",
+  created_in_harness: "claude-code",
+  tags: ["migration"],
+  created_at: "2026-06-01T09:00:00.000Z",
+  claimed_at: null,
+  claimed_by: null,
+};
+
+describe("handoff <-> document mapping", () => {
+  it("round-trips by value: parse(serialize(h)) deep-equals h", () => {
+    expect(parseHandoffDocument(serializeHandoffDocument(handoff))).toEqual(handoff);
+  });
+
+  it("round-trips byte-for-byte: serialize(parse(x)) === x", () => {
+    const x = serializeHandoffDocument(handoff);
+    expect(serializeHandoffDocument(parseHandoffDocument(x))).toBe(x);
+  });
+
+  it("preserves the 5-heading document body verbatim (incl. wikilinks)", () => {
+    const parsed = parseHandoffDocument(serializeHandoffDocument(handoff));
+    expect(parsed.document_md).toBe(handoff.document_md);
+    expect(parsed.document_md).toContain("[[the-librarian]]");
+  });
+
+  it("round-trips a claimed handoff with its nested claimed_by object", () => {
+    const claimed: HandoffDetail = {
+      ...handoff,
+      claimed_at: "2026-06-02T10:00:00.000Z",
+      claimed_by: { agent_id: "agent-b", harness: "codex", source_ref: null, cwd: null },
+    };
+    const parsed = parseHandoffDocument(serializeHandoffDocument(claimed));
+    expect(parsed.claimed_at).toBe("2026-06-02T10:00:00.000Z");
+    expect(parsed.claimed_by).toEqual({
+      agent_id: "agent-b",
+      harness: "codex",
+      source_ref: null,
+      cwd: null,
+    });
+  });
+
+  it("keeps timestamps as strings (not YAML Date)", () => {
+    const parsed = parseHandoffDocument(serializeHandoffDocument(handoff));
+    expect(typeof parsed.created_at).toBe("string");
+  });
+
+  it("rejects a document missing a required field, naming it", () => {
+    const raw = serializeHandoffDocument(handoff).replace(/^handoff_id:.*\n/m, "");
+    expect(() => parseHandoffDocument(raw)).toThrow(/handoff_id/);
+  });
+});


### PR DESCRIPTION
## What

Plan 036 **Phase 2 / spec 035 §F9** — first increment of handoffs-as-markdown. Adds `store/markdown/handoff-doc.ts`: lossless `serializeHandoffDocument` / `parseHandoffDocument` mapping a `HandoffDetail` to/from a `handoffs/<id>.md` file (frontmatter metadata + the **5-heading narrative body, preserved verbatim** — the cross-repo 5-heading contract lives in the body; Zod heading validation stays at the MCP boundary, so this mapping doesn't re-validate structure).

Deterministic frontmatter (fixed key order); `Date`→ISO coercion on read. Value + byte-stable round-trip across nullables and the nested `claimed_by` object.

This is the structural twin of the sub-agent-reviewed memory-doc mapping (#222) — same `gray-matter` + `coerceDates` + Zod + round-trip pattern; the only delta (nested `claimed_by` + dual `created_at`/`claimed_at` timestamps) is covered by the tests, so I self-reviewed against that precedent.

## Scope

Foundation for the markdown `HandoffStore` (store / getById / list / listDetails / purge + the filesystem-atomic claim) in following increments. Not wired in — **no user-visible change**.

## Verification

- New `handoff-doc` suite (6 tests): value + byte round-trip, 5-heading body verbatim (incl. wikilinks), claimed handoff with nested `claimed_by`, timestamps stay strings, teaching error on a missing field.
- `pnpm -r typecheck` + `pnpm run lint` green; core suite 625.

🤖 Generated with [Claude Code](https://claude.com/claude-code)