### PR TITLE
feat(markdown): vault-backed HandoffStore (F9, Phase 2)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -176,7 +176,9 @@ export {
 } from "./store/corpus/index.js";
 export { type GitOps, type SyncGitOps, createGitOps, createSyncGitOps } from "./store/git/index.js";
 export {
+  type MarkdownHandoffStoreDeps,
   type MarkdownMemoryStoreDeps,
+  createMarkdownHandoffStore,
   createMarkdownMemoryStore,
   parseHandoffDocument,
   parseMemoryDocument,

--- a/packages/core/src/store/corpus/vault.ts
+++ b/packages/core/src/store/corpus/vault.ts
@@ -49,6 +49,12 @@ export interface Vault {
   listMarkdown(subdir?: string): string[];
   /** Move a file within the vault — the archive=move (reversible) primitive. */
   moveFile(fromRel: string, toRel: string): void;
+  /**
+   * Hard-delete a file. The vault's rule is archive=move (never destroy
+   * knowledge); this is the narrow admin/test exception (e.g. handoff
+   * `purge`). Idempotent — a no-op when the file is absent.
+   */
+  removeFile(relPath: string): void;
   exists(relPath: string): boolean;
 }
 
@@ -124,6 +130,10 @@ export function createVault(options: VaultOptions = {}): Vault {
     fs.renameSync(absFrom, absTo);
   }
 
+  function removeFile(relPath: string): void {
+    fs.rmSync(within(relPath), { force: true });
+  }
+
   return {
     root,
     writeText,
@@ -134,6 +144,7 @@ export function createVault(options: VaultOptions = {}): Vault {
     tryReadDocument,
     listMarkdown,
     moveFile,
+    removeFile,
     exists,
   };
 }

--- a/packages/core/src/store/markdown/index.ts
+++ b/packages/core/src/store/markdown/index.ts
@@ -5,6 +5,10 @@
 export { parseMemoryDocument, serializeMemoryDocument } from "./memory-doc.js";
 export { parseHandoffDocument, serializeHandoffDocument } from "./handoff-doc.js";
 export {
+  type MarkdownHandoffStoreDeps,
+  createMarkdownHandoffStore,
+} from "./markdown-handoff-store.js";
+export {
   type MarkdownMemoryStoreDeps,
   createMarkdownMemoryStore,
 } from "./markdown-memory-store.js";

--- a/packages/core/src/store/markdown/markdown-handoff-store.ts
+++ b/packages/core/src/store/markdown/markdown-handoff-store.ts
@@ -1,0 +1,153 @@
+// Markdown-backed HandoffStore (plan 036 Phase 2 / spec 035 §F9). Each
+// handoff is `handoffs/<id>.md` (frontmatter + the 5-heading narrative).
+// Built behind the existing `HandoffStore` interface, parity-first; replaces
+// the SQLite handoff-store at the Phase-7 cutover.
+//
+// Sync (like the markdown MemoryStore) with an injected sync committer.
+
+import { makeId, nowIso } from "../../constants.js";
+import type {
+  ClaimHandoffInput,
+  ClaimHandoffOutput,
+  HandoffSummary,
+  ListHandoffsInput,
+  StoreHandoffInput,
+  StoreHandoffOutput,
+} from "../../schemas/handoff.js";
+import type { Vault } from "../corpus/vault.js";
+import {
+  type ClaimedBy,
+  type HandoffDetail,
+  type HandoffStore,
+  type ListHandoffsContext,
+  type StoreHandoffContext,
+  HandoffAlreadyClaimedError,
+  HandoffNotFoundError,
+} from "../handoff-store.js";
+import { parseHandoffDocument, serializeHandoffDocument } from "./handoff-doc.js";
+
+export interface MarkdownHandoffStoreDeps {
+  vault: Vault;
+  /** Sync commit-per-op (e.g. a synchronous git commit). Omit to skip committing. */
+  commit?: (message: string) => void;
+  now?: () => string;
+  generateId?: () => string;
+}
+
+function handoffPath(id: string): string {
+  return `handoffs/${id}.md`;
+}
+function cmpStr(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+export function createMarkdownHandoffStore(deps: MarkdownHandoffStoreDeps): HandoffStore {
+  const { vault } = deps;
+  const now = deps.now ?? nowIso;
+  const generateId = deps.generateId ?? (() => makeId("hdo"));
+  const commit = deps.commit ?? (() => {});
+
+  function getById(handoffId: string): HandoffDetail | null {
+    const raw = vault.tryReadText(handoffPath(handoffId));
+    return raw ? parseHandoffDocument(raw) : null;
+  }
+
+  function store(input: StoreHandoffInput, context: StoreHandoffContext): StoreHandoffOutput {
+    const id = generateId();
+    const createdAt = now();
+    const detail: HandoffDetail = {
+      handoff_id: id,
+      title: input.title,
+      document_md: input.document_md,
+      project_key: input.project_key ?? null,
+      source_ref: input.source_ref ?? null,
+      cwd: input.cwd ?? null,
+      created_by_agent_id: context.created_by_agent_id,
+      created_in_harness: input.harness ?? null,
+      tags: input.tags ?? [],
+      created_at: createdAt,
+      claimed_at: null,
+      claimed_by: null,
+    };
+    vault.writeText(handoffPath(id), serializeHandoffDocument(detail));
+    commit(`handoff: store ${id}`);
+    return { handoff_id: id, created_at: createdAt };
+  }
+
+  function queryDetails(input: ListHandoffsInput, context: ListHandoffsContext): HandoffDetail[] {
+    let docs = vault
+      .listMarkdown("handoffs")
+      .map((rel) => parseHandoffDocument(vault.readText(rel)));
+    if (!context.includeClaimed) docs = docs.filter((d) => d.claimed_at == null);
+    if (input.project_key != null) docs = docs.filter((d) => d.project_key === input.project_key);
+    if (input.cwd != null) docs = docs.filter((d) => d.cwd === input.cwd);
+    if (input.harness != null) docs = docs.filter((d) => d.created_in_harness === input.harness);
+    docs.sort((a, b) => cmpStr(b.created_at, a.created_at));
+    return docs.slice(0, input.limit ?? 20);
+  }
+
+  function list(input: ListHandoffsInput, context: ListHandoffsContext): HandoffSummary[] {
+    return queryDetails(input, context).map(toSummary);
+  }
+
+  function listDetails(input: ListHandoffsInput, context: ListHandoffsContext): HandoffDetail[] {
+    return queryDetails(input, context);
+  }
+
+  function claim(input: ClaimHandoffInput): ClaimHandoffOutput {
+    // The store is sync — read → check → write runs without a yield, so the
+    // claim is atomic within the single server process (no cross-process race
+    // to guard, unlike SQLite's BEGIN IMMEDIATE under multi-writer WAL).
+    const existing = getById(input.handoff_id);
+    if (!existing) throw new HandoffNotFoundError(input.handoff_id);
+    if (existing.claimed_at) {
+      throw new HandoffAlreadyClaimedError(
+        input.handoff_id,
+        existing.claimed_at,
+        existing.claimed_by,
+      );
+    }
+    const claimedAt = now();
+    const claimedBy: ClaimedBy = {
+      agent_id: input.claiming_agent_id ?? null,
+      harness: input.claiming_harness ?? null,
+      source_ref: input.claiming_source_ref ?? null,
+      cwd: input.claiming_cwd ?? null,
+    };
+    const updated: HandoffDetail = { ...existing, claimed_at: claimedAt, claimed_by: claimedBy };
+    vault.writeText(handoffPath(input.handoff_id), serializeHandoffDocument(updated));
+    commit(`handoff: claim ${input.handoff_id}`);
+    return {
+      handoff_id: updated.handoff_id,
+      title: updated.title,
+      document_md: updated.document_md,
+      created_by_agent_id: updated.created_by_agent_id,
+      created_in_harness: updated.created_in_harness,
+      created_at: updated.created_at,
+      claimed_at: claimedAt,
+    };
+  }
+
+  function purge(handoffId: string): boolean {
+    if (!vault.exists(handoffPath(handoffId))) return false;
+    vault.removeFile(handoffPath(handoffId));
+    commit(`handoff: purge ${handoffId}`);
+    return true;
+  }
+
+  return { store, list, listDetails, claim, getById, purge };
+}
+
+function toSummary(detail: HandoffDetail): HandoffSummary {
+  return {
+    handoff_id: detail.handoff_id,
+    title: detail.title,
+    project_key: detail.project_key,
+    source_ref: detail.source_ref,
+    cwd: detail.cwd,
+    created_in_harness: detail.created_in_harness,
+    created_by_agent_id: detail.created_by_agent_id,
+    created_at: detail.created_at,
+    tags: detail.tags,
+  };
+}

--- a/packages/core/tests/store/corpus/vault.test.ts
+++ b/packages/core/tests/store/corpus/vault.test.ts
@@ -94,6 +94,14 @@ describe("vault file I/O", () => {
     expect(vault.readDocument("archive/anna.md").frontmatter.id).toBe("anna");
   });
 
+  it("removeFile hard-deletes (the admin/purge exception) and is idempotent", () => {
+    const vault = createVault({ dataDir });
+    vault.writeDocument("people/anna.md", doc("anna"));
+    vault.removeFile("people/anna.md");
+    expect(vault.exists("people/anna.md")).toBe(false);
+    expect(() => vault.removeFile("people/anna.md")).not.toThrow();
+  });
+
   it("tryReadDocument returns null for a missing file; readDocument throws a teaching error", () => {
     const vault = createVault({ dataDir });
     expect(vault.tryReadDocument("ghost.md")).toBeNull();

--- a/packages/core/tests/store/markdown/markdown-handoff-store.test.ts
+++ b/packages/core/tests/store/markdown/markdown-handoff-store.test.ts
@@ -1,0 +1,158 @@
+// Markdown HandoffStore tests (plan 036 Phase 2 / spec 035 §F9). Mirrors the
+// SQLite handoff-store contract: store → list (unclaimed) → claim → list
+// (gone) → re-claim 409; 404 on unknown; project/cwd filtering; includeClaimed;
+// getById; purge. Each handoff is a `handoffs/<id>.md` file.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type HandoffStore,
+  HandoffAlreadyClaimedError,
+  HandoffNotFoundError,
+  createMarkdownHandoffStore,
+  createVault,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-md-handoff-"));
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+const validDoc = [
+  "## Start & intent",
+  "do the thing.",
+  "## Journey",
+  "tried X then Y.",
+  "## Current state",
+  "green tests.",
+  "## What's left",
+  "ship it.",
+  "## Open questions",
+  "none.",
+].join("\n\n");
+
+function setup() {
+  const vault = createVault({ dataDir });
+  let counter = 0;
+  const store: HandoffStore = createMarkdownHandoffStore({
+    vault,
+    generateId: () => `hdo_t${++counter}`,
+  });
+  const input = (over: Partial<{ project_key: string; cwd: string; harness: string }> = {}) => ({
+    title: "Continue the migration",
+    document_md: validDoc,
+    project_key: over.project_key ?? "proj-x",
+    cwd: over.cwd ?? "/repo",
+    harness: over.harness ?? "claude-code",
+    tags: ["migration"],
+  });
+  const ctx = (agent: string | null = "agent-a") => ({ created_by_agent_id: agent });
+  return { vault, store, input, ctx };
+}
+
+describe("markdown HandoffStore", () => {
+  it("stores → lists → claims → drops from the unclaimed list → re-claim 409", () => {
+    const { store, input, ctx } = setup();
+    const { handoff_id } = store.store(input(), ctx());
+
+    const listed = store.list({ project_key: "proj-x", cwd: "/repo" }, {});
+    expect(listed.map((h) => h.handoff_id)).toEqual([handoff_id]);
+    expect(listed[0]!.tags).toEqual(["migration"]);
+
+    const claimed = store.claim({
+      handoff_id,
+      claiming_agent_id: "agent-b",
+      claiming_harness: "codex",
+    });
+    expect(claimed.document_md).toContain("ship it");
+    expect(claimed.claimed_at).toBeTruthy();
+
+    expect(store.list({ project_key: "proj-x", cwd: "/repo" }, {})).toHaveLength(0);
+    expect(() => store.claim({ handoff_id })).toThrow(HandoffAlreadyClaimedError);
+  });
+
+  it("only one of two back-to-back claims wins (sync atomicity)", () => {
+    const { store, input, ctx } = setup();
+    const { handoff_id } = store.store(input(), ctx());
+    let won = 0;
+    let lost = 0;
+    for (let i = 0; i < 2; i++) {
+      try {
+        store.claim({ handoff_id });
+        won++;
+      } catch (error) {
+        if (error instanceof HandoffAlreadyClaimedError) lost++;
+        else throw error;
+      }
+    }
+    expect([won, lost]).toEqual([1, 1]);
+  });
+
+  it("throws HandoffNotFoundError when claiming an unknown id", () => {
+    const { store } = setup();
+    expect(() => store.claim({ handoff_id: "hdo_ghost" })).toThrow(HandoffNotFoundError);
+  });
+
+  it("filters by project_key + cwd (both must match)", () => {
+    const { store, input, ctx } = setup();
+    store.store(input({ project_key: "proj-x", cwd: "/a" }), ctx());
+    expect(store.list({ project_key: "proj-x", cwd: "/b" }, {})).toHaveLength(0);
+    expect(store.list({ cwd: "/a" }, {})).toHaveLength(1);
+  });
+
+  it("includeClaimed surfaces claimed handoffs for admin views", () => {
+    const { store, input, ctx } = setup();
+    const { handoff_id } = store.store(input(), ctx());
+    store.claim({ handoff_id });
+    expect(store.list({}, {})).toHaveLength(0);
+    expect(store.list({}, { includeClaimed: true })).toHaveLength(1);
+    expect(store.listDetails({}, { includeClaimed: true })[0]!.claimed_by).toEqual({
+      agent_id: null,
+      harness: null,
+      source_ref: null,
+      cwd: null,
+    });
+  });
+
+  it("lists newest-first by created_at and filters by harness", () => {
+    const vault = createVault({ dataDir });
+    const times = [
+      "2026-06-01T00:00:00.000Z",
+      "2026-06-03T00:00:00.000Z",
+      "2026-06-02T00:00:00.000Z",
+    ];
+    let i = 0;
+    let n = 0;
+    const store = createMarkdownHandoffStore({
+      vault,
+      now: () => times[i++] ?? "2026-06-04T00:00:00.000Z",
+      generateId: () => `hdo_o${++n}`,
+    });
+    const mk = (harness: string) => ({ title: "Handoff title", document_md: validDoc, harness });
+    store.store(mk("claude-code"), { created_by_agent_id: null }); // o1 @ 06-01
+    store.store(mk("codex"), { created_by_agent_id: null }); // o2 @ 06-03
+    store.store(mk("claude-code"), { created_by_agent_id: null }); // o3 @ 06-02
+    expect(store.list({}, {}).map((h) => h.handoff_id)).toEqual(["hdo_o2", "hdo_o3", "hdo_o1"]);
+    expect(store.list({ harness: "codex" }, {}).map((h) => h.handoff_id)).toEqual(["hdo_o2"]);
+  });
+
+  it("getById returns full detail or null; purge hard-deletes idempotently", () => {
+    const { store, input, ctx } = setup();
+    const { handoff_id } = store.store({ ...input(), source_ref: "ref://abc" }, ctx());
+    const detail = store.getById(handoff_id);
+    expect(detail?.source_ref).toBe("ref://abc");
+    expect(detail?.claimed_at).toBeNull();
+    expect(store.getById("hdo_ghost")).toBeNull();
+
+    expect(store.purge(handoff_id)).toBe(true);
+    expect(store.getById(handoff_id)).toBeNull();
+    expect(store.purge(handoff_id)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Plan 036 **Phase 2 / spec 035 §F9** — handoffs as markdown. Adds `store/markdown/markdown-handoff-store.ts` (`createMarkdownHandoffStore`, typed **`: HandoffStore`** for compiler-enforced conformance): `store` / `list` / `listDetails` / `getById` / `purge` / `claim` over `handoffs/<id>.md` files, parity with the SQLite handoff-store. Sync, with an injected sync committer (commit-per-op).

**Atomic claim:** the store is sync, so `claim()` is read → check → write with no yield → atomic within the single server process (no cross-process race to guard, unlike SQLite's `BEGIN IMMEDIATE` under multi-writer WAL). The 409 (`HandoffAlreadyClaimedError`) / 404 (`HandoffNotFoundError`) split + result shape are preserved.

Adds a `removeFile` vault primitive — the narrow admin/test hard-delete exception to the vault's archive=move rule — used by `purge` (path-guarded by `within()`, idempotent).

## Review

A review sub-agent confirmed **parity holds across store/list/listDetails/claim (incl. 404/409 + result shape)/getById/purge** against the SQLite handoff-store, the sync-atomicity argument is sound, `: HandoffStore` conformance is genuine (`tsc` clean), and the existing SQLite handoff tests still pass. Closed its two coverage suggestions: added a test pinning `created_at` DESC ordering across multiple handoffs and the `harness` filter.

## Scope

Not wired into `createLibrarianStore` — SQLite stays the live backend, **no user-visible change**. Per the locked plan, next are conv-state (sidecar JSON), then settings/curation (plain files), then the cutover.

## Verification

- New `markdown-handoff-store` (7 tests) + a `removeFile` vault test; SQLite handoff suites still green.
- `pnpm -r typecheck` (incl. `: HandoffStore` conformance) + `pnpm run lint` green; core suite 633.

🤖 Generated with [Claude Code](https://claude.com/claude-code)