### PR TITLE
feat(sidecar): JSON conv-state store, outside the vault (Phase 2)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -185,6 +185,10 @@ export {
   serializeHandoffDocument,
   serializeMemoryDocument,
 } from "./store/markdown/index.js";
+export {
+  type JsonConversationStateStoreDeps,
+  createJsonConversationStateStore,
+} from "./store/sidecar/index.js";
 export { type MemoryWriteVerdict, routeMemoryWrite } from "./store/memory-routing.js";
 export type { Memory, MemoryStore, MemoryStoreDeps } from "./store/memory-store.js";
 export {

--- a/packages/core/src/store/sidecar/conversation-state-store.ts
+++ b/packages/core/src/store/sidecar/conversation-state-store.ts
@@ -1,0 +1,105 @@
+// JSON conv-state store (plan 036 Phase 2). conv-state is ephemeral
+// per-conversation runtime (harness, attached session, off-record gate) —
+// NOT durable knowledge — so it lives on a sidecar JSON file OUTSIDE the git
+// vault (decided 2026-06-01), keyed by conv_id. Same ConversationStateStore
+// contract as the SQLite store; replaces it at the Phase-7 cutover.
+//
+// Sync (single map file, whole-file read/write per op — fine at the scale of
+// a handful of live conversations).
+
+import fs from "node:fs";
+import path from "node:path";
+import { nowIso } from "../../constants.js";
+import {
+  type ConversationState,
+  type ConversationStatePatch,
+  ConversationStatePatchSchema,
+} from "../../schemas/conversation-state.js";
+import type { ConversationStateStore } from "../conversation-state-store.js";
+
+export interface JsonConversationStateStoreDeps {
+  /** Sidecar file path, outside the git vault (e.g. `<data-dir>/conv-state.json`). */
+  filePath: string;
+  now?: () => string;
+}
+
+export function createJsonConversationStateStore(
+  deps: JsonConversationStateStoreDeps,
+): ConversationStateStore {
+  const { filePath } = deps;
+  const now = deps.now ?? nowIso;
+
+  function assertConvId(convId: string): void {
+    if (typeof convId !== "string" || convId.length === 0) {
+      throw new Error("conv_state: conv_id must be a non-empty string.");
+    }
+  }
+
+  function readAll(): Record<string, ConversationState> {
+    if (!fs.existsSync(filePath)) return {};
+    try {
+      const parsed = JSON.parse(fs.readFileSync(filePath, "utf8")) as unknown;
+      return parsed && typeof parsed === "object"
+        ? (parsed as Record<string, ConversationState>)
+        : {};
+    } catch {
+      return {}; // corrupt/empty file → start fresh (it's disposable runtime state)
+    }
+  }
+
+  function writeAll(map: Record<string, ConversationState>): void {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, `${JSON.stringify(map, null, 2)}\n`, "utf8");
+  }
+
+  function get(convId: string): ConversationState | null {
+    assertConvId(convId);
+    return readAll()[convId] ?? null;
+  }
+
+  function upsert(convId: string, patch: ConversationStatePatch): ConversationState {
+    assertConvId(convId);
+    // Validate at the boundary — one canonical shape check for every caller.
+    const parsed = ConversationStatePatchSchema.parse(patch);
+    const map = readAll();
+    const existing = map[convId] ?? null;
+    const ts = now();
+
+    let next: ConversationState;
+    if (existing) {
+      next = {
+        ...existing,
+        harness: parsed.harness ?? existing.harness,
+        session_id: parsed.session_id === undefined ? existing.session_id : parsed.session_id,
+        off_record: parsed.off_record ?? existing.off_record,
+        updated_at: ts,
+      };
+    } else {
+      if (!parsed.harness) {
+        throw new Error("conv_state.upsert: first-create requires `harness`.");
+      }
+      next = {
+        conv_id: convId,
+        harness: parsed.harness,
+        session_id: parsed.session_id ?? null,
+        off_record: parsed.off_record ?? false,
+        created_at: ts,
+        updated_at: ts,
+      };
+    }
+    map[convId] = next;
+    writeAll(map);
+    return next;
+  }
+
+  function clear(convId: string): void {
+    assertConvId(convId);
+    const map = readAll();
+    if (convId in map) {
+      delete map[convId];
+      writeAll(map);
+    }
+  }
+
+  return { get, upsert, clear };
+}

--- a/packages/core/src/store/sidecar/index.ts
+++ b/packages/core/src/store/sidecar/index.ts
@@ -1,0 +1,9 @@
+// Sidecar stores (plan 036 Phase 2) — file-based stores that live OUTSIDE
+// the git-pushed vault: ephemeral runtime state (conv-state) and, in
+// following increments, settings/secrets + curation records. They replace
+// the corresponding SQLite stores at the Phase-7 cutover.
+
+export {
+  type JsonConversationStateStoreDeps,
+  createJsonConversationStateStore,
+} from "./conversation-state-store.js";

--- a/packages/core/tests/store/sidecar/conversation-state-store.test.ts
+++ b/packages/core/tests/store/sidecar/conversation-state-store.test.ts
@@ -1,0 +1,94 @@
+// JSON conv-state store tests (plan 036 Phase 2). conv-state is ephemeral
+// per-conversation runtime — kept on a sidecar JSON file OUTSIDE the git
+// vault (decided 2026-06-01). Same ConversationStateStore contract as the
+// SQLite store: get/upsert/clear, first-create requires harness, patch
+// merges, durable across reopen.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { type ConversationStateStore, createJsonConversationStateStore } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let dir: string;
+let filePath: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-convstate-"));
+  filePath = path.join(dir, "conv-state.json");
+});
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+const make = (): ConversationStateStore => createJsonConversationStateStore({ filePath });
+
+describe("JSON conv-state store", () => {
+  it("get returns null for an unknown conv_id", () => {
+    expect(make().get("claude:never")).toBeNull();
+  });
+
+  it("upsert creates a row (harness only) and get returns it", () => {
+    const store = make();
+    const created = store.upsert("claude:abc", { harness: "claude-code" });
+    expect(created).toMatchObject({
+      conv_id: "claude:abc",
+      harness: "claude-code",
+      session_id: null,
+      off_record: false,
+    });
+    expect(created.created_at).toBe(created.updated_at);
+    expect(store.get("claude:abc")).toEqual(created);
+  });
+
+  it("first-create without harness throws", () => {
+    expect(() => make().upsert("claude:x", { off_record: true })).toThrow(
+      /first-create requires `harness`/,
+    );
+  });
+
+  it("upsert merges a patch, preserves created_at, bumps updated_at", async () => {
+    const store = make();
+    const created = store.upsert("claude:abc", { harness: "claude-code" });
+    await new Promise((r) => setTimeout(r, 5));
+    const updated = store.upsert("claude:abc", { off_record: true, session_id: "ses_1" });
+    expect(updated.off_record).toBe(true);
+    expect(updated.session_id).toBe("ses_1");
+    expect(updated.harness).toBe("claude-code"); // preserved
+    expect(updated.created_at).toBe(created.created_at);
+    expect(updated.updated_at >= created.updated_at).toBe(true);
+  });
+
+  it("explicit session_id: null clears the attached session", () => {
+    const store = make();
+    store.upsert("claude:abc", { harness: "claude-code", session_id: "ses_1" });
+    expect(store.upsert("claude:abc", { session_id: null }).session_id).toBeNull();
+  });
+
+  it("clear removes the row; clear of an unknown id is a no-op", () => {
+    const store = make();
+    store.upsert("claude:abc", { harness: "claude-code" });
+    store.clear("claude:abc");
+    expect(store.get("claude:abc")).toBeNull();
+    expect(() => store.clear("nope")).not.toThrow();
+  });
+
+  it("survives a reopen — the JSON file is the source of truth", () => {
+    make().upsert("claude:abc", { harness: "claude-code", session_id: "ses_durable" });
+    const reopened = make();
+    expect(reopened.get("claude:abc")).toMatchObject({
+      conv_id: "claude:abc",
+      harness: "claude-code",
+      session_id: "ses_durable",
+    });
+  });
+
+  it("keeps each conv_id independent", () => {
+    const store = make();
+    store.upsert("a", { harness: "h1" });
+    store.upsert("b", { harness: "h2" });
+    expect(store.get("a")?.harness).toBe("h1");
+    expect(store.get("b")?.harness).toBe("h2");
+  });
+});


### PR DESCRIPTION
## What

Plan 036 **Phase 2** — conv-state is ephemeral per-conversation runtime (harness, attached session, off-record gate), not durable knowledge, so per the 2026-06-01 decision it lives on a **sidecar JSON file outside the git vault**. Adds `store/sidecar/conversation-state-store.ts` (`createJsonConversationStateStore`, typed **`: ConversationStateStore`**): `get` / `upsert` / `clear` over a single keyed JSON map file.

Behaviourally identical to the SQLite store: first-create requires `harness`, patch merges (`session_id: null` clears, omitted preserves), durable across reopen. New `store/sidecar/` home for the outside-vault file stores (settings/secrets + curation follow).

## Review

The review sub-agent hit a transient API overload, so I self-reviewed against the SQLite `conversation-state-store.ts` parity (I authored both that `upsert` in D16.3 and this one): the merge logic, first-create guard + defaults, Zod boundary validation, and `assertConvId` are identical; `get`/`clear` match; `readAll` is corrupt-tolerant; `: ConversationStateStore` conformance is `tsc`-clean; the file holds no secrets. The 8 tests mirror the SQLite conv-state suite (incl. the `session_id:null` clear vs preserve distinction and reopen durability).

## Scope

Not wired into `createLibrarianStore` — SQLite stays the live backend, **no user-visible change**. Next: settings/secrets + curation as plain files, then the cutover.

## Verification

- New `sidecar/conversation-state-store` suite (8 tests); core suite 641.
- `pnpm -r typecheck` (incl. conformance) + `pnpm run lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)