### PR TITLE
feat(sidecar): JSON settings/secret store, outside the vault (Phase 2)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -187,7 +187,9 @@ export {
 } from "./store/markdown/index.js";
 export {
   type JsonConversationStateStoreDeps,
+  type JsonSettingsStoreDeps,
   createJsonConversationStateStore,
+  createJsonSettingsStore,
 } from "./store/sidecar/index.js";
 export { type MemoryWriteVerdict, routeMemoryWrite } from "./store/memory-routing.js";
 export type { Memory, MemoryStore, MemoryStoreDeps } from "./store/memory-store.js";

--- a/packages/core/src/store/sidecar/index.ts
+++ b/packages/core/src/store/sidecar/index.ts
@@ -7,3 +7,4 @@ export {
   type JsonConversationStateStoreDeps,
   createJsonConversationStateStore,
 } from "./conversation-state-store.js";
+export { type JsonSettingsStoreDeps, createJsonSettingsStore } from "./settings-store.js";

--- a/packages/core/src/store/sidecar/settings-store.ts
+++ b/packages/core/src/store/sidecar/settings-store.ts
@@ -1,0 +1,88 @@
+// JSON settings / secret store (plan 036 Phase 2). Settings (incl. the
+// curator's encrypted LLM token) can't live in the git-pushed vault and
+// aren't knowledge, so they move to a plain JSON file OUTSIDE the vault
+// (decided 2026-06-01). The AES-256-GCM at-rest crypto is unchanged from the
+// SQLite store — only persistence swaps to a file; the file holds ciphertext
+// for secret values, never plaintext. Replaces the SQLite settings-store at
+// the Phase-7 cutover.
+
+import fs from "node:fs";
+import path from "node:path";
+import { nowIso } from "../../constants.js";
+import { decryptSecret, encryptSecret } from "../../secret-crypto.js";
+import type { SettingMeta, SettingsStore } from "../settings-store.js";
+
+interface SettingEntry {
+  value: string;
+  is_secret: boolean;
+  updated_at: string;
+}
+
+export interface JsonSettingsStoreDeps {
+  /** Sidecar file path, outside the git vault (e.g. `<data-dir>/settings.json`). */
+  filePath: string;
+  /** AES-256 master key for secret values; secret ops throw when absent. */
+  secretKey?: Buffer | null;
+}
+
+export function createJsonSettingsStore(deps: JsonSettingsStoreDeps): SettingsStore {
+  const { filePath, secretKey } = deps;
+
+  function requireKey(): Buffer {
+    if (!secretKey) {
+      throw new Error("a master key is required for secret settings (set LIBRARIAN_SECRET_KEY)");
+    }
+    return secretKey;
+  }
+
+  function readAll(): Record<string, SettingEntry> {
+    if (!fs.existsSync(filePath)) return {};
+    try {
+      const parsed = JSON.parse(fs.readFileSync(filePath, "utf8")) as unknown;
+      return parsed && typeof parsed === "object" ? (parsed as Record<string, SettingEntry>) : {};
+    } catch {
+      return {};
+    }
+  }
+
+  function writeAll(map: Record<string, SettingEntry>): void {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    // Owner-only (0600): the file holds AES-GCM ciphertext for secrets, so a
+    // world-readable copy would hand a local attacker the ciphertext for an
+    // offline attack. `mode` applies on create; harmless on overwrite.
+    fs.writeFileSync(filePath, `${JSON.stringify(map, null, 2)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+  }
+
+  function setSetting(key: string, value: string, options: { secret?: boolean } = {}): void {
+    const secret = options.secret === true;
+    const stored = secret ? encryptSecret(value, requireKey()) : value;
+    const map = readAll();
+    map[key] = { value: stored, is_secret: secret, updated_at: nowIso() };
+    writeAll(map);
+  }
+
+  function getSetting(key: string): string | null {
+    const entry = readAll()[key];
+    if (!entry) return null;
+    return entry.is_secret ? decryptSecret(entry.value, requireKey()) : entry.value;
+  }
+
+  function deleteSetting(key: string): void {
+    const map = readAll();
+    if (key in map) {
+      delete map[key];
+      writeAll(map);
+    }
+  }
+
+  function listSettings(): SettingMeta[] {
+    return Object.entries(readAll())
+      .map(([key, entry]) => ({ key, is_secret: entry.is_secret, updated_at: entry.updated_at }))
+      .sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
+  }
+
+  return { setSetting, getSetting, deleteSetting, listSettings };
+}

--- a/packages/core/tests/store/sidecar/settings-store.test.ts
+++ b/packages/core/tests/store/sidecar/settings-store.test.ts
@@ -1,0 +1,85 @@
+// JSON settings store tests (plan 036 Phase 2). Settings (incl. encrypted
+// secrets) can't live in the git-pushed vault and aren't knowledge, so they
+// move to a plain JSON file OUTSIDE the vault (decided 2026-06-01). The
+// AES-256-GCM crypto is unchanged — only persistence swaps SQLite → file.
+// Same SettingsStore contract: plain + secret round-trip, metadata-only list,
+// secrets need the master key, durable across reopen.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createJsonSettingsStore } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let dir: string;
+let filePath: string;
+const KEY_A = Buffer.alloc(32, 7);
+const KEY_B = Buffer.alloc(32, 9);
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-settings-"));
+  filePath = path.join(dir, "settings.json");
+});
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe("JSON settings store", () => {
+  it("round-trips a plain setting", () => {
+    const store = createJsonSettingsStore({ filePath });
+    store.setSetting("model", "gpt-5");
+    expect(store.getSetting("model")).toBe("gpt-5");
+    expect(store.getSetting("missing")).toBeNull();
+  });
+
+  it("round-trips a secret setting, storing only ciphertext on disk", () => {
+    const store = createJsonSettingsStore({ filePath, secretKey: KEY_A });
+    store.setSetting("llm_token", "sk-supersecret", { secret: true });
+    expect(store.getSetting("llm_token")).toBe("sk-supersecret");
+    // The plaintext must never hit disk.
+    expect(fs.readFileSync(filePath, "utf8")).not.toContain("sk-supersecret");
+  });
+
+  it("throws when writing or reading a secret with no master key", () => {
+    const store = createJsonSettingsStore({ filePath });
+    expect(() => store.setSetting("t", "v", { secret: true })).toThrow(/master key/);
+  });
+
+  it("fails to read a secret written under a different key", () => {
+    createJsonSettingsStore({ filePath, secretKey: KEY_A }).setSetting("t", "v", { secret: true });
+    expect(() => createJsonSettingsStore({ filePath, secretKey: KEY_B }).getSetting("t")).toThrow();
+  });
+
+  it("listSettings returns metadata only (never values), sorted by key", () => {
+    const store = createJsonSettingsStore({ filePath, secretKey: KEY_A });
+    store.setSetting("zebra", "z");
+    store.setSetting("alpha", "sk-x", { secret: true });
+    const meta = store.listSettings();
+    expect(meta.map((m) => m.key)).toEqual(["alpha", "zebra"]);
+    expect(meta.find((m) => m.key === "alpha")?.is_secret).toBe(true);
+    expect(JSON.stringify(meta)).not.toContain("sk-x");
+    expect(meta.every((m) => !("value" in m))).toBe(true);
+  });
+
+  it("writes the secret-bearing file owner-only (no group/other access)", () => {
+    const store = createJsonSettingsStore({ filePath, secretKey: KEY_A });
+    store.setSetting("llm_token", "sk-x", { secret: true });
+    expect(fs.statSync(filePath).mode & 0o077).toBe(0);
+  });
+
+  it("deletes a setting", () => {
+    const store = createJsonSettingsStore({ filePath });
+    store.setSetting("k", "v");
+    store.deleteSetting("k");
+    expect(store.getSetting("k")).toBeNull();
+  });
+
+  it("survives a reopen — the JSON file is the source of truth", () => {
+    createJsonSettingsStore({ filePath, secretKey: KEY_A }).setSetting("llm_token", "sk-1", {
+      secret: true,
+    });
+    const reopened = createJsonSettingsStore({ filePath, secretKey: KEY_A });
+    expect(reopened.getSetting("llm_token")).toBe("sk-1");
+  });
+});


### PR DESCRIPTION
## What

Plan 036 **Phase 2** — settings (incl. the curator's encrypted LLM token) can't live in the git-pushed vault and aren't knowledge, so per the 2026-06-01 decision they move to a **plain JSON file outside the vault**. Adds `store/sidecar/settings-store.ts` (`createJsonSettingsStore`, typed **`: SettingsStore`**): `setSetting`/`getSetting`/`deleteSetting`/`listSettings` over a keyed JSON map file.

- The **AES-256-GCM at-rest crypto is unchanged** (`encryptSecret`/`decryptSecret`) — only persistence swaps SQLite → file; the file stores **ciphertext** for secret values, never plaintext. Secrets still require the master key; `listSettings` stays metadata-only.
- The file is written **owner-only (0600)** — defense-in-depth for the ciphertext (a strict improvement over the SQLite db's default mode).

## Review

A security-focused review sub-agent confirmed **secure + parity holds**: no plaintext to disk (ciphertext verified on disk; the test would catch a regression that skipped encryption), master-key gating matches (plain reads need no key), `listSettings` is metadata-only, wrong-key reads throw (GCM auth), and no key/secret material appears in any error path. It suggested the 0600 mode hardening (applied here) and atomic write (deferred to the Phase-7 cutover, noted — matches SQLite's durability profile, not a regression).

## Scope

Not wired into `createLibrarianStore` — SQLite stays the live backend, **no user-visible change**. Next: curation as plain files, then the cutover.

## Verification

- New `sidecar/settings-store` suite (8 tests): plain + secret round-trip, ciphertext-on-disk, secret-without-key throws, wrong-key fails, metadata-only list, owner-only file mode, delete, reopen durability. SQLite settings tests still green.
- `pnpm -r typecheck` + `pnpm run lint` green; core suite 649.

🤖 Generated with [Claude Code](https://claude.com/claude-code)