### PR TITLE
feat(store): markdown backend behind a flag in createLibrarianStore (Phase 2 cutover)

### DIFF
--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -5,12 +5,16 @@ import {
   type ConversationStateStore,
   createConversationStateStore,
 } from "./conversation-state-store.js";
+import { createVault } from "./corpus/index.js";
 import { type CurationStore, createCurationStore } from "./curation-store.js";
+import { createSyncGitOps } from "./git/index.js";
 import { type HandoffStore, createHandoffStore } from "./handoff-store.js";
 import { readJsonl } from "./jsonl.js";
+import { createMarkdownHandoffStore, createMarkdownMemoryStore } from "./markdown/index.js";
 import { type MemoryStore, createMemoryStore } from "./memory-store.js";
 import { ensureSchema, rebuildMemoryIndex } from "./projection.js";
 import { type SettingsStore, createSettingsStore } from "./settings-store.js";
+import { createJsonConversationStateStore, createJsonSettingsStore } from "./sidecar/index.js";
 
 const DEFAULT_DATA_DIR = path.join(process.cwd(), "data");
 
@@ -32,6 +36,14 @@ export interface LibrarianStoreOptions {
    * secret settings throw on access; plain settings still work.
    */
   secretKey?: Buffer | null;
+  /**
+   * Storage backend (plan 036 cutover). `sqlite` (default) is the legacy
+   * event-ledger + SQLite projection. `markdown` routes memory/handoff to the
+   * git vault and conv-state/settings to sidecar JSON files; a residual SQLite
+   * db backs only the (dormant) curator until the Phase-4 consolidator lands.
+   * Falls back to `LIBRARIAN_BACKEND`.
+   */
+  backend?: "sqlite" | "markdown";
 }
 
 export interface LibrarianStore extends MemoryStore, CurationStore, SettingsStore {
@@ -86,6 +98,52 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Inter
 
   const db = new DatabaseSync(dbPath);
   ensureSchema(db, { eventsPath, snapshotPath });
+
+  const backend =
+    options.backend ??
+    (process.env.LIBRARIAN_BACKEND === "markdown" ? "markdown" : undefined) ??
+    "sqlite";
+
+  if (backend === "markdown") {
+    // Store cutover (plan 036 Phase 2): memory + handoff live in the git
+    // vault; conv-state + settings/secrets in sidecar JSON files outside it.
+    // The SQLite `db` created above is residual — it backs only the (dormant)
+    // curator/curation until the Phase-4 consolidator reworks the read-side
+    // and SQLite is removed for good. The event ledger is retired, so
+    // appendEvent/listEvents (markdown stubs) throw and readEvents is empty.
+    const vault = createVault({ dataDir });
+    const git = createSyncGitOps({ cwd: vault.root });
+    git.init();
+    const commit = (message: string): void => {
+      git.commitAll(message);
+    };
+    const markdownMemory = createMarkdownMemoryStore({ vault, commit });
+    const markdownHandoffs = createMarkdownHandoffStore({ vault, commit });
+    const jsonConvState = createJsonConversationStateStore({
+      filePath: path.join(dataDir, "conv-state.json"),
+    });
+    const jsonSettings = createJsonSettingsStore({
+      filePath: path.join(dataDir, "settings.json"),
+      secretKey: options.secretKey ?? null,
+    });
+    const residualCuration = createCurationStore({ db });
+    return {
+      ...markdownMemory,
+      ...residualCuration,
+      ...jsonSettings,
+      convState: jsonConvState,
+      handoffs: markdownHandoffs,
+      dataDir,
+      eventsPath,
+      dbPath,
+      snapshotPath,
+      db,
+      close: () => db.close(),
+      readEvents: () => [],
+      rebuildIndex: () => {},
+      reindex: () => {},
+    };
+  }
 
   function rebuildIndex(): void {
     rebuildMemoryIndex({ db, eventsPath, snapshotPath });

--- a/packages/core/tests/store/librarian-store-backend.test.ts
+++ b/packages/core/tests/store/librarian-store-backend.test.ts
@@ -1,0 +1,87 @@
+// Backend-selection tests for createLibrarianStore (plan 036 Phase 2 cutover,
+// incremental-behind-a-flag). The `markdown` backend routes memory/handoff to
+// the git vault and conv-state/settings to sidecar JSON files; a residual
+// SQLite db backs only the (dormant) curator until Phase 4. SQLite stays the
+// default — no behaviour change for existing consumers.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createLibrarianStore } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-backend-"));
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+const handoffDoc = [
+  "## Start & intent",
+  "do the thing.",
+  "## Journey",
+  "x then y.",
+  "## Current state",
+  "green.",
+  "## What's left",
+  "ship.",
+  "## Open questions",
+  "none.",
+].join("\n\n");
+
+describe("createLibrarianStore — backend selection", () => {
+  it("markdown backend writes memories to the git vault and reads them back", () => {
+    const store = createLibrarianStore({ dataDir, backend: "markdown" });
+    try {
+      const { memory } = store.createMemory({
+        agent_id: "codex",
+        title: "Use pnpm",
+        body: "Always pnpm.",
+      });
+      expect(fs.existsSync(path.join(dataDir, "vault", `memories/${memory.id}.md`))).toBe(true);
+      expect(store.getMemory(memory.id)?.title).toBe("Use pnpm");
+      expect(store.searchMemories({ query: "pnpm" }).map((m) => m.id)).toContain(memory.id);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("markdown backend routes handoffs to the vault and conv-state/settings to sidecar files", () => {
+    const store = createLibrarianStore({
+      dataDir,
+      backend: "markdown",
+      secretKey: Buffer.alloc(32, 7),
+    });
+    try {
+      const { handoff_id } = store.handoffs.store(
+        { title: "Handoff", document_md: handoffDoc, harness: "claude-code", tags: [] },
+        { created_by_agent_id: "agent-a" },
+      );
+      expect(fs.existsSync(path.join(dataDir, "vault", `handoffs/${handoff_id}.md`))).toBe(true);
+
+      store.convState.upsert("claude:abc", { harness: "claude-code" });
+      expect(fs.existsSync(path.join(dataDir, "conv-state.json"))).toBe(true);
+
+      store.setSetting("llm_token", "sk-x", { secret: true });
+      expect(store.getSetting("llm_token")).toBe("sk-x");
+      expect(fs.existsSync(path.join(dataDir, "settings.json"))).toBe(true);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("defaults to the sqlite backend (no vault dir created)", () => {
+    const store = createLibrarianStore({ dataDir });
+    try {
+      store.createMemory({ agent_id: "codex", title: "t", body: "b" });
+      expect(fs.existsSync(path.join(dataDir, "librarian.sqlite"))).toBe(true);
+      expect(fs.existsSync(path.join(dataDir, "vault"))).toBe(false);
+    } finally {
+      store.close();
+    }
+  });
+});


### PR DESCRIPTION
## What

Plan 036 **Phase 2 cutover, step 1** (incremental-behind-a-flag). `createLibrarianStore` gains a `backend` option (default `sqlite`, also `LIBRARIAN_BACKEND` env). `backend: "markdown"` composes the new stores:

- **memory + handoff → the git vault** (markdown `MemoryStore`/`HandoffStore` + a sync git commit-per-op), **conv-state + settings/secrets → sidecar JSON files** outside the vault.
- A **residual SQLite db** backs *only* the (dormant) curator/curation until the Phase-4 consolidator reworks the read-side and SQLite is removed for good.
- The event ledger is retired in markdown mode: `appendEvent`/`listEvents` (markdown stubs) throw, `readEvents` is `[]`, `rebuildIndex`/`reindex` are no-ops (the hybrid index is Phase 3).

**Opt-in only — SQLite stays the live default, so no user-visible change.**

## Review

A review sub-agent confirmed: the **default sqlite path is byte-identical** (the markdown branch is a pure early-return addition; whole core suite + `-r typecheck` green), the markdown branch returns a valid `InternalLibrarianStore` with **no spread collisions**, the residual-SQLite `memories` table is never read on any non-curator path (the curator read-side is only reached from the dormant curator pipeline), `close()` leaks nothing, env coercion is sound, and no circular import is introduced. It also produced the ledger-consumer call-site inventory for the next increment (recorded in notes): the dashboard `memories.events` logs view is the one non-curator consumer to rewire → git history.

## Scope

Opt-in; **no user-visible change**. Next cutover steps: re-point the curator read-side at the markdown corpus, rewire the ledger consumers (logs-view → git history), then flip the default + delete SQLite (Phase 4).

## Verification

- New `librarian-store-backend` suite (3 tests): markdown memory→vault, handoff→vault + conv-state/settings→sidecar, sqlite default unchanged.
- `pnpm -r typecheck` + `pnpm run lint` green; core suite 652.

🤖 Generated with [Claude Code](https://claude.com/claude-code)