### PR TITLE
feat(index): backlink graph for the disposable index (F2/F3, Phase 3)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -175,6 +175,7 @@ export {
   serializeDocument,
 } from "./store/corpus/index.js";
 export { type GitOps, type SyncGitOps, createGitOps, createSyncGitOps } from "./store/git/index.js";
+export { type LinkGraph, buildLinkGraph } from "./store/index/index.js";
 export {
   type MarkdownHandoffStoreDeps,
   type MarkdownMemoryStoreDeps,

--- a/packages/core/src/store/index/index.ts
+++ b/packages/core/src/store/index/index.ts
@@ -1,0 +1,6 @@
+// Disposable hybrid index (plan 036 Phase 3 / spec 035 §F2) — embed +
+// keyword + wikilink graph over the markdown corpus, rebuildable from the
+// source at any time. The backlink graph lands first (the "Anna problem"
+// core); keyword + vector indexes follow.
+
+export { type LinkGraph, buildLinkGraph } from "./link-graph.js";

--- a/packages/core/src/store/index/link-graph.ts
+++ b/packages/core/src/store/index/link-graph.ts
@@ -1,0 +1,51 @@
+// Backlink graph for the disposable index (plan 036 Phase 3 / spec 035
+// §F2, §F3). Turns the corpus's wikilinks into outbound + inbound (backlink)
+// adjacency so backlink-aware recall can return a fact filed under EITHER
+// entity from the other — the "Anna problem" (G1/S2). Pure: built from
+// `parseWikilinks` over document bodies; rebuildable from the markdown at
+// any time (the graph is part of the disposable `.index/`).
+
+import { parseWikilinks } from "../corpus/index.js";
+
+export interface LinkGraph {
+  /** Ids this document links to (deduped). */
+  outbound(id: string): string[];
+  /** Ids that link to this document — its backlinks (deduped). */
+  inbound(id: string): string[];
+  /** Outbound ∪ inbound, deduped, excluding the document itself. */
+  neighbors(id: string): string[];
+}
+
+export function buildLinkGraph(documents: { id: string; body: string }[]): LinkGraph {
+  const outbound = new Map<string, Set<string>>();
+  const inbound = new Map<string, Set<string>>();
+
+  const add = (map: Map<string, Set<string>>, key: string, value: string): void => {
+    let set = map.get(key);
+    if (!set) {
+      set = new Set<string>();
+      map.set(key, set);
+    }
+    set.add(value);
+  };
+
+  for (const doc of documents) {
+    for (const link of parseWikilinks(doc.body)) {
+      const target = link.target;
+      add(outbound, doc.id, target);
+      add(inbound, target, doc.id);
+    }
+  }
+
+  const list = (map: Map<string, Set<string>>, id: string): string[] => [...(map.get(id) ?? [])];
+
+  return {
+    outbound: (id) => list(outbound, id),
+    inbound: (id) => list(inbound, id),
+    neighbors: (id) => {
+      const out = new Set<string>([...list(outbound, id), ...list(inbound, id)]);
+      out.delete(id); // a self-link is not a neighbour
+      return [...out];
+    },
+  };
+}

--- a/packages/core/tests/store/index/link-graph.test.ts
+++ b/packages/core/tests/store/index/link-graph.test.ts
@@ -1,0 +1,53 @@
+// Backlink graph tests (plan 036 Phase 3 / spec 035 §F2, §F3 — the "Anna
+// problem"). The graph turns the corpus's wikilinks into outbound + inbound
+// (backlink) adjacency so recall can return a fact filed under EITHER entity
+// from the other. Pure — built from parseWikilinks over doc bodies.
+
+import { buildLinkGraph } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+describe("buildLinkGraph", () => {
+  it("records outbound wikilink targets (deduped, all forms)", () => {
+    const graph = buildLinkGraph([
+      { id: "a", body: "[[b]] and [[b|again]] and [[c#h]] and ![[d]]" },
+    ]);
+    expect(graph.outbound("a").sort()).toEqual(["b", "c", "d"]);
+  });
+
+  it("records inbound backlinks", () => {
+    const graph = buildLinkGraph([
+      { id: "sophie", body: "daughter of [[anna]]" },
+      { id: "bob", body: "knows [[anna]]" },
+      { id: "anna", body: "the matriarch" },
+    ]);
+    expect(graph.inbound("anna").sort()).toEqual(["bob", "sophie"]);
+    expect(graph.inbound("sophie")).toEqual([]);
+  });
+
+  it("solves the Anna problem: reachable from either entity", () => {
+    // A Sophie+Anna fact filed under sophie, linking [[anna]].
+    const graph = buildLinkGraph([
+      { id: "sophie", body: "Sophie is [[anna]]'s daughter; she loves piano." },
+      { id: "anna", body: "Anna is the matriarch." },
+    ]);
+    // From anna, reach sophie (via the inbound backlink).
+    expect(graph.neighbors("anna")).toContain("sophie");
+    // From sophie, reach anna (via the outbound link).
+    expect(graph.neighbors("sophie")).toContain("anna");
+  });
+
+  it("neighbors unions outbound + inbound, deduped, excluding self", () => {
+    const graph = buildLinkGraph([
+      { id: "a", body: "[[b]] [[c]] [[a]]" }, // self-link ignored
+      { id: "b", body: "links back to [[a]]" },
+    ]);
+    expect(graph.neighbors("a").sort()).toEqual(["b", "c"]);
+  });
+
+  it("returns empty arrays for an unknown id", () => {
+    const graph = buildLinkGraph([{ id: "a", body: "no links" }]);
+    expect(graph.outbound("zzz")).toEqual([]);
+    expect(graph.inbound("zzz")).toEqual([]);
+    expect(graph.neighbors("zzz")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Plan 036 **Phase 3** — the first piece of the disposable hybrid index, and the literal **"Anna problem"** core. Adds `store/index/link-graph.ts`: `buildLinkGraph(docs)` turns the corpus's wikilinks (via `parseWikilinks`) into **outbound + inbound (backlink)** adjacency, with `neighbors()` = the deduped union minus self.

So a fact filed under **either** entity is reachable from the other (G1/S2) — from `anna` you reach `sophie` via the inbound backlink; from `sophie` you reach `anna` via the outbound link. Pure and rebuildable from the markdown (part of the disposable `.index/`).

New `store/index/` home; keyword + vector indexes + backlink-aware recall follow.

## Verification

- New `index/link-graph` suite (5 tests): outbound (all forms, deduped), inbound backlinks, the bidirectional Anna problem, neighbors-minus-self, empty for unknown id.
- `pnpm -r typecheck` + `pnpm run lint` green; core suite 657. (Small pure module — self-reviewed against the reviewed wikilink-scanner precedent; sub-agent review reserved for the vector index + recall.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)