### PR TITLE
feat(index): keyword inverted index (F2, Phase 3)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -175,7 +175,13 @@ export {
   serializeDocument,
 } from "./store/corpus/index.js";
 export { type GitOps, type SyncGitOps, createGitOps, createSyncGitOps } from "./store/git/index.js";
-export { type LinkGraph, buildLinkGraph } from "./store/index/index.js";
+export {
+  type KeywordHit,
+  type KeywordIndex,
+  type LinkGraph,
+  buildKeywordIndex,
+  buildLinkGraph,
+} from "./store/index/index.js";
 export {
   type MarkdownHandoffStoreDeps,
   type MarkdownMemoryStoreDeps,

--- a/packages/core/src/store/index/index.ts
+++ b/packages/core/src/store/index/index.ts
@@ -4,3 +4,4 @@
 // core); keyword + vector indexes follow.
 
 export { type LinkGraph, buildLinkGraph } from "./link-graph.js";
+export { type KeywordHit, type KeywordIndex, buildKeywordIndex } from "./keyword-index.js";

--- a/packages/core/src/store/index/keyword-index.ts
+++ b/packages/core/src/store/index/keyword-index.ts
@@ -1,0 +1,51 @@
+// Keyword index for the disposable index (plan 036 Phase 3 / spec 035 §F2).
+// A deterministic, dependency-free inverted index over the corpus, reusing
+// the shared tokenizer so keyword relevance matches the rest of the system.
+// `search` scores each doc by the summed term-frequency of the matching
+// query terms. Rebuildable from the markdown at any time (the index is
+// disposable). MiniSearch/FlexSearch remain a drop-in option if richer
+// ranking is later needed — the index is swappable.
+
+import { tokenize } from "../memory-tokenize.js";
+
+export interface KeywordHit {
+  id: string;
+  score: number;
+}
+
+export interface KeywordIndex {
+  /** Docs matching any query term, ranked by summed tf (desc), id tie-break. */
+  search(query: string, limit?: number): KeywordHit[];
+}
+
+export function buildKeywordIndex(documents: { id: string; text: string }[]): KeywordIndex {
+  // term → (docId → term frequency)
+  const postings = new Map<string, Map<string, number>>();
+
+  for (const doc of documents) {
+    const counts = new Map<string, number>();
+    for (const term of tokenize(doc.text)) counts.set(term, (counts.get(term) ?? 0) + 1);
+    for (const [term, tf] of counts) {
+      let posting = postings.get(term);
+      if (!posting) {
+        posting = new Map<string, number>();
+        postings.set(term, posting);
+      }
+      posting.set(doc.id, tf);
+    }
+  }
+
+  return {
+    search(query, limit) {
+      const scores = new Map<string, number>();
+      for (const term of new Set(tokenize(query))) {
+        const posting = postings.get(term);
+        if (!posting) continue;
+        for (const [id, tf] of posting) scores.set(id, (scores.get(id) ?? 0) + tf);
+      }
+      const hits = [...scores.entries()].map(([id, score]) => ({ id, score }));
+      hits.sort((a, b) => b.score - a.score || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+      return limit != null ? hits.slice(0, limit) : hits;
+    },
+  };
+}

--- a/packages/core/tests/store/index/keyword-index.test.ts
+++ b/packages/core/tests/store/index/keyword-index.test.ts
@@ -1,0 +1,58 @@
+// Keyword index tests (plan 036 Phase 3 / spec 035 §F2). A deterministic,
+// dependency-free inverted index over the corpus (reusing the shared
+// tokenizer): term → {docId → term-frequency}; search scores by summed tf of
+// the matching query terms. Rebuildable from the markdown (disposable index).
+
+import { buildKeywordIndex } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+describe("buildKeywordIndex", () => {
+  it("returns docs that match the query, ranked by term frequency", () => {
+    const index = buildKeywordIndex([
+      { id: "pnpm", text: "use pnpm for the monorepo; pnpm pnpm pnpm" },
+      { id: "npm", text: "npm is fine too" },
+      { id: "cal", text: "calendar tuesdays" },
+    ]);
+    const hits = index.search("pnpm");
+    expect(hits.map((h) => h.id)).toEqual(["pnpm"]);
+    expect(hits[0]!.score).toBe(4); // four occurrences of "pnpm"
+  });
+
+  it("sums tf across multiple query terms; more-relevant docs rank higher", () => {
+    const index = buildKeywordIndex([
+      { id: "a", text: "deploy deploy command notes" },
+      { id: "b", text: "deploy once" },
+    ]);
+    const hits = index.search("deploy command");
+    expect(hits.map((h) => h.id)).toEqual(["a", "b"]); // a: 2+1=3, b: 1
+  });
+
+  it("excludes non-matching docs and respects the limit", () => {
+    const index = buildKeywordIndex([
+      { id: "a", text: "alpha beta" },
+      { id: "b", text: "alpha gamma" },
+      { id: "c", text: "delta" },
+    ]);
+    expect(
+      index
+        .search("alpha")
+        .map((h) => h.id)
+        .sort(),
+    ).toEqual(["a", "b"]);
+    expect(index.search("alpha", 1)).toHaveLength(1);
+  });
+
+  it("breaks score ties by id for stable ordering", () => {
+    const index = buildKeywordIndex([
+      { id: "zeta", text: "shared" },
+      { id: "alpha", text: "shared" },
+    ]);
+    expect(index.search("shared").map((h) => h.id)).toEqual(["alpha", "zeta"]);
+  });
+
+  it("returns [] for a query with no indexable terms", () => {
+    const index = buildKeywordIndex([{ id: "a", text: "alpha" }]);
+    expect(index.search("")).toEqual([]);
+    expect(index.search("a the and")).toEqual([]); // too-short + stopwords
+  });
+});


### PR DESCRIPTION
## What

Plan 036 **Phase 3** — adds `store/index/keyword-index.ts`: a deterministic, dependency-free **inverted index** over the corpus (`term → {docId → term-frequency}`), reusing the shared tokenizer so keyword relevance is consistent with the rest of the system. `search()` scores each doc by the summed tf of the matching query terms, ranked desc with an id tie-break, and returns `[]` for a no-indexable-terms query.

Rebuildable from the markdown (the index is disposable). MiniSearch/FlexSearch stay a drop-in option if richer ranking is later needed — the index is swappable.

## Verification

- New `index/keyword-index` suite (5 tests): tf-ranked matches, multi-term tf summation, non-match exclusion + limit, id tie-break, empty/stopword query → `[]`.
- `pnpm -r typecheck` + `pnpm run lint` green; core suite 662. (Small pure module — self-reviewed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)