### PR TITLE
feat(index): brute-force cosine vector index (F2, Phase 3)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -179,8 +179,12 @@ export {
   type KeywordHit,
   type KeywordIndex,
   type LinkGraph,
+  type VectorHit,
+  type VectorIndex,
   buildKeywordIndex,
   buildLinkGraph,
+  buildVectorIndex,
+  cosineSimilarity,
 } from "./store/index/index.js";
 export {
   type MarkdownHandoffStoreDeps,

--- a/packages/core/src/store/index/index.ts
+++ b/packages/core/src/store/index/index.ts
@@ -5,3 +5,9 @@
 
 export { type LinkGraph, buildLinkGraph } from "./link-graph.js";
 export { type KeywordHit, type KeywordIndex, buildKeywordIndex } from "./keyword-index.js";
+export {
+  type VectorHit,
+  type VectorIndex,
+  buildVectorIndex,
+  cosineSimilarity,
+} from "./vector-index.js";

--- a/packages/core/src/store/index/vector-index.ts
+++ b/packages/core/src/store/index/vector-index.ts
@@ -1,0 +1,43 @@
+// Vector index for the disposable index (plan 036 Phase 3 / spec 035 §F2).
+// Brute-force cosine similarity over stored embeddings — pure given the
+// vectors; the text→vector embedder is a separate, pluggable async concern.
+// Brute force is fine to ~tens of thousands of docs (spec); an ANN index
+// (hnswlib-wasm / Voy) is post-MVP, triggered by size.
+
+export interface VectorHit {
+  id: string;
+  score: number;
+}
+
+export interface VectorIndex {
+  /** Entries ranked by cosine similarity to `query` (desc), id tie-break. */
+  search(query: number[], limit?: number): VectorHit[];
+}
+
+/** Cosine similarity in [-1, 1]; 0 when either vector has zero magnitude. */
+export function cosineSimilarity(a: number[], b: number[]): number {
+  const shared = Math.min(a.length, b.length);
+  let dot = 0;
+  for (let i = 0; i < shared; i++) dot += (a[i] ?? 0) * (b[i] ?? 0);
+  let normA = 0;
+  for (const x of a) normA += x * x;
+  let normB = 0;
+  for (const y of b) normB += y * y;
+  if (normA === 0 || normB === 0) return 0;
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+export function buildVectorIndex(entries: { id: string; vector: number[] }[]): VectorIndex {
+  // Copy so later caller mutation of the input can't corrupt the index.
+  const stored = entries.map((entry) => ({ id: entry.id, vector: entry.vector }));
+  return {
+    search(query, limit) {
+      const hits = stored.map((entry) => ({
+        id: entry.id,
+        score: cosineSimilarity(query, entry.vector),
+      }));
+      hits.sort((a, b) => b.score - a.score || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+      return limit != null ? hits.slice(0, limit) : hits;
+    },
+  };
+}

--- a/packages/core/tests/store/index/vector-index.test.ts
+++ b/packages/core/tests/store/index/vector-index.test.ts
@@ -1,0 +1,54 @@
+// Vector index tests (plan 036 Phase 3 / spec 035 §F2). Brute-force cosine
+// over stored embeddings — pure given the vectors (the text→vector embedder
+// is a separate, pluggable async concern). Fine to ~tens of thousands of docs
+// per the spec; ANN is post-MVP.
+
+import { buildVectorIndex, cosineSimilarity } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+describe("cosineSimilarity", () => {
+  it("is 1 for identical direction, 0 for orthogonal, -1 for opposite", () => {
+    expect(cosineSimilarity([1, 0], [2, 0])).toBeCloseTo(1);
+    expect(cosineSimilarity([1, 0], [0, 1])).toBeCloseTo(0);
+    expect(cosineSimilarity([1, 0], [-1, 0])).toBeCloseTo(-1);
+  });
+
+  it("is 0 when either vector is all-zero (no division by zero)", () => {
+    expect(cosineSimilarity([0, 0], [1, 1])).toBe(0);
+    expect(cosineSimilarity([1, 1], [0, 0])).toBe(0);
+  });
+});
+
+describe("buildVectorIndex", () => {
+  it("ranks entries by cosine similarity to the query vector", () => {
+    const index = buildVectorIndex([
+      { id: "near", vector: [1, 0.1, 0] },
+      { id: "mid", vector: [0.5, 0.5, 0] },
+      { id: "far", vector: [0, 0, 1] },
+    ]);
+    const hits = index.search([1, 0, 0]);
+    expect(hits.map((h) => h.id)).toEqual(["near", "mid", "far"]);
+    expect(hits[0]!.score).toBeGreaterThan(hits[1]!.score);
+  });
+
+  it("respects the limit", () => {
+    const index = buildVectorIndex([
+      { id: "a", vector: [1, 0] },
+      { id: "b", vector: [0.9, 0.1] },
+      { id: "c", vector: [0.8, 0.2] },
+    ]);
+    expect(index.search([1, 0], 2)).toHaveLength(2);
+  });
+
+  it("returns [] for an empty index", () => {
+    expect(buildVectorIndex([]).search([1, 0])).toEqual([]);
+  });
+
+  it("breaks ties by id for stable ordering", () => {
+    const index = buildVectorIndex([
+      { id: "zeta", vector: [1, 0] },
+      { id: "alpha", vector: [1, 0] },
+    ]);
+    expect(index.search([1, 0]).map((h) => h.id)).toEqual(["alpha", "zeta"]);
+  });
+});


### PR DESCRIPTION
## What

Plan 036 **Phase 3** — adds `store/index/vector-index.ts`: `cosineSimilarity` (in `[-1,1]`, `0` on a zero-magnitude vector — no division by zero) + `buildVectorIndex` (brute-force cosine over stored embeddings, ranked desc with an id tie-break, limit-able). Pure given the vectors; the text→vector **embedder** is a separate, pluggable async concern (next increment), so this is fully testable with fixed vectors — no model download.

Brute force is fine to ~tens of thousands of docs (spec); an ANN index is post-MVP, triggered by size.

## Verification

- New `index/vector-index` suite (6 tests): cosine identity/orthogonal/opposite/zero-vector, cosine ranking, limit, empty index, id tie-break.
- `pnpm -r typecheck` + `pnpm run lint` green; core suite 668. (Pure math/index — self-reviewed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)