### PR TITLE
feat(index): hybrid index — RRF fusion + pluggable embedder (F2, Phase 3)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -176,15 +176,20 @@ export {
 } from "./store/corpus/index.js";
 export { type GitOps, type SyncGitOps, createGitOps, createSyncGitOps } from "./store/git/index.js";
 export {
+  type Embedder,
+  type HybridHit,
+  type HybridIndex,
   type KeywordHit,
   type KeywordIndex,
   type LinkGraph,
   type VectorHit,
   type VectorIndex,
+  buildHybridIndex,
   buildKeywordIndex,
   buildLinkGraph,
   buildVectorIndex,
   cosineSimilarity,
+  createHashEmbedder,
 } from "./store/index/index.js";
 export {
   type MarkdownHandoffStoreDeps,

--- a/packages/core/src/store/index/hybrid-index.ts
+++ b/packages/core/src/store/index/hybrid-index.ts
@@ -1,0 +1,86 @@
+// Hybrid index for the disposable index (plan 036 Phase 3 / spec 035 §F2).
+// Fuses the keyword + vector signals with Reciprocal Rank Fusion (RRF) —
+// robust and normalization-free (the two signals' raw scores are
+// incomparable: keyword tf vs cosine in [-1,1]). The embedder is pluggable
+// and async so the real transformers.js model is a drop-in; the bundled
+// `createHashEmbedder` is a deterministic, zero-dependency fallback (also the
+// test double) usable when no model is configured.
+
+import { tokenize } from "../memory-tokenize.js";
+import { buildKeywordIndex } from "./keyword-index.js";
+import { buildVectorIndex } from "./vector-index.js";
+
+export interface Embedder {
+  embed(text: string): Promise<number[]>;
+}
+
+/**
+ * Deterministic, zero-dependency fallback embedder: hashes each token (FNV-1a)
+ * into a fixed-width bag-of-buckets vector. Shared tokens → shared buckets →
+ * positive cosine. Lexical, not semantic — a functional fallback / test
+ * double; the real transformers.js model is the quality embedder.
+ */
+export function createHashEmbedder(dimensions = 256): Embedder {
+  return {
+    embed(text) {
+      const vector = new Array<number>(dimensions).fill(0);
+      for (const term of tokenize(text)) {
+        let hash = 2166136261;
+        for (let i = 0; i < term.length; i++) {
+          hash ^= term.charCodeAt(i);
+          hash = Math.imul(hash, 16777619);
+        }
+        const bucket = (hash >>> 0) % dimensions;
+        vector[bucket] = (vector[bucket] ?? 0) + 1;
+      }
+      return Promise.resolve(vector);
+    },
+  };
+}
+
+export interface HybridHit {
+  id: string;
+  score: number;
+}
+
+export interface HybridIndex {
+  /** Fused (keyword + vector) ranking for the query, RRF-scored. */
+  search(query: string, limit?: number): Promise<HybridHit[]>;
+}
+
+export async function buildHybridIndex(
+  documents: { id: string; text: string }[],
+  embedder: Embedder,
+  options: { rrfK?: number } = {},
+): Promise<HybridIndex> {
+  const rrfK = options.rrfK ?? 60;
+  const keyword = buildKeywordIndex(documents.map((doc) => ({ id: doc.id, text: doc.text })));
+  const vectors: { id: string; vector: number[] }[] = [];
+  for (const doc of documents) vectors.push({ id: doc.id, vector: await embedder.embed(doc.text) });
+  const vector = buildVectorIndex(vectors);
+
+  return {
+    async search(query, limit) {
+      const queryVector = await embedder.embed(query);
+      const keywordHits = keyword.search(query);
+      // Only positive cosine counts as a semantic match (drop orthogonal/opposite).
+      const vectorHits = vector.search(queryVector).filter((hit) => hit.score > 0);
+
+      // RRF: a doc's fused score is the sum of 1/(k + rank) across the lists
+      // it appears in. No score normalization needed; docs ranking high in
+      // both signals win.
+      const fused = new Map<string, number>();
+      const contribute = (hits: { id: string }[]): void => {
+        hits.forEach((hit, rank) => {
+          fused.set(hit.id, (fused.get(hit.id) ?? 0) + 1 / (rrfK + rank + 1));
+        });
+      };
+      contribute(keywordHits);
+      contribute(vectorHits);
+
+      const ranked = [...fused.entries()].map(([id, score]) => ({ id, score }));
+      ranked.sort((a, b) => b.score - a.score || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+      return limit != null ? ranked.slice(0, limit) : ranked;
+    },
+  };
+}

--- a/packages/core/src/store/index/index.ts
+++ b/packages/core/src/store/index/index.ts
@@ -11,3 +11,10 @@ export {
   buildVectorIndex,
   cosineSimilarity,
 } from "./vector-index.js";
+export {
+  type Embedder,
+  type HybridHit,
+  type HybridIndex,
+  buildHybridIndex,
+  createHashEmbedder,
+} from "./hybrid-index.js";

--- a/packages/core/tests/store/index/hybrid-index.test.ts
+++ b/packages/core/tests/store/index/hybrid-index.test.ts
@@ -1,0 +1,58 @@
+// Hybrid index tests (plan 036 Phase 3 / spec 035 §F2). Fuses the keyword +
+// vector signals with Reciprocal Rank Fusion (RRF) — robust + normalization-
+// free. The embedder is pluggable + async; tests use the deterministic
+// zero-dep hash embedder (also a usable fallback when no model is configured).
+
+import { type Embedder, buildHybridIndex, createHashEmbedder } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+const docs = [
+  { id: "pnpm", text: "use pnpm for the monorepo workspace" },
+  { id: "npm", text: "npm registry publishing notes" },
+  { id: "cal", text: "calendar tuesdays and thursdays" },
+];
+
+describe("createHashEmbedder", () => {
+  it("is deterministic and gives shared-token texts a positive cosine", async () => {
+    const e = createHashEmbedder();
+    const a = await e.embed("pnpm workspace");
+    const b = await e.embed("pnpm workspace");
+    expect(a).toEqual(b); // deterministic
+    expect(a.length).toBeGreaterThan(0);
+  });
+});
+
+describe("buildHybridIndex", () => {
+  it("ranks the matching doc first by fusing keyword + vector", async () => {
+    const index = await buildHybridIndex(docs, createHashEmbedder());
+    const hits = await index.search("pnpm monorepo");
+    expect(hits[0]!.id).toBe("pnpm");
+  });
+
+  it("excludes docs that match neither signal", async () => {
+    const index = await buildHybridIndex(docs, createHashEmbedder());
+    const hits = await index.search("pnpm");
+    expect(hits.map((h) => h.id)).not.toContain("cal");
+  });
+
+  it("respects the limit", async () => {
+    const index = await buildHybridIndex(docs, createHashEmbedder());
+    expect((await index.search("notes registry calendar", 1)).length).toBeLessThanOrEqual(1);
+  });
+
+  it("returns [] for a query with no signal", async () => {
+    const index = await buildHybridIndex(docs, createHashEmbedder());
+    expect(await index.search("zzzznotaword")).toEqual([]);
+  });
+
+  it("works with an injected custom embedder (pluggable)", async () => {
+    // A trivial 1-dim embedder: vector magnitude = token count → all texts
+    // align (cosine 1), so ranking falls to the keyword signal.
+    const oneDim: Embedder = {
+      embed: async (text) => [text.split(/\s+/).filter(Boolean).length || 0.0001],
+    };
+    const index = await buildHybridIndex(docs, oneDim);
+    const hits = await index.search("calendar");
+    expect(hits[0]!.id).toBe("cal");
+  });
+});


### PR DESCRIPTION
## What

Plan 036 **Phase 3** — adds `store/index/hybrid-index.ts`:
- **`Embedder`** interface (async `embed(text) → number[]`) so the real transformers.js model is a drop-in.
- **`createHashEmbedder`** — a deterministic, zero-dependency FNV bag-of-buckets fallback embedder (lexical, *not* semantic), usable when no model is configured and as the test double.
- **`buildHybridIndex`** — fuses the keyword + vector signals with **Reciprocal Rank Fusion** (RRF, k=60), normalization-free (the two signals' raw scores are incomparable). Positive-cosine vector matches only; ranked desc with id tie-break, limit-able. Built from the corpus, rebuildable.

Backlink-aware recall (which expands results via the link graph) builds on this next; the real transformers.js embedder is a separate drop-in.

## Review

A review sub-agent confirmed **sound, no Critical/Important**: RRF formula correct (0-based rank → first place `1/(k+1)`, no double-count), `createHashEmbedder` FNV is textbook + deterministic + honestly documented as lexical, empty text → zero vector → filtered (no NaN), and the "excludes cal" test is deterministic (computed buckets — no collision at dim=256), not luck-dependent. Two trivial optional suggestions (a harmless defensive copy; the `<= limit` assertion) left as-is.

## Verification

- New `index/hybrid-index` suite (6 tests): hash embedder determinism, fused ranking, no-signal exclusion, limit, custom-embedder pluggability.
- `pnpm -r typecheck` + `pnpm run lint` green; core suite 674.

🤖 Generated with [Claude Code](https://claude.com/claude-code)