### PR TITLE
feat(index): backlink-aware recall (F3, Phase 3)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -182,6 +182,9 @@ export {
   type KeywordHit,
   type KeywordIndex,
   type LinkGraph,
+  type RecallDeps,
+  type RecallOptions,
+  type RecalledDoc,
   type VectorHit,
   type VectorIndex,
   buildHybridIndex,
@@ -190,6 +193,7 @@ export {
   buildVectorIndex,
   cosineSimilarity,
   createHashEmbedder,
+  recallFromIndex,
 } from "./store/index/index.js";
 export {
   type MarkdownHandoffStoreDeps,

--- a/packages/core/src/store/index/index.ts
+++ b/packages/core/src/store/index/index.ts
@@ -18,3 +18,9 @@ export {
   buildHybridIndex,
   createHashEmbedder,
 } from "./hybrid-index.js";
+export {
+  type RecallDeps,
+  type RecallOptions,
+  type RecalledDoc,
+  recallFromIndex,
+} from "./recall.js";

--- a/packages/core/src/store/index/recall.ts
+++ b/packages/core/src/store/index/recall.ts
@@ -32,7 +32,10 @@ export interface RecallOptions {
   neighborDecay?: number;
 }
 
-// Seed cap: how many hybrid hits to expand from before bounding to `limit`.
+// Seed cap: how many hybrid hits to expand from. Generous headroom over the
+// default limit so neighbours have room to compete; the final slice bounds the
+// output. Seeded with max(SEED_CAP, limit) so a large `limit` never silently
+// drops direct matches before expansion runs.
 const SEED_CAP = 50;
 
 export async function recallFromIndex(
@@ -42,22 +45,24 @@ export async function recallFromIndex(
 ): Promise<RecalledDoc[]> {
   const limit = options.limit ?? 12;
   const expand = options.expandBacklinks ?? true;
-  const decay = options.neighborDecay ?? 0.5;
+  const decay = options.neighborDecay ?? 0.5; // expected in [0,1]; neighbours are decayed, never boosted
 
-  const primary = await deps.hybrid.search(query, SEED_CAP);
+  const primary = await deps.hybrid.search(query, Math.max(SEED_CAP, limit));
   const entries = new Map<string, { score: number; direct: boolean }>();
   for (const hit of primary) entries.set(hit.id, { score: hit.score, direct: true });
 
   if (expand) {
+    // Single-hop only: neighbours of the direct matches (never neighbours of
+    // neighbours). Neighbours of every seed compete globally by decayed score.
     for (const hit of primary) {
-      const boost = hit.score * decay;
+      const neighborScore = hit.score * decay;
       for (const neighborId of deps.linkGraph.neighbors(hit.id)) {
         const existing = entries.get(neighborId);
         if (!existing) {
-          entries.set(neighborId, { score: boost, direct: false });
+          entries.set(neighborId, { score: neighborScore, direct: false });
         } else if (!existing.direct) {
           // keep the strongest backlink path; never downgrade a direct match
-          existing.score = Math.max(existing.score, boost);
+          existing.score = Math.max(existing.score, neighborScore);
         }
       }
     }

--- a/packages/core/src/store/index/recall.ts
+++ b/packages/core/src/store/index/recall.ts
@@ -1,0 +1,79 @@
+// Backlink-aware recall (plan 036 Phase 3 / spec 035 §F3, S2). Combines the
+// hybrid index (keyword + vector) with the link graph: the query's direct
+// matches PLUS their backlink neighbours (both directions, decayed), so a
+// fact filed under EITHER entity is retrievable from the other and the result
+// is self-contained — the caller can bundle the neighbours' content without
+// ID-chasing (the "Anna problem", G1/S2).
+//
+// Returns ranked ids + provenance; fetching + formatting the markdown bundle
+// is the caller's (recall verb) concern.
+
+import type { HybridIndex } from "./hybrid-index.js";
+import type { LinkGraph } from "./link-graph.js";
+
+export interface RecalledDoc {
+  id: string;
+  score: number;
+  /** True = matched the query; false = pulled in via a backlink neighbour. */
+  matchedDirectly: boolean;
+}
+
+export interface RecallDeps {
+  hybrid: HybridIndex;
+  linkGraph: LinkGraph;
+}
+
+export interface RecallOptions {
+  /** Max results returned (direct-first), default 12. */
+  limit?: number;
+  /** Pull in backlink neighbours of the direct matches (default true). */
+  expandBacklinks?: boolean;
+  /** Neighbour score = parent score × this (default 0.5). */
+  neighborDecay?: number;
+}
+
+// Seed cap: how many hybrid hits to expand from before bounding to `limit`.
+const SEED_CAP = 50;
+
+export async function recallFromIndex(
+  deps: RecallDeps,
+  query: string,
+  options: RecallOptions = {},
+): Promise<RecalledDoc[]> {
+  const limit = options.limit ?? 12;
+  const expand = options.expandBacklinks ?? true;
+  const decay = options.neighborDecay ?? 0.5;
+
+  const primary = await deps.hybrid.search(query, SEED_CAP);
+  const entries = new Map<string, { score: number; direct: boolean }>();
+  for (const hit of primary) entries.set(hit.id, { score: hit.score, direct: true });
+
+  if (expand) {
+    for (const hit of primary) {
+      const boost = hit.score * decay;
+      for (const neighborId of deps.linkGraph.neighbors(hit.id)) {
+        const existing = entries.get(neighborId);
+        if (!existing) {
+          entries.set(neighborId, { score: boost, direct: false });
+        } else if (!existing.direct) {
+          // keep the strongest backlink path; never downgrade a direct match
+          existing.score = Math.max(existing.score, boost);
+        }
+      }
+    }
+  }
+
+  const ranked = [...entries.entries()].map(([id, value]) => ({
+    id,
+    score: value.score,
+    matchedDirectly: value.direct,
+  }));
+  // Direct matches outrank decayed neighbours; id tie-break for determinism.
+  ranked.sort(
+    (a, b) =>
+      Number(b.matchedDirectly) - Number(a.matchedDirectly) ||
+      b.score - a.score ||
+      (a.id < b.id ? -1 : a.id > b.id ? 1 : 0),
+  );
+  return ranked.slice(0, limit);
+}

--- a/packages/core/tests/store/index/recall.test.ts
+++ b/packages/core/tests/store/index/recall.test.ts
@@ -1,0 +1,70 @@
+// Backlink-aware recall tests (plan 036 Phase 3 / spec 035 §F3, S2 — the
+// "Anna problem"). recallFromIndex combines the hybrid index (keyword+vector)
+// with the link graph: direct query matches PLUS their backlink neighbours
+// (both directions), so a fact filed under either entity is retrievable from
+// the other and the bundle is self-contained (no ID-chasing).
+
+import {
+  buildHybridIndex,
+  buildLinkGraph,
+  createHashEmbedder,
+  recallFromIndex,
+} from "@librarian/core";
+import { beforeEach, describe, expect, it } from "vitest";
+
+// NB: queried words are kept mid-sentence (no trailing punctuation). The
+// shared tokenizer retains `. / - _` as in-token chars (for path tokens like
+// `file.ts`), so a sentence-final "piano." would index as the token "piano."
+// and never match a "piano" query — a pre-existing quirk, noted for review.
+const docs = [
+  { id: "sophie", text: "Sophie is [[anna]] daughter and loves playing piano music" },
+  { id: "anna", text: "Anna is the family matriarch and head of household" },
+  { id: "bob", text: "Bob repairs bicycles in his garage workshop" },
+];
+
+let deps: {
+  hybrid: Awaited<ReturnType<typeof buildHybridIndex>>;
+  linkGraph: ReturnType<typeof buildLinkGraph>;
+};
+
+beforeEach(async () => {
+  deps = {
+    hybrid: await buildHybridIndex(docs, createHashEmbedder()),
+    linkGraph: buildLinkGraph(docs.map((d) => ({ id: d.id, body: d.text }))),
+  };
+});
+
+describe("recallFromIndex (backlink-aware)", () => {
+  it("returns a direct match AND pulls in its outbound neighbour", async () => {
+    // "piano" matches sophie; sophie → [[anna]] (outbound) is pulled in.
+    const hits = await recallFromIndex(deps, "piano");
+    const byId = new Map(hits.map((h) => [h.id, h]));
+    expect(byId.get("sophie")?.matchedDirectly).toBe(true);
+    expect(byId.get("anna")?.matchedDirectly).toBe(false); // pulled in via the link
+    expect(byId.has("bob")).toBe(false);
+  });
+
+  it("Anna problem: querying the matriarch also surfaces sophie (inbound backlink)", async () => {
+    const hits = await recallFromIndex(deps, "matriarch");
+    const byId = new Map(hits.map((h) => [h.id, h]));
+    expect(byId.get("anna")?.matchedDirectly).toBe(true);
+    expect(byId.get("sophie")?.matchedDirectly).toBe(false); // backlink from anna
+  });
+
+  it("direct matches rank above backlink-expanded neighbours", async () => {
+    const hits = await recallFromIndex(deps, "piano");
+    const annaRank = hits.findIndex((h) => h.id === "anna");
+    const sophieRank = hits.findIndex((h) => h.id === "sophie");
+    expect(sophieRank).toBeLessThan(annaRank); // direct (sophie) before neighbour (anna)
+  });
+
+  it("expandBacklinks: false returns only direct matches", async () => {
+    const hits = await recallFromIndex(deps, "piano", { expandBacklinks: false });
+    expect(hits.map((h) => h.id)).toEqual(["sophie"]);
+  });
+
+  it("bounds the result set to the limit", async () => {
+    const hits = await recallFromIndex(deps, "piano matriarch bicycles", { limit: 2 });
+    expect(hits.length).toBeLessThanOrEqual(2);
+  });
+});

--- a/packages/core/tests/store/index/recall.test.ts
+++ b/packages/core/tests/store/index/recall.test.ts
@@ -5,12 +5,19 @@
 // the other and the bundle is self-contained (no ID-chasing).
 
 import {
+  type Embedder,
   buildHybridIndex,
   buildLinkGraph,
   createHashEmbedder,
   recallFromIndex,
 } from "@librarian/core";
 import { beforeEach, describe, expect, it } from "vitest";
+
+// Keyword-only embedder: a zero vector gives every doc cosine NaN, so the
+// vector signal contributes nothing and recall falls to pure keyword + graph.
+// Structural tests use this to isolate graph-expansion behaviour from the hash
+// embedder's lexical bucket-collision noise (it is lexical, not semantic).
+const keywordOnly: Embedder = { embed: async () => [0] };
 
 // NB: queried words are kept mid-sentence (no trailing punctuation). The
 // shared tokenizer retains `. / - _` as in-token chars (for path tokens like
@@ -63,8 +70,45 @@ describe("recallFromIndex (backlink-aware)", () => {
     expect(hits.map((h) => h.id)).toEqual(["sophie"]);
   });
 
-  it("bounds the result set to the limit", async () => {
+  it("bounds the result set to the limit, keeping direct matches over neighbours", async () => {
+    // all three docs match directly; with limit < direct-count only direct
+    // matches survive (direct-first), never a decayed neighbour.
     const hits = await recallFromIndex(deps, "piano matriarch bicycles", { limit: 2 });
-    expect(hits.length).toBeLessThanOrEqual(2);
+    expect(hits.length).toBe(2);
+    expect(hits.every((h) => h.matchedDirectly)).toBe(true);
+  });
+
+  it("expands a single hop only — a neighbour's neighbour is not pulled in", async () => {
+    const chain = [
+      { id: "alpha", text: "alpha mentions [[bravo]] and discusses telescopes" },
+      { id: "bravo", text: "bravo mentions [[charlie]] about gardening" },
+      { id: "charlie", text: "charlie writes poetry" },
+    ];
+    const chainDeps = {
+      hybrid: await buildHybridIndex(chain, keywordOnly),
+      linkGraph: buildLinkGraph(chain.map((d) => ({ id: d.id, body: d.text }))),
+    };
+    const hits = await recallFromIndex(chainDeps, "telescopes");
+    const ids = hits.map((h) => h.id);
+    expect(ids).toContain("alpha"); // direct
+    expect(ids).toContain("bravo"); // one hop
+    expect(ids).not.toContain("charlie"); // two hops — excluded
+  });
+
+  it("breaks score ties deterministically by id (two neighbours of one seed)", async () => {
+    // hub links both xray and yankee → both neighbours share the identical
+    // decayed score, so the id tie-break must order xray before yankee.
+    const star = [
+      { id: "hub", text: "hub references [[xray]] and [[yankee]] about astronomy" },
+      { id: "xray", text: "xray holds some content" },
+      { id: "yankee", text: "yankee holds some content" },
+    ];
+    const starDeps = {
+      hybrid: await buildHybridIndex(star, keywordOnly),
+      linkGraph: buildLinkGraph(star.map((d) => ({ id: d.id, body: d.text }))),
+    };
+    const hits = await recallFromIndex(starDeps, "astronomy");
+    const neighbours = hits.filter((h) => !h.matchedDirectly).map((h) => h.id);
+    expect(neighbours).toEqual(["xray", "yankee"]);
   });
 });


### PR DESCRIPTION
## What

`recallFromIndex` — the headline F3 payoff (spec 035 §F3 / S2, plan 036 Phase 3). It fuses the disposable hybrid index (keyword + vector) with the wikilink link graph so a query returns its **direct matches plus their backlink neighbours, both directions**. A fact filed under entity A is now retrievable when querying entity B (the "Anna problem", G1/S2).

- Direct matches outrank decayed neighbours (`neighborScore = hitScore × decay`, decay default 0.5).
- Single-hop expansion only (neighbours of the direct matches, never neighbours of neighbours) — bounds the graph walk.
- Result bounded to `limit`; seeded with `max(SEED_CAP, limit)` so a large limit never drops direct matches before expansion.
- Returns ranked ids + `matchedDirectly` provenance; fetching/formatting the self-contained markdown bundle stays the caller's (recall verb) concern — clean retrieval/presentation boundary.

## Tests

7 tests: outbound + inbound backlink expansion (both Anna-problem directions), direct-first ranking, `expandBacklinks:false`, limit-bounding with direct-first survival, single-hop-only regression, and id tie-break determinism. Structural tests use a keyword-only embedder to isolate graph behaviour from the hash embedder's lexical bucket-collision noise.

## Review

Sub-agent code review (5 axes): no Critical. Important findings fixed in 71caebb — the seed≥limit latent bug, the single-hop regression test, and the direct-first-under-limit assertion. Verdict: sound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)