### PR TITLE
feat(index): namespaced index — Tier-0/Tier-1 isolation + search_references (F4, Phase 3)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -183,6 +183,7 @@ export {
   type KeywordIndex,
   type IndexNamespace,
   type LinkGraph,
+  type LinkGraphOptions,
   type NamespacedDoc,
   type NamespacedIndex,
   type RecallDeps,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -181,10 +181,14 @@ export {
   type HybridIndex,
   type KeywordHit,
   type KeywordIndex,
+  type IndexNamespace,
   type LinkGraph,
+  type NamespacedDoc,
+  type NamespacedIndex,
   type RecallDeps,
   type RecallOptions,
   type RecalledDoc,
+  type ReferenceHit,
   type VectorHit,
   type VectorIndex,
   buildHybridIndex,
@@ -193,6 +197,7 @@ export {
   buildVectorIndex,
   cosineSimilarity,
   createHashEmbedder,
+  createNamespacedIndex,
   recallFromIndex,
 } from "./store/index/index.js";
 export {

--- a/packages/core/src/store/index/index.ts
+++ b/packages/core/src/store/index/index.ts
@@ -24,3 +24,10 @@ export {
   type RecalledDoc,
   recallFromIndex,
 } from "./recall.js";
+export {
+  type IndexNamespace,
+  type NamespacedDoc,
+  type NamespacedIndex,
+  type ReferenceHit,
+  createNamespacedIndex,
+} from "./namespaced-index.js";

--- a/packages/core/src/store/index/index.ts
+++ b/packages/core/src/store/index/index.ts
@@ -3,7 +3,7 @@
 // source at any time. The backlink graph lands first (the "Anna problem"
 // core); keyword + vector indexes follow.
 
-export { type LinkGraph, buildLinkGraph } from "./link-graph.js";
+export { type LinkGraph, type LinkGraphOptions, buildLinkGraph } from "./link-graph.js";
 export { type KeywordHit, type KeywordIndex, buildKeywordIndex } from "./keyword-index.js";
 export {
   type VectorHit,

--- a/packages/core/src/store/index/link-graph.ts
+++ b/packages/core/src/store/index/link-graph.ts
@@ -16,9 +16,23 @@ export interface LinkGraph {
   neighbors(id: string): string[];
 }
 
-export function buildLinkGraph(documents: { id: string; body: string }[]): LinkGraph {
+export interface LinkGraphOptions {
+  /**
+   * Drop edges whose target is not one of the supplied documents (references
+   * in another namespace, or dangling links). Off by default so the general
+   * graph still surfaces dangling targets (link-rot detection, F12); recall
+   * turns it ON so backlink expansion can never escape its own namespace.
+   */
+  restrictToKnownIds?: boolean;
+}
+
+export function buildLinkGraph(
+  documents: { id: string; body: string }[],
+  options: LinkGraphOptions = {},
+): LinkGraph {
   const outbound = new Map<string, Set<string>>();
   const inbound = new Map<string, Set<string>>();
+  const knownIds = options.restrictToKnownIds ? new Set(documents.map((doc) => doc.id)) : null;
 
   const add = (map: Map<string, Set<string>>, key: string, value: string): void => {
     let set = map.get(key);
@@ -32,6 +46,7 @@ export function buildLinkGraph(documents: { id: string; body: string }[]): LinkG
   for (const doc of documents) {
     for (const link of parseWikilinks(doc.body)) {
       const target = link.target;
+      if (knownIds && !knownIds.has(target)) continue; // skip out-of-namespace / dangling targets
       add(outbound, doc.id, target);
       add(inbound, target, doc.id);
     }

--- a/packages/core/src/store/index/namespaced-index.ts
+++ b/packages/core/src/store/index/namespaced-index.ts
@@ -8,6 +8,9 @@
 //
 // References are deliberately hybrid-only (no link graph): they are background
 // material, not consolidated or session-injected, retrieved only on demand.
+//
+// Ids are assumed globally unique across both namespaces (the file/slug layer
+// guarantees this); a Tier-1 and a Tier-0 doc must not share an id.
 
 import { type Embedder, buildHybridIndex } from "./hybrid-index.js";
 import { buildLinkGraph } from "./link-graph.js";
@@ -47,7 +50,12 @@ export async function createNamespacedIndex(
     corpusDocs.map((doc) => ({ id: doc.id, text: doc.text })),
     embedder,
   );
-  const corpusGraph = buildLinkGraph(corpusDocs.map((doc) => ({ id: doc.id, body: doc.text })));
+  // restrictToKnownIds: a corpus doc that links to a reference (or a dangling
+  // target) must not pull that out-of-namespace doc into Tier-1 recall (S8).
+  const corpusGraph = buildLinkGraph(
+    corpusDocs.map((doc) => ({ id: doc.id, body: doc.text })),
+    { restrictToKnownIds: true },
+  );
   const referenceHybrid = await buildHybridIndex(
     referenceDocs.map((doc) => ({ id: doc.id, text: doc.text })),
     embedder,

--- a/packages/core/src/store/index/namespaced-index.ts
+++ b/packages/core/src/store/index/namespaced-index.ts
@@ -1,0 +1,65 @@
+// Namespaced disposable index (plan 036 Phase 3 / spec 035 §F2, F4). Corpus
+// (Tier 1) and references (Tier 0) are indexed SEPARATELY: `recall` runs over
+// the corpus index + link graph (backlink-aware, the self-contained bundle),
+// `searchReferences` runs over the references index only. Keeping them in
+// distinct indexes makes Tier-0/Tier-1 isolation structural — a reference doc
+// can never leak into recall (S8) and is never backlink-expanded — rather than
+// a filter that could be forgotten.
+//
+// References are deliberately hybrid-only (no link graph): they are background
+// material, not consolidated or session-injected, retrieved only on demand.
+
+import { type Embedder, buildHybridIndex } from "./hybrid-index.js";
+import { buildLinkGraph } from "./link-graph.js";
+import { type RecallOptions, type RecalledDoc, recallFromIndex } from "./recall.js";
+
+export type IndexNamespace = "corpus" | "references";
+
+export interface NamespacedDoc {
+  id: string;
+  text: string;
+  namespace: IndexNamespace;
+}
+
+/** A Tier-0 reference hit: a pointer (id) + relevance score. */
+export interface ReferenceHit {
+  id: string;
+  score: number;
+}
+
+export interface NamespacedIndex {
+  /** Tier-1 backlink-aware recall over the corpus namespace only. */
+  recall(query: string, options?: RecallOptions): Promise<RecalledDoc[]>;
+  /** Tier-0 lookup over the references namespace only (pointer + score). */
+  searchReferences(query: string, limit?: number): Promise<ReferenceHit[]>;
+}
+
+const DEFAULT_REFERENCE_LIMIT = 12;
+
+export async function createNamespacedIndex(
+  docs: NamespacedDoc[],
+  embedder: Embedder,
+): Promise<NamespacedIndex> {
+  const corpusDocs = docs.filter((doc) => doc.namespace === "corpus");
+  const referenceDocs = docs.filter((doc) => doc.namespace === "references");
+
+  const corpusHybrid = await buildHybridIndex(
+    corpusDocs.map((doc) => ({ id: doc.id, text: doc.text })),
+    embedder,
+  );
+  const corpusGraph = buildLinkGraph(corpusDocs.map((doc) => ({ id: doc.id, body: doc.text })));
+  const referenceHybrid = await buildHybridIndex(
+    referenceDocs.map((doc) => ({ id: doc.id, text: doc.text })),
+    embedder,
+  );
+
+  return {
+    recall(query, options) {
+      return recallFromIndex({ hybrid: corpusHybrid, linkGraph: corpusGraph }, query, options);
+    },
+    async searchReferences(query, limit) {
+      const hits = await referenceHybrid.search(query, limit ?? DEFAULT_REFERENCE_LIMIT);
+      return hits.map((hit) => ({ id: hit.id, score: hit.score }));
+    },
+  };
+}

--- a/packages/core/tests/store/index/namespaced-index.test.ts
+++ b/packages/core/tests/store/index/namespaced-index.test.ts
@@ -52,8 +52,32 @@ describe("createNamespacedIndex", () => {
     expect(ids).toContain("sophie"); // inbound backlink
   });
 
+  it("S8 (linked): a corpus doc linking to a reference does not pull it into recall", async () => {
+    // the dangerous case — a corpus wikilink straight at a reference id must
+    // NOT backlink-expand the reference into Tier-1 recall.
+    const linkedCorpus = [
+      {
+        id: "note",
+        text: "Project alpha relies on the [[piano-manual]] for tuning details",
+        namespace: "corpus" as const,
+      },
+    ];
+    const index = await createNamespacedIndex(
+      [...linkedCorpus, bigReference],
+      createHashEmbedder(),
+    );
+    const recalled = (await index.recall("project alpha")).map((h) => h.id);
+    expect(recalled).toContain("note");
+    expect(recalled).not.toContain("piano-manual"); // out-of-namespace link is not expanded
+  });
+
   it("returns no references when none are indexed", async () => {
     const index = await createNamespacedIndex(corpus, createHashEmbedder());
     expect(await index.searchReferences("piano")).toEqual([]);
+  });
+
+  it("returns no recall hits when the corpus is empty", async () => {
+    const index = await createNamespacedIndex([bigReference], createHashEmbedder());
+    expect(await index.recall("piano")).toEqual([]);
   });
 });

--- a/packages/core/tests/store/index/namespaced-index.test.ts
+++ b/packages/core/tests/store/index/namespaced-index.test.ts
@@ -1,0 +1,59 @@
+// Namespaced index tests (plan 036 Phase 3 / spec 035 §F2, F4 — Tier 0/Tier 1
+// isolation). corpus docs (Tier 1) and references docs (Tier 0) live in
+// SEPARATE indexes: recall() only ever sees the corpus, search_references()
+// only ever sees the references. That makes S8 (a big reference doc must not
+// change Tier-1 recall) a structural guarantee, not a filter.
+
+import { createHashEmbedder, createNamespacedIndex } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+const corpus = [
+  {
+    id: "sophie",
+    text: "Sophie is [[anna]] daughter and loves playing piano music",
+    namespace: "corpus" as const,
+  },
+  {
+    id: "anna",
+    text: "Anna is the family matriarch and head of household",
+    namespace: "corpus" as const,
+  },
+];
+const bigReference = {
+  id: "piano-manual",
+  text: "piano tuning maintenance guide covering grand piano regulation voicing and piano hammer care",
+  namespace: "references" as const,
+};
+
+describe("createNamespacedIndex", () => {
+  it("S8: adding a reference doc does not change Tier-1 recall", async () => {
+    const withoutRef = await createNamespacedIndex(corpus, createHashEmbedder());
+    const withRef = await createNamespacedIndex([...corpus, bigReference], createHashEmbedder());
+    const before = (await withoutRef.recall("piano")).map((h) => h.id);
+    const after = (await withRef.recall("piano")).map((h) => h.id);
+    expect(after).toEqual(before); // references are invisible to Tier-1 recall
+  });
+
+  it("isolates the namespaces: recall is Tier-1 only, search_references is Tier-0 only", async () => {
+    const index = await createNamespacedIndex([...corpus, bigReference], createHashEmbedder());
+    const recalled = (await index.recall("piano")).map((h) => h.id);
+    expect(recalled).toContain("sophie"); // corpus hit
+    expect(recalled).not.toContain("piano-manual"); // reference excluded from recall
+
+    const refs = (await index.searchReferences("piano")).map((h) => h.id);
+    expect(refs).toContain("piano-manual"); // reference hit
+    expect(refs).not.toContain("sophie"); // corpus excluded from references
+  });
+
+  it("recall still expands backlinks within the corpus (Anna problem through the wrapper)", async () => {
+    const index = await createNamespacedIndex([...corpus, bigReference], createHashEmbedder());
+    const ids = (await index.recall("matriarch")).map((h) => h.id);
+    expect(ids).toContain("anna"); // direct
+    expect(ids).toContain("sophie"); // inbound backlink
+  });
+
+  it("returns no references when none are indexed", async () => {
+    const index = await createNamespacedIndex(corpus, createHashEmbedder());
+    expect(await index.searchReferences("piano")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

`createNamespacedIndex` — the Tier-0/Tier-1 split (spec 035 §F2/F4, plan 036 Phase 3). Corpus (Tier 1, live memory) and references (Tier 0, background docs in `references/`) are indexed **separately**:

- `recall(query, opts)` → corpus hybrid index + link graph (backlink-aware Tier-1 bundle).
- `searchReferences(query, limit)` → references hybrid index only (Tier-0, pointer + score).

Distinct indexes make the isolation **structural**, not a forgettable filter: a reference doc can never enter recall or be backlink-expanded. Delivers **S8** — adding a large reference doc does not change Tier-1 recall.

## Review-driven hardening (Critical)

The sub-agent review caught a real leak the first cut had: a corpus doc containing `[[reference-id]]` recorded a corpus→reference edge in the link graph, so recall backlink-expanded the reference straight into Tier-1. Fixed by giving `buildLinkGraph` an opt-in `restrictToKnownIds` (default **off** — the general graph still surfaces dangling targets for link-rot detection / F12; the corpus recall graph turns it **on**). Backlink expansion now provably cannot escape its namespace.

## Tests

6 tests: S8 (reference invisible to recall), S8-linked (the leak case — corpus `[[reference-id]]` not expanded), bidirectional namespace isolation, backlink expansion still works within corpus, empty-references, empty-corpus.

## Deferred (tracked)

`searchReferences` returns a pointer only; spec F3's "relevant section" snippet (heading-aware extract) is a follow-up before F3 is marked done — the `ReferenceHit` interface is the extension point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)