### PR TITLE
feat(index): search_references returns the relevant section (F3, Phase 3)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -199,6 +199,7 @@ export {
   cosineSimilarity,
   createHashEmbedder,
   createNamespacedIndex,
+  extractRelevantSection,
   recallFromIndex,
 } from "./store/index/index.js";
 export {

--- a/packages/core/src/store/index/index.ts
+++ b/packages/core/src/store/index/index.ts
@@ -31,3 +31,4 @@ export {
   type ReferenceHit,
   createNamespacedIndex,
 } from "./namespaced-index.js";
+export { extractRelevantSection } from "./reference-section.js";

--- a/packages/core/src/store/index/namespaced-index.ts
+++ b/packages/core/src/store/index/namespaced-index.ts
@@ -15,6 +15,7 @@
 import { type Embedder, buildHybridIndex } from "./hybrid-index.js";
 import { buildLinkGraph } from "./link-graph.js";
 import { type RecallOptions, type RecalledDoc, recallFromIndex } from "./recall.js";
+import { extractRelevantSection } from "./reference-section.js";
 
 export type IndexNamespace = "corpus" | "references";
 
@@ -24,16 +25,18 @@ export interface NamespacedDoc {
   namespace: IndexNamespace;
 }
 
-/** A Tier-0 reference hit: a pointer (id) + relevance score. */
+/** A Tier-0 reference hit: a pointer (id) + score + the matched section. */
 export interface ReferenceHit {
   id: string;
   score: number;
+  /** The query-relevant markdown section of the reference doc (not the whole file). */
+  section: string;
 }
 
 export interface NamespacedIndex {
   /** Tier-1 backlink-aware recall over the corpus namespace only. */
   recall(query: string, options?: RecallOptions): Promise<RecalledDoc[]>;
-  /** Tier-0 lookup over the references namespace only (pointer + score). */
+  /** Tier-0 lookup over the references namespace only (pointer + relevant section). */
   searchReferences(query: string, limit?: number): Promise<ReferenceHit[]>;
 }
 
@@ -60,6 +63,7 @@ export async function createNamespacedIndex(
     referenceDocs.map((doc) => ({ id: doc.id, text: doc.text })),
     embedder,
   );
+  const referenceText = new Map(referenceDocs.map((doc) => [doc.id, doc.text]));
 
   return {
     recall(query, options) {
@@ -67,7 +71,11 @@ export async function createNamespacedIndex(
     },
     async searchReferences(query, limit) {
       const hits = await referenceHybrid.search(query, limit ?? DEFAULT_REFERENCE_LIMIT);
-      return hits.map((hit) => ({ id: hit.id, score: hit.score }));
+      return hits.map((hit) => ({
+        id: hit.id,
+        score: hit.score,
+        section: extractRelevantSection(referenceText.get(hit.id) ?? "", query),
+      }));
     },
   };
 }

--- a/packages/core/src/store/index/reference-section.ts
+++ b/packages/core/src/store/index/reference-section.ts
@@ -2,17 +2,32 @@
 // spec 035 §F3). A reference doc can be large; search_references should surface
 // the matched section, not the whole file. Splits the markdown on ATX headings
 // (content before the first heading is its own "preamble" section) and returns
-// the section with the most query-token overlap. Pure + deterministic: ties
-// resolve to the earliest section.
+// the section matching the most DISTINCT query tokens. Pure + deterministic:
+// ties resolve to the earliest section.
+//
+// Scope/heuristics: ATX headings only (setext `===`/`---` underlines are not
+// treated as headings — the corpus emits ATX); fenced code blocks (``` / ~~~)
+// are tracked so a `# comment` line inside a code sample is not mistaken for a
+// heading (length-agnostic fence heuristic — balanced fences assumed). Tokens
+// are compared with trailing in-word punctuation (`. / - _`, which the shared
+// tokenizer keeps for path tokens) stripped, so a sentence-final "tuning."
+// still matches a "tuning" query.
 
 import { tokenize } from "../memory-tokenize.js";
+
+/** Strip trailing in-word punctuation the tokenizer keeps, for prose matching. */
+function normalizeToken(term: string): string {
+  return term.replace(/[./_-]+$/, "");
+}
 
 /** Split markdown into heading-delimited sections (preamble first, if any). */
 function splitIntoSections(markdown: string): string[] {
   const sections: string[] = [];
   let current: string[] = [];
+  let inFence = false;
   for (const line of markdown.split("\n")) {
-    if (/^#{1,6}\s/.test(line) && current.length > 0) {
+    if (/^(```|~~~)/.test(line)) inFence = !inFence;
+    if (!inFence && /^#{1,6}\s/.test(line) && current.length > 0) {
       sections.push(current.join("\n").trim());
       current = [];
     }
@@ -23,17 +38,22 @@ function splitIntoSections(markdown: string): string[] {
 }
 
 export function extractRelevantSection(markdown: string, query: string): string {
-  const sections = splitIntoSections(markdown);
+  const normalized = markdown.replace(/\r\n/g, "\n");
+  const sections = splitIntoSections(normalized);
   const first = sections[0];
-  if (first === undefined) return markdown.trim();
+  if (first === undefined) return normalized.trim();
 
-  const queryTokens = new Set(tokenize(query));
+  const queryTokens = new Set(tokenize(query).map(normalizeToken).filter(Boolean));
   if (queryTokens.size === 0) return first;
 
   let best = first;
   let bestScore = -1;
   for (const section of sections) {
-    const score = tokenize(section).filter((term) => queryTokens.has(term)).length;
+    const present = new Set(tokenize(section).map(normalizeToken));
+    // distinct-token overlap (not raw count) so a long section can't win on
+    // volume alone — the section covering the most query terms wins.
+    let score = 0;
+    for (const token of queryTokens) if (present.has(token)) score += 1;
     if (score > bestScore) {
       bestScore = score;
       best = section;

--- a/packages/core/src/store/index/reference-section.ts
+++ b/packages/core/src/store/index/reference-section.ts
@@ -1,0 +1,43 @@
+// Relevant-section extraction for Tier-0 reference lookup (plan 036 Phase 3 /
+// spec 035 §F3). A reference doc can be large; search_references should surface
+// the matched section, not the whole file. Splits the markdown on ATX headings
+// (content before the first heading is its own "preamble" section) and returns
+// the section with the most query-token overlap. Pure + deterministic: ties
+// resolve to the earliest section.
+
+import { tokenize } from "../memory-tokenize.js";
+
+/** Split markdown into heading-delimited sections (preamble first, if any). */
+function splitIntoSections(markdown: string): string[] {
+  const sections: string[] = [];
+  let current: string[] = [];
+  for (const line of markdown.split("\n")) {
+    if (/^#{1,6}\s/.test(line) && current.length > 0) {
+      sections.push(current.join("\n").trim());
+      current = [];
+    }
+    current.push(line);
+  }
+  if (current.length > 0) sections.push(current.join("\n").trim());
+  return sections.filter((section) => section.length > 0);
+}
+
+export function extractRelevantSection(markdown: string, query: string): string {
+  const sections = splitIntoSections(markdown);
+  const first = sections[0];
+  if (first === undefined) return markdown.trim();
+
+  const queryTokens = new Set(tokenize(query));
+  if (queryTokens.size === 0) return first;
+
+  let best = first;
+  let bestScore = -1;
+  for (const section of sections) {
+    const score = tokenize(section).filter((term) => queryTokens.has(term)).length;
+    if (score > bestScore) {
+      bestScore = score;
+      best = section;
+    }
+  }
+  return best;
+}

--- a/packages/core/tests/store/index/namespaced-index.test.ts
+++ b/packages/core/tests/store/index/namespaced-index.test.ts
@@ -45,6 +45,18 @@ describe("createNamespacedIndex", () => {
     expect(refs).not.toContain("sophie"); // corpus excluded from references
   });
 
+  it("search_references returns the matched section, not just a pointer (F3)", async () => {
+    const sectioned = {
+      id: "manual",
+      text: "## Tuning\nthe grand piano needs tuning twice a year\n\n## Cleaning\nwipe the keys gently",
+      namespace: "references" as const,
+    };
+    const index = await createNamespacedIndex([sectioned], createHashEmbedder());
+    const [hit] = await index.searchReferences("tuning");
+    expect(hit?.section).toContain("## Tuning");
+    expect(hit?.section).not.toContain("## Cleaning");
+  });
+
   it("recall still expands backlinks within the corpus (Anna problem through the wrapper)", async () => {
     const index = await createNamespacedIndex([...corpus, bigReference], createHashEmbedder());
     const ids = (await index.recall("matriarch")).map((h) => h.id);

--- a/packages/core/tests/store/index/reference-section.test.ts
+++ b/packages/core/tests/store/index/reference-section.test.ts
@@ -46,4 +46,48 @@ describe("extractRelevantSection", () => {
     const section = extractRelevantSection(doc, "zzzznotaword");
     expect(section).toContain("Intro preamble");
   });
+
+  it("matches a keyword even when it ends a sentence (trailing punctuation)", () => {
+    const d = "## Alpha\nShort note here.\n\n## Beta\nEverything you need about tuning.";
+    const section = extractRelevantSection(d, "tuning");
+    expect(section).toContain("## Beta"); // "tuning." still matches "tuning"
+  });
+
+  it("prefers the section covering the most query terms, not the longest", () => {
+    const d = [
+      "## Background",
+      "piano piano piano piano history lore saga epic tale of the instrument",
+      "",
+      "## Tuning Procedure",
+      "piano tuning steps",
+    ].join("\n");
+    const section = extractRelevantSection(d, "piano tuning");
+    expect(section).toContain("## Tuning Procedure"); // 2 distinct terms beats volume
+  });
+
+  it("does not treat a heading inside a fenced code block as a section break", () => {
+    const d = [
+      "## Setup",
+      "run the installer",
+      "```bash",
+      "# configure the database now",
+      "createdb mydb",
+      "```",
+      "## Usage",
+      "start the app",
+    ].join("\n");
+    const section = extractRelevantSection(d, "configure database");
+    expect(section).toContain("## Setup"); // the fenced `# configure...` did not split
+  });
+
+  it("normalizes CRLF line endings out of the returned section", () => {
+    const d = "## A\r\nfirst about cats\r\n\r\n## B\r\nsecond about dogs";
+    const section = extractRelevantSection(d, "dogs");
+    expect(section).toContain("## B");
+    expect(section).not.toContain("\r");
+  });
+
+  it("returns the first section for an all-stopword query", () => {
+    expect(extractRelevantSection(doc, "the and for")).toContain("Intro preamble");
+  });
 });

--- a/packages/core/tests/store/index/reference-section.test.ts
+++ b/packages/core/tests/store/index/reference-section.test.ts
@@ -1,0 +1,49 @@
+// Reference-section extraction tests (plan 036 Phase 3 / spec 035 §F3 —
+// search_references returns "pointer + relevant section"). Given a reference
+// doc's markdown and a query, return the heading-delimited section most
+// relevant to the query so the caller surfaces the matched section, not the
+// whole (potentially huge) document.
+
+import { extractRelevantSection } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+const doc = [
+  "Intro preamble about the household.",
+  "",
+  "## Piano",
+  "The grand piano needs tuning twice a year and regular voicing.",
+  "",
+  "## Garden",
+  "The roses are pruned in winter and fed in spring.",
+].join("\n");
+
+describe("extractRelevantSection", () => {
+  it("returns the heading section most relevant to the query", () => {
+    const section = extractRelevantSection(doc, "piano tuning");
+    expect(section).toContain("## Piano");
+    expect(section).toContain("needs tuning");
+    expect(section).not.toContain("roses"); // the Garden section is excluded
+  });
+
+  it("picks a different section for a different query", () => {
+    const section = extractRelevantSection(doc, "roses pruning");
+    expect(section).toContain("## Garden");
+    expect(section).not.toContain("grand piano");
+  });
+
+  it("treats the preamble before the first heading as its own section", () => {
+    const section = extractRelevantSection(doc, "household preamble");
+    expect(section).toContain("Intro preamble");
+    expect(section).not.toContain("## Piano");
+  });
+
+  it("returns the whole text when there are no headings", () => {
+    const flat = "Just a flat note with no headings at all about sailing boats.";
+    expect(extractRelevantSection(flat, "sailing")).toBe(flat);
+  });
+
+  it("falls back to the first section when nothing matches the query", () => {
+    const section = extractRelevantSection(doc, "zzzznotaword");
+    expect(section).toContain("Intro preamble");
+  });
+});


### PR DESCRIPTION
## What

Completes the `search_references` contract (spec 035 §F3: Tier-0 lookup returns "**pointer + relevant section**"). A reference doc can be large, so rather than returning the whole file, `extractRelevantSection(markdown, query)` splits on ATX headings (preamble first) and returns the section matching the most **distinct** query tokens. `ReferenceHit` gains `section`; `createNamespacedIndex` retains the reference texts and extracts per hit. Pure + deterministic (ties → earliest section; no headings → whole text; no match / all-stopword query → first section). Closes the I1 follow-up tracked from PR #242.

## Review-driven hardening

Sub-agent review (5 axes) found two Important relevance defects + two suggestions, all fixed here with regression tests the first cut never exercised:

- **I1** — the shared tokenizer keeps `. / - _` as in-token chars (for path tokens), so a sentence-final `"tuning."` never matched a `"tuning"` query and the extractor fell back to the wrong section. Fixed by stripping trailing in-word punctuation when matching.
- **I2** — raw match-count had no length normalization, so a long incidentally-matching section could outscore a short on-target one. Fixed by scoring on **distinct** query-token overlap.
- **S1** — a `# comment` line inside a fenced code block (``` / ~~~) was treated as a heading. Fixed with fence tracking.
- **S3** — CRLF input left stray `\r` in the returned section. Normalized at entry.
- **S2** — setext (`===`/`---`) headings remain intentionally unsupported (the corpus emits ATX); documented in the module comment.

## Tests

reference-section: 10 (happy path + 3 fallbacks + I1/I2/S1/CRLF/all-stopword). namespaced-index: a `searchReferences` integration assertion that the matched section (not the whole file) is returned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)