### PR TITLE
feat(skills): skill store read side — manifest + get_skill (F7, Phase 5)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -218,6 +218,16 @@ export {
   createJsonConversationStateStore,
   createJsonSettingsStore,
 } from "./store/sidecar/index.js";
+export {
+  type SkillDetail,
+  type SkillDocument,
+  type SkillFrontmatter,
+  type SkillManifestEntry,
+  type SkillStore,
+  SkillFrontmatterSchema,
+  createSkillStore,
+  parseSkillDocument,
+} from "./store/skills/index.js";
 export { type MemoryWriteVerdict, routeMemoryWrite } from "./store/memory-routing.js";
 export type { Memory, MemoryStore, MemoryStoreDeps } from "./store/memory-store.js";
 export {

--- a/packages/core/src/store/skills/index.ts
+++ b/packages/core/src/store/skills/index.ts
@@ -1,0 +1,16 @@
+// Skills subsystem (plan 036 Phase 5 / spec 035 §F7) — skills as
+// `skills/<slug>/SKILL.md` (+ optional resources/), manifest derived from
+// frontmatter, retrieved via the store. find_skills (semantic) layers on top.
+
+export {
+  type SkillDocument,
+  type SkillFrontmatter,
+  SkillFrontmatterSchema,
+  parseSkillDocument,
+} from "./skill-doc.js";
+export {
+  type SkillDetail,
+  type SkillManifestEntry,
+  type SkillStore,
+  createSkillStore,
+} from "./skill-store.js";

--- a/packages/core/src/store/skills/skill-doc.ts
+++ b/packages/core/src/store/skills/skill-doc.ts
@@ -1,0 +1,33 @@
+// Skill <-> markdown-document mapping (plan 036 Phase 5 / spec 035 §F7).
+//
+// A skill is `skills/<slug>/SKILL.md`: a YAML frontmatter block (the manifest
+// fields) + the skill body. Frontmatter is intentionally minimal and matches
+// the conventional skill shape — `name` + `description` — so the manifest is a
+// pure projection of it. Parsing is strict: a SKILL.md missing either field is
+// not a valid skill (the store skips it from the manifest).
+
+import matter from "gray-matter";
+import { z } from "zod";
+
+export const SkillFrontmatterSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().min(1),
+});
+
+export type SkillFrontmatter = z.infer<typeof SkillFrontmatterSchema>;
+
+export interface SkillDocument {
+  frontmatter: SkillFrontmatter;
+  body: string;
+}
+
+/** Parse a SKILL.md; throws if the frontmatter is not a valid skill. */
+export function parseSkillDocument(raw: string): SkillDocument {
+  const { data, content } = matter(raw);
+  const result = SkillFrontmatterSchema.safeParse(data);
+  if (!result.success) {
+    const detail = result.error.issues.map((issue) => issue.message).join("; ");
+    throw new Error(`Invalid SKILL.md frontmatter: ${detail}`);
+  }
+  return { frontmatter: result.data, body: content.trim() };
+}

--- a/packages/core/src/store/skills/skill-doc.ts
+++ b/packages/core/src/store/skills/skill-doc.ts
@@ -10,8 +10,10 @@ import matter from "gray-matter";
 import { z } from "zod";
 
 export const SkillFrontmatterSchema = z.object({
-  name: z.string().min(1),
-  description: z.string().min(1),
+  // trim so a whitespace-only display field is rejected, not surfaced to the
+  // manifest / find_skills index.
+  name: z.string().trim().min(1),
+  description: z.string().trim().min(1),
 });
 
 export type SkillFrontmatter = z.infer<typeof SkillFrontmatterSchema>;
@@ -26,7 +28,9 @@ export function parseSkillDocument(raw: string): SkillDocument {
   const { data, content } = matter(raw);
   const result = SkillFrontmatterSchema.safeParse(data);
   if (!result.success) {
-    const detail = result.error.issues.map((issue) => issue.message).join("; ");
+    const detail = result.error.issues
+      .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+      .join("; ");
     throw new Error(`Invalid SKILL.md frontmatter: ${detail}`);
   }
   return { frontmatter: result.data, body: content.trim() };

--- a/packages/core/src/store/skills/skill-store.ts
+++ b/packages/core/src/store/skills/skill-store.ts
@@ -1,0 +1,66 @@
+// Skill store — read side (plan 036 Phase 5 / spec 035 §F7). Reads
+// `skills/<slug>/SKILL.md` from the vault and projects each one's frontmatter
+// into a manifest entry; get_skill returns the full document. Semantic
+// find_skills (over the manifest, via the hybrid index) is a follow-up that
+// layers on top of listSkills. Greenfield + storage-agnostic: it sits on the
+// vault, independent of the memory-doc schema.
+
+import type { Vault } from "../corpus/vault.js";
+import { parseSkillDocument } from "./skill-doc.js";
+
+/** A manifest entry: the pointer + the frontmatter projection. */
+export interface SkillManifestEntry {
+  slug: string;
+  name: string;
+  description: string;
+}
+
+export interface SkillDetail extends SkillManifestEntry {
+  body: string;
+}
+
+export interface SkillStore {
+  /** The manifest: every well-formed skill, sorted by slug. */
+  listSkills(): SkillManifestEntry[];
+  /** The full skill document, or null if the slug has no SKILL.md. */
+  getSkill(slug: string): SkillDetail | null;
+}
+
+const SKILLS_ROOT = "skills";
+
+/** "skills/<slug>/SKILL.md" → "<slug>"; null for nested or non-SKILL.md paths. */
+function slugOfSkillFile(relPath: string): string | null {
+  const parts = relPath.split("/");
+  if (parts.length !== 3) return null; // exclude resources/ and deeper nesting
+  const [root, slug, file] = parts;
+  if (root !== SKILLS_ROOT || file !== "SKILL.md" || !slug) return null;
+  return slug;
+}
+
+export function createSkillStore(vault: Vault): SkillStore {
+  function getSkill(slug: string): SkillDetail | null {
+    const raw = vault.tryReadText(`${SKILLS_ROOT}/${slug}/SKILL.md`);
+    if (raw === null) return null;
+    const { frontmatter, body } = parseSkillDocument(raw);
+    return { slug, name: frontmatter.name, description: frontmatter.description, body };
+  }
+
+  function listSkills(): SkillManifestEntry[] {
+    const entries: SkillManifestEntry[] = [];
+    for (const relPath of vault.listMarkdown(SKILLS_ROOT)) {
+      const slug = slugOfSkillFile(relPath);
+      if (slug === null) continue;
+      const raw = vault.tryReadText(relPath);
+      if (raw === null) continue;
+      try {
+        const { frontmatter } = parseSkillDocument(raw);
+        entries.push({ slug, name: frontmatter.name, description: frontmatter.description });
+      } catch {
+        // a malformed SKILL.md is not a valid skill — skip it, don't break the manifest
+      }
+    }
+    return entries.sort((a, b) => (a.slug < b.slug ? -1 : a.slug > b.slug ? 1 : 0));
+  }
+
+  return { listSkills, getSkill };
+}

--- a/packages/core/src/store/skills/skill-store.ts
+++ b/packages/core/src/store/skills/skill-store.ts
@@ -22,11 +22,22 @@ export interface SkillDetail extends SkillManifestEntry {
 export interface SkillStore {
   /** The manifest: every well-formed skill, sorted by slug. */
   listSkills(): SkillManifestEntry[];
-  /** The full skill document, or null if the slug has no SKILL.md. */
+  /**
+   * The full skill document, or null if the slug is invalid, has no SKILL.md,
+   * or its SKILL.md is malformed (treated as absent, consistent with the
+   * manifest — fail-soft, never throws on caller-supplied input).
+   */
   getSkill(slug: string): SkillDetail | null;
 }
 
 const SKILLS_ROOT = "skills";
+
+/** A slug must name a single directory under skills/ — no path segments / traversal. */
+function isValidSlug(slug: string): boolean {
+  return (
+    slug.length > 0 && !slug.includes("/") && !slug.includes("\\") && slug !== "." && slug !== ".."
+  );
+}
 
 /** "skills/<slug>/SKILL.md" → "<slug>"; null for nested or non-SKILL.md paths. */
 function slugOfSkillFile(relPath: string): string | null {
@@ -39,10 +50,15 @@ function slugOfSkillFile(relPath: string): string | null {
 
 export function createSkillStore(vault: Vault): SkillStore {
   function getSkill(slug: string): SkillDetail | null {
+    if (!isValidSlug(slug)) return null;
     const raw = vault.tryReadText(`${SKILLS_ROOT}/${slug}/SKILL.md`);
     if (raw === null) return null;
-    const { frontmatter, body } = parseSkillDocument(raw);
-    return { slug, name: frontmatter.name, description: frontmatter.description, body };
+    try {
+      const { frontmatter, body } = parseSkillDocument(raw);
+      return { slug, name: frontmatter.name, description: frontmatter.description, body };
+    } catch {
+      return null; // malformed SKILL.md is treated as absent (matches listSkills)
+    }
   }
 
   function listSkills(): SkillManifestEntry[] {

--- a/packages/core/tests/store/skills/skill-store.test.ts
+++ b/packages/core/tests/store/skills/skill-store.test.ts
@@ -73,4 +73,23 @@ describe("createSkillStore", () => {
   it("returns an empty manifest when there are no skills", () => {
     expect(createSkillStore(vault).listSkills()).toEqual([]);
   });
+
+  it("get_skill returns null (never throws) for a path-traversal slug", () => {
+    // plant a file outside the skills tree; an escaping slug must not reach it
+    vault.writeText("secret.md", "top secret");
+    const store = createSkillStore(vault);
+    expect(store.getSkill("../../secret")).toBeNull();
+    expect(store.getSkill("..")).toBeNull();
+    expect(store.getSkill("a/b")).toBeNull(); // nested — consistent with listSkills
+  });
+
+  it("get_skill returns null (never throws) for a present-but-malformed SKILL.md", () => {
+    vault.writeText("skills/bad/SKILL.md", "---\nname: OnlyName\n---\n\nno description\n");
+    expect(createSkillStore(vault).getSkill("bad")).toBeNull();
+  });
+
+  it("skips a whitespace-only description (trimmed to empty) from the manifest", () => {
+    vault.writeText("skills/blank/SKILL.md", "---\nname: Blank\ndescription: '   '\n---\n\nbody\n");
+    expect(createSkillStore(vault).listSkills()).toEqual([]);
+  });
 });

--- a/packages/core/tests/store/skills/skill-store.test.ts
+++ b/packages/core/tests/store/skills/skill-store.test.ts
@@ -1,0 +1,76 @@
+// Skill store tests (plan 036 Phase 5 / spec 035 §F7). Skills are
+// `skills/<slug>/SKILL.md` (+ optional resources/); the manifest is derived
+// from each SKILL.md's frontmatter; get_skill returns the full document. The
+// read side is greenfield and storage-agnostic — it sits on the vault, not on
+// the memory-doc cutover seam.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createSkillStore, createVault } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let dataDir: string;
+let vault: ReturnType<typeof createVault>;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-skills-"));
+  vault = createVault({ vaultPath: path.join(dataDir, "vault") });
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+const skill = (name: string, description: string, body: string): string =>
+  `---\nname: ${name}\ndescription: ${description}\n---\n\n${body}\n`;
+
+describe("createSkillStore", () => {
+  it("derives a manifest from each SKILL.md frontmatter, sorted by slug", () => {
+    vault.writeText("skills/brewing/SKILL.md", skill("Brewing", "How to brew tea", "## Steps"));
+    vault.writeText("skills/archery/SKILL.md", skill("Archery", "How to shoot a bow", "## Form"));
+    const store = createSkillStore(vault);
+    expect(store.listSkills()).toEqual([
+      { slug: "archery", name: "Archery", description: "How to shoot a bow" },
+      { slug: "brewing", name: "Brewing", description: "How to brew tea" },
+    ]);
+  });
+
+  it("excludes resources/ files from the manifest (only top-level SKILL.md counts)", () => {
+    vault.writeText("skills/brewing/SKILL.md", skill("Brewing", "How to brew tea", "body"));
+    vault.writeText("skills/brewing/resources/SKILL.md", skill("Nested", "Should be ignored", "x"));
+    vault.writeText("skills/brewing/resources/notes.md", "# loose notes");
+    const store = createSkillStore(vault);
+    expect(store.listSkills().map((s) => s.slug)).toEqual(["brewing"]);
+  });
+
+  it("get_skill returns the full document (frontmatter + body)", () => {
+    vault.writeText(
+      "skills/brewing/SKILL.md",
+      skill("Brewing", "How to brew tea", "## Steps\nboil water"),
+    );
+    const store = createSkillStore(vault);
+    const detail = store.getSkill("brewing");
+    expect(detail).toMatchObject({
+      slug: "brewing",
+      name: "Brewing",
+      description: "How to brew tea",
+    });
+    expect(detail?.body).toContain("boil water");
+  });
+
+  it("get_skill returns null for an unknown slug", () => {
+    expect(createSkillStore(vault).getSkill("nope")).toBeNull();
+  });
+
+  it("skips a malformed SKILL.md (missing required frontmatter) in the manifest", () => {
+    vault.writeText("skills/good/SKILL.md", skill("Good", "fine", "ok"));
+    vault.writeText("skills/bad/SKILL.md", "---\nname: OnlyName\n---\n\nno description\n");
+    const store = createSkillStore(vault);
+    expect(store.listSkills().map((s) => s.slug)).toEqual(["good"]);
+  });
+
+  it("returns an empty manifest when there are no skills", () => {
+    expect(createSkillStore(vault).listSkills()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

The read side of the skills subsystem (spec 035 §F7, plan 036 Phase 5). Skills live at `skills/<slug>/SKILL.md` (+ optional `resources/`). `createSkillStore(vault)`:

- `listSkills()` → the manifest: each well-formed SKILL.md's `name`+`description` frontmatter projected to `{slug, name, description}`, sorted by slug. Only top-level `skills/<slug>/SKILL.md` counts (resources/ excluded); a malformed SKILL.md is skipped, not fatal.
- `getSkill(slug)` → the full document (`{slug, name, description, body}`) or `null`.

Greenfield + storage-agnostic — it sits on the vault, independent of the memory-doc cutover seam, so it's buildable now while the index→store bridge waits on the frontmatter cutover. Semantic `find_skills` (over the manifest, via the hybrid index) is the next increment.

## Review-driven hardening

Sub-agent review (5 axes): no Critical; security sound (the vault's `within()` boundary blocks path traversal). Fixed before merge:

- **#1/#2** — `getSkill` now honours its documented null contract: an invalid/traversal slug, a missing file, or a present-but-malformed SKILL.md all return `null` instead of throwing (fail-soft on caller-supplied input; consistent with `listSkills`). `isValidSlug` rejects path segments/traversal before touching the vault, so a nested `a/b` slug is `null` like the manifest.
- **#3** — parse errors now name the offending field (`name`/`description`), matching `memory-doc`.
- **#6** — frontmatter trims before `min(1)`, so a whitespace-only display field is rejected.

## Tests

9 tests: manifest derivation + sort, resources/ exclusion, get full doc, unknown-slug null, malformed-skip, empty manifest, **path-traversal → null**, **malformed-get → null**, **whitespace-description skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)