### PR TITLE
feat(skills): semantic find_skills over the manifest (F7, Phase 5)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -223,9 +223,11 @@ export {
   type SkillDocument,
   type SkillFrontmatter,
   type SkillManifestEntry,
+  type SkillSearchHit,
   type SkillStore,
   SkillFrontmatterSchema,
   createSkillStore,
+  findSkills,
   parseSkillDocument,
 } from "./store/skills/index.js";
 export { type MemoryWriteVerdict, routeMemoryWrite } from "./store/memory-routing.js";

--- a/packages/core/src/store/skills/index.ts
+++ b/packages/core/src/store/skills/index.ts
@@ -14,3 +14,4 @@ export {
   type SkillStore,
   createSkillStore,
 } from "./skill-store.js";
+export { type SkillSearchHit, findSkills } from "./skill-search.js";

--- a/packages/core/src/store/skills/skill-search.ts
+++ b/packages/core/src/store/skills/skill-search.ts
@@ -1,0 +1,33 @@
+// Semantic find_skills (plan 036 Phase 5 / spec 035 §F7). Ranks the skill
+// manifest against a query with the hybrid index (keyword + vector) over each
+// skill's name + description. The index is rebuilt from the manifest per call
+// — disposable, like the rest of the index layer, and cheap for the small
+// skill set. The embedder is pluggable + async (hash embedder now, the real
+// model a drop-in later).
+
+import { type Embedder, buildHybridIndex } from "../index/hybrid-index.js";
+import type { SkillManifestEntry } from "./skill-store.js";
+
+export interface SkillSearchHit extends SkillManifestEntry {
+  score: number;
+}
+
+const DEFAULT_LIMIT = 12;
+
+export async function findSkills(
+  skills: SkillManifestEntry[],
+  query: string,
+  embedder: Embedder,
+  limit = DEFAULT_LIMIT,
+): Promise<SkillSearchHit[]> {
+  const index = await buildHybridIndex(
+    skills.map((skill) => ({ id: skill.slug, text: `${skill.name} ${skill.description}` })),
+    embedder,
+  );
+  const hits = await index.search(query, limit);
+  const bySlug = new Map(skills.map((skill) => [skill.slug, skill]));
+  return hits.flatMap((hit) => {
+    const entry = bySlug.get(hit.id);
+    return entry ? [{ ...entry, score: hit.score }] : [];
+  });
+}

--- a/packages/core/src/store/skills/skill-search.ts
+++ b/packages/core/src/store/skills/skill-search.ts
@@ -14,6 +14,11 @@ export interface SkillSearchHit extends SkillManifestEntry {
 
 const DEFAULT_LIMIT = 12;
 
+/**
+ * Rank the skill manifest against `query`. Slugs are assumed unique (the store
+ * derives them from `skills/<slug>/` directory names); duplicate slugs in the
+ * input collapse to one hit.
+ */
 export async function findSkills(
   skills: SkillManifestEntry[],
   query: string,

--- a/packages/core/tests/store/skills/skill-search.test.ts
+++ b/packages/core/tests/store/skills/skill-search.test.ts
@@ -1,0 +1,46 @@
+// Semantic find_skills tests (plan 036 Phase 5 / spec 035 §F7). find_skills
+// ranks the skill manifest against a query using the hybrid index (keyword +
+// vector) over each skill's name + description. Pluggable async embedder; tests
+// use the deterministic hash embedder (the real model is a later drop-in, same
+// as the rest of the index layer).
+
+import { type SkillManifestEntry, createHashEmbedder, findSkills } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+const skills: SkillManifestEntry[] = [
+  { slug: "archery", name: "Archery", description: "shooting arrows with a bow" },
+  { slug: "brewing", name: "Tea Brewing", description: "steeping loose leaf tea leaves" },
+  { slug: "sailing", name: "Sailing", description: "navigating boats across open water" },
+];
+
+describe("findSkills", () => {
+  it("ranks the matching skill first", async () => {
+    const hits = await findSkills(skills, "tea", createHashEmbedder());
+    expect(hits[0]?.slug).toBe("brewing");
+  });
+
+  it("matches on the name as well as the description", async () => {
+    const hits = await findSkills(skills, "arrows bow", createHashEmbedder());
+    expect(hits[0]?.slug).toBe("archery");
+  });
+
+  it("carries the manifest fields plus a score", async () => {
+    const [hit] = await findSkills(skills, "sailing boats", createHashEmbedder());
+    expect(hit).toMatchObject({ slug: "sailing", name: "Sailing" });
+    expect(typeof hit?.score).toBe("number");
+  });
+
+  it("excludes skills that match neither signal", async () => {
+    const hits = await findSkills(skills, "tea", createHashEmbedder());
+    expect(hits.map((h) => h.slug)).not.toContain("sailing");
+  });
+
+  it("respects the limit", async () => {
+    const hits = await findSkills(skills, "tea bow water", createHashEmbedder(), 1);
+    expect(hits.length).toBeLessThanOrEqual(1);
+  });
+
+  it("returns [] for an empty manifest", async () => {
+    expect(await findSkills([], "anything", createHashEmbedder())).toEqual([]);
+  });
+});

--- a/packages/core/tests/store/skills/skill-search.test.ts
+++ b/packages/core/tests/store/skills/skill-search.test.ts
@@ -30,9 +30,14 @@ describe("findSkills", () => {
     expect(typeof hit?.score).toBe("number");
   });
 
-  it("excludes skills that match neither signal", async () => {
+  it("ranks a matching skill above a non-matching one", async () => {
+    // contract-level invariant (holds for any embedder): the "tea" match
+    // outranks the unrelated skill, whether or not the latter appears at all.
     const hits = await findSkills(skills, "tea", createHashEmbedder());
-    expect(hits.map((h) => h.slug)).not.toContain("sailing");
+    const brewingRank = hits.findIndex((h) => h.slug === "brewing");
+    const sailingRank = hits.findIndex((h) => h.slug === "sailing");
+    expect(brewingRank).toBeGreaterThanOrEqual(0);
+    expect(sailingRank === -1 || brewingRank < sailingRank).toBe(true);
   });
 
   it("respects the limit", async () => {


### PR DESCRIPTION
## What

`findSkills` — semantic `find_skills` (spec 035 §F7), completing the skills read surface (list + get + find). Ranks the skill manifest against a query using the hybrid index (keyword + RRF-fused vector) over each skill's `name + description`, returning `{slug, name, description, score}[]`.

- Disposable index, rebuilt from the manifest per call — cheap for the small skill set, matching the codebase-wide disposable-index pattern.
- Pluggable async embedder (hash embedder now, the real transformers.js model a drop-in later — same seam as the rest of the index layer).
- Standalone pure function over `SkillManifestEntry[]` (keeps the index/embedder dependency out of the filesystem-only `SkillStore`, mirroring `recallFromIndex`/`createNamespacedIndex`).

## Review

Sub-agent review (5 axes): **no Critical, no Important — sound to merge.** Two suggestions applied:
- The exclusion test encoded hash-embedder behaviour (distinct tokens → zero cosine → filtered) and would break on the real embedder; reframed as the contract-level invariant (the match outranks the non-match, whether or not it appears).
- Documented the unique-slug assumption (the store guarantees it from `skills/<slug>/` dir names).

Noted for the verb-wiring boundary (FYI, not blocking): clamp a user-supplied negative `limit`; memoize the index against a manifest hash once the real (slow) embedder lands or a hot caller appears.

## Tests

6 tests: ranking, name+description matching, score field, limit, empty manifest, contract-level ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)