### PR TITLE
feat(skills): get_skill enumerates resources/ + vault.listFiles (F7, Phase 5)

### DIFF
--- a/packages/core/src/store/corpus/vault.ts
+++ b/packages/core/src/store/corpus/vault.ts
@@ -109,7 +109,7 @@ export function createVault(options: VaultOptions = {}): Vault {
 
   function listWithin(subdir: string | undefined, keep: (name: string) => boolean): string[] {
     const base = subdir ? within(subdir) : root;
-    if (!fs.existsSync(base)) return [];
+    if (!fs.existsSync(base) || !fs.statSync(base).isDirectory()) return []; // missing, or a file
     const out: string[] = [];
     const walk = (dir: string): void => {
       for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {

--- a/packages/core/src/store/corpus/vault.ts
+++ b/packages/core/src/store/corpus/vault.ts
@@ -47,6 +47,8 @@ export interface Vault {
   tryReadDocument(relPath: string): CorpusDocument | null;
   /** Recursive list of `.md` files (posix-relative to the root, sorted). */
   listMarkdown(subdir?: string): string[];
+  /** Recursive list of ALL files (any extension; posix-relative to the root, sorted). */
+  listFiles(subdir?: string): string[];
   /** Move a file within the vault — the archive=move (reversible) primitive. */
   moveFile(fromRel: string, toRel: string): void;
   /**
@@ -105,7 +107,7 @@ export function createVault(options: VaultOptions = {}): Vault {
     return exists(relPath) ? readDocument(relPath) : null;
   }
 
-  function listMarkdown(subdir?: string): string[] {
+  function listWithin(subdir: string | undefined, keep: (name: string) => boolean): string[] {
     const base = subdir ? within(subdir) : root;
     if (!fs.existsSync(base)) return [];
     const out: string[] = [];
@@ -113,13 +115,21 @@ export function createVault(options: VaultOptions = {}): Vault {
       for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
         const abs = path.join(dir, entry.name);
         if (entry.isDirectory()) walk(abs);
-        else if (entry.isFile() && entry.name.endsWith(".md")) {
+        else if (entry.isFile() && keep(entry.name)) {
           out.push(path.relative(root, abs).split(path.sep).join("/"));
         }
       }
     };
     walk(base);
     return out.sort();
+  }
+
+  function listMarkdown(subdir?: string): string[] {
+    return listWithin(subdir, (name) => name.endsWith(".md"));
+  }
+
+  function listFiles(subdir?: string): string[] {
+    return listWithin(subdir, () => true);
   }
 
   function moveFile(fromRel: string, toRel: string): void {
@@ -143,6 +153,7 @@ export function createVault(options: VaultOptions = {}): Vault {
     readDocument,
     tryReadDocument,
     listMarkdown,
+    listFiles,
     moveFile,
     removeFile,
     exists,

--- a/packages/core/src/store/skills/skill-store.ts
+++ b/packages/core/src/store/skills/skill-store.ts
@@ -17,6 +17,8 @@ export interface SkillManifestEntry {
 
 export interface SkillDetail extends SkillManifestEntry {
   body: string;
+  /** Resource file paths under the skill dir (e.g. "resources/cheatsheet.md"), sorted. */
+  resources: string[];
 }
 
 export interface SkillStore {
@@ -55,7 +57,17 @@ export function createSkillStore(vault: Vault): SkillStore {
     if (raw === null) return null;
     try {
       const { frontmatter, body } = parseSkillDocument(raw);
-      return { slug, name: frontmatter.name, description: frontmatter.description, body };
+      const skillDir = `${SKILLS_ROOT}/${slug}`;
+      const resources = vault
+        .listFiles(`${skillDir}/resources`)
+        .map((relPath) => relPath.slice(`${skillDir}/`.length)); // → "resources/<file>"
+      return {
+        slug,
+        name: frontmatter.name,
+        description: frontmatter.description,
+        body,
+        resources,
+      };
     } catch {
       return null; // malformed SKILL.md is treated as absent (matches listSkills)
     }

--- a/packages/core/src/store/skills/skill-store.ts
+++ b/packages/core/src/store/skills/skill-store.ts
@@ -60,7 +60,10 @@ export function createSkillStore(vault: Vault): SkillStore {
       const skillDir = `${SKILLS_ROOT}/${slug}`;
       const resources = vault
         .listFiles(`${skillDir}/resources`)
-        .map((relPath) => relPath.slice(`${skillDir}/`.length)); // → "resources/<file>"
+        .map((relPath) => relPath.slice(`${skillDir}/`.length)) // → "resources/<file>"
+        // drop dotfiles — .gitkeep (the idiomatic empty-dir keeper) and the
+        // like aren't author-intended resources, and the vault is git-pushed.
+        .filter((rel) => !rel.slice(rel.lastIndexOf("/") + 1).startsWith("."));
       return {
         slug,
         name: frontmatter.name,

--- a/packages/core/tests/store/corpus/vault.test.ts
+++ b/packages/core/tests/store/corpus/vault.test.ts
@@ -86,6 +86,14 @@ describe("vault file I/O", () => {
     expect(vault.listMarkdown("nope")).toEqual([]);
   });
 
+  it("listFiles lists ALL files recursively (any extension), sorted + posix-relative", () => {
+    const vault = createVault({ dataDir });
+    vault.writeDocument("people/anna.md", doc("anna"));
+    fs.writeFileSync(path.join(vault.root, "people", "photo.png"), "bytes");
+    expect(vault.listFiles("people")).toEqual(["people/anna.md", "people/photo.png"]);
+    expect(vault.listFiles("nope")).toEqual([]);
+  });
+
   it("moves a file (the archive=move primitive)", () => {
     const vault = createVault({ dataDir });
     vault.writeDocument("people/anna.md", doc("anna"));

--- a/packages/core/tests/store/skills/skill-store.test.ts
+++ b/packages/core/tests/store/skills/skill-store.test.ts
@@ -59,6 +59,19 @@ describe("createSkillStore", () => {
     expect(detail?.body).toContain("boil water");
   });
 
+  it("get_skill enumerates resource files (sorted, relative to the skill dir)", () => {
+    vault.writeText("skills/brewing/SKILL.md", skill("Brewing", "How to brew tea", "body"));
+    vault.writeText("skills/brewing/resources/steeps.md", "# steep times");
+    vault.writeText("skills/brewing/resources/kettle.png", "fake-png-bytes");
+    const detail = createSkillStore(vault).getSkill("brewing");
+    expect(detail?.resources).toEqual(["resources/kettle.png", "resources/steeps.md"]);
+  });
+
+  it("get_skill returns an empty resources list when there is no resources/ dir", () => {
+    vault.writeText("skills/brewing/SKILL.md", skill("Brewing", "How to brew tea", "body"));
+    expect(createSkillStore(vault).getSkill("brewing")?.resources).toEqual([]);
+  });
+
   it("get_skill returns null for an unknown slug", () => {
     expect(createSkillStore(vault).getSkill("nope")).toBeNull();
   });

--- a/packages/core/tests/store/skills/skill-store.test.ts
+++ b/packages/core/tests/store/skills/skill-store.test.ts
@@ -72,6 +72,14 @@ describe("createSkillStore", () => {
     expect(createSkillStore(vault).getSkill("brewing")?.resources).toEqual([]);
   });
 
+  it("get_skill includes nested resources and drops dotfiles", () => {
+    vault.writeText("skills/brewing/SKILL.md", skill("Brewing", "How to brew tea", "body"));
+    vault.writeText("skills/brewing/resources/sub/deep.md", "# deep");
+    vault.writeText("skills/brewing/resources/.gitkeep", "");
+    const detail = createSkillStore(vault).getSkill("brewing");
+    expect(detail?.resources).toEqual(["resources/sub/deep.md"]); // dotfile excluded
+  });
+
   it("get_skill returns null for an unknown slug", () => {
     expect(createSkillStore(vault).getSkill("nope")).toBeNull();
   });


### PR DESCRIPTION
## What

Completes `get_skill`'s spec contract — "full **+ resources**" (spec 035 §F7). `getSkill` now returns `resources: string[]`: the skill's resource files under `skills/<slug>/resources/**` (any extension, paths relative to the skill dir, sorted). Adds `vault.listFiles(subdir?)` — a recursive all-files lister mirroring `listMarkdown`, factored via a shared `listWithin(subdir, keep)` helper (the migration/backup tooling will also want a general lister).

## Review-driven hardening

Sub-agent review (5 axes): no Critical/Important; refactor confirmed behaviour-preserving (same sort/posix-normalization/empty-dir handling — the 3 existing `listMarkdown` callers unaffected), slicing correct at all nesting depths, traversal closed (slug gated by `isValidSlug`, base resolved through `within()`, directory symlinks not recursed). Two suggestions applied:

- **Dotfiles** dropped from `resources` — a git-pushed vault makes `.gitkeep` (the idiomatic empty-dir keeper) near-certain, and `.DS_Store`/etc. aren't author-intended resources.
- **`listWithin` hardened** — a base that exists but is a *file* now returns `[]` instead of throwing `ENOTDIR` (previously a file named `resources` made the whole skill vanish via `getSkill`'s catch).

## Tests

skill-store 12 (incl. nested resources + dotfile exclusion + empty/missing dir); vault 15 (incl. a `listFiles` primitive test asserting all-extensions recursive listing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)