### PR TITLE
feat(mcp): session_manifest tool — working-style + skills manifest (F6, Phase 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ changes from this point forward are catalogued here.
 
 ## [Unreleased]
 
+### Added
+
+- **Skills (read surface) — `find_skills`, `get_skill` MCP tools (F7).** Skills live
+  as `skills/<slug>/SKILL.md` (+ optional `resources/`) in the vault; `find_skills`
+  ranks the manifest (name + description) against a query, and `get_skill` returns a
+  skill's full document plus its resource file list. Backend-independent (vault-based),
+  fail-soft on bad input. Semantic ranking currently uses the bundled deterministic
+  embedder; the production model is a drop-in via the same interface.
+- **`session_manifest` MCP tool (F6, server side).** Returns the session-start
+  manifest the client hook consumes: the working-style preamble (from the
+  `working_style` setting) plus a bounded skills manifest.
+
 ### Changed
 
 - **`recall` is no longer domain-scoped (D16, memory side).** Results rank by

--- a/packages/mcp-server/src/mcp/tools/index.ts
+++ b/packages/mcp-server/src/mcp/tools/index.ts
@@ -16,6 +16,7 @@ import listProposals from "./list-proposals.js";
 import proposeMemory from "./propose-memory.js";
 import recall from "./recall.js";
 import remember from "./remember.js";
+import sessionManifest from "./session-manifest.js";
 import startContext from "./start-context.js";
 import storeHandoff from "./store-handoff.js";
 import updateMemory from "./update-memory.js";
@@ -39,6 +40,7 @@ export const tools: ToolDefinition[] = [
   claimHandoff,
   findSkills,
   getSkill,
+  sessionManifest,
 ];
 
 export const toolsByName: Map<string, ToolDefinition> = new Map(

--- a/packages/mcp-server/src/mcp/tools/session-manifest.ts
+++ b/packages/mcp-server/src/mcp/tools/session-manifest.ts
@@ -4,10 +4,20 @@
 //
 // Working-style source: the `working_style` setting (prose authored via the
 // dashboard later) — a small, reversible choice. The skills manifest is the
-// vault-derived list (already bounded to name + description per entry).
+// vault-derived list (already bounded to slug + name + description per entry).
 
 import { textResult } from "../result.js";
 import type { ToolDefinition } from "../tool.js";
+
+/** Read working_style fail-soft: this fires every session, so never let a
+ * settings read (e.g. a secret-stored value with no master key) break it. */
+function readWorkingStyle(store: Parameters<ToolDefinition["handler"]>[0]): string {
+  try {
+    return store.getSetting("working_style") ?? "";
+  } catch {
+    return "";
+  }
+}
 
 const sessionManifest: ToolDefinition = {
   name: "session_manifest",
@@ -18,10 +28,7 @@ const sessionManifest: ToolDefinition = {
   handler(store) {
     return textResult(
       JSON.stringify(
-        {
-          workingStyle: store.getSetting("working_style") ?? "",
-          skills: store.skills.listSkills(),
-        },
+        { workingStyle: readWorkingStyle(store), skills: store.skills.listSkills() },
         null,
         2,
       ),

--- a/packages/mcp-server/src/mcp/tools/session-manifest.ts
+++ b/packages/mcp-server/src/mcp/tools/session-manifest.ts
@@ -1,0 +1,32 @@
+// `session_manifest` MCP tool (plan 036 Phase 5 / spec 035 §F6 server-side
+// criterion). The session-start client hook (a separate spec) consumes this:
+// the working-style preamble + a bounded skills manifest (name + description).
+//
+// Working-style source: the `working_style` setting (prose authored via the
+// dashboard later) — a small, reversible choice. The skills manifest is the
+// vault-derived list (already bounded to name + description per entry).
+
+import { textResult } from "../result.js";
+import type { ToolDefinition } from "../tool.js";
+
+const sessionManifest: ToolDefinition = {
+  name: "session_manifest",
+  description:
+    "Return the session-start manifest: the working-style preamble and a " +
+    "bounded list of available skills (slug, name, description).",
+  inputSchema: { type: "object", properties: {} },
+  handler(store) {
+    return textResult(
+      JSON.stringify(
+        {
+          workingStyle: store.getSetting("working_style") ?? "",
+          skills: store.skills.listSkills(),
+        },
+        null,
+        2,
+      ),
+    );
+  },
+};
+
+export default sessionManifest;

--- a/packages/mcp-server/tests/mcp/mcp.test.ts
+++ b/packages/mcp-server/tests/mcp/mcp.test.ts
@@ -37,6 +37,7 @@ describe("MCP dispatch", () => {
         "list_proposals",
         "get_skill",
         "find_skills",
+        "session_manifest",
       ]) {
         expect(toolNames).toContain(expected);
       }

--- a/packages/mcp-server/tests/mcp/session-manifest.test.ts
+++ b/packages/mcp-server/tests/mcp/session-manifest.test.ts
@@ -1,0 +1,66 @@
+// session_manifest MCP tool (plan 036 Phase 5 / spec 035 §F6 server-side
+// criterion). The session-start client hook consumes one endpoint that returns
+// the working-style preamble + a bounded skills manifest (name + description).
+// The working-style doc is sourced from the `working_style` setting (a small,
+// reversible choice; the dashboard authors it later).
+
+import fs from "node:fs";
+import path from "node:path";
+import { handleMcpPayload } from "@librarian/mcp-server";
+import { describe, expect, it } from "vitest";
+import { withStore } from "../../../../test/helpers.js";
+
+type CallResult = { result: { content: { text: string }[] } };
+
+const call = (store: unknown): Promise<unknown> =>
+  handleMcpPayload(store as never, {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: { name: "session_manifest", arguments: {} },
+  });
+
+describe("session_manifest MCP tool", () => {
+  it("is advertised to agents", async () => {
+    await withStore(async (store: unknown) => {
+      const list = (await handleMcpPayload(store as never, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+        params: {},
+      })) as { result: { tools: { name: string }[] } };
+      expect(list.result.tools.map((t) => t.name)).toContain("session_manifest");
+    });
+  });
+
+  it("returns the working-style doc plus the skills manifest", async () => {
+    await withStore(async (store: unknown, dataDir: string) => {
+      (store as { setSetting: (k: string, v: string) => void }).setSetting(
+        "working_style",
+        "Be concise. Prefer bullet points.",
+      );
+      const dir = path.join(dataDir, "vault", "skills", "brewing");
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, "SKILL.md"),
+        "---\nname: Brewing\ndescription: brew tea\n---\n\nbody\n",
+      );
+
+      const res = (await call(store)) as CallResult;
+      const manifest = JSON.parse(res.result.content[0]!.text);
+      expect(manifest.workingStyle).toBe("Be concise. Prefer bullet points.");
+      expect(manifest.skills).toEqual([
+        { slug: "brewing", name: "Brewing", description: "brew tea" },
+      ]);
+    });
+  });
+
+  it("returns an empty working-style and manifest when nothing is configured", async () => {
+    await withStore(async (store: unknown) => {
+      const res = (await call(store)) as CallResult;
+      const manifest = JSON.parse(res.result.content[0]!.text);
+      expect(manifest.workingStyle).toBe("");
+      expect(manifest.skills).toEqual([]);
+    });
+  });
+});

--- a/packages/mcp-server/tests/mcp/session-manifest.test.ts
+++ b/packages/mcp-server/tests/mcp/session-manifest.test.ts
@@ -63,4 +63,21 @@ describe("session_manifest MCP tool", () => {
       expect(manifest.skills).toEqual([]);
     });
   });
+
+  it("lists multiple skills sorted by slug, independent of working-style", async () => {
+    await withStore(async (store: unknown, dataDir: string) => {
+      for (const slug of ["zebra", "alpha"]) {
+        const dir = path.join(dataDir, "vault", "skills", slug);
+        fs.mkdirSync(dir, { recursive: true });
+        fs.writeFileSync(
+          path.join(dir, "SKILL.md"),
+          `---\nname: ${slug}\ndescription: d-${slug}\n---\n\nbody\n`,
+        );
+      }
+      const res = (await call(store)) as CallResult;
+      const manifest = JSON.parse(res.result.content[0]!.text);
+      expect(manifest.workingStyle).toBe(""); // independent of skills
+      expect(manifest.skills.map((s: { slug: string }) => s.slug)).toEqual(["alpha", "zebra"]);
+    });
+  });
 });


### PR DESCRIPTION
## What

The F6 server-side criterion (spec 035 §F6): the session-start client hook (a separate, not-yet-written spec) consumes one endpoint. `session_manifest` is that endpoint — an MCP tool returning:

- `workingStyle` — the working-style preamble, sourced from the `working_style` setting (prose authored via the dashboard later; a small **reversible** decision).
- `skills` — the bounded skills manifest (`slug, name, description` per entry; no bodies).

Both backends expose settings + the vault-based skills store, so it works regardless of backend. Additive and agent-accessible. Kept separate from `start_context` (which is task-start *memory* context, identity-scoped, prose) — different consumer, inputs, and output medium.

## Review

Sub-agent review (5 axes): **sound, no Critical/Important** — correctness, determinism (skills sorted by slug), security (no input → no injection; manifest leaks no secrets/bodies), and architecture all check out. Applied: the one required CHANGELOG entry (covering this tool **and** the get_skill/find_skills tools), a fail-soft `working_style` read (this fires every session — a settings read must never throw it), the header-comment shape fix, and a multi-skill ordering test.

## Tests

4: advertisement, configured (working-style + skill, exact shape), empty, and multi-skill sorted ordering independent of working-style. Contract test extended to assert `session_manifest` is advertised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)