### PR TITLE
feat(store): vault→index bridge — buildCorpusIndex (cutover, Phase 3/7)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -232,6 +232,7 @@ export {
   findSkills,
   parseSkillDocument,
 } from "./store/skills/index.js";
+export { type CorpusIndexOptions, buildCorpusIndex } from "./store/corpus-index.js";
 export { type MemoryWriteVerdict, routeMemoryWrite } from "./store/memory-routing.js";
 export type { Memory, MemoryStore, MemoryStoreDeps } from "./store/memory-store.js";
 export {

--- a/packages/core/src/store/corpus-index.ts
+++ b/packages/core/src/store/corpus-index.ts
@@ -9,10 +9,12 @@
 // calling this again). Corpus ids are memory ids (resolve via the store);
 // reference ids are vault-relative paths (resolve via vault.readText).
 //
-// Built against the current memory-doc schema (title + body + tags compose the
-// searchable text, matching searchMemories); the D16 frontmatter minimisation
-// is a separable later cleanup and does not gate this.
+// Built against the current memory-doc schema: title + body + tags compose the
+// searchable text (like searchMemories; project_key is omitted — this is a
+// different retrieval engine). The D16 frontmatter minimisation is a separable
+// later cleanup and does not gate this.
 
+import { MemoryStatus } from "./../schemas/common.js";
 import type { Vault } from "./corpus/vault.js";
 import {
   type Embedder,
@@ -25,7 +27,6 @@ import { parseMemoryDocument } from "./markdown/memory-doc.js";
 
 const CORPUS_DIR = "memories";
 const REFERENCES_DIR = "references";
-const ARCHIVED_STATUS = "archived";
 
 export interface CorpusIndexOptions {
   embedder: Embedder;
@@ -54,8 +55,19 @@ export async function buildCorpusIndex(
       continue;
     }
 
-    const memory = parseMemoryDocument(vault.readText(relPath));
-    if (memory.status === ARCHIVED_STATUS) continue; // archived ⇒ out of recall
+    // Fail-soft: a hand-edited / foreign .md under memories/ that doesn't parse
+    // as a memory is skipped, so one bad file can't take down all recall. (The
+    // vault is git-pushed + hand-editable; surfacing corrupt files is a
+    // dashboard/health concern, not a reason to fail the whole index build.)
+    let memory;
+    try {
+      memory = parseMemoryDocument(vault.readText(relPath));
+    } catch {
+      continue;
+    }
+    // Active only — matches searchMemories' recall filter; proposals (pending
+    // approval) and archived memories must not surface in recall.
+    if (memory.status !== MemoryStatus.Active) continue;
     docs.push({
       id: memory.id,
       text: `${memory.title} ${memory.body} ${memory.tags.join(" ")}`,

--- a/packages/core/src/store/corpus-index.ts
+++ b/packages/core/src/store/corpus-index.ts
@@ -1,0 +1,67 @@
+// Vault → index bridge (plan 036 Phase 3/7 cutover / spec 035 §F2-F4). Reads the
+// markdown vault and builds the namespaced hybrid index that recall +
+// search_references run over:
+//   - memories/<id>.md   → Tier-1 corpus (active only; archived are excluded)
+//   - references/**.md    → Tier-0 references (raw markdown, retrieved on demand)
+//
+// This is the disposable index — rebuildable from the vault at any time (the
+// reindex / "delete .index/ → rebuild → equivalent hits" contract is just
+// calling this again). Corpus ids are memory ids (resolve via the store);
+// reference ids are vault-relative paths (resolve via vault.readText).
+//
+// Built against the current memory-doc schema (title + body + tags compose the
+// searchable text, matching searchMemories); the D16 frontmatter minimisation
+// is a separable later cleanup and does not gate this.
+
+import type { Vault } from "./corpus/vault.js";
+import {
+  type Embedder,
+  type IndexNamespace,
+  type NamespacedDoc,
+  type NamespacedIndex,
+  createNamespacedIndex,
+} from "./index/index.js";
+import { parseMemoryDocument } from "./markdown/memory-doc.js";
+
+const CORPUS_DIR = "memories";
+const REFERENCES_DIR = "references";
+const ARCHIVED_STATUS = "archived";
+
+export interface CorpusIndexOptions {
+  embedder: Embedder;
+}
+
+/** memories/ → corpus, references/ → references, anything else → excluded. */
+function classifyNamespace(relPath: string): IndexNamespace | null {
+  if (relPath.startsWith(`${REFERENCES_DIR}/`)) return "references";
+  if (relPath.startsWith(`${CORPUS_DIR}/`)) return "corpus";
+  return null; // handoffs/, skills/, archive/, etc. are not Tier-1 recall material
+}
+
+export async function buildCorpusIndex(
+  vault: Vault,
+  options: CorpusIndexOptions,
+): Promise<NamespacedIndex> {
+  const docs: NamespacedDoc[] = [];
+
+  for (const relPath of vault.listMarkdown()) {
+    const namespace = classifyNamespace(relPath);
+    if (namespace === null) continue;
+
+    if (namespace === "references") {
+      // raw markdown; id is the vault-relative path so the caller can fetch it
+      docs.push({ id: relPath, text: vault.readText(relPath), namespace });
+      continue;
+    }
+
+    const memory = parseMemoryDocument(vault.readText(relPath));
+    if (memory.status === ARCHIVED_STATUS) continue; // archived ⇒ out of recall
+    docs.push({
+      id: memory.id,
+      text: `${memory.title} ${memory.body} ${memory.tags.join(" ")}`,
+      namespace,
+    });
+  }
+
+  return createNamespacedIndex(docs, options.embedder);
+}

--- a/packages/core/tests/store/corpus-index.test.ts
+++ b/packages/core/tests/store/corpus-index.test.ts
@@ -97,6 +97,44 @@ describe("buildCorpusIndex", () => {
     expect(recalled.map((h) => h.id)).not.toContain("references/piano-manual.md");
   });
 
+  it("excludes proposed (pending-approval) memories from recall, matching searchMemories", async () => {
+    const store = createLibrarianStore({ dataDir, backend: "markdown" });
+    let proposedId = "";
+    try {
+      // propose_memory routes to status=proposed (a pending/protected write)
+      proposedId = store.createMemory(
+        {
+          agent_id: "codex",
+          title: "Pending secret plan",
+          body: "draft proposal about quantum widgets awaiting approval",
+          status: "proposed",
+        },
+        { status: "proposed" },
+      ).memory.id;
+    } finally {
+      store.close();
+    }
+    const index = await buildCorpusIndex(createVault({ dataDir }), {
+      embedder: createHashEmbedder(),
+    });
+    const hits = await index.recall("quantum widgets proposal");
+    expect(hits.map((h) => h.id)).not.toContain(proposedId);
+  });
+
+  it("fail-soft: a foreign/malformed .md under memories/ is skipped, recall still works", async () => {
+    const ids = seed();
+    // drop a non-memory markdown file straight into memories/
+    fs.writeFileSync(
+      path.join(dataDir, "vault", "memories", "README.md"),
+      "# not a memory\n\njust notes",
+    );
+    const index = await buildCorpusIndex(createVault({ dataDir }), {
+      embedder: createHashEmbedder(),
+    });
+    const hits = await index.recall("piano tuning"); // must not throw; the good memory still recalls
+    expect(hits[0]?.id).toBe(ids.piano);
+  });
+
   it("returns an empty index for an empty vault", async () => {
     fs.mkdirSync(path.join(dataDir, "vault"), { recursive: true });
     const index = await buildCorpusIndex(createVault({ dataDir }), {

--- a/packages/core/tests/store/corpus-index.test.ts
+++ b/packages/core/tests/store/corpus-index.test.ts
@@ -1,0 +1,108 @@
+// Vault → index bridge tests (plan 036 Phase 3/7 cutover / spec 035 §F2-F4).
+// buildCorpusIndex reads the markdown vault — memories/ as Tier-1 corpus,
+// references/ as Tier-0 — and builds the namespaced hybrid index recall runs
+// over. It's the disposable index: rebuildable from the vault at any time.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  buildCorpusIndex,
+  createHashEmbedder,
+  createLibrarianStore,
+  createVault,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-corpus-index-"));
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+interface SeedIds {
+  piano: string;
+  sailing: string;
+  archived: string;
+}
+
+function seed(): SeedIds {
+  const store = createLibrarianStore({ dataDir, backend: "markdown" });
+  try {
+    const piano = store.createMemory({
+      agent_id: "codex",
+      title: "Piano tuning",
+      body: "the grand piano needs tuning twice a year",
+    }).memory;
+    const sailing = store.createMemory({
+      agent_id: "codex",
+      title: "Sailing",
+      body: "navigating boats across open water",
+    }).memory;
+    const archived = store.createMemory({
+      agent_id: "codex",
+      title: "Old note",
+      body: "obsolete fact about widgets and sprockets",
+    }).memory;
+    store.archiveMemory(archived.id); // archived → must be excluded from the index
+    return { piano: piano.id, sailing: sailing.id, archived: archived.id };
+  } finally {
+    store.close();
+  }
+}
+
+function seedReference(): void {
+  fs.mkdirSync(path.join(dataDir, "vault", "references"), { recursive: true });
+  fs.writeFileSync(
+    path.join(dataDir, "vault", "references", "piano-manual.md"),
+    "## Tuning\nthe steinway grand piano regulation and voicing guide",
+  );
+}
+
+describe("buildCorpusIndex", () => {
+  it("indexes active memories (Tier 1) and recalls the matching one first, by memory id", async () => {
+    const ids = seed();
+    const index = await buildCorpusIndex(createVault({ dataDir }), {
+      embedder: createHashEmbedder(),
+    });
+    const hits = await index.recall("piano tuning");
+    expect(hits[0]?.id).toBe(ids.piano); // recall returns the memory id, top-ranked
+    expect(hits[0]?.matchedDirectly).toBe(true);
+  });
+
+  it("excludes archived memories from recall", async () => {
+    const ids = seed();
+    const index = await buildCorpusIndex(createVault({ dataDir }), {
+      embedder: createHashEmbedder(),
+    });
+    const hits = await index.recall("obsolete widgets sprockets");
+    expect(hits.map((h) => h.id)).not.toContain(ids.archived);
+  });
+
+  it("indexes references/ as Tier 0, retrievable only via search_references", async () => {
+    seed();
+    seedReference();
+    const index = await buildCorpusIndex(createVault({ dataDir }), {
+      embedder: createHashEmbedder(),
+    });
+    const refs = await index.searchReferences("piano regulation voicing");
+    expect(refs.some((r) => r.id === "references/piano-manual.md")).toBe(true);
+    expect(refs[0]?.section).toContain("## Tuning");
+    // the reference must NOT appear in Tier-1 recall
+    const recalled = await index.recall("piano regulation voicing");
+    expect(recalled.map((h) => h.id)).not.toContain("references/piano-manual.md");
+  });
+
+  it("returns an empty index for an empty vault", async () => {
+    fs.mkdirSync(path.join(dataDir, "vault"), { recursive: true });
+    const index = await buildCorpusIndex(createVault({ dataDir }), {
+      embedder: createHashEmbedder(),
+    });
+    expect(await index.recall("anything")).toEqual([]);
+    expect(await index.searchReferences("anything")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

`buildCorpusIndex(vault, {embedder})` — the vault→index bridge that the markdown cutover's recall builds on. Reads the markdown vault into the namespaced hybrid index:

- `memories/<id>.md` → **Tier-1 corpus** (active only; proposed + archived excluded — matches `searchMemories`' recall filter)
- `references/**.md` → **Tier-0 references** (raw markdown, retrieved only via `search_references`)

Corpus hit ids are memory ids (resolve via the store); reference ids are vault-relative paths (resolve via `vault.readText`). It's the **disposable index** — rebuildable from the vault at any time (reindex = call it again). Composes the already-built `createNamespacedIndex` + `parseMemoryDocument`. Searchable text is title+body+tags; D16 frontmatter minimization is a separable later cleanup and does not gate this.

## Review-driven hardening

Sub-agent review (5 axes) caught two real Important issues, both fixed with regression tests:

- **active-only recall** — I'd only excluded `archived`; the keyword `searchMemories` path defaults to active-only (spec 021 §4.11), so index-recall would have surfaced **proposed (pending-approval)** memories. Now filters to `status === Active`.
- **fail-soft** — a foreign/malformed `.md` under `memories/` made `parseMemoryDocument` throw and took down the *entire* index. The vault is git-pushed + hand-editable, so one stray file shouldn't kill recall. Now skipped (surfacing corrupt files is a dashboard/health follow-up).

## Tests

6: ranking by memory id, archived-excluded, **proposed-excluded**, Tier-0 isolation (both directions), **malformed-doc-skipped**, empty vault. Uses the hash embedder (no model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)