### PR TITLE
feat(mcp): search_references — Tier-0 reference lookup verb (cutover, F3/F4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ changes from this point forward are catalogued here.
 
 ### Added
 
+- **`search_references` MCP tool (F3/F4).** Tier-0 lookup over the vault's
+  `references/` — background reference docs that are deliberately kept out of
+  normal recall. Returns each match's path + the query-relevant section (so the
+  agent pulls just the matched section, not the whole file). Backed by the
+  disposable hybrid index; backend-independent (references live in the vault).
+
 - **Real embedding model via `node-llama-cpp` (F2).** `createLlamaEmbedder` runs a
   GGUF embedding model on CPU (default **EmbeddingGemma-300M**, 768-dim, multilingual)
   behind the pluggable `Embedder` interface, with asymmetric query/document prompts

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -232,7 +232,11 @@ export {
   findSkills,
   parseSkillDocument,
 } from "./store/skills/index.js";
-export { type CorpusIndexOptions, buildCorpusIndex } from "./store/corpus-index.js";
+export {
+  type CorpusIndexOptions,
+  buildCorpusIndex,
+  searchReferences,
+} from "./store/corpus-index.js";
 export { type MemoryWriteVerdict, routeMemoryWrite } from "./store/memory-routing.js";
 export type { Memory, MemoryStore, MemoryStoreDeps } from "./store/memory-store.js";
 export {

--- a/packages/core/src/store/corpus-index.ts
+++ b/packages/core/src/store/corpus-index.ts
@@ -21,6 +21,7 @@ import {
   type IndexNamespace,
   type NamespacedDoc,
   type NamespacedIndex,
+  type ReferenceHit,
   createNamespacedIndex,
 } from "./index/index.js";
 import { parseMemoryDocument } from "./markdown/memory-doc.js";
@@ -76,4 +77,23 @@ export async function buildCorpusIndex(
   }
 
   return createNamespacedIndex(docs, options.embedder);
+}
+
+/**
+ * Tier-0 lookup: search the vault's `references/` only (no corpus embedding).
+ * Builds a references-only index per call — references are few and
+ * search_references is infrequent, so this stays simple (no cache). Returns the
+ * matched reference's pointer (vault-relative path) + relevant section.
+ */
+export async function searchReferences(
+  vault: Vault,
+  embedder: Embedder,
+  query: string,
+  limit?: number,
+): Promise<ReferenceHit[]> {
+  const docs: NamespacedDoc[] = vault
+    .listMarkdown(REFERENCES_DIR)
+    .map((relPath) => ({ id: relPath, text: vault.readText(relPath), namespace: "references" }));
+  const index = await createNamespacedIndex(docs, embedder);
+  return index.searchReferences(query, limit);
 }

--- a/packages/core/src/store/corpus-index.ts
+++ b/packages/core/src/store/corpus-index.ts
@@ -79,11 +79,22 @@ export async function buildCorpusIndex(
   return createNamespacedIndex(docs, options.embedder);
 }
 
+const MAX_REFERENCE_LIMIT = 100;
+
+/** Bound the caller-supplied limit at the store level; invalid → the index default. */
+function clampReferenceLimit(limit?: number): number | undefined {
+  if (typeof limit !== "number" || !Number.isFinite(limit) || limit <= 0) return undefined;
+  return Math.min(Math.floor(limit), MAX_REFERENCE_LIMIT);
+}
+
 /**
  * Tier-0 lookup: search the vault's `references/` only (no corpus embedding).
  * Builds a references-only index per call — references are few and
  * search_references is infrequent, so this stays simple (no cache). Returns the
  * matched reference's pointer (vault-relative path) + relevant section.
+ *
+ * The per-call rebuild is bounded by the reference-set size; revisit with a
+ * cache if references/ ever grows large (especially under the real embedder).
  */
 export async function searchReferences(
   vault: Vault,
@@ -95,5 +106,5 @@ export async function searchReferences(
     .listMarkdown(REFERENCES_DIR)
     .map((relPath) => ({ id: relPath, text: vault.readText(relPath), namespace: "references" }));
   const index = await createNamespacedIndex(docs, embedder);
-  return index.searchReferences(query, limit);
+  return index.searchReferences(query, clampReferenceLimit(limit));
 }

--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -6,9 +6,11 @@ import {
   createConversationStateStore,
 } from "./conversation-state-store.js";
 import { createVault } from "./corpus/index.js";
+import { searchReferences as searchVaultReferences } from "./corpus-index.js";
 import { type CurationStore, createCurationStore } from "./curation-store.js";
 import { createSyncGitOps } from "./git/index.js";
 import { type HandoffStore, createHandoffStore } from "./handoff-store.js";
+import { type ReferenceHit, createHashEmbedder } from "./index/index.js";
 import { readJsonl } from "./jsonl.js";
 import { createMarkdownHandoffStore, createMarkdownMemoryStore } from "./markdown/index.js";
 import { type MemoryStore, createMemoryStore } from "./memory-store.js";
@@ -52,6 +54,8 @@ export interface LibrarianStore extends MemoryStore, CurationStore, SettingsStor
   handoffs: HandoffStore;
   /** Skills read surface (vault-based, backend-independent): manifest + get + find. */
   skills: SkillStore;
+  /** Tier-0 reference lookup over the vault's references/ (backend-independent). */
+  searchReferences(query: string, limit?: number): Promise<ReferenceHit[]>;
   dataDir: string;
   close(): void;
   /** Backend-neutral maintenance verb: rebuild the disposable memory index. */
@@ -137,6 +141,8 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Inter
       convState: jsonConvState,
       handoffs: markdownHandoffs,
       skills: createSkillStore(vault),
+      searchReferences: (query, limit) =>
+        searchVaultReferences(vault, createHashEmbedder(), query, limit),
       dataDir,
       eventsPath,
       dbPath,
@@ -170,8 +176,15 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Inter
     convState,
     handoffs,
     // create:false — a SQLite install must not materialize a vault dir just to
-    // expose the (read-only) skills surface; it appears only once skills exist.
+    // expose these read-only vault surfaces; they appear only once files exist.
     skills: createSkillStore(createVault({ dataDir, create: false })),
+    searchReferences: (query, limit) =>
+      searchVaultReferences(
+        createVault({ dataDir, create: false }),
+        createHashEmbedder(),
+        query,
+        limit,
+      ),
     dataDir,
     eventsPath,
     dbPath,

--- a/packages/mcp-server/src/mcp/tools/index.ts
+++ b/packages/mcp-server/src/mcp/tools/index.ts
@@ -16,6 +16,7 @@ import listProposals from "./list-proposals.js";
 import proposeMemory from "./propose-memory.js";
 import recall from "./recall.js";
 import remember from "./remember.js";
+import searchReferences from "./search-references.js";
 import sessionManifest from "./session-manifest.js";
 import startContext from "./start-context.js";
 import storeHandoff from "./store-handoff.js";
@@ -41,6 +42,7 @@ export const tools: ToolDefinition[] = [
   findSkills,
   getSkill,
   sessionManifest,
+  searchReferences,
 ];
 
 export const toolsByName: Map<string, ToolDefinition> = new Map(

--- a/packages/mcp-server/src/mcp/tools/search-references.ts
+++ b/packages/mcp-server/src/mcp/tools/search-references.ts
@@ -23,10 +23,8 @@ const searchReferences: ToolDefinition = {
   async handler(store, args) {
     const query = typeof args.query === "string" ? args.query : "";
     if (!query.trim()) return textResult("search_references rejected: 'query' is required");
-    const limit =
-      typeof args.limit === "number" && args.limit > 0
-        ? Math.min(Math.floor(args.limit), 100)
-        : undefined;
+    // store.searchReferences clamps the limit (the invariant lives there).
+    const limit = typeof args.limit === "number" ? args.limit : undefined;
     const hits = await store.searchReferences(query, limit);
     return textResult(JSON.stringify({ references: hits }, null, 2));
   },

--- a/packages/mcp-server/src/mcp/tools/search-references.ts
+++ b/packages/mcp-server/src/mcp/tools/search-references.ts
@@ -1,0 +1,35 @@
+// `search_references` MCP tool (plan 036 Phase 3 / spec 035 §F3-F4). Tier-0
+// lookup over the vault's references/ — background reference docs that are NOT
+// in default recall. Returns each match's pointer (vault-relative path) + the
+// query-relevant section, so the agent can pull just the matched section.
+
+import { textResult } from "../result.js";
+import type { ToolDefinition } from "../tool.js";
+
+const searchReferences: ToolDefinition = {
+  name: "search_references",
+  description:
+    "Search Tier-0 reference docs (references/) by query. Returns each match's " +
+    "path + the relevant section. References are background material — they are " +
+    "not in normal recall; use this to look them up on demand.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      query: { type: "string", description: "What to look up in the references." },
+      limit: { type: "integer", minimum: 1, maximum: 100 },
+    },
+    required: ["query"],
+  },
+  async handler(store, args) {
+    const query = typeof args.query === "string" ? args.query : "";
+    if (!query.trim()) return textResult("search_references rejected: 'query' is required");
+    const limit =
+      typeof args.limit === "number" && args.limit > 0
+        ? Math.min(Math.floor(args.limit), 100)
+        : undefined;
+    const hits = await store.searchReferences(query, limit);
+    return textResult(JSON.stringify({ references: hits }, null, 2));
+  },
+};
+
+export default searchReferences;

--- a/packages/mcp-server/tests/mcp/mcp.test.ts
+++ b/packages/mcp-server/tests/mcp/mcp.test.ts
@@ -38,6 +38,7 @@ describe("MCP dispatch", () => {
         "get_skill",
         "find_skills",
         "session_manifest",
+        "search_references",
       ]) {
         expect(toolNames).toContain(expected);
       }

--- a/packages/mcp-server/tests/mcp/search-references.test.ts
+++ b/packages/mcp-server/tests/mcp/search-references.test.ts
@@ -61,6 +61,16 @@ describe("search_references MCP tool", () => {
     });
   });
 
+  it("tolerates an out-of-range limit (clamped, never drops the match)", async () => {
+    await withStore(async (store: unknown, dataDir: string) => {
+      writeReference(dataDir, "piano-manual.md", "## Tuning\nthe grand piano needs tuning");
+      // a negative limit must not slice(0,-1) the match away
+      const res = (await call(store, { query: "piano tuning", limit: -1 })) as CallResult;
+      const refs = JSON.parse(res.result.content[0]!.text).references;
+      expect(refs.map((r: { id: string }) => r.id)).toContain("references/piano-manual.md");
+    });
+  });
+
   it("returns an empty list when there are no references", async () => {
     await withStore(async (store: unknown) => {
       const res = (await call(store, { query: "anything" })) as CallResult;

--- a/packages/mcp-server/tests/mcp/search-references.test.ts
+++ b/packages/mcp-server/tests/mcp/search-references.test.ts
@@ -1,0 +1,70 @@
+// search_references MCP tool (plan 036 Phase 3 / spec 035 §F3-F4). Tier-0
+// lookup over the vault's references/ via handleMcpPayload. Backend-independent
+// (references live in the vault), so the default test store (sqlite) serves
+// references dropped under <dataDir>/vault/references/.
+
+import fs from "node:fs";
+import path from "node:path";
+import { handleMcpPayload } from "@librarian/mcp-server";
+import { describe, expect, it } from "vitest";
+import { withStore } from "../../../../test/helpers.js";
+
+type CallResult = { result: { content: { text: string }[] } };
+
+function writeReference(dataDir: string, name: string, body: string): void {
+  const dir = path.join(dataDir, "vault", "references");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, name), body);
+}
+
+const call = (store: unknown, args: Record<string, unknown>): Promise<unknown> =>
+  handleMcpPayload(store as never, {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: { name: "search_references", arguments: args },
+  });
+
+describe("search_references MCP tool", () => {
+  it("is advertised to agents", async () => {
+    await withStore(async (store: unknown) => {
+      const list = (await handleMcpPayload(store as never, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+        params: {},
+      })) as { result: { tools: { name: string }[] } };
+      expect(list.result.tools.map((t) => t.name)).toContain("search_references");
+    });
+  });
+
+  it("returns the matching reference's path + relevant section", async () => {
+    await withStore(async (store: unknown, dataDir: string) => {
+      writeReference(
+        dataDir,
+        "piano-manual.md",
+        "## Tuning\nthe grand piano needs tuning twice a year\n\n## Cleaning\nwipe the keys",
+      );
+      writeReference(dataDir, "sailing.md", "navigating boats across open water");
+      const res = (await call(store, { query: "piano tuning" })) as CallResult;
+      const refs = JSON.parse(res.result.content[0]!.text).references;
+      expect(refs[0].id).toBe("references/piano-manual.md");
+      expect(refs[0].section).toContain("## Tuning");
+      expect(refs[0].section).not.toContain("## Cleaning");
+    });
+  });
+
+  it("rejects an empty query (fail-soft)", async () => {
+    await withStore(async (store: unknown) => {
+      const res = (await call(store, { query: "  " })) as CallResult;
+      expect(res.result.content[0]!.text).toContain("rejected");
+    });
+  });
+
+  it("returns an empty list when there are no references", async () => {
+    await withStore(async (store: unknown) => {
+      const res = (await call(store, { query: "anything" })) as CallResult;
+      expect(JSON.parse(res.result.content[0]!.text).references).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## What

`search_references` MCP verb (spec 035 §F3/F4) — Tier-0 lookup over the vault's `references/`: background reference docs deliberately kept **out of normal recall**. Returns each match's path + the query-relevant section (so the agent pulls just the matched section, not the whole file).

- New `searchReferences(vault, embedder, query, limit)` helper — a references-only index per call (no corpus embedding); reference id = vault-relative path.
- `LibrarianStore.searchReferences` on both backends (markdown reuses its vault; sqlite uses a `create:false` vault so a SQLite-only install never materializes a vault dir — same invariant as the skills store).
- Limit clamp lives in the store helper (the invariant home); the verb passes the numeric limit through. Hash-embedder placeholder (resolveEmbedder + real model follow).

## Review

Sub-agent review (5 axes): **sound, no Critical** — verified backend-independence (no vault dir created on sqlite), references-only isolation (recall empty / search works), fail-soft on every probed bad input, no traversal surface, determinism. Applied the one Important item (a verb-level out-of-range-limit regression test, mirroring `find_skills`) and moved the clamp to the store helper.

## Tests

5: advertised, match+section, empty-query reject, **out-of-range-limit clamp**, no-references empty. (Pre-existing flaky `classifier-worker` timing test is unrelated — passes on rerun.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)