### PR TITLE
feat(store): index-backed recall on the markdown backend (cutover, F3)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -234,7 +234,10 @@ export {
 } from "./store/skills/index.js";
 export {
   type CorpusIndexOptions,
+  type RecallMemoriesDeps,
+  type RecallMemoriesOptions,
   buildCorpusIndex,
+  recallMemories,
   searchReferences,
 } from "./store/corpus-index.js";
 export { type MemoryWriteVerdict, routeMemoryWrite } from "./store/memory-routing.js";

--- a/packages/core/src/store/corpus-index.ts
+++ b/packages/core/src/store/corpus-index.ts
@@ -129,7 +129,14 @@ export interface RecallMemoriesOptions {
  * then apply the same filters searchMemories does (project_key incl. globals,
  * tags any-match) and bound to `limit`. Over-fetches from the index so the
  * post-filter still fills the limit. Per-call index build for now — caching is
- * a follow-up; the no-query / filter-only path stays on searchMemories.
+ * the next increment (required before the real embedder, or every recall
+ * re-embeds the whole corpus); the no-query / filter-only path stays on
+ * searchMemories.
+ *
+ * Recall-quality note: the candidate pool is bounded (over-fetch + the index's
+ * internal seed cap), so a very selective filter (e.g. a rare tag held only by
+ * deep-ranked memories) can return fewer than `limit` even when more matches
+ * exist. Acceptable for typical limits; revisit if it bites.
  */
 export async function recallMemories(
   deps: RecallMemoriesDeps,

--- a/packages/core/src/store/corpus-index.ts
+++ b/packages/core/src/store/corpus-index.ts
@@ -25,6 +25,7 @@ import {
   createNamespacedIndex,
 } from "./index/index.js";
 import { parseMemoryDocument } from "./markdown/memory-doc.js";
+import type { Memory } from "./memory-store.js";
 
 const CORPUS_DIR = "memories";
 const REFERENCES_DIR = "references";
@@ -107,4 +108,47 @@ export async function searchReferences(
     .map((relPath) => ({ id: relPath, text: vault.readText(relPath), namespace: "references" }));
   const index = await createNamespacedIndex(docs, embedder);
   return index.searchReferences(query, clampReferenceLimit(limit));
+}
+
+export interface RecallMemoriesDeps {
+  vault: Vault;
+  embedder: Embedder;
+  getMemory: (id: string) => Memory | null;
+}
+
+export interface RecallMemoriesOptions {
+  /** Project scope; like searchMemories, globals (project_key null) always match. */
+  projectKey?: string | undefined;
+  /** Any-match tag filter. */
+  tags?: string[] | undefined;
+  limit?: number | undefined;
+}
+
+/**
+ * Index-backed memory recall: rank active corpus memories by the hybrid index,
+ * then apply the same filters searchMemories does (project_key incl. globals,
+ * tags any-match) and bound to `limit`. Over-fetches from the index so the
+ * post-filter still fills the limit. Per-call index build for now — caching is
+ * a follow-up; the no-query / filter-only path stays on searchMemories.
+ */
+export async function recallMemories(
+  deps: RecallMemoriesDeps,
+  query: string,
+  options: RecallMemoriesOptions = {},
+): Promise<Memory[]> {
+  const limit = options.limit ?? 8;
+  const index = await buildCorpusIndex(deps.vault, { embedder: deps.embedder });
+  const hits = await index.recall(query, { limit: Math.max(limit * 4, 24) });
+  const projectKey = options.projectKey ?? "";
+  const tagSet = new Set(options.tags ?? []);
+  const out: Memory[] = [];
+  for (const hit of hits) {
+    const memory = deps.getMemory(hit.id);
+    if (!memory) continue; // stale id (vault changed mid-flight) — skip
+    if (projectKey && !(memory.project_key == null || memory.project_key === projectKey)) continue;
+    if (tagSet.size && !(memory.tags ?? []).some((tag) => tagSet.has(tag))) continue;
+    out.push(memory);
+    if (out.length >= limit) break;
+  }
+  return out;
 }

--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -6,14 +6,14 @@ import {
   createConversationStateStore,
 } from "./conversation-state-store.js";
 import { createVault } from "./corpus/index.js";
-import { searchReferences as searchVaultReferences } from "./corpus-index.js";
+import { recallMemories, searchReferences as searchVaultReferences } from "./corpus-index.js";
 import { type CurationStore, createCurationStore } from "./curation-store.js";
 import { createSyncGitOps } from "./git/index.js";
 import { type HandoffStore, createHandoffStore } from "./handoff-store.js";
 import { type ReferenceHit, createHashEmbedder } from "./index/index.js";
 import { readJsonl } from "./jsonl.js";
 import { createMarkdownHandoffStore, createMarkdownMemoryStore } from "./markdown/index.js";
-import { type MemoryStore, createMemoryStore } from "./memory-store.js";
+import { type Memory, type MemoryStore, createMemoryStore } from "./memory-store.js";
 import { ensureSchema, rebuildMemoryIndex } from "./projection.js";
 import { type SettingsStore, createSettingsStore } from "./settings-store.js";
 import { createJsonConversationStateStore, createJsonSettingsStore } from "./sidecar/index.js";
@@ -56,6 +56,12 @@ export interface LibrarianStore extends MemoryStore, CurationStore, SettingsStor
   skills: SkillStore;
   /** Tier-0 reference lookup over the vault's references/ (backend-independent). */
   searchReferences(query: string, limit?: number): Promise<ReferenceHit[]>;
+  /**
+   * Memory recall. On markdown this is index-backed (hybrid keyword+vector,
+   * backlink-aware); on sqlite it delegates to the keyword searchMemories. A
+   * filter-only (no-query) call falls back to searchMemories on both.
+   */
+  recall(input?: Record<string, unknown>): Promise<Memory[]>;
   dataDir: string;
   close(): void;
   /** Backend-neutral maintenance verb: rebuild the disposable memory index. */
@@ -126,6 +132,9 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Inter
     };
     const markdownMemory = createMarkdownMemoryStore({ vault, commit });
     const markdownHandoffs = createMarkdownHandoffStore({ vault, commit });
+    // Hash embedder placeholder for the index (recall + references); the real
+    // model is a drop-in via resolveEmbedder later.
+    const embedder = createHashEmbedder();
     const jsonConvState = createJsonConversationStateStore({
       filePath: path.join(dataDir, "conv-state.json"),
     });
@@ -141,8 +150,21 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Inter
       convState: jsonConvState,
       handoffs: markdownHandoffs,
       skills: createSkillStore(vault),
-      searchReferences: (query, limit) =>
-        searchVaultReferences(vault, createHashEmbedder(), query, limit),
+      searchReferences: (query, limit) => searchVaultReferences(vault, embedder, query, limit),
+      recall: async (input = {}) => {
+        const query = typeof input.query === "string" ? input.query : "";
+        // filter-only (no query) stays on the keyword path
+        if (!query.trim()) return markdownMemory.searchMemories(input);
+        return recallMemories(
+          { vault, embedder, getMemory: (id) => markdownMemory.getMemory(id) },
+          query,
+          {
+            projectKey: typeof input.project_key === "string" ? input.project_key : undefined,
+            tags: Array.isArray(input.tags) ? (input.tags as string[]) : undefined,
+            limit: typeof input.limit === "number" ? input.limit : undefined,
+          },
+        );
+      },
       dataDir,
       eventsPath,
       dbPath,
@@ -185,6 +207,8 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Inter
         query,
         limit,
       ),
+    // sqlite recall is the keyword searchMemories (no markdown vault to index)
+    recall: (input = {}) => Promise.resolve(memoryStore.searchMemories(input)),
     dataDir,
     eventsPath,
     dbPath,

--- a/packages/core/tests/store/librarian-store-backend.test.ts
+++ b/packages/core/tests/store/librarian-store-backend.test.ts
@@ -103,4 +103,66 @@ describe("createLibrarianStore — backend selection", () => {
       }
     }
   });
+
+  it("markdown recall is index-backed: ranks active memories by query, excludes archived", async () => {
+    const store = createLibrarianStore({ dataDir, backend: "markdown" });
+    try {
+      const piano = store.createMemory({
+        agent_id: "codex",
+        title: "Piano tuning",
+        body: "the grand piano needs tuning twice a year",
+      }).memory;
+      store.createMemory({
+        agent_id: "codex",
+        title: "Sailing",
+        body: "navigating boats on water",
+      });
+      const old = store.createMemory({
+        agent_id: "codex",
+        title: "Old",
+        body: "obsolete fact about widgets",
+      }).memory;
+      store.archiveMemory(old.id);
+
+      const hits = await store.recall({ query: "piano tuning" });
+      expect(hits[0]?.id).toBe(piano.id);
+      expect(hits.map((m) => m.id)).not.toContain(old.id);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("markdown recall with a tag filter returns only matching memories", async () => {
+    const store = createLibrarianStore({ dataDir, backend: "markdown" });
+    try {
+      store.createMemory({
+        agent_id: "codex",
+        title: "Piano practice",
+        body: "scales and arpeggios",
+        tags: ["music"],
+      });
+      store.createMemory({
+        agent_id: "codex",
+        title: "Piano history",
+        body: "the instrument",
+        tags: ["trivia"],
+      });
+      const hits = await store.recall({ query: "piano", tags: ["music"] });
+      expect(hits.map((m) => m.title)).toEqual(["Piano practice"]);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("markdown recall with no query falls back to keyword searchMemories (filter-only)", async () => {
+    const store = createLibrarianStore({ dataDir, backend: "markdown" });
+    try {
+      store.createMemory({ agent_id: "codex", title: "Tagged", body: "x", tags: ["alpha"] });
+      store.createMemory({ agent_id: "codex", title: "Untagged", body: "y" });
+      const hits = await store.recall({ tags: ["alpha"] });
+      expect(hits.map((m) => m.title)).toEqual(["Tagged"]);
+    } finally {
+      store.close();
+    }
+  });
 });

--- a/packages/core/tests/store/librarian-store-backend.test.ts
+++ b/packages/core/tests/store/librarian-store-backend.test.ts
@@ -165,4 +165,76 @@ describe("createLibrarianStore — backend selection", () => {
       store.close();
     }
   });
+
+  it("markdown recall never surfaces a proposed memory, even one matching the query", async () => {
+    const store = createLibrarianStore({ dataDir, backend: "markdown" });
+    try {
+      store.createMemory(
+        {
+          agent_id: "codex",
+          title: "Pending piano",
+          body: "draft about piano tuning awaiting approval",
+          status: "proposed",
+        },
+        { status: "proposed" },
+      );
+      const active = store.createMemory({
+        agent_id: "codex",
+        title: "Active piano",
+        body: "piano tuning notes",
+      }).memory;
+      const hits = await store.recall({ query: "piano tuning" });
+      expect(hits.map((m) => m.id)).toEqual([active.id]); // proposed excluded
+    } finally {
+      store.close();
+    }
+  });
+
+  it("markdown recall with project_key includes globals + the matching project, excludes others", async () => {
+    const store = createLibrarianStore({ dataDir, backend: "markdown" });
+    try {
+      const global = store.createMemory({
+        agent_id: "codex",
+        title: "Global piano",
+        body: "piano tuning everywhere",
+      }).memory; // no project_key → null (global)
+      const alpha = store.createMemory({
+        agent_id: "codex",
+        title: "Alpha piano",
+        body: "piano tuning here",
+        project_key: "alpha",
+      }).memory;
+      const beta = store.createMemory({
+        agent_id: "codex",
+        title: "Beta piano",
+        body: "piano tuning elsewhere",
+        project_key: "beta",
+      }).memory;
+      const ids = (await store.recall({ query: "piano tuning", project_key: "alpha" })).map(
+        (m) => m.id,
+      );
+      expect(ids).toContain(global.id); // globals always match (project_key IS NULL)
+      expect(ids).toContain(alpha.id); // matching project
+      expect(ids).not.toContain(beta.id); // other project excluded
+    } finally {
+      store.close();
+    }
+  });
+
+  it("markdown recall bounds results to the limit", async () => {
+    const store = createLibrarianStore({ dataDir, backend: "markdown" });
+    try {
+      for (let i = 0; i < 5; i++) {
+        store.createMemory({
+          agent_id: "codex",
+          title: `Piano ${i}`,
+          body: "piano tuning practice drills",
+        });
+      }
+      const hits = await store.recall({ query: "piano tuning", limit: 2 });
+      expect(hits.length).toBeLessThanOrEqual(2);
+    } finally {
+      store.close();
+    }
+  });
 });

--- a/packages/mcp-server/src/mcp/tools/recall.ts
+++ b/packages/mcp-server/src/mcp/tools/recall.ts
@@ -20,11 +20,12 @@ const recall: ToolDefinition = {
       limit: { type: "number" },
     },
   },
-  handler(store, args, context) {
+  async handler(store, args, context) {
     const scoped = scopeAgentArgs(args, context);
     // conv_id was a domain-routing signal, not a search field.
     delete scoped.conv_id;
-    const memories = store.searchMemories(scoped);
+    // store.recall is index-backed (hybrid) on markdown, keyword searchMemories on sqlite.
+    const memories = await store.recall(scoped);
     store.recordRecall(
       memories,
       (scoped.agent_id as string) || DEFAULT_AGENT_ID,


### PR DESCRIPTION
## What

Rewires `recall` to be **index-backed on the markdown backend** (the F3 cutover step). `LibrarianStore.recall(input)`:

- **markdown** — ranks active corpus memories via the hybrid index (`recallMemories` → `buildCorpusIndex` + `recallFromIndex`), then applies the *exact same filters* `searchMemories` does (`project_key` incl. globals `(IS NULL OR = ?)`, tags any-match) and bounds to `limit`. Active-only is structural (the index only indexes active memories — proposed + archived can't leak). A no-query/filter-only call falls back to `searchMemories`.
- **sqlite** — delegates straight to `searchMemories`, so the recall verb is **behaviourally unchanged** there.

The recall MCP verb now `await store.recall(scoped)`.

## Risk / scope

Sub-agent review (5 axes, probed hard on the core recall path): **sound, no Critical.** Filter parity with `searchMemories` confirmed line-by-line (status/project/tags/limit; no dropped agent scoping). sqlite unchanged → the existing recall verb tests pass untouched.

**Deferred — and tracked as the immediate next increment:** the per-call `buildCorpusIndex` re-embeds the whole corpus on every recall. Harmless under the hash-embedder placeholder, but **caching must land before the real embedder is wired** (else it's a hot-path regression). That's the next PR.

## Tests

10 backend tests incl. the new parity coverage: index ranking, archived-excluded, **proposed-never-surfaced**, **project_key incl. globals**, tag filter, **limit bounding**, no-query fallback. Hash embedder (no model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)