### PR TITLE
perf(store): cache the recall index, invalidate on memory writes (cutover)

### DIFF
--- a/packages/core/src/store/corpus-index.ts
+++ b/packages/core/src/store/corpus-index.ts
@@ -111,8 +111,8 @@ export async function searchReferences(
 }
 
 export interface RecallMemoriesDeps {
-  vault: Vault;
-  embedder: Embedder;
+  /** A built (and ideally cached) corpus index — see buildCorpusIndex. */
+  index: NamespacedIndex;
   getMemory: (id: string) => Memory | null;
 }
 
@@ -125,13 +125,11 @@ export interface RecallMemoriesOptions {
 }
 
 /**
- * Index-backed memory recall: rank active corpus memories by the hybrid index,
- * then apply the same filters searchMemories does (project_key incl. globals,
- * tags any-match) and bound to `limit`. Over-fetches from the index so the
- * post-filter still fills the limit. Per-call index build for now — caching is
- * the next increment (required before the real embedder, or every recall
- * re-embeds the whole corpus); the no-query / filter-only path stays on
- * searchMemories.
+ * Index-backed memory recall: rank active corpus memories by the (caller-
+ * supplied, cacheable) hybrid index, then apply the same filters searchMemories
+ * does (project_key incl. globals, tags any-match) and bound to `limit`.
+ * Over-fetches from the index so the post-filter still fills the limit. The
+ * no-query / filter-only path stays on searchMemories (caller's concern).
  *
  * Recall-quality note: the candidate pool is bounded (over-fetch + the index's
  * internal seed cap), so a very selective filter (e.g. a rare tag held only by
@@ -144,8 +142,7 @@ export async function recallMemories(
   options: RecallMemoriesOptions = {},
 ): Promise<Memory[]> {
   const limit = options.limit ?? 8;
-  const index = await buildCorpusIndex(deps.vault, { embedder: deps.embedder });
-  const hits = await index.recall(query, { limit: Math.max(limit * 4, 24) });
+  const hits = await deps.index.recall(query, { limit: Math.max(limit * 4, 24) });
   const projectKey = options.projectKey ?? "";
   const tagSet = new Set(options.tags ?? []);
   const out: Memory[] = [];

--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -6,11 +6,15 @@ import {
   createConversationStateStore,
 } from "./conversation-state-store.js";
 import { createVault } from "./corpus/index.js";
-import { recallMemories, searchReferences as searchVaultReferences } from "./corpus-index.js";
+import {
+  buildCorpusIndex,
+  recallMemories,
+  searchReferences as searchVaultReferences,
+} from "./corpus-index.js";
 import { type CurationStore, createCurationStore } from "./curation-store.js";
 import { createSyncGitOps } from "./git/index.js";
 import { type HandoffStore, createHandoffStore } from "./handoff-store.js";
-import { type ReferenceHit, createHashEmbedder } from "./index/index.js";
+import { type NamespacedIndex, type ReferenceHit, createHashEmbedder } from "./index/index.js";
 import { readJsonl } from "./jsonl.js";
 import { createMarkdownHandoffStore, createMarkdownMemoryStore } from "./markdown/index.js";
 import { type Memory, type MemoryStore, createMemoryStore } from "./memory-store.js";
@@ -130,11 +134,25 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Inter
     const commit = (message: string): void => {
       git.commitAll(message);
     };
-    const markdownMemory = createMarkdownMemoryStore({ vault, commit });
-    const markdownHandoffs = createMarkdownHandoffStore({ vault, commit });
     // Hash embedder placeholder for the index (recall + references); the real
     // model is a drop-in via resolveEmbedder later.
     const embedder = createHashEmbedder();
+    // Disposable recall index, built lazily + cached, invalidated on every
+    // memory write (onWrite) so recall doesn't rebuild + re-embed the corpus
+    // per call. References change via the filesystem, not memory writes, but
+    // recall only reads the corpus namespace, so memory-write invalidation
+    // suffices for recall (search_references builds its own index).
+    let cachedIndex: Promise<NamespacedIndex> | null = null;
+    const markdownMemory = createMarkdownMemoryStore({
+      vault,
+      commit,
+      onWrite: () => {
+        cachedIndex = null;
+      },
+    });
+    const markdownHandoffs = createMarkdownHandoffStore({ vault, commit });
+    const corpusIndex = (): Promise<NamespacedIndex> =>
+      (cachedIndex ??= buildCorpusIndex(vault, { embedder }));
     const jsonConvState = createJsonConversationStateStore({
       filePath: path.join(dataDir, "conv-state.json"),
     });
@@ -156,7 +174,7 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Inter
         // filter-only (no query) stays on the keyword path
         if (!query.trim()) return markdownMemory.searchMemories(input);
         return recallMemories(
-          { vault, embedder, getMemory: (id) => markdownMemory.getMemory(id) },
+          { index: await corpusIndex(), getMemory: (id) => markdownMemory.getMemory(id) },
           query,
           {
             projectKey: typeof input.project_key === "string" ? input.project_key : undefined,

--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -152,7 +152,10 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Inter
     });
     const markdownHandoffs = createMarkdownHandoffStore({ vault, commit });
     const corpusIndex = (): Promise<NamespacedIndex> =>
-      (cachedIndex ??= buildCorpusIndex(vault, { embedder }));
+      (cachedIndex ??= buildCorpusIndex(vault, { embedder }).catch((error: unknown) => {
+        cachedIndex = null; // a failed/transient build (e.g. real embedder load) must not poison recall
+        throw error;
+      }));
     const jsonConvState = createJsonConversationStateStore({
       filePath: path.join(dataDir, "conv-state.json"),
     });
@@ -191,7 +194,11 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Inter
       close: () => db.close(),
       readEvents: () => [],
       rebuildIndex: () => {},
-      reindex: () => {},
+      // drop the cached recall index → next recall rebuilds from the vault
+      // (also picks up out-of-band vault edits, e.g. a hand-added reference).
+      reindex: () => {
+        cachedIndex = null;
+      },
     };
   }
 

--- a/packages/core/src/store/markdown/markdown-memory-store.ts
+++ b/packages/core/src/store/markdown/markdown-memory-store.ts
@@ -32,6 +32,8 @@ export interface MarkdownMemoryStoreDeps {
   vault: Vault;
   /** Sync commit-per-op (e.g. a synchronous git commit). Omit to skip committing. */
   commit?: (message: string) => void;
+  /** Fired after every successful write (post-commit) — e.g. to invalidate a disposable index cache. */
+  onWrite?: () => void;
   /** Clock injection (defaults to `nowIso`). */
   now?: () => string;
   /** Id generator injection (defaults to `makeId("mem")`). */
@@ -57,7 +59,14 @@ export function createMarkdownMemoryStore(deps: MarkdownMemoryStoreDeps): Memory
   const { vault } = deps;
   const now = deps.now ?? nowIso;
   const generateId = deps.generateId ?? (() => makeId("mem"));
-  const commit = deps.commit ?? (() => {});
+  const rawCommit = deps.commit ?? (() => {});
+  // Wrap commit so every write fires onWrite — one hook covering all mutations
+  // (createMemory + persist, used by update/archive/verify), e.g. to invalidate
+  // the disposable recall index.
+  const commit = (message: string): void => {
+    rawCommit(message);
+    deps.onWrite?.();
+  };
 
   // The append-only event ledger is retired in the markdown model — every
   // write is a git commit, so git history is the audit trail. These two

--- a/packages/core/tests/store/librarian-store-backend.test.ts
+++ b/packages/core/tests/store/librarian-store-backend.test.ts
@@ -221,6 +221,25 @@ describe("createLibrarianStore — backend selection", () => {
     }
   });
 
+  it("markdown recall reflects a memory written after a prior recall (index cache invalidated on write)", async () => {
+    const store = createLibrarianStore({ dataDir, backend: "markdown" });
+    try {
+      store.createMemory({ agent_id: "codex", title: "First piano", body: "piano tuning one" });
+      const first = await store.recall({ query: "piano tuning" });
+      expect(first.length).toBe(1);
+      // a write AFTER the first recall must invalidate the cached index
+      const second = store.createMemory({
+        agent_id: "codex",
+        title: "Second piano",
+        body: "piano tuning two",
+      }).memory;
+      const after = await store.recall({ query: "piano tuning" });
+      expect(after.map((m) => m.id)).toContain(second.id);
+    } finally {
+      store.close();
+    }
+  });
+
   it("markdown recall bounds results to the limit", async () => {
     const store = createLibrarianStore({ dataDir, backend: "markdown" });
     try {

--- a/packages/core/tests/store/librarian-store-backend.test.ts
+++ b/packages/core/tests/store/librarian-store-backend.test.ts
@@ -240,6 +240,24 @@ describe("createLibrarianStore — backend selection", () => {
     }
   });
 
+  it("markdown recall drops a memory archived after a prior recall (cache invalidated)", async () => {
+    const store = createLibrarianStore({ dataDir, backend: "markdown" });
+    try {
+      const m = store.createMemory({
+        agent_id: "codex",
+        title: "Ephemeral piano",
+        body: "piano tuning soon to be archived",
+      }).memory;
+      const before = await store.recall({ query: "piano tuning" });
+      expect(before.map((x) => x.id)).toContain(m.id);
+      store.archiveMemory(m.id); // archive AFTER the recall → must invalidate the cache
+      const after = await store.recall({ query: "piano tuning" });
+      expect(after.map((x) => x.id)).not.toContain(m.id);
+    } finally {
+      store.close();
+    }
+  });
+
   it("markdown recall bounds results to the limit", async () => {
     const store = createLibrarianStore({ dataDir, backend: "markdown" });
     try {


### PR DESCRIPTION
## What

Caches the index-backed recall index instead of rebuilding + re-embedding the whole corpus on every `recall` call. **This is the prerequisite for wiring the real embedder** — without it, every recall would re-embed the corpus through the model.

- The markdown branch builds the corpus index lazily, caches it, and **invalidates on every memory write** via a new `onWrite` hook on the markdown store. `createMarkdownMemoryStore` wraps `commit` so one hook covers all mutations (`createMemory` + the shared `persist` used by update/archive/verify).
- `recallMemories` now takes a pre-built (cacheable) `index` instead of building one.
- `reindex()` on markdown now clears the cache (was a no-op) — so the CLI `rebuild` actually refreshes recall and picks up out-of-band vault edits.
- A failed/transient index build no longer poisons recall forever (null-on-reject, mirroring `llama-embedder`).

## Review

Sub-agent review (5 axes): invalidation correctness confirmed (all writes route through the wrapped `commit`; the idempotent-archive early-return correctly does *not* invalidate; references staleness is irrelevant to recall since recall only reads the corpus namespace; no write bypasses `commit`). Single-threaded — no half-written race. Applied the Important poison-cache fix + the `reindex` wiring + an archive-invalidation test.

## Tests

12 backend tests incl. **invalidation on create AND on archive** after a prior recall, plus the existing parity coverage. (Pre-existing flaky `classifier-worker` timing test is unrelated — passes on rerun; noted for a fake-timers fix.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)