### PR TITLE
feat(store): wire EmbeddingGemma as the production embedder (cutover, F2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ changes from this point forward are catalogued here.
 
 ### Added
 
+- **EmbeddingGemma wired as the production embedder** for index recall +
+  `search_references` (`resolveEmbedder`). Selection is env-driven:
+  `LIBRARIAN_EMBEDDER=hash|llama` (default: hash under tests, the EmbeddingGemma
+  model otherwise). The GGUF (`EmbeddingGemma-300M-Q8_0`, ~333 MB) is downloaded
+  + cached lazily on first embed under `<dataDir>/models`, or supply your own via
+  `LIBRARIAN_MODEL_PATH`. The model loads only on first use, so nothing downloads
+  during boot/healthcheck.
+
 - **`search_references` MCP tool (F3/F4).** Tier-0 lookup over the vault's
   `references/` — background reference docs that are deliberately kept out of
   normal recall. Returns each match's path + the query-relevant section (so the

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -191,6 +191,7 @@ export {
   type RecallOptions,
   type RecalledDoc,
   type ReferenceHit,
+  type ResolveEmbedderOptions,
   type VectorHit,
   type VectorIndex,
   buildHybridIndex,
@@ -203,6 +204,7 @@ export {
   createNamespacedIndex,
   extractRelevantSection,
   recallFromIndex,
+  resolveEmbedder,
 } from "./store/index/index.js";
 export {
   type MarkdownHandoffStoreDeps,

--- a/packages/core/src/store/corpus-index.ts
+++ b/packages/core/src/store/corpus-index.ts
@@ -103,9 +103,15 @@ export async function searchReferences(
   query: string,
   limit?: number,
 ): Promise<ReferenceHit[]> {
-  const docs: NamespacedDoc[] = vault
-    .listMarkdown(REFERENCES_DIR)
-    .map((relPath) => ({ id: relPath, text: vault.readText(relPath), namespace: "references" }));
+  const relPaths = vault.listMarkdown(REFERENCES_DIR);
+  // No references → nothing to search; return early so we never load/download a
+  // model just to embed the query against an empty index.
+  if (relPaths.length === 0) return [];
+  const docs: NamespacedDoc[] = relPaths.map((relPath) => ({
+    id: relPath,
+    text: vault.readText(relPath),
+    namespace: "references",
+  }));
   const index = await createNamespacedIndex(docs, embedder);
   return index.searchReferences(query, clampReferenceLimit(limit));
 }

--- a/packages/core/src/store/index/index.ts
+++ b/packages/core/src/store/index/index.ts
@@ -19,6 +19,7 @@ export {
   createHashEmbedder,
 } from "./hybrid-index.js";
 export { type LlamaEmbedderOptions, createLlamaEmbedder } from "./llama-embedder.js";
+export { type ResolveEmbedderOptions, resolveEmbedder } from "./resolve-embedder.js";
 export {
   type RecallDeps,
   type RecallOptions,

--- a/packages/core/src/store/index/llama-embedder.ts
+++ b/packages/core/src/store/index/llama-embedder.ts
@@ -15,8 +15,12 @@
 import type { Embedder } from "./hybrid-index.js";
 
 export interface LlamaEmbedderOptions {
-  /** Absolute path to the GGUF model file. */
-  modelPath: string;
+  /**
+   * Absolute path to the GGUF model file, or a (lazy, possibly async) resolver
+   * that produces it on first embed — e.g. a downloader/cache. Resolving lazily
+   * keeps construction free of I/O and network until the model is actually used.
+   */
+  modelPath: string | (() => string | Promise<string>);
   /** Prompt wrapper for indexed documents (default: EmbeddingGemma's). */
   documentPrompt?: (text: string) => string;
   /** Prompt wrapper for search queries (default: EmbeddingGemma's). */
@@ -38,7 +42,9 @@ export function createLlamaEmbedder(options: LlamaEmbedderOptions): Embedder {
   async function loadContext(): Promise<EmbeddingContext> {
     const { getLlama, LlamaLogLevel } = await import("node-llama-cpp");
     const llama = await getLlama({ logLevel: LlamaLogLevel.warn }); // quiet model-load spam
-    const model = await llama.loadModel({ modelPath: options.modelPath });
+    const modelPath =
+      typeof options.modelPath === "function" ? await options.modelPath() : options.modelPath;
+    const model = await llama.loadModel({ modelPath });
     return model.createEmbeddingContext();
   }
   const context = (): Promise<EmbeddingContext> =>

--- a/packages/core/src/store/index/resolve-embedder.ts
+++ b/packages/core/src/store/index/resolve-embedder.ts
@@ -24,6 +24,11 @@ export interface ResolveEmbedderOptions {
 
 export function resolveEmbedder(options: ResolveEmbedderOptions): Embedder {
   const choice = process.env.LIBRARIAN_EMBEDDER;
+  // Fail fast on a typo'd value rather than silently falling through to a
+  // surprise model download (e.g. "Hash" / "llamaa").
+  if (choice && choice !== "hash" && choice !== "llama") {
+    throw new Error(`LIBRARIAN_EMBEDDER must be "hash" or "llama" (got "${choice}")`);
+  }
   if (choice === "hash") return createHashEmbedder();
   // Never download a model inside a test run unless explicitly asked for llama.
   if (choice !== "llama" && process.env.VITEST) return createHashEmbedder();

--- a/packages/core/src/store/index/resolve-embedder.ts
+++ b/packages/core/src/store/index/resolve-embedder.ts
@@ -1,0 +1,38 @@
+// Embedder selection (plan 036 Phase 3/7 / spec 035 §F2). Picks the embedder
+// the index + recall run on, from the environment:
+//
+//   LIBRARIAN_EMBEDDER=hash   → the deterministic, zero-dependency hash embedder
+//   LIBRARIAN_EMBEDDER=llama  → EmbeddingGemma via node-llama-cpp
+//   (unset) under a test run  → hash (a vitest run must NEVER download a model)
+//   (unset) otherwise         → llama (the production default)
+//
+// Model file: LIBRARIAN_MODEL_PATH if set (air-gapped / pre-provisioned),
+// otherwise the bundled default GGUF (EmbeddingGemma-300M Q8_0) is downloaded +
+// cached lazily on first embed (≈333 MB). The embedder is lazy, so selecting
+// llama costs nothing until something actually embeds.
+
+import path from "node:path";
+import { type Embedder, createHashEmbedder } from "./hybrid-index.js";
+import { createLlamaEmbedder } from "./llama-embedder.js";
+
+const DEFAULT_MODEL_URI = "hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf";
+
+export interface ResolveEmbedderOptions {
+  /** Data dir; a downloaded model is cached under `<dataDir>/models`. */
+  dataDir: string;
+}
+
+export function resolveEmbedder(options: ResolveEmbedderOptions): Embedder {
+  const choice = process.env.LIBRARIAN_EMBEDDER;
+  if (choice === "hash") return createHashEmbedder();
+  // Never download a model inside a test run unless explicitly asked for llama.
+  if (choice !== "llama" && process.env.VITEST) return createHashEmbedder();
+  return createLlamaEmbedder({ modelPath: () => resolveModelPath(options.dataDir) });
+}
+
+async function resolveModelPath(dataDir: string): Promise<string> {
+  const override = process.env.LIBRARIAN_MODEL_PATH;
+  if (override) return override;
+  const { resolveModelFile } = await import("node-llama-cpp");
+  return resolveModelFile(DEFAULT_MODEL_URI, { directory: path.join(dataDir, "models") });
+}

--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -14,7 +14,7 @@ import {
 import { type CurationStore, createCurationStore } from "./curation-store.js";
 import { createSyncGitOps } from "./git/index.js";
 import { type HandoffStore, createHandoffStore } from "./handoff-store.js";
-import { type NamespacedIndex, type ReferenceHit, createHashEmbedder } from "./index/index.js";
+import { type NamespacedIndex, type ReferenceHit, resolveEmbedder } from "./index/index.js";
 import { readJsonl } from "./jsonl.js";
 import { createMarkdownHandoffStore, createMarkdownMemoryStore } from "./markdown/index.js";
 import { type Memory, type MemoryStore, createMemoryStore } from "./memory-store.js";
@@ -134,9 +134,9 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Inter
     const commit = (message: string): void => {
       git.commitAll(message);
     };
-    // Hash embedder placeholder for the index (recall + references); the real
-    // model is a drop-in via resolveEmbedder later.
-    const embedder = createHashEmbedder();
+    // Index embedder for recall + references — hash under tests, the real model
+    // (EmbeddingGemma) in production (see resolveEmbedder).
+    const embedder = resolveEmbedder({ dataDir });
     // Disposable recall index, built lazily + cached, invalidated on every
     // memory write (onWrite) so recall doesn't rebuild + re-embed the corpus
     // per call. References change via the filesystem, not memory writes, but
@@ -215,6 +215,8 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Inter
   const settingsStore = createSettingsStore({ db, secretKey: options.secretKey ?? null });
   const convState = createConversationStateStore({ db });
   const handoffs = createHandoffStore({ db });
+  // one shared (lazy) embedder so a real model isn't reloaded per call
+  const embedder = resolveEmbedder({ dataDir });
 
   return {
     ...memoryStore,
@@ -226,12 +228,7 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Inter
     // expose these read-only vault surfaces; they appear only once files exist.
     skills: createSkillStore(createVault({ dataDir, create: false })),
     searchReferences: (query, limit) =>
-      searchVaultReferences(
-        createVault({ dataDir, create: false }),
-        createHashEmbedder(),
-        query,
-        limit,
-      ),
+      searchVaultReferences(createVault({ dataDir, create: false }), embedder, query, limit),
     // sqlite recall is the keyword searchMemories (no markdown vault to index)
     recall: (input = {}) => Promise.resolve(memoryStore.searchMemories(input)),
     dataDir,

--- a/packages/core/tests/store/index/resolve-embedder.test.ts
+++ b/packages/core/tests/store/index/resolve-embedder.test.ts
@@ -1,0 +1,38 @@
+// resolveEmbedder selection tests (plan 036 Phase 3/7 / spec 035 §F2).
+// Selection only — these never load/download a model: the llama embedder is
+// lazy, so we assert the SHAPE (asymmetric embedQuery present ⇒ llama; absent ⇒
+// hash) without triggering a model load.
+
+import { resolveEmbedder } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let prev: string | undefined;
+
+beforeEach(() => {
+  prev = process.env.LIBRARIAN_EMBEDDER;
+});
+
+afterEach(() => {
+  if (prev === undefined) delete process.env.LIBRARIAN_EMBEDDER;
+  else process.env.LIBRARIAN_EMBEDDER = prev;
+});
+
+describe("resolveEmbedder", () => {
+  it("defaults to the hash embedder under a test run (VITEST set, no override)", () => {
+    delete process.env.LIBRARIAN_EMBEDDER;
+    const e = resolveEmbedder({ dataDir: "/tmp/does-not-matter" });
+    expect(e.embedQuery).toBeUndefined(); // hash is symmetric — no model, no download
+  });
+
+  it("LIBRARIAN_EMBEDDER=hash forces the hash embedder", () => {
+    process.env.LIBRARIAN_EMBEDDER = "hash";
+    expect(resolveEmbedder({ dataDir: "/tmp/x" }).embedQuery).toBeUndefined();
+  });
+
+  it("LIBRARIAN_EMBEDDER=llama selects the asymmetric model embedder (lazily, not loaded)", () => {
+    process.env.LIBRARIAN_EMBEDDER = "llama";
+    const e = resolveEmbedder({ dataDir: "/tmp/x" });
+    // llama exposes embedQuery (asymmetric prompts); the model is NOT loaded here
+    expect(typeof e.embedQuery).toBe("function");
+  });
+});

--- a/packages/core/tests/store/index/resolve-embedder.test.ts
+++ b/packages/core/tests/store/index/resolve-embedder.test.ts
@@ -35,4 +35,9 @@ describe("resolveEmbedder", () => {
     // llama exposes embedQuery (asymmetric prompts); the model is NOT loaded here
     expect(typeof e.embedQuery).toBe("function");
   });
+
+  it("throws on an unrecognized LIBRARIAN_EMBEDDER value (catches typos before a surprise download)", () => {
+    process.env.LIBRARIAN_EMBEDDER = "Hash"; // wrong case → not a valid value
+    expect(() => resolveEmbedder({ dataDir: "/tmp/x" })).toThrow(/LIBRARIAN_EMBEDDER/);
+  });
 });


### PR DESCRIPTION
## What

Wires the real embedder (EmbeddingGemma via node-llama-cpp) as the production default for index recall + `search_references`, via a new `resolveEmbedder`:

- `LIBRARIAN_EMBEDDER=hash` → the deterministic hash embedder · `=llama` → EmbeddingGemma · **unset** → hash under a test run (`VITEST`), else llama (prod default). Invalid value → fail-fast (catches typos before a surprise download).
- The GGUF (`EmbeddingGemma-300M-Q8_0`, ~333 MB) downloads + caches **lazily on first embed** under `<dataDir>/models`; `LIBRARIAN_MODEL_PATH` overrides for air-gapped/pre-provisioned.
- `createLlamaEmbedder` now accepts a lazy model-path resolver. The librarian store (both backends) uses **one shared lazy embedder** for recall + search_references; `searchReferences` short-circuits on empty references so it never loads a model to search nothing.

## CI-download safety (verified)

Sub-agent review traced every path: **no CI path can trigger the download.** (1) Unit tests run under vitest → hash (the markdown recall test exercises the embed path and stays on hash); (2) smoke + healthcheck run via `node` on the default **sqlite** backend, which never touches the index/embedder; (3) construction is lazy — selecting llama loads nothing until first embed (boot/healthcheck don't embed).

**Carried forward to the default-backend flip increment:** once the default flips to markdown, the CI smoke/healthcheck must be pinned with `LIBRARIAN_EMBEDDER=hash` (else a markdown recall there would download). Noted; out of scope here.

## Review

5-axis sub-agent review: **sound, no Critical/Important.** Applied the fail-fast guard on invalid env values.

## Tests

resolve-embedder selection (hash-under-VITEST, =hash, =llama-lazy, invalid→throws); all existing backend/recall/references tests stay green on hash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)