### PR TITLE
feat(curator): read memory evidence through a backend-pluggable source (Phase 4)

### DIFF
--- a/packages/core/src/curator-evidence.ts
+++ b/packages/core/src/curator-evidence.ts
@@ -5,66 +5,23 @@
 // redacted, deterministically-ordered bundle of memory evidence:
 //
 //   - active + proposed memories for the slice (bodies redacted, §9/§10.4);
-//   - archived memories as METADATA-ONLY tombstones (id/title/category/slice +
-//     archive metadata + a normalized content fingerprint, NO body) so the
-//     §10.3 pre-pass can block resurrection without re-exposing deleted content
-//     (§9.1);
+//   - archived memories as METADATA-ONLY tombstones (id/title/slice + archive
+//     metadata + a normalized content fingerprint, NO body) so the §10.3
+//     pre-pass can block resurrection without re-exposing deleted content (§9.1);
 //   - caps + truncation so the bundle stays bounded and the prompt knows when
 //     evidence was trimmed (§9 evidence caps).
 //
-// Reads are direct SELECTs against the SQLite projection (the read model) — this
-// is read-only and never mutates memory. The curator is memory-only after the
-// sessions rethink (sessions-rethink-spec §12): there is no session evidence.
+// The actual memory reads are delegated to a `CuratorMemorySource` (plan 036
+// Phase 4) so this gather/redact/cap logic is backend-agnostic: the SQLite
+// projection (`createSqliteCuratorMemorySource`) and the markdown vault
+// (`createVaultCuratorMemorySource`) each provide one. This module never touches
+// a storage handle — it is pure over the source. The curator is memory-only
+// after the sessions rethink (sessions-rethink-spec §12): no session evidence.
 
-import type { DatabaseSync } from "node:sqlite";
 import { curationContentFingerprint, curationNormalizedTitle } from "./curator-fingerprint.js";
 import { redactSecrets } from "./curator-redaction.js";
 
 export type SliceKind = "common_project" | "common_global" | "agent_private";
-
-/**
- * Enumerate the candidate slices that have curatable content (§9): the common
- * global slice (project-less common), one common_project per distinct project,
- * and one agent_private per distinct owning agent. Drawn from memories
- * (active/proposed — archived-only slices have nothing to curate). The
- * scheduler then applies due-gating to this set.
- */
-export function listCuratorSlices(db: DatabaseSync): EvidenceSlice[] {
-  const slices: EvidenceSlice[] = [];
-
-  // Section 4d.3 — `memories.visibility` is dropped; all memories are common
-  // now. The curator's memory-side slicing degenerates to project_key alone;
-  // the `agent_private` slice surfaces an agent's authored memories rather
-  // than a privacy-gated set.
-  const hasGlobal = db
-    .prepare("SELECT 1 FROM memories WHERE status != 'archived' AND project_key IS NULL LIMIT 1")
-    .get();
-  if (hasGlobal) slices.push({ kind: "common_global" });
-
-  for (const projectKey of distinctValues(db, [
-    "SELECT DISTINCT project_key AS v FROM memories WHERE status != 'archived' AND project_key IS NOT NULL",
-  ])) {
-    slices.push({ kind: "common_project", projectKey });
-  }
-
-  // The `agent_private` slice was driven by the (now-retired) sessions
-  // table after 4d.3 — memories no longer carry visibility, so no source
-  // exists to enumerate. The slice kind survives in the type so any
-  // historical agent_private run row still validates; new runs are
-  // never enumerated here.
-
-  return slices;
-}
-
-function distinctValues(db: DatabaseSync, queries: string[]): string[] {
-  const values = new Set<string>();
-  for (const query of queries) {
-    for (const row of db.prepare(query).all() as unknown as { v: string | null }[]) {
-      if (row.v) values.add(row.v);
-    }
-  }
-  return [...values].sort();
-}
 
 export interface EvidenceSlice {
   kind: SliceKind;
@@ -72,6 +29,59 @@ export interface EvidenceSlice {
   projectKey?: string;
   /** Required for `agent_private`. */
   agentId?: string;
+}
+
+/**
+ * A memory as a `CuratorMemorySource` returns it — backend-neutral and
+ * PRE-redaction (gatherMemoryEvidence owns redaction + truncation). The source
+ * hands back raw title/body; the emitted bundle is what gets redacted.
+ */
+export interface CuratorMemoryRecord {
+  id: string;
+  title: string;
+  body: string;
+  projectKey: string | null;
+  agentId: string | null;
+  requiresApproval: boolean;
+  isGlobal: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * An archived memory as a `CuratorMemorySource` returns it. Carries the raw
+ * title+body (for fingerprinting — never emitted) plus archive metadata.
+ * `archiveReason` is null when the backend records none (the markdown vault
+ * retires the event ledger, so reasons aren't persisted there).
+ */
+export interface CuratorTombstoneRecord {
+  id: string;
+  title: string;
+  body: string;
+  projectKey: string | null;
+  agentId: string | null;
+  archivedAt: string;
+  archiveReason: string | null;
+}
+
+/**
+ * The memory reads the curator's evidence gathering needs, abstracted over the
+ * storage backend (plan 036 Phase 4). Implementations return records
+ * newest-first (by `updatedAt`) and already capped at `limit`; slice filtering
+ * (exact `projectKey`, project-less global, `agentId` for agent_private) lives
+ * in the source so this module stays backend-neutral.
+ */
+export interface CuratorMemorySource {
+  /** Slices with curatable (active|proposed) content; the scheduler due-gates them. */
+  listSlices(): EvidenceSlice[];
+  /** Active|proposed memories for the slice, newest-first, ≤ limit. */
+  selectMemories(
+    slice: EvidenceSlice,
+    status: "active" | "proposed",
+    limit: number,
+  ): CuratorMemoryRecord[];
+  /** Archived memories for the slice (with archive metadata), newest-first, ≤ limit. */
+  selectTombstones(slice: EvidenceSlice, limit: number): CuratorTombstoneRecord[];
 }
 
 export interface MemoryEvidenceCaps {
@@ -125,25 +135,6 @@ export interface MemoryEvidenceBundle {
 
 const DEFAULT_MAX_BODY_CHARS = 4000;
 const TRUNCATION_MARKER = " …[truncated]";
-const ARCHIVE_EVENT_TYPES = ["memory.archived", "memory.deleted"]; // historical alias
-
-interface MemoryRow {
-  id: string;
-  title: string;
-  body: string;
-  project_key: string | null;
-  agent_id: string | null;
-  status: string;
-  requires_approval: number;
-  is_global: number;
-  created_at: string;
-  updated_at: string;
-}
-
-interface TombstoneRow extends MemoryRow {
-  archive_payload: string | null;
-  archived_at_event: string | null;
-}
 
 /** Running totals threaded through redaction/truncation so the bundle can report them. */
 interface GatherStats {
@@ -151,20 +142,34 @@ interface GatherStats {
   truncatedFields: boolean;
 }
 
+/**
+ * Validate the slice descriptor independently of the source, so an invalid slice
+ * throws even against an empty store (the source's per-record filter would never
+ * run, and thus never fault, on an empty result set).
+ */
+function assertValidSlice(slice: EvidenceSlice): void {
+  if (slice.kind === "common_project" && !slice.projectKey) {
+    throw new Error("common_project slice requires a projectKey");
+  }
+  if (slice.kind === "agent_private" && !slice.agentId) {
+    throw new Error("agent_private slice requires an agentId");
+  }
+}
+
 export function gatherMemoryEvidence(
-  db: DatabaseSync,
+  source: CuratorMemorySource,
   slice: EvidenceSlice,
   caps: MemoryEvidenceCaps,
 ): MemoryEvidenceBundle {
-  const where = sliceWhereForMemories(slice);
+  assertValidSlice(slice);
   const maxBodyChars = caps.maxBodyChars ?? DEFAULT_MAX_BODY_CHARS;
   const stats: GatherStats = { redactionCount: 0, truncatedFields: false };
 
   // Fetch one past the budget per status so we can detect (not just apply) the cap.
   const limit = caps.maxMemories + 1;
-  const activeRows = selectMemories(db, where, "active", limit);
-  const proposedRows = selectMemories(db, where, "proposed", limit);
-  const tombstoneRows = selectTombstones(db, where, limit);
+  const activeRows = source.selectMemories(slice, "active", limit);
+  const proposedRows = source.selectMemories(slice, "proposed", limit);
+  const tombstoneRows = source.selectTombstones(slice, limit);
 
   // Single budget consumed in priority order: active → proposed → tombstones (§9).
   let remaining = caps.maxMemories;
@@ -181,118 +186,49 @@ export function gatherMemoryEvidence(
 
   return {
     slice,
-    activeMemories: activeTaken.map((row) => toItem(row, "active", maxBodyChars, stats)),
-    proposedMemories: proposedTaken.map((row) => toItem(row, "proposed", maxBodyChars, stats)),
-    tombstones: tombstonesTaken.map((row) => toTombstone(row, stats)),
+    activeMemories: activeTaken.map((rec) => toItem(rec, "active", maxBodyChars, stats)),
+    proposedMemories: proposedTaken.map((rec) => toItem(rec, "proposed", maxBodyChars, stats)),
+    tombstones: tombstonesTaken.map((rec) => toTombstone(rec, stats)),
     truncatedMemories,
     truncatedFields: stats.truncatedFields,
     redactionCount: stats.redactionCount,
   };
 }
 
-interface SliceWhere {
-  clause: string;
-  params: string[];
-}
-
-// Section 4d.3 — memories no longer carry `visibility`. The memory-side
-// slicing collapses to project_key alone. `agent_private` selects rows by
-// their owning agent.
-function sliceWhereForMemories(slice: EvidenceSlice): SliceWhere {
-  switch (slice.kind) {
-    case "common_project":
-      if (!slice.projectKey) throw new Error("common_project slice requires a projectKey");
-      return { clause: "project_key = ?", params: [slice.projectKey] };
-    case "common_global":
-      return { clause: "project_key IS NULL", params: [] };
-    case "agent_private":
-      if (!slice.agentId) throw new Error("agent_private slice requires an agentId");
-      return { clause: "agent_id = ?", params: [slice.agentId] };
-  }
-}
-
-function selectMemories(
-  db: DatabaseSync,
-  where: SliceWhere,
-  status: "active" | "proposed",
-  limit: number,
-): MemoryRow[] {
-  return db
-    .prepare(
-      `SELECT id, title, body, project_key, agent_id, status, requires_approval, is_global,
-              created_at, updated_at
-       FROM memories
-       WHERE ${where.clause} AND status = ?
-       ORDER BY updated_at DESC
-       LIMIT ?`,
-    )
-    .all(...where.params, status, limit) as unknown as MemoryRow[];
-}
-
-function selectTombstones(db: DatabaseSync, where: SliceWhere, limit: number): TombstoneRow[] {
-  // Archive date + reason live in the events ledger, not on the memory row.
-  const archiveFilter = ARCHIVE_EVENT_TYPES.map(() => "?").join(", ");
-  return (
-    db
-      .prepare(
-        `SELECT m.id, m.title, m.body, m.project_key, m.agent_id, m.status,
-              m.requires_approval, m.is_global, m.created_at, m.updated_at,
-              (SELECT e.payload_json FROM events e
-                 WHERE e.memory_id = m.id AND e.event_type IN (${archiveFilter})
-                 ORDER BY e.created_at DESC LIMIT 1) AS archive_payload,
-              (SELECT e.created_at FROM events e
-                 WHERE e.memory_id = m.id AND e.event_type IN (${archiveFilter})
-                 ORDER BY e.created_at DESC LIMIT 1) AS archived_at_event
-       FROM memories m
-       WHERE ${where.clause} AND m.status = 'archived'
-       ORDER BY m.updated_at DESC
-       LIMIT ?`,
-      )
-      // Bind in textual placeholder order: the two archive subqueries sit in the
-      // SELECT list (before the WHERE clause), so their event-type params come first.
-      .all(
-        ...ARCHIVE_EVENT_TYPES,
-        ...ARCHIVE_EVENT_TYPES,
-        ...where.params,
-        limit,
-      ) as unknown as TombstoneRow[]
-  );
-}
-
 function toItem(
-  row: MemoryRow,
+  rec: CuratorMemoryRecord,
   status: "active" | "proposed",
   maxBodyChars: number,
   stats: GatherStats,
 ): MemoryEvidenceItem {
   return {
-    id: row.id,
-    title: redact(row.title, stats),
-    body: truncate(redact(row.body, stats), maxBodyChars, stats),
-    projectKey: row.project_key,
-    agentId: row.agent_id,
+    id: rec.id,
+    title: redact(rec.title, stats),
+    body: truncate(redact(rec.body, stats), maxBodyChars, stats),
+    projectKey: rec.projectKey,
+    agentId: rec.agentId,
     status,
-    createdAt: row.created_at,
-    updatedAt: row.updated_at,
-    requiresApproval: row.requires_approval === 1,
-    isGlobal: row.is_global === 1,
+    createdAt: rec.createdAt,
+    updatedAt: rec.updatedAt,
+    requiresApproval: rec.requiresApproval,
+    isGlobal: rec.isGlobal,
   };
 }
 
-function toTombstone(row: TombstoneRow, stats: GatherStats): TombstoneItem {
+function toTombstone(rec: CuratorTombstoneRecord, stats: GatherStats): TombstoneItem {
   // The body is fingerprinted (via the shared redact-then-fingerprint contract)
   // but NEVER emitted, so deleted content is not re-exposed (§9.1). Only the
   // emitted title is redacted here for display + the redaction tally.
-  const redactedTitle = redact(row.title, stats);
+  const redactedTitle = redact(rec.title, stats);
   return {
-    id: row.id,
+    id: rec.id,
     title: redactedTitle,
-    projectKey: row.project_key,
-    agentId: row.agent_id,
-    archivedAt: row.archived_at_event ?? row.updated_at,
-    archiveReason: parseArchiveReason(row.archive_payload),
-    contentFingerprint: curationContentFingerprint(row.title, row.body),
-    normalizedTitle: curationNormalizedTitle(row.title),
+    projectKey: rec.projectKey,
+    agentId: rec.agentId,
+    archivedAt: rec.archivedAt,
+    archiveReason: rec.archiveReason,
+    contentFingerprint: curationContentFingerprint(rec.title, rec.body),
+    normalizedTitle: curationNormalizedTitle(rec.title),
   };
 }
 
@@ -306,14 +242,4 @@ function truncate(value: string, maxChars: number, stats: GatherStats): string {
   if (value.length <= maxChars) return value;
   stats.truncatedFields = true;
   return value.slice(0, maxChars) + TRUNCATION_MARKER;
-}
-
-function parseArchiveReason(payloadJson: string | null): string | null {
-  if (!payloadJson) return null;
-  try {
-    const payload = JSON.parse(payloadJson) as { reason?: unknown };
-    return typeof payload.reason === "string" ? payload.reason : null;
-  } catch {
-    return null;
-  }
 }

--- a/packages/core/src/curator-scheduler.ts
+++ b/packages/core/src/curator-scheduler.ts
@@ -5,8 +5,7 @@
 // each due slice via runCuration as the system-memory-curator actor.
 
 import type { DatabaseSync } from "node:sqlite";
-import type { EvidenceSlice } from "./curator-evidence.js";
-import { listCuratorSlices } from "./curator-evidence.js";
+import type { CuratorMemorySource, EvidenceSlice } from "./curator-evidence.js";
 import { type DueReason, type ScheduleConfig, isSliceDue } from "./curator-schedule.js";
 
 export interface DueSlice {
@@ -15,9 +14,18 @@ export interface DueSlice {
   lastCompletedAt: Date | null;
 }
 
-export function selectDueSlices(db: DatabaseSync, config: ScheduleConfig, now: Date): DueSlice[] {
+// Slices come from the memory source (vault or SQLite projection); run history
+// (last-completed / running) still reads the SQLite-authoritative
+// `memory_curation_runs` via `db`. The run-read side moves off SQLite with the
+// run store at the Phase-4 SQLite removal — until then, this composes the two.
+export function selectDueSlices(
+  memorySource: CuratorMemorySource,
+  db: DatabaseSync,
+  config: ScheduleConfig,
+  now: Date,
+): DueSlice[] {
   const due: DueSlice[] = [];
-  for (const slice of listCuratorSlices(db)) {
+  for (const slice of memorySource.listSlices()) {
     const lastCompletedAt = lastCompletedRunAt(db, slice);
     const decision = isSliceDue(now, { lastCompletedAt }, config);
     if (decision.due) due.push({ slice, reason: decision.reason, lastCompletedAt });

--- a/packages/core/src/curator-source-sqlite.ts
+++ b/packages/core/src/curator-source-sqlite.ts
@@ -1,0 +1,169 @@
+// SQLite-backed CuratorMemorySource (plan 036 Phase 4).
+//
+// The curator's memory-evidence reads against the SQLite projection (the read
+// model) + the events ledger — extracted verbatim from curator-evidence when
+// the source seam landed, so behaviour is unchanged on the SQLite backend. The
+// markdown backend uses `createVaultCuratorMemorySource` instead; this module
+// retires with SQLite at the end of Phase 4.
+//
+// Reads are direct SELECTs and never mutate memory.
+
+import type { DatabaseSync } from "node:sqlite";
+import type {
+  CuratorMemoryRecord,
+  CuratorMemorySource,
+  CuratorTombstoneRecord,
+  EvidenceSlice,
+} from "./curator-evidence.js";
+
+interface SliceWhere {
+  clause: string;
+  params: string[];
+}
+
+// Section 4d.3 — memories no longer carry `visibility`. The memory-side slicing
+// collapses to project_key alone; `agent_private` selects rows by owning agent.
+function sliceWhereForMemories(slice: EvidenceSlice): SliceWhere {
+  switch (slice.kind) {
+    case "common_project":
+      if (!slice.projectKey) throw new Error("common_project slice requires a projectKey");
+      return { clause: "project_key = ?", params: [slice.projectKey] };
+    case "common_global":
+      return { clause: "project_key IS NULL", params: [] };
+    case "agent_private":
+      if (!slice.agentId) throw new Error("agent_private slice requires an agentId");
+      return { clause: "agent_id = ?", params: [slice.agentId] };
+  }
+}
+
+interface MemoryRow {
+  id: string;
+  title: string;
+  body: string;
+  project_key: string | null;
+  agent_id: string | null;
+  status: string;
+  requires_approval: number;
+  is_global: number;
+  created_at: string;
+  updated_at: string;
+}
+
+interface TombstoneRow extends MemoryRow {
+  archive_payload: string | null;
+  archived_at_event: string | null;
+}
+
+const ARCHIVE_EVENT_TYPES = ["memory.archived", "memory.deleted"]; // historical alias
+
+function parseArchiveReason(payloadJson: string | null): string | null {
+  if (!payloadJson) return null;
+  try {
+    const payload = JSON.parse(payloadJson) as { reason?: unknown };
+    return typeof payload.reason === "string" ? payload.reason : null;
+  } catch {
+    return null;
+  }
+}
+
+function toRecord(row: MemoryRow): CuratorMemoryRecord {
+  return {
+    id: row.id,
+    title: row.title,
+    body: row.body,
+    projectKey: row.project_key,
+    agentId: row.agent_id,
+    requiresApproval: row.requires_approval === 1,
+    isGlobal: row.is_global === 1,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export function createSqliteCuratorMemorySource(db: DatabaseSync): CuratorMemorySource {
+  function listSlices(): EvidenceSlice[] {
+    const slices: EvidenceSlice[] = [];
+
+    // Section 4d.3 — `memories.visibility` is dropped; all memories are common
+    // now. The curator's memory-side slicing degenerates to project_key alone.
+    const hasGlobal = db
+      .prepare("SELECT 1 FROM memories WHERE status != 'archived' AND project_key IS NULL LIMIT 1")
+      .get();
+    if (hasGlobal) slices.push({ kind: "common_global" });
+
+    const projectKeys = new Set<string>();
+    for (const row of db
+      .prepare(
+        "SELECT DISTINCT project_key AS v FROM memories WHERE status != 'archived' AND project_key IS NOT NULL",
+      )
+      .all() as unknown as { v: string | null }[]) {
+      if (row.v) projectKeys.add(row.v);
+    }
+    for (const projectKey of [...projectKeys].sort()) {
+      slices.push({ kind: "common_project", projectKey });
+    }
+
+    // The `agent_private` slice was driven by the (now-retired) sessions table;
+    // memories no longer carry visibility, so no source exists to enumerate it.
+    return slices;
+  }
+
+  function selectMemories(
+    slice: EvidenceSlice,
+    status: "active" | "proposed",
+    limit: number,
+  ): CuratorMemoryRecord[] {
+    const where = sliceWhereForMemories(slice);
+    const rows = db
+      .prepare(
+        `SELECT id, title, body, project_key, agent_id, status, requires_approval, is_global,
+                created_at, updated_at
+         FROM memories
+         WHERE ${where.clause} AND status = ?
+         ORDER BY updated_at DESC
+         LIMIT ?`,
+      )
+      .all(...where.params, status, limit) as unknown as MemoryRow[];
+    return rows.map(toRecord);
+  }
+
+  function selectTombstones(slice: EvidenceSlice, limit: number): CuratorTombstoneRecord[] {
+    const where = sliceWhereForMemories(slice);
+    // Archive date + reason live in the events ledger, not on the memory row.
+    const archiveFilter = ARCHIVE_EVENT_TYPES.map(() => "?").join(", ");
+    const rows = db
+      .prepare(
+        `SELECT m.id, m.title, m.body, m.project_key, m.agent_id, m.status,
+                m.requires_approval, m.is_global, m.created_at, m.updated_at,
+                (SELECT e.payload_json FROM events e
+                   WHERE e.memory_id = m.id AND e.event_type IN (${archiveFilter})
+                   ORDER BY e.created_at DESC LIMIT 1) AS archive_payload,
+                (SELECT e.created_at FROM events e
+                   WHERE e.memory_id = m.id AND e.event_type IN (${archiveFilter})
+                   ORDER BY e.created_at DESC LIMIT 1) AS archived_at_event
+         FROM memories m
+         WHERE ${where.clause} AND m.status = 'archived'
+         ORDER BY m.updated_at DESC
+         LIMIT ?`,
+      )
+      // Bind in textual placeholder order: the two archive subqueries sit in the
+      // SELECT list (before the WHERE clause), so their event-type params come first.
+      .all(
+        ...ARCHIVE_EVENT_TYPES,
+        ...ARCHIVE_EVENT_TYPES,
+        ...where.params,
+        limit,
+      ) as unknown as TombstoneRow[];
+    return rows.map((row) => ({
+      id: row.id,
+      title: row.title,
+      body: row.body,
+      projectKey: row.project_key,
+      agentId: row.agent_id,
+      archivedAt: row.archived_at_event ?? row.updated_at,
+      archiveReason: parseArchiveReason(row.archive_payload),
+    }));
+  }
+
+  return { listSlices, selectMemories, selectTombstones };
+}

--- a/packages/core/src/curator-source-vault.ts
+++ b/packages/core/src/curator-source-vault.ts
@@ -1,0 +1,119 @@
+// Markdown-vault-backed CuratorMemorySource (plan 036 Phase 4).
+//
+// Reads memory docs from the git vault (via the markdown memory store's
+// `listAll`) and partitions them into curator slices, so the curator works on
+// the markdown default. Mirrors the SQLite source's slice semantics exactly:
+//   - common_project → exact `project_key` match;
+//   - common_global  → `project_key` IS NULL (project-less);
+//   - agent_private  → owning `agent_id`.
+// Active/proposed feed slice enumeration + evidence; archived feed tombstones.
+//
+// The event ledger is retired on markdown, so a tombstone's `archiveReason` is
+// null and `archivedAt` is the doc's `updatedAt` (which equals archive time —
+// archiveMemory/verifyMemory stamp updated_at when they flip status).
+//
+// The curator runs infrequently over a small corpus, so each public call reads
+// the vault afresh (consistent with out-of-band vault edits) rather than caching.
+
+import type {
+  CuratorMemoryRecord,
+  CuratorMemorySource,
+  CuratorTombstoneRecord,
+  EvidenceSlice,
+} from "./curator-evidence.js";
+import { MemoryStatus } from "./schemas/common.js";
+import type { Memory } from "./store/memory-store.js";
+
+/** The minimal memory read surface the vault curator source needs. */
+export interface CuratorVaultMemoryReader {
+  listAll(filters?: Record<string, unknown>): Memory[];
+}
+
+function sliceMatches(slice: EvidenceSlice, memory: Memory): boolean {
+  switch (slice.kind) {
+    case "common_project":
+      return (memory.project_key ?? null) === slice.projectKey;
+    case "common_global":
+      return memory.project_key == null;
+    case "agent_private":
+      return memory.agent_id === slice.agentId;
+  }
+}
+
+// updated_at DESC, with id DESC as a deterministic tiebreaker. (SQLite's
+// `ORDER BY updated_at DESC` has no tiebreak, so ties there are nondeterministic;
+// a stable id tiebreak is a behavioural superset.)
+function byUpdatedDesc(a: Memory, b: Memory): number {
+  if (a.updated_at !== b.updated_at) return a.updated_at < b.updated_at ? 1 : -1;
+  return a.id < b.id ? 1 : a.id > b.id ? -1 : 0;
+}
+
+function toRecord(memory: Memory): CuratorMemoryRecord {
+  return {
+    id: memory.id,
+    title: String(memory.title ?? ""),
+    body: String(memory.body ?? ""),
+    projectKey: memory.project_key ?? null,
+    agentId: memory.agent_id ?? null,
+    requiresApproval: memory.requires_approval === true,
+    isGlobal: memory.is_global === true,
+    createdAt: String(memory.created_at ?? memory.updated_at),
+    updatedAt: String(memory.updated_at),
+  };
+}
+
+function toTombstoneRecord(memory: Memory): CuratorTombstoneRecord {
+  return {
+    id: memory.id,
+    title: String(memory.title ?? ""),
+    body: String(memory.body ?? ""),
+    projectKey: memory.project_key ?? null,
+    agentId: memory.agent_id ?? null,
+    archivedAt: String(memory.updated_at),
+    archiveReason: null,
+  };
+}
+
+export function createVaultCuratorMemorySource(
+  reader: CuratorVaultMemoryReader,
+): CuratorMemorySource {
+  function listSlices(): EvidenceSlice[] {
+    const live = reader.listAll({}).filter((m) => m.status !== MemoryStatus.Archived);
+    const slices: EvidenceSlice[] = [];
+    if (live.some((m) => m.project_key == null)) slices.push({ kind: "common_global" });
+    const projectKeys = new Set<string>();
+    for (const m of live) {
+      if (m.project_key != null) projectKeys.add(m.project_key);
+    }
+    for (const projectKey of [...projectKeys].sort()) {
+      slices.push({ kind: "common_project", projectKey });
+    }
+    // No agent_private enumeration — parity with the SQLite source (the
+    // sessions-driven source for it is retired).
+    return slices;
+  }
+
+  function selectMemories(
+    slice: EvidenceSlice,
+    status: "active" | "proposed",
+    limit: number,
+  ): CuratorMemoryRecord[] {
+    return reader
+      .listAll({})
+      .filter((m) => m.status === status && sliceMatches(slice, m))
+      .sort(byUpdatedDesc)
+      .slice(0, limit)
+      .map(toRecord);
+  }
+
+  function selectTombstones(slice: EvidenceSlice, limit: number): CuratorTombstoneRecord[] {
+    return reader
+      .listAll({})
+      .filter((m) => m.status === MemoryStatus.Archived && sliceMatches(slice, m))
+      .sort(byUpdatedDesc)
+      .slice(0, limit)
+      .map(toTombstoneRecord);
+  }
+
+  return { listSlices, selectMemories, selectTombstones };
+}

--- a/packages/core/src/curator-source-vault.ts
+++ b/packages/core/src/curator-source-vault.ts
@@ -93,26 +93,30 @@ export function createVaultCuratorMemorySource(
     return slices;
   }
 
+  // Read the vault, keep what `predicate` accepts, then newest-first + cap + map
+  // — the shared shape of both evidence reads.
+  function selectNewest<T>(
+    predicate: (memory: Memory) => boolean,
+    limit: number,
+    map: (memory: Memory) => T,
+  ): T[] {
+    return reader.listAll({}).filter(predicate).sort(byUpdatedDesc).slice(0, limit).map(map);
+  }
+
   function selectMemories(
     slice: EvidenceSlice,
     status: "active" | "proposed",
     limit: number,
   ): CuratorMemoryRecord[] {
-    return reader
-      .listAll({})
-      .filter((m) => m.status === status && sliceMatches(slice, m))
-      .sort(byUpdatedDesc)
-      .slice(0, limit)
-      .map(toRecord);
+    return selectNewest((m) => m.status === status && sliceMatches(slice, m), limit, toRecord);
   }
 
   function selectTombstones(slice: EvidenceSlice, limit: number): CuratorTombstoneRecord[] {
-    return reader
-      .listAll({})
-      .filter((m) => m.status === MemoryStatus.Archived && sliceMatches(slice, m))
-      .sort(byUpdatedDesc)
-      .slice(0, limit)
-      .map(toTombstoneRecord);
+    return selectNewest(
+      (m) => m.status === MemoryStatus.Archived && sliceMatches(slice, m),
+      limit,
+      toTombstoneRecord,
+    );
   }
 
   return { listSlices, selectMemories, selectTombstones };

--- a/packages/core/src/curator-source-vault.ts
+++ b/packages/core/src/curator-source-vault.ts
@@ -40,9 +40,13 @@ function sliceMatches(slice: EvidenceSlice, memory: Memory): boolean {
   }
 }
 
-// updated_at DESC, with id DESC as a deterministic tiebreaker. (SQLite's
-// `ORDER BY updated_at DESC` has no tiebreak, so ties there are nondeterministic;
-// a stable id tiebreak is a behavioural superset.)
+// updated_at DESC, with id DESC as a deterministic tiebreak SQLite's
+// `ORDER BY updated_at DESC` lacks. The curator's input hash is set-based (it
+// sorts the evidence ids before hashing — curator-worker.ts), so this only
+// decides which record survives the maxMemories cap on an exact updated_at tie
+// at the boundary; and only one backend is ever live for a given vault, so
+// there is no cross-backend ordering contract to preserve. It buys the vault's
+// own run-to-run determinism.
 function byUpdatedDesc(a: Memory, b: Memory): number {
   if (a.updated_at !== b.updated_at) return a.updated_at < b.updated_at ? 1 : -1;
   return a.id < b.id ? 1 : a.id > b.id ? -1 : 0;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -88,6 +88,9 @@ export {
   createSerialScheduler,
 } from "./serial-scheduler.js";
 export {
+  type CuratorMemoryRecord,
+  type CuratorMemorySource,
+  type CuratorTombstoneRecord,
   type EvidenceSlice,
   type MemoryEvidenceBundle,
   type MemoryEvidenceCaps,
@@ -95,8 +98,12 @@ export {
   type SliceKind,
   type TombstoneItem,
   gatherMemoryEvidence,
-  listCuratorSlices,
 } from "./curator-evidence.js";
+export { createSqliteCuratorMemorySource } from "./curator-source-sqlite.js";
+export {
+  type CuratorVaultMemoryReader,
+  createVaultCuratorMemorySource,
+} from "./curator-source-vault.js";
 export {
   type LlmClient,
   type LlmClientConfig,

--- a/packages/core/src/store/curation-store.ts
+++ b/packages/core/src/store/curation-store.ts
@@ -13,11 +13,11 @@
 import type { DatabaseSync } from "node:sqlite";
 import { makeId, nowIso } from "../constants.js";
 import {
+  type CuratorMemorySource,
   type EvidenceSlice,
   type MemoryEvidenceBundle,
   type MemoryEvidenceCaps,
   gatherMemoryEvidence as gatherMemoryEvidenceImpl,
-  listCuratorSlices as listCuratorSlicesImpl,
 } from "../curator-evidence.js";
 import type { ScheduleConfig } from "../curator-schedule.js";
 import {
@@ -25,6 +25,7 @@ import {
   findRunningRun as findRunningRunImpl,
   selectDueSlices as selectDueSlicesImpl,
 } from "../curator-scheduler.js";
+import { createSqliteCuratorMemorySource } from "../curator-source-sqlite.js";
 
 export interface CreateCurationRunInput {
   trigger: string; // schedule | manual | maintenance
@@ -203,8 +204,18 @@ function rowToOperation(row: CurationOperationRow): CurationOperation {
   };
 }
 
-export function createCurationStore(deps: { db: DatabaseSync }): CurationStore {
+export function createCurationStore(deps: {
+  db: DatabaseSync;
+  /**
+   * Memory-evidence reads (slices + active/proposed/archived per slice).
+   * Defaults to the SQLite projection over `db`; the markdown backend injects a
+   * vault-backed source so the curator reads the git vault, not the (empty)
+   * residual SQLite `memories` table.
+   */
+  memorySource?: CuratorMemorySource;
+}): CurationStore {
   const { db } = deps;
+  const memorySource = deps.memorySource ?? createSqliteCuratorMemorySource(db);
 
   function createCurationRun(input: CreateCurationRunInput): CurationRun {
     const id = makeId("run");
@@ -355,15 +366,15 @@ export function createCurationStore(deps: { db: DatabaseSync }): CurationStore {
     slice: EvidenceSlice,
     caps: MemoryEvidenceCaps,
   ): MemoryEvidenceBundle {
-    return gatherMemoryEvidenceImpl(db, slice, caps);
+    return gatherMemoryEvidenceImpl(memorySource, slice, caps);
   }
 
   function listCuratorSlices(): EvidenceSlice[] {
-    return listCuratorSlicesImpl(db);
+    return memorySource.listSlices();
   }
 
   function selectDueSlices(config: ScheduleConfig, now: Date): DueSlice[] {
-    return selectDueSlicesImpl(db, config, now);
+    return selectDueSlicesImpl(memorySource, db, config, now);
   }
 
   function findRunningRun(slice: EvidenceSlice): { id: string; startedAt: Date } | null {

--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
+import { createVaultCuratorMemorySource } from "../curator-source-vault.js";
 import {
   type ConversationStateStore,
   createConversationStateStore,
@@ -181,7 +182,14 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Inter
       filePath: path.join(dataDir, "settings.json"),
       secretKey: options.secretKey ?? null,
     });
-    const residualCuration = createCurationStore({ db });
+    // Curator read-side over the vault (Phase 4): memory evidence + slice
+    // enumeration come from the markdown memory store. The run store/read side
+    // (createCurationRun / selectDueSlices' run lookups / findRunningRun) stays
+    // on the residual SQLite `db` until the Phase-4 SQLite removal.
+    const residualCuration = createCurationStore({
+      db,
+      memorySource: createVaultCuratorMemorySource(markdownMemory),
+    });
     return {
       ...markdownMemory,
       ...residualCuration,

--- a/packages/core/tests/curator-apply.test.ts
+++ b/packages/core/tests/curator-apply.test.ts
@@ -14,6 +14,7 @@ import {
   type ValidationContext,
   applyOperations,
   createLibrarianStore,
+  createSqliteCuratorMemorySource,
   gatherMemoryEvidence,
 } from "@librarian/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -70,7 +71,9 @@ function context(prepass: ValidationContext["prepass"] = { findings: [] }): Vali
   const slice = { kind: "common_project" as const, projectKey: "proj-x" };
   return {
     slice,
-    memory: gatherMemoryEvidence(s!.store.db, slice, { maxMemories: 100 }),
+    memory: gatherMemoryEvidence(createSqliteCuratorMemorySource(s!.store.db), slice, {
+      maxMemories: 100,
+    }),
     prepass,
   };
 }

--- a/packages/core/tests/curator-evidence.test.ts
+++ b/packages/core/tests/curator-evidence.test.ts
@@ -14,7 +14,12 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { type LibrarianStore, createLibrarianStore, gatherMemoryEvidence } from "@librarian/core";
+import {
+  type LibrarianStore,
+  createLibrarianStore,
+  createSqliteCuratorMemorySource,
+  gatherMemoryEvidence,
+} from "@librarian/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 interface Scope {
@@ -61,7 +66,7 @@ describe("gatherMemoryEvidence — slice isolation (Section 4d.3 — visibility-
     seed({ title: "other-project", project_key: "proj-y" });
 
     const bundle = gatherMemoryEvidence(
-      s!.store.db,
+      createSqliteCuratorMemorySource(s!.store.db),
       { kind: "common_project", projectKey: "proj-x" },
       { maxMemories: 50 },
     );
@@ -81,7 +86,7 @@ describe("gatherMemoryEvidence — slice isolation (Section 4d.3 — visibility-
     seed({ title: "theirs", agent_id: "agent-b", project_key: undefined });
 
     const bundle = gatherMemoryEvidence(
-      s!.store.db,
+      createSqliteCuratorMemorySource(s!.store.db),
       { kind: "agent_private", agentId: "agent-a" },
       { maxMemories: 50 },
     );
@@ -97,7 +102,7 @@ describe("gatherMemoryEvidence — slice isolation (Section 4d.3 — visibility-
     seed({ title: "project-scoped", project_key: "proj-x" });
 
     const bundle = gatherMemoryEvidence(
-      s!.store.db,
+      createSqliteCuratorMemorySource(s!.store.db),
       { kind: "common_global" },
       { maxMemories: 50 },
     );
@@ -110,12 +115,12 @@ describe("gatherMemoryEvidence — slice isolation (Section 4d.3 — visibility-
     const globalButKeyed = seed({ title: "gp", project_key: "proj-x" }).memory;
 
     const inGlobal = gatherMemoryEvidence(
-      s!.store.db,
+      createSqliteCuratorMemorySource(s!.store.db),
       { kind: "common_global" },
       { maxMemories: 50 },
     ).activeMemories.map((m) => m.id);
     const inProject = gatherMemoryEvidence(
-      s!.store.db,
+      createSqliteCuratorMemorySource(s!.store.db),
       { kind: "common_project", projectKey: "proj-x" },
       { maxMemories: 50 },
     ).activeMemories.map((m) => m.id);
@@ -133,7 +138,7 @@ describe("gatherMemoryEvidence — slice isolation (Section 4d.3 — visibility-
       project_key: "proj-x",
     }).memory;
     const bundle = gatherMemoryEvidence(
-      s!.store.db,
+      createSqliteCuratorMemorySource(s!.store.db),
       { kind: "common_project", projectKey: "proj-x" },
       { maxMemories: 50 },
     );
@@ -147,12 +152,12 @@ describe("gatherMemoryEvidence — slice isolation (Section 4d.3 — visibility-
       project_key: "proj-x",
     }).memory;
     const commonProj = gatherMemoryEvidence(
-      s!.store.db,
+      createSqliteCuratorMemorySource(s!.store.db),
       { kind: "common_project", projectKey: "proj-x" },
       { maxMemories: 50 },
     );
     const priv = gatherMemoryEvidence(
-      s!.store.db,
+      createSqliteCuratorMemorySource(s!.store.db),
       { kind: "agent_private", agentId: "agent-a" },
       { maxMemories: 50 },
     );
@@ -169,7 +174,7 @@ describe("gatherMemoryEvidence — redaction (security)", () => {
     seed({ title: "with-secret", body: 'deploy notes — token = "FAKETOKENFAKETOKEN" — ok' });
 
     const bundle = gatherMemoryEvidence(
-      s!.store.db,
+      createSqliteCuratorMemorySource(s!.store.db),
       { kind: "common_project", projectKey: "proj-x" },
       { maxMemories: 50 },
     );
@@ -203,7 +208,7 @@ describe("gatherMemoryEvidence — status partition + tombstones", () => {
     ).memory;
 
     const bundle = gatherMemoryEvidence(
-      s!.store.db,
+      createSqliteCuratorMemorySource(s!.store.db),
       { kind: "common_project", projectKey: "proj-x" },
       { maxMemories: 50 },
     );
@@ -219,7 +224,7 @@ describe("gatherMemoryEvidence — status partition + tombstones", () => {
     s!.store.archiveMemory(m.id);
 
     const bundle = gatherMemoryEvidence(
-      s!.store.db,
+      createSqliteCuratorMemorySource(s!.store.db),
       { kind: "common_project", projectKey: "proj-x" },
       { maxMemories: 50 },
     );
@@ -240,7 +245,7 @@ describe("gatherMemoryEvidence — status partition + tombstones", () => {
     s!.store.verifyMemory(m.id, "outdated");
 
     const bundle = gatherMemoryEvidence(
-      s!.store.db,
+      createSqliteCuratorMemorySource(s!.store.db),
       { kind: "common_project", projectKey: "proj-x" },
       { maxMemories: 50 },
     );
@@ -252,7 +257,7 @@ describe("gatherMemoryEvidence — status partition + tombstones", () => {
     s!.store.archiveMemory(m.id);
 
     const bundle = gatherMemoryEvidence(
-      s!.store.db,
+      createSqliteCuratorMemorySource(s!.store.db),
       { kind: "common_project", projectKey: "proj-x" },
       { maxMemories: 50 },
     );
@@ -268,7 +273,7 @@ describe("gatherMemoryEvidence — caps + truncation", () => {
     seed({ title: "p1", category: "identity" }); // proposed
 
     const bundle = gatherMemoryEvidence(
-      s!.store.db,
+      createSqliteCuratorMemorySource(s!.store.db),
       { kind: "common_project", projectKey: "proj-x" },
       { maxMemories: 2 },
     );
@@ -282,7 +287,7 @@ describe("gatherMemoryEvidence — caps + truncation", () => {
     seed({ title: "long", body: "abcdefghijklmnopqrstuvwxyz" });
 
     const bundle = gatherMemoryEvidence(
-      s!.store.db,
+      createSqliteCuratorMemorySource(s!.store.db),
       { kind: "common_project", projectKey: "proj-x" },
       { maxMemories: 50, maxBodyChars: 10 },
     );
@@ -298,13 +303,21 @@ describe("gatherMemoryEvidence — caps + truncation", () => {
 describe("gatherMemoryEvidence — slice descriptor validation", () => {
   it("rejects common_project without a projectKey", () => {
     expect(() =>
-      gatherMemoryEvidence(s!.store.db, { kind: "common_project" }, { maxMemories: 5 }),
+      gatherMemoryEvidence(
+        createSqliteCuratorMemorySource(s!.store.db),
+        { kind: "common_project" },
+        { maxMemories: 5 },
+      ),
     ).toThrow(/projectKey/i);
   });
 
   it("rejects agent_private without an agentId", () => {
     expect(() =>
-      gatherMemoryEvidence(s!.store.db, { kind: "agent_private" }, { maxMemories: 5 }),
+      gatherMemoryEvidence(
+        createSqliteCuratorMemorySource(s!.store.db),
+        { kind: "agent_private" },
+        { maxMemories: 5 },
+      ),
     ).toThrow(/agentId/i);
   });
 });

--- a/packages/core/tests/curator-markdown.test.ts
+++ b/packages/core/tests/curator-markdown.test.ts
@@ -1,0 +1,130 @@
+// Curator on the markdown backend (plan 036 Phase 4) — the "awakening" test.
+//
+// Before the read-side cutover the curator was dormant on the markdown default:
+// gatherMemoryEvidence / listCuratorSlices read the (empty) residual SQLite
+// `memories` table. With the vault-backed CuratorMemorySource wired in, the
+// curator enumerates slices + gathers evidence from the git vault, and a full
+// run threads gather → prepass → LLM → apply against the vault. Run bookkeeping
+// still lives in the residual SQLite db (moves at the Phase-4 SQLite removal).
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type ApplyPolicy,
+  type LibrarianStore,
+  type LlmClient,
+  type LlmCompletion,
+  createLibrarianStore,
+  runCuration,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let store: LibrarianStore | null = null;
+let dataDir = "";
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-curator-md-"));
+  store = createLibrarianStore({ dataDir, backend: "markdown" });
+});
+afterEach(() => {
+  try {
+    store?.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  store = null;
+});
+
+function seed(over: Record<string, unknown> = {}, options: Record<string, unknown> = {}) {
+  return store!.createMemory(
+    { agent_id: "agent-a", title: "title", body: "body", project_key: "proj-x", ...over },
+    options,
+  ).memory;
+}
+
+function fakeClient(content: string): LlmClient {
+  const usage: LlmCompletion["usage"] = {
+    promptTokens: 10,
+    completionTokens: 5,
+    totalTokens: 15,
+  };
+  return { complete: async () => ({ content, model: "gpt-x", usage }) };
+}
+
+const SLICE = { kind: "common_project" as const, projectKey: "proj-x" };
+
+describe("curator on the markdown backend — read side reads the vault", () => {
+  it("enumerates slices from vault memories", () => {
+    seed({ project_key: "proj-x" });
+    seed({ project_key: null }); // global (project-less)
+    const slices = store!.listCuratorSlices();
+    expect(slices).toContainEqual({ kind: "common_global" });
+    expect(slices).toContainEqual({ kind: "common_project", projectKey: "proj-x" });
+  });
+
+  it("gathers active/proposed/tombstone evidence for a slice from the vault", () => {
+    const active = seed({ title: "active-one" });
+    const proposed = seed({ title: "proposed-one" }, { requires_approval: true });
+    const archived = seed({ title: "deleted thing", body: "the original body" });
+    store!.archiveMemory(archived.id);
+
+    const bundle = store!.gatherMemoryEvidence(SLICE, { maxMemories: 50 });
+
+    expect(bundle.activeMemories.map((m) => m.id)).toContain(active.id);
+    expect(bundle.proposedMemories.map((m) => m.id)).toContain(proposed.id);
+    const tomb = bundle.tombstones.find((t) => t.id === archived.id);
+    expect(tomb).toBeDefined();
+    expect(tomb!.contentFingerprint).toMatch(/^[0-9a-f]{64}$/);
+    // The deleted body must not be re-exposed.
+    expect(JSON.stringify(tomb)).not.toContain("the original body");
+  });
+
+  it("selects a never-run slice as due (run history empty on a fresh store)", () => {
+    seed({ project_key: "proj-x" });
+    const due = store!.selectDueSlices({ intervalMinutes: 60 }, new Date());
+    const hit = due.find(
+      (d) => d.slice.kind === "common_project" && d.slice.projectKey === "proj-x",
+    );
+    expect(hit?.reason).toBe("never_run");
+  });
+});
+
+describe("curator on the markdown backend — full run mutates the vault", () => {
+  it("runs a curation pass that archives a duplicate memory in the vault", async () => {
+    const dupA = seed({ title: "Dup", body: "same body" });
+    const dupB = seed({ title: "Dup", body: "same body" });
+
+    const client = fakeClient(
+      JSON.stringify({
+        operations: [
+          {
+            type: "archive",
+            source_memory_ids: [dupB.id],
+            rationale: "exact duplicate of the other",
+            confidence: 0.95,
+          },
+        ],
+      }),
+    );
+
+    const run = await runCuration(SLICE, {
+      store: store!,
+      llmClient: client,
+      trigger: "manual",
+      actorId: "system-memory-curator",
+      policy: { level: "safe_only", confidenceThreshold: 0.9 } satisfies ApplyPolicy,
+      model: { provider: "openai", name: "gpt-x" },
+    });
+
+    expect(run).not.toBeNull();
+    expect(run!.status).toBe("completed");
+    // The archive landed on the vault doc (markdown apply path).
+    expect(store!.getMemory(dupB.id)?.status).toBe("archived");
+    expect(store!.getMemory(dupA.id)?.status).toBe("active");
+    // The run + operation were recorded (residual SQLite).
+    const ops = store!.getCurationOperations(run!.id);
+    expect(ops.some((o) => o.operation_type === "archive" && o.status === "applied")).toBe(true);
+  });
+});

--- a/packages/core/tests/curator-scheduler.test.ts
+++ b/packages/core/tests/curator-scheduler.test.ts
@@ -9,6 +9,7 @@ import {
   type LibrarianStore,
   type ScheduleConfig,
   createLibrarianStore,
+  createSqliteCuratorMemorySource,
   selectDueSlices,
 } from "@librarian/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -66,19 +67,26 @@ function completedRun(projectKey: string, completedAt: Date) {
 }
 
 function dueProjectKeys() {
-  return selectDueSlices(store!.db, config(), NOW)
+  return selectDueSlices(createSqliteCuratorMemorySource(store!.db), store!.db, config(), NOW)
     .filter((d) => d.slice.kind === "common_project")
     .map((d) => (d.slice.kind === "common_project" ? d.slice.projectKey : ""));
 }
 
 describe("selectDueSlices", () => {
   it("returns nothing for an empty store", () => {
-    expect(selectDueSlices(store!.db, config(), NOW)).toEqual([]);
+    expect(
+      selectDueSlices(createSqliteCuratorMemorySource(store!.db), store!.db, config(), NOW),
+    ).toEqual([]);
   });
 
   it("a never-run slice with content is due (never_run)", () => {
     seedCommonMemory("proj-new");
-    const due = selectDueSlices(store!.db, config(), NOW);
+    const due = selectDueSlices(
+      createSqliteCuratorMemorySource(store!.db),
+      store!.db,
+      config(),
+      NOW,
+    );
     const hit = due.find((d) => d.slice.kind === "common_project");
     expect(hit?.reason).toBe("never_run");
   });
@@ -92,9 +100,12 @@ describe("selectDueSlices", () => {
   it("is due once the interval has elapsed", () => {
     seedCommonMemory("proj-stale");
     completedRun("proj-stale", minutesAgo(120));
-    const hit = selectDueSlices(store!.db, config(), NOW).find(
-      (d) => d.slice.kind === "common_project" && d.slice.projectKey === "proj-stale",
-    );
+    const hit = selectDueSlices(
+      createSqliteCuratorMemorySource(store!.db),
+      store!.db,
+      config(),
+      NOW,
+    ).find((d) => d.slice.kind === "common_project" && d.slice.projectKey === "proj-stale");
     expect(hit?.reason).toBe("interval_reached");
   });
 });

--- a/packages/core/tests/curator-slices.test.ts
+++ b/packages/core/tests/curator-slices.test.ts
@@ -5,7 +5,11 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { type LibrarianStore, createLibrarianStore, listCuratorSlices } from "@librarian/core";
+import {
+  type LibrarianStore,
+  createLibrarianStore,
+  createSqliteCuratorMemorySource,
+} from "@librarian/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 let store: LibrarianStore | null = null;
@@ -44,7 +48,7 @@ function mem(over: Record<string, unknown>, options: Record<string, unknown> = {
 
 describe("listCuratorSlices", () => {
   it("returns nothing for an empty store", () => {
-    expect(listCuratorSlices(store!.db)).toEqual([]);
+    expect(createSqliteCuratorMemorySource(store!.db).listSlices()).toEqual([]);
   });
 
   it("enumerates the global slice and common projects from memories", () => {
@@ -52,7 +56,7 @@ describe("listCuratorSlices", () => {
     mem({ project_key: "proj-x" });
     mem({ project_key: "proj-y" });
 
-    const slices = listCuratorSlices(store!.db);
+    const slices = createSqliteCuratorMemorySource(store!.db).listSlices();
     expect(slices).toContainEqual({ kind: "common_global" });
     expect(slices).toContainEqual({ kind: "common_project", projectKey: "proj-x" });
     expect(slices).toContainEqual({ kind: "common_project", projectKey: "proj-y" });
@@ -61,21 +65,26 @@ describe("listCuratorSlices", () => {
   it("excludes a project whose only memory is archived", () => {
     const m = mem({ project_key: "proj-dead" });
     store!.archiveMemory(m.id);
-    const projects = listCuratorSlices(store!.db).filter((s) => s.kind === "common_project");
+    const projects = createSqliteCuratorMemorySource(store!.db)
+      .listSlices()
+      .filter((s) => s.kind === "common_project");
     expect(projects).not.toContainEqual({ kind: "common_project", projectKey: "proj-dead" });
   });
 
   it("never enumerates agent_private slices after the sessions-rethink (no sources to derive them from)", () => {
     mem({ agent_id: "agent-a", project_key: undefined });
     mem({ agent_id: "agent-b", project_key: undefined });
-    const agents = listCuratorSlices(store!.db).filter((s) => s.kind === "agent_private");
+    const agents = createSqliteCuratorMemorySource(store!.db)
+      .listSlices()
+      .filter((s) => s.kind === "agent_private");
     expect(agents).toHaveLength(0);
   });
 
   it("is deterministically ordered", () => {
     mem({ project_key: "proj-b" });
     mem({ project_key: "proj-a" });
-    const projectKeys = listCuratorSlices(store!.db)
+    const projectKeys = createSqliteCuratorMemorySource(store!.db)
+      .listSlices()
       .filter((s) => s.kind === "common_project")
       .map((s) => (s.kind === "common_project" ? s.projectKey : ""));
     expect(projectKeys).toEqual(["proj-a", "proj-b"]);

--- a/packages/core/tests/curator-source-vault.test.ts
+++ b/packages/core/tests/curator-source-vault.test.ts
@@ -1,0 +1,184 @@
+// Vault-backed CuratorMemorySource (plan 036 Phase 4). Pins that the markdown
+// source partitions memory docs into curator slices with the SAME semantics as
+// the SQLite source: exact project_key for common_project, project_key IS NULL
+// for common_global, agent_id for agent_private; active/proposed feed slices +
+// evidence, archived feed tombstones (no body, archiveReason null on markdown).
+
+import { type Memory, createVaultCuratorMemorySource } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+function mem(over: Partial<Memory> & { id: string }): Memory {
+  return {
+    agent_id: "agent-a",
+    title: "t",
+    body: "b",
+    status: "active",
+    project_key: null,
+    priority: "normal",
+    confidence: "working",
+    tags: [],
+    applies_to: [],
+    supersedes: [],
+    conflicts_with: [],
+    recall_count: 0,
+    usefulness_score: 0,
+    is_global: false,
+    requires_approval: false,
+    created_at: "2026-06-01T00:00:00.000Z",
+    updated_at: "2026-06-01T00:00:00.000Z",
+    ...over,
+  };
+}
+
+/** A source over a fixed in-memory memory list (mirrors the markdown store's listAll). */
+function sourceOf(memories: Memory[]) {
+  return createVaultCuratorMemorySource({ listAll: () => memories });
+}
+
+describe("createVaultCuratorMemorySource — listSlices", () => {
+  it("enumerates the global slice and common projects from active/proposed memories", () => {
+    const source = sourceOf([
+      mem({ id: "g", project_key: null }),
+      mem({ id: "x", project_key: "proj-x" }),
+      mem({ id: "y", project_key: "proj-y", status: "proposed", requires_approval: true }),
+    ]);
+    const slices = source.listSlices();
+    expect(slices).toContainEqual({ kind: "common_global" });
+    expect(slices).toContainEqual({ kind: "common_project", projectKey: "proj-x" });
+    expect(slices).toContainEqual({ kind: "common_project", projectKey: "proj-y" });
+  });
+
+  it("excludes a project whose only memory is archived", () => {
+    const source = sourceOf([mem({ id: "dead", project_key: "proj-dead", status: "archived" })]);
+    expect(source.listSlices()).toEqual([]);
+  });
+
+  it("omits the global slice when every project-less memory is archived", () => {
+    const source = sourceOf([
+      mem({ id: "g", project_key: null, status: "archived" }),
+      mem({ id: "x", project_key: "proj-x" }),
+    ]);
+    const slices = source.listSlices();
+    expect(slices).not.toContainEqual({ kind: "common_global" });
+    expect(slices).toContainEqual({ kind: "common_project", projectKey: "proj-x" });
+  });
+
+  it("never enumerates agent_private slices (parity with the SQLite source)", () => {
+    const source = sourceOf([
+      mem({ id: "a", agent_id: "agent-a", project_key: null }),
+      mem({ id: "b", agent_id: "agent-b", project_key: null }),
+    ]);
+    expect(source.listSlices().filter((s) => s.kind === "agent_private")).toHaveLength(0);
+  });
+
+  it("orders common projects deterministically", () => {
+    const source = sourceOf([
+      mem({ id: "1", project_key: "proj-b" }),
+      mem({ id: "2", project_key: "proj-a" }),
+    ]);
+    expect(
+      source
+        .listSlices()
+        .filter((s) => s.kind === "common_project")
+        .map((s) => s.projectKey),
+    ).toEqual(["proj-a", "proj-b"]);
+  });
+});
+
+describe("createVaultCuratorMemorySource — selectMemories (slice isolation)", () => {
+  it("common_project returns only that project's memories (exact match, no global bleed)", () => {
+    const source = sourceOf([
+      mem({ id: "here", project_key: "proj-x" }),
+      mem({ id: "other", project_key: "proj-y" }),
+      mem({ id: "global", project_key: null }),
+    ]);
+    expect(
+      source
+        .selectMemories({ kind: "common_project", projectKey: "proj-x" }, "active", 50)
+        .map((m) => m.id),
+    ).toEqual(["here"]);
+  });
+
+  it("common_global returns only project-less memories", () => {
+    const source = sourceOf([
+      mem({ id: "global", project_key: null }),
+      mem({ id: "keyed", project_key: "proj-x" }),
+    ]);
+    const ids = source.selectMemories({ kind: "common_global" }, "active", 50).map((m) => m.id);
+    expect(ids).toContain("global");
+    expect(ids).not.toContain("keyed");
+  });
+
+  it("agent_private returns only the named agent's memories", () => {
+    const source = sourceOf([
+      mem({ id: "mine", agent_id: "agent-a", project_key: null }),
+      mem({ id: "theirs", agent_id: "agent-b", project_key: null }),
+    ]);
+    expect(
+      source
+        .selectMemories({ kind: "agent_private", agentId: "agent-a" }, "active", 50)
+        .map((m) => m.id),
+    ).toEqual(["mine"]);
+  });
+
+  it("partitions active vs proposed", () => {
+    const source = sourceOf([
+      mem({ id: "active-one", project_key: "proj-x" }),
+      mem({ id: "proposed-one", project_key: "proj-x", status: "proposed" }),
+    ]);
+    const slice = { kind: "common_project" as const, projectKey: "proj-x" };
+    expect(source.selectMemories(slice, "active", 50).map((m) => m.id)).toEqual(["active-one"]);
+    expect(source.selectMemories(slice, "proposed", 50).map((m) => m.id)).toEqual(["proposed-one"]);
+  });
+
+  it("orders newest-first and respects the limit", () => {
+    const source = sourceOf([
+      mem({ id: "old", project_key: "proj-x", updated_at: "2026-06-01T00:00:00.000Z" }),
+      mem({ id: "new", project_key: "proj-x", updated_at: "2026-06-03T00:00:00.000Z" }),
+      mem({ id: "mid", project_key: "proj-x", updated_at: "2026-06-02T00:00:00.000Z" }),
+    ]);
+    const slice = { kind: "common_project" as const, projectKey: "proj-x" };
+    expect(source.selectMemories(slice, "active", 50).map((m) => m.id)).toEqual([
+      "new",
+      "mid",
+      "old",
+    ]);
+    expect(source.selectMemories(slice, "active", 2).map((m) => m.id)).toEqual(["new", "mid"]);
+  });
+
+  it("maps the verdict booleans onto the record", () => {
+    const source = sourceOf([
+      mem({ id: "p", project_key: "proj-x", requires_approval: true, is_global: true }),
+    ]);
+    const [rec] = source.selectMemories(
+      { kind: "common_project", projectKey: "proj-x" },
+      "active",
+      50,
+    );
+    expect(rec?.requiresApproval).toBe(true);
+    expect(rec?.isGlobal).toBe(true);
+  });
+});
+
+describe("createVaultCuratorMemorySource — selectTombstones", () => {
+  it("returns archived memories with archivedAt=updated_at, a null reason, and the raw body for fingerprinting", () => {
+    const source = sourceOf([
+      mem({
+        id: "dead",
+        project_key: "proj-x",
+        status: "archived",
+        title: "deleted thing",
+        body: "the original body",
+        updated_at: "2026-06-05T00:00:00.000Z",
+      }),
+      mem({ id: "live", project_key: "proj-x" }),
+    ]);
+    const tombs = source.selectTombstones({ kind: "common_project", projectKey: "proj-x" }, 50);
+    expect(tombs.map((t) => t.id)).toEqual(["dead"]);
+    expect(tombs[0]?.archivedAt).toBe("2026-06-05T00:00:00.000Z");
+    expect(tombs[0]?.archiveReason).toBeNull();
+    // The raw body is carried on the record (gatherMemoryEvidence fingerprints
+    // it then drops it); it must be present here so the resurrection key is real.
+    expect(tombs[0]?.body).toBe("the original body");
+  });
+});

--- a/packages/core/tests/store/curation-reads.test.ts
+++ b/packages/core/tests/store/curation-reads.test.ts
@@ -1,10 +1,11 @@
 // CurationStore curator-read methods (F0 — seal the seam).
 //
-// The curator read functions (gatherMemoryEvidence / listCuratorSlices /
-// selectDueSlices / findRunningRun) are pure functions over the SQLite db.
-// To stop non-storage code (curator-worker, curator-enqueue) from reaching
-// `store.db`, the store exposes thin wrappers that bind its own db. This pins
-// that the wrappers delegate to exactly those functions with the store's db.
+// The curator read functions (gatherMemoryEvidence / selectDueSlices /
+// findRunningRun) are pure over a CuratorMemorySource + the run db, and slice
+// enumeration is the source's listSlices(). To stop non-storage code
+// (curator-worker, curator-enqueue) from reaching `store.db`, the store exposes
+// thin wrappers that bind its own source + db. This pins that the wrappers
+// delegate to exactly those functions with the store's SQLite memory source.
 
 import fs from "node:fs";
 import os from "node:os";
@@ -12,9 +13,9 @@ import path from "node:path";
 import {
   type EvidenceSlice,
   createLibrarianStore,
+  createSqliteCuratorMemorySource,
   findRunningRun,
   gatherMemoryEvidence,
-  listCuratorSlices,
   selectDueSlices,
 } from "@librarian/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -39,18 +40,19 @@ afterEach(() => {
   store = null;
 });
 
-describe("CurationStore — curator read methods bind the store db", () => {
-  it("delegates the curator read functions to the underlying store db", () => {
+describe("CurationStore — curator read methods bind the store source + db", () => {
+  it("delegates the curator read functions to the store's SQLite memory source", () => {
     const s = store!;
+    const source = createSqliteCuratorMemorySource(s.db);
     const slice: EvidenceSlice = { kind: "common_global" };
     const schedule = { intervalMinutes: 60 };
     const now = new Date("2026-06-01T00:00:00.000Z");
 
-    expect(s.listCuratorSlices()).toEqual(listCuratorSlices(s.db));
+    expect(s.listCuratorSlices()).toEqual(source.listSlices());
     expect(s.gatherMemoryEvidence(slice, { maxMemories: 5 })).toEqual(
-      gatherMemoryEvidence(s.db, slice, { maxMemories: 5 }),
+      gatherMemoryEvidence(source, slice, { maxMemories: 5 }),
     );
-    expect(s.selectDueSlices(schedule, now)).toEqual(selectDueSlices(s.db, schedule, now));
+    expect(s.selectDueSlices(schedule, now)).toEqual(selectDueSlices(source, s.db, schedule, now));
     expect(s.findRunningRun(slice)).toEqual(findRunningRun(s.db, slice));
   });
 });


### PR DESCRIPTION
## Summary
Phase 4 increment 1 — **awaken the memory curator on the markdown default**.

The curator was dormant on the markdown backend (the shipped default): its read-side (`gatherMemoryEvidence`, `listCuratorSlices`) read the empty residual SQLite `memories` table, so no slices were enumerated and no evidence gathered.

This introduces a `CuratorMemorySource` seam and re-points the read-side through it:
- **`createSqliteCuratorMemorySource`** — the existing projection + events-ledger SQL, moved verbatim (SQLite behaviour unchanged).
- **`createVaultCuratorMemorySource`** — reads the markdown vault via the memory store's `listAll` and partitions by slice (exact `project_key`, project-less global, `agent_id`), newest-first. Tombstones carry the raw body for fingerprinting (never emitted), `updated_at` as `archivedAt`, and a null `archiveReason` (the event ledger is retired on markdown).

`createLibrarianStore`'s markdown branch injects the vault source, so the curator now enumerates slices, gathers evidence, and runs end-to-end over the git vault. Run bookkeeping (`createCurationRun` / `selectDueSlices`' run lookups / `findRunningRun`) deliberately stays on the residual SQLite `db` until the Phase-4 SQLite removal.

## Tests
- New `curator-source-vault.test.ts` — slice-partition parity (isolation, exact match, archived tombstones, newest-first ordering + caps, verdict booleans).
- New `curator-markdown.test.ts` — end-to-end awakening: lists slices / gathers active+proposed+tombstone evidence / selects due slices from the vault, plus a full `runCuration` pass that archives a duplicate in the vault.
- Existing curator read-side tests updated to the seam.
- Full workspace suite green; all packages build.

## Notes
- Slice-isolation parity between the SQLite WHERE and the vault predicate verified (no cross-slice leak); the archived body cannot leak (`TombstoneItem` has no `body`).
- The pure `listCuratorSlices(db)` export is dropped in favour of `CuratorMemorySource.listSlices()`; the public `store.listCuratorSlices()` method is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)