### PR TITLE
feat(consolidator): inbox queue primitives with once-only atomic claim (Phase 4)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -169,17 +169,27 @@ export { formatRecall } from "./formatters/index.js";
 export {
   type CorpusDocument,
   type CorpusFrontmatter,
+  type InboxDeps,
+  type InboxItem,
+  type InboxItemRef,
   type Vault,
   type VaultOptions,
   type Wikilink,
   CorpusFrontmatterSchema,
+  claimInboxItem,
+  completeInboxItem,
   createVault,
+  listInbox,
   parseDocument,
+  parseInboxItem,
   parseWikilinks,
+  releaseStaleClaims,
   relinkVault,
   renameWikilinkTarget,
   resolveVaultPath,
   serializeDocument,
+  serializeInboxItem,
+  writeInbox,
 } from "./store/corpus/index.js";
 export { type GitOps, type SyncGitOps, createGitOps, createSyncGitOps } from "./store/git/index.js";
 export {

--- a/packages/core/src/store/corpus/inbox.ts
+++ b/packages/core/src/store/corpus/inbox.ts
@@ -1,0 +1,151 @@
+// Inbox queue — the durable submission queue for the consolidator (spec 035
+// §F5 inbox / Open-Q #2 RESOLVED). A submission is stored instantly as
+// `inbox/<ts>-<id>.md` (fire-and-forget, off the hot path); consolidation
+// happens later, async. Processing is once-only via an ATOMIC CLAIM: the item
+// is renamed into `inbox/.processing/`, and the rename winner owns the job —
+// a second claim of the same item finds nothing to move and returns null. A
+// boot reaper (`releaseStaleClaims`) returns claims a crashed worker left
+// behind. One item at a time; the serial FIFO run-chain + scheduler wire on top
+// in a follow-on increment.
+//
+// These are pure vault operations with an injected clock, so FIFO ordering and
+// claim age are deterministic. Filenames carry zero-padded epoch-ms prefixes:
+// the pending name sorts chronologically (FIFO via the vault's sorted listing);
+// the claimed name additionally prefixes the CLAIM time so the reaper can age a
+// claim from its filename alone — no mtime reliance (rename preserves mtime).
+
+import matter from "gray-matter";
+import { makeId } from "../../constants.js";
+import type { Vault } from "./vault.js";
+
+const INBOX_DIR = "inbox";
+const PROCESSING_DIR = "inbox/.processing";
+// Zero-padded width for epoch-ms prefixes: 13 digits today, 14 by ~2286 — 15
+// leaves headroom and keeps lexicographic order == chronological order.
+const TS_WIDTH = 15;
+
+/** Clock + id injection so FIFO order, claim age, and filenames are deterministic. */
+export interface InboxDeps {
+  /** Epoch ms. Defaults to `Date.now()`. */
+  now?: () => number;
+  /** Item id generator. Defaults to `makeId("inbox")`. */
+  generateId?: () => string;
+}
+
+export interface InboxItemRef {
+  /** Vault-relative path of the pending item (`inbox/<ts>-<id>.md`). */
+  relPath: string;
+  id: string;
+}
+
+/** A parsed inbox submission: identity + creation time + the raw text. */
+export interface InboxItem {
+  id: string;
+  created: string;
+  text: string;
+}
+
+function pad(ms: number): string {
+  return String(ms).padStart(TS_WIDTH, "0");
+}
+
+function basename(relPath: string): string {
+  const file = relPath.slice(relPath.lastIndexOf("/") + 1);
+  return file.endsWith(".md") ? file.slice(0, -3) : file;
+}
+
+function quote(value: string): string {
+  const escaped = value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\t/g, "\\t")
+    .replace(/\r/g, "\\r");
+  return `"${escaped}"`;
+}
+
+/** Serialize an inbox submission to its on-disk markdown (frontmatter + text). */
+export function serializeInboxItem(item: InboxItem): string {
+  const head = `---\nid: ${quote(item.id)}\ncreated: ${quote(item.created)}\n---\n`;
+  const body = item.text.trim();
+  return body ? `${head}\n${body}\n` : head;
+}
+
+/** Parse an inbox submission; tolerant of hand edits (coerces a YAML Date back to ISO). */
+export function parseInboxItem(raw: string): InboxItem {
+  const { data, content } = matter(raw);
+  const createdRaw = (data as { created?: unknown }).created;
+  const created = createdRaw instanceof Date ? createdRaw.toISOString() : String(createdRaw ?? "");
+  return {
+    id: String((data as { id?: unknown }).id ?? ""),
+    created,
+    text: content.trim(),
+  };
+}
+
+/**
+ * Store a submission in the inbox (instant, fire-and-forget) and return its
+ * pending path + id. The filename's zero-padded ms prefix gives FIFO order.
+ */
+export function writeInbox(vault: Vault, text: string, deps: InboxDeps = {}): InboxItemRef {
+  const ms = (deps.now ?? Date.now)();
+  const id = (deps.generateId ?? (() => makeId("inbox")))();
+  const relPath = `${INBOX_DIR}/${pad(ms)}-${id}.md`;
+  vault.writeText(relPath, serializeInboxItem({ id, created: new Date(ms).toISOString(), text }));
+  return { relPath, id };
+}
+
+/** Pending items, FIFO-ordered, excluding anything already claimed (`.processing/`). */
+export function listInbox(vault: Vault): string[] {
+  const prefix = `${INBOX_DIR}/`;
+  return vault.listMarkdown(INBOX_DIR).filter((rel) => {
+    if (!rel.startsWith(prefix) || rel.startsWith(`${PROCESSING_DIR}/`)) return false;
+    // Direct children of inbox/ only (a pending item, not a nested file).
+    return !rel.slice(prefix.length).includes("/");
+  });
+}
+
+/**
+ * Atomically claim a pending item: rename `inbox/<stem>.md` →
+ * `inbox/.processing/<claimMs>-<stem>.md`. Returns the claimed path, or null if
+ * the item was already claimed / never existed (the move finds nothing) — the
+ * rename winner owns the job.
+ */
+export function claimInboxItem(vault: Vault, relPath: string, deps: InboxDeps = {}): string | null {
+  const claimMs = (deps.now ?? Date.now)();
+  const target = `${PROCESSING_DIR}/${pad(claimMs)}-${basename(relPath)}.md`;
+  try {
+    vault.moveFile(relPath, target);
+    return target;
+  } catch {
+    return null; // source gone — already claimed, or never written
+  }
+}
+
+/**
+ * Return claims older than `olderThanMs` to the pending queue (the boot reaper
+ * for crashed-worker claims). Claim age comes from the `<claimMs>-` filename
+ * prefix; fresh claims are left in place. Returns the restored pending paths.
+ */
+export function releaseStaleClaims(
+  vault: Vault,
+  opts: { olderThanMs: number; now: number },
+): string[] {
+  const restored: string[] = [];
+  for (const claimed of vault.listMarkdown(PROCESSING_DIR)) {
+    const name = basename(claimed);
+    const dash = name.indexOf("-");
+    if (dash <= 0) continue; // malformed — not a claim we wrote; leave it
+    const claimMs = Number(name.slice(0, dash));
+    if (Number.isNaN(claimMs) || opts.now - claimMs < opts.olderThanMs) continue;
+    const pendingPath = `${INBOX_DIR}/${name.slice(dash + 1)}.md`;
+    vault.moveFile(claimed, pendingPath);
+    restored.push(pendingPath);
+  }
+  return restored;
+}
+
+/** Remove a processed claim from `.processing/`. Idempotent (a no-op if gone). */
+export function completeInboxItem(vault: Vault, processingRelPath: string): void {
+  vault.removeFile(processingRelPath);
+}

--- a/packages/core/src/store/corpus/inbox.ts
+++ b/packages/core/src/store/corpus/inbox.ts
@@ -113,12 +113,19 @@ export function listInbox(vault: Vault): string[] {
  */
 export function claimInboxItem(vault: Vault, relPath: string, deps: InboxDeps = {}): string | null {
   const claimMs = (deps.now ?? Date.now)();
+  // The claim name carries the claim time so the reaper can age it. Distinct
+  // items never collide (unique id), and the single-process serial model means
+  // the same item is never claimed twice concurrently — so the target is fresh.
   const target = `${PROCESSING_DIR}/${pad(claimMs)}-${basename(relPath)}.md`;
   try {
     vault.moveFile(relPath, target);
     return target;
-  } catch {
-    return null; // source gone — already claimed, or never written
+  } catch (error) {
+    // Source gone → already claimed (the rename winner owns it) or never
+    // written: that's the only null. A real failure (path escape, perms) must
+    // surface loudly rather than masquerade as a lost race.
+    if (!vault.exists(relPath)) return null;
+    throw error;
   }
 }
 

--- a/packages/core/src/store/corpus/index.ts
+++ b/packages/core/src/store/corpus/index.ts
@@ -12,3 +12,15 @@ export {
 export { type Wikilink, parseWikilinks, renameWikilinkTarget } from "./wikilink.js";
 export { type Vault, type VaultOptions, createVault, resolveVaultPath } from "./vault.js";
 export { relinkVault } from "./link-integrity.js";
+export {
+  type InboxDeps,
+  type InboxItem,
+  type InboxItemRef,
+  claimInboxItem,
+  completeInboxItem,
+  listInbox,
+  parseInboxItem,
+  releaseStaleClaims,
+  serializeInboxItem,
+  writeInbox,
+} from "./inbox.js";

--- a/packages/core/tests/corpus-inbox.test.ts
+++ b/packages/core/tests/corpus-inbox.test.ts
@@ -133,6 +133,13 @@ describe("releaseStaleClaims (boot reaper)", () => {
     expect(listInbox(vault)).toEqual([]);
   });
 
+  it("leaves a malformed .processing file untouched (not a claim we wrote)", () => {
+    vault.writeText("inbox/.processing/not-a-claim.md", "stray");
+    const restored = releaseStaleClaims(vault, { olderThanMs: 0, now: 9_000_000 });
+    expect(restored).toEqual([]);
+    expect(vault.exists("inbox/.processing/not-a-claim.md")).toBe(true);
+  });
+
   it("a reclaimed item can be claimed again", () => {
     const ref = writeInbox(vault, "retry me", { now: () => 1000, generateId: () => "inbox_a" });
     claimInboxItem(vault, ref.relPath, { now: () => 10_000 });

--- a/packages/core/tests/corpus-inbox.test.ts
+++ b/packages/core/tests/corpus-inbox.test.ts
@@ -1,0 +1,155 @@
+// Inbox queue primitives (plan 036 Phase 4 / spec 035 §F5 inbox, Open-Q #2).
+//
+// The inbox is the durable submission queue: instant fire-and-forget writes,
+// FIFO ordering, a once-only atomic claim (rename inbox/X → inbox/.processing/X
+// — the rename winner owns the job), and a boot reaper that returns stale
+// claims left by a crashed worker. These are pure vault operations — no LLM,
+// no scheduler — so they're fully unit-testable with an injected clock.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type Vault,
+  claimInboxItem,
+  completeInboxItem,
+  createVault,
+  listInbox,
+  parseInboxItem,
+  releaseStaleClaims,
+  writeInbox,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let vault: Vault;
+let dataDir = "";
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-inbox-"));
+  vault = createVault({ dataDir });
+});
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+/** A deterministic clock: each call advances by 1ms from the given start. */
+function clockFrom(startMs: number): { now: () => number } {
+  let t = startMs;
+  return { now: () => t++ };
+}
+
+describe("writeInbox", () => {
+  it("writes a fire-and-forget item under inbox/ and round-trips the text", () => {
+    const ref = writeInbox(vault, "Anna moved to Berlin", {
+      now: () => 1000,
+      generateId: () => "inbox_a",
+    });
+    expect(ref.relPath.startsWith("inbox/")).toBe(true);
+    expect(ref.relPath.endsWith(".md")).toBe(true);
+    expect(vault.exists(ref.relPath)).toBe(true);
+    const parsed = parseInboxItem(vault.readText(ref.relPath));
+    expect(parsed.id).toBe("inbox_a");
+    expect(parsed.text).toBe("Anna moved to Berlin");
+    expect(parsed.created).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("does not place the item under inbox/.processing/", () => {
+    const ref = writeInbox(vault, "x", { now: () => 1 });
+    expect(ref.relPath).not.toContain(".processing");
+  });
+});
+
+describe("listInbox", () => {
+  it("returns pending items in FIFO (write-order) order", () => {
+    const clock = clockFrom(1000);
+    const a = writeInbox(vault, "first", { ...clock, generateId: () => "inbox_a" });
+    const b = writeInbox(vault, "second", { ...clock, generateId: () => "inbox_b" });
+    const c = writeInbox(vault, "third", { ...clock, generateId: () => "inbox_c" });
+    expect(listInbox(vault)).toEqual([a.relPath, b.relPath, c.relPath]);
+  });
+
+  it("excludes claimed items under inbox/.processing/", () => {
+    const clock = clockFrom(1000);
+    const a = writeInbox(vault, "first", { ...clock, generateId: () => "inbox_a" });
+    const b = writeInbox(vault, "second", { ...clock, generateId: () => "inbox_b" });
+    claimInboxItem(vault, a.relPath, { now: () => 5000 });
+    expect(listInbox(vault)).toEqual([b.relPath]);
+  });
+
+  it("is empty when nothing has been submitted", () => {
+    expect(listInbox(vault)).toEqual([]);
+  });
+});
+
+describe("claimInboxItem", () => {
+  it("atomically moves the item into inbox/.processing/ and returns its new path", () => {
+    const ref = writeInbox(vault, "claim me", { now: () => 1000, generateId: () => "inbox_a" });
+    const claimed = claimInboxItem(vault, ref.relPath, { now: () => 5000 });
+    expect(claimed).not.toBeNull();
+    expect(claimed!.startsWith("inbox/.processing/")).toBe(true);
+    expect(vault.exists(claimed!)).toBe(true);
+    expect(vault.exists(ref.relPath)).toBe(false); // moved, not copied
+    // The submission survives the move.
+    expect(parseInboxItem(vault.readText(claimed!)).text).toBe("claim me");
+  });
+
+  it("is once-only: a second claim of the same item returns null (the rename winner owns it)", () => {
+    const ref = writeInbox(vault, "x", { now: () => 1000, generateId: () => "inbox_a" });
+    const first = claimInboxItem(vault, ref.relPath, { now: () => 5000 });
+    const second = claimInboxItem(vault, ref.relPath, { now: () => 5001 });
+    expect(first).not.toBeNull();
+    expect(second).toBeNull();
+  });
+
+  it("returns null for an item that was never written", () => {
+    expect(
+      claimInboxItem(vault, "inbox/000000000001000-inbox_ghost.md", { now: () => 1 }),
+    ).toBeNull();
+  });
+});
+
+describe("releaseStaleClaims (boot reaper)", () => {
+  it("returns a claim older than the TTL back to the pending queue", () => {
+    const ref = writeInbox(vault, "stranded", { now: () => 1000, generateId: () => "inbox_a" });
+    claimInboxItem(vault, ref.relPath, { now: () => 10_000 });
+
+    // 30 min later, the claim is stale (crashed worker).
+    const restored = releaseStaleClaims(vault, { olderThanMs: 60_000, now: 10_000 + 30 * 60_000 });
+
+    expect(restored).toEqual([ref.relPath]); // restored to its original pending path
+    expect(listInbox(vault)).toEqual([ref.relPath]);
+    expect(vault.listMarkdown("inbox/.processing")).toEqual([]);
+  });
+
+  it("leaves a fresh claim in place", () => {
+    const ref = writeInbox(vault, "in flight", { now: () => 1000, generateId: () => "inbox_a" });
+    const claimed = claimInboxItem(vault, ref.relPath, { now: () => 10_000 });
+
+    // Only 1s elapsed — well inside the TTL.
+    const restored = releaseStaleClaims(vault, { olderThanMs: 60_000, now: 11_000 });
+
+    expect(restored).toEqual([]);
+    expect(vault.exists(claimed!)).toBe(true);
+    expect(listInbox(vault)).toEqual([]);
+  });
+
+  it("a reclaimed item can be claimed again", () => {
+    const ref = writeInbox(vault, "retry me", { now: () => 1000, generateId: () => "inbox_a" });
+    claimInboxItem(vault, ref.relPath, { now: () => 10_000 });
+    releaseStaleClaims(vault, { olderThanMs: 60_000, now: 10_000 + 30 * 60_000 });
+    const reclaimed = claimInboxItem(vault, ref.relPath, { now: () => 9_000_000 });
+    expect(reclaimed).not.toBeNull();
+    expect(reclaimed!.startsWith("inbox/.processing/")).toBe(true);
+  });
+});
+
+describe("completeInboxItem", () => {
+  it("removes a processed claim and is idempotent", () => {
+    const ref = writeInbox(vault, "done", { now: () => 1000, generateId: () => "inbox_a" });
+    const claimed = claimInboxItem(vault, ref.relPath, { now: () => 5000 })!;
+    completeInboxItem(vault, claimed);
+    expect(vault.exists(claimed)).toBe(false);
+    // idempotent — a second completion is a no-op, not a throw.
+    expect(() => completeInboxItem(vault, claimed)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
First increment of the **consolidator** (Phase 4 / F5, the differentiator): the durable submission queue the pipeline will sit on. Pure `Vault` operations with an injected clock — no LLM, no scheduler yet (those land in follow-on increments).

Implements spec 035 §F5 inbox / Open-Q #2 ("`inbox/` is the durable queue; once-only via an atomic claim — the rename winner owns the job; a boot reaper returns stale claims; serial FIFO, one item at a time"):

- **`writeInbox`** — instant fire-and-forget store as `inbox/<ms>-<id>.md`; the zero-padded epoch-ms prefix gives FIFO order via the vault's sorted listing.
- **`listInbox`** — pending items FIFO, excluding claimed items under `.processing/`.
- **`claimInboxItem`** — atomic rename `inbox/X → inbox/.processing/<claimMs>-<stem>.md`; the rename winner owns the job, a second claim returns `null` (once-only). A real failure (path escape / perms) rethrows rather than masquerading as a lost race.
- **`releaseStaleClaims`** — boot reaper; ages a claim from its filename's `<claimMs>-` prefix (no mtime reliance, since rename preserves mtime) and returns stale claims to the pending queue; fresh claims stay put; malformed names are left untouched.
- **`completeInboxItem`** — idempotent removal of a processed claim.
- **`serializeInboxItem` / `parseInboxItem`** — minimal `{id, created, text}` doc (inbox items aren't categorized — `category` is a consolidation *output*, so they don't use `CorpusFrontmatter`).

## Tests
`corpus-inbox.test.ts` (13): write/round-trip, FIFO order, `.processing/` exclusion, once-only claim, never-written → null, reaper restore vs fresh-claim-stays vs malformed-skip, reclaim-after-release, idempotent complete.

## Notes
- Single-process serial model (multi-process atomic mutual-exclusion is deferred per the spec); the claim/reaper design is forward-compatible.
- Sub-agent review verdict: ship (0 Critical / 0 Important).
- Full workspace suite green; all packages build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)