### PR TITLE
feat(consolidator): navigate step — recall candidates + corpus ToC (Phase 4)

### DIFF
--- a/packages/core/src/consolidator/index.ts
+++ b/packages/core/src/consolidator/index.ts
@@ -1,0 +1,12 @@
+// Consolidator — the sole server-side LLM brain (spec 035 §F5), built on the
+// kept curator pipeline. Inbox submission → navigate (candidates + ToC map) →
+// judge (augment/create/supersede/archive, confidence-banded) → minimal-edit +
+// wikilinks. This barrel grows as each step lands; navigate is first.
+
+export {
+  type ConsolidationCandidates,
+  type ConsolidatorTocEntry,
+  type NavigateDeps,
+  type NavigateOptions,
+  navigateInbox,
+} from "./navigate.js";

--- a/packages/core/src/consolidator/navigate.ts
+++ b/packages/core/src/consolidator/navigate.ts
@@ -1,0 +1,73 @@
+// Consolidator — navigate step (spec 035 §F5: "navigate (retrieve candidates +
+// ToC map) → judge → edit"). For one inbox submission this assembles the
+// evidence the judge reasons over:
+//   - candidates: the existing memories most relevant to the submission, via the
+//     backend's index recall — the augment / update / supersede targets;
+//   - toc: a bounded table-of-contents of the active corpus — the anchor for a
+//     create/filing decision (so the judge files into an existing area rather
+//     than spawning a near-duplicate, S1/G6).
+//
+// Pure orchestration over injected `recall` + `listActive` (the markdown store
+// supplies these), so it's testable without an index or an LLM.
+
+import type { Memory } from "../store/memory-store.js";
+
+/** A compact corpus entry for the filing/create anchor (no body — the ToC is an overview). */
+export interface ConsolidatorTocEntry {
+  id: string;
+  title: string;
+  tags: string[];
+  projectKey: string | null;
+}
+
+/** The evidence bundle the consolidator's judge step reasons over. */
+export interface ConsolidationCandidates {
+  /** Existing memories most relevant to the submission, highest-ranked first. */
+  candidates: Memory[];
+  /** A bounded table-of-contents of the active corpus. */
+  toc: ConsolidatorTocEntry[];
+}
+
+export interface NavigateDeps {
+  /** Index-backed recall over active memories (the store's query recall). */
+  recall: (query: string, limit: number) => Promise<Memory[]>;
+  /** The active corpus, in the backend's listing order (highest-priority first). */
+  listActive: () => Memory[];
+}
+
+export interface NavigateOptions {
+  /** Max relevant candidates to retrieve (default 8). */
+  candidateLimit?: number;
+  /** Max ToC entries (default 200). */
+  tocLimit?: number;
+}
+
+const DEFAULT_CANDIDATE_LIMIT = 8;
+const DEFAULT_TOC_LIMIT = 200;
+
+function toTocEntry(memory: Memory): ConsolidatorTocEntry {
+  return {
+    id: memory.id,
+    title: String(memory.title ?? ""),
+    tags: memory.tags ?? [],
+    projectKey: memory.project_key ?? null,
+  };
+}
+
+export async function navigateInbox(
+  submissionText: string,
+  deps: NavigateDeps,
+  options: NavigateOptions = {},
+): Promise<ConsolidationCandidates> {
+  const toc = deps
+    .listActive()
+    .slice(0, options.tocLimit ?? DEFAULT_TOC_LIMIT)
+    .map(toTocEntry);
+
+  // An empty submission has nothing to retrieve against — return the ToC alone.
+  const candidates = submissionText.trim()
+    ? await deps.recall(submissionText, options.candidateLimit ?? DEFAULT_CANDIDATE_LIMIT)
+    : [];
+
+  return { candidates, toc };
+}

--- a/packages/core/src/consolidator/navigate.ts
+++ b/packages/core/src/consolidator/navigate.ts
@@ -29,7 +29,12 @@ export interface ConsolidationCandidates {
 }
 
 export interface NavigateDeps {
-  /** Index-backed recall over active memories (the store's query recall). */
+  /**
+   * Index-backed recall over active memories. A narrowed (positional) adapter
+   * over the store's object-shaped `recall({ query, limit })` — the wiring
+   * increment supplies `(q, n) => store.recall({ query: q, limit: n })`. recall
+   * already returns active-only memories (proposals/archived are excluded).
+   */
   recall: (query: string, limit: number) => Promise<Memory[]>;
   /** The active corpus, in the backend's listing order (highest-priority first). */
   listActive: () => Memory[];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -105,6 +105,13 @@ export {
   createVaultCuratorMemorySource,
 } from "./curator-source-vault.js";
 export {
+  type ConsolidationCandidates,
+  type ConsolidatorTocEntry,
+  type NavigateDeps,
+  type NavigateOptions,
+  navigateInbox,
+} from "./consolidator/index.js";
+export {
   type LlmClient,
   type LlmClientConfig,
   type LlmClientDeps,

--- a/packages/core/tests/consolidator-navigate.test.ts
+++ b/packages/core/tests/consolidator-navigate.test.ts
@@ -70,6 +70,12 @@ describe("navigateInbox", () => {
     expect(result.toc.map((t) => t.id)).toEqual(["m0", "m1", "m2", "m3"]);
   });
 
+  it("returns an empty ToC for an empty corpus", async () => {
+    const result = await navigateInbox("q", { recall: async () => [], listActive: () => [] });
+    expect(result.toc).toEqual([]);
+    expect(result.candidates).toEqual([]);
+  });
+
   it("skips recall for an empty submission but still returns the ToC", async () => {
     const recall = vi.fn(async () => [mem({ id: "should-not-appear" })]);
     const result = await navigateInbox("   ", {

--- a/packages/core/tests/consolidator-navigate.test.ts
+++ b/packages/core/tests/consolidator-navigate.test.ts
@@ -1,0 +1,83 @@
+// Consolidator navigate step (plan 036 Phase 4 / spec 035 §F5:
+// "navigate (retrieve candidates + ToC map) → judge → edit"). For one inbox
+// submission, navigate gathers the existing memories most relevant to it (the
+// augment / update / supersede targets, via index recall) plus a bounded
+// table-of-contents of the active corpus (the create/filing anchor). Pure
+// orchestration over injected recall + listing — no LLM, no index internals.
+
+import { type Memory, navigateInbox } from "@librarian/core";
+import { describe, expect, it, vi } from "vitest";
+
+function mem(over: Partial<Memory> & { id: string }): Memory {
+  return {
+    agent_id: "agent-a",
+    title: `title ${over.id}`,
+    body: "body",
+    status: "active",
+    project_key: null,
+    priority: "normal",
+    confidence: "working",
+    tags: [],
+    applies_to: [],
+    supersedes: [],
+    conflicts_with: [],
+    recall_count: 0,
+    usefulness_score: 0,
+    is_global: false,
+    requires_approval: false,
+    created_at: "2026-06-01T00:00:00.000Z",
+    updated_at: "2026-06-01T00:00:00.000Z",
+    ...over,
+  };
+}
+
+describe("navigateInbox", () => {
+  it("returns the recalled candidates and a compact ToC of the active corpus", async () => {
+    const recalled = [mem({ id: "m1", title: "Anna" }), mem({ id: "m2", title: "Berlin" })];
+    const active = [
+      mem({ id: "m1", title: "Anna", tags: ["person"], project_key: "proj-x" }),
+      mem({ id: "m2", title: "Berlin" }),
+    ];
+    const result = await navigateInbox("Anna moved to Berlin", {
+      recall: async () => recalled,
+      listActive: () => active,
+    });
+
+    expect(result.candidates.map((m) => m.id)).toEqual(["m1", "m2"]);
+    expect(result.toc).toEqual([
+      { id: "m1", title: "Anna", tags: ["person"], projectKey: "proj-x" },
+      { id: "m2", title: "Berlin", tags: [], projectKey: null },
+    ]);
+  });
+
+  it("asks recall for candidateLimit candidates (default 8)", async () => {
+    const recall = vi.fn(async () => []);
+    await navigateInbox("x", { recall, listActive: () => [] });
+    expect(recall).toHaveBeenCalledWith("x", 8);
+
+    recall.mockClear();
+    await navigateInbox("x", { recall, listActive: () => [] }, { candidateLimit: 3 });
+    expect(recall).toHaveBeenCalledWith("x", 3);
+  });
+
+  it("bounds the ToC to tocLimit (highest-ranked listing order preserved)", async () => {
+    const active = Array.from({ length: 10 }, (_, i) => mem({ id: `m${i}` }));
+    const result = await navigateInbox(
+      "q",
+      { recall: async () => [], listActive: () => active },
+      { tocLimit: 4 },
+    );
+    expect(result.toc.map((t) => t.id)).toEqual(["m0", "m1", "m2", "m3"]);
+  });
+
+  it("skips recall for an empty submission but still returns the ToC", async () => {
+    const recall = vi.fn(async () => [mem({ id: "should-not-appear" })]);
+    const result = await navigateInbox("   ", {
+      recall,
+      listActive: () => [mem({ id: "m1" })],
+    });
+    expect(recall).not.toHaveBeenCalled();
+    expect(result.candidates).toEqual([]);
+    expect(result.toc.map((t) => t.id)).toEqual(["m1"]);
+  });
+});


### PR DESCRIPTION
## Summary
The first **consolidator** pipeline step (spec 035 §F5: "navigate (retrieve candidates + ToC map) → judge → edit"). For one inbox submission, `navigateInbox` assembles the evidence the (later) judge reasons over:

- **`candidates`** — the existing memories most relevant to the submission, via the backend's index recall (the augment / update / supersede targets; recall is active-only).
- **`toc`** — a bounded table-of-contents of the active corpus (`{id, title, tags, projectKey}`, no body), the create/filing anchor so the judge files into an existing area rather than near-duplicating (S1/G6).

Pure orchestration over injected `recall` + `listActive` (the markdown store supplies both later), so it's unit-testable without an index or an LLM. Empty submission → no recall, ToC only. Establishes the `consolidator/` module.

## Tests
`consolidator-navigate.test.ts` (5): candidate + compact-ToC mapping, `candidateLimit` pass-through (default 8 / override), `tocLimit` bounding with order preserved, empty corpus, empty submission.

## Notes
- `judge`, `edit`/wikilinks, and the scheduler are separate follow-on increments — out of scope here.
- `NavigateDeps.recall` is a narrowed positional adapter over the store's object-shaped `recall({query, limit})`; the wiring increment supplies `(q, n) => store.recall({ query: q, limit: n })`.
- Sub-agent review verdict: ship (0 Critical / 0 Important).

🤖 Generated with [Claude Code](https://claude.com/claude-code)