### PR TITLE
feat(consolidator): judge decision layer — schema + parse + three-band routing (Phase 4)

### DIFF
--- a/packages/core/src/consolidator/index.ts
+++ b/packages/core/src/consolidator/index.ts
@@ -10,3 +10,13 @@ export {
   type NavigateOptions,
   navigateInbox,
 } from "./navigate.js";
+export {
+  type ConsolidationDecision,
+  type ConsolidationJudgment,
+  type ConsolidationPlan,
+  type ConsolidationThresholds,
+  type ParsedConsolidationJudgment,
+  ConsolidationJudgmentSchema,
+  parseConsolidationJudgment,
+  routeConsolidation,
+} from "./judge.js";

--- a/packages/core/src/consolidator/judge.ts
+++ b/packages/core/src/consolidator/judge.ts
@@ -1,0 +1,163 @@
+// Consolidator — judge decision layer (spec 035 §F5: "judge (augment/create/
+// supersede/archive), confidence band ≥0.95 auto / 0.85–0.95 proposal / ≤0.85
+// new (S12)"). Two PURE pieces, both independent of the LLM:
+//
+//   1. parseConsolidationJudgment — the LLM's per-submission decision is
+//      UNTRUSTED; parse the JSON and strictly validate it (strict objects reject
+//      smuggled fields, mirroring parseCuratorOutput). One submission → one
+//      judgment (not a batch like the curator).
+//   2. routeConsolidation — map the judgment + its confidence to a routing
+//      decision by the three bands, per action. The bands encode the safety
+//      posture: a merge we're unsure of becomes a NEW doc rather than a wrong
+//      merge (S12); a contradiction/removal we're unsure of goes to a human
+//      proposal, never a silent auto-apply (S4 / no-clobber).
+//
+// The prompt + LLM call that produces the raw judgment is a separate increment;
+// this layer is what consumes its output.
+
+import { z } from "zod";
+
+const rationale = z.string().min(1);
+const confidence = z.number().min(0).max(1);
+
+/** Novel fact with no good existing home → a fresh doc (S1). */
+const CreateJudgment = z.strictObject({
+  action: z.literal("create"),
+  title: z.string().min(1),
+  body: z.string().min(1),
+  tags: z.array(z.string()).default([]),
+  rationale,
+  confidence,
+});
+/** Weave the new fact into an existing doc (S2/S18) — minimal-edit at apply time. */
+const AugmentJudgment = z.strictObject({
+  action: z.literal("augment"),
+  target_id: z.string().min(1),
+  addition: z.string().min(1),
+  rationale,
+  confidence,
+});
+/** The submission contradicts/updates an existing doc → replace it (S4). */
+const SupersedeJudgment = z.strictObject({
+  action: z.literal("supersede"),
+  target_id: z.string().min(1),
+  title: z.string().min(1),
+  body: z.string().min(1),
+  rationale,
+  confidence,
+});
+/** An existing doc is now stale (no replacement). */
+const ArchiveJudgment = z.strictObject({
+  action: z.literal("archive"),
+  target_id: z.string().min(1),
+  rationale,
+  confidence,
+});
+/** Nothing to do — a duplicate or non-actionable submission. */
+const NoopJudgment = z.strictObject({
+  action: z.literal("noop"),
+  rationale,
+  confidence,
+});
+
+export const ConsolidationJudgmentSchema = z.discriminatedUnion("action", [
+  CreateJudgment,
+  AugmentJudgment,
+  SupersedeJudgment,
+  ArchiveJudgment,
+  NoopJudgment,
+]);
+export type ConsolidationJudgment = z.infer<typeof ConsolidationJudgmentSchema>;
+
+export interface ParsedConsolidationJudgment {
+  judgment?: ConsolidationJudgment;
+  /** Set when the response was unusable (bad JSON or schema-invalid). */
+  parseError?: string;
+}
+
+export function parseConsolidationJudgment(raw: string): ParsedConsolidationJudgment {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stripCodeFence(raw));
+  } catch {
+    return { parseError: "output was not valid JSON" };
+  }
+  const result = ConsolidationJudgmentSchema.safeParse(parsed);
+  if (!result.success) return { parseError: summarizeIssues(result.error) };
+  return { judgment: result.data };
+}
+
+/** auto_apply: do it now · propose: route to a human · create_new: file a fresh
+ * doc instead of touching an existing one · skip: nothing to do. */
+export type ConsolidationDecision = "auto_apply" | "propose" | "create_new" | "skip";
+
+export interface ConsolidationThresholds {
+  /** Confidence at/above which a judgment auto-applies (default 0.95). */
+  autoApply: number;
+  /** Confidence at/above which it routes to a proposal (default 0.85). */
+  propose: number;
+}
+
+const DEFAULT_THRESHOLDS: ConsolidationThresholds = { autoApply: 0.95, propose: 0.85 };
+
+export interface ConsolidationPlan {
+  decision: ConsolidationDecision;
+  judgment: ConsolidationJudgment;
+}
+
+export function routeConsolidation(
+  judgment: ConsolidationJudgment,
+  thresholds: ConsolidationThresholds = DEFAULT_THRESHOLDS,
+): ConsolidationPlan {
+  return { decision: decide(judgment, thresholds), judgment };
+}
+
+function decide(
+  judgment: ConsolidationJudgment,
+  t: ConsolidationThresholds,
+): ConsolidationDecision {
+  switch (judgment.action) {
+    case "noop":
+      return "skip";
+    // A fresh doc puts no existing knowledge at risk, so it's the safe default —
+    // auto-applied regardless of confidence (worst case is a near-duplicate that
+    // later grooming merges, never a clobber).
+    case "create":
+      return "auto_apply";
+    // Weaving into an existing doc: confident → apply; middle → human proposal;
+    // uncertain → create a NEW doc rather than risk a wrong/under-merge (S12).
+    case "augment":
+      if (judgment.confidence >= t.autoApply) return "auto_apply";
+      if (judgment.confidence >= t.propose) return "propose";
+      return "create_new";
+    // Replacing or removing existing knowledge: only a very confident judgment
+    // auto-applies; anything less goes to a human, never a silent replace/remove
+    // (S4 contradiction caution / no-clobber).
+    case "supersede":
+    case "archive":
+      return judgment.confidence >= t.autoApply ? "auto_apply" : "propose";
+  }
+}
+
+// Tolerate a single markdown code fence some providers wrap JSON in.
+function stripCodeFence(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("```")) return trimmed;
+  return trimmed
+    .replace(/^```[a-z]*\n?/i, "")
+    .replace(/\n?```$/, "")
+    .trim();
+}
+
+// Build the error from issue CODE + PATH only — never Zod's message text or the
+// received value, which echo untrusted (possibly secret-looking) model output.
+function summarizeIssues(error: z.ZodError): string {
+  return error.issues
+    .slice(0, 3)
+    .map((issue) => {
+      const path = issue.path.join(".");
+      const detail = issue.code === "unrecognized_keys" ? "unexpected field" : issue.code;
+      return path ? `${path}: ${detail}` : detail;
+    })
+    .join("; ");
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -106,10 +106,18 @@ export {
 } from "./curator-source-vault.js";
 export {
   type ConsolidationCandidates,
+  type ConsolidationDecision,
+  type ConsolidationJudgment,
+  type ConsolidationPlan,
+  type ConsolidationThresholds,
   type ConsolidatorTocEntry,
   type NavigateDeps,
   type NavigateOptions,
+  type ParsedConsolidationJudgment,
+  ConsolidationJudgmentSchema,
   navigateInbox,
+  parseConsolidationJudgment,
+  routeConsolidation,
 } from "./consolidator/index.js";
 export {
   type LlmClient,

--- a/packages/core/tests/consolidator-judge.test.ts
+++ b/packages/core/tests/consolidator-judge.test.ts
@@ -1,0 +1,175 @@
+// Consolidator judge decision layer (plan 036 Phase 4 / spec 035 §F5: "judge
+// (augment/create/supersede/archive), confidence band ≥0.95 auto / 0.85–0.95
+// proposal / ≤0.85 new (S12)"). The PURE half: parse the untrusted LLM judgment
+// for one submission, then route it by the three confidence bands. The LLM
+// prompt + call that produces the raw judgment is a separate increment; here we
+// feed hand-written JSON, so no model is needed.
+
+import {
+  type ConsolidationJudgment,
+  parseConsolidationJudgment,
+  routeConsolidation,
+} from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+describe("parseConsolidationJudgment", () => {
+  it("parses each judge action", () => {
+    const create = parseConsolidationJudgment(
+      JSON.stringify({
+        action: "create",
+        title: "Anna",
+        body: "Anna moved to Berlin.",
+        tags: ["person"],
+        rationale: "novel topic",
+        confidence: 0.9,
+      }),
+    );
+    expect(create.judgment).toMatchObject({ action: "create", title: "Anna" });
+    expect(create.parseError).toBeUndefined();
+
+    expect(
+      parseConsolidationJudgment(
+        JSON.stringify({
+          action: "augment",
+          target_id: "mem_1",
+          addition: "She now lives in Berlin.",
+          rationale: "adds to the Anna doc",
+          confidence: 0.97,
+        }),
+      ).judgment,
+    ).toMatchObject({ action: "augment", target_id: "mem_1" });
+
+    expect(
+      parseConsolidationJudgment(
+        JSON.stringify({
+          action: "supersede",
+          target_id: "mem_1",
+          title: "Anna",
+          body: "Anna works at Acme (was: Globex).",
+          rationale: "job changed",
+          confidence: 0.96,
+        }),
+      ).judgment,
+    ).toMatchObject({ action: "supersede", target_id: "mem_1" });
+
+    expect(
+      parseConsolidationJudgment(
+        JSON.stringify({
+          action: "archive",
+          target_id: "mem_2",
+          rationale: "stale",
+          confidence: 0.99,
+        }),
+      ).judgment,
+    ).toMatchObject({ action: "archive", target_id: "mem_2" });
+
+    expect(
+      parseConsolidationJudgment(
+        JSON.stringify({ action: "noop", rationale: "duplicate", confidence: 0.5 }),
+      ).judgment,
+    ).toMatchObject({ action: "noop" });
+  });
+
+  it("tolerates a markdown code fence", () => {
+    const raw = '```json\n{"action":"noop","rationale":"x","confidence":0.5}\n```';
+    expect(parseConsolidationJudgment(raw).judgment).toMatchObject({ action: "noop" });
+  });
+
+  it("reports a parse error for non-JSON", () => {
+    const parsed = parseConsolidationJudgment("not json");
+    expect(parsed.judgment).toBeUndefined();
+    expect(parsed.parseError).toBeTruthy();
+  });
+
+  it("rejects an unknown action", () => {
+    const parsed = parseConsolidationJudgment(
+      JSON.stringify({ action: "delete_everything", rationale: "x", confidence: 1 }),
+    );
+    expect(parsed.judgment).toBeUndefined();
+    expect(parsed.parseError).toBeTruthy();
+  });
+
+  it("rejects a judgment missing required fields", () => {
+    // augment without a target_id
+    const parsed = parseConsolidationJudgment(
+      JSON.stringify({ action: "augment", addition: "x", rationale: "y", confidence: 0.9 }),
+    );
+    expect(parsed.judgment).toBeUndefined();
+    expect(parsed.parseError).toBeTruthy();
+  });
+
+  it("rejects an out-of-range confidence", () => {
+    const parsed = parseConsolidationJudgment(
+      JSON.stringify({ action: "noop", rationale: "x", confidence: 1.5 }),
+    );
+    expect(parsed.judgment).toBeUndefined();
+  });
+
+  it("rejects unexpected fields (strict — no smuggling)", () => {
+    const parsed = parseConsolidationJudgment(
+      JSON.stringify({
+        action: "noop",
+        rationale: "x",
+        confidence: 0.5,
+        curator_note: "forged",
+      }),
+    );
+    expect(parsed.judgment).toBeUndefined();
+  });
+});
+
+describe("routeConsolidation — three-band confidence policy (S12)", () => {
+  const judge = (
+    over: Partial<ConsolidationJudgment> & { action: string },
+  ): ConsolidationJudgment =>
+    ({ rationale: "r", confidence: 0.9, ...over }) as ConsolidationJudgment;
+
+  it("a noop is skipped", () => {
+    expect(routeConsolidation(judge({ action: "noop" })).decision).toBe("skip");
+  });
+
+  it("a create always auto-applies (a fresh doc risks nothing existing)", () => {
+    expect(
+      routeConsolidation(judge({ action: "create", title: "t", body: "b", confidence: 0.2 }))
+        .decision,
+    ).toBe("auto_apply");
+  });
+
+  it("augment: ≥0.95 auto-applies, 0.85–0.95 proposes, <0.85 creates a new doc (S12)", () => {
+    const augment = (c: number) =>
+      routeConsolidation(judge({ action: "augment", target_id: "m", addition: "a", confidence: c }))
+        .decision;
+    expect(augment(0.97)).toBe("auto_apply");
+    expect(augment(0.95)).toBe("auto_apply"); // boundary → upper band
+    expect(augment(0.9)).toBe("propose");
+    expect(augment(0.85)).toBe("propose"); // boundary → middle band
+    expect(augment(0.84)).toBe("create_new"); // uncertain merge → new doc, not a wrong merge
+  });
+
+  it("supersede auto-applies only when very confident, else proposes (never silently replaces)", () => {
+    const sup = (c: number) =>
+      routeConsolidation(
+        judge({ action: "supersede", target_id: "m", title: "t", body: "b", confidence: c }),
+      ).decision;
+    expect(sup(0.96)).toBe("auto_apply");
+    expect(sup(0.9)).toBe("propose");
+    expect(sup(0.5)).toBe("propose");
+  });
+
+  it("archive auto-applies only when very confident, else proposes (never silently removes)", () => {
+    const arch = (c: number) =>
+      routeConsolidation(judge({ action: "archive", target_id: "m", confidence: c })).decision;
+    expect(arch(0.99)).toBe("auto_apply");
+    expect(arch(0.94)).toBe("propose");
+  });
+
+  it("carries the judgment through on the plan", () => {
+    const j = judge({ action: "archive", target_id: "m", confidence: 0.99 });
+    expect(routeConsolidation(j).judgment).toBe(j);
+  });
+
+  it("honours custom thresholds", () => {
+    const j = judge({ action: "augment", target_id: "m", addition: "a", confidence: 0.7 });
+    expect(routeConsolidation(j, { autoApply: 0.8, propose: 0.6 }).decision).toBe("propose");
+  });
+});


### PR DESCRIPTION
## Summary
The **pure half of the consolidator's judge step** (spec 035 §F5: "judge (augment/create/supersede/archive), confidence band ≥0.95 auto / 0.85–0.95 proposal / ≤0.85 new (S12)"), independent of the LLM:

- **`ConsolidationJudgmentSchema` / `parseConsolidationJudgment`** — the LLM's per-submission decision (`create`/`augment`/`supersede`/`archive`/`noop`) is untrusted; parse + strictly validate it (strict objects reject smuggled fields; the error carries issue code+path only, never echoed model text — mirrors `parseCuratorOutput`). One submission → one judgment, unlike the curator's batch.
- **`routeConsolidation`** — maps the judgment + confidence to a routing decision by the three bands, per action:
  - `create` → `auto_apply` (a fresh doc risks nothing existing);
  - `augment` → ≥0.95 `auto_apply` / 0.85–0.95 `propose` / <0.85 `create_new` (an uncertain merge becomes a new doc, never a wrong/under-merge — S12);
  - `supersede`/`archive` → ≥0.95 `auto_apply` / else `propose` (never silently replace or remove existing knowledge — S4 caution / no-clobber).

## Tests
`consolidator-judge.test.ts` (14): parse of each action, code-fence tolerance, non-JSON / unknown-action / missing-field / out-of-range-confidence / smuggled-field rejection; routing for all five actions, band boundaries (0.95→auto, 0.85→propose), plan pass-through, custom thresholds.

## Notes
- The LLM prompt + call (produces the raw judgment) and the edit/apply step (wikilinks, minimal-edit, vault mutation) are separate follow-on increments.
- The per-action band policy is documented + reversible (see commit body).
- Sub-agent review verdict: ship (0 Critical / 0 Important); exhaustiveness is compiler-enforced, untrusted-parse leaks no model text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)