### PR TITLE
feat(consolidator): minimal-edit / no-clobber transforms (Phase 4, G5/S18)

### DIFF
--- a/packages/core/src/consolidator/edit.ts
+++ b/packages/core/src/consolidator/edit.ts
@@ -1,0 +1,37 @@
+// Consolidator — minimal-edit transforms (spec 035 §F5, gaps G5/S18). The
+// consolidator must NEVER rewrite a hand-authored doc: augmenting one ADDS the
+// new information and leaves the existing prose intact. These are pure string
+// transforms over a memory body; the store wiring (read target → augment →
+// write, with this as the guard) is a separate increment.
+//
+// The judge already emits [[wikilinks]] inside the addition, so these transforms
+// are link-agnostic — they only own the append + the no-clobber guarantee.
+
+/**
+ * Minimal-edit augmentation: weave `addition` into `existing` by APPENDING it as
+ * a new paragraph, never rewriting the existing prose. The original content
+ * survives verbatim (it remains a prefix of the result) — the no-clobber
+ * guarantee (G5/S18). Only outer/trailing whitespace is normalised. An empty
+ * addition leaves the doc unchanged; an empty doc becomes just the addition.
+ */
+export function augmentBody(existing: string, addition: string): string {
+  const add = addition.trim();
+  if (!add) return existing;
+  const base = existing.trimEnd();
+  if (!base.trim()) return add;
+  return `${base}\n\n${add}`;
+}
+
+/**
+ * No-clobber backstop (G5, the "git diff is the backstop" check in code): true
+ * iff every non-empty line of `before` still appears in `after`. `augmentBody`
+ * satisfies it by construction; the apply layer uses it to REJECT any edit that
+ * would drop hand-authored content (e.g. a supersede the model over-rewrote).
+ */
+export function preservesOriginal(before: string, after: string): boolean {
+  return before
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .every((line) => after.includes(line));
+}

--- a/packages/core/src/consolidator/edit.ts
+++ b/packages/core/src/consolidator/edit.ts
@@ -27,6 +27,13 @@ export function augmentBody(existing: string, addition: string): string {
  * iff every non-empty line of `before` still appears in `after`. `augmentBody`
  * satisfies it by construction; the apply layer uses it to REJECT any edit that
  * would drop hand-authored content (e.g. a supersede the model over-rewrote).
+ *
+ * This is a per-line SUBSTRING test, not whole-line membership — so a dropped
+ * line whose text coincidentally appears inside a different `after` line passes
+ * (a false positive). That's an accepted backstop limitation (spec §F5 leans on
+ * layered nets — git revert, the review feed, manual merge — not a perfect
+ * proof): it only ever fails to CATCH a clobber, never wrongly rejects a clean
+ * edit, and the primary augment path is clobber-free by construction anyway.
  */
 export function preservesOriginal(before: string, after: string): boolean {
   return before

--- a/packages/core/src/consolidator/index.ts
+++ b/packages/core/src/consolidator/index.ts
@@ -29,3 +29,4 @@ export {
   buildConsolidatorPrompt,
   judgeSubmission,
 } from "./judge-step.js";
+export { augmentBody, preservesOriginal } from "./edit.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -120,10 +120,12 @@ export {
   type ParsedConsolidationJudgment,
   CONSOLIDATOR_PROMPT_VERSION,
   ConsolidationJudgmentSchema,
+  augmentBody,
   buildConsolidatorPrompt,
   judgeSubmission,
   navigateInbox,
   parseConsolidationJudgment,
+  preservesOriginal,
   routeConsolidation,
 } from "./consolidator/index.js";
 export {

--- a/packages/core/tests/consolidator-edit.test.ts
+++ b/packages/core/tests/consolidator-edit.test.ts
@@ -56,4 +56,12 @@ describe("preservesOriginal (no-clobber backstop)", () => {
     expect(preservesOriginal("", "anything")).toBe(true);
     expect(preservesOriginal("   \n ", "anything")).toBe(true);
   });
+
+  it("known limitation: a dropped line that survives inside another line is a false positive (accepted backstop)", () => {
+    // The per-line substring test can't tell a real preservation from a
+    // coincidental cross-line substring. Pinned so a future "fix" is a conscious
+    // contract change, not an accident. Acceptable: it only ever fails to catch a
+    // clobber (never wrongly rejects), and augmentBody is clobber-free anyway.
+    expect(preservesOriginal("cat", "the cat sat")).toBe(true);
+  });
 });

--- a/packages/core/tests/consolidator-edit.test.ts
+++ b/packages/core/tests/consolidator-edit.test.ts
@@ -1,0 +1,59 @@
+// Consolidator minimal-edit / no-clobber transforms (plan 036 Phase 4 / spec
+// 035 §F5, gaps G5/S18). The consolidator must NEVER rewrite a hand-authored
+// doc — augmenting it adds content and leaves the existing prose intact. These
+// are pure string transforms; the store wiring (read target → augment → write)
+// is a separate increment.
+
+import { augmentBody, preservesOriginal } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+describe("augmentBody (minimal-edit append)", () => {
+  it("appends the addition as a new paragraph, preserving the original verbatim", () => {
+    const out = augmentBody("Anna lives in Paris.", "She now works at [[Acme]].");
+    expect(out).toBe("Anna lives in Paris.\n\nShe now works at [[Acme]].");
+    expect(out.startsWith("Anna lives in Paris.")).toBe(true); // original is a prefix → no-clobber
+  });
+
+  it("never drops any line of the existing doc", () => {
+    const existing = "# Anna\n\n- lives in Paris\n- likes tea";
+    const out = augmentBody(existing, "- moved to [[Berlin]] in 2026");
+    for (const line of existing.split("\n").filter((l) => l.trim())) {
+      expect(out).toContain(line);
+    }
+    expect(out).toContain("[[Berlin]]");
+  });
+
+  it("returns just the addition when the existing doc is empty", () => {
+    expect(augmentBody("", "A brand new fact.")).toBe("A brand new fact.");
+    expect(augmentBody("   \n  ", "A brand new fact.")).toBe("A brand new fact.");
+  });
+
+  it("leaves the doc unchanged when there is nothing to add", () => {
+    expect(augmentBody("Existing.", "")).toBe("Existing.");
+    expect(augmentBody("Existing.", "   ")).toBe("Existing.");
+  });
+
+  it("normalises only trailing whitespace, not content", () => {
+    expect(augmentBody("line one\n\n\n", "line two")).toBe("line one\n\nline two");
+  });
+});
+
+describe("preservesOriginal (no-clobber backstop)", () => {
+  it("is true when every non-empty line of the original survives", () => {
+    const before = "fact A\nfact B";
+    expect(preservesOriginal(before, augmentBody(before, "fact C"))).toBe(true);
+  });
+
+  it("is false when a line of the original was dropped (a clobber)", () => {
+    expect(preservesOriginal("fact A\nfact B", "fact A\nfact C")).toBe(false);
+  });
+
+  it("ignores blank lines + outer whitespace in the original", () => {
+    expect(preservesOriginal("\n  fact A  \n\n", "intro\nfact A\nmore")).toBe(true);
+  });
+
+  it("is vacuously true for an empty original", () => {
+    expect(preservesOriginal("", "anything")).toBe(true);
+    expect(preservesOriginal("   \n ", "anything")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
The consolidator must **never rewrite a hand-authored doc** (spec 035 §F5, gaps G5/S18). Two pure string transforms:

- **`augmentBody(existing, addition)`** — append the addition as a new paragraph, preserving the existing prose **verbatim** (the original stays a prefix of the result; only outer whitespace is normalised). Empty addition → unchanged; empty doc → just the addition.
- **`preservesOriginal(before, after)`** — the no-clobber backstop ("git diff is the backstop", in code): true iff every non-empty line of `before` survives in `after`. The apply layer uses it to reject any edit that drops hand-authored content.

The judge already emits `[[wikilinks]]` inside the addition, so these stay link-agnostic. The store wiring (read target → augment → guard → write) is the next increment.

## Tests
`consolidator-edit.test.ts` (10): append + verbatim-prefix preservation, never-drops-a-line, empty doc / empty addition, trailing-whitespace normalisation; `preservesOriginal` true/false/vacuous + the **pinned, accepted** substring-false-positive limitation.

## Review note
Sub-agent review: ship (0 Critical / 0 Important). Applied its two suggestions: documented that `preservesOriginal` is a per-line *substring* test (an accepted backstop limitation — only ever fails to catch a clobber, never wrongly rejects) and pinned it with a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)