### PR TITLE
feat(consolidator): per-item orchestrator — claim→navigate→judge→apply→complete (Phase 4)

### DIFF
--- a/packages/core/src/consolidator/consolidate.ts
+++ b/packages/core/src/consolidator/consolidate.ts
@@ -48,7 +48,12 @@ export type ConsolidateResult =
  * Consolidate a single pending inbox item. Claims it (once-only); on a lost race
  * returns `claimed_by_other`. On an unusable model response returns `judge_error`
  * and LEAVES the claim in `.processing/` for the boot reaper to retry. Otherwise
- * applies the plan and completes (removes) the item.
+ * applies the plan and completes (removes) the item — INCLUDING when apply
+ * returns `{kind:"rejected"}`: a rejection is treated as terminal and the item is
+ * still removed (it won't be retried). This intentionally trades the rare
+ * transient-store-error drop for never looping on a permanent rejection (e.g. a
+ * protected target). Distinguishing retryable vs terminal rejections (so the
+ * former leaves the claim) is a follow-up that needs apply to tag the outcome.
  */
 export async function consolidateInboxItem(
   pendingRelPath: string,
@@ -81,6 +86,8 @@ export async function consolidateInboxItem(
     ...(deps.onError ? { onError: deps.onError } : {}),
   };
   const outcome = applyConsolidationPlan(judged.plan, applyDeps);
+  // Complete on ANY outcome, including `rejected` — see the contract note above:
+  // a rejection is terminal (won't be retried), so the item is removed.
   completeInboxItem(deps.vault, claimed);
   return { status: "consolidated", outcome };
 }

--- a/packages/core/src/consolidator/consolidate.ts
+++ b/packages/core/src/consolidator/consolidate.ts
@@ -1,0 +1,86 @@
+// Consolidator — the per-item orchestrator (spec 035 §F5). Composes the inbox
+// queue + the pipeline into one callable: claim → parse → navigate → judge →
+// apply → complete. The scheduler (boot-scan + 5-min tick + chokidar) drives
+// this over the inbox; it's a separate increment.
+//
+// Everything it needs is injected (vault, recall, listActive, llmClient, store),
+// so it's testable end-to-end with a temp vault + fakes — no network, no real
+// index. A claim lost to another worker, or an unusable model response, returns
+// a value-free status rather than throwing.
+
+import type { LlmClient } from "../curator-llm-client.js";
+import { claimInboxItem, completeInboxItem, parseInboxItem } from "../store/corpus/inbox.js";
+import type { Vault } from "../store/corpus/vault.js";
+import type { Memory } from "../store/memory-store.js";
+import {
+  type ApplyConsolidationDeps,
+  type ConsolidationOutcome,
+  type ConsolidatorApplyStore,
+  applyConsolidationPlan,
+} from "./apply.js";
+import { judgeSubmission } from "./judge-step.js";
+import type { ConsolidationThresholds } from "./judge.js";
+import { navigateInbox } from "./navigate.js";
+
+export interface ConsolidateInboxItemDeps {
+  vault: Vault;
+  /** Index-backed recall over active memories (store.recall, narrowed). */
+  recall: (query: string, limit: number) => Promise<Memory[]>;
+  /** The active corpus, in listing order (store.listAll({status:"active"})). */
+  listActive: () => Memory[];
+  llmClient: LlmClient;
+  store: ConsolidatorApplyStore;
+  /** Actor id that owns consolidator writes (e.g. "system-consolidator"). */
+  actorId: string;
+  thresholds?: ConsolidationThresholds;
+  /** Clock (epoch ms) for the atomic claim; defaults to Date.now via the inbox. */
+  now?: () => number;
+  /** Optional sink for a swallowed apply error (forwarded to applyConsolidationPlan). */
+  onError?: (error: unknown) => void;
+}
+
+export type ConsolidateResult =
+  | { status: "claimed_by_other" }
+  | { status: "consolidated"; outcome: ConsolidationOutcome }
+  | { status: "judge_error"; parseError: string };
+
+/**
+ * Consolidate a single pending inbox item. Claims it (once-only); on a lost race
+ * returns `claimed_by_other`. On an unusable model response returns `judge_error`
+ * and LEAVES the claim in `.processing/` for the boot reaper to retry. Otherwise
+ * applies the plan and completes (removes) the item.
+ */
+export async function consolidateInboxItem(
+  pendingRelPath: string,
+  deps: ConsolidateInboxItemDeps,
+): Promise<ConsolidateResult> {
+  const claimed = claimInboxItem(deps.vault, pendingRelPath, deps.now ? { now: deps.now } : {});
+  if (!claimed) return { status: "claimed_by_other" };
+
+  const item = parseInboxItem(deps.vault.readText(claimed));
+
+  const evidence = await navigateInbox(item.text, {
+    recall: deps.recall,
+    listActive: deps.listActive,
+  });
+  const judged = await judgeSubmission(
+    { submissionText: item.text, evidence },
+    { llmClient: deps.llmClient, ...(deps.thresholds ? { thresholds: deps.thresholds } : {}) },
+  );
+  if (!judged.plan) {
+    // The model output was unusable — leave the claim for the reaper to retry
+    // rather than dropping the submission. (A persistently-failing model loops
+    // on the reaper TTL; that's the degenerate case, not the norm.)
+    return { status: "judge_error", parseError: judged.parseError ?? "no plan" };
+  }
+
+  const applyDeps: ApplyConsolidationDeps = {
+    store: deps.store,
+    submissionText: item.text,
+    actorId: deps.actorId,
+    ...(deps.onError ? { onError: deps.onError } : {}),
+  };
+  const outcome = applyConsolidationPlan(judged.plan, applyDeps);
+  completeInboxItem(deps.vault, claimed);
+  return { status: "consolidated", outcome };
+}

--- a/packages/core/src/consolidator/index.ts
+++ b/packages/core/src/consolidator/index.ts
@@ -37,3 +37,8 @@ export {
   type ConsolidatorStoredMemory,
   applyConsolidationPlan,
 } from "./apply.js";
+export {
+  type ConsolidateInboxItemDeps,
+  type ConsolidateResult,
+  consolidateInboxItem,
+} from "./consolidate.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -107,6 +107,8 @@ export {
 export {
   type ApplyConsolidationDeps,
   type BuildConsolidatorPromptInput,
+  type ConsolidateInboxItemDeps,
+  type ConsolidateResult,
   type ConsolidationCandidates,
   type ConsolidationDecision,
   type ConsolidationJudgment,
@@ -127,6 +129,7 @@ export {
   applyConsolidationPlan,
   augmentBody,
   buildConsolidatorPrompt,
+  consolidateInboxItem,
   judgeSubmission,
   navigateInbox,
   parseConsolidationJudgment,

--- a/packages/core/tests/consolidator-consolidate.test.ts
+++ b/packages/core/tests/consolidator-consolidate.test.ts
@@ -29,17 +29,28 @@ afterEach(() => {
   fs.rmSync(dataDir, { recursive: true, force: true });
 });
 
-function fakeStore() {
-  const calls = { create: [] as Record<string, unknown>[] };
+function fakeStore(seed: Record<string, { title: string; body: string }> = {}) {
+  const docs = new Map(Object.entries(seed));
+  const calls = {
+    create: [] as Record<string, unknown>[],
+    update: [] as { id: string; patch?: Record<string, unknown> }[],
+    archive: [] as string[],
+  };
   let n = 0;
   const store: ConsolidatorApplyStore = {
     createMemory: (input) => {
       calls.create.push(input);
       return { memory: { id: `mem_${n++}` } };
     },
-    updateMemory: () => null,
-    archiveMemory: () => null,
-    getMemory: () => null,
+    updateMemory: (id, patch) => {
+      calls.update.push({ id, ...(patch ? { patch } : {}) });
+      return null;
+    },
+    archiveMemory: (id) => {
+      calls.archive.push(id);
+      return null;
+    },
+    getMemory: (id) => docs.get(id) ?? null,
   };
   return { store, calls };
 }
@@ -130,5 +141,57 @@ describe("consolidateInboxItem", () => {
 
     expect(result).toMatchObject({ status: "consolidated", outcome: { kind: "created_new" } });
     expect(calls.create[0]).toMatchObject({ body: "Maybe Anna likes tea." });
+  });
+
+  it("applies a high-confidence augment via updateMemory (appended body) and completes", async () => {
+    const ref = writeInbox(vault, "Anna moved to Berlin", {
+      now: () => 1000,
+      generateId: () => "inbox_a",
+    });
+    const { store, calls } = fakeStore({ mem_anna: { title: "Anna", body: "Lives in Paris." } });
+    const client = fakeClient(
+      JSON.stringify({
+        action: "augment",
+        target_id: "mem_anna",
+        addition: "Now in [[Berlin]].",
+        rationale: "adds the move",
+        confidence: 0.97,
+      }),
+    );
+
+    const result = await consolidateInboxItem(ref.relPath, baseDeps(store, client));
+
+    expect(result).toMatchObject({
+      status: "consolidated",
+      outcome: { kind: "augmented", id: "mem_anna" },
+    });
+    const body = String(calls.update[0]?.patch?.body ?? "");
+    expect(body.startsWith("Lives in Paris.")).toBe(true); // no-clobber
+    expect(body).toContain("[[Berlin]]");
+    expect(listInbox(vault)).toEqual([]); // completed
+  });
+
+  it("completes (removes) the item even when apply rejects — a rejection is terminal", async () => {
+    const ref = writeInbox(vault, "archive that", { now: () => 1000, generateId: () => "inbox_a" });
+    const { store } = fakeStore(); // empty → the archive target is missing → rejected
+    const result = await consolidateInboxItem(
+      ref.relPath,
+      baseDeps(
+        store,
+        fakeClient(
+          JSON.stringify({
+            action: "archive",
+            target_id: "ghost",
+            rationale: "r",
+            confidence: 0.99,
+          }),
+        ),
+      ),
+    );
+
+    expect(result).toMatchObject({ status: "consolidated", outcome: { kind: "rejected" } });
+    // Terminal: removed, NOT left in .processing for retry (the documented v1 tradeoff).
+    expect(listInbox(vault)).toEqual([]);
+    expect(vault.listMarkdown("inbox/.processing")).toEqual([]);
   });
 });

--- a/packages/core/tests/consolidator-consolidate.test.ts
+++ b/packages/core/tests/consolidator-consolidate.test.ts
@@ -1,0 +1,134 @@
+// Consolidator per-item orchestrator (plan 036 Phase 4 / spec 035 §F5). Drives
+// the whole pipeline over one inbox item against a REAL temp vault + fakes:
+// claim → parse → navigate → judge → apply → complete. No network (fake LLM),
+// no real index (fake recall/listActive).
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type ConsolidatorApplyStore,
+  type LlmClient,
+  type Vault,
+  claimInboxItem,
+  consolidateInboxItem,
+  createVault,
+  listInbox,
+  writeInbox,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let vault: Vault;
+let dataDir = "";
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-consolidate-"));
+  vault = createVault({ dataDir });
+});
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+function fakeStore() {
+  const calls = { create: [] as Record<string, unknown>[] };
+  let n = 0;
+  const store: ConsolidatorApplyStore = {
+    createMemory: (input) => {
+      calls.create.push(input);
+      return { memory: { id: `mem_${n++}` } };
+    },
+    updateMemory: () => null,
+    archiveMemory: () => null,
+    getMemory: () => null,
+  };
+  return { store, calls };
+}
+
+function fakeClient(content: string): LlmClient {
+  return { complete: async () => ({ content, model: "gpt-x", usage: null }) };
+}
+
+function baseDeps(store: ConsolidatorApplyStore, llmClient: LlmClient) {
+  return {
+    vault,
+    recall: async () => [],
+    listActive: () => [],
+    llmClient,
+    store,
+    actorId: "system-consolidator",
+  };
+}
+
+describe("consolidateInboxItem", () => {
+  it("consolidates an item end-to-end: claim → judge → apply → complete", async () => {
+    const ref = writeInbox(vault, "Anna moved to Berlin.", {
+      now: () => 1000,
+      generateId: () => "inbox_a",
+    });
+    const { store, calls } = fakeStore();
+    const client = fakeClient(
+      JSON.stringify({
+        action: "create",
+        title: "Anna",
+        body: "Anna lives in Berlin.",
+        tags: ["person"],
+        rationale: "novel topic",
+        confidence: 0.97,
+      }),
+    );
+
+    const result = await consolidateInboxItem(ref.relPath, baseDeps(store, client));
+
+    expect(result).toMatchObject({ status: "consolidated", outcome: { kind: "created" } });
+    expect(calls.create[0]).toMatchObject({ title: "Anna", body: "Anna lives in Berlin." });
+    // The item was completed — gone from the inbox, no stale claim left.
+    expect(listInbox(vault)).toEqual([]);
+    expect(vault.listMarkdown("inbox/.processing")).toEqual([]);
+  });
+
+  it("returns claimed_by_other when the item is already claimed", async () => {
+    const ref = writeInbox(vault, "x", { now: () => 1000, generateId: () => "inbox_a" });
+    claimInboxItem(vault, ref.relPath, { now: () => 2000 }); // someone else won it
+    const { store } = fakeStore();
+    const result = await consolidateInboxItem(ref.relPath, baseDeps(store, fakeClient("{}")));
+    expect(result).toEqual({ status: "claimed_by_other" });
+  });
+
+  it("leaves the claim for retry on an unusable model response (judge_error)", async () => {
+    const ref = writeInbox(vault, "some fact", { now: () => 1000, generateId: () => "inbox_a" });
+    const { store, calls } = fakeStore();
+    const result = await consolidateInboxItem(
+      ref.relPath,
+      baseDeps(store, fakeClient("not json at all")),
+    );
+
+    expect(result.status).toBe("judge_error");
+    expect(calls.create.length).toBe(0); // nothing applied
+    // Not completed — still claimed in .processing for the reaper to retry.
+    expect(vault.listMarkdown("inbox/.processing").length).toBe(1);
+    expect(listInbox(vault)).toEqual([]); // not back in pending yet (reaper's job)
+  });
+
+  it("routes a low-confidence augment to a new doc rather than touching the target", async () => {
+    const ref = writeInbox(vault, "Maybe Anna likes tea.", {
+      now: () => 1000,
+      generateId: () => "inbox_a",
+    });
+    const { store, calls } = fakeStore();
+    // augment at 0.5 → below the propose floor → create_new (S12).
+    const client = fakeClient(
+      JSON.stringify({
+        action: "augment",
+        target_id: "mem_anna",
+        addition: "likes tea",
+        rationale: "uncertain",
+        confidence: 0.5,
+      }),
+    );
+
+    const result = await consolidateInboxItem(ref.relPath, baseDeps(store, client));
+
+    expect(result).toMatchObject({ status: "consolidated", outcome: { kind: "created_new" } });
+    expect(calls.create[0]).toMatchObject({ body: "Maybe Anna likes tea." });
+  });
+});


### PR DESCRIPTION
## Summary
`consolidateInboxItem(pendingRelPath, deps)` — the per-item orchestrator (spec 035 §F5) that composes the inbox queue + the pipeline into one callable: atomic-claim → `parseInboxItem` → `navigateInbox` → `judgeSubmission` → `applyConsolidationPlan` → `completeInboxItem`. Everything injected (vault, recall, listActive, llmClient, store), so it's tested **end-to-end against a real temp vault + fakes** — no network, no real index.

Lifecycle / durability:
- **lost claim** → `{status:"claimed_by_other"}` (no mutation).
- **unusable model output** → `{status:"judge_error"}`; the claim is **left** in `.processing/` for the boot reaper to retry (the submission is never dropped).
- otherwise apply + complete → `{status:"consolidated", outcome}`. A `rejected` apply outcome is **terminal** — the item is still completed/removed (documented tradeoff: avoids looping forever on a permanent rejection like a protected/missing target, at the cost of dropping on the rare transient store error; retryable-tagging is a follow-up).

## Tests
`consolidator-consolidate.test.ts` (6): end-to-end create, claimed_by_other, judge_error-leaves-claim, low-confidence augment → create_new (S12), high-confidence augment → `updateMemory` with no-clobber appended body, and **rejected → still-completed** (pins the terminal-drop tradeoff).

## Review note
Sub-agent review: fix-then-ship (0 Critical). Applied all three: documented the rejected→completed drop at the call site + docstring, and added the two coverage tests above (the rejected-drop and the updateMemory-mutation paths were previously uncovered).

## Notes
- The scheduler (boot-scan + 5-min tick + chokidar) that drives this over the inbox, and the `createLibrarianStore` wiring (recall/listActive/store adapters + a `system-consolidator` actor), are the next increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)