### PR TITLE
feat(consolidator): inbox sweep — reap + FIFO process the whole inbox (Phase 4)

### DIFF
--- a/packages/core/src/consolidator/index.ts
+++ b/packages/core/src/consolidator/index.ts
@@ -42,3 +42,4 @@ export {
   type ConsolidateResult,
   consolidateInboxItem,
 } from "./consolidate.js";
+export { type ConsolidatorSweepDeps, type SweepSummary, runConsolidatorSweep } from "./sweep.js";

--- a/packages/core/src/consolidator/sweep.ts
+++ b/packages/core/src/consolidator/sweep.ts
@@ -1,0 +1,67 @@
+// Consolidator — inbox sweep (spec 035 §F5 / Open-Q #2). Processes the whole
+// inbox once: reclaim crashed-worker claims, then walk the pending items in FIFO
+// order through `consolidateInboxItem` one at a time (serial — batching is
+// deferred). This is the single entry point the boot scan, the 5-minute
+// safety-net tick, and the chokidar watcher all call; the scheduler that wires
+// those triggers is a separate increment.
+//
+// One item's failure never aborts the sweep: a thrown LLM/transport error leaves
+// that item's claim in `.processing/` for the next sweep's reaper to retry.
+
+import { listInbox, releaseStaleClaims } from "../store/corpus/inbox.js";
+import { type ConsolidateInboxItemDeps, consolidateInboxItem } from "./consolidate.js";
+
+// A claim still in `.processing/` past this age is treated as a crashed worker
+// and reclaimed (matches the curator's lock TTL). With a serial single-process
+// sweep, this only fires after a real crash.
+const DEFAULT_LOCK_TTL_MS = 60 * 60_000; // 60 minutes
+
+export interface ConsolidatorSweepDeps extends ConsolidateInboxItemDeps {
+  /** Claims older than this are reclaimed before the sweep (default 60 min). */
+  lockTtlMs?: number;
+}
+
+export interface SweepSummary {
+  /** Stale claims returned to the pending queue before processing. */
+  reclaimed: number;
+  /** Items applied + completed. */
+  consolidated: number;
+  /** Items left claimed because the model output was unusable (reaper retries). */
+  judgeErrors: number;
+  /** Items a concurrent worker had already claimed. */
+  claimedByOther: number;
+  /** Items whose processing threw (LLM/transport); claim left for retry. */
+  errored: number;
+}
+
+export async function runConsolidatorSweep(deps: ConsolidatorSweepDeps): Promise<SweepSummary> {
+  const nowMs = (deps.now ?? Date.now)();
+  const reclaimed = releaseStaleClaims(deps.vault, {
+    olderThanMs: deps.lockTtlMs ?? DEFAULT_LOCK_TTL_MS,
+    now: nowMs,
+  }).length;
+
+  const summary: SweepSummary = {
+    reclaimed,
+    consolidated: 0,
+    judgeErrors: 0,
+    claimedByOther: 0,
+    errored: 0,
+  };
+
+  // Serial FIFO over the (reclaimed-inclusive) pending snapshot. One item at a time.
+  for (const pendingPath of listInbox(deps.vault)) {
+    try {
+      const result = await consolidateInboxItem(pendingPath, deps);
+      if (result.status === "consolidated") summary.consolidated++;
+      else if (result.status === "judge_error") summary.judgeErrors++;
+      else summary.claimedByOther++;
+    } catch (error) {
+      // A thrown LLM/transport error leaves the claim in `.processing/` (the
+      // next sweep's reaper retries); never abort the rest of the batch.
+      deps.onError?.(error);
+      summary.errored++;
+    }
+  }
+  return summary;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -117,6 +117,7 @@ export {
   type ConsolidationThresholds,
   type ConsolidatorApplyStore,
   type ConsolidatorStoredMemory,
+  type ConsolidatorSweepDeps,
   type ConsolidatorTocEntry,
   type JudgeSubmissionDeps,
   type JudgeSubmissionInput,
@@ -124,6 +125,7 @@ export {
   type NavigateDeps,
   type NavigateOptions,
   type ParsedConsolidationJudgment,
+  type SweepSummary,
   CONSOLIDATOR_PROMPT_VERSION,
   ConsolidationJudgmentSchema,
   applyConsolidationPlan,
@@ -135,6 +137,7 @@ export {
   parseConsolidationJudgment,
   preservesOriginal,
   routeConsolidation,
+  runConsolidatorSweep,
 } from "./consolidator/index.js";
 export {
   type LlmClient,

--- a/packages/core/tests/consolidator-sweep.test.ts
+++ b/packages/core/tests/consolidator-sweep.test.ts
@@ -126,6 +126,26 @@ describe("runConsolidatorSweep", () => {
     expect(vault.listMarkdown("inbox/.processing").length).toBe(1);
   });
 
+  it("tallies a mixed batch (consolidated + judge_error + errored) correctly", async () => {
+    write("good", 1000, "a");
+    write("bad", 1001, "b");
+    write("boom", 1002, "c");
+    const client: LlmClient = {
+      complete: async (req: LlmCompletionRequest) => {
+        const sub = req.messages[1]?.content ?? "";
+        if (sub.includes("boom")) throw new Error("llm down");
+        if (sub.includes("bad")) return { content: "not json", model: "x", usage: null };
+        return { content: CREATE_JUDGMENT, model: "x", usage: null };
+      },
+    };
+
+    const summary = await runConsolidatorSweep(deps(client));
+
+    expect(summary).toMatchObject({ consolidated: 1, judgeErrors: 1, errored: 1, reclaimed: 0 });
+    // "good" completed; "bad" + "boom" left claimed for the reaper.
+    expect(vault.listMarkdown("inbox/.processing").length).toBe(2);
+  });
+
   it("a thrown error is caught (errored) and the rest of the batch still runs", async () => {
     write("boom", 1000, "a");
     write("fine", 1001, "b");

--- a/packages/core/tests/consolidator-sweep.test.ts
+++ b/packages/core/tests/consolidator-sweep.test.ts
@@ -1,0 +1,151 @@
+// Consolidator inbox sweep (plan 036 Phase 4 / spec 035 §F5). Processes the
+// whole inbox once over a real temp vault + fakes: reclaim stale claims, then
+// FIFO over pending items via consolidateInboxItem. Pins ordering, the reaper
+// integration, and that one item's failure never aborts the rest.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type ConsolidatorApplyStore,
+  type LlmClient,
+  type LlmCompletionRequest,
+  type Vault,
+  claimInboxItem,
+  createVault,
+  listInbox,
+  runConsolidatorSweep,
+  writeInbox,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let vault: Vault;
+let dataDir = "";
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-sweep-"));
+  vault = createVault({ dataDir });
+});
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+const CREATE_JUDGMENT = JSON.stringify({
+  action: "create",
+  title: "T",
+  body: "B",
+  tags: [],
+  rationale: "novel",
+  confidence: 0.97,
+});
+
+function fakeStore(): ConsolidatorApplyStore {
+  let n = 0;
+  return {
+    createMemory: () => ({ memory: { id: `mem_${n++}` } }),
+    updateMemory: () => null,
+    archiveMemory: () => null,
+    getMemory: () => null,
+  };
+}
+
+/** A fake LLM that records the submission text from each prompt it's called with. */
+function capturingClient(content: string): { client: LlmClient; submissions: string[] } {
+  const submissions: string[] = [];
+  return {
+    client: {
+      complete: async (req: LlmCompletionRequest) => {
+        const user = req.messages[1]?.content ?? "";
+        submissions.push(user.split("\n")[1] ?? ""); // the line under "SUBMISSION (...):"
+        return { content, model: "gpt-x", usage: null };
+      },
+    },
+    submissions,
+  };
+}
+
+function deps(client: LlmClient, extra: Record<string, unknown> = {}) {
+  return {
+    vault,
+    recall: async () => [],
+    listActive: () => [],
+    llmClient: client,
+    store: fakeStore(),
+    actorId: "system-consolidator",
+    ...extra,
+  };
+}
+
+function write(text: string, ms: number, id: string) {
+  return writeInbox(vault, text, { now: () => ms, generateId: () => id });
+}
+
+describe("runConsolidatorSweep", () => {
+  it("processes every pending item in FIFO order and empties the inbox", async () => {
+    write("first", 1000, "a");
+    write("second", 1001, "b");
+    write("third", 1002, "c");
+    const { client, submissions } = capturingClient(CREATE_JUDGMENT);
+
+    const summary = await runConsolidatorSweep(deps(client));
+
+    expect(summary.consolidated).toBe(3);
+    expect(submissions).toEqual(["first", "second", "third"]); // FIFO
+    expect(listInbox(vault)).toEqual([]);
+    expect(vault.listMarkdown("inbox/.processing")).toEqual([]);
+  });
+
+  it("reclaims a stale claim, then processes it", async () => {
+    const ref = write("stranded", 1000, "a");
+    claimInboxItem(vault, ref.relPath, { now: () => 10_000 }); // claimed long ago
+
+    const { client } = capturingClient(CREATE_JUDGMENT);
+    const summary = await runConsolidatorSweep(
+      deps(client, { lockTtlMs: 60_000, now: () => 10_000 + 30 * 60_000 }),
+    );
+
+    expect(summary.reclaimed).toBe(1);
+    expect(summary.consolidated).toBe(1);
+    expect(listInbox(vault)).toEqual([]);
+  });
+
+  it("does nothing on an empty inbox", async () => {
+    const { client } = capturingClient(CREATE_JUDGMENT);
+    expect(await runConsolidatorSweep(deps(client))).toMatchObject({
+      reclaimed: 0,
+      consolidated: 0,
+    });
+  });
+
+  it("tallies a judge error and leaves that item's claim for retry", async () => {
+    write("bad", 1000, "a");
+    const { client } = capturingClient("not json");
+    const summary = await runConsolidatorSweep(deps(client));
+    expect(summary.judgeErrors).toBe(1);
+    expect(summary.consolidated).toBe(0);
+    expect(vault.listMarkdown("inbox/.processing").length).toBe(1);
+  });
+
+  it("a thrown error is caught (errored) and the rest of the batch still runs", async () => {
+    write("boom", 1000, "a");
+    write("fine", 1001, "b");
+    // Throw on the first submission, succeed on the rest.
+    const client: LlmClient = {
+      complete: async (req: LlmCompletionRequest) => {
+        if ((req.messages[1]?.content ?? "").includes("boom")) throw new Error("llm down");
+        return { content: CREATE_JUDGMENT, model: "x", usage: null };
+      },
+    };
+    const errors: unknown[] = [];
+
+    const summary = await runConsolidatorSweep(
+      deps(client, { onError: (e: unknown) => errors.push(e) }),
+    );
+
+    expect(summary.errored).toBe(1);
+    expect(summary.consolidated).toBe(1); // "fine" still processed
+    expect(errors).toHaveLength(1);
+    // The thrown item stays claimed for the reaper; the good one is gone.
+    expect(vault.listMarkdown("inbox/.processing").length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
`runConsolidatorSweep(deps)` (spec 035 §F5) — the single "process the inbox once" entry point the boot scan, the 5-minute safety-net tick, and the chokidar watcher will all call:

1. `releaseStaleClaims` (the reaper) — return crashed-worker claims to the pending queue.
2. FIFO over `listInbox(vault)` through `consolidateInboxItem`, **one item at a time** (serial; batching deferred).

Returns `{reclaimed, consolidated, judgeErrors, claimedByOther, errored}`. One item's failure never aborts the sweep: a thrown LLM/transport error is caught (→ `errored`, forwarded to `onError`) and leaves that item's claim in `.processing/` for the next sweep's reaper to retry.

## Tests
`consolidator-sweep.test.ts` (6) over a real temp vault + fakes: FIFO order, reclaim-then-process, empty inbox, judge-error pass-through, **mixed-outcome tally** (consolidated + judge_error + errored in one run), and error-isolation (a throwing item doesn't stop the rest).

## Review note
Sub-agent review: ship (0 Critical / 0 Important). Confirmed: snapshot-loop safety (a vanished path re-claims → `claimed_by_other`), reaper-then-list ordering, exhaustive tallies, and error isolation mirroring `curator-enqueue`. Added the mixed-outcome test per its suggestion.

## Notes
- The scheduler that wires the 5-min tick + chokidar watcher + boot-scan triggers, plus the `createLibrarianStore` adapters (recall/listActive/store + a `system-consolidator` actor + a `writeInbox` path), is the next increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)