### PR TITLE
feat(consolidator): wire submitToInbox + consolidateInbox into the markdown store (Phase 4)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -297,6 +297,7 @@ export {
 export { type MemoryWriteVerdict, routeMemoryWrite } from "./store/memory-routing.js";
 export type { Memory, MemoryStore, MemoryStoreDeps } from "./store/memory-store.js";
 export {
+  type ConsolidateInboxOptions,
   type InternalLibrarianStore,
   type LibrarianStore,
   type LibrarianStoreOptions,

--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -1,12 +1,19 @@
 import fs from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
+import {
+  type ConsolidationThresholds,
+  type SweepSummary,
+  runConsolidatorSweep,
+} from "../consolidator/index.js";
+import type { LlmClient } from "../curator-llm-client.js";
 import { createVaultCuratorMemorySource } from "../curator-source-vault.js";
+import { MemoryStatus } from "../schemas/common.js";
 import {
   type ConversationStateStore,
   createConversationStateStore,
 } from "./conversation-state-store.js";
-import { createVault } from "./corpus/index.js";
+import { createVault, writeInbox } from "./corpus/index.js";
 import {
   buildCorpusIndex,
   recallMemories,
@@ -85,11 +92,34 @@ export interface LibrarianStore extends MemoryStore, CurationStore, SettingsStor
    * filter-only (no-query) call falls back to searchMemories on both.
    */
   recall(input?: Record<string, unknown>): Promise<Memory[]>;
+  /**
+   * Submit raw text to the consolidator inbox (markdown backend only — the inbox
+   * lives in the vault). Fire-and-forget: stored + committed instantly; the
+   * consolidator files it asynchronously. Throws on the sqlite backend.
+   */
+  submitToInbox(text: string): { relPath: string; id: string };
+  /**
+   * Run the consolidator over the inbox once — reap stale claims, then FIFO
+   * through navigate→judge→apply (markdown backend only). The LLM client is
+   * injected by the caller (built from admin config). Returns a sweep summary.
+   */
+  consolidateInbox(deps: ConsolidateInboxOptions): Promise<SweepSummary>;
   dataDir: string;
   close(): void;
   /** Backend-neutral maintenance verb: rebuild the disposable memory index. */
   reindex(): void;
 }
+
+/** Options for `LibrarianStore.consolidateInbox`. */
+export interface ConsolidateInboxOptions {
+  llmClient: LlmClient;
+  thresholds?: ConsolidationThresholds;
+  /** Stale-claim TTL for the reaper (defaults to the sweep's 60 min). */
+  lockTtlMs?: number;
+}
+
+/** Actor id that owns consolidator writes (common-slice, system-owned). */
+const CONSOLIDATOR_ACTOR_ID = "system-consolidator";
 
 /**
  * The concrete store, which also exposes the raw SQLite handle and event-ledger
@@ -190,6 +220,22 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Inter
       db,
       memorySource: createVaultCuratorMemorySource(markdownMemory),
     });
+    // Index-backed recall, extracted so the consolidator's navigate step can
+    // reuse the exact same recall the `recall` verb uses.
+    const storeRecall = async (input: Record<string, unknown> = {}): Promise<Memory[]> => {
+      const query = typeof input.query === "string" ? input.query : "";
+      // filter-only (no query) stays on the keyword path
+      if (!query.trim()) return markdownMemory.searchMemories(input);
+      return recallMemories(
+        { index: await corpusIndex(), getMemory: (id) => markdownMemory.getMemory(id) },
+        query,
+        {
+          projectKey: typeof input.project_key === "string" ? input.project_key : undefined,
+          tags: Array.isArray(input.tags) ? (input.tags as string[]) : undefined,
+          limit: typeof input.limit === "number" ? input.limit : undefined,
+        },
+      );
+    };
     return {
       ...markdownMemory,
       ...residualCuration,
@@ -198,19 +244,28 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Inter
       handoffs: markdownHandoffs,
       skills: createSkillStore(vault),
       searchReferences: (query, limit) => searchVaultReferences(vault, embedder, query, limit),
-      recall: async (input = {}) => {
-        const query = typeof input.query === "string" ? input.query : "";
-        // filter-only (no query) stays on the keyword path
-        if (!query.trim()) return markdownMemory.searchMemories(input);
-        return recallMemories(
-          { index: await corpusIndex(), getMemory: (id) => markdownMemory.getMemory(id) },
-          query,
-          {
-            projectKey: typeof input.project_key === "string" ? input.project_key : undefined,
-            tags: Array.isArray(input.tags) ? (input.tags as string[]) : undefined,
-            limit: typeof input.limit === "number" ? input.limit : undefined,
-          },
-        );
+      recall: storeRecall,
+      submitToInbox: (text: string) => {
+        const ref = writeInbox(vault, text);
+        commit(`inbox: submit ${ref.id}`); // durable + committed instantly
+        return ref;
+      },
+      consolidateInbox: async (deps): Promise<SweepSummary> => {
+        const summary = await runConsolidatorSweep({
+          vault,
+          recall: (q, n) => storeRecall({ query: q, limit: n }),
+          listActive: () => markdownMemory.listAll({ status: MemoryStatus.Active }),
+          store: markdownMemory,
+          actorId: CONSOLIDATOR_ACTOR_ID,
+          llmClient: deps.llmClient,
+          ...(deps.thresholds ? { thresholds: deps.thresholds } : {}),
+          ...(deps.lockTtlMs !== undefined ? { lockTtlMs: deps.lockTtlMs } : {}),
+        });
+        // The apply path commits per memory write; commit once more to capture
+        // the inbox claim/complete moves a no-op or judge-error sweep leaves
+        // behind (commitAll is a no-op when the tree is already clean).
+        commit("inbox: consolidate sweep");
+        return summary;
       },
       dataDir,
       eventsPath,
@@ -257,6 +312,12 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Inter
       searchVaultReferences(createVault({ dataDir, create: false }), embedder, query, limit),
     // sqlite recall is the keyword searchMemories (no markdown vault to index)
     recall: (input = {}) => Promise.resolve(memoryStore.searchMemories(input)),
+    // The consolidator inbox lives in the markdown vault — not available on sqlite.
+    submitToInbox: () => {
+      throw new Error("the consolidator inbox requires the markdown backend");
+    },
+    consolidateInbox: () =>
+      Promise.reject(new Error("the consolidator requires the markdown backend")),
     dataDir,
     eventsPath,
     dbPath,

--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -13,7 +13,7 @@ import {
   type ConversationStateStore,
   createConversationStateStore,
 } from "./conversation-state-store.js";
-import { createVault, writeInbox } from "./corpus/index.js";
+import { type InboxItemRef, createVault, writeInbox } from "./corpus/index.js";
 import {
   buildCorpusIndex,
   recallMemories,
@@ -97,7 +97,7 @@ export interface LibrarianStore extends MemoryStore, CurationStore, SettingsStor
    * lives in the vault). Fire-and-forget: stored + committed instantly; the
    * consolidator files it asynchronously. Throws on the sqlite backend.
    */
-  submitToInbox(text: string): { relPath: string; id: string };
+  submitToInbox(text: string): InboxItemRef;
   /**
    * Run the consolidator over the inbox once — reap stale claims, then FIFO
    * through navigate→judge→apply (markdown backend only). The LLM client is
@@ -251,6 +251,12 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Inter
         return ref;
       },
       consolidateInbox: async (deps): Promise<SweepSummary> => {
+        // PERF: each applied item invalidates the recall index (onWrite) and the
+        // next item's navigate rebuilds + re-embeds the corpus; listActive also
+        // re-reads the vault per item. Correct (later items see earlier filings,
+        // S1/G6) but ~O(items) rebuilds — batch/defer index invalidation across a
+        // sweep when the real embedder makes this a hot spot. Fine while sweeps
+        // are serial + off the hot path.
         const summary = await runConsolidatorSweep({
           vault,
           recall: (q, n) => storeRecall({ query: q, limit: n }),

--- a/packages/core/tests/store/consolidator-store-integration.test.ts
+++ b/packages/core/tests/store/consolidator-store-integration.test.ts
@@ -3,6 +3,7 @@
 // consolidator over it end-to-end against the REAL store (real vault, git, index
 // — only the LLM is faked), and that the sqlite backend refuses both.
 
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -55,6 +56,42 @@ describe("LibrarianStore consolidator wiring (markdown)", () => {
     // The consolidator filed it as a real, recallable memory.
     const found = store.searchMemories({ query: "Anna", status: "active" });
     expect(found.map((m) => m.title)).toContain("Anna");
+  });
+
+  it("augments an existing memory through the real store (no-clobber appended body)", async () => {
+    store = createLibrarianStore({ dataDir, backend: "markdown" });
+    const { memory } = store.createMemory({ title: "Anna", body: "Lives in Paris." });
+    store.submitToInbox("Anna moved to Berlin");
+
+    const summary = await store.consolidateInbox({
+      llmClient: fakeClient(
+        JSON.stringify({
+          action: "augment",
+          target_id: memory.id,
+          addition: "Now in [[Berlin]].",
+          rationale: "adds the move",
+          confidence: 0.97,
+        }),
+      ),
+    });
+
+    expect(summary).toMatchObject({ consolidated: 1 });
+    const updated = store.getMemory(memory.id);
+    expect(updated?.body).toContain("Lives in Paris."); // original preserved (no-clobber)
+    expect(updated?.body).toContain("[[Berlin]]"); // new info woven in
+  });
+
+  it("leaves the vault git tree clean after a judge-error sweep", async () => {
+    store = createLibrarianStore({ dataDir, backend: "markdown" });
+    store.submitToInbox("unparseable submission");
+    // judge_error leaves the claim in .processing; the final sweep commit must
+    // capture that move so the working tree stays clean (Phase-7 git push).
+    await store.consolidateInbox({ llmClient: fakeClient("not json at all") });
+    const porcelain = execFileSync("git", ["status", "--porcelain"], {
+      cwd: path.join(dataDir, "vault"),
+      encoding: "utf8",
+    });
+    expect(porcelain.trim()).toBe("");
   });
 
   it("consolidates a duplicate submission to a no-op (nothing created)", async () => {

--- a/packages/core/tests/store/consolidator-store-integration.test.ts
+++ b/packages/core/tests/store/consolidator-store-integration.test.ts
@@ -1,0 +1,79 @@
+// Consolidator ↔ store wiring (plan 036 Phase 4 / spec 035 §F5). Pins that the
+// markdown LibrarianStore can submit raw text to the inbox and run the
+// consolidator over it end-to-end against the REAL store (real vault, git, index
+// — only the LLM is faked), and that the sqlite backend refuses both.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { type LibrarianStore, type LlmClient, createLibrarianStore } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let store: LibrarianStore | null = null;
+let dataDir = "";
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-consol-store-"));
+});
+afterEach(() => {
+  try {
+    store?.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  store = null;
+});
+
+function fakeClient(content: string): LlmClient {
+  return { complete: async () => ({ content, model: "gpt-x", usage: null }) };
+}
+
+describe("LibrarianStore consolidator wiring (markdown)", () => {
+  it("submits raw text to the inbox and consolidates it into a memory", async () => {
+    store = createLibrarianStore({ dataDir, backend: "markdown" });
+
+    const ref = store.submitToInbox("Anna lives in Berlin.");
+    expect(ref.relPath.startsWith("inbox/")).toBe(true);
+    // The submission is in the inbox, NOT yet a memory.
+    expect(store.searchMemories({ query: "Anna", status: "active" })).toEqual([]);
+
+    const summary = await store.consolidateInbox({
+      llmClient: fakeClient(
+        JSON.stringify({
+          action: "create",
+          title: "Anna",
+          body: "Anna lives in Berlin.",
+          tags: ["person"],
+          rationale: "novel topic",
+          confidence: 0.97,
+        }),
+      ),
+    });
+
+    expect(summary).toMatchObject({ consolidated: 1, judgeErrors: 0, errored: 0 });
+    // The consolidator filed it as a real, recallable memory.
+    const found = store.searchMemories({ query: "Anna", status: "active" });
+    expect(found.map((m) => m.title)).toContain("Anna");
+  });
+
+  it("consolidates a duplicate submission to a no-op (nothing created)", async () => {
+    store = createLibrarianStore({ dataDir, backend: "markdown" });
+    store.submitToInbox("dupe");
+    const summary = await store.consolidateInbox({
+      llmClient: fakeClient(
+        JSON.stringify({ action: "noop", rationale: "duplicate", confidence: 0.9 }),
+      ),
+    });
+    expect(summary).toMatchObject({ consolidated: 1 });
+    expect(store.listMemories({}).total).toBe(0);
+  });
+
+  it("rejects inbox operations on the sqlite backend", async () => {
+    store = createLibrarianStore({ dataDir, backend: "sqlite" });
+    expect(() => store!.submitToInbox("x")).toThrow(/markdown backend/);
+    await expect(store.consolidateInbox({ llmClient: fakeClient("{}") })).rejects.toThrow(
+      /markdown backend/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Bridges the (merged, reviewed) consolidator pipeline to the **real** store — **additive + reversible** (no existing verb changes behavior; no flag/scheduler yet — those are the next two increments):

- **`LibrarianStore.submitToInbox(text)`** — `writeInbox` into the vault + git commit instantly (fire-and-forget); the consolidator files it later.
- **`LibrarianStore.consolidateInbox({ llmClient, thresholds?, lockTtlMs? })`** — `runConsolidatorSweep` over the inbox with the store's own adapters: index recall (the extracted `storeRecall` the `recall` verb uses, byte-equivalent), `listActive`, the markdown memory store as the `ConsolidatorApplyStore`, actor `system-consolidator`; a final `commitAll` captures the inbox claim/complete moves a no-op/judge-error sweep leaves.
- The **sqlite backend throws/rejects** (the inbox lives in the vault).

## Tests
`consolidator-store-integration.test.ts` (5) against the **real** markdown store (real vault + git + index, only the LLM faked): submit → consolidate → recallable memory; **augment mutates an existing memory** (no-clobber: original preserved, `[[wikilink]]` woven in); noop → nothing created; **vault git tree clean after a judge-error sweep**; sqlite refuses both.

## Review note
Sub-agent review: **ship** (0 Critical / 0 Important). It independently verified byte-equivalent recall extraction, the git-tree-clean invariant on all four terminal paths, and augment/supersede/protected-rejection through the real store. Applied its suggestions (the two tests above, a `PERF:` note on the per-item index rebuild, the `ConsolidateInboxOptions` export, the `InboxItemRef` return type).

## Notes
- Next: the `LIBRARIAN_CONSOLIDATOR` flag + `remember`→inbox routing (the cutover), then the http scheduler (5-min tick) + chokidar watcher + boot-scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)