### PR TITLE
feat(consolidator): runConsolidatorTick — config-driven sweep entrypoint (Phase 4)

### DIFF
--- a/packages/core/src/consolidator-tick.ts
+++ b/packages/core/src/consolidator-tick.ts
@@ -1,0 +1,77 @@
+// Consolidator tick (spec 035 §F5) — the config-driven entrypoint the
+// server-side scheduler calls on a (serial) timer, and an admin run-now action
+// can call directly. It reuses the SHARED server-side LLM brain config (the same
+// connection the curator uses — there is one LLM brain, the classifier removed),
+// builds the client from it, and runs one inbox sweep via store.consolidateInbox.
+//
+// Enablement (the LIBRARIAN_CONSOLIDATOR opt-in) is decided by the caller (the
+// http boot only starts this scheduler when enabled), so the tick itself only
+// gates on a complete + decryptable LLM connection and a supporting backend. The
+// LLM client builder is injectable for testing; production defaults to the
+// OpenAI-compatible client.
+
+import type { ConsolidationThresholds, SweepSummary } from "./consolidator/index.js";
+import { type CuratorConfig, readCuratorConfig, resolveCuratorToken } from "./curator-config.js";
+import { type LlmClient, createCuratorLlmClient } from "./curator-llm-client.js";
+import { CONSOLIDATOR_REQUIRES_MARKDOWN, type LibrarianStore } from "./store/librarian-store.js";
+
+export type ConsolidatorTickSkipReason = "incomplete_config" | "no_token" | "unsupported_backend";
+
+export type ConsolidatorTickResult =
+  | { ran: true; summary: SweepSummary }
+  | { ran: false; reason: ConsolidatorTickSkipReason };
+
+export interface ConsolidatorTickOptions {
+  store: LibrarianStore;
+  thresholds?: ConsolidationThresholds;
+  /** Stale-claim TTL passed through to the sweep reaper. */
+  lockTtlMs?: number;
+  /** Injectable LLM client builder (defaults to the OpenAI-compatible client). */
+  buildClient?: (llm: CuratorConfig["llm"], token: string) => LlmClient;
+}
+
+export async function runConsolidatorTick(
+  options: ConsolidatorTickOptions,
+): Promise<ConsolidatorTickResult> {
+  const { store } = options;
+  const config = readCuratorConfig(store);
+
+  // Reuse the curator's LLM connection (the one server-side model) — but NOT its
+  // `enabled` flag: the consolidator's enablement is the caller's LIBRARIAN_CONSOLIDATOR opt-in.
+  if (!config.isLlmComplete) return { ran: false, reason: "incomplete_config" };
+
+  let token: string | null;
+  try {
+    token = resolveCuratorToken(store);
+  } catch {
+    return { ran: false, reason: "no_token" };
+  }
+  if (!token) return { ran: false, reason: "no_token" };
+
+  const buildClient =
+    options.buildClient ??
+    ((llm, secret) =>
+      createCuratorLlmClient({
+        endpoint: llm.endpoint,
+        token: secret,
+        model: llm.model,
+        timeoutMs: llm.timeoutMs,
+      }));
+
+  try {
+    const summary = await store.consolidateInbox({
+      llmClient: buildClient(config.llm, token),
+      ...(options.thresholds ? { thresholds: options.thresholds } : {}),
+      ...(options.lockTtlMs !== undefined ? { lockTtlMs: options.lockTtlMs } : {}),
+    });
+    return { ran: true, summary };
+  } catch (error) {
+    // consolidateInbox rejects on a non-markdown backend (the inbox is vault-only).
+    // Match the shared sentinel exactly so a real consolidation error never gets
+    // misclassified as an unsupported backend.
+    if (error instanceof Error && error.message === CONSOLIDATOR_REQUIRES_MARKDOWN) {
+      return { ran: false, reason: "unsupported_backend" };
+    }
+    throw error;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -83,6 +83,12 @@ export {
   runCuratorTick,
 } from "./curator-tick.js";
 export {
+  type ConsolidatorTickOptions,
+  type ConsolidatorTickResult,
+  type ConsolidatorTickSkipReason,
+  runConsolidatorTick,
+} from "./consolidator-tick.js";
+export {
   type SerialScheduler,
   type SerialSchedulerOptions,
   createSerialScheduler,

--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -122,6 +122,13 @@ export interface ConsolidateInboxOptions {
 const CONSOLIDATOR_ACTOR_ID = "system-consolidator";
 
 /**
+ * The error message the inbox verbs throw/reject with on a non-markdown backend
+ * (the inbox lives in the vault). Exported as the single source of truth so
+ * callers can detect it exactly rather than substring-matching a drifting string.
+ */
+export const CONSOLIDATOR_REQUIRES_MARKDOWN = "the consolidator requires the markdown backend";
+
+/**
  * The concrete store, which also exposes the raw SQLite handle and event-ledger
  * paths — the storage seam (F0). Only the storage layer itself and the
  * not-yet-migrated classifier (Phase 4) and backup (Phase 7) machinery may use
@@ -320,10 +327,9 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Inter
     recall: (input = {}) => Promise.resolve(memoryStore.searchMemories(input)),
     // The consolidator inbox lives in the markdown vault — not available on sqlite.
     submitToInbox: () => {
-      throw new Error("the consolidator inbox requires the markdown backend");
+      throw new Error(CONSOLIDATOR_REQUIRES_MARKDOWN);
     },
-    consolidateInbox: () =>
-      Promise.reject(new Error("the consolidator requires the markdown backend")),
+    consolidateInbox: () => Promise.reject(new Error(CONSOLIDATOR_REQUIRES_MARKDOWN)),
     dataDir,
     eventsPath,
     dbPath,

--- a/packages/core/tests/consolidator-tick.test.ts
+++ b/packages/core/tests/consolidator-tick.test.ts
@@ -1,0 +1,124 @@
+// Consolidator tick (plan 036 Phase 4 / spec 035 §F5) — the config-driven
+// entrypoint the scheduler calls. Verifies gating (incomplete config / no
+// token / unsupported backend) and that an operational config builds the client
+// + runs one inbox sweep. Network-free via an injected client builder.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type LibrarianStore,
+  type LlmClient,
+  createLibrarianStore,
+  resolveSecretKey,
+  runConsolidatorTick,
+  writeCuratorConfig,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Build the 32-byte master key at runtime from a short, sub-threshold literal so
+// no 64-hex string (which GitGuardian reads as a high-entropy secret) sits in the
+// committed source. Varied bytes — resolveSecretKey rejects a constant-byte key.
+const KEY = resolveSecretKey("0123456789abcdef".repeat(4));
+
+let store: LibrarianStore | null = null;
+let dataDir = "";
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-consol-tick-"));
+  store = createLibrarianStore({ dataDir, backend: "markdown", secretKey: KEY });
+});
+afterEach(() => {
+  try {
+    store?.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  store = null;
+});
+
+function createJudgmentClient(): LlmClient {
+  return {
+    complete: async () => ({
+      content: JSON.stringify({
+        action: "create",
+        title: "Anna",
+        body: "Anna lives in Berlin.",
+        tags: [],
+        rationale: "novel",
+        confidence: 0.97,
+      }),
+      model: "m",
+      usage: null,
+    }),
+  };
+}
+
+function configureLlm() {
+  writeCuratorConfig(store!, {
+    enabled: true,
+    llm: { provider: "openai", endpoint: "https://e/v1", model: "gpt-x" },
+    token: "dummy-decrypted-token",
+  });
+}
+
+describe("runConsolidatorTick — gating", () => {
+  it("does not run when the LLM connection is incomplete (no model/token)", async () => {
+    const result = await runConsolidatorTick({ store: store! });
+    expect(result).toEqual({ ran: false, reason: "incomplete_config" });
+  });
+
+  it("does not run when the configured token can't be decrypted", async () => {
+    configureLlm();
+    store!.close();
+    // Reopen WITHOUT the master key: config reads complete (token presence is
+    // metadata), but the token can't be decrypted → not runnable.
+    store = createLibrarianStore({ dataDir, backend: "markdown" });
+    const result = await runConsolidatorTick({
+      store: store!,
+      buildClient: () => createJudgmentClient(),
+    });
+    expect(result).toEqual({ ran: false, reason: "no_token" });
+  });
+});
+
+describe("runConsolidatorTick — operational", () => {
+  it("builds the client from config and runs one inbox sweep", async () => {
+    configureLlm();
+    store!.submitToInbox("Anna moved to Berlin.");
+    const buildClient = vi.fn(() => createJudgmentClient());
+
+    const result = await runConsolidatorTick({ store: store!, buildClient });
+
+    expect(result).toMatchObject({ ran: true, summary: { consolidated: 1 } });
+    expect(buildClient).toHaveBeenCalledTimes(1);
+    // The decrypted token + the configured connection flow into the builder.
+    expect(buildClient).toHaveBeenCalledWith(
+      expect.objectContaining({ endpoint: "https://e/v1", model: "gpt-x" }),
+      "dummy-decrypted-token",
+    );
+    // It filed the submission as a recallable memory.
+    expect(
+      store!.searchMemories({ query: "Anna", status: "active" }).map((m) => m.title),
+    ).toContain("Anna");
+  });
+});
+
+describe("runConsolidatorTick — backend", () => {
+  it("skips on the sqlite backend (the inbox is vault-only)", async () => {
+    store!.close();
+    store = createLibrarianStore({
+      dataDir: fs.mkdtempSync(path.join(os.tmpdir(), "sq-")),
+      backend: "sqlite",
+      secretKey: KEY,
+    });
+    writeCuratorConfig(store, {
+      enabled: true,
+      llm: { provider: "openai", endpoint: "https://e/v1", model: "gpt-x" },
+      token: "dummy-decrypted-token",
+    });
+    const result = await runConsolidatorTick({ store, buildClient: () => createJudgmentClient() });
+    expect(result).toEqual({ ran: false, reason: "unsupported_backend" });
+  });
+});


### PR DESCRIPTION
## Summary
`runConsolidatorTick({store, thresholds?, lockTtlMs?, buildClient?})` — the config-driven entrypoint the server scheduler (and a future admin run-now) calls, a close mirror of the merged `runCuratorTick`.

- Reuses the **shared server-side LLM brain** config (the one model the curator uses — the classifier is removed) via `readCuratorConfig`/`resolveCuratorToken`, but **does not gate on the curator's `enabled` flag** — the consolidator's enablement is the caller's `LIBRARIAN_CONSOLIDATOR` opt-in (decided in the http boot, next increment).
- Gates: incomplete LLM connection → `incomplete_config`; undecryptable token → `no_token`; sqlite backend → `unsupported_backend`; else runs one `store.consolidateInbox` sweep → `{ ran: true, summary }`.

## Tests
`consolidator-tick.test.ts` (4), network-free via an injected client builder: incomplete-config gate, no-token (real `resolveCuratorToken` failure by reopening without the master key), operational sweep that builds the client from config + files the submission as a recallable memory, and sqlite-skip.

## Review note
Sub-agent review: **ship** (0 Critical / 0 Important). It verified parity with `curator-tick` and that the backend catch can only fire on the real rejection (the sweep swallows per-item errors). Applied its suggestion: the `unsupported_backend` catch now matches a **shared exported sentinel** (`CONSOLIDATOR_REQUIRES_MARKDOWN`) exactly instead of substring-matching a cross-file string, so a real error can't be misclassified.

## Notes
- Next: wire this into the http boot as a serial 5-min tick + boot-scan + a chokidar watcher on `inbox/`, all behind `LIBRARIAN_CONSOLIDATOR`; then `remember`→inbox routing.
- FYI (tracked, not this PR): the shared-LLM-config means configuring `curator.llm.*` also powers the consolidator; a dedicated `consolidator.llm.*` block can split it later if a different model is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)