### PR TITLE
feat(consolidator): wire the inbox scheduler + boot-scan into the http boot (Phase 4)

### DIFF
--- a/packages/mcp-server/src/bin/http.ts
+++ b/packages/mcp-server/src/bin/http.ts
@@ -16,6 +16,7 @@ import {
   resolveBootCredentials,
   resolveDataDir,
   runBackupTick,
+  runConsolidatorTick,
   runCuratorTick,
   verifyAgentToken,
 } from "@librarian/core";
@@ -216,6 +217,25 @@ const backupScheduler =
       })
     : null;
 
+// Consolidator scheduler (spec 035 §F5): a serial tick that processes the inbox
+// (navigate→judge→apply) on a cadence. OPT-IN via LIBRARIAN_CONSOLIDATOR — the
+// inbox model ships gated (default off), reversible like the markdown cutover.
+// The tick self-gates on the shared LLM config + the markdown backend (cheap
+// no-op otherwise), so enabling it without a configured model is harmless.
+// Default 5-min cadence; the chokidar watcher (follow-on) makes processing
+// near-immediate. LIBRARIAN_CONSOLIDATOR_TICK_MS=0 disables the timer.
+const consolidatorEnabled =
+  process.env.LIBRARIAN_CONSOLIDATOR === "on" || process.env.LIBRARIAN_CONSOLIDATOR === "true";
+const consolidatorTickMs = Number(process.env.LIBRARIAN_CONSOLIDATOR_TICK_MS ?? 5 * 60_000);
+const consolidatorScheduler =
+  consolidatorEnabled && consolidatorTickMs > 0
+    ? createSerialScheduler({
+        task: () => runConsolidatorTick({ store }),
+        intervalMs: consolidatorTickMs,
+        onError: (error) => logger.error({ err: error }, "consolidator tick failed"),
+      })
+    : null;
+
 // Classifier worker — store-driven boot. Configure via the
 // `/classifier` dashboard cockpit (settings persist in the admin
 // store; see `classifier-startup.ts` for the retired
@@ -234,6 +254,14 @@ const classifierBoot = bootClassifierWorker({
 server.listen(port, host, () => {
   curatorScheduler?.start();
   backupScheduler?.start();
+  consolidatorScheduler?.start();
+  // Boot scan: process anything left in the inbox from a previous run, before
+  // the first interval fires (setInterval fires after the interval, not now).
+  if (consolidatorEnabled) {
+    void runConsolidatorTick({ store }).catch((error) =>
+      logger.error({ err: error }, "consolidator boot scan failed"),
+    );
+  }
   logger.info(
     {
       host,
@@ -241,6 +269,7 @@ server.listen(port, host, () => {
       mcp: `http://${host}:${port}/mcp`,
       trpc: `http://${host}:${port}/trpc`,
       classifier: classifierBoot ? "active" : "off",
+      consolidator: consolidatorEnabled ? "on" : "off",
     },
     "The Librarian MCP service is running",
   );

--- a/packages/mcp-server/src/bin/http.ts
+++ b/packages/mcp-server/src/bin/http.ts
@@ -278,6 +278,9 @@ server.listen(port, host, () => {
 async function shutdown(): Promise<void> {
   curatorScheduler?.stop();
   backupScheduler?.stop();
+  // Stop the consolidator timer before closing the store — a tick writes through
+  // the same store, so it must not fire after store.close() (parity with above).
+  consolidatorScheduler?.stop();
   // Await the worker drain before closing the DB — an in-flight
   // iteration can still write the verdict via the shared connection.
   await classifierBoot?.worker.stop();


### PR DESCRIPTION
## Summary
Wires the (merged) `runConsolidatorTick` into the server boot (`packages/mcp-server/src/bin/http.ts`), **opt-in via `LIBRARIAN_CONSOLIDATOR`** (default off — the inbox model ships gated, reversible like the markdown cutover). Mirrors the existing curator scheduler block. When enabled:

- starts a **serial 5-min tick** (`LIBRARIAN_CONSOLIDATOR_TICK_MS`, `0` disables) running `runConsolidatorTick({ store })`;
- runs a **boot scan** once on startup (`setInterval` fires *after* the interval, so a previous run's leftover inbox items get processed immediately);
- stops the scheduler on graceful shutdown before `store.close()` (parity with curator/backup — a tick writes through the same store);
- logs `consolidator: on/off` in the startup line.

The tick self-gates on the shared LLM config + the markdown backend, so enabling it without a configured model is a harmless no-op.

## Verification
No unit test for the boot entrypoint (consistent with the curator/backup wiring); the smoke/healthcheck CI boots the server (default off). I also booted locally with `LIBRARIAN_CONSOLIDATOR=on` (markdown, no model): clean start, logs `consolidator:"on"`, no crash. Full workspace build + suite green.

## Review note
Sub-agent review: **fix-then-ship** → fixed before this PR: added `consolidatorScheduler?.stop()` to `shutdown()` (it was missing — a graceful-shutdown correctness gap vs the curator/backup peers). Flag dual-form (`on`/`true`) and the inherited `Number()` parsing are consistent with the file (kept).

## Notes
- Next: a chokidar watcher on `inbox/` (near-immediate processing for S3), then the `remember`→inbox routing (the cutover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)