### PR TITLE
feat(consolidator): carry submission hints (agent_id/project_key/tags) through the consolidator (Phase 4)

### DIFF
--- a/packages/core/src/consolidator/apply.ts
+++ b/packages/core/src/consolidator/apply.ts
@@ -10,6 +10,7 @@
 // returned as `rejected`, never thrown, so one bad item can't abort a batch.
 
 import { redactSecrets } from "../curator-redaction.js";
+import type { InboxSubmissionHints } from "../store/corpus/inbox.js";
 import { augmentBody, preservesOriginal } from "./edit.js";
 import type { ConsolidationPlan } from "./judge.js";
 
@@ -34,8 +35,15 @@ export interface ApplyConsolidationDeps {
   store: ConsolidatorApplyStore;
   /** The raw submission text — the doc source for create_new + propose. */
   submissionText: string;
-  /** Actor id that owns the created/updated memories (e.g. "system-consolidator"). */
+  /** Actor id that owns a consolidated memory when the submission carries no agent hint. */
   actorId: string;
+  /**
+   * The original submission's filing/ownership hints. NEW memories (create /
+   * create_new / propose) inherit the submitter's agent_id + project_key so a
+   * consolidated memory keeps its scope; existing-doc edits (augment / supersede
+   * / archive) keep the target's own scope and ignore these.
+   */
+  submissionHints?: InboxSubmissionHints;
   /** Optional sink for a swallowed store error, so a real bug stays observable. */
   onError?: (error: unknown) => void;
 }
@@ -67,6 +75,15 @@ export function applyConsolidationPlan(
   deps: ApplyConsolidationDeps,
 ): ConsolidationOutcome {
   const { store, submissionText, actorId } = deps;
+  const hints = deps.submissionHints;
+  // A consolidated memory is owned by the submitter (so recall scopes it), falling
+  // back to the system actor when the submission carried no agent hint.
+  const owner = hints?.agentId ?? actorId;
+  const scope = (base: Record<string, unknown>): Record<string, unknown> => {
+    const out: Record<string, unknown> = { ...base, agent_id: owner };
+    if (hints?.projectKey !== undefined) out.project_key = hints.projectKey;
+    return out;
+  };
   // The model's rationale is untrusted (could carry a hallucinated secret) and is
   // persisted into the vault + git history — redact it, like the curator does.
   const note = (extra: Record<string, unknown> = {}): Record<string, unknown> => ({
@@ -90,10 +107,9 @@ export function applyConsolidationPlan(
       const proposed = plan.decision === "propose";
       const options = note(proposed ? { proposed_action: plan.judgment.action } : {});
       if (proposed) options.requires_approval = true;
-      const { memory } = store.createMemory(
-        { title: deriveTitle(submissionText), body: submissionText, agent_id: actorId },
-        options,
-      );
+      const input = scope({ title: deriveTitle(submissionText), body: submissionText });
+      if (hints?.tags) input.tags = hints.tags; // the raw submission's tags (no judge tags here)
+      const { memory } = store.createMemory(input, options);
       return { kind: proposed ? "proposed" : "created_new", id: memory.id };
     }
 
@@ -101,8 +117,9 @@ export function applyConsolidationPlan(
     const j = plan.judgment;
     switch (j.action) {
       case "create": {
+        // The judge curated title/body/tags; the submitter's scope still applies.
         const { memory } = store.createMemory(
-          { title: j.title, body: j.body, tags: j.tags, agent_id: actorId },
+          scope({ title: j.title, body: j.body, tags: j.tags }),
           note(),
         );
         return { kind: "created", id: memory.id };

--- a/packages/core/src/consolidator/apply.ts
+++ b/packages/core/src/consolidator/apply.ts
@@ -81,6 +81,10 @@ export function applyConsolidationPlan(
   const owner = hints?.agentId ?? actorId;
   const scope = (base: Record<string, unknown>): Record<string, unknown> => {
     const out: Record<string, unknown> = { ...base, agent_id: owner };
+    // Set project_key only when the hint carries it. NB: today the markdown store
+    // collapses both `null` (explicit global) and absent to `project_key: null`, so
+    // this distinction is currently inert — preserved for forward-compat (a future
+    // store-level default project) rather than load-bearing.
     if (hints?.projectKey !== undefined) out.project_key = hints.projectKey;
     return out;
   };

--- a/packages/core/src/consolidator/consolidate.ts
+++ b/packages/core/src/consolidator/consolidate.ts
@@ -83,6 +83,7 @@ export async function consolidateInboxItem(
     store: deps.store,
     submissionText: item.text,
     actorId: deps.actorId,
+    submissionHints: item.hints, // carry the submitter's scope/ownership onto new memories
     ...(deps.onError ? { onError: deps.onError } : {}),
   };
   const outcome = applyConsolidationPlan(judged.plan, applyDeps);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -213,6 +213,7 @@ export {
   type InboxDeps,
   type InboxItem,
   type InboxItemRef,
+  type InboxSubmissionHints,
   type Vault,
   type VaultOptions,
   type Wikilink,

--- a/packages/core/src/store/corpus/inbox.ts
+++ b/packages/core/src/store/corpus/inbox.ts
@@ -32,17 +32,36 @@ export interface InboxDeps {
   generateId?: () => string;
 }
 
+/**
+ * Filing/ownership hints from the original submission (the `remember` input),
+ * carried on the inbox item so the consolidator can preserve the submitter's
+ * scope + ownership when it files the memory — rather than attributing every
+ * consolidated memory to the system actor with no project scope.
+ */
+export interface InboxSubmissionHints {
+  agentId?: string;
+  projectKey?: string | null;
+  tags?: string[];
+}
+
+/** Write options: clock/id injection (for determinism) + the submission hints to persist. */
+export interface WriteInboxOptions extends InboxDeps {
+  hints?: InboxSubmissionHints;
+}
+
 export interface InboxItemRef {
   /** Vault-relative path of the pending item (`inbox/<ts>-<id>.md`). */
   relPath: string;
   id: string;
 }
 
-/** A parsed inbox submission: identity + creation time + the raw text. */
+/** A parsed inbox submission: identity + creation time + the raw text + hints. */
 export interface InboxItem {
   id: string;
   created: string;
   text: string;
+  /** Filing/ownership hints from the original submission (possibly empty). */
+  hints: InboxSubmissionHints;
 }
 
 function pad(ms: number): string {
@@ -66,7 +85,19 @@ function quote(value: string): string {
 
 /** Serialize an inbox submission to its on-disk markdown (frontmatter + text). */
 export function serializeInboxItem(item: InboxItem): string {
-  const head = `---\nid: ${quote(item.id)}\ncreated: ${quote(item.created)}\n---\n`;
+  const lines = [`id: ${quote(item.id)}`, `created: ${quote(item.created)}`];
+  const { agentId, projectKey, tags } = item.hints;
+  // Hints are written only when present, so an inbox item with none stays minimal.
+  if (agentId !== undefined) lines.push(`agent_id: ${quote(agentId)}`);
+  if (projectKey !== undefined) {
+    lines.push(`project_key: ${projectKey === null ? "null" : quote(projectKey)}`);
+  }
+  if (tags !== undefined) {
+    lines.push(
+      tags.length ? `tags:\n${tags.map((t) => `  - ${quote(t)}`).join("\n")}` : "tags: []",
+    );
+  }
+  const head = `---\n${lines.join("\n")}\n---\n`;
   const body = item.text.trim();
   return body ? `${head}\n${body}\n` : head;
 }
@@ -74,24 +105,40 @@ export function serializeInboxItem(item: InboxItem): string {
 /** Parse an inbox submission; tolerant of hand edits (coerces a YAML Date back to ISO). */
 export function parseInboxItem(raw: string): InboxItem {
   const { data, content } = matter(raw);
-  const createdRaw = (data as { created?: unknown }).created;
+  const d = data as Record<string, unknown>;
+  const createdRaw = d.created;
   const created = createdRaw instanceof Date ? createdRaw.toISOString() : String(createdRaw ?? "");
-  return {
-    id: String((data as { id?: unknown }).id ?? ""),
-    created,
-    text: content.trim(),
-  };
+  const hints: InboxSubmissionHints = {};
+  if (typeof d.agent_id === "string") hints.agentId = d.agent_id;
+  if (d.project_key === null || typeof d.project_key === "string") {
+    hints.projectKey = d.project_key as string | null;
+  }
+  if (Array.isArray(d.tags)) hints.tags = d.tags.filter((t): t is string => typeof t === "string");
+  return { id: String(d.id ?? ""), created, text: content.trim(), hints };
 }
 
 /**
  * Store a submission in the inbox (instant, fire-and-forget) and return its
- * pending path + id. The filename's zero-padded ms prefix gives FIFO order.
+ * pending path + id. The filename's zero-padded ms prefix gives FIFO order;
+ * `options.hints` persists the submission's filing/ownership hints.
  */
-export function writeInbox(vault: Vault, text: string, deps: InboxDeps = {}): InboxItemRef {
-  const ms = (deps.now ?? Date.now)();
-  const id = (deps.generateId ?? (() => makeId("inbox")))();
+export function writeInbox(
+  vault: Vault,
+  text: string,
+  options: WriteInboxOptions = {},
+): InboxItemRef {
+  const ms = (options.now ?? Date.now)();
+  const id = (options.generateId ?? (() => makeId("inbox")))();
   const relPath = `${INBOX_DIR}/${pad(ms)}-${id}.md`;
-  vault.writeText(relPath, serializeInboxItem({ id, created: new Date(ms).toISOString(), text }));
+  vault.writeText(
+    relPath,
+    serializeInboxItem({
+      id,
+      created: new Date(ms).toISOString(),
+      text,
+      hints: options.hints ?? {},
+    }),
+  );
   return { relPath, id };
 }
 

--- a/packages/core/src/store/corpus/index.ts
+++ b/packages/core/src/store/corpus/index.ts
@@ -16,6 +16,8 @@ export {
   type InboxDeps,
   type InboxItem,
   type InboxItemRef,
+  type InboxSubmissionHints,
+  type WriteInboxOptions,
   claimInboxItem,
   completeInboxItem,
   listInbox,

--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -13,7 +13,12 @@ import {
   type ConversationStateStore,
   createConversationStateStore,
 } from "./conversation-state-store.js";
-import { type InboxItemRef, createVault, writeInbox } from "./corpus/index.js";
+import {
+  type InboxItemRef,
+  type InboxSubmissionHints,
+  createVault,
+  writeInbox,
+} from "./corpus/index.js";
 import {
   buildCorpusIndex,
   recallMemories,
@@ -95,9 +100,10 @@ export interface LibrarianStore extends MemoryStore, CurationStore, SettingsStor
   /**
    * Submit raw text to the consolidator inbox (markdown backend only — the inbox
    * lives in the vault). Fire-and-forget: stored + committed instantly; the
-   * consolidator files it asynchronously. Throws on the sqlite backend.
+   * consolidator files it asynchronously, carrying `hints` (the submitter's
+   * agent_id/project_key/tags) onto the resulting memory. Throws on sqlite.
    */
-  submitToInbox(text: string): InboxItemRef;
+  submitToInbox(text: string, hints?: InboxSubmissionHints): InboxItemRef;
   /**
    * Run the consolidator over the inbox once — reap stale claims, then FIFO
    * through navigate→judge→apply (markdown backend only). The LLM client is
@@ -252,8 +258,8 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Inter
       skills: createSkillStore(vault),
       searchReferences: (query, limit) => searchVaultReferences(vault, embedder, query, limit),
       recall: storeRecall,
-      submitToInbox: (text: string) => {
-        const ref = writeInbox(vault, text);
+      submitToInbox: (text: string, hints?: InboxSubmissionHints) => {
+        const ref = writeInbox(vault, text, hints ? { hints } : {});
         commit(`inbox: submit ${ref.id}`); // durable + committed instantly
         return ref;
       },

--- a/packages/core/tests/consolidator-apply.test.ts
+++ b/packages/core/tests/consolidator-apply.test.ts
@@ -207,6 +207,56 @@ describe("applyConsolidationPlan", () => {
     expect(note.rationale).toContain("[REDACTED:secret]");
   });
 
+  it("create_new inherits the submitter's scope from submissionHints", () => {
+    const { store, calls } = fakeStore();
+    applyConsolidationPlan(
+      plan("create_new", { action: "augment", target_id: "x", addition: "a" }),
+      {
+        store,
+        submissionText: "A fact.",
+        actorId: "system-consolidator",
+        submissionHints: { agentId: "agent-a", projectKey: "proj-x", tags: ["t1"] },
+      },
+    );
+    expect(calls.create[0]?.input).toMatchObject({
+      agent_id: "agent-a",
+      project_key: "proj-x",
+      tags: ["t1"],
+    });
+  });
+
+  it("create inherits the submitter's scope but keeps the judge's tags", () => {
+    const { store, calls } = fakeStore();
+    applyConsolidationPlan(
+      plan("auto_apply", { action: "create", title: "T", body: "B", tags: ["judged"] }),
+      {
+        store,
+        submissionText: "x",
+        actorId: "system-consolidator",
+        submissionHints: { agentId: "agent-a", projectKey: "proj-x", tags: ["ignored"] },
+      },
+    );
+    expect(calls.create[0]?.input).toMatchObject({
+      agent_id: "agent-a",
+      project_key: "proj-x",
+      tags: ["judged"], // the judge curated these; the submission's tags don't override
+    });
+  });
+
+  it("an augment ignores submissionHints — it edits the target's body only", () => {
+    const { store, calls } = fakeStore({ mem_anna: { title: "Anna", body: "Lives in Paris." } });
+    applyConsolidationPlan(
+      plan("auto_apply", { action: "augment", target_id: "mem_anna", addition: "moved" }),
+      {
+        store,
+        submissionText: "x",
+        actorId: "system-consolidator",
+        submissionHints: { agentId: "agent-a", projectKey: "proj-x" },
+      },
+    );
+    expect(Object.keys(calls.update[0]?.patch ?? {})).toEqual(["body"]); // no agent_id/project_key
+  });
+
   it("a store rejection (e.g. protected target) becomes a rejected outcome, not a throw", () => {
     const { store } = fakeStore({ mem_p: { title: "P", body: "x" } });
     store.updateMemory = () => {

--- a/packages/core/tests/corpus-inbox.test.ts
+++ b/packages/core/tests/corpus-inbox.test.ts
@@ -88,6 +88,17 @@ describe("writeInbox", () => {
     const ref = writeInbox(vault, "x", { now: () => 1, generateId: () => "inbox_a" });
     expect(parseInboxItem(vault.readText(ref.relPath)).hints).toEqual({});
   });
+
+  it("round-trips hint values needing YAML escaping (quotes, colons, newlines)", () => {
+    const hints = {
+      agentId: 'agent "x": line1\nline2',
+      projectKey: 'proj: "y"',
+      tags: ['tag: with "quote"', "back\\slash"],
+    };
+    const ref = writeInbox(vault, "x", { now: () => 1, generateId: () => "inbox_a", hints });
+    // The escaping must not break the frontmatter or inject keys — values survive verbatim.
+    expect(parseInboxItem(vault.readText(ref.relPath)).hints).toEqual(hints);
+  });
 });
 
 describe("listInbox", () => {

--- a/packages/core/tests/corpus-inbox.test.ts
+++ b/packages/core/tests/corpus-inbox.test.ts
@@ -57,6 +57,37 @@ describe("writeInbox", () => {
     const ref = writeInbox(vault, "x", { now: () => 1 });
     expect(ref.relPath).not.toContain(".processing");
   });
+
+  it("round-trips submission hints (agent_id / project_key / tags)", () => {
+    const ref = writeInbox(vault, "Anna moved to Berlin", {
+      now: () => 1000,
+      generateId: () => "inbox_a",
+      hints: { agentId: "agent-a", projectKey: "proj-x", tags: ["person", "move"] },
+    });
+    expect(parseInboxItem(vault.readText(ref.relPath)).hints).toEqual({
+      agentId: "agent-a",
+      projectKey: "proj-x",
+      tags: ["person", "move"],
+    });
+  });
+
+  it("round-trips a null project_key (global) and an empty tag list", () => {
+    const ref = writeInbox(vault, "global fact", {
+      now: () => 1000,
+      generateId: () => "inbox_a",
+      hints: { agentId: "agent-a", projectKey: null, tags: [] },
+    });
+    expect(parseInboxItem(vault.readText(ref.relPath)).hints).toEqual({
+      agentId: "agent-a",
+      projectKey: null,
+      tags: [],
+    });
+  });
+
+  it("yields empty hints when none are supplied", () => {
+    const ref = writeInbox(vault, "x", { now: () => 1, generateId: () => "inbox_a" });
+    expect(parseInboxItem(vault.readText(ref.relPath)).hints).toEqual({});
+  });
 });
 
 describe("listInbox", () => {

--- a/packages/core/tests/store/consolidator-store-integration.test.ts
+++ b/packages/core/tests/store/consolidator-store-integration.test.ts
@@ -106,6 +106,29 @@ describe("LibrarianStore consolidator wiring (markdown)", () => {
     expect(store.listMemories({}).total).toBe(0);
   });
 
+  it("carries submission hints (agent_id/project_key) onto the consolidated memory", async () => {
+    store = createLibrarianStore({ dataDir, backend: "markdown" });
+    store.submitToInbox("Anna lives in Berlin.", {
+      agentId: "agent-a",
+      projectKey: "proj-x",
+      tags: ["person"],
+    });
+    await store.consolidateInbox({
+      llmClient: fakeClient(
+        JSON.stringify({
+          action: "create",
+          title: "Anna",
+          body: "Anna lives in Berlin.",
+          tags: [],
+          rationale: "novel",
+          confidence: 0.97,
+        }),
+      ),
+    });
+    const anna = store.listMemories({ status: "active" }).memories.find((m) => m.title === "Anna");
+    expect(anna).toMatchObject({ agent_id: "agent-a", project_key: "proj-x" });
+  });
+
   it("rejects inbox operations on the sqlite backend", async () => {
     store = createLibrarianStore({ dataDir, backend: "sqlite" });
     expect(() => store!.submitToInbox("x")).toThrow(/markdown backend/);


### PR DESCRIPTION
## Summary
First step of the `remember`→inbox cutover (the verb reroute is the next increment): thread the submitter's filing/ownership hints end-to-end so a consolidated memory keeps its scope instead of being attributed to the system actor with no project. **Additive + backward-compatible.**

- The inbox item gains an optional `hints` block (`agent_id` / `project_key` / `tags`), serialized into frontmatter **only when present** (an item with none stays minimal); `parseInboxItem` round-trips them (incl. `null` project_key + empty tags). `writeInbox`'s 3rd param is widened to `WriteInboxOptions` (`extends InboxDeps`, adds `hints?`) so existing `{now, generateId}` callers are unaffected.
- `store.submitToInbox(text, hints?)` persists them.
- `consolidateInboxItem` threads them to apply.
- **apply:** NEW memories (`create` / `create_new` / `propose`) inherit the submitter's `agent_id` + `project_key` (owner falls back to the system actor when no agent hint); existing-doc edits (`augment` / `supersede` / `archive`) keep the target's own scope and **never** leak hints into the update patch. `create` keeps the judge's curated tags; `create_new`/`propose` use the submission's tags.

## Tests
Inbox hint round-trips (full / null+empty / none / **YAML-escaping**: quotes, colons, newlines, backslashes survive verbatim with no key injection); apply scope inheritance + create-keeps-judge-tags + augment-ignores-hints; end-to-end `submitToInbox(hints)` → `consolidateInbox` → memory keeps `agent_id`/`project_key`.

## Review note
Sub-agent review: **ship** (0 Critical / 0 Important). It ran an out-of-band YAML-injection probe across 14 adversarial inputs confirming the hand-rolled hints frontmatter is injection-safe. Applied its suggestions (the escaping round-trip test above + a forward-compat note that the null-vs-absent `project_key` distinction is currently inert at the store). CHANGELOG deferred — the consolidator is still internal/flag-gated (per AGENTS.md "internal-only can skip"); the entry lands when it becomes user-visible.

## Notes
- Next: route the `remember` MCP verb → `submitToInbox(hints)` when `LIBRARIAN_CONSOLIDATOR` is on + handle its response contract (the cutover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)