### PR TITLE
feat(consolidator): route remember → inbox when enabled (the cutover, opt-in)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,18 @@ changes from this point forward are catalogued here.
 
 ### Added
 
+- **The consolidator — opt-in async memory filing (plan-036 Phase 4).** With
+  `LIBRARIAN_CONSOLIDATOR=on` on the markdown backend, `remember` becomes a
+  fire-and-forget submission: the note is queued to a vault inbox and an LLM
+  consolidator files it asynchronously (navigate the existing memories → judge
+  whether to augment/supersede an existing one or create a new memory →
+  minimal-edit in place, preferring `[[wikilinks]]` over duplication), carrying
+  the submitter's `agent_id`/`project_key`/`tags`. A serial scheduler drains the
+  inbox on a cadence (`LIBRARIAN_CONSOLIDATOR_TICK_MS`, default 5 min) plus a
+  boot scan; it shares the curator's LLM brain config. **Default off** — when
+  disabled (or on the sqlite backend, which has no vault inbox), `remember` keeps
+  its existing direct-write behaviour unchanged.
+
 - **EmbeddingGemma wired as the production embedder** for index recall +
   `search_references` (`resolveEmbedder`). Selection is env-driven:
   `LIBRARIAN_EMBEDDER=hash|llama` (default: hash under tests, the EmbeddingGemma

--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -85,6 +85,8 @@ export interface LibrarianStoreOptions {
 }
 
 export interface LibrarianStore extends MemoryStore, CurationStore, SettingsStore {
+  /** The storage backend this store actually runs (so callers don't re-derive it from env). */
+  backend: StorageBackend;
   convState: ConversationStateStore;
   handoffs: HandoffStore;
   /** Skills read surface (vault-based, backend-independent): manifest + get + find. */
@@ -253,6 +255,7 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Inter
       ...markdownMemory,
       ...residualCuration,
       ...jsonSettings,
+      backend: "markdown",
       convState: jsonConvState,
       handoffs: markdownHandoffs,
       skills: createSkillStore(vault),
@@ -322,6 +325,7 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Inter
     ...memoryStore,
     ...curationStore,
     ...settingsStore,
+    backend: "sqlite",
     convState,
     handoffs,
     // create:false — a SQLite install must not materialize a vault dir just to

--- a/packages/mcp-server/src/bin/http.ts
+++ b/packages/mcp-server/src/bin/http.ts
@@ -21,6 +21,7 @@ import {
   verifyAgentToken,
 } from "@librarian/core";
 import { bootClassifierWorker } from "../classifier-startup.js";
+import { isConsolidatorEnabled } from "../consolidator-config.js";
 import { type AuthConfig, AgentTokensError, parseAgentTokenMap, parseCsv } from "../http/auth.js";
 import { createHttpServer } from "../http/server.js";
 import { logger } from "../logging.js";
@@ -224,8 +225,7 @@ const backupScheduler =
 // no-op otherwise), so enabling it without a configured model is harmless.
 // Default 5-min cadence; the chokidar watcher (follow-on) makes processing
 // near-immediate. LIBRARIAN_CONSOLIDATOR_TICK_MS=0 disables the timer.
-const consolidatorEnabled =
-  process.env.LIBRARIAN_CONSOLIDATOR === "on" || process.env.LIBRARIAN_CONSOLIDATOR === "true";
+const consolidatorEnabled = isConsolidatorEnabled();
 const consolidatorTickMs = Number(process.env.LIBRARIAN_CONSOLIDATOR_TICK_MS ?? 5 * 60_000);
 const consolidatorScheduler =
   consolidatorEnabled && consolidatorTickMs > 0

--- a/packages/mcp-server/src/consolidator-config.ts
+++ b/packages/mcp-server/src/consolidator-config.ts
@@ -1,0 +1,12 @@
+// Consolidator enablement — the LIBRARIAN_CONSOLIDATOR opt-in (default off).
+//
+// The inbox model (remember → inbox → async consolidation) ships gated, like the
+// markdown-backend cutover. Both the http scheduler (whether to start the tick +
+// boot-scan) and the `remember` verb (whether to route to the inbox) read this
+// single source of truth so they can't drift.
+
+/** True when the consolidator is opted in via `LIBRARIAN_CONSOLIDATOR=on` (or `true`). */
+export function isConsolidatorEnabled(): boolean {
+  const value = process.env.LIBRARIAN_CONSOLIDATOR;
+  return value === "on" || value === "true";
+}

--- a/packages/mcp-server/src/mcp/tools/remember.ts
+++ b/packages/mcp-server/src/mcp/tools/remember.ts
@@ -1,8 +1,23 @@
+import type { InboxSubmissionHints } from "@librarian/core";
 import { isClassifierRuntimeActive } from "../../classifier-startup.js";
+import { isConsolidatorEnabled } from "../../consolidator-config.js";
 import { textResult } from "../result.js";
 import type { ToolDefinition } from "../tool.js";
 import { scopeAgentArgs } from "../visibility.js";
 import { memoryInputSchema } from "./schemas.js";
+
+/** The submitter's filing/ownership hints, carried onto the consolidated memory. */
+function submissionHints(scoped: Record<string, unknown>): InboxSubmissionHints {
+  const hints: InboxSubmissionHints = {};
+  if (typeof scoped.agent_id === "string") hints.agentId = scoped.agent_id;
+  if (scoped.project_key === null || typeof scoped.project_key === "string") {
+    hints.projectKey = scoped.project_key as string | null;
+  }
+  if (Array.isArray(scoped.tags)) {
+    hints.tags = scoped.tags.filter((t): t is string => typeof t === "string");
+  }
+  return hints;
+}
 
 const remember: ToolDefinition = {
   name: "remember",
@@ -16,6 +31,22 @@ const remember: ToolDefinition = {
     const scoped = scopeAgentArgs(args, context);
     // conv_id was a domain-routing signal, not a memory field.
     delete scoped.conv_id;
+
+    // Inbox cutover (opt-in, markdown only): when the consolidator is enabled,
+    // `remember` is a fire-and-forget submission — stored raw in the inbox and
+    // filed asynchronously by the consolidator (navigate→judge→edit), preserving
+    // the submitter's scope via hints. The inbox lives in the vault, so this
+    // only applies on the markdown backend; otherwise the legacy direct write.
+    if (isConsolidatorEnabled() && store.backend === "markdown") {
+      const title = typeof scoped.title === "string" ? scoped.title : "";
+      const body = typeof scoped.body === "string" ? scoped.body : "";
+      const text = title ? `${title}\n\n${body}` : body;
+      store.submitToInbox(text, submissionHints(scoped));
+      return textResult(
+        "Noted — queued for consolidation. The consolidator will file it into your memory shortly.",
+      );
+    }
+
     // Section 4d cutover — when the classifier worker is active, every write
     // lands at conservative defaults so the worker is the source of truth for
     // is_global + requires_approval (and routes protected writes to proposals).

--- a/packages/mcp-server/src/mcp/tools/remember.ts
+++ b/packages/mcp-server/src/mcp/tools/remember.ts
@@ -41,10 +41,16 @@ const remember: ToolDefinition = {
       const title = typeof scoped.title === "string" ? scoped.title : "";
       const body = typeof scoped.body === "string" ? scoped.body : "";
       const text = title ? `${title}\n\n${body}` : body;
-      store.submitToInbox(text, submissionHints(scoped));
-      return textResult(
-        "Noted — queued for consolidation. The consolidator will file it into your memory shortly.",
-      );
+      // An empty submission has nothing to consolidate. Fall through to the
+      // legacy write (which terminally files an "Untitled memory") rather than
+      // enqueueing an empty inbox item — navigate→judge can't make a plan from
+      // empty text, so it would only loop on the reaper TTL.
+      if (text.trim()) {
+        store.submitToInbox(text, submissionHints(scoped));
+        return textResult(
+          "Noted — queued for consolidation. The consolidator will file it into your memory shortly.",
+        );
+      }
     }
 
     // Section 4d cutover — when the classifier worker is active, every write

--- a/packages/mcp-server/tests/mcp/remember-cutover.test.ts
+++ b/packages/mcp-server/tests/mcp/remember-cutover.test.ts
@@ -1,0 +1,81 @@
+// remember verb — inbox cutover routing (plan 036 Phase 4 / spec 035 §F5).
+// When LIBRARIAN_CONSOLIDATOR is on AND the store is on the markdown backend,
+// `remember` is a fire-and-forget submission to the consolidator inbox;
+// otherwise it writes directly via createMemory (the legacy path, unchanged by
+// default). Dispatched through handleMcpPayload over a real store.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { type LibrarianStore, createLibrarianStore } from "@librarian/core";
+import { handleMcpPayload } from "@librarian/mcp-server";
+import { afterEach, describe, expect, it } from "vitest";
+
+let store: LibrarianStore | null = null;
+let dataDir = "";
+let savedFlag: string | undefined;
+
+function makeStore(backend: "markdown" | "sqlite"): void {
+  savedFlag = process.env.LIBRARIAN_CONSOLIDATOR;
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-remember-"));
+  store = createLibrarianStore({ dataDir, backend });
+}
+
+afterEach(() => {
+  try {
+    store?.close();
+  } catch {
+    /* ignore */
+  }
+  if (dataDir) fs.rmSync(dataDir, { recursive: true, force: true });
+  store = null;
+  if (savedFlag === undefined) delete process.env.LIBRARIAN_CONSOLIDATOR;
+  else process.env.LIBRARIAN_CONSOLIDATOR = savedFlag;
+});
+
+type CallResult = { result: { content: { text: string }[] } };
+const remember = (args: Record<string, unknown>): Promise<unknown> =>
+  handleMcpPayload(store as never, {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: { name: "remember", arguments: args },
+  });
+const text = (res: unknown): string => (res as CallResult).result.content[0]!.text;
+
+describe("remember verb — inbox cutover routing", () => {
+  it("submits to the inbox (not a memory) when the consolidator is on + markdown", async () => {
+    makeStore("markdown");
+    process.env.LIBRARIAN_CONSOLIDATOR = "on";
+
+    const res = await remember({ title: "Anna", body: "moved to Berlin", agent_id: "agent-a" });
+
+    expect(text(res)).toMatch(/queued for consolidation/i);
+    // Nothing filed as a memory yet — it's in the inbox awaiting consolidation.
+    expect(store!.listMemories({}).total).toBe(0);
+    const inboxFiles = fs
+      .readdirSync(path.join(dataDir, "vault", "inbox"))
+      .filter((f) => f.endsWith(".md"));
+    expect(inboxFiles).toHaveLength(1);
+  });
+
+  it("writes directly (createMemory) when the consolidator is off — the default", async () => {
+    makeStore("markdown");
+    delete process.env.LIBRARIAN_CONSOLIDATOR;
+
+    const res = await remember({ title: "T", body: "B", agent_id: "agent-a" });
+
+    expect(text(res)).toMatch(/Memory saved/);
+    expect(store!.listMemories({ status: "active" }).total).toBe(1);
+  });
+
+  it("writes directly on the sqlite backend even with the flag on (the inbox is vault-only)", async () => {
+    makeStore("sqlite");
+    process.env.LIBRARIAN_CONSOLIDATOR = "on";
+
+    const res = await remember({ title: "T", body: "B", agent_id: "agent-a" });
+
+    expect(text(res)).toMatch(/Memory saved/);
+    expect(store!.listMemories({ status: "active" }).total).toBe(1);
+  });
+});

--- a/packages/mcp-server/tests/mcp/remember-cutover.test.ts
+++ b/packages/mcp-server/tests/mcp/remember-cutover.test.ts
@@ -69,6 +69,22 @@ describe("remember verb — inbox cutover routing", () => {
     expect(store!.listMemories({ status: "active" }).total).toBe(1);
   });
 
+  it("falls through to a direct write for an empty submission (no empty inbox item to loop on)", async () => {
+    makeStore("markdown");
+    process.env.LIBRARIAN_CONSOLIDATOR = "on";
+
+    // No title and no body → nothing to consolidate.
+    const res = await remember({ agent_id: "agent-a" });
+
+    expect(text(res)).toMatch(/Memory saved/);
+    expect(store!.listMemories({ status: "active" }).total).toBe(1);
+    const inboxDir = path.join(dataDir, "vault", "inbox");
+    const inboxFiles = fs.existsSync(inboxDir)
+      ? fs.readdirSync(inboxDir).filter((f) => f.endsWith(".md"))
+      : [];
+    expect(inboxFiles).toHaveLength(0);
+  });
+
   it("writes directly on the sqlite backend even with the flag on (the inbox is vault-only)", async () => {
     makeStore("sqlite");
     process.env.LIBRARIAN_CONSOLIDATOR = "on";


### PR DESCRIPTION
## What

Wires the `remember` verb to the consolidator inbox — the plan-036 Phase 4 cutover. **Opt-in, default off.**

When `LIBRARIAN_CONSOLIDATOR` is on **and** the store runs the markdown backend, `remember` becomes a fire-and-forget submission: it writes `title`+`body` to the consolidator inbox (carrying the submitter's `agent_id`/`project_key`/`tags` as hints) and returns *"queued for consolidation"*; the consolidator files it asynchronously (navigate→judge→edit). With the flag off — the default — `remember` keeps its existing direct `createMemory` behaviour, byte-for-byte.

## Why this shape

- **`isConsolidatorEnabled()`** is a single source of truth shared by the http scheduler and the verb, so the two readers of the flag can't drift.
- **`LibrarianStore` now reports its own `backend`.** The verb gates on the store's *actual* backend rather than re-deriving it from env via `resolveBackend()` — which mismatches the store when no backend is set (product default `markdown` vs library default `sqlite`). The inbox is vault-only, so this keeps the verb from ever calling the sqlite `submitToInbox` (which throws `CONSOLIDATOR_REQUIRES_MARKDOWN`).
- **Empty submission falls through to a direct write** (terminally files an "Untitled memory") rather than enqueueing an empty inbox item that navigate→judge can't plan from — it would only loop on the reaper TTL. Matches the off-path.

## Tests

`remember-cutover.test.ts` dispatches through `handleMcpPayload` over real stores:
- on + markdown → inbox (no memory filed yet; one inbox file)
- off → direct write ("Memory saved")
- empty submission (on + markdown) → falls through to a direct write, no inbox item
- on + sqlite → direct write (inbox is vault-only)

Full `pnpm -r build` + `pnpm -r test:vitest` green across all 5 packages. Sub-agent code review: **ship** (0 Critical; the one Important — the empty-submission edge — is fixed here).

## Follow-on (logged, not in scope)

The inbox path carries `agent_id`/`project_key`/`tags` but not `applies_to` (a caller-asserted targeting signal the judge can't re-derive). Threading it needs a core `InboxSubmissionHints` change — deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)