### PR TITLE
feat(consolidator-eval): the consolidator evaluation harness (C6, Phase 4 checkpoint)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ changes from this point forward are catalogued here.
 
 ### Added
 
+- **`@librarian/consolidator-eval` — the consolidator evaluation harness.** An
+  operator-driven package (mirroring `@librarian/classifier-eval`) that scores the
+  consolidator's `navigate → judge → route` pipeline against S1/S2/S4/S12/S18
+  fixtures: filing accuracy, decision-band routing, no-clobber of hand-authored
+  prose (S18), contradiction-recall (S4), and entity-resolution under ambiguity
+  (S12). Ships a `consolidator-eval` CLI with a frozen-baseline regression gate
+  (`--update-baseline` / `--baseline … --gate`). Not part of CI (it calls a real
+  model); its own tests drive the pipeline with a deterministic scripted model.
+
 - **The consolidator — opt-in async memory filing (plan-036 Phase 4).** With
   `LIBRARIAN_CONSOLIDATOR=on` on the markdown backend, `remember` becomes a
   fire-and-forget submission: the note is queued to a vault inbox and an LLM

--- a/packages/consolidator-eval/README.md
+++ b/packages/consolidator-eval/README.md
@@ -1,0 +1,52 @@
+# @librarian/consolidator-eval
+
+Operator-driven evaluation harness for the consolidator's `navigate → judge →
+route` pipeline (plan 036 Phase 4, the **C6 checkpoint**). It runs a set of
+fixtures — a submission plus the existing memories the judge can see — through
+the real pipeline with a configured model, and scores the plans against a
+ground-truth outcome.
+
+Like `@librarian/classifier-eval`, this is **not** part of the CI test gate (it
+calls a real model). The package's own unit tests drive the pipeline with a
+deterministic scripted model, so `pnpm test` stays offline and fast.
+
+## Metrics
+
+| metric                   | scenario | question |
+| ------------------------ | -------- | -------- |
+| `filing_accuracy`        | all      | right action, and right target when one is named? |
+| `decision_band_accuracy` | all      | did confidence route to the right band (auto / propose / create_new / skip)? |
+| `no_clobber_rate`        | S18      | did an edit to a hand-authored doc preserve its prose? |
+| `contradiction_recall`   | S4       | was a contradicting update *superseded* (not blindly augmented)? |
+| `entity_resolution`      | S12      | did an ambiguous merge AVOID a confident wrong-merge? |
+
+## Fixtures
+
+`fixtures/seed-v1.json` covers S1/S2/S4/S12/S18 with both `straight` and
+`boundary` cases. The schema (`src/fixture.ts`) enforces, at load time, that a
+targeted action names a corpus doc that exists and that the `action`↔`decision`
+pair is one the router can actually produce.
+
+## Running against a real model
+
+```sh
+export LIBRARIAN_CONSOLIDATOR_EVAL_ENDPOINT=https://api.openai.com/v1
+export LIBRARIAN_CONSOLIDATOR_EVAL_TOKEN=sk-...
+
+# print a summary
+consolidator-eval run --model gpt-4o-mini
+
+# freeze this run as the baseline
+consolidator-eval run --model gpt-4o-mini --update-baseline fixtures/baseline.json
+
+# gate a later run against the frozen baseline (non-zero exit on regression)
+consolidator-eval run --model gpt-4o-mini --baseline fixtures/baseline.json --gate
+```
+
+## The frozen baseline (operator step)
+
+A meaningful baseline must be produced by an **operator running a real model** —
+it can't be generated in CI or from the deterministic fake (which trivially
+scores 1.0). Generate it once with `--update-baseline`, commit the resulting
+`fixtures/baseline.json`, then wire `--baseline … --gate` into whatever cadence
+you want regressions caught at. Until that baseline exists, the gate is inert.

--- a/packages/consolidator-eval/fixtures/seed-v1.json
+++ b/packages/consolidator-eval/fixtures/seed-v1.json
@@ -1,0 +1,155 @@
+[
+  {
+    "id": "fix_s1_create_straight",
+    "scenario": "S1",
+    "category": "straight",
+    "submission": {
+      "text": "The analytics warehouse runs on PostgreSQL 16, migrated from Redshift in May 2026."
+    },
+    "corpus": [
+      {
+        "id": "mem_anna",
+        "title": "Anna Schmidt",
+        "body": "Anna Schmidt is a backend engineer on the platform team.",
+        "tags": ["person"]
+      },
+      {
+        "id": "mem_standup",
+        "title": "Standup cadence",
+        "body": "The team holds standup at 10:00 CET on weekdays.",
+        "tags": ["process"]
+      }
+    ],
+    "expect": { "action": "create", "decision": "auto_apply" },
+    "notes": "A novel topic unrelated to anything in the corpus → file a fresh memory."
+  },
+  {
+    "id": "fix_s1_create_boundary",
+    "scenario": "S1",
+    "category": "boundary",
+    "submission": {
+      "text": "Acme Corp launched a new payments product line, AcmePay, in June 2026."
+    },
+    "corpus": [
+      {
+        "id": "mem_anna_job",
+        "title": "Anna Schmidt — employer",
+        "body": "Anna Schmidt works at Acme Corp as a backend engineer.",
+        "tags": ["person", "employment"]
+      }
+    ],
+    "expect": { "action": "create", "decision": "auto_apply" },
+    "notes": "Mentions Acme, which the corpus knows only as Anna's employer. The fact is about the company, not Anna — a fresh company/topic memory, not an augment of Anna."
+  },
+  {
+    "id": "fix_s1_noop_boundary",
+    "scenario": "S1",
+    "category": "boundary",
+    "submission": { "text": "Anna is employed at Acme Corp." },
+    "corpus": [
+      {
+        "id": "mem_anna_job",
+        "title": "Anna Schmidt — employer",
+        "body": "Anna Schmidt works at Acme Corp as a backend engineer.",
+        "tags": ["person", "employment"]
+      }
+    ],
+    "expect": { "action": "noop", "decision": "skip" },
+    "notes": "The submission restates a fact already recorded — nothing new to file."
+  },
+  {
+    "id": "fix_s2_augment_straight",
+    "scenario": "S2",
+    "category": "straight",
+    "submission": {
+      "text": "Anna Schmidt mentored Sophie Becker through her first on-call rotation."
+    },
+    "corpus": [
+      {
+        "id": "mem_anna",
+        "title": "Anna Schmidt",
+        "body": "Anna Schmidt is a backend engineer on the platform team.",
+        "tags": ["person"]
+      }
+    ],
+    "expect": { "action": "augment", "decision": "auto_apply", "target_id": "mem_anna" },
+    "notes": "A multi-entity fact about a known entity (Anna) and a new one (Sophie). File onto the primary known entity; Sophie can be backlinked."
+  },
+  {
+    "id": "fix_s4_supersede_straight",
+    "scenario": "S4",
+    "category": "straight",
+    "submission": {
+      "text": "Anna Schmidt left Acme Corp and is now a design lead at Globex, as of June 2026."
+    },
+    "corpus": [
+      {
+        "id": "mem_anna_job",
+        "title": "Anna Schmidt — employer",
+        "body": "Anna Schmidt works at Acme Corp as a backend engineer.",
+        "tags": ["person", "employment"]
+      }
+    ],
+    "expect": { "action": "supersede", "decision": "auto_apply", "target_id": "mem_anna_job" },
+    "notes": "A clear, dated contradiction of the recorded employer → supersede, not a blind augment that would leave both facts active."
+  },
+  {
+    "id": "fix_s4_supersede_boundary",
+    "scenario": "S4",
+    "category": "boundary",
+    "submission": { "text": "Anna was promoted to senior backend engineer." },
+    "corpus": [
+      {
+        "id": "mem_anna_role",
+        "title": "Anna Schmidt — role",
+        "body": "Anna Schmidt is a backend engineer on the platform team.",
+        "tags": ["person", "role"]
+      }
+    ],
+    "expect": { "action": "supersede", "decision": "propose", "target_id": "mem_anna_role" },
+    "notes": "A role change that could read as either an addition or a replacement. The corrected state supersedes the old role, but the ambiguity warrants a proposal rather than a silent auto-apply."
+  },
+  {
+    "id": "fix_s12_ambiguous_boundary",
+    "scenario": "S12",
+    "category": "boundary",
+    "submission": { "text": "Anna got married last weekend and is taking her partner's surname." },
+    "corpus": [
+      {
+        "id": "mem_anna_schmidt",
+        "title": "Anna Schmidt",
+        "body": "Anna Schmidt is a backend engineer on the platform team.",
+        "tags": ["person"]
+      },
+      {
+        "id": "mem_anna_kowalski",
+        "title": "Anna Kowalski",
+        "body": "Anna Kowalski is a product designer in the Warsaw office.",
+        "tags": ["person"]
+      }
+    ],
+    "expect": { "action": "augment", "decision": "create_new", "target_id": "mem_anna_schmidt" },
+    "notes": "Two distinct 'Anna's and no disambiguator. An uncertain merge must not silently pick one — the low-confidence band files a fresh memory (create_new) instead of clobbering the wrong Anna."
+  },
+  {
+    "id": "fix_s18_no_clobber_straight",
+    "scenario": "S18",
+    "category": "straight",
+    "submission": { "text": "Project Atlas now supports single sign-on via SAML." },
+    "corpus": [
+      {
+        "id": "mem_atlas",
+        "title": "Project Atlas — overview",
+        "body": "Project Atlas is the customer-facing portal.\n\nArchitecture: a Next.js front end backed by the core API.\nOwners: the platform team.\nStatus: in production since March 2026.",
+        "tags": ["project"]
+      }
+    ],
+    "expect": {
+      "action": "augment",
+      "decision": "auto_apply",
+      "target_id": "mem_atlas",
+      "preserves_corpus": true
+    },
+    "notes": "Augmenting a hand-authored doc: the SSO fact is appended, but every existing line of the overview must survive intact (minimal-edit / no-clobber)."
+  }
+]

--- a/packages/consolidator-eval/fixtures/seed-v1.json
+++ b/packages/consolidator-eval/fixtures/seed-v1.json
@@ -97,17 +97,17 @@
     "id": "fix_s4_supersede_boundary",
     "scenario": "S4",
     "category": "boundary",
-    "submission": { "text": "Anna was promoted to senior backend engineer." },
+    "submission": { "text": "Anna has moved to the Munich office." },
     "corpus": [
       {
-        "id": "mem_anna_role",
-        "title": "Anna Schmidt — role",
-        "body": "Anna Schmidt is a backend engineer on the platform team.",
-        "tags": ["person", "role"]
+        "id": "mem_anna_location",
+        "title": "Anna Schmidt — office",
+        "body": "Anna Schmidt works out of the Berlin office.",
+        "tags": ["person", "location"]
       }
     ],
-    "expect": { "action": "supersede", "decision": "propose", "target_id": "mem_anna_role" },
-    "notes": "A role change that could read as either an addition or a replacement. The corrected state supersedes the old role, but the ambiguity warrants a proposal rather than a silent auto-apply."
+    "expect": { "action": "supersede", "decision": "propose", "target_id": "mem_anna_location" },
+    "notes": "A location change clearly replaces the prior office (supersede, not a blind augment that would leave both offices recorded), but with no effective date the timing is uncertain — a proposal rather than a silent auto-apply."
   },
   {
     "id": "fix_s12_ambiguous_boundary",
@@ -151,5 +151,28 @@
       "preserves_corpus": true
     },
     "notes": "Augmenting a hand-authored doc: the SSO fact is appended, but every existing line of the overview must survive intact (minimal-edit / no-clobber)."
+  },
+  {
+    "id": "fix_s18_supersede_preserve_boundary",
+    "scenario": "S18",
+    "category": "boundary",
+    "submission": {
+      "text": "Project Atlas was re-platformed off Next.js onto SvelteKit in June 2026; everything else about it is unchanged."
+    },
+    "corpus": [
+      {
+        "id": "mem_atlas_stack",
+        "title": "Project Atlas — overview",
+        "body": "Project Atlas is the customer-facing portal.\n\nArchitecture: a Next.js front end backed by the core API.\nOwners: the platform team.\nStatus: in production since March 2026.",
+        "tags": ["project"]
+      }
+    ],
+    "expect": {
+      "action": "supersede",
+      "decision": "propose",
+      "target_id": "mem_atlas_stack",
+      "preserves_corpus": true
+    },
+    "notes": "One architecture line changed, so the doc is replaced (supersede) — but the full rewrite MUST keep every other hand-authored line (owners, status, the portal description). This is the only non-vacuous no_clobber path: a supersede that drops a line is a clobber even though the action is 'right'. Propose, since a rewrite of hand-authored prose warrants review."
   }
 ]

--- a/packages/consolidator-eval/package.json
+++ b/packages/consolidator-eval/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@librarian/consolidator-eval",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Operator-driven consolidator evaluation harness: fixtures + scoring + CLI for the navigate→judge→route pipeline.",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "consolidator-eval": "./dist/cli/bin.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./fixtures/seed-v1": "./fixtures/seed-v1.json"
+  },
+  "scripts": {
+    "prepare": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.json",
+    "test:vitest": "vitest run",
+    "test": "pnpm run build && pnpm run test:vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@librarian/core": "workspace:*",
+    "zod": "^4.0.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.5",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "license": "Apache-2.0"
+}

--- a/packages/consolidator-eval/src/baseline.ts
+++ b/packages/consolidator-eval/src/baseline.ts
@@ -7,6 +7,7 @@
 // present at baseline but is `null` in a later run counts as a regression to 0
 // (the scenario silently stopped being exercised).
 
+import { z } from "zod";
 import type { EvalReport } from "./metrics.js";
 
 export const BASELINE_METRICS = [
@@ -19,7 +20,19 @@ export const BASELINE_METRICS = [
 
 export type BaselineMetric = (typeof BASELINE_METRICS)[number];
 
-export type Baseline = Record<BaselineMetric, number | null>;
+// A baseline must carry every metric (a value in [0,1], or null = "not measured").
+// Validated on load so an empty/stale/typo'd baseline fails loud rather than
+// silently green-gating a comparison that checks nothing.
+const metric = z.number().min(0).max(1).nullable();
+export const BaselineSchema = z.strictObject({
+  filing_accuracy: metric,
+  decision_band_accuracy: metric,
+  no_clobber_rate: metric,
+  contradiction_recall: metric,
+  entity_resolution: metric,
+});
+
+export type Baseline = z.infer<typeof BaselineSchema>;
 
 export interface Regression {
   metric: BaselineMetric;

--- a/packages/consolidator-eval/src/baseline.ts
+++ b/packages/consolidator-eval/src/baseline.ts
@@ -1,0 +1,69 @@
+// The regression gate. An operator runs the eval against a real model once and
+// freezes the headline metrics as a baseline; later runs compare against it and
+// fail if any metric drops by more than a tolerance. Pure — the CLI wires it to
+// file I/O.
+//
+// A baseline metric of `null` means "not measured" (skip it). A metric that was
+// present at baseline but is `null` in a later run counts as a regression to 0
+// (the scenario silently stopped being exercised).
+
+import type { EvalReport } from "./metrics.js";
+
+export const BASELINE_METRICS = [
+  "filing_accuracy",
+  "decision_band_accuracy",
+  "no_clobber_rate",
+  "contradiction_recall",
+  "entity_resolution",
+] as const;
+
+export type BaselineMetric = (typeof BASELINE_METRICS)[number];
+
+export type Baseline = Record<BaselineMetric, number | null>;
+
+export interface Regression {
+  metric: BaselineMetric;
+  baseline: number;
+  observed: number;
+  delta: number;
+}
+
+export interface GateResult {
+  passed: boolean;
+  tolerance: number;
+  regressions: Regression[];
+}
+
+/** The default slack allowed before a drop counts as a regression (real-model runs vary). */
+export const DEFAULT_TOLERANCE = 0.05;
+
+export function baselineFromReport(report: EvalReport): Baseline {
+  return {
+    filing_accuracy: report.filing_accuracy,
+    decision_band_accuracy: report.decision_band_accuracy,
+    no_clobber_rate: report.no_clobber_rate,
+    contradiction_recall: report.contradiction_recall,
+    entity_resolution: report.entity_resolution,
+  };
+}
+
+export function compareToBaseline(
+  report: EvalReport,
+  baseline: Baseline,
+  tolerance: number = DEFAULT_TOLERANCE,
+): GateResult {
+  const observed = baselineFromReport(report);
+  const regressions: Regression[] = [];
+  for (const metric of BASELINE_METRICS) {
+    const base = baseline[metric];
+    if (base === null || base === undefined) continue; // nothing expected of this metric
+    const value = observed[metric];
+    if (value === null) {
+      regressions.push({ metric, baseline: base, observed: 0, delta: -base });
+      continue;
+    }
+    const delta = value - base;
+    if (delta < -tolerance) regressions.push({ metric, baseline: base, observed: value, delta });
+  }
+  return { passed: regressions.length === 0, tolerance, regressions };
+}

--- a/packages/consolidator-eval/src/cli/bin.ts
+++ b/packages/consolidator-eval/src/cli/bin.ts
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// consolidator-eval CLI entry. Wraps `runConsolidatorEval()` for operator runs
+// against a real model + the regression gate. The dashboard / tests use the
+// in-process API directly; this bin exists for ad-hoc runs and CI gating.
+
+import { parseArgs } from "node:util";
+import { runEvalCommand } from "./run-command.js";
+
+async function main(): Promise<void> {
+  const { positionals } = parseArgs({
+    args: process.argv.slice(2),
+    allowPositionals: true,
+    strict: false,
+  });
+
+  const sub = positionals[0];
+  switch (sub) {
+    case "run": {
+      const result = await runEvalCommand(process.argv.slice(3));
+      if (result.gateFailed) process.exit(1);
+      return;
+    }
+    case undefined:
+    case "help":
+    case "--help": {
+      printHelp();
+      return;
+    }
+    default: {
+      process.stderr.write(`consolidator-eval: unknown subcommand "${sub}"\n`);
+      printHelp();
+      process.exit(2);
+    }
+  }
+}
+
+function printHelp(): void {
+  process.stdout.write(
+    [
+      "consolidator-eval — operator-driven consolidator evaluation",
+      "",
+      "Subcommands:",
+      "  run    Run the eval over a fixture against the configured model",
+      "",
+      "Usage:",
+      "  consolidator-eval run --model gpt-4o-mini",
+      "  consolidator-eval run --model gpt-4o-mini --update-baseline fixtures/baseline.json",
+      "  consolidator-eval run --model gpt-4o-mini --baseline fixtures/baseline.json --gate",
+      "",
+      "Options for `run`:",
+      "  --model <id>              Model identifier (required)",
+      "  --fixture <path>          Fixture JSON; defaults to the bundled seed-v1",
+      "  --json                    Print the full report JSON (default: summary)",
+      "  --dry-run                 Validate the fixture + env without calling a model",
+      "  --baseline <path>         Compare the run's metrics against this baseline",
+      "  --update-baseline <path>  Freeze this run's metrics as the baseline (no gate)",
+      "  --gate                    Exit non-zero if any metric regresses past --tolerance",
+      "  --tolerance <f>           Allowed drop before a regression; defaults to 0.05",
+      "",
+      "Environment (for a real run):",
+      "  LIBRARIAN_CONSOLIDATOR_EVAL_ENDPOINT   OpenAI-compatible base URL",
+      "  LIBRARIAN_CONSOLIDATOR_EVAL_TOKEN      Bearer token",
+      "",
+    ].join("\n"),
+  );
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(
+    `consolidator-eval: ${err instanceof Error ? err.message : "unknown error"}\n`,
+  );
+  process.exit(1);
+});

--- a/packages/consolidator-eval/src/cli/run-command.ts
+++ b/packages/consolidator-eval/src/cli/run-command.ts
@@ -1,0 +1,190 @@
+// `consolidator-eval run` — parse flags, build an LLM client from the eval env
+// vars (an OpenAI-compatible endpoint: a hosted model or a local ollama/vllm/
+// llama.cpp server), run the eval over a fixture, print the report, and
+// optionally gate against a frozen baseline.
+//
+// `buildClient` is injectable so the command can be driven end-to-end in tests
+// with a scripted model; the default builds the real remote client.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { parseArgs } from "node:util";
+import { type LlmClient, type LlmClientConfig, createCuratorLlmClient } from "@librarian/core";
+import {
+  type Baseline,
+  type GateResult,
+  baselineFromReport,
+  compareToBaseline,
+} from "../baseline.js";
+import { ConsolidatorFixtureFileSchema, type ConsolidatorFixtureEntry } from "../fixture.js";
+import { type EvalReport, loadSeedFixture, runConsolidatorEval } from "../index.js";
+
+export const ENV_ENDPOINT = "LIBRARIAN_CONSOLIDATOR_EVAL_ENDPOINT";
+export const ENV_TOKEN = "LIBRARIAN_CONSOLIDATOR_EVAL_TOKEN";
+
+export interface RunCommandFlags {
+  model: string;
+  json: boolean;
+  dryRun: boolean;
+  gate: boolean;
+  tolerance: number;
+  fixturePath?: string;
+  baselinePath?: string;
+  updateBaselinePath?: string;
+}
+
+export interface RunCommandDeps {
+  /** Build the LLM client for a real run. Injected in tests with a scripted model. */
+  buildClient?: (model: string) => LlmClient;
+}
+
+export interface RunCommandResult {
+  report: EvalReport;
+  gate?: GateResult;
+  /** True only when --gate was passed AND a regression was found (the bin exits non-zero). */
+  gateFailed: boolean;
+}
+
+export function parseRunFlags(args: string[]): RunCommandFlags {
+  const { values } = parseArgs({
+    args,
+    options: {
+      model: { type: "string" },
+      fixture: { type: "string" },
+      json: { type: "boolean", default: false },
+      "dry-run": { type: "boolean", default: false },
+      baseline: { type: "string" },
+      "update-baseline": { type: "string" },
+      gate: { type: "boolean", default: false },
+      tolerance: { type: "string" },
+    },
+    strict: true,
+  });
+
+  const model = values.model;
+  if (typeof model !== "string" || model.length === 0) {
+    throw new Error("--model is required");
+  }
+  const tolerance = values.tolerance === undefined ? 0.05 : Number(values.tolerance);
+  if (!Number.isFinite(tolerance) || tolerance < 0) {
+    throw new Error("--tolerance must be a non-negative number");
+  }
+
+  const flags: RunCommandFlags = {
+    model,
+    json: Boolean(values.json),
+    dryRun: Boolean(values["dry-run"]),
+    gate: Boolean(values.gate),
+    tolerance,
+  };
+  if (typeof values.fixture === "string") flags.fixturePath = values.fixture;
+  if (typeof values.baseline === "string") flags.baselinePath = values.baseline;
+  if (typeof values["update-baseline"] === "string") {
+    flags.updateBaselinePath = values["update-baseline"];
+  }
+  return flags;
+}
+
+function loadFixture(path: string | undefined): ConsolidatorFixtureEntry[] {
+  if (path === undefined) return loadSeedFixture();
+  return ConsolidatorFixtureFileSchema.parse(JSON.parse(readFileSync(path, "utf8")));
+}
+
+function buildRemoteClient(model: string): LlmClient {
+  const endpoint = process.env[ENV_ENDPOINT];
+  const token = process.env[ENV_TOKEN];
+  if (!endpoint || !token) {
+    throw new Error(`A real run requires ${ENV_ENDPOINT} and ${ENV_TOKEN} environment variables.`);
+  }
+  const config: LlmClientConfig = { endpoint, token, model };
+  return createCuratorLlmClient(config);
+}
+
+export async function runEvalCommand(
+  args: string[],
+  deps: RunCommandDeps = {},
+): Promise<RunCommandResult> {
+  const flags = parseRunFlags(args);
+  const fixture = loadFixture(flags.fixturePath);
+
+  if (flags.dryRun) {
+    // Validate the fixture parses and the real-run env is configured, without
+    // calling any model.
+    buildRemoteClient(flags.model);
+    process.stdout.write(
+      `consolidator-eval: dry-run OK — ${fixture.length} fixtures, env configured for ${flags.model}\n`,
+    );
+    return { report: emptyReport(), gateFailed: false };
+  }
+
+  const llmClient = (deps.buildClient ?? buildRemoteClient)(flags.model);
+  const report = await runConsolidatorEval({ fixture, llmClient });
+
+  if (flags.updateBaselinePath) {
+    writeFileSync(
+      flags.updateBaselinePath,
+      `${JSON.stringify(baselineFromReport(report), null, 2)}\n`,
+    );
+    process.stdout.write(`consolidator-eval: wrote baseline → ${flags.updateBaselinePath}\n`);
+  }
+
+  let gate: GateResult | undefined;
+  if (flags.baselinePath) {
+    const baseline = JSON.parse(readFileSync(flags.baselinePath, "utf8")) as Baseline;
+    gate = compareToBaseline(report, baseline, flags.tolerance);
+  }
+
+  process.stdout.write(flags.json ? `${JSON.stringify(report, null, 2)}\n` : formatSummary(report));
+  if (gate) process.stdout.write(formatGate(gate));
+
+  const gateFailed = Boolean(flags.gate && gate && !gate.passed);
+  return gate ? { report, gate, gateFailed } : { report, gateFailed };
+}
+
+function pct(value: number | null): string {
+  return value === null ? "  n/a" : `${(value * 100).toFixed(1)}%`;
+}
+
+function formatSummary(report: EvalReport): string {
+  const lines = [
+    `Samples: ${report.sample_size}   Parse errors: ${report.parse_error_count}`,
+    "",
+    `  filing_accuracy        ${pct(report.filing_accuracy)}`,
+    `  decision_band_accuracy ${pct(report.decision_band_accuracy)}`,
+    `  no_clobber_rate        ${pct(report.no_clobber_rate)}`,
+    `  contradiction_recall   ${pct(report.contradiction_recall)}`,
+    `  entity_resolution      ${pct(report.entity_resolution)}`,
+    "",
+    "By scenario (action / decision correct):",
+  ];
+  for (const [scenario, b] of Object.entries(report.by_scenario)) {
+    lines.push(
+      `  ${scenario.padEnd(4)} ${b.action_correct}/${b.total}   ${b.decision_correct}/${b.total}`,
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function formatGate(gate: GateResult): string {
+  if (gate.passed) return `\nGate: PASS (tolerance ${gate.tolerance})\n`;
+  const lines = [`\nGate: FAIL (tolerance ${gate.tolerance})`];
+  for (const r of gate.regressions) {
+    lines.push(
+      `  ${r.metric.padEnd(22)} ${(r.baseline * 100).toFixed(1)}% → ${(r.observed * 100).toFixed(1)}% (${(r.delta * 100).toFixed(1)}%)`,
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function emptyReport(): EvalReport {
+  return {
+    sample_size: 0,
+    filing_accuracy: 0,
+    decision_band_accuracy: 0,
+    no_clobber_rate: null,
+    contradiction_recall: null,
+    entity_resolution: null,
+    parse_error_count: 0,
+    by_scenario: {} as EvalReport["by_scenario"],
+    samples: [],
+  };
+}

--- a/packages/consolidator-eval/src/cli/run-command.ts
+++ b/packages/consolidator-eval/src/cli/run-command.ts
@@ -10,8 +10,8 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { parseArgs } from "node:util";
 import { type LlmClient, type LlmClientConfig, createCuratorLlmClient } from "@librarian/core";
 import {
-  type Baseline,
   type GateResult,
+  BaselineSchema,
   baselineFromReport,
   compareToBaseline,
 } from "../baseline.js";
@@ -129,7 +129,7 @@ export async function runEvalCommand(
 
   let gate: GateResult | undefined;
   if (flags.baselinePath) {
-    const baseline = JSON.parse(readFileSync(flags.baselinePath, "utf8")) as Baseline;
+    const baseline = BaselineSchema.parse(JSON.parse(readFileSync(flags.baselinePath, "utf8")));
     gate = compareToBaseline(report, baseline, flags.tolerance);
   }
 
@@ -184,7 +184,7 @@ function emptyReport(): EvalReport {
     contradiction_recall: null,
     entity_resolution: null,
     parse_error_count: 0,
-    by_scenario: {} as EvalReport["by_scenario"],
+    by_scenario: {},
     samples: [],
   };
 }

--- a/packages/consolidator-eval/src/fake-llm.ts
+++ b/packages/consolidator-eval/src/fake-llm.ts
@@ -30,6 +30,8 @@ export function scriptedLlmClient(
   return {
     async complete(request: LlmCompletionRequest): Promise<LlmCompletion> {
       const haystack = request.messages.map((message) => message.content).join("\n");
+      // rawByMatch wins over the scripted judgments: it lets a test simulate a
+      // model returning garbage even for a submission that also has a judgment.
       const raw = Object.entries(options.rawByMatch ?? {}).find(([key]) => haystack.includes(key));
       if (raw) return { content: raw[1], model: "scripted", usage: null };
       const hit = script.find((entry) => haystack.includes(entry.match));

--- a/packages/consolidator-eval/src/fake-llm.ts
+++ b/packages/consolidator-eval/src/fake-llm.ts
@@ -1,0 +1,40 @@
+// A deterministic LlmClient for the eval's own tests (drive navigate→judge→route
+// without a model) and for operator dry-runs over recorded judgments. It returns
+// a scripted judgment whenever its `match` substring appears in the request — the
+// submission text is the natural key, since the judge prompt embeds it verbatim.
+
+import type {
+  ConsolidationJudgment,
+  LlmClient,
+  LlmCompletion,
+  LlmCompletionRequest,
+} from "@librarian/core";
+
+export interface ScriptedJudgment {
+  /** A substring that identifies the request (e.g. a snippet of the submission). */
+  match: string;
+  /** The judgment to return, serialized as the model's JSON content. */
+  judgment: ConsolidationJudgment;
+}
+
+/**
+ * Build a deterministic LlmClient from a script. The first entry whose `match`
+ * appears in the concatenated request messages wins; an unmatched request throws
+ * (a fixture with no scripted answer is a test-authoring error, not a silent
+ * pass). To simulate a model returning garbage, pass `rawContent` for an entry.
+ */
+export function scriptedLlmClient(
+  script: ScriptedJudgment[],
+  options: { rawByMatch?: Record<string, string> } = {},
+): LlmClient {
+  return {
+    async complete(request: LlmCompletionRequest): Promise<LlmCompletion> {
+      const haystack = request.messages.map((message) => message.content).join("\n");
+      const raw = Object.entries(options.rawByMatch ?? {}).find(([key]) => haystack.includes(key));
+      if (raw) return { content: raw[1], model: "scripted", usage: null };
+      const hit = script.find((entry) => haystack.includes(entry.match));
+      if (!hit) throw new Error("scriptedLlmClient: no scripted judgment matches the request");
+      return { content: JSON.stringify(hit.judgment), model: "scripted", usage: null };
+    },
+  };
+}

--- a/packages/consolidator-eval/src/fixture.ts
+++ b/packages/consolidator-eval/src/fixture.ts
@@ -1,0 +1,120 @@
+// Fixture schema for consolidator evaluation samples (plan 036 Phase 4 / the
+// C6 checkpoint; scenarios from spec 035 §F5 + the brainstorm-mvp §9 list).
+//
+// Each entry is a SUBMISSION the consolidator must file, plus the existing
+// memories it can see (the `corpus`), plus the GROUND-TRUTH outcome a correct
+// consolidator should reach: the judge `action` and the routing `decision`
+// (and, for a targeted action, which corpus doc it must touch). The harness
+// runs every entry through navigate→judge→route and reports agreement against
+// these expectations.
+//
+// `category: "straight"` is a clear case; `category: "boundary"` flags a case
+// where the right answer needs judgement (ambiguous entity, contradiction,
+// hand-authored prose that must not be clobbered). The harness can filter to
+// boundary-only to surface the hard evaluations.
+//
+// The five scenarios:
+//   S1  — new fact on a novel topic → create.
+//   S2  — multi-entity fact (the "Anna problem") → augment the primary entity.
+//   S4  — updated/conflicting fact → supersede, not blind augment.
+//   S12 — ambiguous entity (two "Anna"s) → an uncertain merge must NOT silently
+//         under-merge: route to create_new (low-confidence augment) or propose.
+//   S18 — augmenting a hand-authored doc → never clobber the existing prose.
+
+import { z } from "zod";
+
+export const CONSOLIDATOR_SCENARIOS = ["S1", "S2", "S4", "S12", "S18"] as const;
+export type ConsolidatorScenario = (typeof CONSOLIDATOR_SCENARIOS)[number];
+
+/** A judge action (the discriminated-union actions of ConsolidationJudgment). */
+export const JUDGE_ACTIONS = ["create", "augment", "supersede", "archive", "noop"] as const;
+/** A routing decision (the bands `routeConsolidation` can emit). */
+export const ROUTING_DECISIONS = ["auto_apply", "propose", "create_new", "skip"] as const;
+
+// Which routing decisions each action can actually reach (mirrors
+// `routeConsolidation` in @librarian/core). A fixture pairing an action with an
+// unreachable decision is an authoring error — reject it at parse time.
+const REACHABLE: Record<
+  (typeof JUDGE_ACTIONS)[number],
+  readonly (typeof ROUTING_DECISIONS)[number][]
+> = {
+  noop: ["skip"],
+  create: ["auto_apply"],
+  augment: ["auto_apply", "propose", "create_new"],
+  supersede: ["auto_apply", "propose"],
+  archive: ["auto_apply", "propose"],
+};
+
+const CorpusDocSchema = z.strictObject({
+  id: z.string().min(1),
+  title: z.string(),
+  body: z.string(),
+  tags: z.array(z.string()),
+  project_key: z.string().nullable().optional(),
+});
+export type ConsolidatorCorpusDoc = z.infer<typeof CorpusDocSchema>;
+
+const ExpectedSchema = z.strictObject({
+  action: z.enum(JUDGE_ACTIONS),
+  decision: z.enum(ROUTING_DECISIONS),
+  // Required for augment/supersede/archive — the corpus doc the judge must
+  // touch. Validated to exist in the corpus by the cross-field refinement.
+  target_id: z.string().min(1).optional(),
+  // S18: when augmenting, the targeted doc's existing body must survive intact
+  // (minimal-edit / no-clobber). The harness asserts `preservesOriginal`.
+  preserves_corpus: z.boolean().optional(),
+});
+
+const SubmissionSchema = z.strictObject({
+  text: z.string().min(1),
+  hints: z
+    .strictObject({
+      agent_id: z.string().optional(),
+      project_key: z.string().nullable().optional(),
+      tags: z.array(z.string()).optional(),
+    })
+    .optional(),
+});
+
+export const ConsolidatorFixtureEntrySchema = z
+  .strictObject({
+    id: z.string().min(1),
+    scenario: z.enum(CONSOLIDATOR_SCENARIOS),
+    category: z.enum(["straight", "boundary"]),
+    submission: SubmissionSchema,
+    corpus: z.array(CorpusDocSchema),
+    expect: ExpectedSchema,
+    notes: z.string().optional(),
+  })
+  .superRefine((entry, ctx) => {
+    const { action, decision, target_id } = entry.expect;
+
+    if (!REACHABLE[action].includes(decision)) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["expect", "decision"],
+        message: `routing: action '${action}' can never route to decision '${decision}' (reachable: ${REACHABLE[action].join(", ")})`,
+      });
+    }
+
+    const needsTarget = action === "augment" || action === "supersede" || action === "archive";
+    if (needsTarget && !target_id) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["expect", "target_id"],
+        message: `action '${action}' requires expect.target_id`,
+      });
+    }
+    if (target_id && !entry.corpus.some((doc) => doc.id === target_id)) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["expect", "target_id"],
+        message: `expect.target_id '${target_id}' must exist in the corpus`,
+      });
+    }
+  });
+
+export type ConsolidatorFixtureEntry = z.infer<typeof ConsolidatorFixtureEntrySchema>;
+
+export const ConsolidatorFixtureFileSchema = z.array(ConsolidatorFixtureEntrySchema);
+export type ConsolidatorFixtureFile = z.infer<typeof ConsolidatorFixtureFileSchema>;

--- a/packages/consolidator-eval/src/index.ts
+++ b/packages/consolidator-eval/src/index.ts
@@ -1,0 +1,41 @@
+// @librarian/consolidator-eval — operator-driven evaluation harness for the
+// consolidator's navigate→judge→route pipeline (plan 036 Phase 4 / the C6
+// checkpoint).
+//
+// Public surface (C6a — fixtures):
+//   - the fixture schema + types (a submission, the corpus the judge sees, and
+//     the ground-truth action/decision a correct consolidator should reach);
+//   - `loadSeedFixture()` — the bundled S1/S2/S4/S12/S18 seed set.
+//
+// The scoring engine, the deterministic fake LLM client, and the CLI land in
+// the follow-on increments (C6b/C6c).
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { ConsolidatorFixtureFileSchema, type ConsolidatorFixtureEntry } from "./fixture.js";
+
+export {
+  CONSOLIDATOR_SCENARIOS,
+  JUDGE_ACTIONS,
+  ROUTING_DECISIONS,
+  ConsolidatorFixtureEntrySchema,
+  ConsolidatorFixtureFileSchema,
+} from "./fixture.js";
+export type {
+  ConsolidatorScenario,
+  ConsolidatorCorpusDoc,
+  ConsolidatorFixtureEntry,
+  ConsolidatorFixtureFile,
+} from "./fixture.js";
+
+/**
+ * Load the bundled seed fixture — a small set covering each consolidator
+ * scenario (S1/S2/S4/S12/S18) with both straight and boundary cases. Parsed
+ * against the schema, so cross-field invariants (target exists; action↔decision
+ * is routing-reachable) are enforced on load.
+ */
+export function loadSeedFixture(): ConsolidatorFixtureEntry[] {
+  const url = new URL("../fixtures/seed-v1.json", import.meta.url);
+  const raw = readFileSync(fileURLToPath(url), "utf8");
+  return ConsolidatorFixtureFileSchema.parse(JSON.parse(raw));
+}

--- a/packages/consolidator-eval/src/index.ts
+++ b/packages/consolidator-eval/src/index.ts
@@ -7,8 +7,7 @@
 //     the ground-truth action/decision a correct consolidator should reach);
 //   - `loadSeedFixture()` — the bundled S1/S2/S4/S12/S18 seed set.
 //
-// The scoring engine, the deterministic fake LLM client, and the CLI land in
-// the follow-on increments (C6b/C6c).
+// The operator CLI + frozen baseline land in the follow-on increment (C6c).
 
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -27,6 +26,21 @@ export type {
   ConsolidatorFixtureEntry,
   ConsolidatorFixtureFile,
 } from "./fixture.js";
+
+export { runConsolidatorEval } from "./run.js";
+export type { RunConsolidatorEvalOptions } from "./run.js";
+export { scoreSample, summarize } from "./metrics.js";
+export type { EvalReport, SampleResult, SampleOutcome, ScenarioBreakdown } from "./metrics.js";
+export { scriptedLlmClient } from "./fake-llm.js";
+export type { ScriptedJudgment } from "./fake-llm.js";
+
+export {
+  BASELINE_METRICS,
+  DEFAULT_TOLERANCE,
+  baselineFromReport,
+  compareToBaseline,
+} from "./baseline.js";
+export type { Baseline, BaselineMetric, GateResult, Regression } from "./baseline.js";
 
 /**
  * Load the bundled seed fixture — a small set covering each consolidator

--- a/packages/consolidator-eval/src/index.ts
+++ b/packages/consolidator-eval/src/index.ts
@@ -37,6 +37,7 @@ export type { ScriptedJudgment } from "./fake-llm.js";
 export {
   BASELINE_METRICS,
   DEFAULT_TOLERANCE,
+  BaselineSchema,
   baselineFromReport,
   compareToBaseline,
 } from "./baseline.js";

--- a/packages/consolidator-eval/src/metrics.ts
+++ b/packages/consolidator-eval/src/metrics.ts
@@ -76,13 +76,19 @@ export function scoreSample(
   };
   const base = { id: entry.id, scenario: entry.scenario, category: entry.category, expected };
 
+  // Only grade the target when the expected outcome actually keeps it. A
+  // create_new routing files a fresh doc and DISCARDS the judgment's target
+  // (apply.ts), so grading the named id on a create_new entry would penalise the
+  // correct "don't confidently merge" behaviour on an arbitrary tiebreak.
+  const gradeTarget = Boolean(entry.expect.target_id) && entry.expect.decision !== "create_new";
+
   if (!plan) {
     return {
       ...base,
       actual: null,
       action_match: false,
       decision_match: false,
-      target_match: entry.expect.target_id ? false : null,
+      target_match: gradeTarget ? false : null,
       no_clobber: entry.expect.preserves_corpus ? false : null,
       filed_correctly: false,
       ...(parseError ? { parse_error: parseError } : {}),
@@ -97,7 +103,7 @@ export function scoreSample(
     ...(actualTarget ? { target_id: actualTarget } : {}),
   };
   const action_match = judgment.action === entry.expect.action;
-  const target_match = entry.expect.target_id ? actualTarget === entry.expect.target_id : null;
+  const target_match = gradeTarget ? actualTarget === entry.expect.target_id : null;
 
   return {
     ...base,
@@ -127,7 +133,8 @@ export interface EvalReport {
   /** S12: fraction of ambiguous cases that avoided a confident wrong-merge. null when no S12. */
   entity_resolution: number | null;
   parse_error_count: number;
-  by_scenario: Record<ConsolidatorScenario, ScenarioBreakdown>;
+  // Partial: a run over a fixture subset only populates the scenarios it covers.
+  by_scenario: Partial<Record<ConsolidatorScenario, ScenarioBreakdown>>;
   samples: SampleResult[];
 }
 
@@ -135,8 +142,16 @@ function ratio(numerator: number, denominator: number): number | null {
   return denominator === 0 ? null : numerator / denominator;
 }
 
+// A confident, destructive merge: an auto-applied action that touches an existing
+// doc (augment / supersede / archive — anything but a fresh create or a noop).
+// This is the failure S12's entity_resolution must catch.
+function confidentWrongMerge(outcome: SampleResult["actual"]): boolean {
+  if (!outcome || outcome.decision !== "auto_apply") return false;
+  return outcome.action !== "create" && outcome.action !== "noop";
+}
+
 export function summarize(samples: SampleResult[]): EvalReport {
-  const by_scenario: Record<string, ScenarioBreakdown> = {};
+  const by_scenario: Partial<Record<ConsolidatorScenario, ScenarioBreakdown>> = {};
   for (const sample of samples) {
     const bucket = (by_scenario[sample.scenario] ??= {
       total: 0,
@@ -167,15 +182,11 @@ export function summarize(samples: SampleResult[]): EvalReport {
       s4.length,
     ),
     entity_resolution: ratio(
-      s12.filter(
-        (s) =>
-          !s.parse_error &&
-          !(s.actual?.action === "augment" && s.actual?.decision === "auto_apply"),
-      ).length,
+      s12.filter((s) => !s.parse_error && !confidentWrongMerge(s.actual)).length,
       s12.length,
     ),
     parse_error_count: samples.filter((s) => s.parse_error).length,
-    by_scenario: by_scenario as Record<ConsolidatorScenario, ScenarioBreakdown>,
+    by_scenario,
     samples,
   };
 }

--- a/packages/consolidator-eval/src/metrics.ts
+++ b/packages/consolidator-eval/src/metrics.ts
@@ -1,0 +1,181 @@
+// Scoring for the consolidator eval. Pure functions: given a fixture entry and
+// the plan the pipeline produced (or a parse failure), grade one sample; then
+// aggregate a run into a report. No I/O, no model — the run engine wires these
+// to navigate→judge→route.
+//
+// The headline metrics map to the Phase-4 scenarios:
+//   - filing_accuracy        — did the judge pick the right action (and target)?
+//   - decision_band_accuracy — did confidence route to the right band?
+//   - no_clobber_rate (S18)  — did an edit to a hand-authored doc preserve it?
+//   - contradiction_recall (S4) — was a contradicting update superseded?
+//   - entity_resolution (S12)   — did an ambiguous merge AVOID a confident
+//     wrong-merge (it should propose or create_new, never auto-augment)?
+
+import {
+  type ConsolidationJudgment,
+  type ConsolidationPlan,
+  augmentBody,
+  preservesOriginal,
+} from "@librarian/core";
+import type { ConsolidatorFixtureEntry, ConsolidatorScenario } from "./fixture.js";
+
+export interface SampleOutcome {
+  action: string;
+  decision: string;
+  target_id?: string;
+}
+
+export interface SampleResult {
+  id: string;
+  scenario: ConsolidatorScenario;
+  category: "straight" | "boundary";
+  expected: SampleOutcome;
+  actual: SampleOutcome | null;
+  action_match: boolean;
+  decision_match: boolean;
+  /** null when the expected action has no target. */
+  target_match: boolean | null;
+  /** null when the entry doesn't assert preserves_corpus. */
+  no_clobber: boolean | null;
+  /** action matched AND (no target expected OR the target matched). */
+  filed_correctly: boolean;
+  parse_error?: string;
+}
+
+function judgmentTarget(judgment: ConsolidationJudgment): string | undefined {
+  return "target_id" in judgment ? judgment.target_id : undefined;
+}
+
+// Whether an edit to the expected target preserved its existing prose. Vacuously
+// true when the judge didn't touch that doc (you can't clobber what you didn't
+// edit); the wrong-action case is caught by filing_accuracy, not here.
+function computeNoClobber(
+  entry: ConsolidatorFixtureEntry,
+  judgment: ConsolidationJudgment,
+): boolean {
+  const target = entry.corpus.find((doc) => doc.id === entry.expect.target_id);
+  if (!target) return true;
+  if (judgmentTarget(judgment) !== target.id) return true;
+  if (judgment.action === "augment") {
+    return preservesOriginal(target.body, augmentBody(target.body, judgment.addition));
+  }
+  if (judgment.action === "supersede") return preservesOriginal(target.body, judgment.body);
+  if (judgment.action === "archive") return false; // removed the doc → its prose is gone
+  return true;
+}
+
+export function scoreSample(
+  entry: ConsolidatorFixtureEntry,
+  plan: ConsolidationPlan | null,
+  parseError?: string,
+): SampleResult {
+  const expected: SampleOutcome = {
+    action: entry.expect.action,
+    decision: entry.expect.decision,
+    ...(entry.expect.target_id ? { target_id: entry.expect.target_id } : {}),
+  };
+  const base = { id: entry.id, scenario: entry.scenario, category: entry.category, expected };
+
+  if (!plan) {
+    return {
+      ...base,
+      actual: null,
+      action_match: false,
+      decision_match: false,
+      target_match: entry.expect.target_id ? false : null,
+      no_clobber: entry.expect.preserves_corpus ? false : null,
+      filed_correctly: false,
+      ...(parseError ? { parse_error: parseError } : {}),
+    };
+  }
+
+  const { judgment } = plan;
+  const actualTarget = judgmentTarget(judgment);
+  const actual: SampleOutcome = {
+    action: judgment.action,
+    decision: plan.decision,
+    ...(actualTarget ? { target_id: actualTarget } : {}),
+  };
+  const action_match = judgment.action === entry.expect.action;
+  const target_match = entry.expect.target_id ? actualTarget === entry.expect.target_id : null;
+
+  return {
+    ...base,
+    actual,
+    action_match,
+    decision_match: plan.decision === entry.expect.decision,
+    target_match,
+    no_clobber: entry.expect.preserves_corpus ? computeNoClobber(entry, judgment) : null,
+    filed_correctly: action_match && target_match !== false,
+  };
+}
+
+export interface ScenarioBreakdown {
+  total: number;
+  action_correct: number;
+  decision_correct: number;
+}
+
+export interface EvalReport {
+  sample_size: number;
+  filing_accuracy: number;
+  decision_band_accuracy: number;
+  /** null when no entry asserts preserves_corpus. */
+  no_clobber_rate: number | null;
+  /** S4: fraction of contradiction cases the judge superseded. null when no S4. */
+  contradiction_recall: number | null;
+  /** S12: fraction of ambiguous cases that avoided a confident wrong-merge. null when no S12. */
+  entity_resolution: number | null;
+  parse_error_count: number;
+  by_scenario: Record<ConsolidatorScenario, ScenarioBreakdown>;
+  samples: SampleResult[];
+}
+
+function ratio(numerator: number, denominator: number): number | null {
+  return denominator === 0 ? null : numerator / denominator;
+}
+
+export function summarize(samples: SampleResult[]): EvalReport {
+  const by_scenario: Record<string, ScenarioBreakdown> = {};
+  for (const sample of samples) {
+    const bucket = (by_scenario[sample.scenario] ??= {
+      total: 0,
+      action_correct: 0,
+      decision_correct: 0,
+    });
+    bucket.total += 1;
+    if (sample.action_match) bucket.action_correct += 1;
+    if (sample.decision_match) bucket.decision_correct += 1;
+  }
+
+  const total = samples.length;
+  const clobberable = samples.filter((s) => s.no_clobber !== null);
+  const s4 = samples.filter((s) => s.scenario === "S4");
+  const s12 = samples.filter((s) => s.scenario === "S12");
+
+  return {
+    sample_size: total,
+    filing_accuracy: total === 0 ? 0 : samples.filter((s) => s.filed_correctly).length / total,
+    decision_band_accuracy:
+      total === 0 ? 0 : samples.filter((s) => s.decision_match).length / total,
+    no_clobber_rate: ratio(
+      clobberable.filter((s) => s.no_clobber === true).length,
+      clobberable.length,
+    ),
+    contradiction_recall: ratio(
+      s4.filter((s) => s.actual?.action === "supersede").length,
+      s4.length,
+    ),
+    entity_resolution: ratio(
+      s12.filter(
+        (s) =>
+          !s.parse_error &&
+          !(s.actual?.action === "augment" && s.actual?.decision === "auto_apply"),
+      ).length,
+      s12.length,
+    ),
+    parse_error_count: samples.filter((s) => s.parse_error).length,
+    by_scenario: by_scenario as Record<ConsolidatorScenario, ScenarioBreakdown>,
+    samples,
+  };
+}

--- a/packages/consolidator-eval/src/run.ts
+++ b/packages/consolidator-eval/src/run.ts
@@ -1,0 +1,104 @@
+// The eval run engine. For each fixture entry it stands up an in-memory corpus,
+// runs the real pipeline (navigate→judge→route) with an injected LlmClient, and
+// scores the plan. Deterministic: the recall adapter ranks by lexical overlap
+// (stable tie-break by corpus order), and the ToC carries the whole (small)
+// corpus, so the judge always has every candidate available.
+//
+// Never throws on a model/judge failure — a thrown LLM client or an unparseable
+// judgment lands as a graded miss, so one bad case can't abort the run (mirrors
+// classifier-eval's contract).
+
+import {
+  type ConsolidationThresholds,
+  type LlmClient,
+  type Memory,
+  judgeSubmission,
+  navigateInbox,
+} from "@librarian/core";
+import type { ConsolidatorCorpusDoc, ConsolidatorFixtureEntry } from "./fixture.js";
+import { type EvalReport, type SampleResult, scoreSample, summarize } from "./metrics.js";
+
+export interface RunConsolidatorEvalOptions {
+  fixture: ConsolidatorFixtureEntry[];
+  llmClient: LlmClient;
+  thresholds?: ConsolidationThresholds;
+}
+
+function corpusDocToMemory(doc: ConsolidatorCorpusDoc): Memory {
+  return {
+    id: doc.id,
+    agent_id: "system-eval",
+    title: doc.title,
+    body: doc.body,
+    status: "active",
+    project_key: doc.project_key ?? null,
+    priority: "normal",
+    confidence: "working",
+    tags: doc.tags,
+    applies_to: [],
+    supersedes: [],
+    conflicts_with: [],
+    recall_count: 0,
+    usefulness_score: 0,
+    is_global: false,
+    requires_approval: false,
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function tokenize(text: string): Set<string> {
+  return new Set(text.toLowerCase().match(/[a-z0-9]+/g) ?? []);
+}
+
+function overlap(a: Set<string>, b: Set<string>): number {
+  let shared = 0;
+  for (const token of a) if (b.has(token)) shared += 1;
+  return shared;
+}
+
+// A deterministic stand-in for index recall: rank the corpus by lexical overlap
+// with the query, stable on ties by original order.
+function rankByOverlap(memories: Memory[], query: string): Memory[] {
+  const queryTokens = tokenize(query);
+  return memories
+    .map((memory, index) => ({
+      memory,
+      index,
+      score: overlap(queryTokens, tokenize(`${memory.title} ${memory.body}`)),
+    }))
+    .sort((a, b) => b.score - a.score || a.index - b.index)
+    .map((ranked) => ranked.memory);
+}
+
+async function evaluateEntry(
+  entry: ConsolidatorFixtureEntry,
+  llmClient: LlmClient,
+  thresholds: ConsolidationThresholds | undefined,
+): Promise<SampleResult> {
+  const memories = entry.corpus.map(corpusDocToMemory);
+  const deps = {
+    recall: async (query: string, limit: number) => rankByOverlap(memories, query).slice(0, limit),
+    listActive: () => memories,
+  };
+  try {
+    const evidence = await navigateInbox(entry.submission.text, deps);
+    const result = await judgeSubmission(
+      { submissionText: entry.submission.text, evidence },
+      { llmClient, ...(thresholds ? { thresholds } : {}) },
+    );
+    return scoreSample(entry, result.plan ?? null, result.parseError);
+  } catch (error) {
+    return scoreSample(entry, null, (error as Error).message);
+  }
+}
+
+export async function runConsolidatorEval(
+  options: RunConsolidatorEvalOptions,
+): Promise<EvalReport> {
+  const samples: SampleResult[] = [];
+  for (const entry of options.fixture) {
+    samples.push(await evaluateEntry(entry, options.llmClient, options.thresholds));
+  }
+  return summarize(samples);
+}

--- a/packages/consolidator-eval/tests/baseline.test.ts
+++ b/packages/consolidator-eval/tests/baseline.test.ts
@@ -3,7 +3,7 @@
 // metric that vanishes (null where the baseline had a value) is a regression.
 
 import { describe, expect, it } from "vitest";
-import { type Baseline, type EvalReport, compareToBaseline } from "../src/index.js";
+import { type Baseline, BaselineSchema, type EvalReport, compareToBaseline } from "../src/index.js";
 
 function report(over: Partial<EvalReport>): EvalReport {
   return {
@@ -57,5 +57,19 @@ describe("compareToBaseline", () => {
     const gate = compareToBaseline(report({ contradiction_recall: null }), baseline);
     expect(gate.passed).toBe(false);
     expect(gate.regressions.map((r) => r.metric)).toContain("contradiction_recall");
+  });
+});
+
+describe("BaselineSchema", () => {
+  it("rejects an empty baseline (so a gate can't silently pass on no data)", () => {
+    expect(() => BaselineSchema.parse({})).toThrow();
+  });
+
+  it("rejects an out-of-range metric", () => {
+    expect(() => BaselineSchema.parse({ ...baseline, filing_accuracy: 1.5 })).toThrow();
+  });
+
+  it("accepts a well-formed baseline (with nulls)", () => {
+    expect(() => BaselineSchema.parse({ ...baseline, no_clobber_rate: null })).not.toThrow();
   });
 });

--- a/packages/consolidator-eval/tests/baseline.test.ts
+++ b/packages/consolidator-eval/tests/baseline.test.ts
@@ -1,0 +1,61 @@
+// The regression gate: a metric that drops past the tolerance fails; small
+// noise within tolerance passes; a baseline metric of null is ignored; and a
+// metric that vanishes (null where the baseline had a value) is a regression.
+
+import { describe, expect, it } from "vitest";
+import { type Baseline, type EvalReport, compareToBaseline } from "../src/index.js";
+
+function report(over: Partial<EvalReport>): EvalReport {
+  return {
+    sample_size: 8,
+    filing_accuracy: 0.9,
+    decision_band_accuracy: 0.9,
+    no_clobber_rate: 1,
+    contradiction_recall: 1,
+    entity_resolution: 1,
+    parse_error_count: 0,
+    by_scenario: {} as EvalReport["by_scenario"],
+    samples: [],
+    ...over,
+  };
+}
+
+const baseline: Baseline = {
+  filing_accuracy: 0.9,
+  decision_band_accuracy: 0.9,
+  no_clobber_rate: 1,
+  contradiction_recall: 1,
+  entity_resolution: 1,
+};
+
+describe("compareToBaseline", () => {
+  it("passes when metrics match the baseline", () => {
+    expect(compareToBaseline(report({}), baseline).passed).toBe(true);
+  });
+
+  it("passes a drop within tolerance", () => {
+    expect(compareToBaseline(report({ filing_accuracy: 0.86 }), baseline, 0.05).passed).toBe(true);
+  });
+
+  it("fails a drop past tolerance and names the metric", () => {
+    const gate = compareToBaseline(report({ filing_accuracy: 0.7 }), baseline, 0.05);
+    expect(gate.passed).toBe(false);
+    expect(gate.regressions.map((r) => r.metric)).toEqual(["filing_accuracy"]);
+    expect(gate.regressions[0]!.delta).toBeCloseTo(-0.2, 5);
+  });
+
+  it("does not flag an improvement", () => {
+    expect(compareToBaseline(report({ filing_accuracy: 1 }), baseline).passed).toBe(true);
+  });
+
+  it("ignores a baseline metric that is null", () => {
+    const partial: Baseline = { ...baseline, no_clobber_rate: null };
+    expect(compareToBaseline(report({ no_clobber_rate: null }), partial).passed).toBe(true);
+  });
+
+  it("treats a vanished metric as a regression to zero", () => {
+    const gate = compareToBaseline(report({ contradiction_recall: null }), baseline);
+    expect(gate.passed).toBe(false);
+    expect(gate.regressions.map((r) => r.metric)).toContain("contradiction_recall");
+  });
+});

--- a/packages/consolidator-eval/tests/cli.test.ts
+++ b/packages/consolidator-eval/tests/cli.test.ts
@@ -1,0 +1,149 @@
+// The `run` command, driven end-to-end with an injected scripted model (no
+// network): flag parsing, the dry-run validation path, and the baseline
+// round-trip (freeze with --update-baseline, then gate a later run against it).
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ConsolidationJudgment } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ENV_ENDPOINT, ENV_TOKEN, parseRunFlags, runEvalCommand } from "../src/cli/run-command.js";
+import {
+  type ConsolidatorFixtureEntry,
+  type ScriptedJudgment,
+  loadSeedFixture,
+  scriptedLlmClient,
+} from "../src/index.js";
+
+const fixture = loadSeedFixture();
+
+function oracleJudgment(entry: ConsolidatorFixtureEntry): ConsolidationJudgment {
+  const confidence =
+    entry.expect.decision === "auto_apply"
+      ? 0.99
+      : entry.expect.decision === "propose"
+        ? 0.9
+        : entry.expect.decision === "create_new"
+          ? 0.5
+          : 0.99;
+  const target = entry.expect.target_id ?? "";
+  switch (entry.expect.action) {
+    case "create":
+      return { action: "create", title: "T", body: "B", tags: [], rationale: "r", confidence };
+    case "augment":
+      return {
+        action: "augment",
+        target_id: target,
+        addition: "New fact.",
+        rationale: "r",
+        confidence,
+      };
+    case "supersede":
+      return {
+        action: "supersede",
+        target_id: target,
+        title: "T",
+        body: "B",
+        rationale: "r",
+        confidence,
+      };
+    case "archive":
+      return { action: "archive", target_id: target, rationale: "r", confidence };
+    default:
+      return { action: "noop", rationale: "r", confidence };
+  }
+}
+
+const oracle = () => ({
+  buildClient: () =>
+    scriptedLlmClient(
+      fixture.map<ScriptedJudgment>((e) => ({
+        match: e.submission.text,
+        judgment: oracleJudgment(e),
+      })),
+    ),
+});
+
+const alwaysNoop = () => ({
+  buildClient: () =>
+    scriptedLlmClient(
+      fixture.map<ScriptedJudgment>((e) => ({
+        match: e.submission.text,
+        judgment: { action: "noop", rationale: "r", confidence: 0.99 },
+      })),
+    ),
+});
+
+describe("parseRunFlags", () => {
+  it("requires --model", () => {
+    expect(() => parseRunFlags([])).toThrow(/--model/);
+  });
+
+  it("parses the baseline + gate flags", () => {
+    const flags = parseRunFlags([
+      "--model",
+      "m",
+      "--baseline",
+      "b.json",
+      "--gate",
+      "--tolerance",
+      "0.1",
+    ]);
+    expect(flags).toMatchObject({ model: "m", baselinePath: "b.json", gate: true, tolerance: 0.1 });
+  });
+});
+
+describe("runEvalCommand", () => {
+  let dir = "";
+  let savedEndpoint: string | undefined;
+  let savedToken: string | undefined;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "ceval-"));
+    savedEndpoint = process.env[ENV_ENDPOINT];
+    savedToken = process.env[ENV_TOKEN];
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+    if (savedEndpoint === undefined) delete process.env[ENV_ENDPOINT];
+    else process.env[ENV_ENDPOINT] = savedEndpoint;
+    if (savedToken === undefined) delete process.env[ENV_TOKEN];
+    else process.env[ENV_TOKEN] = savedToken;
+  });
+
+  it("dry-run validates the env without calling a model", async () => {
+    process.env[ENV_ENDPOINT] = "https://example.test/v1";
+    process.env[ENV_TOKEN] = "tok";
+    const result = await runEvalCommand(["--model", "m", "--dry-run"]);
+    expect(result.report.sample_size).toBe(0);
+  });
+
+  it("dry-run fails loud when the env is missing", async () => {
+    delete process.env[ENV_ENDPOINT];
+    delete process.env[ENV_TOKEN];
+    await expect(runEvalCommand(["--model", "m", "--dry-run"])).rejects.toThrow(/ENDPOINT/);
+  });
+
+  it("freezes a baseline and then passes the gate on an identical run", async () => {
+    const baselinePath = path.join(dir, "baseline.json");
+    await runEvalCommand(["--model", "m", "--update-baseline", baselinePath], oracle());
+    expect(fs.existsSync(baselinePath)).toBe(true);
+
+    const gated = await runEvalCommand(["--model", "m", "--baseline", baselinePath], oracle());
+    expect(gated.gate?.passed).toBe(true);
+    expect(gated.gateFailed).toBe(false);
+  });
+
+  it("fails the gate when a later run regresses", async () => {
+    const baselinePath = path.join(dir, "baseline.json");
+    await runEvalCommand(["--model", "m", "--update-baseline", baselinePath], oracle());
+
+    const gated = await runEvalCommand(
+      ["--model", "m", "--baseline", baselinePath, "--gate"],
+      alwaysNoop(),
+    );
+    expect(gated.gate?.passed).toBe(false);
+    expect(gated.gate?.regressions.length).toBeGreaterThan(0);
+    expect(gated.gateFailed).toBe(true);
+  });
+});

--- a/packages/consolidator-eval/tests/cli.test.ts
+++ b/packages/consolidator-eval/tests/cli.test.ts
@@ -38,15 +38,18 @@ function oracleJudgment(entry: ConsolidatorFixtureEntry): ConsolidationJudgment 
         rationale: "r",
         confidence,
       };
-    case "supersede":
+    case "supersede": {
+      const doc = entry.corpus.find((d) => d.id === entry.expect.target_id);
+      const body = entry.expect.preserves_corpus && doc ? `${doc.body}\n\nUpdated.` : "B";
       return {
         action: "supersede",
         target_id: target,
         title: "T",
-        body: "B",
+        body,
         rationale: "r",
         confidence,
       };
+    }
     case "archive":
       return { action: "archive", target_id: target, rationale: "r", confidence };
     default:

--- a/packages/consolidator-eval/tests/fixture.test.ts
+++ b/packages/consolidator-eval/tests/fixture.test.ts
@@ -1,0 +1,86 @@
+// The seed fixture parses against the schema and covers every consolidator
+// scenario the Phase-4 checkpoint cares about (S1/S2/S4/S12/S18), and the
+// cross-field invariants (target must exist; action↔decision must be a
+// routing-reachable pair) are enforced by the schema itself.
+
+import { describe, expect, it } from "vitest";
+import {
+  CONSOLIDATOR_SCENARIOS,
+  ConsolidatorFixtureEntrySchema,
+  loadSeedFixture,
+} from "../src/index.js";
+
+describe("consolidator seed fixture", () => {
+  const fixture = loadSeedFixture();
+
+  it("loads and parses cleanly", () => {
+    expect(fixture.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("covers every consolidator scenario (S1/S2/S4/S12/S18)", () => {
+    const scenarios = new Set(fixture.map((f) => f.scenario));
+    for (const scenario of CONSOLIDATOR_SCENARIOS) {
+      expect(scenarios).toContain(scenario);
+    }
+  });
+
+  it("includes both straight and boundary cases", () => {
+    const categories = new Set(fixture.map((f) => f.category));
+    expect(categories).toContain("straight");
+    expect(categories).toContain("boundary");
+  });
+
+  it("exercises the create/augment/supersede branches across the set", () => {
+    const actions = new Set(fixture.map((f) => f.expect.action));
+    expect(actions).toContain("create");
+    expect(actions).toContain("augment");
+    expect(actions).toContain("supersede");
+  });
+
+  it("references real corpus docs for every targeted action", () => {
+    for (const entry of fixture) {
+      if (!entry.expect.target_id) continue;
+      const ids = entry.corpus.map((d) => d.id);
+      expect(ids, `${entry.id} targets a corpus doc`).toContain(entry.expect.target_id);
+    }
+  });
+
+  it("has unique entry ids", () => {
+    const ids = fixture.map((f) => f.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe("ConsolidatorFixtureEntrySchema cross-field invariants", () => {
+  const base = {
+    id: "fix_x",
+    scenario: "S1" as const,
+    category: "straight" as const,
+    submission: { text: "A new, novel fact." },
+    corpus: [{ id: "mem_1", title: "Unrelated", body: "Something else.", tags: ["x"] }],
+    expect: { action: "create" as const, decision: "auto_apply" as const },
+  };
+
+  it("accepts a well-formed create entry", () => {
+    expect(() => ConsolidatorFixtureEntrySchema.parse(base)).not.toThrow();
+  });
+
+  it("rejects an augment without a target_id", () => {
+    const bad = { ...base, expect: { action: "augment", decision: "auto_apply" } };
+    expect(() => ConsolidatorFixtureEntrySchema.parse(bad)).toThrow(/target_id/);
+  });
+
+  it("rejects a target_id that is absent from the corpus", () => {
+    const bad = {
+      ...base,
+      expect: { action: "augment", decision: "auto_apply", target_id: "mem_missing" },
+    };
+    expect(() => ConsolidatorFixtureEntrySchema.parse(bad)).toThrow(/corpus/);
+  });
+
+  it("rejects an action↔decision pair the router can never produce", () => {
+    // `create` always routes to auto_apply — `propose` is unreachable.
+    const bad = { ...base, expect: { action: "create", decision: "propose" } };
+    expect(() => ConsolidatorFixtureEntrySchema.parse(bad)).toThrow(/routing/i);
+  });
+});

--- a/packages/consolidator-eval/tests/metrics.test.ts
+++ b/packages/consolidator-eval/tests/metrics.test.ts
@@ -1,0 +1,132 @@
+// Unit tests for the pure scoring layer — scoreSample grades one plan against a
+// fixture's ground truth, and summarize aggregates the sub-metrics with correct
+// null handling (a metric with no applicable samples is null, not 0).
+
+import type { ConsolidationPlan } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+import {
+  type ConsolidatorFixtureEntry,
+  type SampleResult,
+  scoreSample,
+  summarize,
+} from "../src/index.js";
+
+const augmentEntry: ConsolidatorFixtureEntry = {
+  id: "e_augment",
+  scenario: "S2",
+  category: "straight",
+  submission: { text: "Anna mentored Sophie." },
+  corpus: [{ id: "mem_anna", title: "Anna", body: "Anna is an engineer.", tags: [] }],
+  expect: { action: "augment", decision: "auto_apply", target_id: "mem_anna" },
+};
+
+const plan = (judgment: ConsolidationPlan["judgment"], decision: ConsolidationPlan["decision"]) =>
+  ({ judgment, decision }) as ConsolidationPlan;
+
+describe("scoreSample", () => {
+  it("credits a correct augment (action + decision + target)", () => {
+    const result = scoreSample(
+      augmentEntry,
+      plan(
+        {
+          action: "augment",
+          target_id: "mem_anna",
+          addition: "Mentored Sophie.",
+          rationale: "r",
+          confidence: 0.99,
+        },
+        "auto_apply",
+      ),
+    );
+    expect(result.action_match).toBe(true);
+    expect(result.decision_match).toBe(true);
+    expect(result.target_match).toBe(true);
+    expect(result.filed_correctly).toBe(true);
+  });
+
+  it("marks a wrong target as not filed correctly", () => {
+    const result = scoreSample(
+      augmentEntry,
+      plan(
+        {
+          action: "augment",
+          target_id: "mem_other",
+          addition: "x",
+          rationale: "r",
+          confidence: 0.99,
+        },
+        "auto_apply",
+      ),
+    );
+    expect(result.action_match).toBe(true);
+    expect(result.target_match).toBe(false);
+    expect(result.filed_correctly).toBe(false);
+  });
+
+  it("leaves target_match null when no target is expected", () => {
+    const createEntry: ConsolidatorFixtureEntry = {
+      ...augmentEntry,
+      id: "e_create",
+      scenario: "S1",
+      expect: { action: "create", decision: "auto_apply" },
+    };
+    const result = scoreSample(
+      createEntry,
+      plan(
+        { action: "create", title: "T", body: "B", tags: [], rationale: "r", confidence: 0.99 },
+        "auto_apply",
+      ),
+    );
+    expect(result.target_match).toBeNull();
+    expect(result.filed_correctly).toBe(true);
+  });
+
+  it("records a parse failure as a total miss", () => {
+    const result = scoreSample(augmentEntry, null, "bad json");
+    expect(result.actual).toBeNull();
+    expect(result.action_match).toBe(false);
+    expect(result.filed_correctly).toBe(false);
+    expect(result.parse_error).toBe("bad json");
+  });
+});
+
+describe("summarize", () => {
+  const mk = (over: Partial<SampleResult>): SampleResult => ({
+    id: "x",
+    scenario: "S1",
+    category: "straight",
+    expected: { action: "create", decision: "auto_apply" },
+    actual: { action: "create", decision: "auto_apply" },
+    action_match: true,
+    decision_match: true,
+    target_match: null,
+    no_clobber: null,
+    filed_correctly: true,
+    ...over,
+  });
+
+  it("returns null sub-metrics when no samples apply", () => {
+    const report = summarize([mk({}), mk({ id: "y" })]);
+    expect(report.no_clobber_rate).toBeNull();
+    expect(report.contradiction_recall).toBeNull();
+    expect(report.entity_resolution).toBeNull();
+    expect(report.filing_accuracy).toBe(1);
+  });
+
+  it("computes contradiction_recall over S4 samples only", () => {
+    const report = summarize([
+      mk({ id: "a", scenario: "S4", actual: { action: "supersede", decision: "auto_apply" } }),
+      mk({ id: "b", scenario: "S4", actual: { action: "augment", decision: "auto_apply" } }),
+      mk({ id: "c", scenario: "S1" }), // ignored by the S4 metric
+    ]);
+    expect(report.contradiction_recall).toBe(0.5);
+  });
+
+  it("counts an ambiguous auto-augment as a failed entity resolution (S12)", () => {
+    const report = summarize([
+      mk({ id: "a", scenario: "S12", actual: { action: "augment", decision: "create_new" } }), // avoided
+      mk({ id: "b", scenario: "S12", actual: { action: "augment", decision: "auto_apply" } }), // under-merged
+    ]);
+    expect(report.entity_resolution).toBe(0.5);
+  });
+});

--- a/packages/consolidator-eval/tests/metrics.test.ts
+++ b/packages/consolidator-eval/tests/metrics.test.ts
@@ -88,6 +88,32 @@ describe("scoreSample", () => {
     expect(result.filed_correctly).toBe(false);
     expect(result.parse_error).toBe("bad json");
   });
+
+  it("does not grade the target on a create_new entry (the target is discarded)", () => {
+    const ambiguous: ConsolidatorFixtureEntry = {
+      ...augmentEntry,
+      id: "e_create_new",
+      scenario: "S12",
+      expect: { action: "augment", decision: "create_new", target_id: "mem_anna" },
+    };
+    // A correct low-confidence augment that names the "wrong" doc — but create_new
+    // discards the target, so it must not be docked on filing.
+    const result = scoreSample(
+      ambiguous,
+      plan(
+        {
+          action: "augment",
+          target_id: "mem_other",
+          addition: "x",
+          rationale: "r",
+          confidence: 0.5,
+        },
+        "create_new",
+      ),
+    );
+    expect(result.target_match).toBeNull();
+    expect(result.filed_correctly).toBe(true);
+  });
 });
 
 describe("summarize", () => {
@@ -126,6 +152,16 @@ describe("summarize", () => {
     const report = summarize([
       mk({ id: "a", scenario: "S12", actual: { action: "augment", decision: "create_new" } }), // avoided
       mk({ id: "b", scenario: "S12", actual: { action: "augment", decision: "auto_apply" } }), // under-merged
+    ]);
+    expect(report.entity_resolution).toBe(0.5);
+  });
+
+  it("counts a confident wrong-supersede (and archive) as a failed entity resolution (S12)", () => {
+    const report = summarize([
+      mk({ id: "a", scenario: "S12", actual: { action: "supersede", decision: "auto_apply" } }), // destructive
+      mk({ id: "b", scenario: "S12", actual: { action: "archive", decision: "auto_apply" } }), // destructive
+      mk({ id: "c", scenario: "S12", actual: { action: "create", decision: "auto_apply" } }), // safe: fresh doc
+      mk({ id: "d", scenario: "S12", actual: { action: "supersede", decision: "propose" } }), // safe: not auto
     ]);
     expect(report.entity_resolution).toBe(0.5);
   });

--- a/packages/consolidator-eval/tests/run.test.ts
+++ b/packages/consolidator-eval/tests/run.test.ts
@@ -53,15 +53,23 @@ function oracleJudgment(entry: ConsolidatorFixtureEntry): ConsolidationJudgment 
         rationale: "r",
         confidence,
       };
-    case "supersede":
+    case "supersede": {
+      // A preserving rewrite when the doc is hand-authored (keep every line);
+      // otherwise a plain replacement.
+      const doc = entry.corpus.find((d) => d.id === entry.expect.target_id);
+      const body =
+        entry.expect.preserves_corpus && doc
+          ? `${doc.body}\n\nUpdated per the latest submission.`
+          : "Replacement.";
       return {
         action: "supersede",
         target_id: target,
         title: "T",
-        body: "Replacement.",
+        body,
         rationale: "r",
         confidence,
       };
+    }
     case "archive":
       return { action: "archive", target_id: target, rationale: "r", confidence };
     default:
@@ -77,8 +85,13 @@ function oracleClient() {
   return scriptedLlmClient(script);
 }
 
-describe("runConsolidatorEval — perfect oracle", () => {
-  it("scores 1.0 on every headline metric", async () => {
+// This proves the fixtures are internally routing-consistent (every expected
+// action+decision is reachable through the real routeConsolidation at a
+// band-appropriate confidence) and that the navigate→judge→route→score plumbing
+// is wired. It does NOT prove the metrics are meaningful or the model is good —
+// the discriminating tests below (wrong model, parse error, no-clobber) do that.
+describe("runConsolidatorEval — fixtures are routing-consistent (oracle)", () => {
+  it("scores 1.0 on every headline metric when fed the expected judgments", async () => {
     const report = await runConsolidatorEval({ fixture, llmClient: oracleClient() });
 
     expect(report.sample_size).toBe(fixture.length);

--- a/packages/consolidator-eval/tests/run.test.ts
+++ b/packages/consolidator-eval/tests/run.test.ts
@@ -1,0 +1,154 @@
+// runConsolidatorEval drives the real navigate→judge→route pipeline over the
+// seed fixture with a scripted LLM, and grades the plans. A perfect oracle
+// scores 1.0 across the board; a wrong model scores low; a model that returns
+// garbage is recorded as a parse failure, never thrown.
+
+import type { ConsolidationJudgment } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+import {
+  type ConsolidatorFixtureEntry,
+  type ScriptedJudgment,
+  loadSeedFixture,
+  runConsolidatorEval,
+  scriptedLlmClient,
+} from "../src/index.js";
+
+const fixture = loadSeedFixture();
+
+// A confidence that routes to the entry's expected band under the default
+// thresholds (auto_apply ≥0.95, propose ≥0.85, else create_new for augment).
+function confidenceFor(decision: string): number {
+  switch (decision) {
+    case "auto_apply":
+      return 0.99;
+    case "propose":
+      return 0.9;
+    case "create_new":
+      return 0.5;
+    default:
+      return 0.99; // skip (noop)
+  }
+}
+
+// The "model answer" for an entry: the action it expects, at a band-appropriate
+// confidence, targeting the corpus doc it names.
+function oracleJudgment(entry: ConsolidatorFixtureEntry): ConsolidationJudgment {
+  const confidence = confidenceFor(entry.expect.decision);
+  const target = entry.expect.target_id ?? "";
+  switch (entry.expect.action) {
+    case "create":
+      return {
+        action: "create",
+        title: "New doc",
+        body: "Body.",
+        tags: [],
+        rationale: "r",
+        confidence,
+      };
+    case "augment":
+      return {
+        action: "augment",
+        target_id: target,
+        addition: "A fact not already present in the target.",
+        rationale: "r",
+        confidence,
+      };
+    case "supersede":
+      return {
+        action: "supersede",
+        target_id: target,
+        title: "T",
+        body: "Replacement.",
+        rationale: "r",
+        confidence,
+      };
+    case "archive":
+      return { action: "archive", target_id: target, rationale: "r", confidence };
+    default:
+      return { action: "noop", rationale: "r", confidence };
+  }
+}
+
+function oracleClient() {
+  const script: ScriptedJudgment[] = fixture.map((entry) => ({
+    match: entry.submission.text,
+    judgment: oracleJudgment(entry),
+  }));
+  return scriptedLlmClient(script);
+}
+
+describe("runConsolidatorEval — perfect oracle", () => {
+  it("scores 1.0 on every headline metric", async () => {
+    const report = await runConsolidatorEval({ fixture, llmClient: oracleClient() });
+
+    expect(report.sample_size).toBe(fixture.length);
+    expect(report.filing_accuracy).toBe(1);
+    expect(report.decision_band_accuracy).toBe(1);
+    expect(report.no_clobber_rate).toBe(1);
+    expect(report.contradiction_recall).toBe(1);
+    expect(report.entity_resolution).toBe(1);
+    expect(report.parse_error_count).toBe(0);
+  });
+
+  it("reports every scenario as fully correct", async () => {
+    const report = await runConsolidatorEval({ fixture, llmClient: oracleClient() });
+    for (const breakdown of Object.values(report.by_scenario)) {
+      expect(breakdown.action_correct).toBe(breakdown.total);
+      expect(breakdown.decision_correct).toBe(breakdown.total);
+    }
+  });
+});
+
+describe("runConsolidatorEval — a wrong model", () => {
+  it("scores poorly but still credits the genuine noop case", async () => {
+    // A model that says "noop" to everything: only the redundant-fact entry is right.
+    const alwaysNoop = scriptedLlmClient(
+      fixture.map((entry) => ({
+        match: entry.submission.text,
+        judgment: { action: "noop", rationale: "r", confidence: 0.99 } as ConsolidationJudgment,
+      })),
+    );
+    const report = await runConsolidatorEval({ fixture, llmClient: alwaysNoop });
+
+    const noopEntries = fixture.filter((e) => e.expect.action === "noop").length;
+    expect(report.filing_accuracy).toBeCloseTo(noopEntries / fixture.length, 5);
+    expect(report.contradiction_recall).toBe(0); // never superseded
+  });
+});
+
+describe("runConsolidatorEval — unparseable output", () => {
+  it("records a parse error instead of throwing", async () => {
+    const garbage = scriptedLlmClient([], {
+      rawByMatch: Object.fromEntries(fixture.map((e) => [e.submission.text, "not json at all"])),
+    });
+    const report = await runConsolidatorEval({ fixture, llmClient: garbage });
+
+    expect(report.parse_error_count).toBe(fixture.length);
+    expect(report.filing_accuracy).toBe(0);
+  });
+});
+
+describe("runConsolidatorEval — no-clobber detection (S18)", () => {
+  it("flags a supersede that drops the hand-authored prose", async () => {
+    const s18 = fixture.find((e) => e.scenario === "S18" && e.expect.preserves_corpus);
+    expect(s18).toBeDefined();
+    // The model supersedes the doc with a replacement that omits the original lines.
+    const clobbering = scriptedLlmClient([
+      {
+        match: s18!.submission.text,
+        judgment: {
+          action: "supersede",
+          target_id: s18!.expect.target_id!,
+          title: "Project Atlas",
+          body: "Atlas supports SSO via SAML.",
+          rationale: "r",
+          confidence: 0.99,
+        },
+      },
+    ]);
+    const report = await runConsolidatorEval({ fixture: [s18!], llmClient: clobbering });
+
+    expect(report.no_clobber_rate).toBe(0);
+    expect(report.samples[0]!.no_clobber).toBe(false);
+  });
+});

--- a/packages/consolidator-eval/tsconfig.json
+++ b/packages/consolidator-eval/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules", "tests"]
+}

--- a/packages/consolidator-eval/vitest.config.ts
+++ b/packages/consolidator-eval/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+    passWithNoTests: true,
+    server: {
+      deps: {
+        external: [/\/packages\/core\/(src|dist)\//],
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,6 +222,25 @@ importers:
         specifier: 'catalog:'
         version: 2.1.9(@types/node@22.19.19)(jsdom@25.0.1)(lightningcss@1.32.0)
 
+  packages/consolidator-eval:
+    dependencies:
+      '@librarian/core':
+        specifier: workspace:*
+        version: link:../core
+      zod:
+        specifier: ^4.0.1
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.5
+        version: 22.19.19
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.9(@types/node@22.19.19)(jsdom@25.0.1)(lightningcss@1.32.0)
+
   packages/core:
     dependencies:
       gray-matter:


### PR DESCRIPTION
## What

A new operator-driven package, `@librarian/consolidator-eval` — the **Phase-4 C6 checkpoint**. It scores the consolidator's `navigate → judge → route` pipeline against scenario fixtures, mirroring `@librarian/classifier-eval`.

Like classifier-eval, it is **not** part of the CI test gate (it calls a real model); the package's own tests drive the pipeline with a deterministic scripted `LlmClient`, so `pnpm test` stays offline and fast.

## Structure (4 commits)

- **C6a** — package scaffold + Zod fixture schema + S1/S2/S4/S12/S18 seed fixtures. The schema enforces, at load time, that a targeted action names a corpus doc that exists and that the `action`↔`decision` pair is one the router can actually produce.
- **C6b** — `runConsolidatorEval` drives the real pipeline per fixture over an in-memory corpus (deterministic lexical-overlap recall adapter; the ToC carries the whole small corpus). Pure scoring: `filing_accuracy`, `decision_band_accuracy`, `no_clobber_rate` (S18), `contradiction_recall` (S4), `entity_resolution` (S12). Never throws on a model/judge failure — a thrown client or unparseable judgment lands as a graded miss. Plus `scriptedLlmClient` (deterministic fake).
- **C6c** — `consolidator-eval run` CLI against an OpenAI-compatible endpoint, with a frozen-baseline regression gate (`--update-baseline` / `--baseline … --gate`, `--tolerance`). `buildClient` is injectable so the command is driven end-to-end in tests.
- **review fixes** — addressed the sub-agent review (verdict: fix-then-ship), see below.

## Metrics

| metric | scenario | question |
| --- | --- | --- |
| `filing_accuracy` | all | right action, and right target when one is kept? |
| `decision_band_accuracy` | all | did confidence route to the right band? |
| `no_clobber_rate` | S18 | did an edit to a hand-authored doc preserve its prose? |
| `contradiction_recall` | S4 | was a contradicting update superseded? |
| `entity_resolution` | S12 | did an ambiguous merge AVOID a confident wrong-merge? |

## Review fixes (sub-agent, fix-then-ship)

- **I1** — stop grading the target on a `create_new` entry (the routing discards the judgment's target, so grading it docked correct "don't confidently merge" behaviour).
- **I2** — `entity_resolution` now counts a confident wrong *supersede/archive* as an under-merge, not just augment.
- **I3** — the baseline file is Zod-validated on load (an empty/stale baseline no longer silently green-gates).
- **I4** — `by_scenario` typed `Partial` (a fixture subset no longer lies to consumers).
- Added a non-vacuous preserving-supersede S18 fixture (the only no-clobber branch that isn't always-true); swapped the debatable promotion S4 case for a clearer location-change supersede.

## Tests / gate

39 offline tests green. Full `pnpm -r build` + `pnpm -r test:vitest` green across all 5 packages.

## Operator-only follow-up (blocked, documented)

A meaningful frozen baseline must be produced by an operator running a **real model** (`--update-baseline`) — it can't be generated in CI or from the deterministic fake (which trivially scores 1.0). Until that `fixtures/baseline.json` exists, the gate is inert. See the package README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)