### PR TITLE
feat(consolidator): thread applies_to through the inbox (D-c5b.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ changes from this point forward are catalogued here.
   consolidator files it asynchronously (navigate the existing memories → judge
   whether to augment/supersede an existing one or create a new memory →
   minimal-edit in place, preferring `[[wikilinks]]` over duplication), carrying
-  the submitter's `agent_id`/`project_key`/`tags`. A serial scheduler drains the
+  the submitter's `agent_id`/`project_key`/`tags`/`applies_to`. A serial scheduler drains the
   inbox on a cadence (`LIBRARIAN_CONSOLIDATOR_TICK_MS`, default 5 min) plus a
   boot scan; it shares the curator's LLM brain config. **Default off** — when
   disabled (or on the sqlite backend, which has no vault inbox), `remember` keeps

--- a/packages/core/src/consolidator/apply.ts
+++ b/packages/core/src/consolidator/apply.ts
@@ -86,6 +86,9 @@ export function applyConsolidationPlan(
     // this distinction is currently inert — preserved for forward-compat (a future
     // store-level default project) rather than load-bearing.
     if (hints?.projectKey !== undefined) out.project_key = hints.projectKey;
+    // applies_to is a caller-asserted targeting signal the judge can't re-derive
+    // from text, so carry it onto the new memory (the judge never sets it).
+    if (hints?.appliesTo !== undefined) out.applies_to = hints.appliesTo;
     return out;
   };
   // The model's rationale is untrusted (could carry a hallucinated secret) and is

--- a/packages/core/src/store/corpus/inbox.ts
+++ b/packages/core/src/store/corpus/inbox.ts
@@ -42,6 +42,12 @@ export interface InboxSubmissionHints {
   agentId?: string;
   projectKey?: string | null;
   tags?: string[];
+  /**
+   * The submission's caller-asserted targeting (`applies_to`) — which entities
+   * the note is about. Unlike tags it can't be re-derived from the text, so it's
+   * carried through and applied to a NEW consolidated memory.
+   */
+  appliesTo?: string[];
 }
 
 /** Write options: clock/id injection (for determinism) + the submission hints to persist. */
@@ -86,7 +92,7 @@ function quote(value: string): string {
 /** Serialize an inbox submission to its on-disk markdown (frontmatter + text). */
 export function serializeInboxItem(item: InboxItem): string {
   const lines = [`id: ${quote(item.id)}`, `created: ${quote(item.created)}`];
-  const { agentId, projectKey, tags } = item.hints;
+  const { agentId, projectKey, tags, appliesTo } = item.hints;
   // Hints are written only when present, so an inbox item with none stays minimal.
   if (agentId !== undefined) lines.push(`agent_id: ${quote(agentId)}`);
   if (projectKey !== undefined) {
@@ -95,6 +101,13 @@ export function serializeInboxItem(item: InboxItem): string {
   if (tags !== undefined) {
     lines.push(
       tags.length ? `tags:\n${tags.map((t) => `  - ${quote(t)}`).join("\n")}` : "tags: []",
+    );
+  }
+  if (appliesTo !== undefined) {
+    lines.push(
+      appliesTo.length
+        ? `applies_to:\n${appliesTo.map((a) => `  - ${quote(a)}`).join("\n")}`
+        : "applies_to: []",
     );
   }
   const head = `---\n${lines.join("\n")}\n---\n`;
@@ -114,6 +127,9 @@ export function parseInboxItem(raw: string): InboxItem {
     hints.projectKey = d.project_key as string | null;
   }
   if (Array.isArray(d.tags)) hints.tags = d.tags.filter((t): t is string => typeof t === "string");
+  if (Array.isArray(d.applies_to)) {
+    hints.appliesTo = d.applies_to.filter((a): a is string => typeof a === "string");
+  }
   return { id: String(d.id ?? ""), created, text: content.trim(), hints };
 }
 

--- a/packages/core/tests/consolidator-apply.test.ts
+++ b/packages/core/tests/consolidator-apply.test.ts
@@ -215,13 +215,19 @@ describe("applyConsolidationPlan", () => {
         store,
         submissionText: "A fact.",
         actorId: "system-consolidator",
-        submissionHints: { agentId: "agent-a", projectKey: "proj-x", tags: ["t1"] },
+        submissionHints: {
+          agentId: "agent-a",
+          projectKey: "proj-x",
+          tags: ["t1"],
+          appliesTo: ["Anna"],
+        },
       },
     );
     expect(calls.create[0]?.input).toMatchObject({
       agent_id: "agent-a",
       project_key: "proj-x",
       tags: ["t1"],
+      applies_to: ["Anna"], // the caller's targeting signal the judge can't re-derive
     });
   });
 

--- a/packages/core/tests/corpus-inbox.test.ts
+++ b/packages/core/tests/corpus-inbox.test.ts
@@ -58,16 +58,22 @@ describe("writeInbox", () => {
     expect(ref.relPath).not.toContain(".processing");
   });
 
-  it("round-trips submission hints (agent_id / project_key / tags)", () => {
+  it("round-trips submission hints (agent_id / project_key / tags / applies_to)", () => {
     const ref = writeInbox(vault, "Anna moved to Berlin", {
       now: () => 1000,
       generateId: () => "inbox_a",
-      hints: { agentId: "agent-a", projectKey: "proj-x", tags: ["person", "move"] },
+      hints: {
+        agentId: "agent-a",
+        projectKey: "proj-x",
+        tags: ["person", "move"],
+        appliesTo: ["Anna", "Berlin"],
+      },
     });
     expect(parseInboxItem(vault.readText(ref.relPath)).hints).toEqual({
       agentId: "agent-a",
       projectKey: "proj-x",
       tags: ["person", "move"],
+      appliesTo: ["Anna", "Berlin"],
     });
   });
 
@@ -94,6 +100,8 @@ describe("writeInbox", () => {
       agentId: 'agent "x": line1\nline2',
       projectKey: 'proj: "y"',
       tags: ['tag: with "quote"', "back\\slash"],
+      // applies_to is caller-supplied + untrusted — pin its escaping directly.
+      appliesTo: ['Anna "the boss": x\nid: spoofed', "---\ninjected: pwned"],
     };
     const ref = writeInbox(vault, "x", { now: () => 1, generateId: () => "inbox_a", hints });
     // The escaping must not break the frontmatter or inject keys — values survive verbatim.

--- a/packages/mcp-server/src/mcp/tools/remember.ts
+++ b/packages/mcp-server/src/mcp/tools/remember.ts
@@ -16,6 +16,9 @@ function submissionHints(scoped: Record<string, unknown>): InboxSubmissionHints 
   if (Array.isArray(scoped.tags)) {
     hints.tags = scoped.tags.filter((t): t is string => typeof t === "string");
   }
+  if (Array.isArray(scoped.applies_to)) {
+    hints.appliesTo = scoped.applies_to.filter((a): a is string => typeof a === "string");
+  }
   return hints;
 }
 


### PR DESCRIPTION
## What

Threads `applies_to` through the consolidator inbox. The remember→inbox cutover (#270) carried the submitter's `agent_id`/`project_key`/`tags` but dropped `applies_to` — the one caller-asserted targeting signal the judge **can't** re-derive from the submission text. Now a consolidated *new* memory keeps it.

This closes the single open follow-on flagged by the cutover review (#270).

## Changes

- `InboxSubmissionHints` gains `appliesTo?: string[]`. The hand-rolled, injection-safe inbox serializer/parser handle it with the exact `quote()` + filter-to-strings pattern already used for `tags` (untrusted, caller-supplied).
- `apply.ts` `scope()` sets `applies_to` on **new** memories (create / create_new / propose) only — existing-doc edits (augment / supersede / archive) keep the target's own `applies_to` and never receive it.
- `remember.ts` `submissionHints()` reads `scoped.applies_to`.

## Tests

- inbox serializer round-trip for `applies_to`, including an **adversarial YAML-escaping** case (the untrusted field can't break out of frontmatter or inject a sibling key).
- the create_new apply path asserts `applies_to` reaches `createMemory`; the augment patch stays `body`-only (no scope leak).

## Review + gate

Sub-agent review: **ship** — injection-safe (byte-equivalent to the trusted `tags` path), persists as a first-class `Memory` field on both backends, no leak onto existing-doc edits. Full `pnpm -r build` + `pnpm -r test:vitest` green across all 5 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)