### PR TITLE
refactor(core): extract CurationRunReader seam from the curator scheduler (c.1a)

### DIFF
--- a/packages/core/src/curator-scheduler.ts
+++ b/packages/core/src/curator-scheduler.ts
@@ -3,8 +3,12 @@
 // of slices that should run now under the interval gate. Read-only; the
 // server-side scheduler wraps this with a timer + slice locking, and runs
 // each due slice via runCuration as the system-memory-curator actor.
+//
+// Run-history reads go through `CurationRunReader`, so this module is pure over
+// the backend: SQLite supplies a db-backed reader today; the vault/sidecar run
+// store supplies one at the Phase-4 SQLite removal. (The SQL itself lives with
+// the SQLite store, not here.)
 
-import type { DatabaseSync } from "node:sqlite";
 import type { CuratorMemorySource, EvidenceSlice } from "./curator-evidence.js";
 import { type DueReason, type ScheduleConfig, isSliceDue } from "./curator-schedule.js";
 
@@ -14,76 +18,33 @@ export interface DueSlice {
   lastCompletedAt: Date | null;
 }
 
-// Slices come from the memory source (vault or SQLite projection); run history
-// (last-completed / running) still reads the SQLite-authoritative
-// `memory_curation_runs` via `db`. The run-read side moves off SQLite with the
-// run store at the Phase-4 SQLite removal — until then, this composes the two.
+/**
+ * The run-history reads the scheduler needs, abstracted over the backend.
+ * `memory_curation_runs` is SQLite-authoritative today (createSqliteCurationRunReader);
+ * the vault/sidecar run store will provide an equivalent reader when SQLite is removed.
+ */
+export interface CurationRunReader {
+  /** Latest completed run time for a slice, or null if it has never completed. */
+  lastCompletedRunAt(slice: EvidenceSlice): Date | null;
+  /**
+   * The latest in-progress (running) run for a slice — the §10.1 lock. A non-null
+   * result means the slice is being worked; the caller compares startedAt against a
+   * TTL to distinguish an active lock from a stale (crashed-worker) one to reclaim.
+   */
+  findRunningRun(slice: EvidenceSlice): { id: string; startedAt: Date } | null;
+}
+
 export function selectDueSlices(
   memorySource: CuratorMemorySource,
-  db: DatabaseSync,
+  runReader: CurationRunReader,
   config: ScheduleConfig,
   now: Date,
 ): DueSlice[] {
   const due: DueSlice[] = [];
   for (const slice of memorySource.listSlices()) {
-    const lastCompletedAt = lastCompletedRunAt(db, slice);
+    const lastCompletedAt = runReader.lastCompletedRunAt(slice);
     const decision = isSliceDue(now, { lastCompletedAt }, config);
     if (decision.due) due.push({ slice, reason: decision.reason, lastCompletedAt });
   }
   return due;
-}
-
-interface Filter {
-  clause: string;
-  params: string[];
-}
-
-// Slice → run-row filter (runs key the owning agent on agent_id).
-function runFilter(slice: EvidenceSlice): Filter {
-  switch (slice.kind) {
-    case "common_global":
-      return { clause: "visibility = 'common' AND project_key IS NULL", params: [] };
-    case "common_project":
-      return {
-        clause: "visibility = 'common' AND project_key = ?",
-        params: [slice.projectKey ?? ""],
-      };
-    case "agent_private":
-      return {
-        clause: "visibility = 'agent_private' AND agent_id = ?",
-        params: [slice.agentId ?? ""],
-      };
-  }
-}
-
-/**
- * The latest in-progress (running) run for a slice — the §10.1 lock. A non-null
- * result means the slice is being worked; the caller compares startedAt against a
- * TTL to distinguish an active lock from a stale (crashed-worker) one to reclaim.
- */
-export function findRunningRun(
-  db: DatabaseSync,
-  slice: EvidenceSlice,
-): { id: string; startedAt: Date } | null {
-  const { clause, params } = runFilter(slice);
-  const row = db
-    .prepare(
-      `SELECT id, started_at FROM memory_curation_runs
-       WHERE ${clause} AND status = 'running' AND started_at IS NOT NULL
-       ORDER BY started_at DESC LIMIT 1`,
-    )
-    .get(...params) as { id: string; started_at: string } | undefined;
-  return row ? { id: row.id, startedAt: new Date(row.started_at) } : null;
-}
-
-function lastCompletedRunAt(db: DatabaseSync, slice: EvidenceSlice): Date | null {
-  const { clause, params } = runFilter(slice);
-  const row = db
-    .prepare(
-      `SELECT completed_at FROM memory_curation_runs
-       WHERE ${clause} AND status = 'completed' AND completed_at IS NOT NULL
-       ORDER BY completed_at DESC LIMIT 1`,
-    )
-    .get(...params) as { completed_at: string } | undefined;
-  return row?.completed_at ? new Date(row.completed_at) : null;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -69,7 +69,7 @@ export {
   nextScheduledRun,
 } from "./curator-schedule.js";
 export { findLegacyScheduleKeys } from "./curator-config.js";
-export { type DueSlice, findRunningRun, selectDueSlices } from "./curator-scheduler.js";
+export { type CurationRunReader, type DueSlice, selectDueSlices } from "./curator-scheduler.js";
 export {
   type CuratorTrigger,
   type RunDueCurationOptions,
@@ -429,6 +429,7 @@ export {
   type FailCurationRunInput,
   type ListCurationRunsInput,
   type RecordCurationOperationInput,
+  createSqliteCurationRunReader,
 } from "./store/curation-store.js";
 export {
   type SettingMeta,

--- a/packages/core/src/store/curation-store.ts
+++ b/packages/core/src/store/curation-store.ts
@@ -21,11 +21,66 @@ import {
 } from "../curator-evidence.js";
 import type { ScheduleConfig } from "../curator-schedule.js";
 import {
+  type CurationRunReader,
   type DueSlice,
-  findRunningRun as findRunningRunImpl,
   selectDueSlices as selectDueSlicesImpl,
 } from "../curator-scheduler.js";
 import { createSqliteCuratorMemorySource } from "../curator-source-sqlite.js";
+
+interface RunFilter {
+  clause: string;
+  params: string[];
+}
+
+// Slice → run-row filter (runs key the owning agent on agent_id).
+function runFilter(slice: EvidenceSlice): RunFilter {
+  switch (slice.kind) {
+    case "common_global":
+      return { clause: "visibility = 'common' AND project_key IS NULL", params: [] };
+    case "common_project":
+      return {
+        clause: "visibility = 'common' AND project_key = ?",
+        params: [slice.projectKey ?? ""],
+      };
+    case "agent_private":
+      return {
+        clause: "visibility = 'agent_private' AND agent_id = ?",
+        params: [slice.agentId ?? ""],
+      };
+  }
+}
+
+/**
+ * The SQLite-backed run reader over `memory_curation_runs` — the scheduler's
+ * run-history seam (last-completed / running-lock lookups). Moves to a
+ * vault/sidecar reader at the Phase-4 SQLite removal.
+ */
+export function createSqliteCurationRunReader(db: DatabaseSync): CurationRunReader {
+  return {
+    lastCompletedRunAt(slice: EvidenceSlice): Date | null {
+      const { clause, params } = runFilter(slice);
+      const row = db
+        .prepare(
+          `SELECT completed_at FROM memory_curation_runs
+           WHERE ${clause} AND status = 'completed' AND completed_at IS NOT NULL
+           ORDER BY completed_at DESC LIMIT 1`,
+        )
+        .get(...params) as { completed_at: string } | undefined;
+      return row?.completed_at ? new Date(row.completed_at) : null;
+    },
+    findRunningRun(slice: EvidenceSlice): { id: string; startedAt: Date } | null {
+      const { clause, params } = runFilter(slice);
+      const row = db
+        .prepare(
+          `SELECT id, started_at FROM memory_curation_runs
+           WHERE ${clause} AND status = 'running' AND started_at IS NOT NULL
+           ORDER BY started_at DESC LIMIT 1`,
+        )
+        .get(...params) as { id: string; started_at: string } | undefined;
+      return row ? { id: row.id, startedAt: new Date(row.started_at) } : null;
+    },
+  };
+}
 
 export interface CreateCurationRunInput {
   trigger: string; // schedule | manual | maintenance
@@ -216,6 +271,7 @@ export function createCurationStore(deps: {
 }): CurationStore {
   const { db } = deps;
   const memorySource = deps.memorySource ?? createSqliteCuratorMemorySource(db);
+  const runReader = createSqliteCurationRunReader(db);
 
   function createCurationRun(input: CreateCurationRunInput): CurationRun {
     const id = makeId("run");
@@ -374,11 +430,11 @@ export function createCurationStore(deps: {
   }
 
   function selectDueSlices(config: ScheduleConfig, now: Date): DueSlice[] {
-    return selectDueSlicesImpl(memorySource, db, config, now);
+    return selectDueSlicesImpl(memorySource, runReader, config, now);
   }
 
   function findRunningRun(slice: EvidenceSlice): { id: string; startedAt: Date } | null {
-    return findRunningRunImpl(db, slice);
+    return runReader.findRunningRun(slice);
   }
 
   return {

--- a/packages/core/tests/curator-scheduler.test.ts
+++ b/packages/core/tests/curator-scheduler.test.ts
@@ -10,6 +10,7 @@ import {
   type ScheduleConfig,
   createLibrarianStore,
   createSqliteCuratorMemorySource,
+  createSqliteCurationRunReader,
   selectDueSlices,
 } from "@librarian/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -67,7 +68,12 @@ function completedRun(projectKey: string, completedAt: Date) {
 }
 
 function dueProjectKeys() {
-  return selectDueSlices(createSqliteCuratorMemorySource(store!.db), store!.db, config(), NOW)
+  return selectDueSlices(
+    createSqliteCuratorMemorySource(store!.db),
+    createSqliteCurationRunReader(store!.db),
+    config(),
+    NOW,
+  )
     .filter((d) => d.slice.kind === "common_project")
     .map((d) => (d.slice.kind === "common_project" ? d.slice.projectKey : ""));
 }
@@ -75,7 +81,12 @@ function dueProjectKeys() {
 describe("selectDueSlices", () => {
   it("returns nothing for an empty store", () => {
     expect(
-      selectDueSlices(createSqliteCuratorMemorySource(store!.db), store!.db, config(), NOW),
+      selectDueSlices(
+        createSqliteCuratorMemorySource(store!.db),
+        createSqliteCurationRunReader(store!.db),
+        config(),
+        NOW,
+      ),
     ).toEqual([]);
   });
 
@@ -83,7 +94,7 @@ describe("selectDueSlices", () => {
     seedCommonMemory("proj-new");
     const due = selectDueSlices(
       createSqliteCuratorMemorySource(store!.db),
-      store!.db,
+      createSqliteCurationRunReader(store!.db),
       config(),
       NOW,
     );
@@ -102,7 +113,7 @@ describe("selectDueSlices", () => {
     completedRun("proj-stale", minutesAgo(120));
     const hit = selectDueSlices(
       createSqliteCuratorMemorySource(store!.db),
-      store!.db,
+      createSqliteCurationRunReader(store!.db),
       config(),
       NOW,
     ).find((d) => d.slice.kind === "common_project" && d.slice.projectKey === "proj-stale");

--- a/packages/core/tests/store/curation-reads.test.ts
+++ b/packages/core/tests/store/curation-reads.test.ts
@@ -13,8 +13,8 @@ import path from "node:path";
 import {
   type EvidenceSlice,
   createLibrarianStore,
+  createSqliteCurationRunReader,
   createSqliteCuratorMemorySource,
-  findRunningRun,
   gatherMemoryEvidence,
   selectDueSlices,
 } from "@librarian/core";
@@ -52,7 +52,10 @@ describe("CurationStore — curator read methods bind the store source + db", ()
     expect(s.gatherMemoryEvidence(slice, { maxMemories: 5 })).toEqual(
       gatherMemoryEvidence(source, slice, { maxMemories: 5 }),
     );
-    expect(s.selectDueSlices(schedule, now)).toEqual(selectDueSlices(source, s.db, schedule, now));
-    expect(s.findRunningRun(slice)).toEqual(findRunningRun(s.db, slice));
+    const runReader = createSqliteCurationRunReader(s.db);
+    expect(s.selectDueSlices(schedule, now)).toEqual(
+      selectDueSlices(source, runReader, schedule, now),
+    );
+    expect(s.findRunningRun(slice)).toEqual(runReader.findRunningRun(slice));
   });
 });


### PR DESCRIPTION
## What

Decouples the curator scheduler's run-history reads from the raw SQLite `db` handle, behind a `CurationRunReader` seam. **Behavior-preserving.**

This is the foundation step (c.1a) of the Phase-4 SQLite-removal prerequisite — moving curator-run bookkeeping off the residual SQLite db onto a vault/sidecar store. The scheduler comment already anticipated exactly this ("the run-read side moves off SQLite with the run store at the Phase-4 SQLite removal").

## Changes

- `curator-scheduler.ts` is now pure: a `CurationRunReader { lastCompletedRunAt, findRunningRun }` interface + `selectDueSlices(memorySource, runReader, config, now)`. The `runFilter` + the two SQL queries were removed from here.
- `curation-store.ts` gains `createSqliteCurationRunReader(db)` — the moved SQL, byte-for-byte — and builds one to back the store's `selectDueSlices`/`findRunningRun` wrappers.
- Dropped the standalone `findRunningRun` core export (only tests imported it); added `CurationRunReader` + `createSqliteCurationRunReader`.

## Follow-on (this track)

- **c.1b** — a JSON sidecar run store implementing the same `CurationRunReader` + the run/operation CRUD.
- **c.1c** — wire the sidecar into the markdown backend + move `new DatabaseSync`/`ensureSchema` into the sqlite branch, so the markdown backend never opens sqlite (its last residual sqlite dependency).

> Note: the broader SQLite *backend deletion* is sequenced (per plan 036 Phase 7) **after** a sqlite→markdown migration tool that doesn't exist yet — that step is **not** part of this track and awaits a sequencing decision. This PR is a pure internal decoupling that strands no one.

## Review + gate

Sub-agent review: **ship** — byte-for-byte SQL preservation verified, no orphaned consumer of the dropped export, full-workspace typecheck + suite green. Full `pnpm -r build` + `pnpm -r test:vitest` green across all 5 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)