### PR TITLE
feat(core): markdown curation bookkeeping → JSON sidecar (SQLite-removal c.1c-i)

### DIFF
--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -33,7 +33,11 @@ import { createMarkdownHandoffStore, createMarkdownMemoryStore } from "./markdow
 import { type Memory, type MemoryStore, createMemoryStore } from "./memory-store.js";
 import { ensureSchema, rebuildMemoryIndex } from "./projection.js";
 import { type SettingsStore, createSettingsStore } from "./settings-store.js";
-import { createJsonConversationStateStore, createJsonSettingsStore } from "./sidecar/index.js";
+import {
+  createJsonConversationStateStore,
+  createJsonCurationStore,
+  createJsonSettingsStore,
+} from "./sidecar/index.js";
 import { type SkillStore, createSkillStore } from "./skills/index.js";
 
 const DEFAULT_DATA_DIR = path.join(process.cwd(), "data");
@@ -228,11 +232,13 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Inter
       secretKey: options.secretKey ?? null,
     });
     // Curator read-side over the vault (Phase 4): memory evidence + slice
-    // enumeration come from the markdown memory store. The run store/read side
-    // (createCurationRun / selectDueSlices' run lookups / findRunningRun) stays
-    // on the residual SQLite `db` until the Phase-4 SQLite removal.
-    const residualCuration = createCurationStore({
-      db,
+    // enumeration come from the markdown memory store; run/operation bookkeeping
+    // lives in a sidecar JSON file (curation-runs.json), NOT the residual SQLite
+    // `db` (SQLite-removal c.1c-i). The `db` opened above is now used by the
+    // markdown branch only to satisfy the InternalLibrarianStore contract +
+    // close(); a follow-on makes `db` optional and stops opening it here (c.1c-ii).
+    const markdownCuration = createJsonCurationStore({
+      filePath: path.join(dataDir, "curation-runs.json"),
       memorySource: createVaultCuratorMemorySource(markdownMemory),
     });
     // Index-backed recall, extracted so the consolidator's navigate step can
@@ -253,7 +259,7 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Inter
     };
     return {
       ...markdownMemory,
-      ...residualCuration,
+      ...markdownCuration,
       ...jsonSettings,
       backend: "markdown",
       convState: jsonConvState,

--- a/packages/core/tests/store/librarian-store-backend.test.ts
+++ b/packages/core/tests/store/librarian-store-backend.test.ts
@@ -1,8 +1,9 @@
 // Backend-selection tests for createLibrarianStore (plan 036 Phase 2 cutover,
 // incremental-behind-a-flag). The `markdown` backend routes memory/handoff to
-// the git vault and conv-state/settings to sidecar JSON files; a residual
-// SQLite db backs only the (dormant) curator until Phase 4. SQLite stays the
-// default — no behaviour change for existing consumers.
+// the git vault and conv-state/settings/curation-runs to sidecar JSON files
+// (the residual SQLite db is opened only for the InternalLibrarianStore contract
+// + close() until c.1c-ii removes it). SQLite stays the default — no behaviour
+// change for existing consumers.
 
 import fs from "node:fs";
 import os from "node:os";
@@ -69,6 +70,12 @@ describe("createLibrarianStore — backend selection", () => {
       store.setSetting("llm_token", "sk-x", { secret: true });
       expect(store.getSetting("llm_token")).toBe("sk-x");
       expect(fs.existsSync(path.join(dataDir, "settings.json"))).toBe(true);
+
+      // Curator run/operation bookkeeping lands in a sidecar JSON file (c.1c-i),
+      // OUTSIDE the git vault — not the residual SQLite db.
+      store.createCurationRun({ trigger: "manual", visibility: "common", input_hash: "h1" });
+      expect(fs.existsSync(path.join(dataDir, "curation-runs.json"))).toBe(true);
+      expect(fs.existsSync(path.join(dataDir, "vault", "curation-runs.json"))).toBe(false);
     } finally {
       store.close();
     }


### PR DESCRIPTION
## What

The **markdown** backend now persists curator run/operation bookkeeping via the c.1b JSON sidecar (`createJsonCurationStore` → `<dataDir>/curation-runs.json`, outside the git vault) instead of the residual SQLite `createCurationStore({ db })`.

This gives the c.1b sidecar a real production consumer — markdown's curation data is now human-readable JSON alongside `conv-state.json` / `settings.json`, not opaque sqlite tables.

## Intermediate state (intentional)

The residual `db` is **still opened** on markdown: the `InternalLibrarianStore` contract requires a `db` field and `close()` calls `db.close()`. Removing the open entirely needs interface surgery (making `db` optional + updating consumers) and is the deliberately-deferred follow-on **c.1c-ii**. So an opened-but-data-unused db on markdown is the expected intermediate here. The **sqlite branch is untouched**.

## Tests

- The markdown-curator full-run + consolidator-store-integration suites pass against the sidecar (run/operation bookkeeping now flows through `createJsonCurationStore`).
- Added a placement assertion: a markdown curation run lands at `<dataDir>/curation-runs.json` and **not** inside the git vault.

## Review + gate

Sub-agent review: **ship** — behavior-for-behavior identical swap; no `CurationStore` method lost/shadowed; sidecar file confirmed outside the vault. Full `pnpm -r build` + `pnpm -r test:vitest` green except the pre-existing flaky `classifier-worker.test.ts:513` timing test (unrelated to this core-only change; passes 14/14 in isolation).

## Context

Part of the SQLite-removal prerequisite track (c.1a `CurationRunReader` seam + c.1b JSON sidecar store already landed). Independent of the Jim-gated sqlite *backend deletion* (which awaits a migration tool, per plan 036 Phase 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)