### PR TITLE
docs: curation mission (README) + entity-granularity spec (039) + refactoring TODO

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,16 @@
 [![CI](https://github.com/JimJafar/the-librarian/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/JimJafar/the-librarian/actions/workflows/ci.yml)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
-A portable **memory + handoff layer for AI agents**. The Librarian gives agents
+**The Librarian is a living, markdown-native knowledge graph for AI agents — with
+a resident curator that tends it.** Knowledge, skills, and context accumulate as
+plain, Obsidian-flavoured markdown notes, linked into a graph by `[[wikilinks]]`;
+a resident "librarian" curates the collection as it grows — filing each new memory
+where it belongs, linking it to its neighbours, and organising the whole for
+*retrieval*, not just storage. It's all plain files you can read, edit, and
+reorganise yourself (in the dashboard or in Obsidian); git gives it history;
+nothing is locked in a database.
+
+Practically, that makes it a portable **memory + handoff layer for AI agents**:
 one disciplined funnel for recalling, proposing, saving, updating, and reviewing
 durable context — plus an explicit **cross-harness handoff surface** so work
 started in one harness (Claude Code, Codex, Hermes, OpenCode, Pi) can be packaged

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -208,6 +208,18 @@ this repo.
 
 ## Features / functional improvements
 
+- **Curator retrospective refactoring / re-organisation (later phase).** Today the
+  consolidator only acts on INCOMING submissions — one judgment (create / augment /
+  supersede / archive) against one target. It never revisits existing nodes to
+  reorganise them. A later phase: a periodic grooming pass that reasons over the
+  whole graph and refactors it — **split** a node that has accreted several entities
+  into a hub + spokes (e.g. a "Team" doc that collected per-person facts → a Team
+  hub + a wikilinked node per member), **merge** near-duplicates, and **repair/add
+  missing links**. Distinct from the per-submission judge (corpus-level, not one
+  fact); gated behind git review so every refactor is a reviewable, revertable diff.
+  _(design conversation 2026-06-03; spec 039's per-submission entity-granularity
+  guidance reduces — but doesn't remove — the need for this, since the judge can't
+  retro-fix nodes that already grew too coarse)_
 - Look at offering a tiny local LLM as an alternative to cloud / API LLM for the
   memory consolidator (see https://github.com/tgrytnes/mnemosyne).
 - Improve memory storage & retrieval with polyphonic recall (see

--- a/docs/specs/039-curator-entity-granularity-spec.md
+++ b/docs/specs/039-curator-entity-granularity-spec.md
@@ -1,0 +1,137 @@
+# Spec 039 — Curator entity-granularity guidance (node vs facet; hub-and-spoke)
+
+**Status:** Draft for review (Specify phase) — pick up as a subsequent piece of work
+**Version target:** PATCH/MINOR (consolidator prompt + eval fixtures; opt-in feature, no default-runtime change)
+**Depends on:** the consolidator (036 Phase 4, shipped), the v2 curation prompt (shipped), `@librarian/consolidator-eval` (C6, shipped)
+**Relates to:** 038 (seed ingest — the `seed score` loop this spec is measured by); `docs/TODO.md` "Curator retrospective refactoring" (the corpus-level counterpart this does NOT cover)
+
+---
+
+## Objective
+
+**What.** Sharpen the consolidator judge's **entity-granularity** decision so the
+graph it builds has the right *nodes*: a distinct entity (a person, project,
+company, system) gets its **own node, linked to its hub**, while a new *facet* of
+an existing topic **augments** the existing node — and a fact's *kind* routes it
+to the right node (a person-specific fact → the person's node; a structural fact →
+the hub).
+
+**Why.** The judge already decides create-vs-augment, but nothing tells it *how
+granular a node should be*. From the 2026-06-03 design conversation: the owner
+wants hub-and-spoke knowledge — e.g. a **Team** hub plus a node **per team member**,
+where each member's node carries person-specific detail and the team/company facts
+stay on the hub. The current prompt leaves "is this a new entity, or a new facet?"
+to undirected LLM discretion, and its preserve/augment-first bias can pile
+person-specific facts onto a hub instead of spinning out a clean spoke. This makes
+the *emergent graph* fuzzier than it should be — and because backlink-aware recall
+is one-hop (verified), a fact orphaned on the wrong node or left unlinked is
+genuinely harder to retrieve.
+
+**Who.** The owner + any user whose memory grows into entity clusters (people,
+projects, systems). Improves the opt-in consolidator only.
+
+**Success, in one line.** Given a "Team" hub and an incoming person-specific fact,
+the judge **creates (or augments) the person's spoke node and `[[wikilinks]]` it to
+the hub**, rather than burying the fact in the hub — and the `seed score` /
+consolidator-eval metrics show this measurably, not anecdotally.
+
+---
+
+## Background — what's there, and the gap
+
+- The judge sees the relevant candidate docs **and** a table-of-contents of the
+  whole corpus, then emits one action (`create`/`augment`/`supersede`/`archive`/
+  `noop`) with a confidence. So the create-vs-augment *mechanism* exists.
+- A `create`d node can embed `[[Hub]]` in its body; wikilinks resolve to docs by
+  **title/alias**, and recall expands **one hop** over inbound+outbound edges
+  (the "Anna problem" recall is built + tested). So hub↔spoke linking *works* once
+  the link text is present.
+- **Gap:** no guidance on *node granularity*. The prompt doesn't say "a distinct
+  entity deserves its own node; a new facet augments," doesn't distinguish
+  person-specific from structural facts, and gives no spin-out heuristic. Result:
+  granularity is undirected and the augment-first bias under-creates spokes.
+
+This is the **per-submission** half of the granularity problem. The
+**corpus-level** half — retrospectively splitting a node that already grew too
+coarse — is explicitly out of scope here (see the TODO item).
+
+---
+
+## The change
+
+### 1. Prompt — add an "entity granularity" section to the judge `SYSTEM_INSTRUCTIONS`
+
+Bump `CONSOLIDATOR_PROMPT_VERSION` (v2 → v3). Add guidance, roughly:
+
+- **A distinct entity deserves its own node.** A person, project, company, team,
+  system, or place that the submission is *primarily about* should be its **own
+  doc**, even if a related hub already exists. A new *facet* of an entity that
+  already has a node → **augment** that node.
+- **Hub-and-spoke + routing by kind.** When both a hub (e.g. "Team at Expend") and a
+  spoke (e.g. "Brett") are plausible homes, route by what the fact is *about*:
+  **person/entity-specific** detail → the **spoke**; **structural / relational**
+  detail (who reports to whom, team composition) → the **hub**. Don't put
+  person-specific facts on the hub.
+- **Spin out, then link.** If the right entity has **no node yet** and the fact is
+  primarily about it, `create` that node and put `[[Hub]]` in its body so the edge
+  forms — prefer this over augmenting the hub with an entity-specific fact.
+- **But don't over-fragment.** A genuine *facet* (one more preference, one more
+  detail about the same thing) augments; only spin out when the submission is
+  substantively about a *distinct* entity. (This is the counterweight that keeps
+  "preserve/augment-first" intact for true facets.)
+
+Keep the OUTPUT CONTRACT, the code-enforced RULES, and the untrusted-data framing
+unchanged (as v2 did). This is additive judgement guidance.
+
+### 2. Eval — entity-granularity fixtures + a metric in `consolidator-eval`
+
+Add a **synthetic** scenario set (no personal data) modelling hub-and-spoke:
+
+- A "Team" hub exists; an incoming **person-specific** fact about a member with **no
+  node yet** → expect `create` (a spoke) — NOT `augment` the hub.
+- The member's node exists; another **person-specific** fact → expect `augment` the
+  **spoke** (not the hub).
+- A **structural** fact (team composition) → expect `augment` the **hub**.
+- A genuine **facet** of an existing single-entity node → expect `augment` (the
+  anti-over-fragmentation guard).
+
+Add a metric (e.g. `node_granularity` / `hub_spoke_routing`): the fraction of
+granularity fixtures where the judge picked the right node-vs-facet action and the
+right target. Wire it into `seed score` so the 038 iterate loop can track it.
+
+---
+
+## Commands / Project Structure / Testing
+
+- **Touches:** `packages/core/src/consolidator/judge-step.ts` (the prompt + version),
+  `packages/core/tests/consolidator-judge-step.test.ts` (pin the new guidance present),
+  `packages/consolidator-eval/fixtures/` + `src/metrics.ts` (the granularity scenarios + metric).
+- **Testing:** offline, the prompt-build test pins the v3 guidance strings; the
+  eval scenarios are scored with the scripted `LlmClient` for the *plumbing*, and
+  with a **real model** in the operator iterate loop for the *quality* number (the
+  prompt change cannot be quality-validated offline — same caveat as v2).
+- **Code style / boundaries:** synthetic fixtures only; additive prompt change; no
+  change to the output contract or code-enforced rules; opt-in consolidator only.
+
+## Success Criteria
+
+- [ ] v3 prompt carries explicit entity-node / hub-spoke / spin-out guidance; the prompt-build test pins it; offline consolidator tests stay green.
+- [ ] `consolidator-eval` has hub-and-spoke granularity fixtures + a granularity metric, surfaced by `seed score`.
+- [ ] On a real-model run, the granularity metric is **measurable and improved vs v2** (the operator records the before/after — this is the proof, and it can only be produced by a real-model run).
+- [ ] The "don't over-fragment" guard holds: a genuine facet still augments (a fixture proves the prompt didn't swing to over-creating).
+
+## Open Questions
+
+1. **How explicit to make "kinds"?** Name concrete entity kinds (person / project /
+   company / system / place) in the prompt, or keep it abstract ("a distinct
+   entity")? Concrete may anchor better but risks missing kinds.
+2. **Confidence interaction.** Should "spin out a new entity node" lean on the
+   existing low-confidence→`create_new` band, or is spin-out a *high*-confidence
+   `create`? (They're different: create_new files the raw submission and drops the
+   judgment; an intentional spoke wants the judge's curated title/body + the `[[Hub]]`
+   link.) Likely the latter — confirm.
+3. **Does this want a navigate change too?** For the judge to choose the right
+   spoke, navigate must surface both the hub and any existing spokes as candidates.
+   Confirm recall + ToC reliably surface sibling spokes at the relevant corpus size,
+   or whether navigate needs entity-aware candidate selection (bigger; likely a
+   follow-up).


### PR DESCRIPTION
From the design conversation on how the librarian's knowledge graph should grow. **Docs only.**

## README — the mission, near the top
A mission statement before the feature list, so visitors grasp the core idea first: *a living, markdown-native knowledge graph for AI agents, with a resident curator that tends it* — knowledge/skills/context as linked markdown notes, a librarian that files each new memory where it belongs, links it to its neighbours, and organises the whole for retrieval. (Accurate to what's shipped: markdown vault + `[[wikilink]]` graph + backlink-aware recall + the consolidator; plain files, git history, Obsidian-compatible.)

## spec 039 — curator entity-granularity guidance (to be picked up)
Sharpen the judge's **node-vs-facet** decision so the emergent graph has the right nodes:
- a distinct entity → its own node, `[[wikilinked]]` to its hub; a new *facet* → augment;
- route **person-specific** facts to the **spoke**, **structural** facts to the **hub**;
- spin-out-then-link when the entity has no node yet; an anti-over-fragmentation guard so true facets still augment;
- hub-and-spoke **eval fixtures** + a granularity metric, surfaced by `seed score` (spec 038's loop) so the change is *measured*, not asserted.

Prompt bump v2 → v3; additive judgement guidance; opt-in consolidator only.

## TODO — the deferred corpus-level counterpart
A note for a later phase: a curator **grooming pass** that retrospectively *splits / merges / relinks* existing nodes (distinct from the per-submission judge; gated behind git review). 039 reduces — but can't remove — the need for it.

---
Note: the seed-ingest spec (038) is intentionally **not** in this PR — it's still under review (the Q1–Q6 design questions), and lands once that's settled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)