### PR TITLE
feat(scripts): maintainer-only seed/migration tool (scripts/seed)

### DIFF
--- a/docs/specs/039-curator-entity-granularity-spec.md
+++ b/docs/specs/039-curator-entity-granularity-spec.md
@@ -3,7 +3,7 @@
 **Status:** Draft for review (Specify phase) — pick up as a subsequent piece of work
 **Version target:** PATCH/MINOR (consolidator prompt + eval fixtures; opt-in feature, no default-runtime change)
 **Depends on:** the consolidator (036 Phase 4, shipped), the v2 curation prompt (shipped), `@librarian/consolidator-eval` (C6, shipped)
-**Relates to:** 038 (seed ingest — the `seed score` loop this spec is measured by); `docs/TODO.md` "Curator retrospective refactoring" (the corpus-level counterpart this does NOT cover)
+**Relates to:** `scripts/seed/` (the wipe-and-re-import loop this spec is measured by — see its README); `docs/TODO.md` "Curator retrospective refactoring" (the corpus-level counterpart this does NOT cover)
 
 ---
 
@@ -32,8 +32,8 @@ projects, systems). Improves the opt-in consolidator only.
 
 **Success, in one line.** Given a "Team" hub and an incoming person-specific fact,
 the judge **creates (or augments) the person's spoke node and `[[wikilinks]]` it to
-the hub**, rather than burying the fact in the hub — and the `seed score` /
-consolidator-eval metrics show this measurably, not anecdotally.
+the hub**, rather than burying the fact in the hub — and the `consolidator-eval`
+metrics show this measurably, not anecdotally.
 
 ---
 
@@ -97,7 +97,7 @@ Add a **synthetic** scenario set (no personal data) modelling hub-and-spoke:
 
 Add a metric (e.g. `node_granularity` / `hub_spoke_routing`): the fraction of
 granularity fixtures where the judge picked the right node-vs-facet action and the
-right target. Wire it into `seed score` so the 038 iterate loop can track it.
+right target — surfaced by `consolidator-eval` so the `scripts/seed` wipe-and-re-import loop can track it.
 
 ---
 
@@ -116,7 +116,7 @@ right target. Wire it into `seed score` so the 038 iterate loop can track it.
 ## Success Criteria
 
 - [ ] v3 prompt carries explicit entity-node / hub-spoke / spin-out guidance; the prompt-build test pins it; offline consolidator tests stay green.
-- [ ] `consolidator-eval` has hub-and-spoke granularity fixtures + a granularity metric, surfaced by `seed score`.
+- [ ] `consolidator-eval` has hub-and-spoke granularity fixtures + a granularity metric, runnable in the `scripts/seed` wipe-and-re-import loop.
 - [ ] On a real-model run, the granularity metric is **measurable and improved vs v2** (the operator records the before/after — this is the proof, and it can only be produced by a real-model run).
 - [ ] The "don't over-fragment" guard holds: a genuine facet still augments (a fixture proves the prompt didn't swing to over-creating).
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@eslint/js": "^9.17.0",
     "@librarian/cli": "workspace:*",
     "@librarian/core": "workspace:*",
+    "@librarian/mcp-server": "workspace:*",
     "@vitest/eslint-plugin": "^1.1.40",
     "eslint": "^9.17.0",
     "eslint-plugin-import": "^2.31.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
       '@librarian/core':
         specifier: workspace:*
         version: link:packages/core
+      '@librarian/mcp-server':
+        specifier: workspace:*
+        version: link:packages/mcp-server
       '@vitest/eslint-plugin':
         specifier: ^1.1.40
         version: 1.6.17(@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)(vitest@2.1.9(@types/node@22.19.19)(jsdom@25.0.1)(lightningcss@1.32.0))

--- a/scripts/seed/README.md
+++ b/scripts/seed/README.md
@@ -1,0 +1,58 @@
+# `scripts/seed` — seed / migration tool (maintainer-only)
+
+A small, local, **maintainer-only** tool to bootstrap or re-seed a markdown vault
+from an external source, grooming everything through the consolidator. It is
+**not** a product feature and **not** exposed over HTTP/MCP — general users add
+content via Obsidian/the filesystem (references) or the dashboard, and the vault
+file-manager (plan-036 F10) is the eventual UI for that. (This supersedes the
+withdrawn spec 038, which over-specified a CLI feature we decided not to build.)
+
+## Model
+
+Two layers, deliberately:
+
+- **Raw source** (external, immutable, git-tracked *by you* — **never** in this repo):
+  - `<source>/memories/**.md` — hand-authored context/identity docs → **memories**
+  - `<source>/references/**.md` — background/research docs → **references** (verbatim)
+  - `<source>/skills/**` — (later) → the skills namespace
+  - `<source>/extract/**.json` — an exported dump of an old SQLite store (see `extract`)
+- **Derived vault** (`<dataDir>/vault`) — a rebuildable *artifact*. Anything here can be
+  reproduced by re-running `import`.
+
+References are **copied verbatim** (that namespace just reads files off disk).
+Every memory — your `memories/**` docs *and* the SQLite `extract/**` records —
+is replayed through the **real `remember` endpoint in-process**, consolidator
+**on**, **seed-first** (your curated docs first, DB memories merge onto them),
+then the consolidator grooms the inbox (navigate → judge → file with
+`[[wikilinks]]`). No manifest, no idempotency layer.
+
+## Commands
+
+```sh
+# 1. (migration only) dump an old SQLite store's ACTIVE memories → extract JSON
+node scripts/seed/extract.mjs --db <old-sqlite-dataDir> --out <source>/extract
+
+# 2. bootstrap / re-seed the vault (needs the curator LLM configured)
+node scripts/seed/import.mjs --source <source> --data-dir <vault-dataDir> [--extract <source>/extract]
+
+# refine the curator prompt: wipe + rebuild from the same source, then score
+node scripts/seed/import.mjs --source <source> --data-dir <vault-dataDir> --extract <source>/extract --wipe --yes
+pnpm --filter @librarian/consolidator-eval exec consolidator-eval run --model <model>   # the scoring loop
+```
+
+- `import` needs the **curator LLM** configured in the store (endpoint/model/token) —
+  it reuses the curator's brain to groom. A real run is a maintainer action.
+- `--wipe` clears the **entire** derived vault (memories/references/inbox/index),
+  including any live memories — so it requires `--yes`. It's for bootstrap +
+  the prompt-refinement loop, not for topping up a live store.
+- Re-running `import` without `--wipe` is safe: references never overwrite
+  (add-new-only), and memories merge via the consolidator (it `noop`s duplicates)
+  — though a plain re-run may accrue minor LLM-dedup noise, which is why `--wipe`
+  is the clean-rebuild path.
+
+## Tests
+
+`test/seed-import.test.ts` (root `pnpm test` suite) drives the pure helpers and
+`runSeedImport` end-to-end against a real markdown store with a **scripted**
+consolidator — no network. The real-model groom is exercised by the maintainer,
+not CI. **All test fixtures are synthetic; no personal seed data lives in this repo.**

--- a/scripts/seed/extract.mjs
+++ b/scripts/seed/extract.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+// seed extract — dump an existing SQLite store's ACTIVE memories to JSON (one
+// file per memory) for replay by import.mjs. Read-only on the db. See README.md.
+//
+//   node scripts/seed/extract.mjs --db <sqlite-dataDir> --out <extract-dir>
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { parseArgs } from "node:util";
+import { createLibrarianStore } from "@librarian/core";
+import { extractActiveMemories } from "./lib.mjs";
+
+const { values } = parseArgs({
+  options: { db: { type: "string" }, "data-dir": { type: "string" }, out: { type: "string" } },
+  strict: true,
+});
+const dataDir = values.db ?? values["data-dir"];
+const out = values.out;
+if (!dataDir || !out) {
+  console.error("usage: node scripts/seed/extract.mjs --db <sqlite-dataDir> --out <extract-dir>");
+  process.exit(2);
+}
+
+const store = createLibrarianStore({ dataDir, backend: "sqlite" });
+try {
+  const records = extractActiveMemories(store);
+  fs.mkdirSync(out, { recursive: true });
+  records.forEach((rec, i) => {
+    fs.writeFileSync(
+      path.join(out, `${String(i + 1).padStart(5, "0")}.json`),
+      `${JSON.stringify(rec, null, 2)}\n`,
+    );
+  });
+  console.log(`seed extract: wrote ${records.length} active memories → ${out}`);
+} finally {
+  store.close();
+}

--- a/scripts/seed/import.mjs
+++ b/scripts/seed/import.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+// seed import — bootstrap / re-seed a markdown vault from an external source,
+// grooming everything through the consolidator. See README.md.
+//
+//   node scripts/seed/import.mjs --source <seed-dir> --data-dir <vault-dataDir> \
+//        [--extract <extract-dir>] [--wipe --yes]
+//
+// Needs the curator LLM configured (the consolidator's brain) — the same
+// endpoint/model/token the curator uses, read from the store's settings.
+
+import path from "node:path";
+import process from "node:process";
+import { parseArgs } from "node:util";
+import {
+  createCuratorLlmClient,
+  createLibrarianStore,
+  readCuratorConfig,
+  resolveBootCredentials,
+  resolveCuratorToken,
+} from "@librarian/core";
+import { runSeedImport } from "./lib.mjs";
+
+const { values } = parseArgs({
+  options: {
+    source: { type: "string" },
+    "data-dir": { type: "string" },
+    extract: { type: "string" },
+    wipe: { type: "boolean", default: false },
+    yes: { type: "boolean", default: false },
+  },
+  strict: true,
+});
+
+const source = values.source;
+const dataDir = values["data-dir"];
+if (!source || !dataDir) {
+  console.error(
+    "usage: node scripts/seed/import.mjs --source <seed-dir> --data-dir <vault-dataDir> [--extract <dir>] [--wipe --yes]",
+  );
+  process.exit(2);
+}
+if (values.wipe && !values.yes) {
+  console.error(
+    "seed import: --wipe clears the ENTIRE vault (including any live memories that arrived after the initial seed). Re-run with --wipe --yes to confirm.",
+  );
+  process.exit(1);
+}
+
+// `remember` routes to the inbox (→ consolidator) only when this is on.
+process.env.LIBRARIAN_CONSOLIDATOR = "on";
+
+const { secretKey } = resolveBootCredentials({
+  env: process.env,
+  dataDir,
+  boundBeyondLocalhost: false,
+});
+const store = createLibrarianStore({ dataDir, backend: "markdown", secretKey });
+try {
+  const config = readCuratorConfig(store);
+  if (!config.isLlmComplete) {
+    console.error(
+      "seed import: configure the curator LLM (endpoint/model/token) first — the consolidator needs it to groom.",
+    );
+    process.exit(1);
+  }
+  const token = resolveCuratorToken(store);
+  if (!token) {
+    console.error("seed import: no curator LLM token configured.");
+    process.exit(1);
+  }
+  const llmClient = createCuratorLlmClient({
+    endpoint: config.llm.endpoint,
+    token,
+    model: config.llm.model,
+  });
+
+  const summary = await runSeedImport({
+    store,
+    vaultRoot: path.join(dataDir, "vault"),
+    sourceDir: source,
+    extractDir: values.extract,
+    llmClient,
+    wipe: values.wipe,
+  });
+  console.log(
+    `seed import: wiped [${summary.wiped.join(", ")}] · ${summary.referencesCopied} references copied · ${summary.remembered} memories submitted · sweep ${JSON.stringify(summary.sweep)}`,
+  );
+} finally {
+  store.close();
+}

--- a/scripts/seed/lib.mjs
+++ b/scripts/seed/lib.mjs
@@ -1,0 +1,234 @@
+// Seed/migration helpers (spec 038 superseded — see scripts/seed/README.md).
+//
+// A us-only tool to bootstrap / re-seed a markdown vault from an external raw
+// layer, grooming everything through the consolidator. Pure helpers + the
+// import orchestration live here so they're unit-testable; the `extract.mjs` /
+// `import.mjs` bins are thin arg-parsing wrappers.
+//
+// Design (settled 2026-06-03): references are copied verbatim; every memory
+// (hand-authored `memories/**` + an exported SQLite `extract/**`) is replayed
+// through the REAL `remember` MCP handler in-process, consolidator ON, seed-first;
+// the consolidator then grooms the inbox (navigate→judge→file with [[wikilinks]]).
+// Re-seeding = wipe the vault + re-run. No manifest, no idempotency layer.
+
+import fs from "node:fs";
+import path from "node:path";
+import { handleMcpPayload } from "@librarian/mcp-server";
+
+const MAX_TITLE = 120;
+
+const unquote = (s) => s.replace(/^["']|["']$/g, "");
+
+/**
+ * Minimal frontmatter split — `{ data, content }`. Dependency-free (the script
+ * stays self-contained). Handles the only shapes a seed file needs: scalars,
+ * inline `[a, b]` arrays, and block `- item` arrays. No frontmatter → all body.
+ */
+export function parseFrontmatter(input) {
+  // Normalise CRLF first — otherwise `split("\n")` leaves a trailing \r that the
+  // key/value regex never matches, silently dropping every frontmatter field
+  // (Windows / git autocrlf checkouts).
+  const raw = input.replace(/\r\n/g, "\n");
+  if (!raw.startsWith("---")) return { data: {}, content: raw };
+  const close = raw.indexOf("\n---", 3);
+  if (close === -1) return { data: {}, content: raw };
+  const block = raw.slice(raw.indexOf("\n") + 1, close);
+  const content = raw.slice(close + 4).replace(/^\r?\n/, "");
+  const data = {};
+  const lines = block.split("\n");
+  for (let i = 0; i < lines.length; i += 1) {
+    const m = lines[i].match(/^([A-Za-z_][\w-]*):\s*(.*)$/);
+    if (!m) continue;
+    const key = m[1];
+    const value = m[2].trim();
+    if (value === "") {
+      const arr = [];
+      while (i + 1 < lines.length && /^\s*-\s+/.test(lines[i + 1])) {
+        arr.push(unquote(lines[(i += 1)].replace(/^\s*-\s+/, "").trim()));
+      }
+      data[key] = arr;
+    } else if (value.startsWith("[") && value.endsWith("]")) {
+      data[key] = value
+        .slice(1, -1)
+        .split(",")
+        .map((s) => unquote(s.trim()))
+        .filter(Boolean);
+    } else {
+      data[key] = unquote(value);
+    }
+  }
+  return { data, content };
+}
+
+/** Recursive list of `.md` files under `dir`, returned as `{ rel, abs }` (posix rel), sorted. */
+export function listMarkdown(dir) {
+  if (!fs.existsSync(dir)) return [];
+  const out = [];
+  const walk = (d) => {
+    for (const entry of fs
+      .readdirSync(d, { withFileTypes: true })
+      .sort((a, b) => a.name.localeCompare(b.name))) {
+      const abs = path.join(d, entry.name);
+      if (entry.isDirectory()) walk(abs);
+      else if (entry.isFile() && entry.name.endsWith(".md")) {
+        out.push({ rel: path.relative(dir, abs).split(path.sep).join("/"), abs });
+      }
+    }
+  };
+  walk(dir);
+  return out;
+}
+
+/**
+ * Route a source layer by folder (the settled convention): `memories/` →
+ * memories, `references/` → references. Anything else is ignored (with a note).
+ */
+export function routeSourceDir(sourceDir) {
+  return {
+    memoryFiles: listMarkdown(path.join(sourceDir, "memories")),
+    referenceFiles: listMarkdown(path.join(sourceDir, "references")),
+  };
+}
+
+/** First markdown heading text, else first non-empty line, else the filename stem. */
+export function deriveTitle(body, relPath) {
+  for (const line of body.split("\n")) {
+    const heading = line.match(/^#{1,6}\s+(.+?)\s*$/);
+    if (heading) return heading[1].slice(0, MAX_TITLE);
+    if (line.trim()) return line.trim().slice(0, MAX_TITLE);
+  }
+  const stem = relPath.slice(relPath.lastIndexOf("/") + 1).replace(/\.md$/, "");
+  return stem || "Untitled note";
+}
+
+/** Build `remember` arguments from a hand-authored markdown file (frontmatter optional). */
+export function rememberArgsFromMarkdown(relPath, raw, agentId) {
+  const { data, content } = parseFrontmatter(raw);
+  const body = content.trim();
+  const args = { agent_id: agentId, title: deriveTitle(body, relPath), body };
+  if (Array.isArray(data.tags)) args.tags = data.tags.filter((t) => typeof t === "string");
+  if (Array.isArray(data.applies_to)) {
+    args.applies_to = data.applies_to.filter((a) => typeof a === "string");
+  }
+  if (typeof data.project_key === "string") args.project_key = data.project_key;
+  return args;
+}
+
+/** Build `remember` arguments from one exported SQLite memory record (extract/*.json). */
+export function rememberArgsFromExtractRecord(rec, fallbackAgentId) {
+  const args = {
+    agent_id: typeof rec.agent_id === "string" && rec.agent_id ? rec.agent_id : fallbackAgentId,
+    title: typeof rec.title === "string" ? rec.title : "Untitled note",
+    body: typeof rec.body === "string" ? rec.body : "",
+  };
+  if (Array.isArray(rec.tags)) args.tags = rec.tags.filter((t) => typeof t === "string");
+  if (Array.isArray(rec.applies_to))
+    args.applies_to = rec.applies_to.filter((a) => typeof a === "string");
+  if (typeof rec.project_key === "string") args.project_key = rec.project_key;
+  return args;
+}
+
+/** Active memories from a (sqlite) store, as portable extract records (no ids/timestamps). */
+export function extractActiveMemories(store) {
+  return store.listAll({ status: "active" }).map((m) => ({
+    title: String(m.title ?? ""),
+    body: String(m.body ?? ""),
+    tags: Array.isArray(m.tags) ? m.tags : [],
+    applies_to: Array.isArray(m.applies_to) ? m.applies_to : [],
+    project_key: typeof m.project_key === "string" ? m.project_key : null,
+    agent_id: String(m.agent_id ?? ""),
+  }));
+}
+
+/** Read exported `extract/*.json` records from a directory. */
+export function readExtractRecords(extractDir) {
+  if (!extractDir || !fs.existsSync(extractDir)) return [];
+  return fs
+    .readdirSync(extractDir)
+    .filter((f) => f.endsWith(".json"))
+    .sort()
+    .map((f) => JSON.parse(fs.readFileSync(path.join(extractDir, f), "utf8")));
+}
+
+/** Invoke the real `remember` MCP handler in-process. Returns its result text. */
+export async function remember(store, args) {
+  const res = await handleMcpPayload(store, {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: { name: "remember", arguments: args },
+  });
+  return res?.result?.content?.[0]?.text ?? "";
+}
+
+/** Copy reference files verbatim into the vault, never overwriting an existing one. */
+export function copyReferences(referenceFiles, vaultReferencesDir) {
+  let copied = 0;
+  for (const file of referenceFiles) {
+    const dest = path.join(vaultReferencesDir, file.rel);
+    if (fs.existsSync(dest)) continue; // never overwrite
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.copyFileSync(file.abs, dest);
+    copied += 1;
+  }
+  return copied;
+}
+
+/** Clear the derived knowledge from a vault (memories/references/inbox + the index). NOT the source. */
+export function wipeVaultKnowledge(vaultRoot) {
+  const removed = [];
+  for (const sub of ["memories", "references", "inbox", ".index"]) {
+    const target = path.join(vaultRoot, sub);
+    if (fs.existsSync(target)) {
+      fs.rmSync(target, { recursive: true, force: true });
+      removed.push(sub);
+    }
+  }
+  return removed;
+}
+
+/**
+ * Run the seed import against a markdown store (consolidator ON): wipe (optional),
+ * copy references verbatim, replay every memory through `remember` SEED-FIRST
+ * (hand-authored `memories/**` before the SQLite `extract/**`), then drain the
+ * inbox through the consolidator. Returns a summary. `llmClient` is injected (a
+ * real curator client from the bin; a scripted one in tests).
+ */
+export async function runSeedImport({
+  store,
+  vaultRoot,
+  sourceDir,
+  extractDir,
+  llmClient,
+  agentId = "seed-import",
+  wipe = false,
+}) {
+  if (store.backend !== "markdown") {
+    throw new Error(`seed import requires the markdown backend (got '${store.backend}')`);
+  }
+  const summary = { wiped: [], referencesCopied: 0, remembered: 0, sweep: null };
+
+  if (wipe) summary.wiped = wipeVaultKnowledge(vaultRoot);
+
+  const { memoryFiles, referenceFiles } = routeSourceDir(sourceDir);
+  summary.referencesCopied = copyReferences(referenceFiles, path.join(vaultRoot, "references"));
+
+  // Seed-first: hand-authored memory docs, then the exported SQLite records — so
+  // DB memories merge ONTO the curated context, not the reverse.
+  for (const file of memoryFiles) {
+    await remember(
+      store,
+      rememberArgsFromMarkdown(file.rel, fs.readFileSync(file.abs, "utf8"), agentId),
+    );
+    summary.remembered += 1;
+  }
+  for (const rec of readExtractRecords(extractDir)) {
+    await remember(store, rememberArgsFromExtractRecord(rec, agentId));
+    summary.remembered += 1;
+  }
+
+  // Drain the inbox: this script runs in-process with no scheduler, so we groom
+  // explicitly (the http server would do this on a tick).
+  summary.sweep = await store.consolidateInbox({ llmClient });
+  return summary;
+}

--- a/test/seed-import.test.ts
+++ b/test/seed-import.test.ts
@@ -1,0 +1,145 @@
+// scripts/seed — the us-only seed/migration tool. Pure helpers (folder routing,
+// remember-arg derivation) + the import orchestration driven end-to-end against a
+// real markdown store with a SCRIPTED consolidator (no network): references copy
+// verbatim, memories replay through the real `remember` handler seed-first, the
+// consolidator grooms them, and `--wipe` clears the derived vault.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { type InternalLibrarianStore, createLibrarianStore } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const lib = await import(path.resolve(__dirname, "..", "scripts", "seed", "lib.mjs"));
+
+// A scripted curator brain: files every submission as a fresh `create`.
+const scriptedClient = {
+  async complete() {
+    return {
+      content: JSON.stringify({
+        action: "create",
+        title: "Filed",
+        body: "Body.",
+        tags: [],
+        rationale: "r",
+        confidence: 0.99,
+      }),
+      model: "scripted",
+      usage: null,
+    };
+  },
+};
+
+describe("seed lib — pure helpers", () => {
+  it("derives a title from the first heading, else first line, else filename", () => {
+    expect(lib.deriveTitle("# Communication Style\n\nbody", "x.md")).toBe("Communication Style");
+    expect(lib.deriveTitle("just a line\nmore", "x.md")).toBe("just a line");
+    expect(lib.deriveTitle("", "context/role-and-responsibilities.md")).toBe(
+      "role-and-responsibilities",
+    );
+  });
+
+  it("builds remember args from markdown, honouring optional frontmatter", () => {
+    const withFm = lib.rememberArgsFromMarkdown(
+      "a.md",
+      "---\ntags: [identity]\napplies_to: [Jim]\nproject_key: proj-x\n---\n# Anna\nmoved",
+      "agent-a",
+    );
+    expect(withFm).toMatchObject({
+      agent_id: "agent-a",
+      title: "Anna",
+      tags: ["identity"],
+      applies_to: ["Jim"],
+      project_key: "proj-x",
+    });
+    const noFm = lib.rememberArgsFromMarkdown("b.md", "# Plain\ntext", "agent-a");
+    expect(noFm).toEqual({ agent_id: "agent-a", title: "Plain", body: "# Plain\ntext" });
+
+    // CRLF-authored frontmatter must still parse (Windows / git autocrlf).
+    const crlf = lib.rememberArgsFromMarkdown(
+      "c.md",
+      "---\r\ntags: [a, b]\r\n---\r\n# T\r\nbody",
+      "agent-a",
+    );
+    expect(crlf.tags).toEqual(["a", "b"]);
+  });
+
+  it("builds remember args from an extract record, falling back the agent id", () => {
+    expect(
+      lib.rememberArgsFromExtractRecord({ title: "T", body: "B", tags: ["x"] }, "fallback"),
+    ).toEqual({ agent_id: "fallback", title: "T", body: "B", tags: ["x"] });
+  });
+});
+
+describe("seed lib — runSeedImport (end to end, scripted consolidator)", () => {
+  let dataDir = "";
+  let sourceDir = "";
+  let store: InternalLibrarianStore | null = null;
+  let savedFlag: string | undefined;
+
+  beforeEach(() => {
+    savedFlag = process.env.LIBRARIAN_CONSOLIDATOR;
+    process.env.LIBRARIAN_CONSOLIDATOR = "on"; // remember → inbox
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-seed-data-"));
+    sourceDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-seed-src-"));
+    fs.mkdirSync(path.join(sourceDir, "memories"), { recursive: true });
+    fs.mkdirSync(path.join(sourceDir, "references", "AI"), { recursive: true });
+    fs.writeFileSync(
+      path.join(sourceDir, "memories", "identity.md"),
+      "# Identity\nJim builds agents.",
+    );
+    fs.writeFileSync(path.join(sourceDir, "references", "AI", "note.md"), "# Background\nlong doc");
+    store = createLibrarianStore({ dataDir, backend: "markdown" });
+  });
+  afterEach(() => {
+    try {
+      store?.close();
+    } catch {
+      /* ignore */
+    }
+    fs.rmSync(dataDir, { recursive: true, force: true });
+    fs.rmSync(sourceDir, { recursive: true, force: true });
+    if (savedFlag === undefined) delete process.env.LIBRARIAN_CONSOLIDATOR;
+    else process.env.LIBRARIAN_CONSOLIDATOR = savedFlag;
+  });
+
+  it("copies references verbatim and grooms memories through the consolidator", async () => {
+    const summary = await lib.runSeedImport({
+      store,
+      vaultRoot: path.join(dataDir, "vault"),
+      sourceDir,
+      llmClient: scriptedClient,
+    });
+
+    expect(summary.referencesCopied).toBe(1);
+    expect(summary.remembered).toBe(1);
+    // The reference landed verbatim in the vault, subpath preserved.
+    expect(fs.existsSync(path.join(dataDir, "vault", "references", "AI", "note.md"))).toBe(true);
+    // The memory was submitted + groomed into an active memory by the (scripted) curator.
+    expect(store!.listMemories({ status: "active" }).total).toBeGreaterThanOrEqual(1);
+  });
+
+  it("--wipe clears the derived vault before re-importing", async () => {
+    await lib.runSeedImport({
+      store,
+      vaultRoot: path.join(dataDir, "vault"),
+      sourceDir,
+      llmClient: scriptedClient,
+    });
+    const before = store!.listMemories({ status: "active" }).total;
+    expect(before).toBeGreaterThanOrEqual(1);
+
+    const summary = await lib.runSeedImport({
+      store,
+      vaultRoot: path.join(dataDir, "vault"),
+      sourceDir,
+      llmClient: scriptedClient,
+      wipe: true,
+    });
+    expect(summary.wiped).toContain("memories");
+    // Rebuilt from the source, not doubled.
+    expect(store!.listMemories({ status: "active" }).total).toBe(before);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,7 +15,13 @@ export default defineConfig({
     // own loader handles the import chain.
     server: {
       deps: {
-        external: [/\/packages\/core\/(src|dist)\//],
+        external: [
+          /\/packages\/core\/(src|dist)\//,
+          /\/packages\/mcp-server\/(src|dist)\//,
+          // The seed scripts are plain .mjs run by node in production; let node's
+          // own loader resolve them (and their deps, e.g. gray-matter) in tests too.
+          /\/scripts\//,
+        ],
       },
     },
   },


### PR DESCRIPTION
A small, **local, maintainer-only** tool to bootstrap or re-seed a markdown vault from an external source, grooming everything through the consolidator. **Not a product feature; not exposed over HTTP/MCP.** This is the outcome of the design conversation that withdrew the heavy `038` CLI-feature spec in favour of a simple script.

## What it does

- **References** → copied **verbatim** into `<vault>/references/` (never overwrite).
- **Memories** (hand-authored `memories/**.md` + an exported SQLite `extract/**.json`) → replayed through the **real `remember` handler in-process** (consolidator on), **seed-first**, then `consolidateInbox()` grooms them (navigate → judge → `[[wikilinks]]`).
- **`--wipe`** clears the whole derived vault for the prompt-refinement loop (needs `--yes`).
- No manifest, no idempotency layer — re-seed = wipe + re-run.

```
node scripts/seed/extract.mjs --db <old-sqlite-dataDir> --out <source>/extract
node scripts/seed/import.mjs  --source <source> --data-dir <vault-dataDir> [--extract <dir>] [--wipe --yes]
```

## Structure

- `scripts/seed/lib.mjs` — pure helpers + `runSeedImport` orchestration.
- `scripts/seed/{extract,import}.mjs` — thin bins; `import` preflights the curator LLM config.
- `scripts/seed/README.md` — the design + usage (replaces 038).
- `test/seed-import.test.ts` (root `pnpm test` suite) drives the **real** pipeline end-to-end with a **scripted** consolidator (no network).

## Notes

- `vitest.config.ts` externalizes `/scripts/` + mcp-server so node resolves the `.mjs` natively in tests; `@librarian/mcp-server` added as a root devDep (root is private).
- **No maintainer personal data** in the repo or its tests — synthetic fixtures only; the tool operates on external `--source`/`--db` paths.
- Sub-agent review: **fix-then-ship** — caught a CRLF frontmatter-drop (Windows/autocrlf), now fixed + tested; everything else verified correct (wipe blast radius, pipeline faithfulness, no path-escape, no data leak).

Full `pnpm test` (build + per-package + root suite) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)