### PR TITLE
fix(scripts/seed): accept the consolidator LLM directly via flags/env

### DIFF
--- a/scripts/seed/README.md
+++ b/scripts/seed/README.md
@@ -32,16 +32,21 @@ then the consolidator grooms the inbox (navigate → judge → file with
 # 1. (migration only) dump an old SQLite store's ACTIVE memories → extract JSON
 node scripts/seed/extract.mjs --db <old-sqlite-dataDir> --out <source>/extract
 
-# 2. bootstrap / re-seed the vault (needs the curator LLM configured)
-node scripts/seed/import.mjs --source <source> --data-dir <vault-dataDir> [--extract <source>/extract]
+# 2. bootstrap / re-seed the vault (needs a consolidator LLM — flags or stored config)
+node scripts/seed/import.mjs --source <source> --data-dir <vault-dataDir> [--extract <source>/extract] \
+     --endpoint <openai-compatible-url> --model <id> --token <key>
 
 # refine the curator prompt: wipe + rebuild from the same source, then score
 node scripts/seed/import.mjs --source <source> --data-dir <vault-dataDir> --extract <source>/extract --wipe --yes
 pnpm --filter @librarian/consolidator-eval exec consolidator-eval run --model <model>   # the scoring loop
 ```
 
-- `import` needs the **curator LLM** configured in the store (endpoint/model/token) —
-  it reuses the curator's brain to groom. A real run is a maintainer action.
+- `import` needs a **consolidator LLM** to groom. Provide it EITHER directly via
+  `--endpoint <url> --model <id> --token <key>` (or the `LIBRARIAN_SEED_LLM_{ENDPOINT,MODEL,TOKEN}`
+  env vars), OR let it fall back to the **curator config stored in `--data-dir`'s settings**
+  (what the dashboard writes — but only into that store, so the dashboard's data dir + backend
+  must match `--data-dir`). The direct flags are simplest for a one-off and avoid the mismatch.
+  A real run is a maintainer action.
 - `--wipe` clears the **entire** derived vault (memories/references/inbox/index),
   including any live memories — so it requires `--yes`. It's for bootstrap +
   the prompt-refinement loop, not for topping up a live store.

--- a/scripts/seed/import.mjs
+++ b/scripts/seed/import.mjs
@@ -5,8 +5,11 @@
 //   node scripts/seed/import.mjs --source <seed-dir> --data-dir <vault-dataDir> \
 //        [--extract <extract-dir>] [--wipe --yes]
 //
-// Needs the curator LLM configured (the consolidator's brain) — the same
-// endpoint/model/token the curator uses, read from the store's settings.
+// Needs the consolidator's LLM (its "brain"). Provide it EITHER directly via
+// --endpoint/--model/--token (or LIBRARIAN_SEED_LLM_{ENDPOINT,MODEL,TOKEN}), OR
+// let it fall back to the curator config stored in THIS data dir's settings.
+// The direct flags are the simplest for a one-off — they don't require the
+// target vault's store to already have the curator configured.
 
 import path from "node:path";
 import process from "node:process";
@@ -27,15 +30,47 @@ const { values } = parseArgs({
     extract: { type: "string" },
     wipe: { type: "boolean", default: false },
     yes: { type: "boolean", default: false },
+    endpoint: { type: "string" },
+    model: { type: "string" },
+    token: { type: "string" },
   },
   strict: true,
 });
+
+// Build the consolidator's LLM client: explicit flags/env win; otherwise the
+// curator config persisted in this store's settings.
+function resolveLlmClient(store, dataDir) {
+  const endpoint = values.endpoint ?? process.env.LIBRARIAN_SEED_LLM_ENDPOINT;
+  const model = values.model ?? process.env.LIBRARIAN_SEED_LLM_MODEL;
+  const token = values.token ?? process.env.LIBRARIAN_SEED_LLM_TOKEN;
+  if (endpoint && model && token) return createCuratorLlmClient({ endpoint, token, model });
+
+  const config = readCuratorConfig(store);
+  const storedToken = config.isLlmComplete ? resolveCuratorToken(store) : null;
+  if (config.isLlmComplete && storedToken) {
+    return createCuratorLlmClient({
+      endpoint: config.llm.endpoint,
+      token: storedToken,
+      model: config.llm.model,
+    });
+  }
+
+  console.error(
+    `seed import: no consolidator LLM available.\n` +
+      `  Read curator config from ${path.join(dataDir, "settings.json")} — ` +
+      `endpoint=${config.llm.endpoint ? "set" : "missing"}, model=${config.llm.model ? "set" : "missing"}, token=${config.hasToken ? "set" : "missing"}.\n` +
+      `  Either pass --endpoint <url> --model <id> --token <key> directly, or run with --data-dir pointing at the\n` +
+      `  markdown store whose dashboard you configured the curator in (the config lives in that store's settings).`,
+  );
+  return null;
+}
 
 const source = values.source;
 const dataDir = values["data-dir"];
 if (!source || !dataDir) {
   console.error(
-    "usage: node scripts/seed/import.mjs --source <seed-dir> --data-dir <vault-dataDir> [--extract <dir>] [--wipe --yes]",
+    "usage: node scripts/seed/import.mjs --source <seed-dir> --data-dir <vault-dataDir>\n" +
+      "         [--extract <dir>] [--wipe --yes] [--endpoint <url> --model <id> --token <key>]",
   );
   process.exit(2);
 }
@@ -56,23 +91,8 @@ const { secretKey } = resolveBootCredentials({
 });
 const store = createLibrarianStore({ dataDir, backend: "markdown", secretKey });
 try {
-  const config = readCuratorConfig(store);
-  if (!config.isLlmComplete) {
-    console.error(
-      "seed import: configure the curator LLM (endpoint/model/token) first — the consolidator needs it to groom.",
-    );
-    process.exit(1);
-  }
-  const token = resolveCuratorToken(store);
-  if (!token) {
-    console.error("seed import: no curator LLM token configured.");
-    process.exit(1);
-  }
-  const llmClient = createCuratorLlmClient({
-    endpoint: config.llm.endpoint,
-    token,
-    model: config.llm.model,
-  });
+  const llmClient = resolveLlmClient(store, dataDir);
+  if (!llmClient) process.exit(1);
 
   const summary = await runSeedImport({
     store,


### PR DESCRIPTION
The import bin only read the curator LLM from the **target store's settings**, so seeding a fresh markdown vault — or one configured on a different data-dir/backend (e.g. a SQLite server) — failed the preflight (`configure the curator LLM first`) even with the dashboard configured. (Reported in use.)

`resolveLlmClient` now prefers explicit `--endpoint/--model/--token` (or `LIBRARIAN_SEED_LLM_{ENDPOINT,MODEL,TOKEN}`) and only falls back to the stored curator config — so a one-off seed doesn't require the target store to already hold the config. The not-found error now reports which `settings.json` it read and which of endpoint/model/token were present, and points at both fixes.

Bin + README only; the `runSeedImport` test (real pipeline, scripted client) stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)