### PR TITLE
fix(core): resolveVaultPath always returns an absolute path

### DIFF
--- a/packages/core/src/store/corpus/vault.ts
+++ b/packages/core/src/store/corpus/vault.ts
@@ -31,13 +31,19 @@ export interface VaultOptions {
  * Resolve the vault directory: an explicit `vaultPath` wins, then
  * `LIBRARIAN_VAULT_PATH`, then `<dataDir>/vault` (dataDir itself resolving
  * via `LIBRARIAN_DATA_DIR` / `<cwd>/data`).
+ *
+ * Always ABSOLUTE: `within()`'s escape check resolves a relative path to an
+ * absolute one and compares it against `root`, so a relative `root` (e.g. a
+ * `--data-dir ./x`) would make every subpath look like an escape. Callers that
+ * route through `resolveDataDir` already pass an absolute dir; this guards the
+ * ones (like the seed script) that don't.
  */
 export function resolveVaultPath(options: VaultOptions = {}): string {
-  if (options.vaultPath) return options.vaultPath;
-  if (process.env.LIBRARIAN_VAULT_PATH) return process.env.LIBRARIAN_VAULT_PATH;
+  if (options.vaultPath) return path.resolve(options.vaultPath);
+  if (process.env.LIBRARIAN_VAULT_PATH) return path.resolve(process.env.LIBRARIAN_VAULT_PATH);
   const dataDir =
     options.dataDir || process.env.LIBRARIAN_DATA_DIR || path.join(process.cwd(), "data");
-  return path.join(dataDir, "vault");
+  return path.resolve(dataDir, "vault");
 }
 
 export interface Vault {

--- a/packages/core/tests/store/corpus/vault.test.ts
+++ b/packages/core/tests/store/corpus/vault.test.ts
@@ -55,6 +55,24 @@ describe("resolveVaultPath", () => {
       else process.env.LIBRARIAN_VAULT_PATH = prev;
     }
   });
+
+  it("always returns an ABSOLUTE path, even from a relative dataDir / vaultPath", () => {
+    // within()'s escape check resolves subpaths to absolute then compares to
+    // root, so a relative root would flag every subpath as an escape.
+    expect(path.isAbsolute(resolveVaultPath({ dataDir: "./rel/data" }))).toBe(true);
+    expect(path.isAbsolute(resolveVaultPath({ vaultPath: "rel/vault" }))).toBe(true);
+  });
+});
+
+describe("vault with a relative dataDir (escape-guard regression)", () => {
+  it("lists a hidden subdir (inbox/.processing) instead of throwing 'escapes the vault root'", () => {
+    // The seed script passed `--data-dir ./x` straight through; with a relative
+    // root, listMarkdown('inbox/.processing') threw an escape error mid-sweep.
+    const relative = path.relative(process.cwd(), dataDir);
+    const vault = createVault({ dataDir: relative });
+    expect(() => vault.listMarkdown("inbox/.processing")).not.toThrow();
+    expect(vault.listMarkdown("inbox/.processing")).toEqual([]);
+  });
 });
 
 describe("vault file I/O", () => {

--- a/scripts/seed/import.mjs
+++ b/scripts/seed/import.mjs
@@ -66,8 +66,8 @@ function resolveLlmClient(store, dataDir) {
 }
 
 const source = values.source;
-const dataDir = values["data-dir"];
-if (!source || !dataDir) {
+const dataDirArg = values["data-dir"];
+if (!source || !dataDirArg) {
   console.error(
     "usage: node scripts/seed/import.mjs --source <seed-dir> --data-dir <vault-dataDir>\n" +
       "         [--extract <dir>] [--wipe --yes] [--endpoint <url> --model <id> --token <key>]",
@@ -80,6 +80,9 @@ if (values.wipe && !values.yes) {
   );
   process.exit(1);
 }
+
+// Absolute so the vault's path-escape guard doesn't trip on a relative root.
+const dataDir = path.resolve(dataDirArg);
 
 // `remember` routes to the inbox (→ consolidator) only when this is on.
 process.env.LIBRARIAN_CONSOLIDATOR = "on";


### PR DESCRIPTION
## The bug

A **relative data dir** (the seed script's `--data-dir ./data-seed`) made the vault root relative. The vault's path-escape guard (`within()`) resolves a subpath to absolute and compares it against `root`, so with a *relative* root **every** subpath looks like an escape:

```
Error: vault: path 'inbox/.processing' escapes the vault root
  at within → listMarkdown → releaseStaleClaims → runConsolidatorSweep → consolidateInbox
```

It blew up the moment the consolidator started its sweep. Server/CLI callers route the data dir through `resolveDataDir` (absolute) and never hit it; the seed script passed the flag straight through.

## Fix

`resolveVaultPath` now `path.resolve`s its result for all three sources (explicit `vaultPath`, `LIBRARIAN_VAULT_PATH`, and the `<dataDir>/vault` fallback), so the root is always absolute. The seed import bin also resolves `--data-dir` defensively.

## Tests

Regression tests reproduce the failure: `resolveVaultPath` is always absolute (from a relative dataDir/vaultPath), and a vault built from a relative dataDir lists `inbox/.processing` (the exact failing call) instead of throwing.

Full `pnpm test` (build + per-package + root suite) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)