### PR TITLE
feat(seed): fail-fast LLM preflight before the import

### DIFF
--- a/scripts/seed/import.mjs
+++ b/scripts/seed/import.mjs
@@ -21,7 +21,7 @@ import {
   resolveBootCredentials,
   resolveCuratorToken,
 } from "@librarian/core";
-import { runSeedImport } from "./lib.mjs";
+import { preflightLlm, runSeedImport } from "./lib.mjs";
 
 const { values } = parseArgs({
   options: {
@@ -96,6 +96,22 @@ const store = createLibrarianStore({ dataDir, backend: "markdown", secretKey });
 try {
   const llmClient = resolveLlmClient(store, dataDir);
   if (!llmClient) process.exit(1);
+
+  // Fail-fast: one cheap call so a bad endpoint/model/token dies in ~2s, before
+  // loading the embedder and replaying every memory.
+  process.stdout.write("seed import: checking the consolidator LLM… ");
+  try {
+    await preflightLlm(llmClient);
+    console.log("ok");
+  } catch (error) {
+    console.log("failed");
+    console.error(
+      `seed import: the consolidator LLM rejected a test call — fix this before re-running.\n` +
+        `  ${error instanceof Error ? error.message : String(error)}\n` +
+        `  (check --endpoint / --model / --token, or the curator config in the dashboard.)`,
+    );
+    process.exit(1);
+  }
 
   const summary = await runSeedImport({
     store,

--- a/scripts/seed/lib.mjs
+++ b/scripts/seed/lib.mjs
@@ -150,6 +150,19 @@ export function readExtractRecords(extractDir) {
     .map((f) => JSON.parse(fs.readFileSync(path.join(extractDir, f), "utf8")));
 }
 
+/**
+ * Fail-fast probe of the consolidator LLM: one tiny (1-token) completion so a bad
+ * endpoint / model / token surfaces in ~2s, BEFORE the import loads the ~300MB
+ * embedder and replays every memory. Resolves on success; rethrows the client's
+ * error otherwise (the bin turns it into a friendly message).
+ */
+export async function preflightLlm(llmClient) {
+  await llmClient.complete({
+    messages: [{ role: "user", content: "Reply with: ok" }],
+    maxTokens: 1,
+  });
+}
+
 /** Invoke the real `remember` MCP handler in-process. Returns its result text. */
 export async function remember(store, args) {
   const res = await handleMcpPayload(store, {

--- a/test/seed-import.test.ts
+++ b/test/seed-import.test.ts
@@ -71,6 +71,17 @@ describe("seed lib — pure helpers", () => {
       lib.rememberArgsFromExtractRecord({ title: "T", body: "B", tags: ["x"] }, "fallback"),
     ).toEqual({ agent_id: "fallback", title: "T", body: "B", tags: ["x"] });
   });
+
+  it("preflightLlm resolves when the LLM answers, and rethrows when it errors", async () => {
+    await expect(lib.preflightLlm(scriptedClient)).resolves.toBeUndefined();
+    const throwing = {
+      async complete() {
+        throw new Error("HTTP 401: invalid key");
+      },
+    };
+    // Fails fast — the bad key surfaces here, before any embedder load / import.
+    await expect(lib.preflightLlm(throwing)).rejects.toThrow("HTTP 401");
+  });
 });
 
 describe("seed lib — runSeedImport (end to end, scripted consolidator)", () => {


### PR DESCRIPTION
## Why

The seed import loads a ~300 MB embedder and replays every memory before the consolidator makes its first judge call — so a bad `--endpoint` / `--model` / `--token` only surfaced deep into the run (after the model download + every submission). On a real run this meant minutes of wasted work to discover a one-character key typo.

## What

A one-token preflight completion right after resolving the LLM client, before any embedder load or submission. A bad config now dies in ~2s:

```
seed import: checking the consolidator LLM… failed
seed import: the consolidator LLM rejected a test call — fix this before re-running.
  HTTP 401: invalid key
  (check --endpoint / --model / --token, or the curator config in the dashboard.)
```

`preflightLlm` is a small testable helper in `lib.mjs` (probe + rethrow); the bin turns a rejection into the friendly message above. Tested both directions: resolves on a working client, rethrows the underlying error on a failing one.

Complements the earlier error-surfacing (#280) — that makes a mid-sweep failure visible; this makes a *config* failure instant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)