### PR TITLE
fix(seed): preflight in plain-text mode so it doesn't false-400

### DIFF
--- a/scripts/seed/lib.mjs
+++ b/scripts/seed/lib.mjs
@@ -151,15 +151,23 @@ export function readExtractRecords(extractDir) {
 }
 
 /**
- * Fail-fast probe of the consolidator LLM: one tiny (1-token) completion so a bad
+ * Fail-fast probe of the consolidator LLM: one tiny completion so a bad
  * endpoint / model / token surfaces in ~2s, BEFORE the import loads the ~300MB
  * embedder and replays every memory. Resolves on success; rethrows the client's
  * error otherwise (the bin turns it into a friendly message).
+ *
+ * Probes in PLAIN-TEXT mode (`jsonResponse: false`). The client defaults to
+ * json_object response_format, but OpenAI-compatible providers (incl. DeepSeek)
+ * return HTTP 400 in json mode unless the prompt contains the word "json", and a
+ * tight max_tokens can't fit a JSON object — both would make this synthetic probe
+ * a false negative. A plain-text call still validates what a preflight is for:
+ * endpoint reachable, model exists, token accepted. Any json-mode-specific issue
+ * surfaces on the first real judge call (which the sweep error-surfacing reports).
  */
 export async function preflightLlm(llmClient) {
   await llmClient.complete({
     messages: [{ role: "user", content: "Reply with: ok" }],
-    maxTokens: 1,
+    jsonResponse: false,
   });
 }
 

--- a/test/seed-import.test.ts
+++ b/test/seed-import.test.ts
@@ -82,6 +82,19 @@ describe("seed lib — pure helpers", () => {
     // Fails fast — the bad key surfaces here, before any embedder load / import.
     await expect(lib.preflightLlm(throwing)).rejects.toThrow("HTTP 401");
   });
+
+  it("preflightLlm probes in plain-text mode (json_object would 400 on this synthetic prompt)", async () => {
+    let seen: { jsonResponse?: boolean } | undefined;
+    await lib.preflightLlm({
+      async complete(req: { jsonResponse?: boolean }) {
+        seen = req;
+        return { content: "ok", model: "m", usage: null };
+      },
+    });
+    // The bug guard: OpenAI-compatible providers 400 in json mode unless the
+    // prompt says "json", so the probe must NOT request json_object.
+    expect(seen?.jsonResponse).toBe(false);
+  });
 });
 
 describe("seed lib — runSeedImport (end to end, scripted consolidator)", () => {


### PR DESCRIPTION
## Bug

The LLM preflight added in #282 used the curator client's **default** `json_object` response format with a synthetic `"Reply with: ok"` prompt. OpenAI-compatible providers (including DeepSeek) return **HTTP 400** in json mode unless the prompt contains the word `"json"`, and `max_tokens: 1` can't fit a JSON object. So the probe rejected configs that actually work:

```
seed import: the consolidator LLM rejected a test call — fix this before re-running.
  LLM request failed: HTTP 400
```

The real consolidator judge calls are unaffected — their prompt explicitly asks for JSON.

## Fix

Probe with `jsonResponse: false` (plain text). That still validates what a preflight is for — endpoint reachable, model exists, token accepted — without the json-mode prompt constraint. A regression test asserts the probe never requests `json_object`.

Any json-mode-specific issue (rare) now surfaces on the first real judge call, which the sweep error-surfacing (#280) already reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)