### PR TITLE
fix(seed): skip dotfiles and macOS AppleDouble (._*) sidecars on import

### DIFF
--- a/scripts/seed/lib.mjs
+++ b/scripts/seed/lib.mjs
@@ -68,6 +68,11 @@ export function listMarkdown(dir) {
     for (const entry of fs
       .readdirSync(d, { withFileTypes: true })
       .sort((a, b) => a.name.localeCompare(b.name))) {
+      // Skip dotfiles + dot-directories: hidden config (.obsidian, .git) and —
+      // crucially — macOS AppleDouble sidecars (._Foo.md), which are BINARY
+      // resource forks that share the .md extension. Importing them feeds the
+      // consolidator garbage (and the LLM chokes on the binary blob).
+      if (entry.name.startsWith(".")) continue;
       const abs = path.join(d, entry.name);
       if (entry.isDirectory()) walk(abs);
       else if (entry.isFile() && entry.name.endsWith(".md")) {

--- a/test/seed-import.test.ts
+++ b/test/seed-import.test.ts
@@ -32,6 +32,22 @@ const scriptedClient = {
   },
 };
 
+describe("seed lib — listMarkdown", () => {
+  it("returns real .md files but skips dotfiles and macOS AppleDouble (._*) sidecars", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-listmd-"));
+    try {
+      fs.writeFileSync(path.join(dir, "Family.md"), "# Family\nreal note");
+      fs.writeFileSync(path.join(dir, "._Family.md"), "  binary resource fork");
+      fs.mkdirSync(path.join(dir, ".obsidian"));
+      fs.writeFileSync(path.join(dir, ".obsidian", "workspace.md"), "hidden config");
+      const rels = lib.listMarkdown(dir).map((f: { rel: string }) => f.rel);
+      expect(rels).toEqual(["Family.md"]); // only the real file — junk + hidden excluded
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("seed lib — pure helpers", () => {
   it("derives a title from the first heading, else first line, else filename", () => {
     expect(lib.deriveTitle("# Communication Style\n\nbody", "x.md")).toBe("Communication Style");


### PR DESCRIPTION
## Bug (found debugging a real seed run)

The import looked "crazy slow" with one item stuck in `inbox/.processing` for ages. Root cause: the seed source had **21 macOS AppleDouble files** (`._Foo.md` — binary resource-fork sidecars macOS creates) next to 102 real notes. `listMarkdown` matched every `*.md`, so those binary blobs got submitted as memories. The consolidator then fed `This resource fork intentionally left blank` (binary) to the judge LLM — a reasoning model burning a full 60s timeout per blob. Not model speed; junk input.

## Fix

Skip any directory entry whose name starts with `.` in the walk — covers AppleDouble sidecars, `.DS_Store`, and hidden config dirs (`.obsidian` / `.git`) that shouldn't be imported. Regression test asserts a `._Foo.md` sibling and a dot-directory are excluded while the real file is kept.

`scripts/seed` is the maintainer-only migration tool, so no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)