### PR TITLE
fix(core): give the vault its own git repo when nested in a parent checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ changes from this point forward are catalogued here.
 
 ### Fixed
 
+- **The vault always gets its own git repo, even when nested in another checkout.**
+  The store inits the vault as a git repo (a commit per write), but the init guard
+  treated "inside *any* repo" as done — so a data dir placed under an existing git
+  checkout skipped init and committed every memory write into that *parent* repo
+  (running `git add -A` over its whole working tree). The guard now checks whether
+  the vault is its own repo *root*, creating a dedicated repo when nested. A
+  standalone/Docker `./data` was unaffected; this only bit vaults under a checkout.
+
 - **Recall no longer re-embeds the whole corpus on every write.** The disposable
   recall index is rebuilt (and every active memory re-embedded) whenever a memory
   is written; a bulk groom — consolidating many inbox items one at a time — did

--- a/packages/core/src/store/git/git-ops.ts
+++ b/packages/core/src/store/git/git-ops.ts
@@ -9,7 +9,7 @@
 // are". Promise API throughout (simple-git over the git CLI).
 
 import fs from "node:fs";
-import { type SimpleGit, simpleGit } from "simple-git";
+import { CheckRepoActions, type SimpleGit, simpleGit } from "simple-git";
 
 export interface GitOps {
   /** Idempotently `git init` the repo + ensure a commit identity exists. */
@@ -45,7 +45,12 @@ export function createGitOps(opts: { cwd: string }): GitOps {
   }
 
   async function init(): Promise<void> {
-    if (!(await git.checkIsRepo())) await git.init();
+    // IS_REPO_ROOT, not the default (IS_REPO): the latter is satisfied by a
+    // PARENT repo, so a vault nested under a checkout would skip init and commit
+    // into that parent. Only skip init when cwd is its own repo root. (Same
+    // semantics as sync-git-ops' --show-toplevel check, via simple-git's
+    // --git-dir probe.)
+    if (!(await git.checkIsRepo(CheckRepoActions.IS_REPO_ROOT))) await git.init();
     await ensureIdentity();
   }
 

--- a/packages/core/src/store/git/sync-git-ops.ts
+++ b/packages/core/src/store/git/sync-git-ops.ts
@@ -50,6 +50,18 @@ export function createSyncGitOps(opts: { cwd: string }): SyncGitOps {
     return tryGit(["rev-parse", "--is-inside-work-tree"])?.trim() === "true";
   }
 
+  // True only when `cwd` is the root of ITS OWN repo. `--is-inside-work-tree`
+  // (isRepo) is also true inside a PARENT repo — e.g. a vault under a project
+  // checkout — which would make init skip and every commit land in that parent,
+  // sweeping the parent's working tree into "memory:" commits. Compare the repo
+  // toplevel to cwd so a nested vault gets its own dedicated repo.
+  function isRepoRoot(): boolean {
+    const top = tryGit(["rev-parse", "--show-toplevel"])?.trim();
+    // realpath both sides so a symlinked vault still matches; cwd is guaranteed
+    // to exist (mkdirSync'd in the factory above), so realpathSync won't throw.
+    return top != null && fs.realpathSync(top) === fs.realpathSync(opts.cwd);
+  }
+
   function ensureIdentity(): void {
     if (tryGit(["config", "user.email"])?.trim()) return;
     git(["config", "user.email", "librarian@localhost"]);
@@ -57,7 +69,7 @@ export function createSyncGitOps(opts: { cwd: string }): SyncGitOps {
   }
 
   function init(): void {
-    if (!isRepo()) git(["init"]);
+    if (!isRepoRoot()) git(["init"]);
     ensureIdentity();
   }
 

--- a/packages/core/tests/store/git/git-ops.test.ts
+++ b/packages/core/tests/store/git/git-ops.test.ts
@@ -6,6 +6,7 @@
 // every file op. Pins: init idempotency, commit-per-op, no empty commits,
 // deletions staged, and log/head reads. Runs real `git` via simple-git.
 
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -36,6 +37,37 @@ describe("git-ops service", () => {
     expect(await git.isRepo()).toBe(true);
     await git.init(); // second call must not throw
     expect(await git.isRepo()).toBe(true);
+  });
+
+  it("init creates a DEDICATED repo when nested in a parent repo, so commits don't bubble", async () => {
+    const parent = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-gitops-parent-"));
+    execFileSync("git", ["init"], { cwd: parent, stdio: "ignore" });
+    const vault = path.join(parent, "data", "vault");
+    try {
+      const git = createGitOps({ cwd: vault });
+      await git.init();
+      expect(fs.existsSync(path.join(vault, ".git"))).toBe(true); // its own repo
+
+      fs.writeFileSync(path.join(vault, "note.md"), "x");
+      expect(await git.commitAll("memory: store")).not.toBeNull();
+      expect(await git.log()).toContain("memory: store");
+
+      // The parent repo's history stays empty — the commit didn't bubble up.
+      const parentHead = (() => {
+        try {
+          return execFileSync("git", ["rev-parse", "HEAD"], {
+            cwd: parent,
+            encoding: "utf8",
+            stdio: ["ignore", "pipe", "ignore"],
+          }).trim();
+        } catch {
+          return null;
+        }
+      })();
+      expect(parentHead).toBeNull();
+    } finally {
+      fs.rmSync(parent, { recursive: true, force: true });
+    }
   });
 
   it("head is null on a fresh repo with no commits", async () => {

--- a/packages/core/tests/store/git/sync-git-ops.test.ts
+++ b/packages/core/tests/store/git/sync-git-ops.test.ts
@@ -5,6 +5,7 @@
 // one — idempotent init, commit-per-op, no empty commits, deletions staged.
 // Runs real `git` via child_process.
 
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -35,6 +36,40 @@ describe("sync git-ops", () => {
     expect(git.isRepo()).toBe(true);
     git.init();
     expect(git.isRepo()).toBe(true);
+  });
+
+  it("init creates a DEDICATED repo when nested in a parent repo, so commits don't bubble", () => {
+    // A parent repo with the vault dir nested inside it (e.g. a data/ dir under a
+    // project checkout). Without IS_REPO_ROOT, init sees the parent and skips —
+    // then every commitAll lands in the parent, sweeping its working tree.
+    const parent = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-parent-"));
+    execFileSync("git", ["init"], { cwd: parent, stdio: "ignore" });
+    const vault = path.join(parent, "data", "vault");
+    try {
+      const git = createSyncGitOps({ cwd: vault });
+      git.init();
+      expect(fs.existsSync(path.join(vault, ".git"))).toBe(true); // its own repo
+
+      fs.writeFileSync(path.join(vault, "note.md"), "x");
+      expect(git.commitAll("memory: store")).not.toBeNull();
+      expect(git.log()).toContain("memory: store"); // landed in the vault repo
+
+      // ...and NOT in the parent: its history stays empty (no HEAD yet).
+      const parentHead = (() => {
+        try {
+          return execFileSync("git", ["rev-parse", "HEAD"], {
+            cwd: parent,
+            encoding: "utf8",
+            stdio: ["ignore", "pipe", "ignore"],
+          }).trim();
+        } catch {
+          return null;
+        }
+      })();
+      expect(parentHead).toBeNull();
+    } finally {
+      fs.rmSync(parent, { recursive: true, force: true });
+    }
   });
 
   it("head is null and log empty on a fresh repo", () => {


### PR DESCRIPTION
## Bug (hit during a real seed import)

The markdown store commits every write via git, and `init()` is meant to make the vault its own repo. But it gated `git init` on `--is-inside-work-tree` (sync) / `checkIsRepo()` (async) — **both true when the dir merely sits inside a *parent* repo**. So a vault under an existing checkout (e.g. a `data-seed/` dir inside this project repo) skipped init, and every memory write ran `git add -A` + commit against the **parent** repo — sweeping its whole working tree into `memory: store` / `memory: propose` commits.

This actually happened: a seed import with `--data-dir ./data-seed` committed *unrelated source edits* under memory messages, corrupting in-progress work.

## Fix

Gate `init` on whether cwd is its own repo **root**:
- sync committer: compare `git rev-parse --show-toplevel` (realpath'd) to cwd
- async committer: `simple-git`'s `CheckRepoActions.IS_REPO_ROOT`

A nested vault now gets a dedicated repo; a standalone/Docker `./data` (already its own repo root) is unchanged.

## Tests

Both committers: a vault nested in a parent repo gets its own `.git`, its commit lands in the vault repo, and the parent's HEAD stays null (no bubbling). These fail on the old gating.

Reviewed by a sub-agent (verdict: ship; verified sync/async parity, `CheckRepoActions` export, and that the tests fail on the old code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)