### PR TITLE
perf(core): embed references lazily, not on every recall-index build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ changes from this point forward are catalogued here.
 
 ### Fixed
 
+- **Recall no longer embeds references it never queries.** The recall index built
+  both the corpus (memories) and the references tier eagerly, but `recall` only
+  ever queries the corpus — references are searched through the separate
+  `search_references` path. Embedding every reference on each index build was pure
+  waste, and brutal when references are large (a single 553 KB reference is a ~10s
+  embed under the real model, so a groom over a reference-heavy vault stalled for
+  minutes before processing a single memory). References are now embedded lazily —
+  only when `search_references` is actually called. (`search_references`'s own
+  per-call cost is tracked separately in docs/TODO.md.)
+
 - **The vault always gets its own git repo, even when nested in another checkout.**
   The store inits the vault as a git repo (a commit per write), but the init guard
   treated "inside *any* repo" as done — so a data dir placed under an existing git

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -229,3 +229,13 @@ this repo.
   the agent has to call `recall include_ids:true` after a `remember` to discover
   the id, which is wasteful. Surface it in the result text (e.g. "Memory stored
   ([mem_…])") so the existing `content[0].text` channel carries it.
+- **Make references properly searchable (persist their embeddings).** References
+  are now embedded lazily — only when `search_references` is actually called — so
+  the consolidator/seed no longer pays to embed them. But `search_references` still
+  rebuilds the reference index per call with no persistent cache, so the FIRST call
+  after a process start re-embeds every reference (minutes under the real model with
+  large refs — e.g. a 553 KB doc). Persist reference embeddings to disk (embed once,
+  ever; invalidate per-file on change) so `search_references` is fast at runtime.
+  Also: large references are truncated to the model's context window before
+  embedding (only the first ~2 K tokens are searchable), so consider chunking big
+  reference docs into sections. _(surfaced 2026-06-03 during the seed/migration work)_

--- a/packages/core/src/store/index/namespaced-index.ts
+++ b/packages/core/src/store/index/namespaced-index.ts
@@ -59,18 +59,27 @@ export async function createNamespacedIndex(
     corpusDocs.map((doc) => ({ id: doc.id, body: doc.text })),
     { restrictToKnownIds: true },
   );
-  const referenceHybrid = await buildHybridIndex(
-    referenceDocs.map((doc) => ({ id: doc.id, text: doc.text })),
-    embedder,
-  );
   const referenceText = new Map(referenceDocs.map((doc) => [doc.id, doc.text]));
+
+  // References are embedded LAZILY — built only when searchReferences is actually
+  // called, and memoized after. recall() (the consolidator's hot path) never
+  // touches them, so a groom over a vault with large references doesn't pay to
+  // embed them. Eager embedding here made the seed/consolidation O(references) for
+  // a tier it never queries (a 553 KB reference is a ~10s embed under the real
+  // model). See docs/TODO.md for persisting these across calls.
+  let referenceHybrid: ReturnType<typeof buildHybridIndex> | null = null;
+  const references = (): ReturnType<typeof buildHybridIndex> =>
+    (referenceHybrid ??= buildHybridIndex(
+      referenceDocs.map((doc) => ({ id: doc.id, text: doc.text })),
+      embedder,
+    ));
 
   return {
     recall(query, options) {
       return recallFromIndex({ hybrid: corpusHybrid, linkGraph: corpusGraph }, query, options);
     },
     async searchReferences(query, limit) {
-      const hits = await referenceHybrid.search(query, limit ?? DEFAULT_REFERENCE_LIMIT);
+      const hits = await (await references()).search(query, limit ?? DEFAULT_REFERENCE_LIMIT);
       return hits.map((hit) => ({
         id: hit.id,
         score: hit.score,

--- a/packages/core/tests/store/index/namespaced-index.test.ts
+++ b/packages/core/tests/store/index/namespaced-index.test.ts
@@ -92,4 +92,25 @@ describe("createNamespacedIndex", () => {
     const index = await createNamespacedIndex([bigReference], createHashEmbedder());
     expect(await index.recall("piano")).toEqual([]);
   });
+
+  it("embeds references LAZILY — recall never pays to embed them, only search_references does", async () => {
+    // The consolidator/seed only calls recall(); references are a tier it never
+    // queries. Embedding them at build time was pure waste (a 553 KB reference is
+    // a ~10s embed under the real model). Prove recall touches no reference text.
+    const embedded: string[] = [];
+    const hash = createHashEmbedder();
+    const counting = {
+      embed: (text: string) => {
+        embedded.push(text);
+        return hash.embed(text);
+      },
+    };
+    const index = await createNamespacedIndex([...corpus, bigReference], counting);
+
+    await index.recall("piano"); // building + recall must NOT embed the reference
+    expect(embedded).not.toContain(bigReference.text);
+
+    await index.searchReferences("piano"); // ...only this does
+    expect(embedded).toContain(bigReference.text);
+  });
 });


### PR DESCRIPTION
## Why

`createNamespacedIndex` eagerly embedded **both** the corpus (memories) and the references tier. But `recall` only ever queries the corpus — references are served by the separate `search_references` path. So every recall-index build paid to embed all references for a tier it never queries.

With large references this is brutal: a single **553 KB** reference is a ~10s embed under EmbeddingGemma, so a groom over a reference-heavy vault stalled for ~9 minutes embedding 47 references *before processing a single memory* (diagnosed on a real seed run — it was mistaken for an embedder cold-start).

## What

Build the reference hybrid index **lazily** — only when `search_references` is actually called, memoized after. `recall()` is byte-for-byte untouched; the consolidator/seed never embeds references.

A counting-embedder test asserts `recall()` touches no reference text and `search_references` is what triggers the embed. The existing `search_references` tests still pass unchanged (they call it, so they trigger the lazy build).

## Not in scope (tracked in docs/TODO.md)

`search_references` still rebuilds its reference index per call with no persistent cache, so its *first* call after a process start re-embeds every reference. Persisting reference embeddings (embed once, ever) + chunking large refs is the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)