### PR TITLE
feat(core): human-readable memory filenames (title slug + short id)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ changes from this point forward are catalogued here.
 
 ## [Unreleased]
 
+### Changed
+
+- **Memory files now have human-readable names.** A memory is written to
+  `memories/<title-slug>-<shortid>.md` (e.g. `role-and-responsibilities-2dd76e5c.md`)
+  instead of `memories/<id>.md` — far easier to browse, diff, and maintain by hand.
+  The id suffix keeps names unique; the filename is set once at creation and never
+  renamed (the frontmatter id + title stay authoritative). The store now resolves a
+  memory's file by its frontmatter id, so existing `<id>.md` files keep working
+  unchanged — no migration needed.
+
 ### Fixed
 
 - **Recall no longer embeds references it never queries.** The recall index built

--- a/packages/core/src/store/markdown/markdown-memory-store.ts
+++ b/packages/core/src/store/markdown/markdown-memory-store.ts
@@ -8,8 +8,10 @@
 // The store is SYNC (the storage-agnostic verb tests are sync): vault I/O
 // is sync, and the git commit-per-op is an injected sync committer
 // (`commit`) — most unit tests inject none (fast); production wires a
-// synchronous git commit. Each memory is `memories/<id>.md`; status lives
-// in frontmatter (folder-based inbox/consolidation filing is Phase 4).
+// synchronous git commit. Each memory is a human-readable
+// `memories/<title-slug>-<shortid>.md` (resolved back to a memory by its
+// frontmatter id); status lives in frontmatter (folder-based inbox/consolidation
+// filing is Phase 4).
 
 import {
   DEFAULT_AGENT_ID,
@@ -40,8 +42,36 @@ export interface MarkdownMemoryStoreDeps {
   generateId?: () => string;
 }
 
-function memoryPath(id: string): string {
-  return `memories/${id}.md`;
+const SLUG_MAX = 60;
+
+/** A human-readable, filesystem-safe slug from a memory title (ASCII kebab-case). */
+function slugify(title: string): string {
+  const slug = title
+    .normalize("NFKD")
+    .replace(/[̀-ͯ]/g, "") // drop accents (é → e)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-") // any run of non-alphanumerics → one hyphen
+    .replace(/^-+|-+$/g, "")
+    .slice(0, SLUG_MAX)
+    .replace(/-+$/g, ""); // a hyphen left dangling by the slice
+  return slug || "memory"; // symbol-only / empty titles still get a name
+}
+
+/** A short, stable id fragment that makes the filename unique + greppable. */
+function shortId(id: string): string {
+  const core = id.replace(/^mem_/, "").replace(/[^a-z0-9]/gi, "");
+  return core.slice(0, 8) || id;
+}
+
+/**
+ * Human-readable memory filename: `memories/<title-slug>-<shortid>.md`. The id
+ * suffix guarantees uniqueness (no collision logic needed) and keeps the id
+ * greppable. The name is set once at creation and never changes — the frontmatter
+ * id + title are authoritative — so id→path lookups resolve by scanning ids, not
+ * by recomputing the path from a (possibly changed) title.
+ */
+function memoryFileName(memory: { id: string; title: string }): string {
+  return `memories/${slugify(memory.title)}-${shortId(memory.id)}.md`;
 }
 
 const PRIORITY_RANK: Record<string, number> = { core: 0, high: 1, normal: 2 };
@@ -67,6 +97,32 @@ export function createMarkdownMemoryStore(deps: MarkdownMemoryStoreDeps): Memory
     rawCommit(message);
     deps.onWrite?.();
   };
+
+  // id → relative path. Filenames are human-readable slugs (memoryFileName), so
+  // reads + write-backs resolve a memory's file by its frontmatter id rather than
+  // computing the path. Built lazily by scanning memories/, kept current as we
+  // create, and rescanned once on a miss (the vault is git-backed + hand-editable,
+  // and pre-slug `<id>.md` files must still resolve).
+  let idToPath: Map<string, string> | null = null;
+  function scanIdToPath(): Map<string, string> {
+    const map = new Map<string, string>();
+    for (const rel of vault.listMarkdown("memories")) {
+      try {
+        map.set(parseMemoryDocument(vault.readText(rel)).id, rel);
+      } catch {
+        // a hand-edited / foreign .md that doesn't parse is just not
+        // id-addressable (fail-soft, mirrors buildCorpusIndex).
+      }
+    }
+    return map;
+  }
+  function pathForId(id: string): string | null {
+    idToPath ??= scanIdToPath();
+    const hit = idToPath.get(id);
+    if (hit) return hit;
+    idToPath = scanIdToPath(); // miss → maybe written outside the store; rescan once
+    return idToPath.get(id) ?? null;
+  }
 
   // The append-only event ledger is retired in the markdown model — every
   // write is a git commit, so git history is the audit trail. These two
@@ -113,7 +169,14 @@ export function createMarkdownMemoryStore(deps: MarkdownMemoryStoreDeps): Memory
       curator_note: curatorNote,
     };
     const related = detectRelated(memory);
-    vault.writeText(memoryPath(memory.id), serializeMemoryDocument(memory));
+    // Human-readable filename; the id suffix keeps it unique, but guard against
+    // the astronomically rare same-slug + same-fragment clash so we never
+    // silently overwrite a different memory.
+    let rel = memoryFileName(memory);
+    if (vault.exists(rel))
+      rel = `memories/${slugify(memory.title)}-${memory.id.replace(/^mem_/, "")}.md`;
+    vault.writeText(rel, serializeMemoryDocument(memory));
+    idToPath?.set(memory.id, rel); // keep the resolver cache current
     commit(`memory: ${status === MemoryStatus.Proposed ? "propose" : "store"} ${memory.id}`);
     // Narrow to the interface's active|proposed return shape — the same cast
     // the SQLite createMemory makes over the identical normalize+route
@@ -127,7 +190,9 @@ export function createMarkdownMemoryStore(deps: MarkdownMemoryStoreDeps): Memory
   }
 
   function getMemory(id: string): Memory | null {
-    const raw = vault.tryReadText(memoryPath(id));
+    const rel = pathForId(id);
+    if (rel === null) return null;
+    const raw = vault.tryReadText(rel);
     return raw ? parseMemoryDocument(raw) : null;
   }
 
@@ -136,7 +201,10 @@ export function createMarkdownMemoryStore(deps: MarkdownMemoryStoreDeps): Memory
   // SQLite store reaches via events); the markdown store applies them
   // directly to the document.
   function persist(memory: Memory, message: string): Memory {
-    vault.writeText(memoryPath(memory.id), serializeMemoryDocument(memory));
+    // Write back to the existing file (resolved by id) so the filename stays
+    // stable across updates/retitles; fall back to a fresh name if somehow absent.
+    const rel = pathForId(memory.id) ?? memoryFileName(memory);
+    vault.writeText(rel, serializeMemoryDocument(memory));
     commit(message);
     return memory;
   }

--- a/packages/core/tests/store/librarian-store-backend.test.ts
+++ b/packages/core/tests/store/librarian-store-backend.test.ts
@@ -43,7 +43,9 @@ describe("createLibrarianStore — backend selection", () => {
         title: "Use pnpm",
         body: "Always pnpm.",
       });
-      expect(fs.existsSync(path.join(dataDir, "vault", `memories/${memory.id}.md`))).toBe(true);
+      // Human-readable filename (title slug + short id), resolvable by id.
+      const files = fs.readdirSync(path.join(dataDir, "vault", "memories"));
+      expect(files.some((f) => /^use-pnpm-[0-9a-f]{8}\.md$/.test(f))).toBe(true);
       expect(store.getMemory(memory.id)?.title).toBe("Use pnpm");
       expect(store.searchMemories({ query: "pnpm" }).map((m) => m.id)).toContain(memory.id);
     } finally {

--- a/packages/core/tests/store/markdown/markdown-memory-store.test.ts
+++ b/packages/core/tests/store/markdown/markdown-memory-store.test.ts
@@ -1,8 +1,9 @@
 // Markdown-backed MemoryStore — createMemory + getMemory (plan 036 Phase 2).
 //
-// The inbox/write path: createMemory writes a markdown file (memories/<id>.md)
-// via the shared normalize + routeMemoryWrite logic and the memory-doc
-// mapping, optionally committing; getMemory reads it back by id. Parity-first
+// The inbox/write path: createMemory writes a markdown file (a human-readable
+// `memories/<title-slug>-<shortid>.md`) via the shared normalize + routeMemoryWrite
+// logic and the memory-doc mapping, optionally committing; getMemory reads it back
+// by frontmatter id (path resolved by scan). Parity-first
 // (full Memory shape), sync, with an injected sync committer. These pin the
 // write→read round-trip and the status routing on the new backend.
 
@@ -48,8 +49,9 @@ describe("markdown MemoryStore — createMemory + getMemory", () => {
     expect(result.status).toBe("active");
     expect(result.memory.id).toBe("mem_test1");
     expect(result.duplicates).toEqual([]);
-    expect(vault.exists("memories/mem_test1.md")).toBe(true);
-    expect(vault.readText("memories/mem_test1.md")).toContain("Always use pnpm.");
+    // Human-readable filename: title slug + short id fragment (id is "mem_test1").
+    expect(vault.exists("memories/use-pnpm-test1.md")).toBe(true);
+    expect(vault.readText("memories/use-pnpm-test1.md")).toContain("Always use pnpm.");
   });
 
   it("getMemory round-trips the stored memory exactly", () => {
@@ -112,5 +114,72 @@ describe("markdown MemoryStore — createMemory + getMemory", () => {
     const store = createMarkdownMemoryStore({ vault });
     const { memory } = store.createMemory({ agent_id: "codex", title: "a", body: "b" });
     expect(store.getMemory(memory.id)).not.toBeNull();
+  });
+});
+
+describe("markdown MemoryStore — human-readable filenames", () => {
+  const names = (): string[] => fs.readdirSync(path.join(dataDir, "vault", "memories"));
+
+  it("names the file from a title slug + short id, not the raw id", () => {
+    const { store, vault } = makeStore();
+    const { memory } = store.createMemory({
+      agent_id: "a",
+      title: "Role & Responsibilities!",
+      body: "x",
+    }); // id mem_test1 → shortid "test1"
+    expect(vault.exists("memories/role-responsibilities-test1.md")).toBe(true);
+    expect(store.getMemory(memory.id)?.title).toBe("Role & Responsibilities!"); // resolvable by id
+  });
+
+  it("keeps the filename stable when an update changes the title", () => {
+    const { store, vault } = makeStore();
+    const { memory } = store.createMemory({ agent_id: "a", title: "Family", body: "x" });
+    expect(vault.exists("memories/family-test1.md")).toBe(true);
+
+    store.updateMemory(memory.id, { title: "Family and Home" });
+    expect(vault.exists("memories/family-test1.md")).toBe(true); // unchanged — no rename
+    expect(vault.exists("memories/family-and-home-test1.md")).toBe(false);
+    expect(store.getMemory(memory.id)?.title).toBe("Family and Home"); // title is authoritative
+  });
+
+  it("gives two same-titled memories distinct filenames via the id suffix", () => {
+    const { store } = makeStore();
+    store.createMemory({ agent_id: "a", title: "Notes", body: "one" }); // notes-test1
+    store.createMemory({ agent_id: "a", title: "Notes", body: "two" }); // notes-test2
+    expect(names()).toEqual(expect.arrayContaining(["notes-test1.md", "notes-test2.md"]));
+  });
+
+  it("slugifies edge cases: accents, symbol-only fallback, length cap", () => {
+    const { store } = makeStore();
+    store.createMemory({ agent_id: "a", title: "Café Ñoño", body: "x" }); // test1
+    store.createMemory({ agent_id: "a", title: "!!!", body: "x" }); // test2
+    store.createMemory({ agent_id: "a", title: "x".repeat(100), body: "x" }); // test3
+    const filed = names();
+    expect(filed).toContain("cafe-nono-test1.md"); // accents stripped
+    expect(filed).toContain("memory-test2.md"); // symbol-only → "memory" fallback
+    const long = filed.find((n) => n.endsWith("-test3.md"));
+    expect(long?.replace("-test3.md", "").length).toBeLessThanOrEqual(60); // slug capped
+  });
+
+  it("backward-compat: resolves + updates a legacy `<id>.md` file in place (no duplicate)", () => {
+    const { store, vault } = makeStore();
+    const { memory } = store.createMemory({ agent_id: "a", title: "Legacy Note", body: "old" });
+    const memDir = path.join(dataDir, "vault", "memories");
+
+    // Relocate the slug file to the OLD `<id>.md` convention — what an upgraded
+    // pre-slug vault has on disk.
+    const slugFile = names().find((f) => f.endsWith("-test1.md"))!;
+    const content = fs.readFileSync(path.join(memDir, slugFile), "utf8");
+    fs.unlinkSync(path.join(memDir, slugFile));
+    fs.writeFileSync(path.join(memDir, `${memory.id}.md`), content);
+
+    // A FRESH store (cold id-cache) must resolve the legacy file by id and write
+    // updates back to that same legacy name — no migration, no duplicate.
+    const store2 = createMarkdownMemoryStore({ vault });
+    expect(store2.getMemory(memory.id)?.title).toBe("Legacy Note");
+    store2.updateMemory(memory.id, { body: "new" });
+    expect(fs.existsSync(path.join(memDir, `${memory.id}.md`))).toBe(true);
+    expect(names()).toHaveLength(1); // updated in place, no second file
+    expect(store2.getMemory(memory.id)?.body).toBe("new");
   });
 });

--- a/packages/core/tests/store/markdown/markdown-store-git.test.ts
+++ b/packages/core/tests/store/markdown/markdown-store-git.test.ts
@@ -40,7 +40,8 @@ describe("markdown store + git — commit per write", () => {
       title: "Use pnpm",
       body: "Always pnpm.",
     });
-    expect(fs.existsSync(path.join(vault.root, `memories/${memory.id}.md`))).toBe(true);
+    const files = fs.readdirSync(path.join(vault.root, "memories"));
+    expect(files.some((f) => /^use-pnpm-.+\.md$/.test(f))).toBe(true); // human-readable slug name
     expect(git.head()).toMatch(/^[0-9a-f]{7,40}$/);
     expect(git.log()).toEqual([`memory: store ${memory.id}`]);
   });


### PR DESCRIPTION
## Why

Memories were written to `memories/<id>.md` — opaque uuids, painful to browse, diff, or maintain by hand. The vault is meant to be human-maintainable (git-backed, hand-editable), so the filenames should be too.

## What

Memories are now `memories/<title-slug>-<shortid>.md`, e.g. `role-and-responsibilities-2dd76e5c.md`.

Two decisions confirmed with the maintainer:
- **slug + short id** — the id suffix guarantees uniqueness (no collision logic). Slug is ASCII kebab-case, accent-folded, capped at 60 chars, `"memory"` fallback for empty/symbol-only titles.
- **keep stable** — the filename is set once at creation and **never renamed** when a title changes; the frontmatter id + title stay authoritative.

To support slug names (and stability), the store resolves a memory's file by its **frontmatter id** via a lazily-built, incrementally-maintained `id→path` map (rescans once on a miss to pick up hand-edits). `createMemory` guards against the astronomically rare same-slug+fragment clash by falling back to the full id, so a write never silently overwrites.

## Backward compatible — no migration

Existing `<id>.md` vaults keep working unchanged: files resolve by frontmatter id and update **in place** (no duplicate). A dedicated test pins this.

## Tests

Slug-from-title, stable-on-retitle (no rename), uniqueness via id suffix, slugify edge cases (accents/symbols/length cap), and legacy `<id>.md` update-in-place with no duplicate.

Sub-agent reviewed (verdict: ship) — confirmed `memoryPath` was the *only* id→path construction in the repo, so nothing downstream assumed filename == id; the new backward-compat test was added per its one Important finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)