### PR TITLE
feat(consolidator): curation prompt v3 — title-craft + discard transient noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ changes from this point forward are catalogued here.
 
 ### Changed
 
+- **Consolidator curation prompt → v3.** Two additions to the judge's "ways of
+  working": (1) **title-craft** — write a concise, entity-first noun phrase (the
+  title is also the memory's filename now), avoiding category prefixes, colons, and
+  sentence/status-style titles; (2) a **gatekeeping bias** — `noop` (discard)
+  submissions that are obviously transient or low-value (one-off task notes,
+  resolved bugs/typos, ephemeral status) rather than cluttering the library, while
+  still filing anything of genuinely unclear value. `CONSOLIDATOR_PROMPT_VERSION`
+  bumped v2 → v3.
+
 - **Memory files now have human-readable names.** A memory is written to
   `memories/<title-slug>-<shortid>.md` (e.g. `role-and-responsibilities-2dd76e5c.md`)
   instead of `memories/<id>.md` — far easier to browse, diff, and maintain by hand.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -7,6 +7,48 @@ group. Remove an item when its PR merges. (Completed specs are archived under
 [`docs/specs/done/`](./specs/done/); resolved backlog items are dropped here rather
 than struck — git history holds the record.)
 
+## ⭐ Next headline feature — a self-improving curator
+
+Give the resident curator the ability to **learn and improve from operator feedback**,
+the way a Hermes agent edits its own SOUL.md. The admin reviews the curator's recent
+grooming, gives feedback — including, ideally, a **chat with the configured curator
+LLM in the dashboard** to discuss what went well or badly — and the curator proposes
+an improvement to its own prompt. _(operator idea, design conversation 2026-06-03)_
+
+The architecture already has most of the bones, which is why this is promising rather
+than from-scratch:
+
+- **Self-edit only the addendum, never the core.** The judge prompt is already two
+  layers: a fixed core contract (output schema, safety rules, "untrusted data"
+  framing) that `judge-step.ts` guarantees "an injected addendum can't relax," and a
+  mutable `curator.prompt_addendum` (≤2 KB, in settings). The curator may rewrite
+  **only the addendum** — the structural/safety core stays immutable by construction.
+  So "the LLM updates its own prompt" = "the LLM proposes an addendum edit."
+- **propose → admin-approve → git commit.** Ride the existing memory-proposal rails:
+  the curator _proposes_ an addendum change, the admin approves, it lands as a
+  reviewable, revertable git diff (exactly like a SOUL.md edit). Never auto-applied.
+- **Eval-gate every self-edit.** This is what makes it real learning, not the LLM
+  rationalising about itself: re-run `@librarian/consolidator-eval` on the fixtures
+  for a proposed addendum, show the before/after score delta, and only allow approval
+  on no-regression. Without the eval, the addendum drifts on vibes.
+- **Capture structured feedback, not just chat.** A 👍/👎 + note on specific groom
+  decisions is far richer signal than freeform conversation. The git history of grooms
+  _plus_ the admin's labels becomes the "dataset" the curator reasons over to propose a
+  better addendum; the chat is the discussion layer on top.
+- **Learning should condense, not append.** The 2 KB cap is a feature — force the
+  curator to _rewrite_ its lessons into a tighter set rather than pile on forever.
+  Prompt-bloat is its own failure mode.
+- **Per-install by design.** The shipped core prompt (`CONSOLIDATOR_PROMPT_VERSION`,
+  improved by us for everyone) vs the addendum (this install's curator learning _this_
+  owner's preferences and vault quirks). That per-install learning layer is the whole
+  point — "a resident librarian who learns how **you** like things."
+- **Distinct from the retrospective-refactor pass** (below, under Consolidator): that
+  reorganises the _vault_; this improves the curator's _judgement_. They compose
+  (better judgement → better future grooms; refactor → fix past ones) but are separate.
+
+Write a proper spec when sequenced — it's meaty (dashboard chat UI, feedback capture,
+the propose/eval/approve loop, addendum versioning). **Basics ship first.**
+
 ## Security & hardening
 
 - **`/healthz` info disclosure.** `GET /healthz` returns auth-posture booleans

--- a/packages/core/src/consolidator/judge-step.ts
+++ b/packages/core/src/consolidator/judge-step.ts
@@ -19,11 +19,12 @@ import {
 import type { ConsolidationCandidates } from "./navigate.js";
 
 // Bump when the prompt changes meaningfully (participates in any future
-// idempotency/caching key, like CURATOR_PROMPT_VERSION). v2 bakes in the
+// idempotency/caching key, like CURATOR_PROMPT_VERSION). v2 baked in the
 // curation "ways of working" — preserve-don't-destroy, calibrated confidence,
-// cautious entity resolution, file-for-retrieval — i.e. the JUDGEMENT behind
-// the choice, not just the output contract.
-export const CONSOLIDATOR_PROMPT_VERSION = "v2";
+// cautious entity resolution, file-for-retrieval. v3 adds title-craft (a concise,
+// entity-first noun phrase — the title is also the filename) and a gatekeeping
+// bias: noop OBVIOUSLY transient / low-value submissions rather than clutter.
+export const CONSOLIDATOR_PROMPT_VERSION = "v3";
 
 const SYSTEM_INSTRUCTIONS = `You are the Consolidator for The Librarian — the curator of a single owner's long-term memory. Think library, not logbook: your job is to file each new SUBMISSION into an evolving, interlinked body of knowledge so that it — and everything related to it — is findable later.
 
@@ -36,13 +37,15 @@ HOW TO CURATE — the judgement behind the choice:
 - File for RETRIEVAL, not just storage. A fact about two entities belongs under one of them, with a [[wikilink]] to the other (by its title/alias), so it is findable from either side — that is the whole point of a knowledge graph. Curate the way the fact will be recalled.
 - Minimal edit. Make the smallest change that captures what's new. augment's "addition" is ONLY the new content — never a rewrite, and never a restatement of what the doc already says.
 - Add, don't duplicate. If the submission says nothing the store doesn't already hold, noop. If it adds even a little that is genuinely new, augment.
+- File durable knowledge, not transient noise. Memory is for what will be worth recalling later: stable facts about people, projects, preferences, conventions, infrastructure, decisions. A submission that is OBVIOUSLY transient or low-value — a one-off task note, an already-resolved bug or typo, an ephemeral status update — has no lasting recall value, so noop it. (When the lasting value is genuinely unclear, file a lean note rather than discard — bias toward discarding only the obvious noise.)
+- Title for a human browsing the files. A doc's title is ALSO its filename, so make it a concise, specific noun phrase that NAMES the thing and leads with the entity (e.g. "Expend Team", "Trash Over rm", "Anna — Piano Teacher"). Avoid category prefixes ("Preference:", "Convention:", "Note:"), avoid colons, and avoid sentence- or status-style titles ("AI Engineering Progress: Exercise 01 Complete"). Aim for ~3–6 words.
 
 OUTPUT CONTRACT — respond with a single JSON object and nothing else, exactly one of:
 - { "action": "create", "title": string, "body": string, "tags": string[], "rationale": string, "confidence": number } — a novel fact with no good existing home; file a new doc.
 - { "action": "augment", "target_id": string, "addition": string, "rationale": string, "confidence": number } — add the new information to an existing doc. "addition" is ONLY the new content to weave in; never restate or rewrite the existing doc (minimal-edit).
 - { "action": "supersede", "target_id": string, "title": string, "body": string, "rationale": string, "confidence": number } — the submission contradicts/updates an existing doc; give its full replacement.
 - { "action": "archive", "target_id": string, "rationale": string, "confidence": number } — an existing doc is now stale, with no replacement.
-- { "action": "noop", "rationale": string, "confidence": number } — a duplicate or nothing to do.
+- { "action": "noop", "rationale": string, "confidence": number } — nothing worth filing: a duplicate, OR a submission that is obviously transient or low-value (a one-off task note, a resolved bug/typo, an ephemeral status) with no lasting recall value.
 
 RULES (re-checked in code after you respond — a judgment that breaks one is discarded):
 - "target_id" MUST be an id that appears in the EVIDENCE (a candidate or toc entry). Never invent an id.

--- a/packages/core/tests/consolidator-judge-step.test.ts
+++ b/packages/core/tests/consolidator-judge-step.test.ts
@@ -66,13 +66,15 @@ describe("buildConsolidatorPrompt", () => {
     expect(user.toLowerCase()).toContain("untrusted");
   });
 
-  it("instructs the v2 curation ways of working (preserve / calibrate / resolve cautiously / file for retrieval)", () => {
+  it("instructs the v3 curation ways of working (preserve / calibrate / cautious / retrieval / title-craft / discard-transient)", () => {
     const system = buildConsolidatorPrompt({ submissionText: "x", evidence })[0]!.content;
     const lower = system.toLowerCase();
     expect(lower).toContain("preserve"); // preserve, don't destroy
     expect(lower).toContain("score low"); // calibrate confidence on ambiguity
     expect(lower).toContain("cautiously"); // resolve entities cautiously
     expect(lower).toContain("retrieval"); // file for retrieval, not just storage
+    expect(lower).toContain("also its filename"); // v3: title-craft (title == filename)
+    expect(lower).toContain("transient or low-value"); // v3: discard obvious noise
   });
 
   it("redacts secrets from every untrusted field before sending (submission, candidate title+body, toc title+tags, addendum)", () => {


### PR DESCRIPTION
## Why

From reviewing a real 198-memory migration: titles were verbose/inconsistent ("AI Engineering Progress: Exercise 01 Complete") — and now that the **title is also the filename**, that matters for browsing — and the curator filed obvious one-off noise from the old DB (typo reports, resolved-bug notes) as durable memories.

## What

Two additions to the judge's "ways of working" (`judge-step.ts`):

- **Title-craft** — a concise, entity-first noun phrase; no category prefixes / colons / sentence-or-status titles; ~3–6 words.
- **Gatekeeping bias** — `noop` (discard) submissions that are *obviously* transient or low-value (one-off task notes, resolved bugs/typos, ephemeral status), while still filing anything of genuinely unclear value. `noop`'s description widened to match.

`CONSOLIDATOR_PROMPT_VERSION` v2 → v3; the prompt-content test asserts both additions.

## Also

Captures the operator's **self-improving curator** idea as the headline next-feature in `docs/TODO.md` — admin feedback + a dashboard chat with the configured LLM → the curator proposes an edit to its own (bounded, ≤2 KB) prompt addendum, **eval-gated**, admin-approved, git-committed; the immutable core contract stays untouchable. Design opinions included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)