### PR TITLE
fix(dashboard): show full memory body on the Proposals screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ changes from this point forward are catalogued here.
 
 ### Changed
 
+- **Proposals screen shows full memory text.** The Proposals review list no longer
+  clamps a proposed memory's body to two lines — it renders the full body with
+  preserved line breaks, so a proposal can be read and judged without opening it
+  elsewhere. The Archive list keeps its two-line preview (the new `expandBody` prop
+  on `SimpleMemoryList` defaults to the clamped behaviour).
+
 - **`backup.github.repo` is validated as an `owner/repo` slug at the config
   boundary.** A malformed value (a bare repo name, a full URL, junk) used to fail
   deep in the `git push` with a confusing message; the dashboard `backup.setConfig`

--- a/apps/dashboard/components/memories/proposals-view.tsx
+++ b/apps/dashboard/components/memories/proposals-view.tsx
@@ -10,6 +10,7 @@ export function ProposalsView({ memories }: { memories: MemoryRow[] }) {
   return (
     <SimpleMemoryList
       memories={memories}
+      expandBody
       emptyMessage="No proposals pending."
       actions={[
         {

--- a/apps/dashboard/components/memories/simple-list.tsx
+++ b/apps/dashboard/components/memories/simple-list.tsx
@@ -15,9 +15,16 @@ interface Props {
   memories: MemoryRow[];
   emptyMessage: string;
   actions?: Action[];
+  /** Render the full memory body instead of clamping it to two lines. */
+  expandBody?: boolean;
 }
 
-export function SimpleMemoryList({ memories, emptyMessage, actions = [] }: Props) {
+export function SimpleMemoryList({
+  memories,
+  emptyMessage,
+  actions = [],
+  expandBody = false,
+}: Props) {
   const [pending, startTransition] = useTransition();
   if (memories.length === 0) {
     return <p className="text-sm text-muted-foreground">{emptyMessage}</p>;
@@ -29,7 +36,15 @@ export function SimpleMemoryList({ memories, emptyMessage, actions = [] }: Props
           <div className="flex items-start justify-between gap-2">
             <div className="min-w-0">
               <h3 className="truncate font-medium">{memory.title || "(untitled)"}</h3>
-              <p className="line-clamp-2 text-sm text-muted-foreground">{memory.body}</p>
+              <p
+                className={
+                  expandBody
+                    ? "whitespace-pre-wrap break-words text-sm text-muted-foreground"
+                    : "line-clamp-2 text-sm text-muted-foreground"
+                }
+              >
+                {memory.body}
+              </p>
               <div className="mt-1 flex flex-wrap items-center gap-1 text-xs text-muted-foreground">
                 <Pill>{memory.category}</Pill>
                 <span>{memory.visibility}</span>


### PR DESCRIPTION
## Why

The Proposals review list clamped each proposed memory's body to two lines (`line-clamp-2`), so a proposal couldn't be read and judged in place — you had to open it elsewhere to see the full text.

## What

- `SimpleMemoryList` gains an opt-in `expandBody?: boolean` prop (default `false`). When set, the body renders with `whitespace-pre-wrap break-words` (full text, line breaks preserved) instead of `line-clamp-2`.
- The Proposals view passes `expandBody`.
- The Archive view omits the prop, so its two-line preview is unchanged.
- CHANGELOG entry under `[Unreleased] → Changed`.

## Verification

- `pnpm --filter @librarian/dashboard typecheck` — clean
- `eslint` on changed files — clean (also via lefthook pre-commit)
- `prettier --check` — clean

No tests asserted the clamp behaviour, so none needed updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)