### PR TITLE
refactor(core): extract shared store types into type-only modules (spec 040 PR-1)

### DIFF
--- a/packages/core/src/store/conversation-state-store.ts
+++ b/packages/core/src/store/conversation-state-store.ts
@@ -18,15 +18,13 @@ import {
   type ConversationStatePatch,
   ConversationStatePatchSchema,
 } from "../schemas/conversation-state.js";
+import type { ConversationStateStore } from "./conversation-state-types.js";
+
+// Re-exported from the old path so existing importers don't change (PR-1).
+export type { ConversationStateStore } from "./conversation-state-types.js";
 
 export interface ConversationStateStoreDeps {
   db: DatabaseSync;
-}
-
-export interface ConversationStateStore {
-  get(convId: string): ConversationState | null;
-  upsert(convId: string, patch: ConversationStatePatch): ConversationState;
-  clear(convId: string): void;
 }
 
 interface ConversationStateRow {

--- a/packages/core/src/store/conversation-state-types.ts
+++ b/packages/core/src/store/conversation-state-types.ts
@@ -1,0 +1,13 @@
+// Conversation-state store — shared type contract (memory-domain-isolation §4.8).
+//
+// The backend-agnostic `ConversationStateStore` surface: the per-conversation
+// runtime registry keyed by `conv_id`. The concrete SQLite implementation lives
+// in `conversation-state-store.ts` and re-exports this for back-compat.
+
+import type { ConversationState, ConversationStatePatch } from "../schemas/conversation-state.js";
+
+export interface ConversationStateStore {
+  get(convId: string): ConversationState | null;
+  upsert(convId: string, patch: ConversationStatePatch): ConversationState;
+  clear(convId: string): void;
+}

--- a/packages/core/src/store/curation-store.ts
+++ b/packages/core/src/store/curation-store.ts
@@ -26,6 +26,28 @@ import {
   selectDueSlices as selectDueSlicesImpl,
 } from "../curator-scheduler.js";
 import { createSqliteCuratorMemorySource } from "../curator-source-sqlite.js";
+import type {
+  CompleteCurationRunInput,
+  CreateCurationRunInput,
+  CurationOperation,
+  CurationRun,
+  CurationStore,
+  FailCurationRunInput,
+  ListCurationRunsInput,
+  RecordCurationOperationInput,
+} from "./curation-types.js";
+
+// Re-exported from the old path so existing importers don't change (PR-1).
+export type {
+  CompleteCurationRunInput,
+  CreateCurationRunInput,
+  CurationOperation,
+  CurationRun,
+  CurationStore,
+  FailCurationRunInput,
+  ListCurationRunsInput,
+  RecordCurationOperationInput,
+} from "./curation-types.js";
 
 interface RunFilter {
   clause: string;
@@ -80,107 +102,6 @@ export function createSqliteCurationRunReader(db: DatabaseSync): CurationRunRead
       return row ? { id: row.id, startedAt: new Date(row.started_at) } : null;
     },
   };
-}
-
-export interface CreateCurationRunInput {
-  trigger: string; // schedule | manual | maintenance
-  visibility: string; // common | agent_private
-  input_hash: string;
-  status?: string; // defaults to "pending"
-  mode?: string; // defaults to "apply"
-  project_key?: string | null;
-  agent_id?: string | null; // only for agent_private slices
-  input_memory_ids?: string[];
-  model_provider?: string | null;
-  model_name?: string | null;
-}
-
-export interface CurationRun {
-  id: string;
-  status: string;
-  trigger: string;
-  mode: string;
-  project_key: string | null;
-  visibility: string;
-  agent_id: string | null;
-  input_hash: string;
-  input_memory_ids: string[];
-  model_provider: string | null;
-  model_name: string | null;
-  usage_input_tokens: number;
-  usage_output_tokens: number;
-  summary: string | null;
-  error: string | null;
-  created_at: string;
-  started_at: string | null;
-  completed_at: string | null;
-}
-
-export interface RecordCurationOperationInput {
-  run_id: string;
-  operation_type: string; // noop | create | update | archive | merge | split
-  status: string; // proposed | applied | skipped | failed | superseded
-  confidence: number;
-  risk_level: string; // safe | normal | risky | protected
-  rationale: string;
-  proposed_payload: Record<string, unknown>;
-  source_memory_ids?: string[];
-  target_memory_ids?: string[];
-  title?: string | null;
-}
-
-export interface CurationOperation {
-  id: string;
-  run_id: string;
-  operation_type: string;
-  status: string;
-  confidence: number;
-  risk_level: string;
-  source_memory_ids: string[];
-  target_memory_ids: string[];
-  title: string | null;
-  rationale: string;
-  proposed_payload: Record<string, unknown>;
-  applied_at: string | null;
-  error: string | null;
-}
-
-export interface ListCurationRunsInput {
-  status?: string;
-  trigger?: string;
-  /** Page size, defaulted to 50 and clamped to a 200 ceiling. */
-  limit?: number;
-}
-
-export interface CompleteCurationRunInput {
-  summary?: string | null;
-  usage_input_tokens?: number;
-  usage_output_tokens?: number;
-}
-
-export interface FailCurationRunInput {
-  /** A value-free error label (no secrets / untrusted content). */
-  error: string;
-}
-
-export interface CurationStore {
-  createCurationRun: (input: CreateCurationRunInput) => CurationRun;
-  getCurationRun: (id: string) => CurationRun | null;
-  /** Latest completed apply-mode run with this input hash, for §10.2 idempotency. */
-  findCompletedApplyRun: (inputHash: string) => CurationRun | null;
-  listCurationRuns: (input?: ListCurationRunsInput) => CurationRun[];
-  recordCurationOperation: (input: RecordCurationOperationInput) => CurationOperation;
-  getCurationOperations: (runId: string) => CurationOperation[];
-  // Lifecycle transitions — direct UPDATEs on the SQLite-authoritative run row.
-  startCurationRun: (id: string) => CurationRun;
-  completeCurationRun: (id: string, input?: CompleteCurationRunInput) => CurationRun;
-  failCurationRun: (id: string, input: FailCurationRunInput) => CurationRun;
-  // Curator read-side (F0): thin wrappers binding the store db to the pure
-  // curator functions so curator-worker/enqueue never touch `store.db`.
-  gatherMemoryEvidence: (slice: EvidenceSlice, caps: MemoryEvidenceCaps) => MemoryEvidenceBundle;
-  listCuratorSlices: () => EvidenceSlice[];
-  selectDueSlices: (config: ScheduleConfig, now: Date) => DueSlice[];
-  findRunningRun: (slice: EvidenceSlice) => { id: string; startedAt: Date } | null;
 }
 
 interface CurationRunRow {

--- a/packages/core/src/store/curation-types.ts
+++ b/packages/core/src/store/curation-types.ts
@@ -1,0 +1,114 @@
+// Curation data-model store — shared type contract (memory-curator spec §8).
+//
+// The backend-agnostic run/operation types and the `CurationStore` interface.
+// The concrete SQLite implementation lives in `curation-store.ts` and
+// re-exports these from its old path for back-compat.
+
+import type {
+  EvidenceSlice,
+  MemoryEvidenceBundle,
+  MemoryEvidenceCaps,
+} from "../curator-evidence.js";
+import type { ScheduleConfig } from "../curator-schedule.js";
+import type { DueSlice } from "../curator-scheduler.js";
+
+export interface CreateCurationRunInput {
+  trigger: string; // schedule | manual | maintenance
+  visibility: string; // common | agent_private
+  input_hash: string;
+  status?: string; // defaults to "pending"
+  mode?: string; // defaults to "apply"
+  project_key?: string | null;
+  agent_id?: string | null; // only for agent_private slices
+  input_memory_ids?: string[];
+  model_provider?: string | null;
+  model_name?: string | null;
+}
+
+export interface CurationRun {
+  id: string;
+  status: string;
+  trigger: string;
+  mode: string;
+  project_key: string | null;
+  visibility: string;
+  agent_id: string | null;
+  input_hash: string;
+  input_memory_ids: string[];
+  model_provider: string | null;
+  model_name: string | null;
+  usage_input_tokens: number;
+  usage_output_tokens: number;
+  summary: string | null;
+  error: string | null;
+  created_at: string;
+  started_at: string | null;
+  completed_at: string | null;
+}
+
+export interface RecordCurationOperationInput {
+  run_id: string;
+  operation_type: string; // noop | create | update | archive | merge | split
+  status: string; // proposed | applied | skipped | failed | superseded
+  confidence: number;
+  risk_level: string; // safe | normal | risky | protected
+  rationale: string;
+  proposed_payload: Record<string, unknown>;
+  source_memory_ids?: string[];
+  target_memory_ids?: string[];
+  title?: string | null;
+}
+
+export interface CurationOperation {
+  id: string;
+  run_id: string;
+  operation_type: string;
+  status: string;
+  confidence: number;
+  risk_level: string;
+  source_memory_ids: string[];
+  target_memory_ids: string[];
+  title: string | null;
+  rationale: string;
+  proposed_payload: Record<string, unknown>;
+  applied_at: string | null;
+  error: string | null;
+}
+
+export interface ListCurationRunsInput {
+  status?: string;
+  trigger?: string;
+  /** Page size, defaulted to 50 and clamped to a 200 ceiling. */
+  limit?: number;
+}
+
+export interface CompleteCurationRunInput {
+  summary?: string | null;
+  usage_input_tokens?: number;
+  usage_output_tokens?: number;
+}
+
+export interface FailCurationRunInput {
+  /** A value-free error label (no secrets / untrusted content). */
+  error: string;
+}
+
+export interface CurationStore {
+  createCurationRun: (input: CreateCurationRunInput) => CurationRun;
+  getCurationRun: (id: string) => CurationRun | null;
+  /** Latest completed apply-mode run with this input hash, for §10.2 idempotency. */
+  findCompletedApplyRun: (inputHash: string) => CurationRun | null;
+  listCurationRuns: (input?: ListCurationRunsInput) => CurationRun[];
+  recordCurationOperation: (input: RecordCurationOperationInput) => CurationOperation;
+  getCurationOperations: (runId: string) => CurationOperation[];
+  // Lifecycle transitions — direct UPDATEs on the SQLite-authoritative run row.
+  startCurationRun: (id: string) => CurationRun;
+  completeCurationRun: (id: string, input?: CompleteCurationRunInput) => CurationRun;
+  failCurationRun: (id: string, input: FailCurationRunInput) => CurationRun;
+  // Curator read-side (F0): thin wrappers binding the store db to the pure
+  // curator functions so curator-worker/enqueue never touch `store.db`.
+  gatherMemoryEvidence: (slice: EvidenceSlice, caps: MemoryEvidenceCaps) => MemoryEvidenceBundle;
+  listCuratorSlices: () => EvidenceSlice[];
+  selectDueSlices: (config: ScheduleConfig, now: Date) => DueSlice[];
+  findRunningRun: (slice: EvidenceSlice) => { id: string; startedAt: Date } | null;
+}

--- a/packages/core/src/store/handoff-store.ts
+++ b/packages/core/src/store/handoff-store.ts
@@ -20,46 +20,24 @@ import type {
   StoreHandoffInput,
   StoreHandoffOutput,
 } from "../schemas/handoff.js";
+import { HandoffAlreadyClaimedError, HandoffNotFoundError } from "./handoff-types.js";
+import type {
+  ClaimedBy,
+  HandoffDetail,
+  HandoffStore,
+  ListHandoffsContext,
+  StoreHandoffContext,
+} from "./handoff-types.js";
 
-/** Server-resolved metadata the MCP layer attaches before calling the store. */
-export interface StoreHandoffContext {
-  /** The agent that ran `/handoff` (resolved from auth context). */
-  created_by_agent_id: string | null;
-}
-
-/**
- * The MCP/agent path always sees `claimed_at IS NULL` (claim removes it from
- * the picker). Admin paths (CLI, dashboard) can pass `includeClaimed: true`
- * to surface already-claimed handoffs for forensic / audit use.
- */
-export interface ListHandoffsContext {
-  includeClaimed?: boolean;
-}
-
-export class HandoffNotFoundError extends Error {
-  constructor(public readonly handoffId: string) {
-    super(`No handoff found for id ${handoffId}`);
-    this.name = "HandoffNotFoundError";
-  }
-}
-
-export class HandoffAlreadyClaimedError extends Error {
-  constructor(
-    public readonly handoffId: string,
-    public readonly claimedAt: string,
-    public readonly claimedBy: ClaimedBy | null,
-  ) {
-    super(`Handoff ${handoffId} already claimed at ${claimedAt}`);
-    this.name = "HandoffAlreadyClaimedError";
-  }
-}
-
-export interface ClaimedBy {
-  agent_id?: string | null;
-  harness?: string | null;
-  source_ref?: string | null;
-  cwd?: string | null;
-}
+// Re-exported from the old path so existing importers don't change (PR-1).
+export { HandoffAlreadyClaimedError, HandoffNotFoundError } from "./handoff-types.js";
+export type {
+  ClaimedBy,
+  HandoffDetail,
+  HandoffStore,
+  ListHandoffsContext,
+  StoreHandoffContext,
+} from "./handoff-types.js";
 
 interface HandoffRow {
   id: string;
@@ -74,43 +52,6 @@ interface HandoffRow {
   created_at: string;
   claimed_at: string | null;
   claimed_by_json: string | null;
-}
-
-/**
- * Full handoff detail for admin/dashboard + CLI surfaces (read by id). Unlike
- * `HandoffSummary` this carries the document body + claim status, so the
- * dashboard `byId` view and `the-librarian handoffs show` don't reach for raw
- * SQL against the store's database (F0 — seal the seam).
- */
-export interface HandoffDetail {
-  handoff_id: string;
-  title: string;
-  document_md: string;
-  project_key: string | null;
-  source_ref: string | null;
-  cwd: string | null;
-  created_by_agent_id: string | null;
-  created_in_harness: string | null;
-  tags: string[];
-  created_at: string;
-  claimed_at: string | null;
-  claimed_by: ClaimedBy | null;
-}
-
-export interface HandoffStore {
-  store: (input: StoreHandoffInput, context: StoreHandoffContext) => StoreHandoffOutput;
-  list: (input: ListHandoffsInput, context: ListHandoffsContext) => HandoffSummary[];
-  /**
-   * Like `list`, but returns full `HandoffDetail` rows (incl. claim status and
-   * the document body) for the admin dashboard list view, which renders fields
-   * `HandoffSummary` omits. Same filtering semantics as `list`.
-   */
-  listDetails: (input: ListHandoffsInput, context: ListHandoffsContext) => HandoffDetail[];
-  claim: (input: ClaimHandoffInput) => ClaimHandoffOutput;
-  /** Admin / dashboard / CLI detail lookup by id; not domain-scoped. Null when absent. */
-  getById: (handoffId: string) => HandoffDetail | null;
-  /** Admin / test path — hard-delete a single row regardless of claim status. */
-  purge: (handoffId: string) => boolean;
 }
 
 export function createHandoffStore(deps: { db: DatabaseSync }): HandoffStore {

--- a/packages/core/src/store/handoff-types.ts
+++ b/packages/core/src/store/handoff-types.ts
@@ -1,0 +1,91 @@
+// Handoff store — shared type contract (sessions-rethink spec §6.2).
+//
+// The backend-agnostic handoff types, the `HandoffStore` interface, and the
+// store's error classes. The concrete SQLite implementation lives in
+// `handoff-store.ts` and re-exports these from its old path for back-compat.
+
+import type {
+  ClaimHandoffInput,
+  ClaimHandoffOutput,
+  HandoffSummary,
+  ListHandoffsInput,
+  StoreHandoffInput,
+  StoreHandoffOutput,
+} from "../schemas/handoff.js";
+
+/** Server-resolved metadata the MCP layer attaches before calling the store. */
+export interface StoreHandoffContext {
+  /** The agent that ran `/handoff` (resolved from auth context). */
+  created_by_agent_id: string | null;
+}
+
+/**
+ * The MCP/agent path always sees `claimed_at IS NULL` (claim removes it from
+ * the picker). Admin paths (CLI, dashboard) can pass `includeClaimed: true`
+ * to surface already-claimed handoffs for forensic / audit use.
+ */
+export interface ListHandoffsContext {
+  includeClaimed?: boolean;
+}
+
+export class HandoffNotFoundError extends Error {
+  constructor(public readonly handoffId: string) {
+    super(`No handoff found for id ${handoffId}`);
+    this.name = "HandoffNotFoundError";
+  }
+}
+
+export class HandoffAlreadyClaimedError extends Error {
+  constructor(
+    public readonly handoffId: string,
+    public readonly claimedAt: string,
+    public readonly claimedBy: ClaimedBy | null,
+  ) {
+    super(`Handoff ${handoffId} already claimed at ${claimedAt}`);
+    this.name = "HandoffAlreadyClaimedError";
+  }
+}
+
+export interface ClaimedBy {
+  agent_id?: string | null;
+  harness?: string | null;
+  source_ref?: string | null;
+  cwd?: string | null;
+}
+
+/**
+ * Full handoff detail for admin/dashboard + CLI surfaces (read by id). Unlike
+ * `HandoffSummary` this carries the document body + claim status, so the
+ * dashboard `byId` view and `the-librarian handoffs show` don't reach for raw
+ * SQL against the store's database (F0 — seal the seam).
+ */
+export interface HandoffDetail {
+  handoff_id: string;
+  title: string;
+  document_md: string;
+  project_key: string | null;
+  source_ref: string | null;
+  cwd: string | null;
+  created_by_agent_id: string | null;
+  created_in_harness: string | null;
+  tags: string[];
+  created_at: string;
+  claimed_at: string | null;
+  claimed_by: ClaimedBy | null;
+}
+
+export interface HandoffStore {
+  store: (input: StoreHandoffInput, context: StoreHandoffContext) => StoreHandoffOutput;
+  list: (input: ListHandoffsInput, context: ListHandoffsContext) => HandoffSummary[];
+  /**
+   * Like `list`, but returns full `HandoffDetail` rows (incl. claim status and
+   * the document body) for the admin dashboard list view, which renders fields
+   * `HandoffSummary` omits. Same filtering semantics as `list`.
+   */
+  listDetails: (input: ListHandoffsInput, context: ListHandoffsContext) => HandoffDetail[];
+  claim: (input: ClaimHandoffInput) => ClaimHandoffOutput;
+  /** Admin / dashboard / CLI detail lookup by id; not domain-scoped. Null when absent. */
+  getById: (handoffId: string) => HandoffDetail | null;
+  /** Admin / test path — hard-delete a single row regardless of claim status. */
+  purge: (handoffId: string) => boolean;
+}

--- a/packages/core/src/store/memory-store.ts
+++ b/packages/core/src/store/memory-store.ts
@@ -24,6 +24,7 @@ import { formatContextPackage, uniqueById } from "./memory-context.js";
 import { cleanPatch } from "./memory-patch.js";
 import { routeMemoryWrite } from "./memory-routing.js";
 import { tokenize } from "./memory-tokenize.js";
+import type { AppendMemoryEventOptions, Memory, MemoryEvent, MemoryStore } from "./memory-types.js";
 
 // ---------- Public types ----------
 
@@ -33,124 +34,9 @@ export interface MemoryStoreDeps {
   rebuildMemoryIndex: () => void;
 }
 
-export type Memory = Record<string, unknown> & {
-  id: string;
-  agent_id: string;
-  // Legacy columns kept for backward compatibility with pre-4d.2
-  // events and existing rows. The classifier worker is the source of
-  // truth for the policy booleans now; these are not consulted on the
-  // write path. Optional because new memories don't populate them.
-  category?: string;
-  visibility?: string;
-  scope?: string;
-  status: string;
-  tags: string[];
-  applies_to: string[];
-  supersedes: string[];
-  conflicts_with: string[];
-  recall_count: number;
-  usefulness_score: number;
-  title: string;
-  body: string;
-  priority: string;
-  confidence: string;
-  project_key?: string | null;
-  updated_at: string;
-  curator_note?: Record<string, unknown> | null;
-  // Classifier verdict booleans — set by the classifier worker, surfaced for
-  // the proposal flow + dashboard. (Domain scoping was removed in D16; these
-  // booleans retire with the classifier in Phase 4.)
-  is_global: boolean;
-  requires_approval: boolean;
-};
-
-export interface AppendMemoryEventOptions {
-  memory_id?: string | null;
-  agent_id?: string;
-}
-
-export interface MemoryEvent {
-  event_id: string;
-  event_type: string;
-  memory_id: string | null;
-  agent_id: string;
-  created_at: string;
-  payload: Record<string, unknown>;
-}
-
-export interface MemoryStore {
-  appendEvent: (
-    eventType: string,
-    payload?: Record<string, unknown>,
-    options?: AppendMemoryEventOptions,
-  ) => MemoryEvent;
-  listAll: (filters?: Record<string, unknown>) => Memory[];
-  listMemories: (filters?: Record<string, unknown>) => {
-    memories: Memory[];
-    total: number;
-    limit: number;
-    offset: number;
-  };
-  getAggregates: () => {
-    agents: { value: unknown; count: number }[];
-    projects: { value: unknown; count: number }[];
-    categories: { value: unknown; count: number }[];
-    statuses: { value: unknown; count: number }[];
-    scopes: { value: unknown; count: number }[];
-    priorities: { value: unknown; count: number }[];
-    total: number;
-  };
-  getRelated: (id: string) => null | {
-    memory: Memory;
-    related: { memory: Memory; ratio: number; isDuplicate: boolean }[];
-  };
-  getMemory: (id: string) => Memory | null;
-  listEvents: (filters?: Record<string, unknown>) => {
-    events: MemoryEvent[];
-    total: number;
-    limit: number;
-    offset: number;
-  };
-  searchMemories: (input?: Record<string, unknown>) => Memory[];
-  detectRelated: (candidate: Memory, options?: { threshold?: number }) => { duplicates: Memory[] };
-  createMemory: (
-    input: Record<string, unknown>,
-    options?: Record<string, unknown>,
-  ) => {
-    status: MemoryStatus.Active | MemoryStatus.Proposed;
-    memory: Memory;
-    duplicates: Memory[];
-  };
-  updateMemory: (
-    id: string,
-    patch?: Record<string, unknown>,
-    agent_id?: string,
-    options?: { allowProtected?: boolean },
-  ) => Memory | null;
-  bulkUpdateMemory: (input: {
-    ids: string[];
-    patch: { agent_id?: string; project_key?: string };
-    agent_id?: string;
-  }) => { transaction_id: string; updated: number };
-  distinctValues: (input: { field: string; include_archived?: boolean }) => string[];
-  // Caller-backfill read seam (F0): group memory counts per stored agent id, and
-  // list the memory ids owned by one agent — so backfill never touches store.db.
-  countMemoriesByAgentId: () => { agent_id: string; count: number }[];
-  listMemoryIdsByAgentId: (agentId: string) => string[];
-  archiveMemory: (id: string, agent_id?: string) => Memory | null;
-  verifyMemory: (id: string, result: string, note?: string, agent_id?: string) => Memory | null;
-  recordRecall: (memories: Memory[], agent_id?: string, query?: string) => void;
-  approveProposal: (
-    id: string,
-    action?: string,
-    patch?: Record<string, unknown>,
-    agent_id?: string,
-  ) => Memory | null;
-  startContext: (input?: { agent_id?: string; project_key?: string; task_summary?: string }) => {
-    memories: Memory[];
-    text: string;
-  };
-}
+// The backend-agnostic memory types now live in `memory-types.ts`; re-exported
+// from this old path so existing importers don't change (PR-1).
+export type { AppendMemoryEventOptions, Memory, MemoryEvent, MemoryStore } from "./memory-types.js";
 
 // ---------- Factory ----------
 

--- a/packages/core/src/store/memory-types.ts
+++ b/packages/core/src/store/memory-types.ts
@@ -1,0 +1,131 @@
+// Memory store — shared type contract.
+//
+// The backend-agnostic memory types (`Memory`, `MemoryEvent`, `MemoryStore`
+// and the `appendEvent` options) that both the SQLite store (`memory-store.ts`)
+// and the markdown store implement. The store modules re-export these from
+// their old paths for back-compat.
+//
+// Typing is intentionally loose for now (`Memory = Record<string, unknown>
+// & { id: string }`). Tightening to the Zod-derived `Memory` from
+// @librarian/core/schemas is a follow-up.
+
+import type { MemoryStatus } from "../schemas/common.js";
+
+export type Memory = Record<string, unknown> & {
+  id: string;
+  agent_id: string;
+  // Legacy columns kept for backward compatibility with pre-4d.2
+  // events and existing rows. The classifier worker is the source of
+  // truth for the policy booleans now; these are not consulted on the
+  // write path. Optional because new memories don't populate them.
+  category?: string;
+  visibility?: string;
+  scope?: string;
+  status: string;
+  tags: string[];
+  applies_to: string[];
+  supersedes: string[];
+  conflicts_with: string[];
+  recall_count: number;
+  usefulness_score: number;
+  title: string;
+  body: string;
+  priority: string;
+  confidence: string;
+  project_key?: string | null;
+  updated_at: string;
+  curator_note?: Record<string, unknown> | null;
+  // Classifier verdict booleans — set by the classifier worker, surfaced for
+  // the proposal flow + dashboard. (Domain scoping was removed in D16; these
+  // booleans retire with the classifier in Phase 4.)
+  is_global: boolean;
+  requires_approval: boolean;
+};
+
+export interface AppendMemoryEventOptions {
+  memory_id?: string | null;
+  agent_id?: string;
+}
+
+export interface MemoryEvent {
+  event_id: string;
+  event_type: string;
+  memory_id: string | null;
+  agent_id: string;
+  created_at: string;
+  payload: Record<string, unknown>;
+}
+
+export interface MemoryStore {
+  appendEvent: (
+    eventType: string,
+    payload?: Record<string, unknown>,
+    options?: AppendMemoryEventOptions,
+  ) => MemoryEvent;
+  listAll: (filters?: Record<string, unknown>) => Memory[];
+  listMemories: (filters?: Record<string, unknown>) => {
+    memories: Memory[];
+    total: number;
+    limit: number;
+    offset: number;
+  };
+  getAggregates: () => {
+    agents: { value: unknown; count: number }[];
+    projects: { value: unknown; count: number }[];
+    categories: { value: unknown; count: number }[];
+    statuses: { value: unknown; count: number }[];
+    scopes: { value: unknown; count: number }[];
+    priorities: { value: unknown; count: number }[];
+    total: number;
+  };
+  getRelated: (id: string) => null | {
+    memory: Memory;
+    related: { memory: Memory; ratio: number; isDuplicate: boolean }[];
+  };
+  getMemory: (id: string) => Memory | null;
+  listEvents: (filters?: Record<string, unknown>) => {
+    events: MemoryEvent[];
+    total: number;
+    limit: number;
+    offset: number;
+  };
+  searchMemories: (input?: Record<string, unknown>) => Memory[];
+  detectRelated: (candidate: Memory, options?: { threshold?: number }) => { duplicates: Memory[] };
+  createMemory: (
+    input: Record<string, unknown>,
+    options?: Record<string, unknown>,
+  ) => {
+    status: MemoryStatus.Active | MemoryStatus.Proposed;
+    memory: Memory;
+    duplicates: Memory[];
+  };
+  updateMemory: (
+    id: string,
+    patch?: Record<string, unknown>,
+    agent_id?: string,
+    options?: { allowProtected?: boolean },
+  ) => Memory | null;
+  bulkUpdateMemory: (input: {
+    ids: string[];
+    patch: { agent_id?: string; project_key?: string };
+    agent_id?: string;
+  }) => { transaction_id: string; updated: number };
+  distinctValues: (input: { field: string; include_archived?: boolean }) => string[];
+  // Caller-backfill read seam (F0): group memory counts per stored agent id, and
+  // list the memory ids owned by one agent — so backfill never touches store.db.
+  countMemoriesByAgentId: () => { agent_id: string; count: number }[];
+  listMemoryIdsByAgentId: (agentId: string) => string[];
+  archiveMemory: (id: string, agent_id?: string) => Memory | null;
+  verifyMemory: (id: string, result: string, note?: string, agent_id?: string) => Memory | null;
+  recordRecall: (memories: Memory[], agent_id?: string, query?: string) => void;
+  approveProposal: (
+    id: string,
+    action?: string,
+    patch?: Record<string, unknown>,
+    agent_id?: string,
+  ) => Memory | null;
+  startContext: (input?: { agent_id?: string; project_key?: string; task_summary?: string }) => {
+    memories: Memory[];
+    text: string;
+  };
+}

--- a/packages/core/src/store/settings-store.ts
+++ b/packages/core/src/store/settings-store.ts
@@ -14,20 +14,10 @@
 import type { DatabaseSync } from "node:sqlite";
 import { nowIso } from "../constants.js";
 import { decryptSecret, encryptSecret } from "../secret-crypto.js";
+import type { SettingMeta, SettingsStore } from "./settings-types.js";
 
-export interface SettingMeta {
-  key: string;
-  is_secret: boolean;
-  updated_at: string;
-}
-
-export interface SettingsStore {
-  setSetting: (key: string, value: string, options?: { secret?: boolean }) => void;
-  getSetting: (key: string) => string | null;
-  deleteSetting: (key: string) => void;
-  /** Metadata for every setting — never includes values (secret or otherwise). */
-  listSettings: () => SettingMeta[];
-}
+// Re-exported from the old path so existing importers don't change (PR-1).
+export type { SettingMeta, SettingsStore } from "./settings-types.js";
 
 interface SettingRow {
   key: string;

--- a/packages/core/src/store/settings-types.ts
+++ b/packages/core/src/store/settings-types.ts
@@ -1,0 +1,21 @@
+// Admin settings / secret store — shared type contract (memory-curator spec §7.1).
+//
+// The backend-agnostic surface for the operator settings store: `SettingMeta`
+// (the listing shape, which never carries a value — secret or otherwise) and
+// the `SettingsStore` interface. The concrete SQLite implementation lives in
+// `settings-store.ts` and re-exports these for back-compat; `SettingMeta` is
+// also consumed by `llm-connection.ts`.
+
+export interface SettingMeta {
+  key: string;
+  is_secret: boolean;
+  updated_at: string;
+}
+
+export interface SettingsStore {
+  setSetting: (key: string, value: string, options?: { secret?: boolean }) => void;
+  getSetting: (key: string) => string | null;
+  deleteSetting: (key: string) => void;
+  /** Metadata for every setting — never includes values (secret or otherwise). */
+  listSettings: () => SettingMeta[];
+}


### PR DESCRIPTION
## Spec 040 PR-1 — extract shared store types

First increment of the [SQLite backend removal](docs/specs/040-sqlite-backend-removal.md) demolition. Before the SQLite store bodies can be deleted (PR-3), the type contracts they share with the markdown backend must outlive them.

This moves the type/interface exports out of the five "mixed" store files into sibling **type-only modules** and re-exports them from the original paths, so **no importer changes**:

| Store file | New type module |
|---|---|
| `memory-store.ts` | `memory-types.ts` |
| `curation-store.ts` | `curation-types.ts` |
| `settings-store.ts` | `settings-types.ts` |
| `conversation-state-store.ts` | `conversation-state-types.ts` |
| `handoff-store.ts` | `handoff-types.ts` |

### What stays put (deleted in PR-3)
- The SQLite `createXxxStore` bodies.
- SQLite-coupled types: `MemoryStoreDeps`, `ConversationStateStoreDeps`.
- Internal row shapes (`HandoffRow`, `CurationRunRow`, …).

### Notes
- The handoff error classes (`HandoffNotFoundError`, `HandoffAlreadyClaimedError`) are runtime values, so they move with the handoff types and are re-exported as **values** (`export { … }`), not `export type`.
- `verbatimModuleSyntax: true` is respected throughout (`import type`/`export type` for types, plain `import`/`export` for the error classes).

**Pure refactor, zero behaviour change.**

## Verification
- `pnpm typecheck` — green (all 5 workspaces)
- `pnpm build` — green
- `pnpm lint` — green (+ lefthook prettier/eslint on commit)
- `pnpm test` — green (core 861·1 skip, mcp 113, cli 52, consolidator-eval 39, dashboard 160, root 22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)