### PR TITLE
feat(backup): git-native restore + dashboard restore UI (spec 040 / PR-6 B3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,11 @@ changes from this point forward are catalogued here.
   the vault. A new `check:no-secrets-in-vault` CI guard asserts secrets never land
   in the pushed vault. **Secrets are not auto-backed-up** — save your
   `LIBRARIAN_SECRET_KEY` (shown once on first boot); other settings are
-  re-enterable via the dashboard. **Dashboard restore UI is temporarily removed**
-  pending the git-native restore flow.
+  re-enterable via the dashboard. **Restore** clones the backup repo into a staging
+  dir, then swaps it in on the next restart (never under the live store), keeping
+  your current vault as `vault.pre-restore.bak` — available from the dashboard
+  `/backups` page (validate-before-swap, restart-gated, reversible) and applied at
+  boot before the store opens.
 
 - **Consolidator curation prompt → v3.** Two additions to the judge's "ways of
   working": (1) **title-craft** — write a concise, entity-first noun phrase (the

--- a/apps/dashboard/app/backups/actions.ts
+++ b/apps/dashboard/app/backups/actions.ts
@@ -43,3 +43,28 @@ export async function saveBackupConfigAction(
     return { ok: false, error: message(error) };
   }
 }
+
+export type StageRestoreResult = { ok: true; staged: string } | { ok: false; error: string };
+
+// Clone the backup remote into a staging dir + write the pending-restore marker.
+// The swap happens on the next boot (never under the live store).
+export async function stageRestoreAction(): Promise<StageRestoreResult> {
+  try {
+    const r = await serverTRPC.backup.stageRestore.mutate();
+    revalidatePath("/backups");
+    return { ok: true, staged: r.staged };
+  } catch (error) {
+    return { ok: false, error: message(error) };
+  }
+}
+
+export type RestartResult = { ok: true } | { ok: false; error: string };
+
+export async function restartAction(): Promise<RestartResult> {
+  try {
+    await serverTRPC.backup.restart.mutate();
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: message(error) };
+  }
+}

--- a/apps/dashboard/app/backups/page.tsx
+++ b/apps/dashboard/app/backups/page.tsx
@@ -2,10 +2,16 @@
 // remote + schedule + webhook), and run history. A backup is a `git push` of the
 // memory vault to the configured GitHub repo; restore is `git clone` (runbook).
 
-import { backupNowAction, saveBackupConfigAction } from "./actions";
+import {
+  backupNowAction,
+  restartAction,
+  saveBackupConfigAction,
+  stageRestoreAction,
+} from "./actions";
 import { BackupNowButton } from "@/components/backups/backup-now-button";
 import { BackupConfigForm } from "@/components/backups/config-form";
 import { type BackupCockpitConfig, BackupConfigSummary } from "@/components/backups/config-summary";
+import { RestoreButton } from "@/components/backups/restore-button";
 import { BackupRunsTable } from "@/components/backups/runs-table";
 import { serverTRPC } from "@/lib/trpc-server";
 
@@ -63,11 +69,19 @@ export default async function BackupsPage() {
         <BackupConfigForm initial={config as BackupCockpitConfig} onSave={saveBackupConfigAction} />
       ) : null}
 
+      <section className="rounded-md border bg-card p-4" aria-label="Restore">
+        <h2 className="mb-1 font-semibold">Restore</h2>
+        <p className="mb-3 text-sm text-muted-foreground">
+          Clone the latest backup from the configured repo and swap it in on the next restart. Your
+          current vault is preserved as <code>vault.pre-restore.bak</code>.
+        </p>
+        <RestoreButton onStage={stageRestoreAction} onRestart={restartAction} />
+      </section>
+
       <section className="rounded-md border bg-card p-4" aria-label="Run history">
         <h2 className="mb-3 font-semibold">Run history</h2>
         <p className="mb-3 text-sm text-muted-foreground">
-          Each backup pushes the memory vault to your GitHub repo. To restore, clone the repo into a
-          fresh data dir (see the runbook).
+          Each backup pushes the memory vault to your GitHub repo.
         </p>
         <BackupRunsTable runs={runs} />
       </section>

--- a/apps/dashboard/components/backups/restart-prompt.tsx
+++ b/apps/dashboard/components/backups/restart-prompt.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import type { RestartResult } from "@/app/backups/actions";
+
+export function RestartPrompt({
+  onRestart,
+  stagedFrom,
+}: {
+  onRestart: () => Promise<RestartResult>;
+  stagedFrom?: string;
+}) {
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const restart = () =>
+    startTransition(async () => {
+      const res = await onRestart();
+      if (!res.ok) setError(res.error);
+    });
+
+  return (
+    <div className="flex flex-col gap-2 rounded-md border border-amber-500/50 bg-amber-50 p-3 text-sm dark:bg-amber-950/20">
+      <p>
+        ✓ Restore staged{stagedFrom ? ` from ${stagedFrom}` : ""}.{" "}
+        <strong>Restart required to apply</strong> — the backup is swapped in on the next boot, and
+        your current vault is kept as <code>vault.pre-restore.bak</code>.
+      </p>
+      <p className="text-muted-foreground">
+        Heads up: this only recovers if the server runs under an auto-restart supervisor — otherwise
+        it will <strong>not come back</strong> on its own.
+      </p>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          disabled={pending}
+          onClick={restart}
+          className="rounded-md border bg-destructive px-3 py-1.5 text-sm font-medium text-destructive-foreground disabled:opacity-50"
+        >
+          {pending ? "Restarting…" : "Restart now"}
+        </button>
+        {error ? <span className="text-sm text-destructive">Error: {error}</span> : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/components/backups/restore-button.tsx
+++ b/apps/dashboard/components/backups/restore-button.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { RestartPrompt } from "./restart-prompt";
+import type { RestartResult, StageRestoreResult } from "@/app/backups/actions";
+
+export function RestoreButton({
+  onStage,
+  onRestart,
+}: {
+  onStage: () => Promise<StageRestoreResult>;
+  onRestart: () => Promise<RestartResult>;
+}) {
+  const [pending, startTransition] = useTransition();
+  const [confirming, setConfirming] = useState(false);
+  const [staged, setStaged] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const stage = () =>
+    startTransition(async () => {
+      const res = await onStage();
+      if (res.ok) {
+        setStaged(res.staged);
+        setConfirming(false);
+      } else {
+        setError(res.error);
+      }
+    });
+
+  // Once staged, the only next step is the restart that applies it.
+  if (staged) return <RestartPrompt onRestart={onRestart} stagedFrom={staged} />;
+
+  return (
+    <div className="flex flex-col gap-2">
+      {confirming ? (
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm text-destructive">
+            This clones the latest backup and replaces your current vault on the next restart.
+            Continue?
+          </span>
+          <button
+            type="button"
+            disabled={pending}
+            onClick={stage}
+            className="rounded-md border bg-destructive px-3 py-1.5 text-sm font-medium text-destructive-foreground disabled:opacity-50"
+          >
+            {pending ? "Cloning…" : "Confirm restore"}
+          </button>
+          <button
+            type="button"
+            onClick={() => setConfirming(false)}
+            className="rounded-md border px-3 py-1.5 text-sm font-medium"
+          >
+            Cancel
+          </button>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setConfirming(true)}
+          className="self-start rounded-md border px-3 py-1.5 text-sm font-medium"
+        >
+          Restore from backup…
+        </button>
+      )}
+      {error ? <span className="text-sm text-destructive">Error: {error}</span> : null}
+    </div>
+  );
+}

--- a/apps/dashboard/tests/components/backups/cockpit.test.tsx
+++ b/apps/dashboard/tests/components/backups/cockpit.test.tsx
@@ -7,6 +7,8 @@ vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
 const { BackupConfigSummary } = await import("@/components/backups/config-summary");
 const { BackupConfigForm } = await import("@/components/backups/config-form");
 const { BackupRunsTable } = await import("@/components/backups/runs-table");
+const { RestoreButton } = await import("@/components/backups/restore-button");
+const { RestartPrompt } = await import("@/components/backups/restart-prompt");
 
 type Config = Parameters<typeof BackupConfigSummary>[0]["config"];
 
@@ -92,5 +94,33 @@ describe("BackupRunsTable", () => {
     rerender(<BackupRunsTable runs={[run({ status: "error", error: "boom" })]} />);
     expect(screen.getByText("error")).toBeTruthy();
     expect(screen.getByText("boom")).toBeTruthy();
+  });
+});
+
+describe("RestoreButton → RestartPrompt", () => {
+  it("confirms, stages, then reveals the warned restart prompt", async () => {
+    const onStage = vi.fn().mockResolvedValue({ ok: true, staged: "me/bk" });
+    const onRestart = vi.fn().mockResolvedValue({ ok: true });
+    render(<RestoreButton onStage={onStage} onRestart={onRestart} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Restore from backup/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm restore" }));
+
+    await waitFor(() => expect(screen.getByText(/Restart required to apply/)).toBeTruthy());
+    expect(onStage).toHaveBeenCalledTimes(1);
+    // The load-bearing warning is present.
+    expect(screen.getByText(/not come back/)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Restart now" }));
+    await waitFor(() => expect(onRestart).toHaveBeenCalledTimes(1));
+  });
+});
+
+describe("RestartPrompt", () => {
+  it("surfaces a restart error", async () => {
+    const onRestart = vi.fn().mockResolvedValue({ ok: false, error: "nope" });
+    render(<RestartPrompt onRestart={onRestart} />);
+    fireEvent.click(screen.getByRole("button", { name: "Restart now" }));
+    await waitFor(() => expect(screen.getByText(/Error: nope/)).toBeTruthy());
   });
 });

--- a/packages/core/src/backup/restore-staging.ts
+++ b/packages/core/src/backup/restore-staging.ts
@@ -2,26 +2,27 @@
 // live store (the open git repo + in-memory index), so a restore is two phases:
 //
 //   stageRestore()        — runs in the live server (tRPC): clone the backup remote
-//                           into a staging dir, validate it, and drop a
-//                           `restore.pending.json` marker. Live data is untouched.
+//                           into a staging dir beside the vault, validate it, and
+//                           drop a `restore.pending.json` marker. Live data is
+//                           untouched.
 //   applyPendingRestore() — runs at BOOT, before the store opens: back up the live
-//                           vault to `vault.pre-restore.bak` (reversible), swap the
-//                           clone in, clear the marker. On failure the live vault is
-//                           put back and the marker is quarantined (not retried).
+//                           vault to `<vault>.pre-restore.bak` (reversible), swap
+//                           the clone in, clear the marker. On failure the live
+//                           vault is put back and the marker is quarantined.
 
 import fs from "node:fs";
 import path from "node:path";
+import { resolveVaultPath } from "../store/corpus/index.js";
 import { cloneVaultBackup } from "../store/git/index.js";
 import type { LibrarianStore } from "../store/librarian-store.js";
 import { resolveBackupRemote } from "./config.js";
 
 export const RESTORE_MARKER = "restore.pending.json";
 export const RESTORE_FAILED_MARKER = "restore.failed.json";
-const STAGING_SUBDIR = "restore-staging";
-const STAGED_VAULT = "vault";
-const VAULT_DIR = "vault";
-/** The live vault is moved here before a restore swaps the backup in — reversible. */
-export const PRE_RESTORE_BAK = "vault.pre-restore.bak";
+const PRE_RESTORE_SUFFIX = ".pre-restore.bak";
+const STAGING_NAME = ".restore-staging";
+/** Default-layout pre-restore backup name (display + the default-path tests). */
+export const PRE_RESTORE_BAK = `vault${PRE_RESTORE_SUFFIX}`;
 
 export interface StageRestoreResult {
   /** The "owner/repo" the restore was staged from. */
@@ -40,9 +41,38 @@ interface RestoreMarker {
   staged_at: string;
 }
 
-/** Validate that `dir` is a cloned vault (a git repo on disk). */
-function isClonedVault(dir: string): boolean {
-  return fs.existsSync(path.join(dir, ".git"));
+interface RestorePaths {
+  liveVault: string;
+  stagedVault: string;
+  bak: string;
+  markerPath: string;
+  failedMarkerPath: string;
+}
+
+// Resolve the live vault the SAME way the store does (honors LIBRARIAN_VAULT_PATH),
+// and keep the staging clone + the pre-restore backup as siblings of it — so the
+// swap is always a same-filesystem rename and never silently targets the wrong dir.
+// The marker lives in the data dir, where the boot path looks for it.
+function restorePaths(dataDir: string): RestorePaths {
+  const liveVault = resolveVaultPath({ dataDir });
+  const parent = path.dirname(liveVault);
+  return {
+    liveVault,
+    stagedVault: path.join(parent, STAGING_NAME),
+    bak: `${liveVault}${PRE_RESTORE_SUFFIX}`,
+    markerPath: path.join(dataDir, RESTORE_MARKER),
+    failedMarkerPath: path.join(dataDir, RESTORE_FAILED_MARKER),
+  };
+}
+
+// A restored vault must look like a Librarian vault — a git repo containing at
+// least one known vault directory — so a wrong/arbitrary repo configured as the
+// backup remote can't silently replace it. (A never-committed repo fails the clone
+// before we ever get here.)
+const VAULT_DIRS = ["memories", "inbox", "references", "handoffs", "skills"];
+function isLibrarianVault(dir: string): boolean {
+  if (!fs.existsSync(path.join(dir, ".git"))) return false;
+  return VAULT_DIRS.some((d) => fs.existsSync(path.join(dir, d)));
 }
 
 export function stageRestore(store: LibrarianStore): StageRestoreResult {
@@ -53,9 +83,8 @@ export function stageRestore(store: LibrarianStore): StageRestoreResult {
     );
   }
 
-  const stagingRoot = path.join(store.dataDir, STAGING_SUBDIR);
-  fs.rmSync(stagingRoot, { recursive: true, force: true }); // clear any prior staging
-  const stagedVault = path.join(stagingRoot, STAGED_VAULT);
+  const { stagedVault, markerPath } = restorePaths(store.dataDir);
+  fs.rmSync(stagedVault, { recursive: true, force: true }); // clear any prior staging
 
   cloneVaultBackup({
     remoteUrl: remote.auth.remoteUrl,
@@ -65,38 +94,49 @@ export function stageRestore(store: LibrarianStore): StageRestoreResult {
   });
 
   // Refuse to stage a clone that doesn't look like a vault — better to fail here
-  // (live data untouched) than at boot.
-  if (!isClonedVault(stagedVault)) {
-    fs.rmSync(stagingRoot, { recursive: true, force: true });
-    throw new Error("restore: the cloned backup is not a git repository");
+  // (live data untouched) than swap junk in at boot.
+  if (!isLibrarianVault(stagedVault)) {
+    fs.rmSync(stagedVault, { recursive: true, force: true });
+    throw new Error(
+      "restore: the cloned repo does not look like a Librarian vault " +
+        "(no memories/inbox/references/handoffs) — check the configured backup repo",
+    );
   }
 
   const marker: RestoreMarker = { repo: remote.repo, staged_at: new Date().toISOString() };
-  fs.writeFileSync(
-    path.join(store.dataDir, RESTORE_MARKER),
-    `${JSON.stringify(marker, null, 2)}\n`,
-  );
+  fs.writeFileSync(markerPath, `${JSON.stringify(marker, null, 2)}\n`);
   return { staged: remote.repo, restartRequired: true };
 }
 
 export function applyPendingRestore(dataDir: string): ApplyRestoreResult {
-  const markerPath = path.join(dataDir, RESTORE_MARKER);
+  const { liveVault, stagedVault, bak, markerPath, failedMarkerPath } = restorePaths(dataDir);
   if (!fs.existsSync(markerPath)) return { applied: false };
+
+  // Quarantine the marker so a bad restore neither retries on every boot nor is
+  // silently lost. If quarantining itself fails, leave the pending marker.
+  const quarantine = (marker: RestoreMarker | null, error: string): ApplyRestoreResult => {
+    try {
+      fs.writeFileSync(
+        failedMarkerPath,
+        `${JSON.stringify({ ...(marker ?? {}), error, failed_at: new Date().toISOString() }, null, 2)}\n`,
+      );
+      fs.rmSync(markerPath, { force: true });
+    } catch {
+      /* couldn't quarantine — keep the pending marker rather than lose it */
+    }
+    return { applied: false, ...(marker?.repo ? { repo: marker.repo } : {}), error };
+  };
 
   let marker: RestoreMarker;
   try {
     marker = JSON.parse(fs.readFileSync(markerPath, "utf8")) as RestoreMarker;
   } catch (err) {
-    return { applied: false, error: `unreadable ${RESTORE_MARKER}: ${(err as Error).message}` };
+    return quarantine(null, `unreadable ${RESTORE_MARKER}: ${(err as Error).message}`);
   }
 
-  const stagedVault = path.join(dataDir, STAGING_SUBDIR, STAGED_VAULT);
-  const liveVault = path.join(dataDir, VAULT_DIR);
-  const bak = path.join(dataDir, PRE_RESTORE_BAK);
-
   try {
-    if (!isClonedVault(stagedVault)) {
-      throw new Error("the staged restore is missing or not a git repository");
+    if (!isLibrarianVault(stagedVault)) {
+      throw new Error("the staged restore is missing or does not look like a Librarian vault");
     }
 
     // Back up the live vault (reversible), then swap the clone in. Same-dir renames
@@ -112,22 +152,11 @@ export function applyPendingRestore(dataDir: string): ApplyRestoreResult {
       throw swapErr;
     }
 
-    fs.rmSync(path.join(dataDir, STAGING_SUBDIR), { recursive: true, force: true });
+    fs.rmSync(stagedVault, { recursive: true, force: true });
     fs.rmSync(markerPath, { force: true });
     return { applied: true, repo: marker.repo };
   } catch (err) {
-    // Live data is untouched (or recovered). Quarantine the marker as
-    // `restore.failed.json` — kept for the operator, NOT retried on every boot.
-    const error = (err as Error).message;
-    try {
-      fs.writeFileSync(
-        path.join(dataDir, RESTORE_FAILED_MARKER),
-        `${JSON.stringify({ ...marker, error, failed_at: new Date().toISOString() }, null, 2)}\n`,
-      );
-      fs.rmSync(markerPath, { force: true });
-    } catch {
-      // couldn't quarantine — leave the pending marker rather than lose it
-    }
-    return { applied: false, repo: marker.repo, error };
+    // Live vault is untouched (or recovered); its prior content is in `bak`.
+    return quarantine(marker, (err as Error).message);
   }
 }

--- a/packages/core/src/backup/restore-staging.ts
+++ b/packages/core/src/backup/restore-staging.ts
@@ -1,0 +1,133 @@
+// Restart-staged restore (git-native). The dashboard can't swap the vault under a
+// live store (the open git repo + in-memory index), so a restore is two phases:
+//
+//   stageRestore()        — runs in the live server (tRPC): clone the backup remote
+//                           into a staging dir, validate it, and drop a
+//                           `restore.pending.json` marker. Live data is untouched.
+//   applyPendingRestore() — runs at BOOT, before the store opens: back up the live
+//                           vault to `vault.pre-restore.bak` (reversible), swap the
+//                           clone in, clear the marker. On failure the live vault is
+//                           put back and the marker is quarantined (not retried).
+
+import fs from "node:fs";
+import path from "node:path";
+import { cloneVaultBackup } from "../store/git/index.js";
+import type { LibrarianStore } from "../store/librarian-store.js";
+import { resolveBackupRemote } from "./config.js";
+
+export const RESTORE_MARKER = "restore.pending.json";
+export const RESTORE_FAILED_MARKER = "restore.failed.json";
+const STAGING_SUBDIR = "restore-staging";
+const STAGED_VAULT = "vault";
+const VAULT_DIR = "vault";
+/** The live vault is moved here before a restore swaps the backup in — reversible. */
+export const PRE_RESTORE_BAK = "vault.pre-restore.bak";
+
+export interface StageRestoreResult {
+  /** The "owner/repo" the restore was staged from. */
+  staged: string;
+  restartRequired: true;
+}
+
+export interface ApplyRestoreResult {
+  applied: boolean;
+  repo?: string;
+  error?: string;
+}
+
+interface RestoreMarker {
+  repo: string;
+  staged_at: string;
+}
+
+/** Validate that `dir` is a cloned vault (a git repo on disk). */
+function isClonedVault(dir: string): boolean {
+  return fs.existsSync(path.join(dir, ".git"));
+}
+
+export function stageRestore(store: LibrarianStore): StageRestoreResult {
+  const remote = resolveBackupRemote(store);
+  if (!remote) {
+    throw new Error(
+      "restore: no backup remote configured — set the GitHub repo + token in the backup settings",
+    );
+  }
+
+  const stagingRoot = path.join(store.dataDir, STAGING_SUBDIR);
+  fs.rmSync(stagingRoot, { recursive: true, force: true }); // clear any prior staging
+  const stagedVault = path.join(stagingRoot, STAGED_VAULT);
+
+  cloneVaultBackup({
+    remoteUrl: remote.auth.remoteUrl,
+    branch: remote.auth.branch,
+    token: remote.auth.token,
+    dest: stagedVault,
+  });
+
+  // Refuse to stage a clone that doesn't look like a vault — better to fail here
+  // (live data untouched) than at boot.
+  if (!isClonedVault(stagedVault)) {
+    fs.rmSync(stagingRoot, { recursive: true, force: true });
+    throw new Error("restore: the cloned backup is not a git repository");
+  }
+
+  const marker: RestoreMarker = { repo: remote.repo, staged_at: new Date().toISOString() };
+  fs.writeFileSync(
+    path.join(store.dataDir, RESTORE_MARKER),
+    `${JSON.stringify(marker, null, 2)}\n`,
+  );
+  return { staged: remote.repo, restartRequired: true };
+}
+
+export function applyPendingRestore(dataDir: string): ApplyRestoreResult {
+  const markerPath = path.join(dataDir, RESTORE_MARKER);
+  if (!fs.existsSync(markerPath)) return { applied: false };
+
+  let marker: RestoreMarker;
+  try {
+    marker = JSON.parse(fs.readFileSync(markerPath, "utf8")) as RestoreMarker;
+  } catch (err) {
+    return { applied: false, error: `unreadable ${RESTORE_MARKER}: ${(err as Error).message}` };
+  }
+
+  const stagedVault = path.join(dataDir, STAGING_SUBDIR, STAGED_VAULT);
+  const liveVault = path.join(dataDir, VAULT_DIR);
+  const bak = path.join(dataDir, PRE_RESTORE_BAK);
+
+  try {
+    if (!isClonedVault(stagedVault)) {
+      throw new Error("the staged restore is missing or not a git repository");
+    }
+
+    // Back up the live vault (reversible), then swap the clone in. Same-dir renames
+    // are atomic; if the swap fails after the backup, put the live vault back so a
+    // failed restore never loses data.
+    fs.rmSync(bak, { recursive: true, force: true }); // drop any prior pre-restore backup
+    const hadLive = fs.existsSync(liveVault);
+    if (hadLive) fs.renameSync(liveVault, bak);
+    try {
+      fs.renameSync(stagedVault, liveVault);
+    } catch (swapErr) {
+      if (hadLive) fs.renameSync(bak, liveVault); // recover the live vault
+      throw swapErr;
+    }
+
+    fs.rmSync(path.join(dataDir, STAGING_SUBDIR), { recursive: true, force: true });
+    fs.rmSync(markerPath, { force: true });
+    return { applied: true, repo: marker.repo };
+  } catch (err) {
+    // Live data is untouched (or recovered). Quarantine the marker as
+    // `restore.failed.json` — kept for the operator, NOT retried on every boot.
+    const error = (err as Error).message;
+    try {
+      fs.writeFileSync(
+        path.join(dataDir, RESTORE_FAILED_MARKER),
+        `${JSON.stringify({ ...marker, error, failed_at: new Date().toISOString() }, null, 2)}\n`,
+      );
+      fs.rmSync(markerPath, { force: true });
+    } catch {
+      // couldn't quarantine — leave the pending marker rather than lose it
+    }
+    return { applied: false, repo: marker.repo, error };
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -226,6 +226,7 @@ export {
   type GitOps,
   type GitPushAuth,
   type SyncGitOps,
+  cloneVaultBackup,
   createGitOps,
   createSyncGitOps,
 } from "./store/git/index.js";
@@ -312,6 +313,15 @@ export {
   resolveBackend,
   resolveDataDir,
 } from "./store/librarian-store.js";
+export {
+  type ApplyRestoreResult,
+  type StageRestoreResult,
+  PRE_RESTORE_BAK,
+  RESTORE_FAILED_MARKER,
+  RESTORE_MARKER,
+  applyPendingRestore,
+  stageRestore,
+} from "./backup/restore-staging.js";
 // Portable data export (distinct from backup — a human/tool-readable dump).
 export { type ExportFormat, exportData } from "./backup/export.js";
 export { type GithubSyncConfig, resolveGithubSyncConfig } from "./backup/sync/github-config.js";

--- a/packages/core/src/store/git/index.ts
+++ b/packages/core/src/store/git/index.ts
@@ -2,4 +2,9 @@
 // in Phase 7). Spec 035 §F12.
 
 export { type GitOps, createGitOps } from "./git-ops.js";
-export { type GitPushAuth, type SyncGitOps, createSyncGitOps } from "./sync-git-ops.js";
+export {
+  type GitPushAuth,
+  type SyncGitOps,
+  cloneVaultBackup,
+  createSyncGitOps,
+} from "./sync-git-ops.js";

--- a/packages/core/src/store/git/sync-git-ops.ts
+++ b/packages/core/src/store/git/sync-git-ops.ts
@@ -114,37 +114,69 @@ export function createSyncGitOps(opts: { cwd: string }): SyncGitOps {
   }
 
   function push(auth: GitPushAuth): void {
-    // GIT_ASKPASS feeds the token to git when it prompts for the password. The
-    // helper reads it from the child env var `LIBRARIAN_GIT_TOKEN` (not its argv),
-    // and the remote URL carries only the `x-access-token@` username — so git asks
-    // for the password only, and the token never lands in the URL, .git/config,
-    // the command line, or any error output. The remote is passed inline (never
-    // `git remote add`-ed), so `.git/config` stays clean.
-    const askDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-askpass-"));
-    const helper = path.join(askDir, "askpass.sh");
-    fs.writeFileSync(helper, '#!/bin/sh\nprintf "%s" "$LIBRARIAN_GIT_TOKEN"\n', { mode: 0o700 });
-    try {
-      git(["push", auth.remoteUrl, `${auth.ref ?? "HEAD"}:refs/heads/${auth.branch}`], {
-        GIT_ASKPASS: helper,
-        GIT_TERMINAL_PROMPT: "0",
-        LIBRARIAN_GIT_TOKEN: auth.token,
-      });
-    } catch (err) {
-      // The token is env-only (never in the URL/argv), but scrub it from the
-      // error message + stderr at the source so every caller surfaces a
-      // token-free error, in case a future git echoes the credential.
-      if (err instanceof Error && auth.token) {
-        err.message = err.message.split(auth.token).join("***");
-        const withStderr = err as Error & { stderr?: unknown };
-        if (typeof withStderr.stderr === "string") {
-          withStderr.stderr = withStderr.stderr.split(auth.token).join("***");
-        }
-      }
-      throw err;
-    } finally {
-      fs.rmSync(askDir, { recursive: true, force: true });
-    }
+    // The remote URL carries only the `x-access-token@` username and is passed
+    // inline (never `git remote add`-ed), so `.git/config` stays clean; the token
+    // is fed to git via GIT_ASKPASS (env-only) and scrubbed from errors at source.
+    runGitWithToken(
+      ["push", auth.remoteUrl, `${auth.ref ?? "HEAD"}:refs/heads/${auth.branch}`],
+      auth.token,
+      opts.cwd,
+    );
   }
 
   return { init, commitAll, head, log, isRepo, push };
+}
+
+/**
+ * Run a git command with a token supplied via a transient GIT_ASKPASS helper. The
+ * helper reads the token from the child env (`LIBRARIAN_GIT_TOKEN`), not its argv,
+ * so the token never lands in the URL, `.git/config`, the command line (`ps`), or
+ * git's error output (scrubbed from message + stderr at the source). Shared by
+ * push + clone.
+ */
+function runGitWithToken(args: string[], token: string, cwd?: string): string {
+  const askDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-askpass-"));
+  const helper = path.join(askDir, "askpass.sh");
+  fs.writeFileSync(helper, '#!/bin/sh\nprintf "%s" "$LIBRARIAN_GIT_TOKEN"\n', { mode: 0o700 });
+  try {
+    return execFileSync("git", args, {
+      ...(cwd ? { cwd } : {}),
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        GIT_ASKPASS: helper,
+        GIT_TERMINAL_PROMPT: "0",
+        LIBRARIAN_GIT_TOKEN: token,
+      },
+    });
+  } catch (err) {
+    if (err instanceof Error && token) {
+      err.message = err.message.split(token).join("***");
+      const withStderr = err as Error & { stderr?: unknown };
+      if (typeof withStderr.stderr === "string") {
+        withStderr.stderr = withStderr.stderr.split(token).join("***");
+      }
+    }
+    throw err;
+  } finally {
+    fs.rmSync(askDir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Clone the backup remote (the git-pushed vault) into `dest`, token-safe via the
+ * same GIT_ASKPASS path as push. `dest` must not already exist (git refuses).
+ */
+export function cloneVaultBackup(opts: {
+  remoteUrl: string;
+  branch: string;
+  token: string;
+  dest: string;
+}): void {
+  fs.mkdirSync(path.dirname(opts.dest), { recursive: true });
+  runGitWithToken(
+    ["clone", "--branch", opts.branch, "--single-branch", opts.remoteUrl, opts.dest],
+    opts.token,
+  );
 }

--- a/packages/core/tests/backup-restore.test.ts
+++ b/packages/core/tests/backup-restore.test.ts
@@ -1,0 +1,90 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type LibrarianStore,
+  PRE_RESTORE_BAK,
+  RESTORE_FAILED_MARKER,
+  RESTORE_MARKER,
+  applyPendingRestore,
+  stageRestore,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "lib-restore-"));
+});
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+// A cloned vault is a git repo dir; fabricate one (the real clone is covered by
+// cloneVaultBackup's own test).
+function makeVault(dir: string, content: string, asRepo = true): void {
+  fs.mkdirSync(path.join(dir, "memories"), { recursive: true });
+  fs.writeFileSync(path.join(dir, "memories", "a.md"), content);
+  if (asRepo) execFileSync("git", ["init"], { cwd: dir, stdio: "ignore" });
+}
+
+function writeMarker(): void {
+  fs.writeFileSync(
+    path.join(dataDir, RESTORE_MARKER),
+    JSON.stringify({ repo: "me/bk", staged_at: new Date().toISOString() }),
+  );
+}
+
+describe("stageRestore", () => {
+  it("throws when no backup remote is configured", async () => {
+    const { createLibrarianStore } = await import("@librarian/core");
+    const store: LibrarianStore = createLibrarianStore({ dataDir });
+    try {
+      expect(() => stageRestore(store)).toThrow(/no backup remote/);
+    } finally {
+      store.close();
+    }
+  });
+});
+
+describe("applyPendingRestore", () => {
+  it("no-ops when there is no pending marker", () => {
+    expect(applyPendingRestore(dataDir)).toEqual({ applied: false });
+  });
+
+  it("swaps the staged vault in and preserves the live vault as a backup", () => {
+    makeVault(path.join(dataDir, "vault"), "live\n");
+    makeVault(path.join(dataDir, "restore-staging", "vault"), "restored\n");
+    writeMarker();
+
+    expect(applyPendingRestore(dataDir)).toEqual({ applied: true, repo: "me/bk" });
+
+    // The vault is now the restored content; the live vault is kept as a backup.
+    expect(fs.readFileSync(path.join(dataDir, "vault", "memories", "a.md"), "utf8")).toBe(
+      "restored\n",
+    );
+    expect(fs.readFileSync(path.join(dataDir, PRE_RESTORE_BAK, "memories", "a.md"), "utf8")).toBe(
+      "live\n",
+    );
+    // Marker + staging cleared.
+    expect(fs.existsSync(path.join(dataDir, RESTORE_MARKER))).toBe(false);
+    expect(fs.existsSync(path.join(dataDir, "restore-staging"))).toBe(false);
+  });
+
+  it("quarantines the marker and leaves the live vault when the staged clone is invalid", () => {
+    makeVault(path.join(dataDir, "vault"), "live\n");
+    // A staged dir that is NOT a git repo → invalid restore.
+    makeVault(path.join(dataDir, "restore-staging", "vault"), "junk\n", false);
+    writeMarker();
+
+    const result = applyPendingRestore(dataDir);
+    expect(result.applied).toBe(false);
+    expect(result.error).toBeTruthy();
+
+    // Live vault untouched; pending marker quarantined (not retried).
+    expect(fs.readFileSync(path.join(dataDir, "vault", "memories", "a.md"), "utf8")).toBe("live\n");
+    expect(fs.existsSync(path.join(dataDir, RESTORE_MARKER))).toBe(false);
+    expect(fs.existsSync(path.join(dataDir, RESTORE_FAILED_MARKER))).toBe(true);
+  });
+});

--- a/packages/core/tests/backup-restore.test.ts
+++ b/packages/core/tests/backup-restore.test.ts
@@ -10,7 +10,7 @@ import {
   applyPendingRestore,
   stageRestore,
 } from "@librarian/core";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 let dataDir: string;
 
@@ -19,6 +19,7 @@ beforeEach(() => {
 });
 afterEach(() => {
   fs.rmSync(dataDir, { recursive: true, force: true });
+  vi.unstubAllEnvs();
 });
 
 // A cloned vault is a git repo dir; fabricate one (the real clone is covered by
@@ -55,7 +56,7 @@ describe("applyPendingRestore", () => {
 
   it("swaps the staged vault in and preserves the live vault as a backup", () => {
     makeVault(path.join(dataDir, "vault"), "live\n");
-    makeVault(path.join(dataDir, "restore-staging", "vault"), "restored\n");
+    makeVault(path.join(dataDir, ".restore-staging"), "restored\n");
     writeMarker();
 
     expect(applyPendingRestore(dataDir)).toEqual({ applied: true, repo: "me/bk" });
@@ -69,13 +70,13 @@ describe("applyPendingRestore", () => {
     );
     // Marker + staging cleared.
     expect(fs.existsSync(path.join(dataDir, RESTORE_MARKER))).toBe(false);
-    expect(fs.existsSync(path.join(dataDir, "restore-staging"))).toBe(false);
+    expect(fs.existsSync(path.join(dataDir, ".restore-staging"))).toBe(false);
   });
 
   it("quarantines the marker and leaves the live vault when the staged clone is invalid", () => {
     makeVault(path.join(dataDir, "vault"), "live\n");
     // A staged dir that is NOT a git repo → invalid restore.
-    makeVault(path.join(dataDir, "restore-staging", "vault"), "junk\n", false);
+    makeVault(path.join(dataDir, ".restore-staging"), "junk\n", false);
     writeMarker();
 
     const result = applyPendingRestore(dataDir);
@@ -86,5 +87,37 @@ describe("applyPendingRestore", () => {
     expect(fs.readFileSync(path.join(dataDir, "vault", "memories", "a.md"), "utf8")).toBe("live\n");
     expect(fs.existsSync(path.join(dataDir, RESTORE_MARKER))).toBe(false);
     expect(fs.existsSync(path.join(dataDir, RESTORE_FAILED_MARKER))).toBe(true);
+  });
+
+  it("rejects a clone that is a git repo but not a Librarian vault", () => {
+    makeVault(path.join(dataDir, "vault"), "live\n");
+    // A git repo with no vault dirs (e.g. the wrong repo configured as the remote).
+    const staged = path.join(dataDir, ".restore-staging");
+    fs.mkdirSync(staged, { recursive: true });
+    fs.writeFileSync(path.join(staged, "README.md"), "not a vault\n");
+    execFileSync("git", ["init"], { cwd: staged, stdio: "ignore" });
+    writeMarker();
+
+    expect(applyPendingRestore(dataDir).applied).toBe(false);
+    expect(fs.readFileSync(path.join(dataDir, "vault", "memories", "a.md"), "utf8")).toBe("live\n");
+    expect(fs.existsSync(path.join(dataDir, RESTORE_FAILED_MARKER))).toBe(true);
+  });
+
+  it("restores the LIBRARIAN_VAULT_PATH vault, not <dataDir>/vault", () => {
+    const customVault = path.join(dataDir, "custom-vault");
+    vi.stubEnv("LIBRARIAN_VAULT_PATH", customVault);
+    makeVault(customVault, "live\n");
+    makeVault(path.join(dataDir, ".restore-staging"), "restored\n");
+    writeMarker();
+
+    expect(applyPendingRestore(dataDir).applied).toBe(true);
+    // The configured vault is the one that was swapped, with its prior copy kept.
+    expect(fs.readFileSync(path.join(customVault, "memories", "a.md"), "utf8")).toBe("restored\n");
+    expect(
+      fs.readFileSync(
+        path.join(dataDir, "custom-vault.pre-restore.bak", "memories", "a.md"),
+        "utf8",
+      ),
+    ).toBe("live\n");
   });
 });

--- a/packages/core/tests/store/git/sync-git-ops.test.ts
+++ b/packages/core/tests/store/git/sync-git-ops.test.ts
@@ -9,7 +9,7 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { createSyncGitOps } from "@librarian/core";
+import { cloneVaultBackup, createSyncGitOps } from "@librarian/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 let cwd: string;
@@ -137,6 +137,29 @@ describe("sync git-ops", () => {
       expect(config).not.toContain("leak-canary-token");
     } finally {
       fs.rmSync(remote, { recursive: true, force: true });
+    }
+  });
+
+  it("cloneVaultBackup clones a remote branch into a fresh dir", () => {
+    const git = createSyncGitOps({ cwd });
+    git.init();
+    write("memories/a.md", "hello\n");
+    git.commitAll("memory: a");
+
+    const remote = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-remote-"));
+    const dest = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-clone-"));
+    fs.rmSync(dest, { recursive: true, force: true }); // git clone refuses an existing dir
+    try {
+      execFileSync("git", ["init", "--bare", remote], { stdio: "ignore" });
+      git.push({ remoteUrl: remote, branch: "main", token: "unused" });
+
+      cloneVaultBackup({ remoteUrl: remote, branch: "main", token: "unused", dest });
+
+      expect(fs.existsSync(path.join(dest, ".git"))).toBe(true);
+      expect(fs.readFileSync(path.join(dest, "memories", "a.md"), "utf8")).toBe("hello\n");
+    } finally {
+      fs.rmSync(remote, { recursive: true, force: true });
+      fs.rmSync(dest, { recursive: true, force: true });
     }
   });
 });

--- a/packages/core/tests/store/git/sync-git-ops.test.ts
+++ b/packages/core/tests/store/git/sync-git-ops.test.ts
@@ -153,10 +153,14 @@ describe("sync git-ops", () => {
       execFileSync("git", ["init", "--bare", remote], { stdio: "ignore" });
       git.push({ remoteUrl: remote, branch: "main", token: "unused" });
 
-      cloneVaultBackup({ remoteUrl: remote, branch: "main", token: "unused", dest });
+      cloneVaultBackup({ remoteUrl: remote, branch: "main", token: "clone-leak-canary", dest });
 
       expect(fs.existsSync(path.join(dest, ".git"))).toBe(true);
       expect(fs.readFileSync(path.join(dest, "memories", "a.md"), "utf8")).toBe("hello\n");
+      // The token (fed via GIT_ASKPASS) must never land in the cloned repo's config.
+      expect(fs.readFileSync(path.join(dest, ".git", "config"), "utf8")).not.toContain(
+        "clone-leak-canary",
+      );
     } finally {
       fs.rmSync(remote, { recursive: true, force: true });
       fs.rmSync(dest, { recursive: true, force: true });

--- a/packages/mcp-server/src/bin/http.ts
+++ b/packages/mcp-server/src/bin/http.ts
@@ -7,6 +7,7 @@
 
 import fs from "node:fs";
 import {
+  applyPendingRestore,
   createLibrarianStore,
   createSerialScheduler,
   findLegacyScheduleKeys,
@@ -72,6 +73,25 @@ try {
 } catch (error) {
   logger.fatal(`Invalid boot credentials: ${(error as Error).message}`);
   process.exit(1);
+}
+
+// Apply a dashboard-staged restore BEFORE the store opens — the vault dir is
+// swapped while no store holds it. A failed restore leaves the live vault in place
+// (or recovers it) and quarantines the marker for the operator.
+{
+  const restore = applyPendingRestore(dataDir);
+  if (restore.applied) {
+    logger.warn(
+      { repo: restore.repo },
+      "applied a staged restore (vault cloned from backup) on boot",
+    );
+  } else if (restore.error) {
+    logger.error(
+      { repo: restore.repo, reason: restore.error },
+      "staged restore failed on boot; live vault left in place. The pending marker was " +
+        "quarantined to restore.failed.json (not retried) — inspect it and re-stage to retry.",
+    );
+  }
 }
 
 const store = createLibrarianStore({ secretKey, dataDir, backend: resolveBackend() });

--- a/packages/mcp-server/src/bin/stdio.ts
+++ b/packages/mcp-server/src/bin/stdio.ts
@@ -7,6 +7,7 @@
 
 import fs from "node:fs";
 import {
+  applyPendingRestore,
   createLibrarianStore,
   resolveBackend,
   resolveBootCredentials,
@@ -37,6 +38,17 @@ try {
   process.stderr.write(`Invalid LIBRARIAN_SECRET_KEY: ${(error as Error).message}\n`);
   process.exit(1);
 }
+// Apply a dashboard-staged restore BEFORE the store opens — the vault dir is
+// swapped while nothing holds it. A failed restore leaves the live vault in place.
+{
+  const restore = applyPendingRestore(dataDir);
+  if (restore.error) {
+    process.stderr.write(
+      `Staged restore failed on boot; live vault left in place (quarantined to restore.failed.json): ${restore.error}\n`,
+    );
+  }
+}
+
 const store = createLibrarianStore({ secretKey, dataDir, backend: resolveBackend() });
 
 process.stdin.setEncoding("utf8");

--- a/packages/mcp-server/src/trpc/backup.ts
+++ b/packages/mcp-server/src/trpc/backup.ts
@@ -89,10 +89,12 @@ export const backupRouter = router({
 
   // Exit the server so the supervisor/orchestrator restarts it (applying any staged
   // restore on boot). The cockpit's "Restart now" button warns that this only
-  // recovers under an auto-restart supervisor. The exit is deferred so the
-  // { restarting: true } ack flushes first.
+  // recovers under an auto-restart supervisor. Sends SIGTERM (not a raw exit) so the
+  // bin's graceful shutdown runs — schedulers stop + `store.close()` — before the
+  // process leaves, so the next boot applies the restore on a quiesced vault. The
+  // signal is deferred so the { restarting: true } ack flushes first.
   restart: adminProcedure.mutation(() => {
-    setTimeout(() => process.exit(0), 250);
+    setTimeout(() => process.kill(process.pid, "SIGTERM"), 250);
     return { restarting: true as const };
   }),
 });

--- a/packages/mcp-server/src/trpc/backup.ts
+++ b/packages/mcp-server/src/trpc/backup.ts
@@ -9,6 +9,7 @@ import {
   listBackupRuns,
   readBackupConfig,
   runBackup,
+  stageRestore,
   writeBackupConfig,
 } from "@librarian/core";
 import { z } from "zod";
@@ -78,5 +79,20 @@ export const backupRouter = router({
     }
 
     return { ok: true };
+  }),
+
+  // Stage a restore: clone the backup remote into a staging dir and write the
+  // pending-restore marker. It is APPLIED on the next boot — never under the live
+  // store (the vault dir is swapped while nothing holds it). The cockpit then
+  // prompts a restart.
+  stageRestore: adminProcedure.mutation(({ ctx }) => stageRestore(ctx.store)),
+
+  // Exit the server so the supervisor/orchestrator restarts it (applying any staged
+  // restore on boot). The cockpit's "Restart now" button warns that this only
+  // recovers under an auto-restart supervisor. The exit is deferred so the
+  // { restarting: true } ack flushes first.
+  restart: adminProcedure.mutation(() => {
+    setTimeout(() => process.exit(0), 250);
+    return { restarting: true as const };
   }),
 });


### PR DESCRIPTION
## Spec 040 / PR-6 (B3) — git-native restore

Completes the backup/restore feature B2 left at "restore is a git clone (runbook)". Restore now clones the backup repo and swaps it into the vault on the next restart, with safety nets, available from the dashboard `/backups` page.

### Flow (two-phase, restart-gated)
- **`stageRestore(store)`** (live server / tRPC): clone the configured remote into a staging dir beside the vault, validate it looks like a Librarian vault, drop a `restore.pending.json` marker. **Live data untouched.**
- **`applyPendingRestore(dataDir)`** (at boot, before the store opens — `http.ts` *and* `stdio.ts`): back up the live vault to `<vault>.pre-restore.bak` (reversible), swap the clone in via same-filesystem atomic renames, recover the live vault if the swap fails, clear/quarantine the marker.

### Safety nets
- validate-before-swap (must be a git repo **with a known vault dir** — a wrong/arbitrary repo can't silently replace your memories)
- reversible: the prior vault is kept as `<vault>.pre-restore.bak`
- restart-gated: nothing mutates the live vault while the store is open
- honors `LIBRARIAN_VAULT_PATH` (resolves the live vault the same way the store does)
- failed/unreadable marker is **quarantined** (no per-boot error loop)
- token-safe clone via the same GIT_ASKPASS path as push (shared `runGitWithToken`)

### Restart
The dashboard "Restart now" sends **SIGTERM** (graceful shutdown — schedulers stop + `store.close()`), not a raw `process.exit`, and the prompt warns it only recovers under an auto-restart supervisor.

### Review
A focused sub-agent review (data-loss + token-safety) found 4 Important issues — all fixed in the 2nd commit: graceful restart, `LIBRARIAN_VAULT_PATH` silent-no-op, loose validation, and stdio boot-apply. Two minor suggestions deferred (logged in build notes).

## Verification
- `pnpm typecheck` + `build` + `lint` — green
- `pnpm test` — green (core 823·1skip, mcp 111, cli 44, dashboard 159, root 22)
- `pnpm smoke` + `pnpm healthcheck` + `check:no-secrets-in-vault` — green
- `applyPendingRestore` swap / recovery / quarantine / vault-path / validation all unit-tested; `cloneVaultBackup` (incl. token-not-in-config) against a local bare repo. The github.com clone happy path isn't unit-tested (network).

🤖 Generated with [Claude Code](https://claude.com/claude-code)