### PR TITLE
docs(skill): curator owns consolidation; drop classifier/domain residue

### DIFF
--- a/.claude/commands/learn.md
+++ b/.claude/commands/learn.md
@@ -35,10 +35,9 @@ Render the candidate lessons as a numbered multi-select list. For each, show a o
 For each chosen lesson, call `propose_memory` (not `remember`) with:
 
 - `title`, `body`, `tags`, `applies_to` — derived from the candidate.
-- `conv_id` — the harness conversation id (so the server can resolve `domain` from `conv_state`).
 
-Protected categories (identity, relationship) are routed through the existing proposal flow automatically by the classifier worker; nothing extra to do here.
+Protected categories (identity, relationship) are routed through the proposal flow automatically by the server; nothing extra to do here.
 
 ## Report
 
-Tell the user how many lessons landed as proposals and where they can review them ([dashboard /proposals](http://localhost:3838/proposals) or `/lib-session-list` etc.).
+Tell the user how many lessons landed as proposals and where they can review them ([dashboard /proposals](http://localhost:3838/proposals)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,18 @@ changes from this point forward are catalogued here.
 
 ### Changed
 
+- **Agent guidance: the curator owns consolidation.** The `use-the-librarian`
+  skill no longer tells agents to recall/search for duplicates before
+  `remember`, or to hand-consolidate via `update` + `verify(outdated)` — the
+  consolidator/curator de-duplicates, merges, and supersedes asynchronously
+  (with the consolidator on, `remember` is fire-and-forget and returns no
+  `duplicates` list). The `/learn` command drops its stale `conv_id`→`domain`
+  resolution and "classifier worker" references. Docs accuracy: README drops the
+  retired `domain` handoff scope, the removed `/logs` + `/recall` dashboard tabs,
+  and the stale "JSONL ledgers + SQLite/FTS5 index" storage line (it's a
+  git-backed markdown vault now); the skill's storage example is updated to match.
+  (The harness plugin repos carry the same agent-guidance fix.)
+
 - **The per-turn `<conversation-state>` block is trimmed to `conv_id` +
   `off_record`.** D16 had already removed the `domain` line from the canonical
   renderer; the `session_id` line is now dropped too — the session lifecycle that

--- a/README.md
+++ b/README.md
@@ -116,11 +116,12 @@ That's it — memory tools and the handoff surface are live.
   promotes lessons from the conversation into memory proposals.
 - **Memory curator** — an optional scheduled LLM pass that grooms memory
   (dedupe, archive stale, refine), configured and observed from the dashboard.
-- **Dashboard** — a Next.js admin cockpit (Memories, Handoffs, Recall,
-  Proposals, Archive, Logs, Analytics, Curator) with a ⌘K command palette.
+- **Dashboard** — a Next.js admin cockpit (Memories, Handoffs, Proposals,
+  Archive, Analytics, Curator, Backups) with a ⌘K command palette.
 
-Event-sourced and dependency-light: append-only JSONL ledgers + a generated
-SQLite/FTS5 index over the built-in `node:sqlite` — no external database to run.
+Markdown-native and dependency-light: memories are plain `[[wikilinked]]` notes
+in a git-backed vault, recall runs over a disposable in-memory index rebuilt from
+the vault — no external database to run.
 
 ## Quick start
 
@@ -189,11 +190,11 @@ approves.
 
 - `store_handoff` — store a handoff document (five required headings) for the
   next agent / harness to pick up.
-- `list_handoffs` — list handoffs in the current domain / project / cwd.
+- `list_handoffs` — list handoffs in the current project / cwd.
 - `claim_handoff` — atomically claim a handoff by id.
 
-Handoffs are domain-isolated by default. Claiming is one-shot per handoff —
-once claimed, the row is closed to other callers.
+Claiming is one-shot per handoff — once claimed, the row is closed to other
+callers.
 
 ## Slash commands
 
@@ -227,7 +228,7 @@ the-librarian auth disable                             # break-glass: turn enfor
 ```
 
 Every handoff verb supports `--json`, `--agent <id>`, `--admin`, and the
-domain / project / cwd / harness scope flags.
+project / cwd / harness scope flags.
 
 ## Memory curator
 

--- a/skills/use-the-librarian/SKILL.md
+++ b/skills/use-the-librarian/SKILL.md
@@ -15,7 +15,7 @@ Memories live in one of three states:
 - `proposed` — protected category awaiting user approval
 - `archived` — no longer surfaced by default recall
 
-The reason a memory is archived (rejected proposal, agent verified it as outdated, admin archived it) lives in the events ledger via the originating event type — there is no separate `deleted`, `rejected`, or `conflicted` state.
+A memory is archived for one of several reasons (rejected proposal, agent verified it as outdated, admin archived it) — there is no separate `deleted`, `rejected`, or `conflicted` state.
 
 The Librarian returns clean prose context for agent use. Do not expose raw metadata to the user unless asked.
 
@@ -146,15 +146,15 @@ Operational direct-write example:
 ```json
 {
   "agent_id": "guybrush",
-  "title": "The Librarian uses JSONL as canonical storage",
-  "body": "In the-librarian, `data/events.jsonl` is the source of truth; SQLite and Markdown snapshots are generated from it.",
+  "title": "The Librarian stores memories as a git-backed markdown vault",
+  "body": "In the-librarian, memories are plain markdown notes in a git vault (a commit per write); recall runs over a disposable in-memory index rebuilt from the vault. There is no SQL database.",
   "category": "projects",
   "visibility": "common",
   "scope": "project",
   "project_key": "the-librarian",
   "priority": "high",
   "confidence": "strong",
-  "tags": ["storage", "jsonl", "sqlite"]
+  "tags": ["storage", "markdown", "vault"]
 }
 ```
 
@@ -174,19 +174,13 @@ Use `remember` for active technical, project, environment, tool, lesson, people,
 
 Use `propose_memory` for protected or user-review-worthy memories.
 
-If the server returns possible duplicates, do not create near-identical clutter. Prefer updating the existing memory, superseding it, or asking for resolution.
+Write the smallest useful memory. You do **not** need to `recall` or search for existing memories first to avoid duplicates — the curator/consolidator de-duplicates, merges, and supersedes for you, asynchronously.
 
-`remember` always saves. If similar memories already exist they come back on the response as `duplicates` (informational). Treat that list as a nudge to consolidate manually — update the canonical memory and call `verify_memory result=outdated` against the duplicates — not as a refusal.
+## Consolidation is automatic
 
-## Duplicates and Consolidation
+When the consolidator is enabled, `remember` is fire-and-forget: it returns `queued for consolidation` (no `duplicates` list), and the curator later navigates, judges, merges, and supersedes your submission as it grooms the corpus. You do not hand-consolidate.
 
-When `remember` returns duplicates, decide:
-
-- **Same fact, better wording** — `update_memory` the canonical entry with the clearer text, then `verify_memory result=outdated` against the new duplicate you just created.
-- **Different scopes** — leave both. The recall layer will rank by query relevance.
-- **Older one is wrong** — `verify_memory result=outdated` against the older memory.
-
-There is no `resolve_conflict` verb anymore. Consolidation is `update` + `verify(outdated)`.
+On a legacy install with the consolidator off, `remember` saves directly and may return a `duplicates` list — that's informational, never a refusal. You generally don't need to act on it; reserve `update_memory` / `verify_memory result=outdated` for genuine corrections (see below), not as a manual dedup pass. (The `resolve_conflict` verb is retired.)
 
 ## Update and Verify
 
@@ -269,7 +263,7 @@ Keep it brief.
 
 - `start_context`: required task-start context
 - `recall`: targeted search
-- `remember`: save active memory; protected categories become proposals; always succeeds, returns `duplicates`
+- `remember`: submit a memory. With the consolidator on it's queued for async consolidation (the curator dedupes/merges); otherwise it saves directly. Protected categories become proposals.
 - `propose_memory`: submit protected or review-worthy memory
 - `update_memory`: edit while preserving history
 - `verify_memory`: useful (+1), not_useful (-1), outdated (archive)


### PR DESCRIPTION
Agent-facing guidance was telling agents to do work the curator/consolidator now owns.

- **SKILL.md** — replace the "Duplicates and Consolidation" manual recipe (`update` + `verify(outdated)`) with "consolidation is automatic": agents just write the memory, no recall-before-remember, no hand-consolidation. With the consolidator on, `remember` is fire-and-forget and returns no `duplicates` list; a one-line note covers legacy consolidator-off installs. Tool-map `remember` line updated.
- **.claude/commands/learn.md** — drop the `conv_id`→`domain` resolution (D16 removed the domain model) and the "classifier worker" reference (classifier subsystem removed).
- **README.md** — drop the retired `domain` scope from the handoff verb wording.

Docs-only. The five harness plugin repos carry the same fix in coordinated PRs (lockstep cross-harness contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)