### PR TITLE
refactor(core): trim the conv-state block to conv_id + off_record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ changes from this point forward are catalogued here.
 
 ### Changed
 
+- **The per-turn `<conversation-state>` block is trimmed to `conv_id` +
+  `off_record`.** D16 had already removed the `domain` line from the canonical
+  renderer; the `session_id` line is now dropped too — the session lifecycle that
+  populated it is retired, so it was always `none`. `off_record` (the privacy
+  signal) and `conv_id` (the key) remain. The five harness plugins, which mirror
+  this block byte-for-byte, are updated in lockstep.
+
 - **Backup is now `git push` of the memory vault.** On the markdown backend the
   old backup bundled an empty `librarian.sqlite` (memories live in the git vault,
   not SQLite) — so it backed up almost nothing. Backup now pushes the vault repo

--- a/packages/core/src/conv-state-render.ts
+++ b/packages/core/src/conv-state-render.ts
@@ -15,22 +15,20 @@ import type { ConversationState } from "./schemas/conversation-state.js";
  * yet — first-turn behaviour falls through to the signal-precedence
  * chain (§4.10), which is harness-side and out of scope for this helper.
  *
- * Shape pinned by spec §4.9 (D16 dropped the `domain` line):
+ * Shape (D16 dropped `domain`; sessions retired → `session_id` dropped too,
+ * since the lifecycle that populated it is gone and it was always `none`):
  *
  *   <conversation-state>
  *     conv_id: <id>
- *     session_id: <id or none>
  *     off_record: <true|false>
  *   </conversation-state>
  */
 export function renderConvStateBlock(state: ConversationState | null): string {
   if (!state) return "";
-  const sessionId = state.session_id ?? "none";
   const offRecord = state.off_record ? "true" : "false";
   return [
     "<conversation-state>",
     `  conv_id: ${state.conv_id}`,
-    `  session_id: ${sessionId}`,
     `  off_record: ${offRecord}`,
     "</conversation-state>",
   ].join("\n");

--- a/packages/core/tests/conv-state-render.test.ts
+++ b/packages/core/tests/conv-state-render.test.ts
@@ -3,7 +3,8 @@
 // The exact rendered shape is contractual — every harness integration
 // reads it via the same helper, and the LLM consumes a stable byte
 // sequence each turn. Locking it down here. (D16 dropped the `domain`
-// line from the block.)
+// line; sessions-retirement dropped the always-`none` `session_id` line —
+// the block is now just `conv_id` + `off_record`.)
 
 import { renderConvStateBlock } from "@librarian/core";
 import { describe, expect, it } from "vitest";
@@ -13,7 +14,7 @@ describe("renderConvStateBlock (T2.3)", () => {
     expect(renderConvStateBlock(null)).toBe("");
   });
 
-  it("renders the canonical block with all fields set", () => {
+  it("renders the canonical block (conv_id + off_record only)", () => {
     const out = renderConvStateBlock({
       conv_id: "claude:abc-123",
       harness: "claude-code",
@@ -26,23 +27,23 @@ describe("renderConvStateBlock (T2.3)", () => {
       [
         "<conversation-state>",
         "  conv_id: claude:abc-123",
-        "  session_id: ses_xyz",
         "  off_record: false",
         "</conversation-state>",
       ].join("\n"),
     );
   });
 
-  it("renders 'none' for a null session_id", () => {
+  it("never renders the retired domain/session_id lines", () => {
     const out = renderConvStateBlock({
       conv_id: "claude:abc-123",
       harness: "claude-code",
-      session_id: null,
+      session_id: "ses_xyz",
       off_record: false,
       created_at: "2026-05-27T00:00:00.000Z",
       updated_at: "2026-05-27T00:00:00.000Z",
     });
-    expect(out).toContain("  session_id: none");
+    expect(out).not.toContain("session_id");
+    expect(out).not.toContain("domain");
   });
 
   it("renders off_record true when the flag is on", () => {


### PR DESCRIPTION
The per-turn `<conversation-state>` block that harness hooks reinject already dropped `domain` (D16). This drops the `session_id` line too — the session lifecycle that populated it is retired, so it was always `none`. The block is now just `conv_id` (the key) + `off_record` (the privacy signal).

The five harness plugins mirror this renderer byte-for-byte (a declared cross-harness contract); they're updated in lockstep in their own PRs — this core change anchors the shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)