### PR TITLE
docs: feature brainstorms + spec 041 (Librarian awareness primer)

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -208,6 +208,16 @@ this repo.
   _(design conversation 2026-06-03; spec 039's per-submission entity-granularity
   guidance reduces — but doesn't remove — the need for this, since the judge can't
   retro-fix nodes that already grew too coarse)_
+- **Better intake navigation via vault "maps" (parked — iterate later).** Today the
+  consolidator's `navigate` step hands the judge ~K=8 recall candidates + a flat,
+  title-only ToC, so finding the right place to file relies on semantic recall alone.
+  Idea: auto-generate markdown "map of content" / hub notes that describe the vault's
+  structure (frontmatter + wikilinks) so the LLM judge can navigate to the right
+  neighbourhood structurally, not just by recall. Relatedly, a structured graph-query
+  layer (Dataview-style queries over frontmatter + links — orphans, broken backlinks,
+  overloaded nodes) would serve the grooming/refactor pass above. Connects to spec 039
+  (hub-and-spoke). _(operator idea, 2026-06-05; ship current recall + 1-hop for now,
+  revisit with the whole-graph grooming work)_
 - Look at offering a tiny local LLM as an alternative to cloud / API LLM for the
   memory consolidator (see https://github.com/tgrytnes/mnemosyne).
 - Improve memory storage & retrieval with polyphonic recall (see

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -9,45 +9,10 @@ than struck — git history holds the record.)
 
 ## ⭐ Next headline feature — a self-improving curator
 
-Give the resident curator the ability to **learn and improve from operator feedback**,
-the way a Hermes agent edits its own SOUL.md. The admin reviews the curator's recent
-grooming, gives feedback — including, ideally, a **chat with the configured curator
-LLM in the dashboard** to discuss what went well or badly — and the curator proposes
-an improvement to its own prompt. _(operator idea, design conversation 2026-06-03)_
-
-The architecture already has most of the bones, which is why this is promising rather
-than from-scratch:
-
-- **Self-edit only the addendum, never the core.** The judge prompt is already two
-  layers: a fixed core contract (output schema, safety rules, "untrusted data"
-  framing) that `judge-step.ts` guarantees "an injected addendum can't relax," and a
-  mutable `curator.prompt_addendum` (≤2 KB, in settings). The curator may rewrite
-  **only the addendum** — the structural/safety core stays immutable by construction.
-  So "the LLM updates its own prompt" = "the LLM proposes an addendum edit."
-- **propose → admin-approve → git commit.** Ride the existing memory-proposal rails:
-  the curator _proposes_ an addendum change, the admin approves, it lands as a
-  reviewable, revertable git diff (exactly like a SOUL.md edit). Never auto-applied.
-- **Eval-gate every self-edit.** This is what makes it real learning, not the LLM
-  rationalising about itself: re-run `@librarian/consolidator-eval` on the fixtures
-  for a proposed addendum, show the before/after score delta, and only allow approval
-  on no-regression. Without the eval, the addendum drifts on vibes.
-- **Capture structured feedback, not just chat.** A 👍/👎 + note on specific groom
-  decisions is far richer signal than freeform conversation. The git history of grooms
-  _plus_ the admin's labels becomes the "dataset" the curator reasons over to propose a
-  better addendum; the chat is the discussion layer on top.
-- **Learning should condense, not append.** The 2 KB cap is a feature — force the
-  curator to _rewrite_ its lessons into a tighter set rather than pile on forever.
-  Prompt-bloat is its own failure mode.
-- **Per-install by design.** The shipped core prompt (`CONSOLIDATOR_PROMPT_VERSION`,
-  improved by us for everyone) vs the addendum (this install's curator learning _this_
-  owner's preferences and vault quirks). That per-install learning layer is the whole
-  point — "a resident librarian who learns how **you** like things."
-- **Distinct from the retrospective-refactor pass** (below, under Consolidator): that
-  reorganises the _vault_; this improves the curator's _judgement_. They compose
-  (better judgement → better future grooms; refactor → fix past ones) but are separate.
-
-Write a proper spec when sequenced — it's meaty (dashboard chat UI, feedback capture,
-the propose/eval/approve loop, addendum versioning). **Basics ship first.**
+Now a brainstorm: **[`docs/research/self-improving-curator-brainstorm.md`](research/self-improving-curator-brainstorm.md)**
+— the resident curator learns this install's preferences by proposing eval-gated,
+admin-approved edits to its own prompt addendum (never the safety core), from
+structured operator feedback + an optional dashboard chat.
 
 ## Security & hardening
 
@@ -181,29 +146,10 @@ landing than the autonomous run had room for.
 
 ## Harness integration ideas
 
-- **Auto-manage Librarian sessions via Claude Code lifecycle hooks.** Investigate
-  whether Claude Code's hook surface can drive the Librarian lifecycle without the
-  user typing `/lib-session-*` verbs manually:
-  - **`SessionEnd` → auto-pause** the attached Librarian session, but only when the
-    user resumed/attached one this conversation (the resume skill keeps the
-    `session_id` in conversational state — the hook reads that).
-  - **`PostCompact` → auto-checkpoint** with the rolling summary so compacted-away
-    context lands in the ledger first. Likely the highest-value hook (compaction is
-    where session evidence is most at risk).
-  - **`TaskCompleted` (or equivalent) → auto-checkpoint** at a finer grain. Lower
-    priority — risk of a noisy ledger; might gate on "task touched ≥ N files".
-  - Open questions: how to thread the resumed `session_id` into the hook process
-    (env var? side-channel file?); whether to suppress hook-driven calls right after
-    an agent-side checkpoint; whether other harnesses (Hermes, OpenCode) have
-    analogous lifecycle events worth wiring the same way.
-- **Hermes per-verb commands.** Pending whether Hermes supports per-command
-  registration with autocomplete. If it does, port the per-verb pattern; if not, stay
-  with single-command-plus-parse and update the package docs.
-- **Codex slash surface (shelved).** Codex CLI has no user-invokable slash-command
-  primitive. Options: a single `lib-session` skill priming the verb surface, a
-  `UserPromptSubmit` hook intercepting `/lib-session-*`, or waiting for native
-  commands.
-- **Pi runtime (shelved).** Revisit once Pi's interface is defined.
+Moved to a brainstorm: **[`docs/research/harness-driven-capture-brainstorm.md`](research/harness-driven-capture-brainstorm.md)**
+— harness-driven raw-text capture (offload extraction to the server consolidator),
+awareness injection at session-start / post-compaction, and lifecycle-boundary hooks
+(the per-harness command-registration notes for Hermes/Codex/Pi are parked there too).
 
 ## Deploy & ops
 

--- a/docs/research/harness-driven-capture-brainstorm.md
+++ b/docs/research/harness-driven-capture-brainstorm.md
@@ -1,0 +1,620 @@
+---
+title: Harness-driven capture, lifecycle hooks & awareness injection — working doc
+status: 1A (auto-capture) SHELVED by owner 2026-06-05 (unsure + huge change); 1B (awareness primer) → SPEC FIRST
+started: 2026-06-05
+---
+
+# Harness-driven capture, lifecycle hooks & awareness injection
+
+> Living working doc. §1–§2 are frozen; §3+ are the iteration surface; §10 captures meta-insights.
+
+---
+
+## 1. The question
+
+Can the harness drive Librarian usage at lifecycle boundaries — rather than relying on
+the agent to remember to call the verbs — across three related but distinct moves:
+
+- **(A) Harness-driven raw-text capture** — the harness deterministically + cheaply ships
+  conversation text to the server for *server-side* processing, so durable lessons get
+  captured **without spending the agent LLM's tokens** on reading/extracting them.
+- **(B) Awareness injection** — remind the agent it *has* `remember`/`recall`/`learn`, and
+  prompt it to re-ground, at **session start** and **after compaction**.
+- **(C) Auto-capture at boundaries** — fire capture automatically at compaction, task
+  completion, or conversation end (the agent forgets; a hook never does).
+
+---
+
+## 1.5 Owner's framing (Jim, 2026-06-05)
+
+> "Using the harness to **deterministically and cheaply** send raw conversation text to the
+> librarian for processing **without burdening the agent LLM**." Plus: injecting awareness of
+> the librarian and the key tools `remember` & `recall` at the start of a session and after
+> compaction. Pull the scattered harness-integration ideas out of TODO.md into this doc.
+
+---
+
+## 2. Audit — what's actually there (2026-06-05)
+
+> Frozen evidence. file:line citations. Only update if the code changes. (Server =
+> `the-librarian`; plugins = the five `the-librarian-*` repos in `~/code`.)
+
+### 2.1 `learn` — the agent does the extraction today
+There is **no server-side `learn` MCP tool** (not in `packages/mcp-server/src/mcp/tools/index.ts:26-46`).
+`/learn` is a harness slash command that drives the **agent LLM**: read transcript, extract
+durable facts, present a multi-select, call `propose_memory` for chosen items
+(`the-librarian-claude-plugin/commands/learn.md:13-39`). The server only stores finished
+proposals (`propose-memory.ts:10-13`). So **all extraction LLM work is agent-side**.
+
+### 2.2 The consolidator inbox — server-side raw-text mining already exists (gated off)
+With the consolidator enabled, `remember` is fire-and-forget: it concats title+body → `text`
+→ `submitToInbox(text, hints)` (`remember.ts:40-53`). `submitToInbox` writes raw text to
+`inbox/<ts>-<id>.md` + commits (`librarian-store.ts:220-224`; queue `corpus/inbox.ts:141-159`).
+A server scheduler sweeps FIFO (`consolidator/sweep.ts:37-67`) → per item **navigate → judge →
+apply** (`consolidate.ts:58-94`): navigate retrieves candidates from raw `submissionText`
+(`navigate.ts:62-78`); judge calls the **server LLM** for create/augment/supersede/archive/noop
+(`judge.ts:108-140`). **The mining engine accepts arbitrary raw text and runs fully
+server-side** — but it's gated by `LIBRARIAN_CONSOLIDATOR` (default **off**,
+`consolidator-config.ts:9-12`), and its **only producer is `remember`** (one note at a time).
+
+### 2.3 Awareness-injection substrate (idea B) — server half built, client half missing
+The per-turn `<conversation-state>` block is injected by each harness's UserPromptSubmit-equivalent
+hook (claude: `hooks.json:3-12` → `conv-state-inject.ts:42-65`; renderer `conv-state-render.ts:26-35`,
+now `conv_id` + `off_record` only). A **`session_manifest`** tool exists that returns exactly the
+working-style preamble + bounded skills manifest idea (B) wants (`session-manifest.ts:22-37`, doc-comment
+cites "spec 035 §F6"). **But no plugin consumes it** (zero `session_manifest` callers across the five).
+Only Hermes calls `start_context` once in `system_prompt_block` (`hermes provider.py:212-217`).
+
+### 2.4 Lifecycle hooks were BUILT then DELIBERATELY RETIRED (idea C has no live substrate)
+The sessions-rethink refactor retired the whole session lifecycle. Every plugin now wires **only
+per-turn conv-state injection**:
+- claude: only `UserPromptSubmit` (`hooks.json:3`).
+- codex: only `UserPromptSubmit`; SessionStart/PostCompact/Stop **retired** and `validate.mjs:84`
+  asserts they must NOT be registered (`dispatch.mjs:7-10,25-27`).
+- opencode: only `chat.system.transform`; session.created/idle/compacted **retired** (`index.ts:9-12,69-82`).
+- pi: only `before_agent_start`; input/agent_end/session_compact/session_shutdown **retired** (`index.ts:3-14`).
+- hermes: `sync_turn`/`on_pre_compress`/`on_session_end` are **explicit no-ops** (`provider.py:253-274`).
+
+There is **no `@librarian/lifecycle` shared bundle**. **Zero live lifecycle-boundary hooks today.**
+
+### 2.5 Privacy gate is now LLM-honored, not enforced
+Post-rethink `/toggle-private` is "Pure in-context — no MCP call, no server flag, no plugin hook"
+(`claude .../toggle-private.md:5`). On `[librarian:private=on]` the **agent** must not call
+`remember`/`propose_memory` (`:7`); `/learn` needs explicit confirmation (`learn.md:9`). There's a
+server `off_record` field surfaced read-only (`conv-state-render.ts:27-34`) but **enforcement is the
+LLM's**. The marker survives compaction "only by luck" (`toggle-private.md:19-21`).
+
+### 2.6 No bulk/transcript intake surface
+The HTTP server exposes a single `/mcp` surface (`http.ts:250`). No `/transcript`/`/inbox`/bulk
+endpoint. `submitToInbox`'s only caller is `remember` with one concatenated note — **nothing ships a
+raw transcript or chunks one into the inbox**.
+
+### 2.7 Per-harness capability audit (2026-06-05) — settings persistence, lifecycle events, transcript access
+
+| Harness | Persistent setting | Compaction event | End/Stop event | Transcript to hook | Can check `off_record` |
+|---|---|---|---|---|---|
+| Claude Code | **env vars only** (`userConfig` doesn't reach hook subprocs — `CONTRIBUTING.md:18-23`) | `PostCompact` (avail, retired) | `SessionEnd`/`TaskCompleted` (avail, retired) | **unconfirmed in-repo** (Claude passes `transcript_path` JSONL, just not exercised here) | yes (`conv_state_get`) |
+| Codex | env vars + `config.toml` (not plugin-read) | `PostCompact` | `Stop` per-turn; **no SessionEnd** (real gap) | **unconfirmed/partial** (spec hints last-message only) | yes |
+| Hermes | **JSON config file** (`librarian-plugin/config.json`, `provider.py:97-140`) | `on_pre_compress(messages)` | `on_session_end(messages)`+`sync_turn` | **yes — messages passed directly** (`provider.py:253-274`) | yes (`provider.py:239`) |
+| OpenCode | env vars + plugin-data dir | `session.compacting`/`compacted`/`messages.transform` | `session.idle` | **yes** (`messages.transform` / `client.session.messages()`) | yes (`system-transform.ts:45`) |
+| Pi | env vars only (`config.ts:31-44`) | `session_before_compact`/`session_compact` | `agent_end`/`turn_end`/`session_shutdown` | **yes** (`event.messages`, `AgentSession.messages`) | yes (`system-prompt-augment.ts:45`) |
+
+Two key facts for the toggle's home:
+- **Server-side admin setting has a proven in-tree pattern: `curator.enabled`.** Stored in `SettingsStore`
+  (`curator-config.ts:28,114,179`), admin-only tRPC (`trpc/curator.ts:25-37`), dashboard `/curator` page, and
+  the **server worker gates on it before acting** (`curator-tick.ts:43`, `consolidator-tick.ts:37`). The
+  consolidator ingest is *also* env-gated by `LIBRARIAN_CONSOLIDATOR` (`consolidator-config.ts:9-12`). So an
+  admin-controlled "process / drop auto-learn submissions" setting that the ingest path consults is a
+  copy of an existing, working pattern — and it's the **only** mechanism that drops submissions centrally
+  regardless of which harness sent them.
+- **All five hooks already call `conv_state_get`** → a capture hook can read `off_record` and refuse to ship a
+  private conversation, with **no agent involvement** (`conv-state-get.ts:24-26` serializes the full row).
+
+Capability bottom line: **Hermes / OpenCode / Pi support fully-deterministic (no-agent) transcript capture
+today.** Claude is very likely fine (`transcript_path`) but unproven in-repo. **Codex is the weak link** (no
+session-end event; transcript payload may be last-message-only) → degraded or agent-mediated there.
+
+### 2.x Bottom line from the audit
+- **Idea (A) is ~70% built but mis-plumbed.** The server-side mining engine (inbox + navigate→judge→apply
+  + server LLM + confidence bands) is real; the **gap is intake** — there's no surface that takes a raw
+  transcript and no harness path that ships one. (A) = "add a bulk/transcript producer in front of the
+  existing consolidator," NOT "build extraction."
+- **The agent-LLM burden today sits entirely at extraction/decision** (`/learn`, choosing what to
+  `remember`). The consolidator already removes the *filing/merge* burden, not the *reading-the-transcript* one.
+- **Idea (B)'s server half exists (`session_manifest`), client half doesn't.** "After compaction" has **no
+  signal** in any plugin.
+- **Idea (C) means reversing a deliberate decision** — lifecycle hooks were built and removed. Understand *why* first.
+- **Privacy:** any auto-capture runs outside the agent's awareness → outside the `[private=on]` marker; it'd
+  have to consult server `off_record` directly, which the marker model doesn't keep authoritative.
+
+---
+
+## 3. Reframing
+
+The audit collapses three "build it" ideas into one "re-plumb + decide policy" question:
+
+1. The **engine** for (A) exists (the consolidator). The work is a **transcript intake** + a **harness
+   producer**, plus the policy around cost and privacy of shipping raw text.
+2. (B) is a **separable, cheaper, lower-risk** win: wire the already-built `session_manifest` into a
+   start-of-session + post-compaction injection. It nudges the agent; it doesn't touch the privacy/cost risk.
+3. (C) is **not greenfield** — it's "should we re-introduce lifecycle hooks that were deliberately retired,
+   now repurposed for capture rather than session management?" That's a decision, not a build, and §4.1 gates it.
+
+So the real question isn't "can we?" (mostly yes, cheaply) but **"what's the right policy for shipping raw
+conversation text server-side — on cost, precision, and privacy — and which lifecycle signals justify it?"**
+
+### 3.1 Trigger-point mapping (the moments sort by direction)
+The two directions have *different* natural triggers — and **SessionStart serves neither capture nor recall**
+(nothing to capture yet; no query to recall against). It earns its keep for **setup** instead (§3.2).
+
+| Direction | Purpose | Natural trigger(s) |
+|---|---|---|
+| **Outbound** (recall / awareness — *ground the agent*) | inject relevant memory | **first meaningful turn** (a query exists) · **post-compaction** (context lost, query exists) |
+| **Inbound** (capture — *save what happened*) | ship transcript → consolidator | **pre-compaction** (save before loss) · **Stop / end / task-done** (save the whole thing) |
+
+Symmetry: **compaction is the pivotal boundary for both** — `PreCompact` = capture-before-loss; `PostCompact`
+= recall-to-restore. (Matches the old TODO note calling PostCompact "the highest-value hook.")
+
+### 3.2 The first-turn injection does *setup*, not capture (Jim, 2026-06-05; see D1)
+*Considered dropping SessionStart entirely; revised — but the work rides the **first meaningful turn** (the
+existing per-turn channel), not a resurrected SessionStart hook. Two setup jobs:*
+1. **Brief awareness primer.** Inject a short "you have The Librarian — durable memory; use `recall`/`remember`"
+   note. Rationale: **we can't rely on the agent auto-loading the skill/plugin**, so without a deterministic
+   primer the agent may never realise the Librarian exists. Keep it brief (context budget); it's a reliability
+   floor, not a replacement for the skill.
+2. **Auto-learn consent gate.** Ask the user once per conversation: *"Enable auto-learning for this
+   conversation?"* → if yes, the inbound transcript capture (idea A) is armed; if no, nothing is shipped. This
+   makes auto-capture **explicitly opt-in** — which is the privacy story (see §4.3).
+
+---
+
+## 4. Open questions
+
+### 4.1 Why were the lifecycle hooks retired? — **RESOLVED (Jim, 2026-06-05)**
+They were coupled to the now-redundant **session** model (auto-start/checkpoint/pause/end a Librarian
+*session*). The **purpose** died, not the **mechanism**. → Re-using lifecycle hooks for capture/awareness is a
+**clean new purpose, not a reversal**. Idea (C) is on the table.
+
+### 4.2 "Cheaply" — cheap for whom? — **RESOLVED:** cheap on the agent's critical path (zero tokens, fire-and-forget delta); server pays the extraction async + batched (D7/D8).
+"Deterministically and cheaply send raw text without burdening the agent LLM" bundles two cost models:
+- **The send** is genuinely cheap + deterministic: a hook POSTs raw text → **zero agent tokens**, fires every
+  time (the agent can't forget).
+- **The processing** is the existing consolidator — an **LLM** call per item, **not** cheap and **not**
+  deterministic; it just moves **off the agent's turn** onto the **server's async budget**.
+
+Is the intent "cheap *for the agent's critical path*, paid for by the server async" (almost certainly yes)? If
+so, the design owns a new **server-side LLM cost** that scales with transcript volume — see §4.4.
+
+### 4.3 Privacy — raw text leaves the agent's judgment — **RESOLVED:** dashboard arming (D2) + per-turn `off_record` skip (D7) + secret-redaction on intake (D6).
+Today the off-record gate is the **agent** declining to call `remember` when it sees `[private=on]`. A
+deterministic harness capture path **bypasses the agent entirely** — it would ship private text to the server
+unless gated. **The opt-in consent gate (§3.2) is the primary answer:** auto-capture is default-OFF and only
+arms on explicit per-conversation consent, so the harness never ships transcripts the user didn't agree to.
+Residual sub-questions: (a) within an opted-in conversation, can the user still go off-record mid-stream
+(`[private=on]`) and have the *hook* respect it (it must check `off_record`, not the agent)? (b) raw transcript
+still moves **redaction** (secrets/credentials) to "the server must scrub what it was handed" — so server-side
+redaction-on-intake is still needed even with consent.
+
+### 4.4 The granularity mismatch — a raw transcript isn't a "submission" — **RESOLVED by D4 (option b, no pre-filter)**
+The consolidator's navigate→judge→apply judges **one submission at a time** — it decides a single
+create/augment/supersede/archive/noop against one candidate fact (`judge.ts:108-140`). A 50-turn raw transcript
+is **not one fact**, so feeding it in as a single `submissionText` judges at the wrong granularity. So the
+producer has to do one of:
+- **(a) Dumb chunk** the transcript into many inbox items (per-turn / per-N-tokens). Cheap to produce, but each
+  chunk gets its own navigate→judge LLM pass (**many server-LLM calls**) and a chunk often isn't a clean fact →
+  noisy, low precision.
+- **(b) Server-side extraction stage** — a new component that mines the transcript into **discrete candidate
+  facts** *before* the inbox. This is exactly the `/learn` extraction job **moved from the agent to the
+  server** (the audit confirmed no server-side extractor exists today, §2.1). It's an **LLM pass over the
+  transcript** — *cheap for the agent (zero tokens), a real cost for the server*, run async off the turn.
+- **(c) Pre-filter at the hook** — only ship on "substantial work" signals (files changed, length threshold),
+  to bound how often (b) runs.
+
+So idea (A)'s actual new build is **(b): a server-side transcript→candidates extractor in front of the existing
+consolidator**, optionally gated by **(c)**. Open: is (b) a bespoke stage, or can the consolidator's
+navigate/judge be adapted to "given this transcript, propose N candidate facts"? And where does (c)'s
+"substantial" line sit — hook-side heuristic vs. server-side cheap classifier? This is where the server-LLM
+cost lives.
+
+### 4.5 Which lifecycle signals are worth wiring, per harness? — **RESOLVED:** capture = the per-turn hook (D7), not boundary events; `PostCompact` (where available) serves the separate recall/awareness direction (B).
+Claude Code has the richest set (`SessionStart`, `UserPromptSubmit`, `PreCompact`, `PostCompact`, `Stop`,
+`SessionEnd`). Map each idea to a signal: setup → `SessionStart` (§3.2); awareness/recall → first
+`UserPromptSubmit` + `PostCompact`; capture → `PreCompact` + `Stop`/`SessionEnd`. Which harnesses even have
+compaction / end signals (per §2.4 most were retired; Hermes/opencode/pi differ)? Do we wire the
+lowest-common-denominator, or per-harness best-effort?
+
+### 4.6 Can a SessionStart hook actually *ask* the user a question? — **MOOT (D2: no question; dashboard toggle)**
+The consent gate (§3.2) assumes the harness can surface a yes/no at session start. But Claude Code SessionStart
+hooks return *injected context*, they don't run interactive prompts. So the real mechanism is probably one of:
+(a) the hook **injects an instruction** telling the agent to ask on its first turn (costs a turn + relies on the
+agent to comply); (b) a **harness-native prompt** if the harness supports it (varies per harness); (c) a
+**remembered preference** (ask once ever / per-project, store the answer) so it isn't asked every conversation.
+Empirical per-harness question — audit before committing.
+
+### 4.7 Consent granularity + default — **MOOT (D2: dashboard on/off + `off_record` per-conversation opt-out)**
+Per-conversation consent matches "this conversation" but adds friction (asked every time → annoying → users
+reflexively say no → low capture rate). Alternatives: a remembered **per-project** or **global** default with
+an easy per-conversation override; or **default-on with a visible off-switch** (higher capture, weaker
+consent). What's the default, and at what scope is consent remembered?
+
+---
+
+## 5. Working hypotheses
+
+> Tentative — refined/discarded as we go.
+
+- **H1 (idea A):** Add a thin **transcript-intake** path (a "submit raw text for consolidation" surface that
+  chunks → inbox), and a harness producer (a `PreCompact`/`Stop` hook) that ships the recent transcript. Reuses
+  the existing consolidator as-is. Owns a new server-LLM cost (§4.4) + a privacy gate move (§4.3).
+- **H2 (idea B, separable):** Brief awareness primer at `SessionStart` (reliability floor for unreliable skill
+  auto-load) + a recall-grounding on the first turn / after `PostCompact`. Pure nudge, zero capture risk,
+  cheapest win — likely worth doing first/independently.
+- **H3 (idea C):** Re-introduce lifecycle hooks *repurposed for capture/awareness* (not session management).
+  *(§4.1 resolved — mechanism is fine; (C) is a clean new purpose.)*
+- **H4 (consent-gated capture)** *(consent-question mechanism superseded by D2; intent survives):* the
+  default-off + explicitly-controlled intent is kept, but delivered via the **dashboard toggle + `off_record`
+  self-gate** (D2), not a per-conversation question. §4.6/§4.7 are moot under D2.
+
+---
+
+## 6. Decisions
+
+**D1 (2026-06-05)** — **Setup rides the first meaningful turn, not a SessionStart hook.** The two setup jobs —
+(1) a brief deterministic awareness primer (reliability floor, since the skill/plugin may not auto-load) and
+(2) arming the auto-learn capture — are injected on the **first turn** via the per-turn `UserPromptSubmit`-style
+channel that already exists in all five plugins. Capture and recall-grounding happen at later boundaries
+(turn / compaction / end). *Rationale:* a `SessionStart` hook can't run interactive prompts and is the least
+uniform event across harnesses; the per-turn injection channel works everywhere and is already wired.
+
+**D3 (2026-06-05)** — **North star: take ~everything off the agent. The hook is dumb + deterministic; all
+intelligence is server-side.** The capture hook ships the transcript when (armed **and** not `off_record`) with
+**no agent judgment and no unreliable hook-side heuristics** — conversation **length is explicitly rejected** as
+a "worth learning" signal. Deciding *what's worth keeping* (and controlling its cost) happens **server-side**.
+*Rationale (the motivation for the whole feature):* agent-side capture is (a) **disruptive** — it interrupts and
+slows the user's conversation pace — and (b) **unreliable** — agents forget it or apply it inconsistently. Every
+design choice should push work off the agent toward the deterministic hook + the server.
+
+**D2 (2026-06-05)** — **Auto-learn is a server-side admin (dashboard) toggle; the plugin gates the wire on it.**
+The on/off lives as a server setting in `SettingsStore`, edited from the dashboard, mirroring the existing
+`curator.enabled` pattern (admin tRPC + worker-gates-before-acting). The **first-turn setup call returns the
+armed/disarmed flag** to the plugin (alongside the awareness primer + manifest — same round-trip), so when
+auto-learn is **off the plugin sends nothing over the wire** (not shipped-then-dropped). The capture hook ships
+the transcript at compaction/end **only if** (armed) **and** (`off_record` false) — both read from the server,
+**no agent in the loop**. The server keeps an authoritative drop as a backstop. Per-conversation opt-out is the
+existing "this is private" marker; **no consent question**. Best-effort per harness (Hermes/OpenCode/Pi support
+it today; Claude pending `transcript_path` confirmation; Codex degraded — last-message-only, no session-end).
+*Implementation note:* hooks are separate subprocesses (§2.7), so the armed flag must reach the capture hook via
+the per-session local state file the conv-state hook already uses, **or** the capture hook re-reads it from the
+server when it fires (simplest, freshest). *Supersedes the SessionStart/first-turn **consent-question**
+mechanism* — the consent *intent* (default-off, owner-controlled, per-conversation opt-out) survives; the
+mechanism is now a dashboard toggle + the `off_record` self-gate, which removes the agent-participation and
+per-conversation-friction problems entirely.
+
+**D4 (2026-06-05)** — **Keep extraction simple: one curator-LLM pass, no pre-filter.** The server-side extractor
+is a single curator-LLM pass over the transcript → candidate facts → the existing consolidator inbox
+(navigate→judge→file). **No semantic/novelty pre-filter** — *rejected* (Jim): we *want* similar/related material
+to reach the judge so it can `augment`/`supersede` into richer documents, so a similarity gate would discard the
+highest-value updates; and it's premature optimisation with no baseline. Cost optimisation is **deferred** (the
+§8.1 menu is parked, not chosen). *Rationale:* don't optimise before there's a working baseline; the obvious
+filter fights the merge purpose.
+
+**D5 (2026-06-05; ⚠ blind review M1: the "Claude is capture-capable" claim is ASSUMED, not confirmed — needs a spike)** — **The transcript is opaque, best-effort text; never hard-parse it in the hook.** Harnesses
+expose a transcript "for convenience" with **no format-stability guarantee** (Claude Code's `transcript_path`
+JSONL may change shape over time). So the hook ships it **raw**, and the **server LLM extractor reads whatever
+arrives** (robust to format drift in a way a parser isn't) — which is just D3 again. Fail soft if a transcript
+can't be read (house rule: never break the user's turn). This confirms **Claude Code is capture-capable**
+(`transcript_path`), resolving §2.7's "unconfirmed". *(The Codex "no session-end" gap noted here is later
+**fixed** by D7 — incremental per-turn capture doesn't need an end event; Codex's per-turn `Stop` is the delta.)*
+
+**D6 (2026-06-05, confirmed)** — **Redaction on intake.** Secret-redaction runs on each delta *before* it is
+written to the transcript buffer (reuse the consolidator's redaction, moved earlier). Non-negotiable — secrets
+must never reach git history (or even the sidecar buffer in the clear).
+
+**D7 (2026-06-05, confirmed)** — **Capture is incremental per-turn, not big-bang at end.** Driven by the
+reliable per-turn hook (already wired in all five plugins); ships the delta since a per-conversation **cursor**
+(in conv-state); **skips `off_record` turns** (per-turn privacy skip — resolves §4.8 B & C); accumulates into a
+server-side buffer; **extraction is decoupled** and runs when the conversation settles (D8). Survives
+app-close / `/clear` / abandon (loses at most the last un-ingested turn). *Supersedes the PreCompact/Stop/end
+**capture** triggers; PostCompact still serves the separate recall/awareness direction. Also upgrades Codex
+(per-turn `Stop` = the delta; no end event needed).*
+
+**D9 (2026-06-05, resolves C2)** — **Awareness = a passive primer; active recall-injection deferred.** Idea B
+(the owner's co-equal goal §1.5) is, for now, a **brief passive primer** ("you have The Librarian —
+`recall`/`remember`/`learn`"); **not** active recall-injection (that richer "(b-ii) pull relevant memory and
+inject it after compaction" is deferred). **Mechanism:** the primer **rides the existing per-turn conv-state
+injection** — the block already fires every turn in all five plugins and already survives compaction by
+re-injecting each turn — so it needs **no new post-compaction hook** and **genuinely reuses the uniform channel**
+(contrast capture, which needs per-harness adapters, §11.2). Primer text is **server-sourced** (updatable without
+re-releasing plugins); the richer F6 `session_manifest` preamble is a deferrable upgrade. *Rationale:* a passive
+primer is the reliability floor the owner asked for (agents may not auto-load the skill); riding the per-turn
+block makes compaction-survival free. *(Supersedes D1's "first-turn-only" framing of the primer — it's now
+every-turn via the existing block, which is strictly simpler and covers post-compaction for free.)*
+
+**D10 (2026-06-05, resolves C3 — cost)** — **Accept the extraction cost for now; no explicit cap.** The owner
+judged it tolerable: auto-learn only assesses **text** (no tool execution), the install is effectively
+**single-user**, and it's already **default-off + opt-in** (D2) and **per-conversation batched** (D8) — so the
+spend is modest. No per-install cap/rate-limit for the baseline; the smart optimisations (cheap/local model,
+§8.1) stay deferred. **Known caveat (deferred):** a busy *multi-user* install might want a cap — documented as a
+scaling consideration, not built now. *(This is now an explicit decision, not the "deferred-then-stamped" the
+review flagged.)*
+
+**D11 (2026-06-05, resolves C3 — quality + review M3)** — **Auto-captured memories land as PROPOSALS, not
+auto-active.** Every auto-learn extraction routes to the proposal queue (`requires_approval`) regardless of the
+judge's confidence — overriding the consolidator's default auto-apply **for this lane** — so the owner reviews
+them on the existing dashboard `/proposals` page. This bounds the extractor-hallucination/noise risk (M3) and
+gives the owner a visible backstop, while keeping the **agent** out of the loop (D3 intact — the burden is
+*owner* curation, async + batched, never in-conversation). Trade-off: an owner-review queue (acceptable; reuses
+the existing proposal flow).
+
+**D8 (2026-06-05)** — **The buffer + "settled" rule.** Each conversation accumulates into a per-conversation
+buffer **`transcripts/<conv_id>.md`** (deltas appended; secrets redacted on write per D6). A curator pass every
+~10 min treats any buffer **idle for ~20 min as complete** → extracts it → **deletes** it; a later delta with
+the same `conv_id` after deletion (the always-on `/clear` remote scenario) starts a fresh buffer = a new
+conversation. **The buffer is a SIDECAR (outside the git vault), not committed** — it's high-churn raw
+conversation; committing it would bloat git history and persist conversation content there permanently.
+Delete-after-extract leaves zero trace; only extracted *facts* reach the committed inbox→consolidator→memory
+path. **Ingest atomically claims the buffer** (rename to `.processing`) before extracting, so a straggler delta
+starts a fresh buffer rather than racing the delete. *(Thresholds tunable; a pause longer than the idle window
+splits a conversation into two buffers — the consolidator reconciles. Whether `conv_id` survives `/clear` is
+harness-specific; if it changes, the reuse case is automatic.)*
+
+---
+
+## 7. Loose ends / parking lot
+
+**Pulled from `docs/TODO.md` "Harness integration ideas" (2026-06-05) — superseded framing noted:**
+
+- **Auto-manage via Claude Code lifecycle hooks** *(original framing was session-centric; sessions are now
+  retired — reframe onto remember/recall/learn per this doc):*
+  - `SessionEnd` → auto-pause (session model — **retired**; reframe = capture-then-stop?).
+  - `PostCompact` → auto-checkpoint with the rolling summary ("highest-value hook — compaction is where
+    [context] is most at risk"). **Reframe:** `PreCompact`/`PostCompact` → capture + re-inject awareness.
+  - `TaskCompleted` → finer-grained capture; "risk of a noisy ledger; gate on 'task touched ≥ N files'."
+  - Open Qs (still live): how to thread session/conv id into the hook process (env var vs side-channel file —
+    cf. audit note that hooks can't reliably export env into the parent); whether other harnesses have analogous
+    lifecycle events.
+- **Per-harness command registration** (tangential to capture; parked here for completeness):
+  - Hermes per-verb commands — pending whether Hermes supports per-command registration w/ autocomplete.
+  - Codex slash surface (shelved) — no user-invokable slash primitive; options: priming skill / `UserPromptSubmit`
+    intercept / wait for native commands.
+  - Pi runtime (shelved) — revisit once Pi's interface is defined.
+- **Stale operator chore (TODO.md §Operator):** "Exercise the remaining `/lib-session-*` verbs end-to-end" —
+  references retired sessions; should be deleted, not done.
+
+---
+
+## 8. Sub-question deep-dives
+
+### 8.1 Making server-side extraction quick + cheap — **PARKED (D4: simple baseline first)**
+Per D4 we ship the simple one-pass extractor first and optimise only if a real cost problem appears. Deferred
+options, for later:
+- **Semantic novelty pre-filter — *REJECTED* (D4):** would gate on dissimilarity-to-known, but we *want* similar
+  material to reach the judge (that's how `augment`/`supersede` enrich existing docs); it would drop the
+  highest-value updates. Do not build.
+- **Cheap/local model for the extraction pass** (cf. the bundled embedder; the old TODO's "tiny local LLM").
+- **Incremental / delta** — mine only the transcript since the last capture, not the whole thing each time.
+- **Two-tier** — cheap extractor → the existing navigate→judge for dedup/merge/file.
+All of the above are **deferred tuning**, revisited only with a baseline + real cost data.
+
+---
+
+## 9. Sanity-check: end-to-end scenarios (2026-06-05)
+
+### A — User corrects a known fact mid-conversation ✓
+"Actually X is Y now." Capture ships the transcript → extractor emits "X is Y" → judge matches the existing "X
+is Z" memory → `supersede`/`augment`. **Verdict:** works *because* D4 kept the novelty filter out — the
+correction reaches the judge. This is the case that justified D4.
+
+### B — User goes `[private=on]` at turn 10 of 20, stays private ⚠
+Capture fires at end; hook reads `off_record` = **ON** → ships **nothing**, losing turns 1–9 (which were public
+and possibly valuable). **Verdict:** safe but lossy — fire-time off_record over-suppresses.
+
+### C — User goes private at turn 10, back on record at turn 18 ✗ **(privacy leak)**
+Capture fires at end; hook reads `off_record` = **OFF** (they're back on record) → ships the **whole
+transcript, including the private turns 10–17**. **Verdict:** a real leak. **Fire-time off_record is the wrong
+model for a multi-turn transcript** — see §4.8.
+
+### D — Conversation full of secrets/credentials ✗ **(secrets in vault)**
+Raw transcript ships → `submitToInbox` writes it to `inbox/<ts>.md` → **committed to the git vault**. The
+consolidator redacts at *evidence* time, but the **raw inbox file is written + committed first** → unredacted
+secrets land in git history. **Verdict:** must **redact on intake**, before the inbox file is written. See §4.9.
+
+### E — Codex conversation that ends without compaction ⚠
+Codex has no session-end event and only per-turn `Stop`/`PostCompact`. A short Codex chat that never compacts
+never hits a capture boundary → never captured. **Verdict:** degraded/best-effort on Codex, as D5 noted.
+
+### F — "Thanks, bye" trivial conversation ⚠
+Ships + mined (no length gate, D3); extractor/judge discard-bias noops it. **Verdict:** correct outcome, at the
+cost of a wasted extraction pass — the cost we consciously deferred (D4).
+
+### G — Admin toggles auto-learn OFF mid-conversation ✓
+Capture hook re-reads the flag at fire time (D2) → sees OFF → ships nothing; server's authoritative gate is the
+backstop either way. **Verdict:** clean.
+
+### H — Compaction, then more work, then end ⚠
+Whole-transcript capture at `PreCompact` *and* at end re-mines turns 1–N twice; judge is idempotent-ish
+(noop/augment dupes) but it's wasted cost. **Verdict:** works; the parked **incremental/delta** optimisation
+(§8.1) would fix the redundancy.
+
+### I — Two harnesses (Claude + Codex) in one cwd ✓
+Both ship; two candidate sets → consolidator dedups/merges. **Verdict:** fine — dedup is the consolidator's job.
+
+### J — Server unreachable when the capture hook fires ✓
+Fail-soft (D5 / house rule): the hook swallows the error, never breaks the user's turn; the transcript is just
+not captured. **Verdict:** acceptable (best-effort capture, never blocks).
+
+### Findings summary *(updated after the §8.2 incremental reframe + D6–D8)*
+- **Clean:** A, G, I, J.
+- **Resolved by the incremental model (D7/D8):** **B & C** — privacy is a per-turn skip; no retroactive leak,
+  no loss of earlier public turns. **E** — Codex no longer needs an end event (per-turn `Stop` = the delta).
+  **H** — incremental delta means no re-mining.
+- **Resolved by D6:** **D** — secret-redaction on intake, before anything is written.
+- **Works with notes:** **F** — a "thanks bye" conversation still costs one (batched, server-side) extraction
+  pass; the cost we consciously deferred (D4). No remaining ✗.
+
+---
+
+## 8.2 (Jim's reframe) — INCREMENTAL ingestion off the per-turn hook, not big-bang at end
+**Problem with end-of-session triggers:** there's no reliable one — users close the app, end the chat, or
+`/clear` a long-running remote session. Building capture on an end event loses those conversations entirely.
+
+**The reframe:** drive capture from the **per-turn hook** (the `UserPromptSubmit`-equivalent that *already fires
+every turn in all five plugins*), ingesting only the **delta since the last ingestion point**. Mechanism:
+
+1. **Cursor** (per conversation) records "ingested up to here," stored in **conv-state** (the hook already
+   reads/writes conv-state, keyed by `conv_id`).
+2. **Each turn**, the per-turn hook ships the **just-completed turn(s) since the cursor**, then advances the
+   cursor. Forward-only.
+3. **Privacy becomes a trivial per-turn skip:** if `off_record` was on for a turn, **don't ship that turn** —
+   no span-parsing needed (the per-turn granularity *is* the privacy granularity). Because the cursor only moves
+   forward, a private turn is **never retroactively shipped** when off_record later flips back. This resolves
+   §4.8 Scenarios B **and** C outright, and is simpler than the strip-spans options.
+4. **Reliability:** since we've been ingesting all along, an app-close / `/clear` / abandon loses **at most the
+   last un-ingested turn**, not the conversation.
+5. **Cost — the key decoupling:** *ingestion* (ship a small delta, fire-and-forget) is cheap and happens every
+   turn; **extraction is DECOUPLED** — the server mines a conversation's accumulated buffer **only when it
+   settles** (idle timeout / turn threshold / the existing consolidator sweep), not per turn. So per-turn
+   overhead ≈ one extra cheap POST; the expensive LLM extraction is batched server-side.
+
+**Reuses:** the per-turn hooks (wired), conv-state (read/written already), the inbox + consolidator sweep
+(exists). **New bits:** a cursor field in conv-state; delta-slicing in the per-turn hook; a **per-conversation
+accumulating buffer** server-side (different shape from today's one-shot `remember` inbox items); a
+"conversation settled → extract" trigger.
+
+**Open / feasibility:**
+- **Per-turn transcript access varies:** Hermes `sync_turn(user, assistant)` hands the turn directly; Claude
+  reads `transcript_path` and slices since the cursor; OpenCode/Pi get `messages`. Codex `Stop` fires per turn
+  but its payload may be last-message-only — slicing-since-cursor needs confirming there.
+- **Timing:** `UserPromptSubmit` fires *before* the assistant replies, so it ingests "up to the previous
+  completed turn" (always one turn behind — fine).
+- **The "settled" trigger:** ~~tuning~~ → **decided (D8):** per-conversation sidecar buffer, ~10-min curator
+  pass, ~20-min-idle = complete → extract → delete; same-`conv_id`-after-delete = new conversation.
+- **Buffer + cursor crash-safety:** double-shipped turns are deduped by the consolidator; a lost cursor just
+  re-ships (idempotent).
+
+*This supersedes the PreCompact/Stop/end **capture** triggers (§3.1) — capture is now per-turn incremental;
+those boundaries are unnecessary for capture. `PostCompact` still serves the separate recall/awareness direction.*
+
+## 4.8 (raised by Scenario C) — privacy is per-*turn*, capture is per-*transcript* — **RESOLVED by §8.2 (per-turn skip)**
+`off_record` is a point-in-time flag (most-recent-marker-wins), but capture ships a multi-turn span whose
+privacy state can change within it. A single fire-time check **leaks** (private-then-public, Scenario C) or
+**over-suppresses** (public-then-private, Scenario B). Options: **(a)** per-turn privacy tagging — exclude turns
+that were `off_record` *when they occurred* (precise; needs per-turn privacy state to travel with the
+transcript); **(b)** "**ever** off_record in this conversation → never capture it" (simple, conservative, safe,
+but loses whole conversations for one private turn); **(c)** **incremental capture** — ship the delta since last
+capture, gated by the off_record state *of that delta* (aligns timing with privacy; needs segment-level capture).
+
+## 4.9 (raised by Scenario D) — redaction must happen on intake, before the vault write
+The capture path must run the existing secret-redaction **before** `submitToInbox` writes/commits the inbox
+file — otherwise raw secrets enter git history. Reuses the consolidator's redaction, but moves it earlier in the
+pipeline (intake, not evidence-gathering). Likely a hard requirement, not an option.
+
+---
+
+## 10. Late-stage observations
+
+### 10.1 The design is additive — but `/learn`'s role narrows
+This design adds a server-side capture lane and reuses the existing consolidator wholesale; it deletes almost no
+legacy. The one thing whose role *shrinks*: the agent-driven **`/learn`** command. With auto-learn on, the
+server captures continuously, so `/learn` is no longer the primary capture path — it becomes a **manual
+fallback** ("save what we just figured out, now") for when auto-learn is off, or for an explicit on-demand
+flush. Worth keeping (it's the user-initiated escape hatch), but the docs/skill should stop presenting it as
+*the* way lessons get saved. Not a deletion — a demotion.
+
+### 10.2 The whole design rides existing rails *(⚠ overturned by blind review §11/C1 — see below)*
+Almost every piece is a small addition to something already built: the per-turn hook (wired), conv-state (the
+cursor's home), the consolidator inbox + sweep (the extraction engine), the `curator.enabled` settings pattern
+(the toggle), the secret-redaction (moved earlier). *The blind review found this **overstated**: the wired
+per-turn hooks do **not** deliver the turn delta in 4/5 harnesses (C1), and the consolidator is **env**-gated not
+`curator.enabled`-gated (I5). The genuinely new + unproven work is larger than "~70% pre-built" implied.*
+
+---
+
+## 11. Blind review (2026-06-05) — NOT spec-ready; three Criticals reopen the design
+
+An independent **cold, adversarial** review (no conversation context; codebase access; briefed to attack, not
+bless) found the audit (§2) largely accurate but three **Critical** holes that block spec-readiness.
+
+**C1 — [RESOLVED with per-harness adaptation — see §11.2] The per-turn *delta* D7/D8 depend on is NOT available in the wired hooks (4 of 5 harnesses).** The wired
+per-turn hooks deliver the incoming **prompt / system-prompt**, not the just-completed **turn delta**: Claude
+reads only `session_id` (`conv-state-inject.ts:106`) — getting the delta needs `transcript_path` (never
+exercised in-repo) and `UserPromptSubmit` fires *before* the assistant replies; Codex carries only `prompt`, has
+**no** `Stop` handler (`dispatch.mjs:25-27`, forbidden by `validate.mjs:84`); OpenCode `chat.system.transform`
+gets `{sessionID}` only; Pi `before_agent_start` uses `systemPrompt` (`messages` assumed). **Only Hermes** hands
+turn content (`sync_turn`) — and that's a *different method* from the conv-state channel. So D1/D7's "rides the
+existing per-turn injection channel" is **wrong**; delta-slicing is new, per-harness, unproven work. → **Reopens
+D7/D8. Needs a real per-harness feasibility spike before either is a decision.**
+
+**C2 — [RESOLVED by D9: passive primer riding the per-turn block; active recall-injection deferred] Idea (B), a co-equal owner goal (§1.5), was never designed — only stamped.** Awareness of
+`remember`/`recall` at session-start + **after compaction** got one clause in D1; "after compaction" has **no
+live signal in any harness** (all compaction hooks retired; no decision reinstates one — the very reversal §4.1
+justifies, but only for capture), and `session_manifest` has **zero callers**. (a) got D2–D8 + 10 scenarios;
+(b) got "MOOT/RESOLVED" stamps that resolve by deferral. → **Reopens idea B as its own design track.**
+
+**C3 — [RESOLVED by D10 (accept cost, single-user/text-only) + D11 (auto-captured → proposals)] Cost is unbounded by an explicit decision.** D4 deferred cost on an **O(items)** engine that
+re-embeds + judges **per item** (`librarian-store.ts:226-231`), and every trivial conversation pays (D3 rejected
+length gates). Legitimate for a prototype, but a **Critical open item for a spec**, presented as settled. →
+**D4's "deferred" must become an explicit bounded-cost policy** (per-install cap, batching, cheap pre-classify,
+or "manual `/learn` only at scale").
+
+**Important:** **I1** D3 "dumb hook" contradicts D7's stateful slicing + D5's "never parse" (slicing *is*
+parsing) — resolve it. **I2** `conv_id` is **cwd-keyed on Codex** (no stable id) → two Codex convs in one cwd
+collide into one cursor+buffer. **I3** the 20-min "settled" rule **splits the owner's own** long-running-remote
+usage into disjoint buffers (never scenario-walked); "the consolidator reconciles" is hand-waved (it judges
+fact-by-fact, no cross-buffer context). **I4** the sidecar buffer is redacted-but-real conversation **at rest
+~30 min**, and redaction is a **known-format regex** that misses exotic secrets (worse on high-volume
+transcripts than on a hand-written `remember`). **I5** D2 mirrors `curator.enabled` but the consolidator is
+**env-gated** → new work + a two-gate confusion (auto-learn ON in dashboard while consolidator OFF in env →
+buffering into an unswept inbox).
+
+**Minor:** **M1** D5 laundered an assumption into "confirmed" (now marked ASSUMED). **M2** crash mid-buffer /
+orphaned `.processing` has no reaper (the inbox has one; the new buffer doesn't). **M3** extractor hallucination
+→ auto-created noise (the judge auto-applies `create` regardless of confidence, `judge.ts:125`). **M4**
+default-off + demoted `/learn` (§10.1) + un-wired awareness (C2) = **a capture *and* awareness gap in the common
+(default) case.**
+
+### 11.1 Resolution status (all three Criticals closed)
+1. **C1** — ✅ resolved (§11.2): per-harness acquisition adapter → uniform server contract; Pi+Hermes proven,
+   Claude+OpenCode feasible-pending-live-test, Codex a known limitation (no stable id).
+2. **C2** — ✅ resolved (D9): passive primer riding the per-turn block; active recall deferred.
+3. **C3** — ✅ resolved (D10 accept-cost + D11 auto-captured→proposals).
+4. **Importants:** **I1** ✅ (D3 reworded: mechanical adapter, no judgment). **I2** ✅ owned (Codex limitation,
+   §11.2). **I3** (20-min split of long sessions) **accepted** — lower-stakes now that captures are proposals
+   (D11) + consolidator dedups; threshold tunable. **I4** (buffer-at-rest ~30 min redacted; regex redaction
+   imperfect) **accepted residual** for the single-user/self-hosted baseline — the buffer is on the owner's own
+   box, transient, redacted; the regex-redaction gap is pre-existing, flagged not fixed here. **I5** (the
+   dashboard auto-learn toggle vs the env `LIBRARIAN_CONSOLIDATOR` gate) — **spec must define their
+   interaction** so auto-learn can't buffer into an inbox nothing sweeps. **M2** (orphaned `.processing` buffer
+   needs a reaper) — spec/build detail.
+
+### Pre-spec / pre-build gates (carry into the spec)
+- **3 live tests** (§11.2): Claude `Stop`+`transcript_path`; Codex `Stop` payload + any stable id; OpenCode
+  `session.idle` bracketing.
+- **I5** two-gate interaction; **M2** buffer reaper; the **Codex** coarse-or-deferred decision.
+
+### 11.2 C1 spike outcome (2026-06-05) — RESOLVED with per-harness adaptation; Codex is the real limit
+The model **survives**, but the design's **uniform-mechanism assumption was wrong**. There is no single per-turn
+channel; instead a **per-harness *acquisition adapter* feeds a uniform server contract** (a turn-delta POST).
+Acquisition differs structurally:
+
+| Harness | Per-turn surface | Mechanism | Cost | conv_id | Verdict |
+|---|---|---|---|---|---|
+| **Pi** | `turn_end`/`agent_end` event | completed `AgentMessage` **in-payload** | O(1) | stable `getSessionId()` | **FEASIBLE, no spike** |
+| **Hermes** | `sync_turn(user, assistant)` | both halves handed in as args | O(1) | stable `session_id` | **FEASIBLE, no spike** (cleanest) |
+| **OpenCode** | `event`→`message.updated`, flush on `session.idle` | accumulate by id; **avoid** `session.messages()` (no cursor, O(n)) | O(1) | stable `sessionID` | **FEASIBLE-WITH-CAVEATS** (idle-bracketing → live test; `event` hook unwired) |
+| **Claude** | unwired `Stop` + `transcript_path` JSONL | slice from a **byte-offset** cursor | O(delta) w/ offset | stable `session_id` | **FEASIBLE-WITH-CAVEATS** (`transcript_path` presence/shape → live test) |
+| **Codex** | `Stop` ("fires every turn"), payload unverified | n/a | — | **NONE** (only per-cwd fallback; `CODEX_RUN_ID` env-only + post-first-turn) | **BLOCKED** → coarser per-cwd capture, or excluded until upstream exposes a stable id |
+
+**Consequences:**
+- **Reframe (corrects D1/D7):** capture = a **per-harness acquisition adapter → uniform server contract**, *not*
+  "the same per-turn injection channel everywhere" (that was the overstatement). The *output* (a per-turn delta,
+  stably keyed) is uniform, so the **server contract (D8 buffer/cursor/extractor) is unaffected** — only the
+  small per-plugin acquisition code differs.
+- **Pi + Hermes are a proven floor** — in-payload, O(1), stable key, **no spike needed**. Ship those first.
+- **D3 wording fix (I1):** the hook is a mechanical adapter (receive/slice a delta, skip `off_record`,
+  fire-and-forget) — **no judgment, no agent burden** (D3's real intent) — but **not literally "dumb"** (it holds
+  a cursor + slices). Reword D3 "no judgment / no agent," not "no logic."
+- **Codex is the one genuine limitation** (I2 confirmed): no stable per-conversation id → a per-turn cursor can't
+  attribute deltas; it gets coarse per-cwd capture or is deferred pending an upstream id.
+- **Three maintainer-run live tests gate the build:** ① Claude `Stop`+`transcript_path` (exists? append-only?);
+  ② Codex `Stop` payload + any stable id; ③ OpenCode `session.idle` brackets exactly one assistant turn.

--- a/docs/research/self-improving-curator-brainstorm.md
+++ b/docs/research/self-improving-curator-brainstorm.md
@@ -1,0 +1,560 @@
+---
+title: Self-improving curator — working doc
+status: design-settled (v2, post-review) — C1+assumption resolved (D7/D8); 7 spec-scope items flagged (§11.1)
+started: 2026-06-05
+---
+
+# Self-improving curator
+
+> Living working doc. §1–§2 are frozen; §3+ are the iteration surface; §10 captures meta-insights.
+
+---
+
+## 1. The question
+
+Can the resident curator learn to groom *this* install's vault the way its owner wants — by proposing
+**eval-gated, admin-approved edits to its own prompt addendum** from operator feedback — without (a) drifting
+"on vibes," (b) relaxing its safety/structural core, or (c) bloating its prompt? And which of the three
+composable pieces — the **self-edit loop**, the **feedback capture**, and the **dashboard chat** — is the
+load-bearing minimum that "ships first"?
+
+---
+
+## 1.5 Owner's framing (Jim, via TODO.md, design conversation 2026-06-03)
+
+> Give the resident curator the ability to **learn and improve from operator feedback**, the way a Hermes agent
+> edits its own SOUL.md. The admin reviews recent grooming, gives feedback — ideally a **chat with the
+> configured curator LLM in the dashboard** — and the curator proposes an improvement to its own prompt.
+
+The operator's stated design (most "bones" claimed to already exist):
+- **Self-edit only the addendum, never the core.** The judge prompt is two layers — a fixed core contract
+  (schema, safety, "untrusted data" framing) that `judge-step.ts` guarantees an injected addendum *can't relax*,
+  and a mutable `curator.prompt_addendum` (≤2 KB, in settings). The curator rewrites only the addendum.
+- **propose → admin-approve → git commit.** Ride the existing memory-proposal rails; never auto-applied; lands
+  as a reviewable, revertable diff (like a SOUL.md edit).
+- **Eval-gate every self-edit.** Re-run `@librarian/consolidator-eval` for a proposed addendum, show the
+  before/after score delta, allow approval only on no-regression. "Without the eval, the addendum drifts on vibes."
+- **Capture structured feedback, not just chat.** 👍/👎 + a note on specific groom decisions; the git history of
+  grooms + the admin's labels becomes the "dataset" the curator reasons over. Chat is the discussion layer on top.
+- **Learning should condense, not append.** The 2 KB cap forces a *rewrite* into a tighter lesson set, not pile-on.
+- **Per-install by design.** Shipped core prompt (`CONSOLIDATOR_PROMPT_VERSION`, improved by us for everyone) vs
+  the addendum (this install's curator learning *this* owner's preferences + vault quirks). "A resident
+  librarian who learns how **you** like things."
+- **Distinct from the retrospective-refactor pass** (reorganises the *vault*); this improves the curator's
+  *judgement*. They compose but are separate.
+- **Basics ship first.** It's meaty (dashboard chat UI, feedback capture, propose/eval/approve loop, addendum
+  versioning).
+
+---
+
+## 2. Audit — what's actually there (2026-06-05)
+
+> Frozen evidence. file:line citations on every concrete claim.
+
+### 2.0 THE load-bearing fact: there are TWO pipelines, and the framing conflates them
+- **Curator** (`packages/core/src/curator-*.ts`) — scheduled, slice-based grooming. `CURATOR_PROMPT_VERSION="v2"`
+  (`curator-prompt.ts:32`). **Consumes the addendum** (`curator-prompt.ts:61-103`) **and** persists a full
+  per-decision log (§2.5). Has the `/curator` dashboard.
+- **Consolidator** (`packages/core/src/consolidator/*.ts`) — per-submission inbox judge (create/augment/
+  supersede/archive/noop). `CONSOLIDATOR_PROMPT_VERSION="v3"` (`judge-step.ts:27`). **The eval harness
+  (`@librarian/consolidator-eval`) tests THIS one** — *not* the curator. Persists **no** decision log; the live
+  sweep does **not** pass the addendum (`consolidate.ts:70-73`, though `judge-step.ts:67` accepts the param).
+
+**The mismatch:** the addendum the dashboard edits feeds the **curator**; the eval grades the **consolidator**;
+the decision log exists for the **curator** only. **No single pipeline has all three** (addendum + eval + log).
+"Eval-gate the addendum edit" does not connect today.
+
+### 2.1 Two-layer prompt; "addendum can't relax core" — PARTLY
+Both build `[core] + [evidence] + [OPERATOR GUIDANCE addendum]`, addendum last + "advisory only … cannot
+override the rules/schema/apply policy" (`curator-prompt.ts:96`, `judge-step.ts:101`), redacted before send
+(`curator-prompt.ts:93`). ≤2 KB cap enforced at write (`curator-config.ts:46,148-152`); stored as setting
+`curator.prompt_addendum` (`curator-config.ts:29`). **But the guarantee is downstream *code re-validation*, not
+prompt ordering** — "RULES (re-checked in code after you respond — an operation that breaks one is discarded)"
+(`curator-prompt.ts:50`; enforced in `curator-validate.ts` / `consolidator/judge.ts`). So the addendum can't
+relax the **hard, code-checked** rules — but nothing proves it can't bias the *judgement* in ways the validator
+doesn't catch.
+
+### 2.2 Version constant (shipped) vs per-install addendum — TRUE
+`CONSOLIDATOR_PROMPT_VERSION` / `CURATOR_PROMPT_VERSION` are shipped-code constants feeding the run hash
+(`curator-worker.ts:156`); the addendum is per-install in settings, dashboard-editable
+(`config-form.tsx:149-156`). Confirmed.
+
+### 2.3 Proposal rails reusable for an addendum proposal — FALSE (net-new)
+`approveProposal` keys on `memory_id` + `status=proposed` (`markdown-memory-store.ts:279-288`); the MCP tool,
+tRPC (`trpc/memories.ts:230,246`), and dashboard `/proposals` all key on memory rows. **No generic proposal
+entity.** An addendum proposal is net-new (entity + approve path + dashboard surface).
+
+### 2.4 Eval re-runnable on demand w/ candidate addendum → before/after delta — PARTLY
+Real + programmatic: `runConsolidatorEval({fixture, llmClient, thresholds})` (`consolidator-eval/src/run.ts:96`)
+runs the real navigate→judge→route against an injected client; metrics = filing_accuracy / decision_band /
+no_clobber / contradiction_recall / entity_resolution / parse_errors (`metrics.ts:125-139`); fixture
+`fixtures/seed-v1.json`; baseline-gate with per-metric delta + 0.05 tolerance (`baseline.ts:63-82`). **Missing:**
+no `promptAddendum` param (`run.ts:21-25,86-89`), **no two-run A/B** (compares to a *frozen, uncommitted,
+operator-generated* baseline, not two live runs), CLI-driven for real models. Both addendum-injection
+(run→judge) and the two-run delta layer are **net-new**.
+
+### 2.5 Per-groom decision record (the "dataset") — PARTLY
+**Curator** persists full per-op detail: `operation_type, status, confidence, risk_level, rationale,
+proposed_payload, source/target_memory_ids` (`curation-types.ts:62-76`), queryable via `listCurationRuns` +
+`getCurationOperations` → tRPC `curator.runs`/`runOperations` (`trpc/curator.ts:40-46`), in sidecar
+`curation-runs.json`. **Consolidator persists nothing** (`consolidate.ts:58-90` never records) — only the git
+commit of the *outcome* (`librarian-store.ts:243-246`). So the "dataset" exists for the curator, **not** for the
+consolidator (the path that actually does create/augment/supersede/archive/noop).
+
+### 2.6 Dashboard curator surface + LLM reachable for chat — PARTLY
+`/curator` page (config summary, editable config incl. addendum textarea, run-now, recent-runs) + admin tRPC
+`curatorRouter` (`config/setConfig/runs/runOperations/runNow`, `trpc/curator.ts:25-53`). **But the curator LLM
+client is server-loop-only** (`curator-tick.ts:61`, `consolidator-tick.ts:54`, eval CLI) — **no admin path can
+message the live LLM.** Chat is net-new.
+
+### 2.7 Operator-feedback capture (👍/👎/notes on grooms) — NOT-FOUND
+No thumbs/ratings/notes anywhere in `packages/` or `apps/dashboard/`. The premise "learn from operator feedback"
+has **no existing capture point**.
+
+### 2.x Bottom line from the audit
+- **Real + reusable:** the addendum *slot* (stored, ≤2 KB, redacted, advisory-framed, dashboard-editable) — but
+  wired to the **curator** only.
+- **The two explicitly-load-bearing bones are NOT pre-built:** (1) a *proof* that a candidate addendum didn't
+  weaken the safety core (today it's emergent from framing + downstream re-checks, with no isolated assertion),
+  and (2) on-demand eval **A/B with a candidate addendum** (no addendum param, no two-run delta, no committed
+  baseline — and it grades the *consolidator*, a different pipeline from the addendum the dashboard edits).
+- **Four of seven "bones" are absent or memory-only:** generic proposal entity (2.3), consolidator decision log
+  (2.5), admin→LLM chat (2.6), feedback capture (2.7).
+- **The framing's "most bones exist" is optimistic.** The addendum mechanism is the one solid bone; the loop
+  around it (feedback → propose → eval-A/B → approve), and the pipeline it targets, are mostly to be built.
+
+---
+
+## 3. Reframing
+
+The feature assumed one coherent "curator" with a prompt + an editable addendum + an eval + a decision log. The
+audit (§2.0) shows those four ingredients are **scattered across two pipelines**:
+
+| Ingredient | Curator (slice grooming) | Consolidator (inbox judge) |
+|---|---|---|
+| Editable addendum (`curator.prompt_addendum`) | **wired + consumed** (`curator-prompt.ts`) | param exists, **not wired** (`consolidate.ts:70-73`) |
+| Eval harness (`consolidator-eval`) | **none** | **yes** (but tests *this* pipeline) |
+| Per-decision log (rationale/confidence) | **yes** (`curation-types.ts`) | **none** |
+
+So the real first question isn't "how does the curator self-improve" — it's **"which pipeline's judgement are we
+improving, and how do we get all three ingredients (addendum + eval + decision-log) onto that one pipeline?"**
+Three shapes:
+- **P1 — target the Curator:** has the addendum + the decision log; **needs a new eval** (the existing one is
+  the consolidator's).
+- **P2 — target the Consolidator:** has the eval + does the actual create/augment/supersede filing; **needs the
+  addendum wired** (cheap — the param exists) **+ a new decision log**.
+- **P3 — unify** the two pipelines so there's one learnable judgement surface (biggest, but kills the split that
+  caused this).
+
+Everything downstream — where feedback is captured, what the eval grades, what the addendum changes — hangs off
+this choice. Second, the "can't relax the core" guarantee (§2.1) is weaker than the framing assumes (downstream
+re-checks of *hard* rules, no proof against *judgement* bias) — a self-edit loop needs its own safety guard.
+
+### 3.1 Reframe-of-the-reframe (after §8.1 + §8.2): two *tilings*, one *brain*
+The owner pushed to delete the curator (merge happens at ingestion; split can happen at ingestion). §8.2 shows
+why that doesn't fully work: the context window forces the graph to be **tiled**, and the consolidator only ever
+tiles *locally* (a recall neighbourhood around one new submission) — so **whole-graph restructuring can't happen
+at ingestion**. You need a pass that systematically tiles the *whole* graph (the curator's slice approach). So:
+- The two pipelines aren't "redundant vs distinct" — they're **two tiling strategies** forced by one constraint:
+  **reactive/recall** (consolidator, per submission) and **proactive/slice** (curator, whole graph over time).
+  Both are needed; neither subsumes the other.
+- But they do the **same *kind* of judgement** (where does this belong; merge/split/archive/supersede) and
+  **already share the LLM brain** (`curator-llm-client`, redaction, config). So the thing to unify is **the
+  judgement (the prompt/addendum) + the eval + the dashboard + the self-improvement loop — one brain** — *not*
+  the two tilings.
+- Honours the owner's instincts: **retire the nightly cron** → the whole-graph pass becomes **triggered**
+  (admin-invoked / threshold / post-ingestion-burst), not scheduled; **add local `split`** to the consolidator;
+  **one unified dashboard** over the whole thing; **one learned addendum feeds *both* prompts** (fixes §8.1's
+  latent gap). The whole-graph capability stays, just not as a cron.
+
+→ This makes the self-improving feature target **the shared judgement brain**, applied across both tilings —
+which is cleaner than picking P1/P2/P3, and dissolves §2.0's scattered-ingredients problem at the *brain* layer.
+
+---
+
+## 4. Open questions
+
+### 4.1 Which pipeline learns? — **RESOLVED by D1: neither — the shared *judgement brain* learns; both tilings apply it. (Superseded P1.)**
+Interim history: audit said keep the curator (§8.1), pointing at P1. The recall-vs-graph audit (§8.2) + the
+owner's push then reframed it (§3.1) → D1: two tilings, one self-improving brain. Eval shape for that brain is
+the next open question (improvement-process).
+
+### 4.2 Does eval-gating an *addendum* even work? — **MOOT (D4 dropped the stored eval; D8 replaced it with under-evaluation on real traffic).**
+The "eval-gate every self-edit" promise requires the eval to run the **same** prompt the addendum modifies. If
+the target is the consolidator, the eval must thread the candidate addendum into the run (net-new, §2.4). If the
+curator, there is no eval at all yet.
+
+### 4.4 Provider/model config split — open details (D3) — **RESOLVED (all sub-items below).**
+- **(b) Embeddings — RESOLVED (Jim): stay bundled-local, not a provider consumer.** No API-embeddings option
+  exists; keep it local + zero-config.
+- **(a) `endpoint` = base URL — RESOLVED (Jim): keep the current convention.** It's already a base URL today
+  (`curator-llm-client.ts:16` "Base URL, e.g. `https://api.openai.com/v1`"; `:102` appends `/chat/completions`).
+  The provider holds `{ base URL, key }`; the chat jobs append the path. No behaviour change.
+- **(c) Multiple named providers — RESOLVED (Jim):** yes, a dashboard-managed list (add/edit/delete); each job
+  picks `{ provider, model }`; mixing across jobs is the point.
+- **(d) Model selection — RESOLVED (Jim):** dropdown auto-populated from `GET ${endpoint}/models` (uniform under
+  OpenAI-compat), free-text fallback.
+- **(e) OpenAI-compatible-only — RESOLVED (Jim):** no provider `type`; native APIs (e.g. Anthropic `/v1/messages`)
+  out of scope; Anthropic via its OpenAI-compat endpoint. *(Caveat to verify at spec/build: the compat shim must
+  honour JSON mode `response_format: json_object`, which the curator relies on.)*
+
+### 4.5 Where does the eval fit? — **RESOLVED by D4: no stored eval; a live before/after preview + human approval.**
+Both eval flavors fail (generic = wrong target; per-install collection = stale + complex + premature, the vault
+won't hold still). Replaced by a live current-state preview the admin judges. *(Rejected: stored eval-collection
+of corrections — vault evolution makes the labels stale.)*
+
+### 4.6 Grounded vs freeform chat — **RESOLVED by D5: grounded via the "discuss this memory" button.**
+Concrete cases (the memory + the decision-log §2.5), not impressions.
+
+### 4.7 One shared addendum (D1) vs per-job addenda — **RESOLVED by D6: two per-job addenda; admins duplicate cross-cutting guidance manually.**
+
+### 4.8 (Scenario A) Which job does "discuss this memory" target when the admin can't attribute the error?
+Options: (a) ask the admin (D5's fork) — but they often can't tell filing-error from grooming-error; (b) the
+curator *infers* the responsible job from the memory's history (git/decision log — who last touched it); (c) the
+chat covers *both* and the curator decides which addendum (if any) to edit. Likely (b)/(c) > (a).
+
+### 4.9 (Scenario D) The live preview maps to per-submission intake, not per-slice grooming. — **RESOLVED by D8** (under-evaluation propose-mode replaces the preview for both jobs — no slice-preview needed).
+Re-running the *grooming* judgement "on this memory" means re-running its slice — expensive, and not a clean
+single-memory before/after. Options: preview grooming at the **slice** level (show the slice's before/after
+plan); or accept "no clean preview for grooming addendum edits" and lean harder on human judgement there; or
+scope grooming previews to "the operations that touched *this* memory."
+
+### 4.10 (Scenario F) The chat/self-improvement is a third LLM consumer — config it.
+D3 has intake + grooming consumers; the addendum-authoring chat needs a model too. Reuse the discussed job's
+model, or add a third "curator chat" consumer to D3?
+
+### 4.11 (Scenario H) fix-now vs addendum-edit — approval mechanics.
+Is the immediate fix applied direct from chat or routed through the proposal flow? Bundled with the addendum
+approval or separate? (Two different changes — a memory mutation now + a previewed addendum edit.)
+
+### 4.3 What guards "the addendum can't make the curator worse/unsafe"? — **RESOLVED (D4 + §2.1):**
+*unsafe* — the hard rules are re-checked in code regardless of the addendum (§2.1), so a self-written addendum
+can't relax the safety/structural core; *worse* — the live before/after preview (D4) + human approval + the
+revertable git diff are the guard, with the 2 KB cap limiting blast radius. Accepted for "basics ship first";
+revisit only if observed drift demands more (D4).
+
+---
+
+## 5. Working hypotheses
+
+- **H1 (owner, 2026-06-05) — Chat-driven addendum co-authoring — ADOPTED (refined by D4/D5).** A dashboard
+  split-screen **chat** (chat left, addendum draft right) where the admin + curator co-author the **addendum**
+  (system prompts fixed; preferences + domain subtleties in the addendum). Entry via the **"discuss this memory"
+  button** (D5); honesty guard is the **live before/after preview** (D4), not a stored eval. *Still open: per-job
+  vs shared addendum (§4.7).* Final loop: **discuss a memory → fix-now + (if structural) propose addendum edit →
+  live preview → admin approves → git diff.**
+
+---
+
+## 6. Decisions
+
+**D1 (2026-06-05) — Two tilings, one brain.** The consolidator and curator are kept as **two tiling strategies**
+forced by the LLM context window (§8.2) — *reactive/recall* (per submission) and *proactive/slice* (whole graph)
+— neither subsuming the other, because whole-graph restructuring can't happen at ingestion (the consolidator
+only ever sees a local tile). But they do the **same kind of judgement** and already **share the LLM brain**, so
+**the judgement is unified, not the tilings**. Concretely:
+- **One judgement brain:** ~~one learned addendum that feeds both tilings~~ *(superseded by D6 → **two** addenda,
+  one per job, both wired — fixing the §8.1 gap where the addendum fed only the grooming/curator path)*, one
+  **dashboard**, one **self-improvement loop**. This dissolves §2.0's scattered-ingredients problem at the
+  *brain* layer. *(Eval → D4: no stored eval, a live preview.)*
+- **Retire the nightly curator cron** → the whole-graph pass becomes **triggered** (admin-invoked / threshold /
+  post-ingestion-burst), not scheduled. The capability stays; the cron goes.
+- **Add `split` to the consolidator** so an overloaded doc can be split at ingestion (owner's idea — overload is
+  *caused* by ingestion, so catch it there).
+
+*Rationale:* the context window forces the graph to be tiled either way (§8.2); two tilings are genuinely needed
+(reactive local filing + systematic whole-graph review), but unifying the *judgement* (the part that actually
+learns) honours the owner's "merge into one thing / no nightly cron / split at ingestion / one dashboard" while
+keeping the whole-graph capability. *(Supersedes §4.1's interim "target the curator (P1)" framing — the target
+is the shared brain, applied across both tilings.)* *(Eval shape for the unified brain → deferred to the
+improvement-process discussion, §4/next.)*
+
+**D2 (2026-06-05) — One entity, "the curator," with two jobs.** Collapse the consolidator + curator into a
+single conceptual entity, **the curator** (operator-facing name), which does two jobs at different times, with
+different prompts and **optionally different models**:
+- **Intake** job — reactive, per-submission, recall-tiled (formerly "the consolidator").
+- **Grooming** job — proactive, whole-graph, slice-tiled, *triggered* (formerly the "curator pipeline").
+A naming / mental-model simplification (the code's `consolidator/*` + `curator-*` remain the two jobs'
+implementations); aligns with D1's "one brain." *(Job names "intake"/"grooming" provisional — rename freely.)*
+
+**D3 (2026-06-05) — Model config = providers + per-consumer model selection (OpenAI-compatible only).** Replace
+the single `curator.llm.*` connection with:
+- **Named providers** `{ name, endpoint (base URL), key }` (key in the secret store), **managed in the admin
+  dashboard** (add / edit / delete) — e.g. one each for OpenAI, Ollama, Anthropic-compat.
+- **Per-consumer selection** `{ provider, model }` for **the curator's intake job + its grooming job** (so one
+  provider is reused with a different model per job). **Embeddings are NOT a consumer** — they stay the bundled
+  local model (no API-embeddings option; keeps zero-config).
+- **Model picker:** a dropdown auto-populated from `GET ${endpoint}/models` (the OpenAI-compat list endpoint,
+  uniform across providers); **free-text fallback** if a provider doesn't support `/models` or errors.
+- **OpenAI-compatible-only** — no provider `type`; the client speaks OpenAI (`/chat/completions`, `Bearer`, JSON
+  mode) to every provider (`curator-llm-client.ts:102,131`). **Anthropic is configured via its OpenAI-compat
+  endpoint**, not its native `/v1/messages` API. Native provider types are explicitly out of scope.
+*A separable config refactor this feature motivates* (the two jobs want different models). §4.4 fully resolved.
+
+**D4 (2026-06-05) — No automated eval gate; a live before/after *preview* + human approval.** There is **no
+stable ground truth** for per-install grooming — the vault evolves, so **generic fixtures measure the wrong
+target** (per-install tuning) and **stored per-install corrections go stale** (the memory a correction referenced
+gets split/archived/grown; recall returns a different candidate set; the right answer is contextual to a moment).
+So the self-improvement loop has **no stored pass/fail eval**. ~~Instead a live before/after preview on the
+discussed memory.~~ *(Synthetic preview **superseded by D8** — "under-evaluation on real traffic" is a stronger,
+real-results guard; and the "revertable git diff" guard was broken, fixed by D7.)* *The admin is the judge.*
+Remaining guards: hard rules re-checked in code regardless of the addendum (§2.1); the 2 KB cap forces
+condense-not-append; **under-evaluation propose-mode (D8)** + **revertable vault-file versioning (D7)**. The generic `consolidator-eval` stays a dev/release check on the **shipped** prompt —
+**not** part of the per-install addendum loop. **Automated per-install eval is explicitly DEFERRED** until/unless
+drift is an *observed* problem. *Rationale:* the ground truth is genuinely unstable, so an automated gate fights
+the nature of the thing; the human + a concrete live preview is the honest guard, not a compromise. *(Reverses
+the TODO's "eval-gate every self-edit" premise — for a real reason, recorded here.)*
+
+**D7 (2026-06-05, resolves §11/C1) — The addendum is a committed file in the vault, not a setting.** Each
+per-job addendum is stored as markdown **in the vault** (`<vault>/.curator/intake-addendum.md` +
+`grooming-addendum.md`) → git-versioned, so **diff, revert, and backup** (the vault is pushed) come for free —
+the real "SOUL.md edit" model the design wanted. Provider keys stay in `settings.json` (secret store); the
+addendum (guidance, not a secret) moves into the vault. *Supersedes the `curator.prompt_addendum` setting; fixes
+C1's broken "revertable git diff" guard.*
+
+**D8 (2026-06-05, resolves §11's blast-radius assumption + M2/§4.9; supersedes D4's synthetic preview) — Safety =
+an "under evaluation" lifecycle on REAL traffic.** An addendum version goes **draft → under-evaluation → accepted
+(or rolled back)**. While **under evaluation**, the curator *uses* the new addendum but **forces everything it
+produces to `proposed`** (override the apply-policy / confidence-bands to always `propose`) — so the admin reviews
+its **actual** effects on real memories in the existing proposal queue, over time, then **accepts** (normal
+auto-apply resumes) or **rolls back** (D7's vault versioning). Reuses existing propose paths — both jobs have
+them (intake confidence-bands `judge.ts:130-131`; grooming `proposeOp` `curator-apply.ts:115-125`). **Escape
+hatch:** "re-evaluate everything in proposals" (batch re-judge) if a prompt produces garbage. *Wrinkle:* grooming
+`archive` has no clean propose path (`curator-apply.ts:202`) → under-eval **skips** auto-archives (safe). The
+admin takes explicit responsibility (no automated no-regression gate — there's no stable ground truth, D4) — but
+judged on **real results**, not a synthetic sample. *(Also resolves §11/M2 + Scenario D: grooming ops are
+proposed for review — no slice-preview needed.)*
+
+**D9 (2026-06-05, strengthens D8 for the grooming job) — Grooming addendum edits can be dry-run on demand over
+the existing corpus.** Because the grooming job's *input is the existing corpus*, the admin can edit the grooming
+addendum and **immediately run a grooming pass over the corpus (or a chosen slice) with the candidate addendum,
+forced to propose-mode** — producing a reviewable **batch of proposed operations** (merge/split/update) that show
+the addendum's *actual* impact on the real vault, to keep or re-edit. Composes existing pieces: the "run now"
+trigger (`trpc/curator.ts`) + the D8 propose-override + the candidate addendum threaded in. **Visualization** =
+the existing proposal queue, tagged by addendum version ("from grooming-addendum vN — evaluating"). **Cost/time
+scales with corpus size** → offer "dry-run this slice" (fast) vs "dry-run everything" (background batch).
+**Intake has no equivalent** — its input is *new submissions*, not replayable — so intake stays on **D8's
+new-traffic probation**. *(Inherits D8's `archive` wrinkle — see D8.)*
+
+**D6 (2026-06-05, supersedes D1's "one shared addendum") — Two addenda, one per job.** The **intake** job and
+the **grooming** job each have their **own** prompt addendum — *filing* preferences vs *graph-restructuring*
+preferences are different concerns a single blob would blur, and the D5 "discuss this memory" fork / job picker
+targets one job's addendum. **No shared-section / cross-addendum sync machinery:** if a piece of guidance
+genuinely belongs in both, the admin **puts it in both manually** — let admins figure that out rather than
+building dedup. Each addendum keeps its own ≤2 KB cap.
+
+**D5 (2026-06-05) — Feedback = a "discuss this memory" button; fix-now always, addendum-edit only when
+structural.** A button on a memory opens the curator chat with the memory's **id + content pre-populated**
+("I want to chat about this memory you recorded: …"). In the chat the curator can **(a) always fix the immediate
+problem** then and there (e.g. merge/edit — a one-off correction), and **(b) only when it's a recurring/
+*structural* error** (not a one-off edge case) propose an **addendum edit**. Grounds feedback in concrete cases
+(no freeform vibes); the one-off-vs-structural split is the guard against addendum-bloat. *Supersedes the TODO's
+"👍/👎 + notes" capture* — the button + chat + the existing grooming decision-log (§2.5) is the richer capture.
+
+*Clarification (Jim, 2026-06-05) — the chat also has a **general (memory-less) entry point.*** The
+"discuss this memory" button is **one** way in (memory pre-populated); the same curator chat can **also be opened
+fresh from the dashboard with no specific memory** for general feedback ("I've noticed you keep over-merging
+person memories…"). Same chat surface, same fix-now / addendum-edit affordances; it just starts without a seeded
+memory. So the chat is **not** exclusively memory-anchored — the per-memory button is the grounded shortcut, and
+the general entry is the catch-all for cross-cutting guidance the admin can't pin to a single memory. *(The
+job-picker fork from §4.8 still applies: a general chat may need the admin — or the curator — to choose which
+job's addendum, if any, an edit targets, since there's no memory history to infer it from.)*
+
+---
+
+## 7. Loose ends / parking lot
+
+- **"Basics ship first"** (owner) — identify the minimal load-bearing slice (likely the self-edit loop + eval
+  gate; chat is a later UX layer).
+- **Retrospective-refactor pass** (separate TODO item, under Consolidator) — reorganises the vault (split coarse
+  nodes into hub+spokes, merge dups, repair links); *distinct* from this (improves judgement, not the vault).
+  They compose; keep separate.
+
+---
+
+## 8. Sub-question deep-dives
+
+### 8.1 "Do we even need the curator?" — audit verdict: KEEP (distinct + load-bearing) (2026-06-05)
+The consolidator does **not** subsume the curator. Three structural differences, all load-bearing:
+1. **Re-grooms EXISTING memories.** The consolidator only judges *incoming* submissions one at a time and
+   **never revisits** a filed memory (`consolidator/sweep.ts:52`, `consolidate.ts:58-93`); the curator's entire
+   input is the existing slice corpus (`curator-evidence.ts:170-172`). Only the curator revisits.
+2. **`merge` + `split`.** The consolidator's judgment schema is a closed union `create|augment|supersede|archive|noop`
+   (`consolidator/judge.ts:63-69`) — **no merge/split**. The curator has them (`curator-output.ts:58-91`,
+   `curator-apply.ts:161-177`). Cross-memory reorganisation has **no consolidator equivalent**.
+3. **Slice-level reasoning + idempotency** — the curator reasons over a whole slice with an input-hash skip
+   (`curator-worker.ts:65-74`); the consolidator's unit is one submission.
+
+**History:** specs are explicit the consolidator was *"built on the **kept** curator pipeline"* (035 §F5,
+`docs/specs/035-…:27-28,75`), not a replacement; the curator was still being maintained 2026-06-04. The
+**retrospective whole-graph refactor** (TODO) is the curator's *unbuilt* extension, not the consolidator's job.
+
+**Shared machinery (removing the curator frees almost nothing):** the consolidator imports
+`curator-llm-client.ts`, `curator-redaction.ts`, and the `curator.llm.*` config (`consolidate.ts:11`,
+`judge-step.ts:11-12`, `consolidator-tick.ts:37-41`). Those stay regardless.
+
+**Honest caveat (bears on sequencing):** both pipelines are **off by default** (`curator.enabled` defaults off
+`curator-config.ts:114`; consolidator env-gated off `consolidator-config.ts:9-12`), and the curator's headline
+payoff (whole-graph retrospective refactor) is still a TODO — so today the curator earns its keep largely as
+**scaffolding for a not-yet-shipped capability**.
+
+**Two consequences for the feature:**
+- The curator is the right **target** (P1): addendum + decision log + dashboard already there; the gap is an
+  **eval** for *this* pipeline (the existing eval is the consolidator's).
+- **Latent gap:** the addendum (`curator.prompt_addendum`) feeds the **curator** prompt but the live
+  consolidator sweep never passes it (`consolidate.ts:70-73`) — so "how I like things" shapes *grooming* but not
+  *filing*. Worth deciding whether one learned addendum should feed **both** prompts (they share the LLM brain).
+
+---
+
+### 8.2 "Why recall, not the graph itself?" — audit answer: the context window forces *tiling* (2026-06-05)
+- The judge **never sees the whole vault.** `navigateInbox` (`consolidator/navigate.ts:62-78`) hands it
+  **K=8 full candidate bodies** (`DEFAULT_CANDIDATE_LIMIT`, :50, via `recall`) + a **200-entry title-only ToC**
+  (`DEFAULT_TOC_LIMIT`, :51, titles+tags, *no bodies*). That's it.
+- **The binding constraint is the LLM context window — fundamental, not incidental.** You can't put thousands
+  of markdown bodies in one prompt, so the graph **must be tiled**. The consolidator tiles by **recall
+  relevance** (a neighbourhood around the new submission); the curator tiles by **ownership slice**
+  (`curator-evidence.ts`, ≤200 capped bodies). *Same move, different axis.*
+- **Recall is already partly graph-aware.** `recallFromIndex` (`store/index/recall.ts:41-69`) expands **one hop**
+  along wikilinks + backlinks (the "Anna problem" fix, `neighborDecay=0.5`). So "look at the graph" isn't an
+  unexplored alternative — it's literally inside recall, just single-hop, re-bounded to K=8.
+- **A richer graph-native evidence step is feasible + unblocked but doesn't escape the limit.** The wikilink
+  graph is first-class walkable data (`LinkGraph.neighbors/inbound/outbound`, `link-graph.ts:10-17`) the judge
+  is never explicitly shown; wiring a backlink neighbourhood / multi-hop walk into `navigate` is feasible — but
+  it only changes *which* tile, not the need to tile.
+
+**The consequence that matters:** **whole-graph restructuring cannot happen at ingestion** — the consolidator
+structurally only ever sees a *local* tile (one submission's neighbourhood). Covering the *whole* graph
+systematically (so every cluster gets a structural review, and orphan dups recall missed get caught) requires a
+**separate tiling pass over the whole graph** — which is exactly what the curator's slice approach is. That, not
+"it has the prompt," is the real justification for a curator-shaped pass. *(But it need not be a nightly cron —
+see §3.1.)*
+
+## 9. Sanity-check: end-to-end scenarios (2026-06-05)
+
+### A — Admin clicks "discuss this memory" on a badly-organised memory ✗ **(which job?)**
+The memory looks wrong. But was it **filed** wrong by *intake* or **restructured** wrong by *grooming*? The
+admin often can't tell — and D5/D6 require picking which job's addendum to target. **Verdict:** the fork assumes
+the admin can attribute the error to a job; frequently they can't. → §4.8.
+
+### B — Memory was filed fine, then grooming merged it badly ⚠
+It's a *grooming* error, and "fix it now" must **undo** a grooming merge (split it back out) — a different action
+from the intake-side fixes. **Verdict:** works only if (a) the error is attributed to grooming (see A) and (b)
+"fix it now" can reverse a prior groom, not just edit the current doc.
+
+### C — Live preview for an *intake* error ✓
+Re-run the filing judge on this one memory (current vault) with old vs new intake-addendum → a clean,
+single-memory before/after. **Verdict:** the preview maps perfectly to intake (the unit *is* one submission).
+
+### D — Live preview for a *grooming* error ✗ **(preview unit mismatch)**
+Grooming judges a **slice** (a whole-graph tile), not one memory. "Preview how grooming would handle *this
+memory*" doesn't map — you'd have to re-run the whole slice-groom, which is expensive and isn't a single-memory
+before/after. **Verdict:** D4's "preview on the discussed memory" is clean for intake, **awkward for grooming**.
+→ §4.9.
+
+### E — Grounding an *intake* error ✗ **(intake has no decision log)**
+§2.5: only the grooming job logs its decisions; **intake (the consolidator) logs nothing**. So for an intake
+error the chat can show the memory but **not why intake filed it that way** — the D5/§4.6 grounding is
+asymmetric. **Verdict:** intake needs a decision log built for "discuss this memory" to be grounded on the
+intake side. → build item, but it bites the feedback design.
+
+### F — Which model powers the chat/self-improvement? ⚠
+D3's consumers are the **intake job** + the **grooming job**. The "discuss + co-author addendum" chat is a
+**third** LLM consumer with no configured provider/model. **Verdict:** config gap — add a third consumer (or
+reuse the discussed job's model). → §4.10.
+
+### G — An addendum that passes the single-case preview but biases other cases ⚠
+"Always keep family memories granular" fixes this case but would over-fragment other clusters; the single-memory
+preview can't show that. **Verdict:** accepted blast-radius limit of D4 — guard is human judgement + revert +
+2 KB cap. Real but consciously accepted.
+
+### H — fix-now + addendum-edit: one approval or two? ⚠
+The immediate fix is a real mutation (merge/split); the addendum edit is a separate, previewed, approved change.
+**Verdict:** mechanics undefined — is fix-now applied direct from chat or via the proposal flow, and is it
+bundled with or separate from the addendum approval? → §4.11.
+
+### I — Condense-not-append at the 2 KB cap ⚠
+The Nth structural correction forces a rewrite to fit 2 KB; the rewrite may drop a still-load-bearing earlier
+rule. **Verdict:** condense is lossy — the curator must be told to preserve load-bearing rules; cap is a feature
+but needs care.
+
+### J — Day-one empty addendum ✓
+No addendum, no corrections; base behaviour; nothing to diff. Loop is inert until first use. **Verdict:** fine —
+the system gets better with use, correct shape.
+
+### K — "discuss" on an already-archived/merged-away memory ⚠
+The grooming job already archived/merged it; the id may not resolve to a live doc. **Verdict:** edge case — the
+chat must handle "this memory no longer exists as such (it was merged into X / archived)".
+
+### Findings summary
+- **Clean:** C (intake preview), J (cold start).
+- **Works with notes:** B, G (accepted), H, I, K.
+- **Unresolved (✗):** **A** — which job does "discuss this" target when the admin can't attribute the error
+  (§4.8). **D** — the live preview is clean for intake but doesn't map to the *slice*-level grooming job (§4.9).
+  **E** — intake keeps no decision log, so intake-side feedback is ungrounded. *(All three cluster on the same
+  root: the two jobs are genuinely different shapes — per-submission vs per-slice — and the feedback/preview/log
+  design was implicitly modelled on the per-submission intake job.)*
+
+---
+
+## 11. Blind review (2026-06-05) — one Critical (C1); not spec-ready until resolved
+Independent cold/adversarial review (no conversation context, codebase access, briefed to attack). The audit
+(§2/§8) verified strong + accurate; but one **false safety claim is baked into a decision**, plus spec-must-close gaps.
+
+**C1 (CRITICAL) — "revertable git diff like a SOUL.md edit" does NOT exist.** The addendum is a *setting*
+(`curator.prompt_addendum`, `curator-config.ts:29,181`) persisted to `settings.json` **outside** the vault git
+repo (sidecar JSON, no git — `settings-store.ts:1-7,48-57`; `librarian-store.ts:145-146`); backup is a vault-HEAD
+push (`backup/run.ts:6,78`), so settings are never versioned/diffed/backed-up. `setConfig` **blind-overwrites**
+(`trpc/curator.ts:31-37`) — the prior addendum is gone, no history, no revert. D4 dropped the eval and leaned the
+guard set on "admin-approved, **revertable git diff**"; that guard doesn't exist, leaving only
+human-judgment-on-one-preview. → **Fix:** build **addendum versioning** — store each per-job addendum as a
+*committed file in the vault* (git diff + revert for free — the real "SOUL.md" model), or rewrite D4's guards
+honestly. Changes D4.
+
+**Important:**
+- **I1 — "one brain" (D1/D2) is conceptual only.** Two jobs = two hardcoded prompts with *different op schemas*
+  (`curator-prompt.ts:41-46` `noop|archive|update|merge|split` vs `judge-step.ts:43-48`
+  `create|augment|supersede|archive|noop`); they share only transport. D6 (two addenda) concedes it. Spec must
+  state "one brain" buys nothing mechanically — the missing ingredients get built **twice**.
+- **I2 — "fix it now" is net-new; reversing a groom has no primitive.** memories tRPC has no merge/split
+  (`trpc/memories.ts:152-264`); merge/split live only in the scheduled `curator-apply.ts`; the curator router is
+  "deliberately NO consumer-agent surface." Splitting a bad merge back out (Scenario B) exists **nowhere**.
+- **I3 — D3 ripples more than "separable."** Both jobs read one shared `curator.llm.*` today
+  (`consolidator-tick.ts:34-37`); the addendum is coupled into the same `CuratorConfig` object — splitting
+  providers touches the addendum-bearing config. (Stale `classifier` consumer comment in `llm-connection.ts`;
+  `classifier-config.ts` doesn't exist — confirm.)
+- **I4 — self-improvement runs on jobs OFF by default.** `curator.enabled` off (`curator-config.ts:114`),
+  consolidator env-gated off. §9 never asked: if grooming is off there are no grooms / no log / nothing to
+  discuss. Spec must define the loop when a job is disabled (inert + dashboard says so).
+- **I5 — the live preview is net-new, NOT the eval.** The eval builds a synthetic fixture corpus + never passes
+  an addendum (`run.ts:79-89`); D4's preview must call `judgeSubmission` (`judge-step.ts:132`) against the
+  *live* vault with old-vs-new addendum — feasible + cheap for **intake**, but new code; the addendum must be
+  threaded into the live path (`consolidate.ts:71-74` omits it today).
+
+**Minor:** **M2** — grooming preview (§4.9) genuinely unsolved → the **grooming addendum has no working preview
+guard** (half the feature approves blind). **M3** — 2 KB is a hard *reject* (throws, `curator-config.ts:148-152`),
+no retry-tighter machinery. **M4** — intake has no decision log → ungrounded intake feedback + a new write on the
+perf-sensitive ingestion path. **M5** — doc cites stale trpc paths (real: `packages/mcp-server/src/trpc/`).
+
+**The unexamined assumption:** *a single-case live preview ≈ "the addendum improved judgement generally."* With
+no eval + no revert (C1) + no grooming preview (M2), "real learning, not rationalising" reduces to "the admin
+approved one before/after." An addendum that fixes the shown case but biases ten unshown ones **passes every
+guard**. Honest fix: working revert (C1) + a **multi-case preview** ("show 3 other recent memories under the new
+addendum") to widen the blast-radius window; and the spec must *say* it trades the no-regression guarantee for a
+human spot-check.
+
+**Verdict:** not spec-ready — resolve **C1** first; **I2 / I4 / M2** close behind.
+
+### 11.1 Resolution status
+- **C1** ✅ **resolved by D7** (addendum is a committed vault file → real git diff/revert/backup).
+- **Blast-radius assumption + M2 (grooming preview) + §4.9 + Scenario D** ✅ **resolved by D8** (under-evaluation
+  on real traffic → propose-mode for both jobs; no synthetic preview; honest "admin takes responsibility").
+- **Remaining = spec-scope notes (not design forks):** **I1** "one brain" is conceptual — build ingredients
+  twice. **I2** "fix it now" merge/split + **reversing a groom** are net-new admin mutations. **I3** the
+  provider/model split touches the addendum-bearing `CuratorConfig` (verify the stale `classifier` consumer).
+  **I4** define the loop when a job is **off by default** (inert + dashboard says so). **I5** the under-eval path
+  must thread the addendum into the live judge (`consolidate.ts:71-74` omits it). **M3** 2 KB over-cap is a hard
+  *reject* — add "condense / retry tighter." **M4** build an **intake decision log** (new write on the
+  perf-sensitive ingestion path) so intake-side feedback is grounded. **M5** fix stale trpc paths in citations.
+
+## 10. Late-stage observations

--- a/docs/specs/041-librarian-awareness-primer-spec.md
+++ b/docs/specs/041-librarian-awareness-primer-spec.md
@@ -1,0 +1,218 @@
+# Spec 041 — Librarian awareness primer
+
+**Status:** Draft for review (Specify phase)
+**Version target:** MINOR (new server-sourced setting + a small, lockstep response-shape
+change to `conv_state_get`; no behaviour change when the primer is empty)
+**Depends on:** the per-turn conv-state injection contract (specs 022 §4.9, 024–026, shipped);
+the `SettingsStore` + dashboard-config pattern (curator settings, shipped)
+**Relates to:** `docs/research/harness-driven-capture-brainstorm.md` (the working doc — this
+spec is feature **1B**, decisions **D1 / D9** and §3.2; feature 1A "auto-capture" is shelved)
+**Cross-repo:** lockstep change across **6 repos** — `the-librarian` (server + dashboard) +
+the five plugins (`-claude-plugin`, `-codex-plugin`, `-hermes-plugin`, `-pi-extension`,
+`-opencode-plugin`). The `conv_state_get` response shape is a *sacred cross-repo contract*
+(AGENTS.md §2) — change all or none, in one coordinated push.
+
+---
+
+## Objective
+
+**What.** On every turn, in every one of the five harnesses, inject a short,
+**server-sourced** note telling the model that the Librarian exists and which verbs to reach
+for — e.g. *"You have The Librarian: durable cross-session memory. Use `recall` to check what
+you already know before asking, and `remember` / `learn` to save durable facts."* The text
+rides the **existing** per-turn `<conversation-state>` injection channel; it is **passive**
+(awareness only — not active recall-injection) and **brief** (1–2 sentences, a context-budget
+floor, not a replacement for the skill).
+
+**Why.** We can't rely on the agent auto-loading the Librarian skill/plugin (the brainstorm's
+§3.2 reliability-floor argument). Without a deterministic primer, an agent may never realise the
+Librarian is available and simply never call `recall` / `remember`. The conv-state block already
+fires every turn in all five plugins and already survives compaction by re-injecting each turn —
+so a primer that rides it gets **compaction-survival for free** with **no new hook** (brainstorm
+D9, which resolved blind-review Critical **C2**: idea B was "stamped, never designed").
+
+**Who.** Every Librarian user on every harness. Server-sourced means the admin can edit the
+primer text from the dashboard **without re-releasing any plugin**.
+
+**Success, in one line.** A fresh conversation on **any** of the five harnesses — including
+**Codex** (no stable per-conversation id) and including the **first turn before any conv-state
+row exists** — carries the server's primer in the model's context, and editing the primer text in
+the dashboard changes what the next turn sees, with no plugin redeploy.
+
+---
+
+## Background — what's there, and the gap
+
+### What already works (frozen evidence, 2026-06-05)
+
+- **One per-turn server round-trip, already universal.** Every plugin calls `conv_state_get`
+  once per turn and renders the block client-side:
+  - claude — `UserPromptSubmit` hook, emits via `hookSpecificOutput.additionalContext`
+    (`the-librarian-claude-plugin/src/bin/conv-state-inject.ts:42-66`; MCP call `:120-148`).
+  - codex — `UserPromptSubmit`, same envelope
+    (`the-librarian-codex-plugin/plugins/the-librarian/bin/librarian-codex-hook.js:20-57`; call `:33`).
+  - hermes — `system_prompt_block()` / `prefetch()`
+    (`the-librarian-hermes-plugin/provider.py:212-217,228-249`; call `:239`; prefix `:405-411`).
+  - pi — `before_agent_start`, appends to `event.systemPrompt`
+    (`the-librarian-pi-extension/extensions/librarian/handlers/system-prompt-augment.ts:38-61`; call `:45`).
+  - opencode — `experimental.chat.system.transform`, pushes onto `output.system`
+    (`the-librarian-opencode-plugin/src/handlers/system-transform.ts:36-57`; call `:45`).
+  - **Consequence:** adding primer text to the `conv_state_get` *response* reaches every turn in
+    every harness **with zero new network cost and no new hook.**
+- **The renderer is five byte-identical peer copies, not a shared dependency.** Canonical
+  source `packages/core/src/conv-state-render.ts:26-35` renders a two-field block
+  (`conv_id` + `off_record`; returns `""` when state is null); each plugin replicates it locally
+  (AGENTS.md §2 "five peer implementations" rule; spec 025 D5). Any block-shape change is therefore
+  a deliberate lockstep edit in all six repos.
+- **Server-sourced text has a proven pattern.** `session_manifest` already reads a settings value
+  server-side (`working_style` via `getSetting`, `packages/mcp-server/src/mcp/tools/session-manifest.ts:14-20`,
+  fail-soft → `""`); the curator config is the proven **dashboard-edited setting** pattern (admin
+  tRPC `trpc/curator.ts:25-37`; worker reads the setting). A new primer setting is a copy of an
+  existing, working shape.
+
+### The gap
+
+- `conv_state_get` returns **only** the conv-state row (or the text `"No conversation state for
+  conv_id…"`) — `packages/mcp-server/src/mcp/tools/conv-state-get.ts:22-28`. It carries no primer.
+- `renderConvStateBlock(null)` returns `""` — so on a **brand-new conversation with no row**, the
+  block is empty and nothing is injected. A primer must appear **even when there is no row** (its
+  whole job is the day-one floor), so it cannot be a field *on the row*.
+- `session_manifest` (the richer F6 preamble: working-style + skills manifest) has **zero callers**
+  in any plugin. That richer preamble is a **deferred** upgrade (brainstorm D9) — **out of scope
+  here**. 1B ships the brief primer only.
+
+---
+
+## The change
+
+### 1. Server — a new server-sourced primer setting (dashboard-editable)
+
+- Add a `SettingsStore` key (proposed `awareness.primer`, string) with a **shipped default** so
+  the primer works out-of-the-box before any admin edit. **Empty string disables it** (no block).
+- Surface it on the dashboard with an admin tRPC read/write, mirroring the curator-config pattern
+  (`trpc/curator.ts:25-37`): a labelled textarea on an existing admin/settings page, with the
+  shipped default pre-filled and a short "this text is injected every turn on every harness" hint.
+- Reads are **fail-soft**: if the setting store is locked/unreadable, treat the primer as `""`
+  (same posture as `readWorkingStyle`), never throw.
+
+### 2. Server — `conv_state_get` returns the primer alongside the row
+
+`conv_state_get` reads the primer setting and returns it **on every call, whether or not a
+conv-state row exists**. Recommended response shape (final wire detail is the implementer's, see
+Open Questions):
+
+```jsonc
+{
+  "state": { "conv_id": "...", "off_record": false, /* … */ } | null,
+  "primer": "You have The Librarian: durable cross-session memory. Use `recall` before asking; `remember` / `learn` to save durable facts."
+}
+```
+
+- This **replaces** the bare-row JSON and the `"No conversation state…"` text response — a
+  deliberate, lockstep response-shape change (sacred contract).
+- The primer is **global, not conversation-keyed** — it does **not** depend on `conv_id` being
+  stable or on a row existing. This is what makes 1B work on **Codex** (only a per-cwd fallback id,
+  the genuine blocker for the *capture* feature) and on the **first turn** of any conversation.
+- **`off_record` does not suppress the primer.** The primer is generic awareness text with no
+  conversation content; the off-record gate still governs all actual recording. (Phrase the
+  default primer so it doesn't *urge* recording — "use `recall`; `remember` when appropriate" — so
+  it reads sensibly even mid-off-record. See Open Questions on tone.)
+
+### 3. Plugins — render the primer block (×5, byte-identical)
+
+Each plugin's local renderer gains a sibling `renderAwarenessPrimer(primer)` that returns a small
+block (proposed `<librarian>…</librarian>`) when `primer` is non-empty and `""` otherwise; each
+injection handler reads `response.primer` and emits `renderAwarenessPrimer(primer)` **alongside**
+the existing `renderConvStateBlock(state)` (concatenated into the same `additionalContext` /
+`output.system` push / `systemPrompt` append — no second injection point, no second fetch).
+
+- The primer block is **separate** from `<conversation-state>` (it is static awareness, not
+  per-turn state) but rides the same emit.
+- Keep all five implementations byte-identical (the peer-implementation rule). Update the canonical
+  `packages/core/src/conv-state-render.ts` too, as the reference the five copies track.
+- Each plugin keeps its existing fail-soft contract unchanged: any error → no block, turn proceeds.
+
+---
+
+## Per-harness feasibility (all five; Codex included)
+
+| Harness | Per-turn injection | Primer feasible? | Note |
+|---|---|---|---|
+| claude | `UserPromptSubmit` → `additionalContext` | **yes** | already round-trips `conv_state_get` every turn |
+| codex | `UserPromptSubmit` → `additionalContext` | **yes** | primer is global → the missing stable `conv_id` (capture's blocker) is irrelevant here |
+| pi | `before_agent_start` → `systemPrompt` | **yes** | appends per turn |
+| opencode | `experimental.chat.system.transform` → `output.system` | **yes** | pushes per turn; experimental-hook risk already tracked (spec 025 §7.1) |
+| hermes | `system_prompt_block()` / `prefetch()` | **yes, verify cadence** | confirm `system_prompt_block()` re-fires per turn (not once at session start) so the primer survives compaction on Hermes — see Open Questions |
+
+The primer's independence from `conv_id` is the key property: **1B is feasible on all five
+harnesses**, unlike capture (1A), which Codex blocks.
+
+---
+
+## Commands / Project structure / Testing
+
+- **Server touches:** a new settings key + its default (`packages/core/src/store/settings-*`);
+  `packages/mcp-server/src/mcp/tools/conv-state-get.ts` (read the setting, new response shape);
+  `packages/core/src/conv-state-render.ts` (reference `renderAwarenessPrimer`); a dashboard admin
+  field + tRPC read/write (`apps/dashboard`, mirroring curator config).
+- **Plugin touches (×5):** the local renderer (add `renderAwarenessPrimer`) + the injection handler
+  (read `response.primer`, emit the block) in each plugin repo, byte-identical.
+- **Testing:**
+  - Server unit: `conv_state_get` returns `primer` **with a row, with no row, and with the setting
+    empty** (empty → `primer: ""`); fail-soft when the setting store is unreadable → `primer: ""`.
+  - Per-plugin unit (mirror the existing conv-state tests): primer present → primer block emitted
+    even when `state` is null; primer empty → no primer block; `conv_state_get` failure → no block,
+    turn proceeds (fail-soft).
+  - One **eyeball test per harness** (reuse the spec-025 pattern): seed/keep the default primer, ask
+    the model "do you have durable memory and how do you save a fact?" — it can answer from the
+    primer alone. Confirms injection reaches the model (and, for opencode, that the experimental
+    hook isn't silently discarded — issue #17100).
+- **CHANGELOG:** an `## [Unreleased]` entry in **each** of the six repos in the lockstep push.
+
+## Boundaries
+
+- **Always:** brief primer (1–2 sentences); server-sourced (no hard-coded primer text in plugins);
+  fail-soft (never block a turn); byte-identical peer renderers; branch + PR per repo; CHANGELOG in
+  every repo touched; lockstep across all six (the `conv_state_get` response is a sacred contract).
+- **Ask first / out of scope:** the richer `session_manifest` preamble (working-style + skills) —
+  deferred (D9); **active recall-injection** ("pull relevant memories and inject them") — deferred
+  (D9, this is *passive awareness only*); any capture/auto-learn behaviour (feature 1A — shelved).
+- **Never:** make the primer depend on a stable `conv_id` (it must work on Codex + day-one);
+  suppress the conv-state row's existing fields; introduce a second per-turn fetch or a new hook.
+
+## Success criteria
+
+- [ ] A new dashboard-editable primer setting exists with a shipped default; clearing it to empty
+  disables the primer (no block emitted anywhere).
+- [ ] `conv_state_get` returns the primer **on every call**, including when no conv-state row
+  exists for the `conv_id`; reads are fail-soft (`""` on unreadable store).
+- [ ] All five plugins emit the primer block every turn (byte-identical renderer), alongside the
+  conv-state block, with no second fetch and no new hook.
+- [ ] **Codex** shows the primer despite having no stable per-conversation id.
+- [ ] A **brand-new conversation** (no row yet) shows the primer on its first turn.
+- [ ] Editing the primer text in the dashboard changes what the next turn sees — **no plugin
+  redeploy**.
+- [ ] Eyeball test passes on each harness (model can name the Librarian + a save verb from the
+  primer alone); opencode injection confirmed reaching the model.
+- [ ] Every error path (store down, parse failure, off-record) leaves the turn unblocked and
+  leaks no stack trace into the model's context.
+- [ ] Hermes cadence confirmed: the primer re-injects per turn (survives compaction), not once.
+
+## Open questions
+
+1. **Response-shape vs forward-compat.** The clean `{ state, primer }` shape is a breaking change
+   to `conv_state_get` (mitigated by lockstep + fail-soft: version skew during rollout just drops a
+   block, never crashes). The additive alternative — keep the row at top level and add a `primer`
+   field — lets an un-updated plugin keep working through the rollout window. Pick at implementation
+   time; recommend `{ state, primer }` for clarity unless a staggered rollout is expected.
+2. **Block tag + placement.** `<librarian>` sibling block vs folding the primer into
+   `<conversation-state>`. Recommend a separate tag (it is static awareness, not per-turn state).
+3. **Tone vs off-record.** Default primer wording that reads correctly even when the user is
+   off-record (favour "recall before asking; `remember` when appropriate" over "always remember").
+4. **Every-turn vs throttle.** D9 chose every-turn (compaction-survival for free; there is no
+   post-compaction signal to throttle against). If the repetition proves wasteful, a first-turn +
+   periodic cadence is a later optimisation — but it needs a compaction signal the plugins don't
+   currently have. Leave every-turn for v1.
+5. **Hermes `system_prompt_block()` cadence** — verify it re-fires per turn before relying on it
+   for compaction survival; if it only fires at session start, ride `prefetch()` or the per-turn
+   path instead.

--- a/docs/specs/041-librarian-awareness-primer-spec.md
+++ b/docs/specs/041-librarian-awareness-primer-spec.md
@@ -142,10 +142,36 @@ the existing `renderConvStateBlock(state)` (concatenated into the same `addition
 | codex | `UserPromptSubmit` → `additionalContext` | **yes** | primer is global → the missing stable `conv_id` (capture's blocker) is irrelevant here |
 | pi | `before_agent_start` → `systemPrompt` | **yes** | appends per turn |
 | opencode | `experimental.chat.system.transform` → `output.system` | **yes** | pushes per turn; experimental-hook risk already tracked (spec 025 §7.1) |
-| hermes | `system_prompt_block()` / `prefetch()` | **yes, verify cadence** | confirm `system_prompt_block()` re-fires per turn (not once at session start) so the primer survives compaction on Hermes — see Open Questions |
+| hermes | `prefetch()` per-turn — **not** `system_prompt_block()` (session-start only) | **yes, w/ 2 notes** | ride `prefetch`; decouple the primer from the row-existence gate (see below); one residual live-test |
 
 The primer's independence from `conv_id` is the key property: **1B is feasible on all five
 harnesses**, unlike capture (1A), which Codex blocks.
+
+### Hermes specifics (verified 2026-06-05, `the-librarian-hermes-plugin/provider.py`)
+
+Reading the Hermes provider resolved the cadence question and surfaced two concrete
+implementation requirements:
+
+- **Ride `prefetch()`, not `system_prompt_block()`.** `system_prompt_block()` is *"a frozen recall
+  snapshot injected **once at session start**"* (`provider.py:213`) — a primer riding it would
+  appear once and die at the next compaction. The per-turn / compaction-survival guarantee already
+  rides `prefetch()`: *"the LLM sees the current `conv_id` / `off_record` **on every turn** —
+  defeating context-compaction-driven state loss"* (`provider.py:222-223`). The primer must ride
+  the same `prefetch()` path.
+- **Decouple the primer from the row-existence gate.** Hermes drops the *entire* block when no
+  conv-state row exists: `_fetch_conv_state` returns `None` on the `"No conversation state…"`
+  response and on any payload lacking `conv_id` (`provider.py:243,249`), and
+  `_prefix_with_conv_state(None, …)` returns just the recall text (`provider.py:405-408`). The
+  primer must show **even with no row** (success criterion), so the Hermes implementation must emit
+  the primer from the response independently of the row gate — not behind `_fetch_conv_state`'s
+  `None`. (Under the `{ state, primer }` shape, `_fetch_conv_state`'s `"conv_id" in parsed` guard
+  also breaks — `conv_id` moves under `state` — confirming the parser change is part of the lockstep.)
+- **One residual live-test (carry into dev).** Whether the Hermes runtime calls `prefetch()`
+  automatically before **every** model API call (vs only on agent-driven recall) is a property of
+  the `MemoryProvider` ABC, which *lives in the Hermes codebase, not this repo*
+  (`provider.py:16-21`). The plugin's own docstring asserts per-turn, but our code can't prove the
+  runtime's calling convention — so confirm it in a live Hermes session (the spec-025 eyeball-test
+  pattern) before relying on per-turn primer delivery there.
 
 ---
 
@@ -196,7 +222,8 @@ harnesses**, unlike capture (1A), which Codex blocks.
   primer alone); opencode injection confirmed reaching the model.
 - [ ] Every error path (store down, parse failure, off-record) leaves the turn unblocked and
   leaks no stack trace into the model's context.
-- [ ] Hermes cadence confirmed: the primer re-injects per turn (survives compaction), not once.
+- [ ] Hermes: the primer rides `prefetch()` (per-turn), shows even with no conv-state row, and a
+  live-test confirms `prefetch()` fires every turn.
 
 ## Open questions
 
@@ -213,6 +240,7 @@ harnesses**, unlike capture (1A), which Codex blocks.
    post-compaction signal to throttle against). If the repetition proves wasteful, a first-turn +
    periodic cadence is a later optimisation — but it needs a compaction signal the plugins don't
    currently have. Leave every-turn for v1.
-5. **Hermes `system_prompt_block()` cadence** — verify it re-fires per turn before relying on it
-   for compaction survival; if it only fires at session start, ride `prefetch()` or the per-turn
-   path instead.
+5. **Hermes cadence — RESOLVED (2026-06-05):** ride `prefetch()` (per-turn), not
+   `system_prompt_block()` (session-start only); decouple the primer from the row-existence gate.
+   See "Hermes specifics" above. One residual carries into dev: confirm the Hermes runtime calls
+   `prefetch()` automatically every turn (the ABC is external to our repos) via a live eyeball-test.

--- a/docs/specs/041-librarian-awareness-primer-spec.md
+++ b/docs/specs/041-librarian-awareness-primer-spec.md
@@ -1,16 +1,20 @@
 # Spec 041 — Librarian awareness primer
 
-**Status:** Draft for review (Specify phase)
-**Version target:** MINOR (new server-sourced setting + a small, lockstep response-shape
-change to `conv_state_get`; no behaviour change when the primer is empty)
+**Status:** Draft for review (Specify phase) — **decision-complete / build-ready** (no open
+questions block dev; the remaining items are deterministic verify-then-fallback gates).
+**Version target:** MINOR (new server-sourced setting + a **backward-compatible additive** field on
+the `conv_state_get` response; no behaviour change when the primer is empty)
 **Depends on:** the per-turn conv-state injection contract (specs 022 §4.9, 024–026, shipped);
 the `SettingsStore` + dashboard-config pattern (curator settings, shipped)
 **Relates to:** `docs/research/harness-driven-capture-brainstorm.md` (the working doc — this
 spec is feature **1B**, decisions **D1 / D9** and §3.2; feature 1A "auto-capture" is shelved)
-**Cross-repo:** lockstep change across **6 repos** — `the-librarian` (server + dashboard) +
-the five plugins (`-claude-plugin`, `-codex-plugin`, `-hermes-plugin`, `-pi-extension`,
-`-opencode-plugin`). The `conv_state_get` response shape is a *sacred cross-repo contract*
-(AGENTS.md §2) — change all or none, in one coordinated push.
+**Cross-repo:** touches **6 repos** — `the-librarian` (server + dashboard) + the five plugins
+(`-claude-plugin`, `-codex-plugin`, `-hermes-plugin`, `-pi-extension`, `-opencode-plugin`) — but
+the change is **additive and backward-compatible** (Decision 1): the server adds a `primer` field;
+an un-updated plugin ignores it and keeps working (no regression). So the six repos do **not** need
+a single atomic push — the server can ship first, each plugin renders the primer once updated. This
+respects the spirit of the sacred `conv_state_get` contract (AGENTS.md §2 — don't break consumers)
+without an all-or-none merge.
 
 ---
 
@@ -62,8 +66,9 @@ the dashboard changes what the next turn sees, with no plugin redeploy.
 - **The renderer is five byte-identical peer copies, not a shared dependency.** Canonical
   source `packages/core/src/conv-state-render.ts:26-35` renders a two-field block
   (`conv_id` + `off_record`; returns `""` when state is null); each plugin replicates it locally
-  (AGENTS.md §2 "five peer implementations" rule; spec 025 D5). Any block-shape change is therefore
-  a deliberate lockstep edit in all six repos.
+  (AGENTS.md §2 "five peer implementations" rule; spec 025 D5). Adding the primer block is therefore
+  a coordinated edit across the five plugin renderers + the canonical copy — but **additive**: an
+  un-updated plugin simply omits the new block (no regression), so the repos update incrementally.
 - **Server-sourced text has a proven pattern.** `session_manifest` already reads a settings value
   server-side (`working_style` via `getSetting`, `packages/mcp-server/src/mcp/tools/session-manifest.ts:14-20`,
   fail-soft → `""`); the curator config is the proven **dashboard-edited setting** pattern (admin
@@ -95,28 +100,36 @@ the dashboard changes what the next turn sees, with no plugin redeploy.
 - Reads are **fail-soft**: if the setting store is locked/unreadable, treat the primer as `""`
   (same posture as `readWorkingStyle`), never throw.
 
-### 2. Server — `conv_state_get` returns the primer alongside the row
+### 2. Server — `conv_state_get` returns the primer as an additive top-level field
 
 `conv_state_get` reads the primer setting and returns it **on every call, whether or not a
-conv-state row exists**. Recommended response shape (final wire detail is the implementer's, see
-Open Questions):
+conv-state row exists**, as an **additive `primer` field that sits alongside the existing row
+fields** (Decision 1 — backward-compatible, so an un-updated plugin ignores it):
 
 ```jsonc
-{
-  "state": { "conv_id": "...", "off_record": false, /* … */ } | null,
-  "primer": "You have The Librarian: durable cross-session memory. Use `recall` before asking; `remember` / `learn` to save durable facts."
-}
+// row exists:
+{ "conv_id": "...", "off_record": false, /* … existing row fields … */, "primer": "You have The Librarian: durable, cross-session memory. Use `recall` to check what's already known before asking; use `remember` / `/learn` to save durable facts, preferences, and decisions worth keeping." }
+
+// no row for this conv_id:
+{ "primer": "…same text…" }
 ```
 
-- This **replaces** the bare-row JSON and the `"No conversation state…"` text response — a
-  deliberate, lockstep response-shape change (sacred contract).
+- **Why additive, not a `{ state, primer }` wrapper:** the row fields stay top-level, so all five
+  plugins' existing `conv_id`-based parsing keeps working untouched, and the server can deploy
+  **before** the plugins update without dropping the conv-state block anywhere (a clean wrapper
+  would break every un-updated plugin during the rollout window). The no-row case returns `{ primer }`
+  (replacing today's `"No conversation state…"` text); old plugins find no `conv_id` → no block,
+  exactly as today (fail-soft, no regression).
 - The primer is **global, not conversation-keyed** — it does **not** depend on `conv_id` being
   stable or on a row existing. This is what makes 1B work on **Codex** (only a per-cwd fallback id,
   the genuine blocker for the *capture* feature) and on the **first turn** of any conversation.
+- Because `primer` is its own top-level field, it is **naturally decoupled from the row gate**: a
+  plugin reads `primer` independently of whether it found a conv-state row (this is what fixes the
+  Hermes drop-on-no-row problem — see Hermes specifics).
 - **`off_record` does not suppress the primer.** The primer is generic awareness text with no
-  conversation content; the off-record gate still governs all actual recording. (Phrase the
-  default primer so it doesn't *urge* recording — "use `recall`; `remember` when appropriate" — so
-  it reads sensibly even mid-off-record. See Open Questions on tone.)
+  conversation content; the off-record gate still governs all actual recording. The default text
+  (Decision 3) is phrased so it reads sensibly even mid-off-record ("save … worth keeping", not
+  "always remember").
 
 ### 3. Plugins — render the primer block (×5, byte-identical)
 
@@ -158,27 +171,32 @@ implementation requirements:
   rides `prefetch()`: *"the LLM sees the current `conv_id` / `off_record` **on every turn** —
   defeating context-compaction-driven state loss"* (`provider.py:222-223`). The primer must ride
   the same `prefetch()` path.
-- **Decouple the primer from the row-existence gate.** Hermes drops the *entire* block when no
+- **Read the primer independently of the row gate.** Hermes drops the *entire* block when no
   conv-state row exists: `_fetch_conv_state` returns `None` on the `"No conversation state…"`
   response and on any payload lacking `conv_id` (`provider.py:243,249`), and
   `_prefix_with_conv_state(None, …)` returns just the recall text (`provider.py:405-408`). The
-  primer must show **even with no row** (success criterion), so the Hermes implementation must emit
-  the primer from the response independently of the row gate — not behind `_fetch_conv_state`'s
-  `None`. (Under the `{ state, primer }` shape, `_fetch_conv_state`'s `"conv_id" in parsed` guard
-  also breaks — `conv_id` moves under `state` — confirming the parser change is part of the lockstep.)
-- **One residual live-test (carry into dev).** Whether the Hermes runtime calls `prefetch()`
-  automatically before **every** model API call (vs only on agent-driven recall) is a property of
-  the `MemoryProvider` ABC, which *lives in the Hermes codebase, not this repo*
-  (`provider.py:16-21`). The plugin's own docstring asserts per-turn, but our code can't prove the
-  runtime's calling convention — so confirm it in a live Hermes session (the spec-025 eyeball-test
-  pattern) before relying on per-turn primer delivery there.
+  primer must show **even with no row** (success criterion). The **additive response shape
+  (Decision 1) makes this clean**: `conv_id` stays top-level so `_fetch_conv_state` is unchanged
+  (the row gate keeps working), and a **new one-line read** of `parsed["primer"]` emits the primer
+  regardless of whether a row was found. (The `{ state, primer }` wrapper would instead have broken
+  `_fetch_conv_state`'s `"conv_id" in parsed` guard — another reason additive wins.)
+- **One residual live-test (deterministic, with fallback — does NOT block the build).** Whether the
+  Hermes runtime calls `prefetch()` automatically before **every** model API call (vs only on
+  agent-driven recall) is a property of the `MemoryProvider` ABC, which *lives in the Hermes
+  codebase, not this repo* (`provider.py:16-21`). **Build instruction:** implement the primer on the
+  **same path the conv-state block already uses** (`prefetch`/`_prefix_with_conv_state`) — so the
+  primer inherits *exactly* the cadence the existing Hermes conv-state injection already has. The
+  spec-025-style eyeball test then **verifies** per-turn delivery; **if** it turns out `prefetch`
+  isn't per-turn, that's a *pre-existing* limitation of the Hermes conv-state block (not introduced
+  here) and the primer is no worse off — also emit it from `system_prompt_block()` (session-start)
+  as a floor. Either way the build proceeds; the test informs, it doesn't gate.
 
 ---
 
 ## Commands / Project structure / Testing
 
 - **Server touches:** a new settings key + its default (`packages/core/src/store/settings-*`);
-  `packages/mcp-server/src/mcp/tools/conv-state-get.ts` (read the setting, new response shape);
+  `packages/mcp-server/src/mcp/tools/conv-state-get.ts` (read the setting, add the `primer` field);
   `packages/core/src/conv-state-render.ts` (reference `renderAwarenessPrimer`); a dashboard admin
   field + tRPC read/write (`apps/dashboard`, mirroring curator config).
 - **Plugin touches (×5):** the local renderer (add `renderAwarenessPrimer`) + the injection handler
@@ -193,13 +211,15 @@ implementation requirements:
     the model "do you have durable memory and how do you save a fact?" — it can answer from the
     primer alone. Confirms injection reaches the model (and, for opencode, that the experimental
     hook isn't silently discarded — issue #17100).
-- **CHANGELOG:** an `## [Unreleased]` entry in **each** of the six repos in the lockstep push.
+- **CHANGELOG:** an `## [Unreleased]` entry in **each** of the six repos as they update (server
+  first, then the five plugins — incremental, not an atomic push, per Decision 1).
 
 ## Boundaries
 
 - **Always:** brief primer (1–2 sentences); server-sourced (no hard-coded primer text in plugins);
   fail-soft (never block a turn); byte-identical peer renderers; branch + PR per repo; CHANGELOG in
-  every repo touched; lockstep across all six (the `conv_state_get` response is a sacred contract).
+  every repo touched; keep the `conv_state_get` change **additive / backward-compatible** so the
+  contract isn't broken for un-updated plugins (Decision 1 — respects the sacred-contract spirit).
 - **Ask first / out of scope:** the richer `session_manifest` preamble (working-style + skills) —
   deferred (D9); **active recall-injection** ("pull relevant memories and inject them") — deferred
   (D9, this is *passive awareness only*); any capture/auto-learn behaviour (feature 1A — shelved).
@@ -225,22 +245,42 @@ implementation requirements:
 - [ ] Hermes: the primer rides `prefetch()` (per-turn), shows even with no conv-state row, and a
   live-test confirms `prefetch()` fires every turn.
 
-## Open questions
+## Decisions (settled — build-ready)
 
-1. **Response-shape vs forward-compat.** The clean `{ state, primer }` shape is a breaking change
-   to `conv_state_get` (mitigated by lockstep + fail-soft: version skew during rollout just drops a
-   block, never crashes). The additive alternative — keep the row at top level and add a `primer`
-   field — lets an un-updated plugin keep working through the rollout window. Pick at implementation
-   time; recommend `{ state, primer }` for clarity unless a staggered rollout is expected.
-2. **Block tag + placement.** `<librarian>` sibling block vs folding the primer into
-   `<conversation-state>`. Recommend a separate tag (it is static awareness, not per-turn state).
-3. **Tone vs off-record.** Default primer wording that reads correctly even when the user is
-   off-record (favour "recall before asking; `remember` when appropriate" over "always remember").
-4. **Every-turn vs throttle.** D9 chose every-turn (compaction-survival for free; there is no
-   post-compaction signal to throttle against). If the repetition proves wasteful, a first-turn +
-   periodic cadence is a later optimisation — but it needs a compaction signal the plugins don't
-   currently have. Leave every-turn for v1.
-5. **Hermes cadence — RESOLVED (2026-06-05):** ride `prefetch()` (per-turn), not
-   `system_prompt_block()` (session-start only); decouple the primer from the row-existence gate.
-   See "Hermes specifics" above. One residual carries into dev: confirm the Hermes runtime calls
-   `prefetch()` automatically every turn (the ABC is external to our repos) via a live eyeball-test.
+**No open question blocks an autonomous build.** The five former open questions are decided below;
+the only items that "carry into dev" are deterministic verification gates (eyeball tests) with
+defined fallbacks, not design choices.
+
+1. **Response shape = additive `primer` field, backward-compatible** (not a `{ state, primer }`
+   wrapper). Row fields stay top-level; `primer` is added; no-row returns `{ primer }`. An un-updated
+   plugin ignores `primer` and keeps working, so the server can deploy first and plugins follow
+   incrementally (no atomic six-repo merge). See §2. *(Reverses the earlier `{ state, primer }` lean
+   — additive is strictly safer for rollout and naturally decouples the primer from Hermes's row
+   gate.)*
+2. **Block tag = a separate `<librarian>` block**, not folded into `<conversation-state>` (the
+   primer is static awareness, not per-turn state). Byte-identical `renderAwarenessPrimer(primer)`
+   in all five plugins + the canonical core renderer.
+3. **Default primer text** (shipped default; admin-editable; phrased to read sensibly even
+   off-record): *"You have The Librarian: durable, cross-session memory. Use `recall` to check
+   what's already known before asking; use `remember` / `/learn` to save durable facts, preferences,
+   and decisions worth keeping."* Empty string disables the primer.
+4. **Cadence = every turn** (D9): compaction-survival for free; there is no post-compaction signal
+   to throttle against. A first-turn-plus-periodic cadence is a deferred optimisation that would need
+   a compaction signal the plugins don't have. Ship every-turn.
+5. **Hermes path = `prefetch()`** (the per-turn channel), not `system_prompt_block()` (session-start
+   only); read the primer from the top-level `primer` field, independent of the row gate (Decision 1
+   makes this a one-liner). See "Hermes specifics". **Carry-into-dev (non-blocking):** an eyeball
+   test verifies `prefetch()` is per-turn; the fallback (also emit from `system_prompt_block()`) is
+   defined, so the build never stalls on it.
+
+### Verification gates (run during dev — deterministic, never block design)
+
+These are test steps the build executes, each with a defined outcome — they are **not** unresolved
+decisions:
+- **Per-harness eyeball test** (spec-025 pattern): model can name the Librarian + a save verb from
+  the primer alone. Fallback if a harness fails: that harness's injection path is wrong → fix the
+  adapter (the design holds; the other four are unaffected).
+- **opencode** injection-reaches-model check (the tracked experimental-hook `#17100` risk, spec 025
+  §7.1). Fallback: escalate upstream; opencode degrades to no-primer, others unaffected.
+- **Hermes** `prefetch()` per-turn check (Decision 5) with the `system_prompt_block()` floor as
+  fallback.


### PR DESCRIPTION
## What

Two design docs from this session's `/feature-brainstorming` runs, plus the first spec derived from them.

**Provenance (`docs/research/`)**
- `harness-driven-capture-brainstorm.md` — feature 1: harness-driven raw-text capture + awareness injection + lifecycle hooks. Feature **1A** (auto-capture) is shelved by the owner (unsure + huge change); feature **1B** (awareness primer) is specced here. Three blind-review Criticals resolved.
- `self-improving-curator-brainstorm.md` — feature 2: the curator learns this install's preferences via admin-approved edits to its own prompt addendum (never the safety core). One blind-review Critical resolved (D7: addendum becomes a committed vault file). Specs 2A–2C come next.
- `docs/TODO.md` now points at both docs instead of holding the raw notes.

**Spec 041 — Librarian awareness primer (`docs/specs/`)**
A short, **server-sourced** note ("you have The Librarian — `recall`/`remember`/`learn`") that rides the **existing** per-turn `conv_state_get` round-trip in all five plugins:

- **No new hook, no second fetch** — every plugin already round-trips `conv_state_get` each turn and renders the conv-state block client-side; the primer rides the same call/emit.
- **Compaction-survival for free** — the block re-injects every turn.
- **Global, not `conv_id`-keyed** — so it works on **Codex** (no stable conv id, the blocker for the capture feature) and on a **brand-new conversation** before any conv-state row exists.
- **Server-sourced** — admin edits the text from the dashboard with **no plugin redeploy**.
- Passive awareness only; active recall-injection and the richer `session_manifest` preamble stay **deferred**.

## Scope / shape

- **Docs only** — no code. Spec 041 is a Specify-phase draft for review.
- Spec 041 describes a **lockstep change across 6 repos** (server + 5 plugins) because the `conv_state_get` response shape is a sacred cross-repo contract — flagged in the spec, not done here.

## Review asks

1. Sanity-check the **`conv_state_get` response-shape** decision (clean `{ state, primer }` vs additive `primer` field for forward-compat) — Open Question 1.
2. Confirm the **Hermes `system_prompt_block()` cadence** assumption (re-fires per turn) before build — Open Question 5.
3. Primer default **wording/tone**, especially the off-record interaction — Open Question 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)