### PR TITLE
feat(backup): validate github.repo as owner/repo at the config boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,14 @@ changes from this point forward are catalogued here.
 
 ### Changed
 
+- **`backup.github.repo` is validated as an `owner/repo` slug at the config
+  boundary.** A malformed value (a bare repo name, a full URL, junk) used to fail
+  deep in the `git push` with a confusing message; the dashboard `backup.setConfig`
+  procedure now rejects it up front with a teaching error that shows the expected
+  shape and echoes the bad value (e.g. `Expected "owner/repo" (e.g.
+  "octocat/hello-world"), got "hello-world"`), never any token. An empty/unset repo
+  stays allowed.
+
 - **Agent guidance: the curator owns consolidation.** The `use-the-librarian`
   skill no longer tells agents to recall/search for duplicates before
   `remember`, or to hand-consolidate via `update` + `verify(outdated)` — the

--- a/packages/core/src/backup/sync/github-config.ts
+++ b/packages/core/src/backup/sync/github-config.ts
@@ -14,6 +14,25 @@ export interface GithubSyncConfig {
   token: string;
 }
 
+// The backup remote URL is built as `…/${repo}.git`, so the repo must be a bare
+// "owner/repo" slug — a full URL or a lone name breaks the push deep in git with a
+// confusing message. This pragmatic shape check (a teaching gate at the config
+// boundary, not a security boundary) catches the common mistakes early.
+const REPO_SLUG_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+
+/** True when `repo` is a bare "owner/repo" slug (the shape the remote URL expects). */
+export function isValidGithubRepoSlug(repo: string): boolean {
+  return REPO_SLUG_RE.test(repo);
+}
+
+/**
+ * The teaching message for a malformed `backup.github.repo`. Echoes the offending
+ * value (the repo slug only — never a token) so the reader sees what they typed.
+ */
+export function githubRepoSlugError(repo: string): string {
+  return `Expected "owner/repo" (e.g. "octocat/hello-world"), got ${JSON.stringify(repo)}`;
+}
+
 type SettingsReader = Pick<LibrarianStore, "getSetting">;
 
 function readSetting(store: SettingsReader, key: string): string {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -320,7 +320,12 @@ export {
 } from "./backup/restore-staging.js";
 // Portable data export (distinct from backup — a human/tool-readable dump).
 export { type ExportFormat, exportData } from "./backup/export.js";
-export { type GithubSyncConfig, resolveGithubSyncConfig } from "./backup/sync/github-config.js";
+export {
+  type GithubSyncConfig,
+  githubRepoSlugError,
+  isValidGithubRepoSlug,
+  resolveGithubSyncConfig,
+} from "./backup/sync/github-config.js";
 export { type RunBackupResult, runBackup, runBackupTick } from "./backup/run.js";
 export {
   type BackupConfig,

--- a/packages/core/tests/github-repo-slug.test.ts
+++ b/packages/core/tests/github-repo-slug.test.ts
@@ -1,0 +1,32 @@
+// The backup remote URL is built as `…/${repo}.git`, so `backup.github.repo` must
+// be a bare "owner/repo" slug. These tests pin the canonical shape rule + the
+// teaching error (which echoes the offending value, never a token) so the gate at
+// the tRPC config boundary stays honest.
+
+import { githubRepoSlugError, isValidGithubRepoSlug } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+describe("isValidGithubRepoSlug", () => {
+  it("accepts a bare owner/repo slug, including dots, dashes and underscores", () => {
+    expect(isValidGithubRepoSlug("octocat/hello-world")).toBe(true);
+    expect(isValidGithubRepoSlug("me/backups")).toBe(true);
+    expect(isValidGithubRepoSlug("My_Org/my.repo-1")).toBe(true);
+  });
+
+  it("rejects a lone name, a full URL, and other junk that breaks the push", () => {
+    expect(isValidGithubRepoSlug("hello-world")).toBe(false);
+    expect(isValidGithubRepoSlug("https://github.com/me/backups.git")).toBe(false);
+    expect(isValidGithubRepoSlug("me/backups.git extra")).toBe(false);
+    expect(isValidGithubRepoSlug("a/b/c")).toBe(false);
+    expect(isValidGithubRepoSlug("")).toBe(false);
+  });
+});
+
+describe("githubRepoSlugError", () => {
+  it("teaches the expected shape and echoes the offending value verbatim", () => {
+    const msg = githubRepoSlugError("hello-world");
+    expect(msg).toContain('Expected "owner/repo"');
+    expect(msg).toContain("octocat/hello-world");
+    expect(msg).toContain("hello-world");
+  });
+});

--- a/packages/mcp-server/src/trpc/backup.ts
+++ b/packages/mcp-server/src/trpc/backup.ts
@@ -4,6 +4,8 @@
 
 import type { BackupConfigPatch } from "@librarian/core";
 import {
+  githubRepoSlugError,
+  isValidGithubRepoSlug,
   lastSuccessfulBackupRun,
   latestTerminalBackupRun,
   listBackupRuns,
@@ -25,7 +27,18 @@ const SetConfigSchema = z.strictObject({
   // value leaves the stored token unchanged (the form never round-trips it).
   github: z
     .strictObject({
-      repo: z.string().optional(),
+      // The repo is interpolated into the push remote URL as `…/<repo>.git`, so it
+      // must be a bare "owner/repo" slug. An empty string is allowed (it leaves the
+      // stored value untouched); a non-empty value must match the slug shape, with a
+      // teaching error that echoes the bad value (never a token).
+      repo: z
+        .string()
+        .optional()
+        .refine((repo) => repo === undefined || repo === "" || isValidGithubRepoSlug(repo), {
+          // The message echoes the offending value so the reader sees their typo; the
+          // value here is always the repo slug — never a token.
+          error: (issue) => githubRepoSlugError(typeof issue.input === "string" ? issue.input : ""),
+        }),
       token: z.string().optional(),
     })
     .optional(),

--- a/packages/mcp-server/tests/trpc/backup.test.ts
+++ b/packages/mcp-server/tests/trpc/backup.test.ts
@@ -118,6 +118,47 @@ describe("tRPC backup surface", () => {
     }
   });
 
+  it("rejects a malformed GitHub repo with a teaching error, but allows owner/repo and unset", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      // A bare repo name (no owner) would fail deep in the git push with a confusing
+      // message — reject it here with a message that teaches the expected shape and
+      // echoes the bad value (but never any token).
+      const rawRes = await fetch(`${server.url}/trpc/backup.setConfig`, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: `Bearer ${server.token}` },
+        body: JSON.stringify({ github: { repo: "hello-world" } }),
+      });
+      expect(rawRes.status).toBeGreaterThanOrEqual(400);
+      const body = await rawRes.text();
+      expect(body).toContain("owner/repo");
+      expect(body).toContain("octocat/hello-world");
+      expect(body).toContain("hello-world");
+
+      // A full URL is also rejected (the remote is built from owner/repo).
+      await expect(
+        trpcPost(server, "backup.setConfig", {
+          github: { repo: "https://github.com/me/backups.git" },
+        }),
+      ).rejects.toThrow();
+
+      // A well-formed owner/repo passes, and an unset repo stays allowed (optional).
+      await trpcPost(server, "backup.setConfig", { github: { repo: "octocat/hello-world" } });
+      await trpcPost(server, "backup.setConfig", { enabled: true });
+
+      const after = await trpcGet<{ github: { repo: string }; enabled: boolean }>(
+        server,
+        "backup.config",
+      );
+      expect(after.github.repo).toBe("octocat/hello-world");
+      expect(after.enabled).toBe(true);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
   it("createNow without a remote surfaces an error run", async () => {
     const dataDir = makeTempDir();
     const server = await startHttpServer({ dataDir });


### PR DESCRIPTION
## Why

`backup.github.repo` was accepted as a bare `z.string().optional()` and interpolated straight into the push remote URL (`https://x-access-token@github.com/<repo>.git`) with no shape check. A malformed value — a lone repo name, a full URL, or junk — slipped past the config boundary and only failed deep in the `git push`, where the error is confusing and far from where the value was entered.

## What

- Add a shared, pragmatic shape validator in `packages/core` next to where the remote URL is built (`packages/core/src/backup/sync/github-config.ts`): `isValidGithubRepoSlug(repo)` (regex `^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`) and `githubRepoSlugError(repo)`, which produces the teaching message and echoes the offending value — never a token. Exported from the core barrel.
- Apply it as a Zod `.refine` on the `repo` field of the dashboard `backup.setConfig` tRPC input (`packages/mcp-server/src/trpc/backup.ts`) — the earliest, friendliest boundary. An empty/unset repo stays allowed (the field is optional; a blank leaves the stored value untouched).
- The teaching error reads e.g. `Expected "owner/repo" (e.g. "octocat/hello-world"), got "hello-world"`.

The CLI has no write path for this setting (it's dashboard- or env-configured), and the read-time resolver in core builds the remote — throwing there would reproduce the deep-in-push failure we're fixing. So the write boundary (tRPC `setConfig`) is the right place; the shared rule lives in core so the "owner/repo" definition has one home.

## Verification

- `pnpm run typecheck` — green across all 5 workspaces.
- `pnpm --filter @librarian/mcp-server test` — 108 passed (18 files), including a new test: a present-but-malformed `repo` is rejected with the teaching message (echoing the bad value), a full URL is rejected, a valid `owner/repo` passes, and an unset repo stays allowed.
- New core unit test (`packages/core/tests/github-repo-slug.test.ts`) pins the slug rule + teaching message.
- `pnpm run lint` — clean. CHANGELOG `## [Unreleased] → ### Changed` updated.

No token or secret is ever echoed — only the repo string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)