### PR TITLE
feat(core): named LLM provider store (spec 042 §1, 2A PR-B1)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -188,6 +188,20 @@ export {
   writeLlmConnection,
 } from "./llm-connection.js";
 export {
+  type LlmProvider,
+  type LlmProviderInput,
+  type LlmProviderPatch,
+  LlmProviderInputSchema,
+  LlmProviderPatchSchema,
+  addProvider,
+  deleteProvider,
+  getProvider,
+  listProviderIds,
+  listProviders,
+  resolveProviderToken,
+  updateProvider,
+} from "./llm-providers.js";
+export {
   type BackfillChange,
   type BackfillOptions,
   type BackfillSection,

--- a/packages/core/src/llm-connection.ts
+++ b/packages/core/src/llm-connection.ts
@@ -1,9 +1,8 @@
-// Shared LLM-connection helper — the per-LLM connection block both the
-// curator (`packages/core/src/curator-config.ts`) and the classifier
-// (`packages/core/src/classifier-config.ts`) need: provider/endpoint/
-// model/timeoutMs + an encrypted bearer token. A consumer passes its
-// own keyspace prefix (e.g. `curator.llm` or `classifier.llm`) and the
-// helper composes the five settings keys under it.
+// Shared LLM-connection helper — the per-LLM connection block a consumer
+// needs: provider/endpoint/model/timeoutMs + an encrypted bearer token. A
+// consumer passes its own keyspace prefix (e.g. `curator.llm`) and the helper
+// composes the five settings keys under it. The named-provider store
+// (`llm-providers.ts`) reuses the same secret-token-as-separate-key pattern.
 //
 // Reads NEVER include the token plaintext — only `hasToken`. The
 // settings-store metadata carries presence, so the cockpit can render
@@ -51,8 +50,8 @@ export interface LlmConnectionKeys {
 
 /**
  * Derive the five settings keys for a given prefix. The prefix
- * conventionally ends in `.llm` (e.g. `curator.llm`, `classifier.llm`)
- * but the helper does not enforce that — any unique prefix works.
+ * conventionally ends in `.llm` (e.g. `curator.llm`) but the helper does
+ * not enforce that — any unique prefix works.
  */
 export function llmConnectionKeys(prefix: string): LlmConnectionKeys {
   return {

--- a/packages/core/src/llm-providers.ts
+++ b/packages/core/src/llm-providers.ts
@@ -1,0 +1,191 @@
+// Named LLM provider store (spec 042 §1). A provider is `{ id, name, endpoint,
+// token }`; consumers (intake / grooming) reference a provider by its stable
+// `id` and add their own `{ model, timeout_ms }`. The list is modelled on the
+// flat single-string settings store rather than redesigning it:
+//
+//   llm.providers                = JSON array of provider ids   (non-secret)
+//   llm.provider.<id>.name       = display label                (non-secret)
+//   llm.provider.<id>.endpoint   = base URL                     (non-secret)
+//   llm.provider.<id>.token      = bearer key                   (SECRET)
+//
+// Keeping the names/endpoints non-secret lets the dashboard list providers
+// without the master key; only `resolveProviderToken` decrypts. The id is
+// generated and stable, so renaming a provider never breaks a consumer's
+// reference.
+//
+// The `llm.providers` index is updated read-modify-write; like every key in
+// the settings store it is last-writer-wins on a single file (no locking).
+// Provider CRUD is single-admin, low-frequency, so that matches the system's
+// concurrency model rather than introducing a new risk.
+
+import { z } from "zod";
+import { makeId } from "./constants.js";
+import type { LlmConnectionReader, LlmConnectionWriter } from "./llm-connection.js";
+
+export interface LlmProvider {
+  id: string;
+  name: string;
+  endpoint: string;
+  /** Whether a bearer token is stored — never the value. */
+  hasToken: boolean;
+}
+
+export interface LlmProviderInput {
+  name: string;
+  endpoint: string;
+  /** Plaintext bearer key; stored encrypted. Omitted/empty = no token. */
+  token?: string;
+}
+
+export interface LlmProviderPatch {
+  name?: string;
+  endpoint?: string;
+  /** Plaintext token; stored encrypted. Empty string clears it. */
+  token?: string;
+}
+
+// Zod input shapes for admin validation at the tRPC boundary. Permissive
+// (presence-only); the non-empty invariants are enforced in add/updateProvider,
+// the single source of truth.
+export const LlmProviderInputSchema = z.strictObject({
+  name: z.string(),
+  endpoint: z.string(),
+  token: z.string().optional(),
+});
+
+export const LlmProviderPatchSchema = z.strictObject({
+  name: z.string().optional(),
+  endpoint: z.string().optional(),
+  token: z.string().optional(),
+});
+
+const INDEX_KEY = "llm.providers";
+
+type ProviderReader = LlmConnectionReader;
+type ProviderStore = LlmConnectionReader & LlmConnectionWriter;
+
+interface ProviderKeys {
+  name: string;
+  endpoint: string;
+  token: string;
+}
+
+function providerKeys(id: string): ProviderKeys {
+  const prefix = `llm.provider.${id}`;
+  return { name: `${prefix}.name`, endpoint: `${prefix}.endpoint`, token: `${prefix}.token` };
+}
+
+/** Parse the provider-id index. Fail-soft: a missing or malformed value is []. */
+export function listProviderIds(store: ProviderReader): string[] {
+  const raw = store.getSetting(INDEX_KEY);
+  if (!raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((x): x is string => typeof x === "string");
+  } catch {
+    return [];
+  }
+}
+
+function writeProviderIds(store: ProviderStore, ids: string[]): void {
+  store.setSetting(INDEX_KEY, JSON.stringify(ids));
+}
+
+function tokenPresent(store: ProviderReader, keys: ProviderKeys): boolean {
+  return store.listSettings().some((m) => m.key === keys.token);
+}
+
+/** Read one provider, or null when the id is not in the index. */
+export function getProvider(store: ProviderReader, id: string): LlmProvider | null {
+  if (!listProviderIds(store).includes(id)) return null;
+  const keys = providerKeys(id);
+  return {
+    id,
+    name: store.getSetting(keys.name) ?? "",
+    endpoint: store.getSetting(keys.endpoint) ?? "",
+    hasToken: tokenPresent(store, keys),
+  };
+}
+
+/** Every provider, in index (insertion) order. Never includes token values. */
+export function listProviders(store: ProviderReader): LlmProvider[] {
+  return listProviderIds(store)
+    .map((id) => getProvider(store, id))
+    .filter((p): p is LlmProvider => p !== null);
+}
+
+/**
+ * Create a provider. `name` + `endpoint` are required (teaching error
+ * otherwise). The token is stored encrypted; omit it to add a provider whose
+ * key is set later. Returns the created provider (presence-only).
+ */
+export function addProvider(
+  store: ProviderStore,
+  input: LlmProviderInput,
+  options: { generateId?: () => string } = {},
+): LlmProvider {
+  const name = input.name.trim();
+  const endpoint = input.endpoint.trim();
+  if (!name) throw new Error("provider name must not be empty");
+  if (!endpoint) throw new Error("provider endpoint must not be empty");
+
+  const id = (options.generateId ?? (() => makeId("prov")))();
+  // The id becomes part of every per-provider settings key
+  // (`llm.provider.<id>.token`); keep it key-safe so one provider's namespace
+  // can never collide with another's. The default `makeId` already satisfies this.
+  if (!/^[A-Za-z0-9_-]+$/.test(id)) {
+    throw new Error(`provider id must match /^[A-Za-z0-9_-]+$/ (got "${id}")`);
+  }
+  const keys = providerKeys(id);
+  store.setSetting(keys.name, name);
+  store.setSetting(keys.endpoint, endpoint);
+  if (input.token !== undefined && input.token !== "") {
+    store.setSetting(keys.token, input.token, { secret: true });
+  }
+  writeProviderIds(store, [...listProviderIds(store), id]);
+  // Non-null: we just wrote the index entry + keys.
+  return getProvider(store, id) as LlmProvider;
+}
+
+/** Patch a provider's name/endpoint/token without changing its id. */
+export function updateProvider(store: ProviderStore, id: string, patch: LlmProviderPatch): void {
+  if (!listProviderIds(store).includes(id)) {
+    throw new Error(`unknown provider id: ${id}`);
+  }
+  const keys = providerKeys(id);
+  if (patch.name !== undefined) {
+    const name = patch.name.trim();
+    if (!name) throw new Error("provider name must not be empty");
+    store.setSetting(keys.name, name);
+  }
+  if (patch.endpoint !== undefined) {
+    const endpoint = patch.endpoint.trim();
+    if (!endpoint) throw new Error("provider endpoint must not be empty");
+    store.setSetting(keys.endpoint, endpoint);
+  }
+  if (patch.token !== undefined) {
+    if (patch.token === "") store.deleteSetting(keys.token);
+    else store.setSetting(keys.token, patch.token, { secret: true });
+  }
+}
+
+/** Remove a provider, its keys, and its index entry. Idempotent. */
+export function deleteProvider(store: ProviderStore, id: string): void {
+  const ids = listProviderIds(store);
+  if (!ids.includes(id)) return;
+  const keys = providerKeys(id);
+  store.deleteSetting(keys.name);
+  store.deleteSetting(keys.endpoint);
+  store.deleteSetting(keys.token);
+  writeProviderIds(
+    store,
+    ids.filter((x) => x !== id),
+  );
+}
+
+/** Decrypt a provider's bearer token. Null when the provider/token is absent. Needs the master key. */
+export function resolveProviderToken(store: ProviderReader, id: string): string | null {
+  if (!listProviderIds(store).includes(id)) return null;
+  return store.getSetting(providerKeys(id).token);
+}

--- a/packages/core/tests/llm-providers.test.ts
+++ b/packages/core/tests/llm-providers.test.ts
@@ -1,0 +1,225 @@
+// Named LLM provider store (spec 042 §1) — a provider *list* modelled on the
+// flat single-string settings store: `llm.providers` index + per-provider
+// `llm.provider.<id>.{name,endpoint}` (non-secret) + `.token` (secret). Mirrors
+// the llm-connection harness: a real LibrarianStore on a temp dir.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type LibrarianStore,
+  addProvider,
+  createLibrarianStore,
+  deleteProvider,
+  getProvider,
+  listProviders,
+  resolveProviderToken,
+  resolveSecretKey,
+  updateProvider,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// Assemble the 64-hex test key at runtime — keep a secret-shaped literal out of
+// committed source so GitGuardian stays clean (AGENTS.md GitGuardian note).
+const KEY = resolveSecretKey("0123456789abcdef".repeat(4));
+
+interface Scope {
+  store: LibrarianStore;
+  dataDir: string;
+}
+
+function scope(): Scope {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-llm-prov-"));
+  const store = createLibrarianStore({ dataDir, secretKey: KEY });
+  return { store, dataDir };
+}
+
+function teardown(s: Scope | null): void {
+  if (!s) return;
+  try {
+    s.store.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(s.dataDir, { recursive: true, force: true });
+}
+
+// Deterministic id generator for tests (the production default is makeId("prov")).
+function seqIds(): () => string {
+  let n = 0;
+  return () => `prov_test_${++n}`;
+}
+
+describe("llm provider store", () => {
+  let s: Scope | null = null;
+  beforeEach(() => {
+    s = scope();
+  });
+  afterEach(() => {
+    teardown(s);
+    s = null;
+  });
+
+  describe("addProvider / listProviders / getProvider", () => {
+    it("returns an empty list when nothing is stored", () => {
+      expect(listProviders(s!.store)).toEqual([]);
+    });
+
+    it("creates a provider with a generated id and lists it back", () => {
+      const { store } = s!;
+      const created = addProvider(
+        store,
+        { name: "OpenAI", endpoint: "https://api.openai.com/v1", token: "dummy-openai-token" },
+        { generateId: seqIds() },
+      );
+      expect(created.id).toBe("prov_test_1");
+      expect(created.name).toBe("OpenAI");
+      expect(created.endpoint).toBe("https://api.openai.com/v1");
+      expect(created.hasToken).toBe(true);
+
+      const list = listProviders(store);
+      expect(list).toHaveLength(1);
+      expect(list[0]).toEqual(created);
+      expect(getProvider(store, created.id)).toEqual(created);
+      expect(getProvider(store, "prov_does_not_exist")).toBeNull();
+    });
+
+    it("keeps multiple providers with stable, unique ids in insertion order", () => {
+      const { store } = s!;
+      const gen = seqIds();
+      const a = addProvider(
+        store,
+        { name: "A", endpoint: "https://a.example/v1" },
+        { generateId: gen },
+      );
+      const b = addProvider(
+        store,
+        { name: "B", endpoint: "https://b.example/v1" },
+        { generateId: gen },
+      );
+      expect(a.id).not.toBe(b.id);
+      expect(listProviders(store).map((p) => p.id)).toEqual([a.id, b.id]);
+      // A provider added without a token is valid but not token-complete.
+      expect(a.hasToken).toBe(false);
+    });
+
+    it("rejects a missing name or endpoint with a teaching error", () => {
+      const { store } = s!;
+      expect(() => addProvider(store, { name: "", endpoint: "https://x.example/v1" })).toThrow(
+        /name/i,
+      );
+      expect(() => addProvider(store, { name: "X", endpoint: "" })).toThrow(/endpoint/i);
+    });
+
+    it("rejects an id that is not key-safe, so it can't collide with another provider's namespace", () => {
+      const { store } = s!;
+      // A `.` in the id would let `llm.provider.<id>.token` bleed into a sibling's keys.
+      expect(() =>
+        addProvider(
+          store,
+          { name: "X", endpoint: "https://x.example/v1" },
+          { generateId: () => "bad.id" },
+        ),
+      ).toThrow(/id/i);
+      expect(listProviders(store)).toEqual([]);
+    });
+  });
+
+  describe("secret handling", () => {
+    it("never round-trips the token — presence-only + decrypt-on-demand", () => {
+      const { store } = s!;
+      const p = addProvider(
+        store,
+        { name: "Secret Co", endpoint: "https://s.example/v1", token: "dummy-secret-do-not-leak" },
+        { generateId: seqIds() },
+      );
+      const got = getProvider(store, p.id)!;
+      expect(got.hasToken).toBe(true);
+      expect(Object.keys(got)).not.toContain("token");
+      expect(JSON.stringify(listProviders(store))).not.toContain("dummy-secret");
+      // Only the explicit resolver decrypts.
+      expect(resolveProviderToken(store, p.id)).toBe("dummy-secret-do-not-leak");
+      expect(resolveProviderToken(store, "prov_missing")).toBeNull();
+    });
+  });
+
+  describe("updateProvider", () => {
+    it("patches name/endpoint/token without changing the id", () => {
+      const { store } = s!;
+      const p = addProvider(
+        store,
+        { name: "Old", endpoint: "https://old.example/v1" },
+        { generateId: seqIds() },
+      );
+      updateProvider(store, p.id, {
+        name: "New",
+        endpoint: "https://new.example/v1",
+        token: "dummy-tok-1",
+      });
+      const got = getProvider(store, p.id)!;
+      expect(got.id).toBe(p.id);
+      expect(got.name).toBe("New");
+      expect(got.endpoint).toBe("https://new.example/v1");
+      expect(got.hasToken).toBe(true);
+    });
+
+    it("clears the token when patched with an empty string", () => {
+      const { store } = s!;
+      const p = addProvider(
+        store,
+        { name: "T", endpoint: "https://t.example/v1", token: "dummy-tok-2" },
+        { generateId: seqIds() },
+      );
+      updateProvider(store, p.id, { token: "" });
+      expect(getProvider(store, p.id)!.hasToken).toBe(false);
+      expect(resolveProviderToken(store, p.id)).toBeNull();
+    });
+
+    it("throws a teaching error for an unknown id", () => {
+      const { store } = s!;
+      expect(() => updateProvider(store, "prov_nope", { name: "X" })).toThrow(
+        /unknown|not found|exist/i,
+      );
+    });
+  });
+
+  describe("deleteProvider", () => {
+    it("removes the provider, its keys, and its index entry, leaving others intact", () => {
+      const { store } = s!;
+      const gen = seqIds();
+      const a = addProvider(
+        store,
+        { name: "A", endpoint: "https://a.example/v1", token: "dummy-a" },
+        { generateId: gen },
+      );
+      const b = addProvider(
+        store,
+        { name: "B", endpoint: "https://b.example/v1", token: "dummy-b" },
+        { generateId: gen },
+      );
+
+      deleteProvider(store, a.id);
+
+      expect(getProvider(store, a.id)).toBeNull();
+      expect(resolveProviderToken(store, a.id)).toBeNull();
+      expect(listProviders(store).map((p) => p.id)).toEqual([b.id]);
+      // No stray keys left for the deleted provider.
+      expect(store.listSettings().some((m) => m.key.startsWith(`llm.provider.${a.id}.`))).toBe(
+        false,
+      );
+    });
+
+    it("is idempotent for an unknown id", () => {
+      const { store } = s!;
+      expect(() => deleteProvider(store, "prov_ghost")).not.toThrow();
+    });
+  });
+
+  describe("fail-soft index parsing", () => {
+    it("treats a malformed index as empty rather than throwing", () => {
+      const { store } = s!;
+      store.setSetting("llm.providers", "{not json");
+      expect(listProviders(store)).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
First increment of **spec 042 (2A — LLM provider + per-consumer model config)**, per Plan 045 Track B.

### What
Adds `packages/core/src/llm-providers.ts` — a named-provider list `{ id, name, endpoint, token }` modelled on the existing flat single-string settings store:

| key | secret? |
|---|---|
| `llm.providers` (JSON array of ids) | no |
| `llm.provider.<id>.name` | no |
| `llm.provider.<id>.endpoint` | no |
| `llm.provider.<id>.token` | **yes** (AES-256-GCM) |

Non-secret names/endpoints mean the dashboard can list providers without the master key; only `resolveProviderToken` decrypts. Ids are generated + stable so a rename never breaks a consumer reference (042 D2). Reuses the proven secret-token-as-separate-key + presence-only-metadata pattern from `llm-connection.ts`.

Also clears the stale `classifier-config.ts` reference in `llm-connection.ts` (classifier removed in spec 032).

### Scope / not in this PR
Internal plumbing only — **no user-visible surface yet**, so no CHANGELOG entry (the single 042 entry lands with the dashboard CRUD in PR-B4). Per-consumer resolution + the legacy `curator.llm.*` migration are PR-B2; consumers wire-up is PR-B3.

### Tests
`packages/core/tests/llm-providers.test.ts` (11 cases): CRUD round-trip, generated/stable ids, secret never round-tripped (presence-only + decrypt-on-demand), teaching errors on empty name/endpoint + unknown id, idempotent delete with no stray keys, fail-soft malformed index. Full core suite green (710 passed/1 skipped); typecheck clean across all workspaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)