### PR TITLE
feat(core): per-consumer LLM resolution + legacy migration (spec 042 §2/§6, 2A PR-B2)

### DIFF
--- a/packages/core/src/curator-consumers.ts
+++ b/packages/core/src/curator-consumers.ts
@@ -1,0 +1,183 @@
+// Per-consumer LLM resolution (spec 042 §2). The two LLM-consuming curator jobs
+// — `intake` (the consolidator) and `grooming` (the curator) — each reference a
+// named provider (`llm-providers.ts`) by id and add their own `{ model,
+// timeout_ms }`, so they can run on different models (and providers) while
+// reusing one stored connection. Setting keys (042 D1, fixed now so 2B/2C don't
+// re-key):
+//
+//   curator.<consumer>.provider    = provider id reference
+//   curator.<consumer>.model       = model name
+//   curator.<consumer>.timeout_ms  = per-request timeout
+//
+// Resolution joins the consumer's keys with the referenced provider (endpoint +
+// presence-only token). A consumer whose provider was deleted resolves to
+// not-operational (inert, never throws) — the caller skips it.
+
+import { z } from "zod";
+import {
+  type LlmConnectionReader,
+  type LlmConnectionWriter,
+  llmConnectionKeys,
+  resolveLlmToken,
+} from "./llm-connection.js";
+import {
+  addProvider,
+  getProvider,
+  listProviderIds,
+  resolveProviderToken,
+} from "./llm-providers.js";
+
+export type CuratorConsumer = "intake" | "grooming";
+export const CURATOR_CONSUMERS: readonly CuratorConsumer[] = ["intake", "grooming"];
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+const MIN_TIMEOUT_MS = 1_000;
+const MAX_TIMEOUT_MS = 600_000;
+
+export interface ConsumerConfig {
+  consumer: CuratorConsumer;
+  /** Referenced provider id; "" when unset. */
+  providerId: string;
+  /** Whether `providerId` resolves to an existing provider. */
+  providerExists: boolean;
+  /** The resolved provider's endpoint; "" when the provider is missing. */
+  endpoint: string;
+  model: string;
+  timeoutMs: number;
+  /** The resolved provider exists AND has a token stored. */
+  hasToken: boolean;
+  /** providerExists && hasToken && model set — the resolution a tick needs to run. */
+  isOperational: boolean;
+}
+
+export interface ConsumerConfigPatch {
+  providerId?: string;
+  model?: string;
+  timeoutMs?: number;
+}
+
+// Permissive admin-patch shape; the timeout bound is enforced in
+// `writeConsumerConfig`, the single source of truth.
+export const ConsumerConfigPatchSchema = z.strictObject({
+  providerId: z.string().optional(),
+  model: z.string().optional(),
+  timeoutMs: z.number().optional(),
+});
+
+type ConsumerReader = LlmConnectionReader;
+type ConsumerStore = LlmConnectionReader & LlmConnectionWriter;
+
+interface ConsumerKeys {
+  provider: string;
+  model: string;
+  timeoutMs: string;
+}
+
+function consumerKeys(consumer: CuratorConsumer): ConsumerKeys {
+  const prefix = `curator.${consumer}`;
+  return {
+    provider: `${prefix}.provider`,
+    model: `${prefix}.model`,
+    timeoutMs: `${prefix}.timeout_ms`,
+  };
+}
+
+// Bounded timeout parse: a valid in-range integer, else undefined. The read path
+// defaults; the migration omits (lets the consumer default). Clamping on read
+// means a hand-edited vault value can never feed a tick a 0/negative timeout.
+function boundedTimeout(raw: string | null): number | undefined {
+  if (raw === null) return undefined;
+  const n = Number(raw);
+  return Number.isInteger(n) && n >= MIN_TIMEOUT_MS && n <= MAX_TIMEOUT_MS ? n : undefined;
+}
+
+function parseTimeoutMs(raw: string | null): number {
+  return boundedTimeout(raw) ?? DEFAULT_TIMEOUT_MS;
+}
+
+/** Read a consumer's resolved config, joined with its referenced provider. Never throws. */
+export function readConsumerConfig(
+  store: ConsumerReader,
+  consumer: CuratorConsumer,
+): ConsumerConfig {
+  const keys = consumerKeys(consumer);
+  const providerId = store.getSetting(keys.provider) ?? "";
+  const model = store.getSetting(keys.model) ?? "";
+  const timeoutMs = parseTimeoutMs(store.getSetting(keys.timeoutMs));
+  const provider = providerId ? getProvider(store, providerId) : null;
+  const providerExists = provider !== null;
+  const hasToken = provider?.hasToken ?? false;
+  return {
+    consumer,
+    providerId,
+    providerExists,
+    endpoint: provider?.endpoint ?? "",
+    model,
+    timeoutMs,
+    hasToken,
+    isOperational: providerExists && hasToken && model !== "",
+  };
+}
+
+/** Patch a consumer's provider/model/timeout. Validates the timeout bound. */
+export function writeConsumerConfig(
+  store: ConsumerStore,
+  consumer: CuratorConsumer,
+  patch: ConsumerConfigPatch,
+): void {
+  if (patch.timeoutMs !== undefined) {
+    const t = patch.timeoutMs;
+    if (!Number.isInteger(t) || t < MIN_TIMEOUT_MS || t > MAX_TIMEOUT_MS) {
+      throw new Error(
+        `curator.${consumer}.timeout_ms must be an integer between ${MIN_TIMEOUT_MS} and ${MAX_TIMEOUT_MS} (1s and 10min)`,
+      );
+    }
+  }
+  const keys = consumerKeys(consumer);
+  if (patch.providerId !== undefined) store.setSetting(keys.provider, patch.providerId);
+  if (patch.model !== undefined) store.setSetting(keys.model, patch.model);
+  if (patch.timeoutMs !== undefined) store.setSetting(keys.timeoutMs, String(patch.timeoutMs));
+}
+
+/** Decrypt the token of the provider a consumer references. Null when unset/missing. Needs the master key. */
+export function resolveConsumerToken(
+  store: ConsumerReader,
+  consumer: CuratorConsumer,
+): string | null {
+  const providerId = store.getSetting(consumerKeys(consumer).provider) ?? "";
+  if (!providerId) return null;
+  return resolveProviderToken(store, providerId);
+}
+
+/**
+ * One-shot migration of a pre-existing `curator.llm.*` install: synthesise a
+ * `default` provider from the legacy endpoint/token and point both consumers at
+ * it with the legacy model + timeout. Idempotent — a no-op once any provider
+ * exists. Returns whether it migrated. Leaves the legacy keys in place (the
+ * cutover that retires them is PR-B3, when the consumers actually switch).
+ */
+export function migrateLegacyCuratorLlm(store: ConsumerStore): boolean {
+  if (listProviderIds(store).length > 0) return false;
+
+  const legacy = llmConnectionKeys("curator.llm");
+  const endpoint = (store.getSetting(legacy.endpoint) ?? "").trim();
+  if (!endpoint) return false; // nothing meaningful to migrate without an endpoint
+
+  const model = store.getSetting(legacy.model) ?? "";
+  const token = resolveLlmToken(store, legacy);
+  const created = addProvider(store, {
+    name: "default",
+    endpoint,
+    ...(token ? { token } : {}),
+  });
+
+  const timeoutMs = boundedTimeout(store.getSetting(legacy.timeoutMs));
+  for (const consumer of CURATOR_CONSUMERS) {
+    writeConsumerConfig(store, consumer, {
+      providerId: created.id,
+      model,
+      ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+    });
+  }
+  return true;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -202,6 +202,17 @@ export {
   updateProvider,
 } from "./llm-providers.js";
 export {
+  type ConsumerConfig,
+  type ConsumerConfigPatch,
+  type CuratorConsumer,
+  CURATOR_CONSUMERS,
+  ConsumerConfigPatchSchema,
+  migrateLegacyCuratorLlm,
+  readConsumerConfig,
+  resolveConsumerToken,
+  writeConsumerConfig,
+} from "./curator-consumers.js";
+export {
   type BackfillChange,
   type BackfillOptions,
   type BackfillSection,

--- a/packages/core/tests/curator-consumers.test.ts
+++ b/packages/core/tests/curator-consumers.test.ts
@@ -1,0 +1,249 @@
+// Per-consumer LLM resolution (spec 042 §2). Each curator consumer — `intake`
+// (the consolidator) and `grooming` (the curator) — references a named provider
+// by id and adds its own `{ model, timeout_ms }`. `readConsumerConfig` joins the
+// consumer's settings with the provider; `resolveConsumerToken` decrypts the
+// provider's key; `migrateLegacyCuratorLlm` synthesises a `default` provider from
+// a pre-existing `curator.llm.*` install. Mirrors the provider-store harness.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type LibrarianStore,
+  addProvider,
+  createLibrarianStore,
+  deleteProvider,
+  listProviders,
+  llmConnectionKeys,
+  migrateLegacyCuratorLlm,
+  readConsumerConfig,
+  resolveConsumerToken,
+  resolveSecretKey,
+  writeConsumerConfig,
+  writeLlmConnection,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// Assemble the 64-hex key at runtime — no secret-shaped literal in source (GitGuardian).
+const KEY = resolveSecretKey("0123456789abcdef".repeat(4));
+
+interface Scope {
+  store: LibrarianStore;
+  dataDir: string;
+}
+
+function scope(): Scope {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-consumers-"));
+  const store = createLibrarianStore({ dataDir, secretKey: KEY });
+  return { store, dataDir };
+}
+
+function teardown(s: Scope | null): void {
+  if (!s) return;
+  try {
+    s.store.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(s.dataDir, { recursive: true, force: true });
+}
+
+describe("per-consumer LLM resolution", () => {
+  let s: Scope | null = null;
+  beforeEach(() => {
+    s = scope();
+  });
+  afterEach(() => {
+    teardown(s);
+    s = null;
+  });
+
+  describe("readConsumerConfig defaults", () => {
+    it("returns inert defaults when nothing is configured", () => {
+      const { store } = s!;
+      for (const c of ["intake", "grooming"] as const) {
+        const cfg = readConsumerConfig(store, c);
+        expect(cfg).toMatchObject({
+          consumer: c,
+          providerId: "",
+          providerExists: false,
+          endpoint: "",
+          model: "",
+          timeoutMs: 60_000,
+          hasToken: false,
+          isOperational: false,
+        });
+      }
+    });
+
+    it("clamps an out-of-range stored timeout back to the default on read", () => {
+      const { store } = s!;
+      // A hand-edited vault value must never reach a tick as 0/negative/huge.
+      store.setSetting("curator.intake.timeout_ms", "0");
+      expect(readConsumerConfig(store, "intake").timeoutMs).toBe(60_000);
+      store.setSetting("curator.intake.timeout_ms", "999999999");
+      expect(readConsumerConfig(store, "intake").timeoutMs).toBe(60_000);
+      store.setSetting("curator.intake.timeout_ms", "not-a-number");
+      expect(readConsumerConfig(store, "intake").timeoutMs).toBe(60_000);
+    });
+  });
+
+  describe("operational truth table", () => {
+    it("is operational only when the provider exists, has a token, and a model is set", () => {
+      const { store } = s!;
+      const p = addProvider(store, {
+        name: "OpenAI",
+        endpoint: "https://api.openai.com/v1",
+        token: "dummy-openai-token",
+      });
+
+      // provider set + model set + token present -> operational, endpoint resolved
+      writeConsumerConfig(store, "grooming", { providerId: p.id, model: "gpt-4o" });
+      let cfg = readConsumerConfig(store, "grooming");
+      expect(cfg.providerExists).toBe(true);
+      expect(cfg.endpoint).toBe("https://api.openai.com/v1");
+      expect(cfg.hasToken).toBe(true);
+      expect(cfg.isOperational).toBe(true);
+
+      // model cleared -> not operational
+      writeConsumerConfig(store, "grooming", { model: "" });
+      expect(readConsumerConfig(store, "grooming").isOperational).toBe(false);
+
+      // points at a provider with no token -> not operational
+      const noTok = addProvider(store, { name: "Local", endpoint: "http://localhost:11434/v1" });
+      writeConsumerConfig(store, "intake", { providerId: noTok.id, model: "llama3" });
+      cfg = readConsumerConfig(store, "intake");
+      expect(cfg.providerExists).toBe(true);
+      expect(cfg.hasToken).toBe(false);
+      expect(cfg.isOperational).toBe(false);
+
+      // points at a non-existent provider -> not operational, no throw
+      writeConsumerConfig(store, "intake", { providerId: "prov_ghost", model: "x" });
+      cfg = readConsumerConfig(store, "intake");
+      expect(cfg.providerExists).toBe(false);
+      expect(cfg.endpoint).toBe("");
+      expect(cfg.isOperational).toBe(false);
+    });
+  });
+
+  describe("independence", () => {
+    it("lets intake and grooming use different providers + models", () => {
+      const { store } = s!;
+      const cheap = addProvider(store, {
+        name: "Cheap",
+        endpoint: "https://cheap.example/v1",
+        token: "dummy-cheap",
+      });
+      const strong = addProvider(store, {
+        name: "Strong",
+        endpoint: "https://strong.example/v1",
+        token: "dummy-strong",
+      });
+      writeConsumerConfig(store, "intake", { providerId: cheap.id, model: "mini" });
+      writeConsumerConfig(store, "grooming", { providerId: strong.id, model: "max" });
+
+      const intake = readConsumerConfig(store, "intake");
+      const grooming = readConsumerConfig(store, "grooming");
+      expect(intake.endpoint).toBe("https://cheap.example/v1");
+      expect(intake.model).toBe("mini");
+      expect(grooming.endpoint).toBe("https://strong.example/v1");
+      expect(grooming.model).toBe("max");
+      expect(resolveConsumerToken(store, "intake")).toBe("dummy-cheap");
+      expect(resolveConsumerToken(store, "grooming")).toBe("dummy-strong");
+    });
+  });
+
+  describe("resolveConsumerToken", () => {
+    it("returns null when unset and after the provider is deleted", () => {
+      const { store } = s!;
+      expect(resolveConsumerToken(store, "grooming")).toBeNull();
+      const p = addProvider(store, {
+        name: "P",
+        endpoint: "https://p.example/v1",
+        token: "dummy-p-token",
+      });
+      writeConsumerConfig(store, "grooming", { providerId: p.id, model: "m" });
+      expect(resolveConsumerToken(store, "grooming")).toBe("dummy-p-token");
+
+      deleteProvider(store, p.id);
+      expect(resolveConsumerToken(store, "grooming")).toBeNull();
+      const cfg = readConsumerConfig(store, "grooming");
+      expect(cfg.providerExists).toBe(false);
+      expect(cfg.isOperational).toBe(false);
+    });
+  });
+
+  describe("writeConsumerConfig validation", () => {
+    it("rejects an out-of-bounds timeout", () => {
+      const { store } = s!;
+      expect(() => writeConsumerConfig(store, "intake", { timeoutMs: 0 })).toThrow(/timeout/i);
+      expect(() => writeConsumerConfig(store, "intake", { timeoutMs: 600_001 })).toThrow(
+        /timeout/i,
+      );
+      expect(() => writeConsumerConfig(store, "intake", { timeoutMs: 1.5 })).toThrow(/timeout/i);
+    });
+  });
+
+  describe("legacy migration", () => {
+    function seedLegacy(store: LibrarianStore): void {
+      writeLlmConnection(store, llmConnectionKeys("curator.llm"), {
+        provider: "openai",
+        endpoint: "https://legacy.example/v1",
+        model: "legacy-model",
+        timeoutMs: 45_000,
+        token: "dummy-legacy-token",
+      });
+    }
+
+    it("synthesises a `default` provider and points both consumers at it", () => {
+      const { store } = s!;
+      seedLegacy(store);
+
+      expect(migrateLegacyCuratorLlm(store)).toBe(true);
+
+      const providers = listProviders(store);
+      expect(providers).toHaveLength(1);
+      expect(providers[0].name).toBe("default");
+      expect(providers[0].endpoint).toBe("https://legacy.example/v1");
+      expect(providers[0].hasToken).toBe(true);
+
+      for (const c of ["intake", "grooming"] as const) {
+        const cfg = readConsumerConfig(store, c);
+        expect(cfg.providerId).toBe(providers[0].id);
+        expect(cfg.model).toBe("legacy-model");
+        expect(cfg.timeoutMs).toBe(45_000);
+        expect(cfg.isOperational).toBe(true);
+        expect(resolveConsumerToken(store, c)).toBe("dummy-legacy-token");
+      }
+    });
+
+    it("is idempotent — a second run is a no-op", () => {
+      const { store } = s!;
+      seedLegacy(store);
+      expect(migrateLegacyCuratorLlm(store)).toBe(true);
+      expect(migrateLegacyCuratorLlm(store)).toBe(false);
+      expect(listProviders(store)).toHaveLength(1);
+    });
+
+    it("does nothing when there is no legacy config", () => {
+      const { store } = s!;
+      expect(migrateLegacyCuratorLlm(store)).toBe(false);
+      expect(listProviders(store)).toEqual([]);
+    });
+
+    it("skips when providers already exist", () => {
+      const { store } = s!;
+      seedLegacy(store);
+      addProvider(store, { name: "Existing", endpoint: "https://x.example/v1" });
+      expect(migrateLegacyCuratorLlm(store)).toBe(false);
+      expect(listProviders(store).map((p) => p.name)).toEqual(["Existing"]);
+    });
+
+    it("skips a legacy config that has no endpoint (nothing meaningful to migrate)", () => {
+      const { store } = s!;
+      writeLlmConnection(store, llmConnectionKeys("curator.llm"), { model: "m", token: "dummy-x" });
+      expect(migrateLegacyCuratorLlm(store)).toBe(false);
+      expect(listProviders(store)).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
Second increment of **spec 042 (2A)**, per Plan 045. Builds on PR-B1 (provider store, #314).

### What
Adds `packages/core/src/curator-consumers.ts` — per-consumer LLM resolution for the two jobs **intake** (consolidator) and **grooming** (curator). Each references a named provider by id and adds its own `{ model, timeout_ms }`, so they can run on different models/providers while sharing one stored connection. Keys are the 042-D1 target names (`curator.intake.*` / `curator.grooming.*`) so 2B/2C never re-key persisted settings.

- `readConsumerConfig(store, consumer)` — joins the consumer's keys with the referenced provider (endpoint + presence-only token). **Never throws**: a deleted/missing provider → `isOperational:false` (inert).
- `resolveConsumerToken(store, consumer)` — decrypts the referenced provider's key on demand.
- `migrateLegacyCuratorLlm(store)` — one-shot: synthesises a `default` provider from a pre-existing `curator.llm.*` install and points both consumers at it (legacy model + timeout carried). Idempotent (no-op once any provider exists); skips when there's no legacy endpoint.

### Scope / sequencing
**Additive** — `readCuratorConfig` and the two ticks are untouched, so `main` stays green and there's no behaviour change. The cutover (ticks switch to per-consumer resolution, boot calls the migration, **legacy `curator.llm.*` keys retired**) is **PR-B3**; the dashboard + the single 042 CHANGELOG entry are **PR-B4**. No user-visible surface yet → no CHANGELOG here.

### Tests
`packages/core/tests/curator-consumers.test.ts` (10 cases): inert defaults, operational truth table (provider missing / no token / no model / all-present), intake≠grooming independence, token resolve + null-after-delete, timeout-bound validation, and migration (synthesise `default`, both consumers pointed at it, idempotent, skip-when-no-legacy, skip-when-providers-exist, skip-when-no-endpoint). Full core suite green (721 passed/1 skipped); typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)