### PR TITLE
feat(core): ticks resolve per-consumer LLM config + auto-migrate (spec 042 §3/§6, 2A PR-B3)

### DIFF
--- a/packages/core/src/consolidator-tick.ts
+++ b/packages/core/src/consolidator-tick.ts
@@ -1,8 +1,8 @@
 // Consolidator tick (spec 035 §F5) — the config-driven entrypoint the
 // server-side scheduler calls on a (serial) timer, and an admin run-now action
-// can call directly. It reuses the SHARED server-side LLM brain config (the same
-// connection the curator uses — there is one LLM brain, the classifier removed),
-// builds the client from it, and runs one inbox sweep via store.consolidateInbox.
+// can call directly. It uses the `intake` consumer's own LLM connection (042 2A
+// — intake and grooming each pick their own provider+model), builds the client
+// from it, and runs one inbox sweep via store.consolidateInbox.
 //
 // Enablement (the LIBRARIAN_CONSOLIDATOR opt-in) is decided by the caller (the
 // http boot only starts this scheduler when enabled), so the tick itself only
@@ -11,7 +11,11 @@
 // OpenAI-compatible client.
 
 import type { ConsolidationThresholds, SweepSummary } from "./consolidator/index.js";
-import { type CuratorConfig, readCuratorConfig, resolveCuratorToken } from "./curator-config.js";
+import {
+  migrateLegacyCuratorLlm,
+  readConsumerConfig,
+  resolveConsumerToken,
+} from "./curator-consumers.js";
 import { type LlmClient, createCuratorLlmClient } from "./curator-llm-client.js";
 import type { LibrarianStore } from "./store/librarian-store.js";
 
@@ -27,22 +31,26 @@ export interface ConsolidatorTickOptions {
   /** Stale-claim TTL passed through to the sweep reaper. */
   lockTtlMs?: number;
   /** Injectable LLM client builder (defaults to the OpenAI-compatible client). */
-  buildClient?: (llm: CuratorConfig["llm"], token: string) => LlmClient;
+  buildClient?: (
+    conn: { endpoint: string; model: string; timeoutMs: number },
+    token: string,
+  ) => LlmClient;
 }
 
 export async function runConsolidatorTick(
   options: ConsolidatorTickOptions,
 ): Promise<ConsolidatorTickResult> {
   const { store } = options;
-  const config = readCuratorConfig(store);
-
-  // Reuse the curator's LLM connection (the one server-side model) — but NOT its
-  // `enabled` flag: the consolidator's enablement is the caller's LIBRARIAN_CONSOLIDATOR opt-in.
-  if (!config.isLlmComplete) return { ran: false, reason: "incomplete_config" };
+  // Preserve a pre-existing curator.llm.* install (idempotent once migrated).
+  migrateLegacyCuratorLlm(store);
+  // The intake job's own LLM connection — its enablement is the caller's
+  // LIBRARIAN_CONSOLIDATOR opt-in, not a curator flag.
+  const llm = readConsumerConfig(store, "intake");
+  if (!llm.isOperational) return { ran: false, reason: "incomplete_config" };
 
   let token: string | null;
   try {
-    token = resolveCuratorToken(store);
+    token = resolveConsumerToken(store, "intake");
   } catch {
     return { ran: false, reason: "no_token" };
   }
@@ -50,16 +58,19 @@ export async function runConsolidatorTick(
 
   const buildClient =
     options.buildClient ??
-    ((llm, secret) =>
+    ((conn, secret) =>
       createCuratorLlmClient({
-        endpoint: llm.endpoint,
+        endpoint: conn.endpoint,
         token: secret,
-        model: llm.model,
-        timeoutMs: llm.timeoutMs,
+        model: conn.model,
+        timeoutMs: conn.timeoutMs,
       }));
 
   const summary = await store.consolidateInbox({
-    llmClient: buildClient(config.llm, token),
+    llmClient: buildClient(
+      { endpoint: llm.endpoint, model: llm.model, timeoutMs: llm.timeoutMs },
+      token,
+    ),
     ...(options.thresholds ? { thresholds: options.thresholds } : {}),
     ...(options.lockTtlMs !== undefined ? { lockTtlMs: options.lockTtlMs } : {}),
   });

--- a/packages/core/src/curator-consumers.ts
+++ b/packages/core/src/curator-consumers.ts
@@ -164,7 +164,17 @@ export function migrateLegacyCuratorLlm(store: ConsumerStore): boolean {
   if (!endpoint) return false; // nothing meaningful to migrate without an endpoint
 
   const model = store.getSetting(legacy.model) ?? "";
-  const token = resolveLlmToken(store, legacy);
+  let token: string | null;
+  try {
+    token = resolveLlmToken(store, legacy);
+  } catch {
+    // A legacy token exists but the master key is absent, so it can't be read to
+    // re-encrypt under the new provider. Defer the whole migration (retry next
+    // tick when the key is back) rather than half-migrate a token-less provider —
+    // migration is one-shot, so that would permanently drop the key. Fail-soft:
+    // never throw out of a tick.
+    return false;
+  }
   const created = addProvider(store, {
     name: "default",
     endpoint,

--- a/packages/core/src/curator-tick.ts
+++ b/packages/core/src/curator-tick.ts
@@ -10,7 +10,12 @@
 // the OpenAI-compatible client.
 
 import { SYSTEM_ACTOR_IDS } from "./caller-identity.js";
-import { type CuratorConfig, readCuratorConfig, resolveCuratorToken } from "./curator-config.js";
+import { readCuratorConfig } from "./curator-config.js";
+import {
+  migrateLegacyCuratorLlm,
+  readConsumerConfig,
+  resolveConsumerToken,
+} from "./curator-consumers.js";
 import {
   type CuratorTrigger,
   type RunDueCurationSummary,
@@ -35,21 +40,28 @@ export interface CuratorTickOptions {
   bypassSkip?: boolean;
   caps?: RunCurationCaps;
   /** Injectable LLM client builder (defaults to the OpenAI-compatible client). */
-  buildClient?: (llm: CuratorConfig["llm"], token: string) => LlmClient;
+  buildClient?: (
+    conn: { endpoint: string; model: string; timeoutMs: number },
+    token: string,
+  ) => LlmClient;
 }
 
 export async function runCuratorTick(options: CuratorTickOptions): Promise<CuratorTickResult> {
   const { store } = options;
+  // Preserve a pre-existing curator.llm.* install: seed the per-consumer config
+  // from it on first run (idempotent — a no-op once any provider exists).
+  migrateLegacyCuratorLlm(store);
   const config = readCuratorConfig(store);
+  const llm = readConsumerConfig(store, "grooming");
 
   if (!config.enabled) return { ran: false, reason: "disabled" };
-  if (!config.isLlmComplete) return { ran: false, reason: "incomplete_config" };
+  if (!llm.isOperational) return { ran: false, reason: "incomplete_config" };
 
-  // The token is configured (isLlmComplete ⇒ hasToken); decryption can still fail
+  // The token is configured (isOperational ⇒ hasToken); decryption can still fail
   // if the server is missing the master key — treat that as "not runnable".
   let token: string | null;
   try {
-    token = resolveCuratorToken(store);
+    token = resolveConsumerToken(store, "grooming");
   } catch {
     return { ran: false, reason: "no_token" };
   }
@@ -57,23 +69,26 @@ export async function runCuratorTick(options: CuratorTickOptions): Promise<Curat
 
   const buildClient =
     options.buildClient ??
-    ((llm, secret) =>
+    ((conn, secret) =>
       createCuratorLlmClient({
-        endpoint: llm.endpoint,
+        endpoint: conn.endpoint,
         token: secret,
-        model: llm.model,
-        timeoutMs: llm.timeoutMs,
+        model: conn.model,
+        timeoutMs: conn.timeoutMs,
       }));
 
   const summary = await runDueCuration({
     store,
     now: options.now ?? new Date(),
     schedule: { intervalMinutes: config.intervalMinutes },
-    llmClient: buildClient(config.llm, token),
+    llmClient: buildClient(
+      { endpoint: llm.endpoint, model: llm.model, timeoutMs: llm.timeoutMs },
+      token,
+    ),
     actorId: SYSTEM_ACTOR_IDS.memoryCurator,
     policy: { level: config.defaultAutoApply, confidenceThreshold: config.autoApplyConfidence },
     promptAddendum: config.promptAddendum,
-    model: { provider: config.llm.provider, name: config.llm.model },
+    model: { provider: llm.providerId, name: llm.model },
     trigger: options.trigger ?? "schedule",
     ...(options.bypassSkip !== undefined ? { bypassSkip: options.bypassSkip } : {}),
     ...(options.caps !== undefined ? { caps: options.caps } : {}),

--- a/packages/core/tests/consolidator-tick.test.ts
+++ b/packages/core/tests/consolidator-tick.test.ts
@@ -9,10 +9,11 @@ import path from "node:path";
 import {
   type LibrarianStore,
   type LlmClient,
+  addProvider,
   createLibrarianStore,
   resolveSecretKey,
   runConsolidatorTick,
-  writeCuratorConfig,
+  writeConsumerConfig,
 } from "@librarian/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -55,12 +56,14 @@ function createJudgmentClient(): LlmClient {
   };
 }
 
+// Point the intake consumer at a provider with a token (042 2A).
 function configureLlm() {
-  writeCuratorConfig(store!, {
-    enabled: true,
-    llm: { provider: "openai", endpoint: "https://e/v1", model: "gpt-x" },
+  const provider = addProvider(store!, {
+    name: "default",
+    endpoint: "https://e/v1",
     token: "dummy-decrypted-token",
   });
+  writeConsumerConfig(store!, "intake", { providerId: provider.id, model: "gpt-x" });
 }
 
 describe("runConsolidatorTick — gating", () => {

--- a/packages/core/tests/curator-consumers.test.ts
+++ b/packages/core/tests/curator-consumers.test.ts
@@ -245,5 +245,22 @@ describe("per-consumer LLM resolution", () => {
       expect(migrateLegacyCuratorLlm(store)).toBe(false);
       expect(listProviders(store)).toEqual([]);
     });
+
+    it("defers without throwing when a legacy token exists but the master key is absent", () => {
+      const { store, dataDir } = s!;
+      seedLegacy(store); // endpoint + model + token
+      store.close();
+      // Reopen WITHOUT the master key: the legacy token can't be decrypted. The
+      // migration must fail soft (never throw out of a tick) and defer — not
+      // half-migrate a token-less provider that would permanently drop the key.
+      const keyless = createLibrarianStore({ dataDir });
+      try {
+        expect(() => migrateLegacyCuratorLlm(keyless)).not.toThrow();
+        expect(migrateLegacyCuratorLlm(keyless)).toBe(false);
+        expect(listProviders(keyless)).toEqual([]);
+      } finally {
+        keyless.close();
+      }
+    });
   });
 });

--- a/packages/core/tests/curator-tick.test.ts
+++ b/packages/core/tests/curator-tick.test.ts
@@ -1,7 +1,7 @@
 // Curator tick (spec §12/§14) — the config-driven entrypoint. Verifies gating
 // (disabled / incomplete / undecryptable token) and that an operational config
-// builds the client from config and runs due slices. Network-free via an injected
-// client builder.
+// builds the client from the GROOMING consumer's provider+model (042 2A) and runs
+// due slices. Network-free via an injected client builder.
 
 import fs from "node:fs";
 import os from "node:os";
@@ -9,14 +9,17 @@ import path from "node:path";
 import {
   type LibrarianStore,
   type LlmClient,
+  addProvider,
   createLibrarianStore,
   resolveSecretKey,
   runCuratorTick,
+  writeConsumerConfig,
   writeCuratorConfig,
 } from "@librarian/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const KEY = resolveSecretKey("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+// Assemble the 64-hex key at runtime — no secret-shaped literal in source (GitGuardian).
+const KEY = resolveSecretKey("0123456789abcdef".repeat(4));
 
 let store: LibrarianStore | null = null;
 let dataDir = "";
@@ -53,44 +56,44 @@ function seedMemory() {
   });
 }
 
+// Point the grooming consumer at a provider (optionally with a token).
+function configureGrooming(opts: { token?: string } = {}) {
+  const provider = addProvider(store!, {
+    name: "default",
+    endpoint: "https://api.example.com/v1",
+    ...(opts.token !== undefined ? { token: opts.token } : {}),
+  });
+  writeConsumerConfig(store!, "grooming", { providerId: provider.id, model: "gpt-x" });
+}
+
 describe("runCuratorTick — gating", () => {
   it("does nothing when curation is disabled (the default)", async () => {
     const result = await runCuratorTick({ store: store! });
     expect(result).toEqual({ ran: false, reason: "disabled" });
   });
 
-  it("does nothing when the LLM config is incomplete (no token)", async () => {
-    writeCuratorConfig(store!, {
-      enabled: true,
-      llm: { provider: "openai", endpoint: "https://e/v1", model: "gpt-x" },
-    });
+  it("does nothing when the grooming LLM config is incomplete (no token)", async () => {
+    writeCuratorConfig(store!, { enabled: true });
+    configureGrooming(); // provider has no token
     const result = await runCuratorTick({ store: store! });
     expect(result).toEqual({ ran: false, reason: "incomplete_config" });
   });
 });
 
 describe("runCuratorTick — operational", () => {
-  it("builds the client from config (with the decrypted token) and runs due slices", async () => {
+  it("builds the client from the grooming consumer (with the decrypted token) and runs due slices", async () => {
     seedMemory();
-    writeCuratorConfig(store!, {
-      enabled: true,
-      llm: { provider: "openai", endpoint: "https://api.example.com/v1", model: "gpt-x" },
-      token: "dummy-decrypted-token",
-    });
+    writeCuratorConfig(store!, { enabled: true });
+    configureGrooming({ token: "dummy-decrypted-token" });
     const buildClient = vi.fn(() => noOpClient);
 
     const result = await runCuratorTick({ store: store!, buildClient });
 
     expect(result.ran).toBe(true);
     expect(buildClient).toHaveBeenCalledTimes(1);
-    // The decrypted token + the configured connection flow into the builder.
+    // The grooming connection + decrypted token flow into the builder.
     expect(buildClient).toHaveBeenCalledWith(
-      {
-        provider: "openai",
-        endpoint: "https://api.example.com/v1",
-        model: "gpt-x",
-        timeoutMs: 60_000,
-      },
+      { endpoint: "https://api.example.com/v1", model: "gpt-x", timeoutMs: 60_000 },
       "dummy-decrypted-token",
     );
     if (result.ran) expect(result.summary.ran).toBeGreaterThanOrEqual(1);
@@ -99,15 +102,12 @@ describe("runCuratorTick — operational", () => {
 
 describe("runCuratorTick — token undecryptable without the master key", () => {
   it("does not run when the configured token can't be decrypted", async () => {
-    writeCuratorConfig(store!, {
-      enabled: true,
-      llm: { provider: "openai", endpoint: "https://e/v1", model: "gpt-x" },
-      token: "dummy-secret",
-    });
+    writeCuratorConfig(store!, { enabled: true });
+    configureGrooming({ token: "dummy-secret" });
     store!.close();
 
-    // Reopen WITHOUT the master key: config still reads as complete (token presence
-    // is metadata), but the token can't be decrypted → not runnable.
+    // Reopen WITHOUT the master key: the provider still reads as having a token
+    // (presence is metadata), but it can't be decrypted → not runnable.
     store = createLibrarianStore({ dataDir });
     const result = await runCuratorTick({ store: store!, buildClient: () => noOpClient });
     expect(result).toEqual({ ran: false, reason: "no_token" });


### PR DESCRIPTION
Third increment of **spec 042 (2A)**, per Plan 045. The cutover — builds on PR-B1 (#314) + PR-B2 (#315).

### What
The two pipeline ticks now resolve **their own** provider+model instead of a single shared `curator.llm.*`:
- **`runCuratorTick`** (grooming) → `readConsumerConfig(store, "grooming")` + `resolveConsumerToken(…, "grooming")`. Gate becomes `enabled && grooming.isOperational`. Still reads `enabled`/interval/addendum/auto-apply from `readCuratorConfig`.
- **`runConsolidatorTick`** (intake) → the `intake` consumer; no longer reads the curator config at all (enablement stays the `LIBRARIAN_CONSOLIDATOR` opt-in).

Each tick first calls **`migrateLegacyCuratorLlm(store)`** (idempotent — no-op once any provider exists), so a pre-existing `curator.llm.*` install seeds a `default` provider + both consumers on first run and **keeps working with no admin action**. The injectable `buildClient` now takes a minimal `{ endpoint, model, timeoutMs }`.

### Sequencing
Legacy `curator.llm.*` keys are deliberately **left in place** (still read by the dashboard via `readCuratorConfig`). Retiring them + the dashboard provider UI + the single 042 CHANGELOG entry are **PR-B4** (next). No user-visible surface changes here → no CHANGELOG yet. Behaviour is preserved for existing installs (migration); fresh installs had the curator off by default.

### Tests
Reworked `curator-tick.test.ts` + `consolidator-tick.test.ts` onto the provider/consumer setup (gating: disabled / incomplete / undecryptable-token; operational builds the client from the right consumer's connection). Full core suite green (722 passed/1 skipped), mcp-server suite green (108), typecheck clean across all workspaces. (Also moved the curator-tick test's 64-hex master key to runtime assembly for GitGuardian.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)