### PR TITLE
feat(mcp-server): admin tRPC for LLM providers + per-consumer config (spec 042 §4, 2A PR-B4a)

### DIFF
--- a/packages/mcp-server/src/trpc/llm.ts
+++ b/packages/mcp-server/src/trpc/llm.ts
@@ -1,0 +1,73 @@
+// LLM provider + per-consumer model config admin tRPC (spec 042 §4).
+//
+// The admin cockpit's typed surface for named LLM providers and the per-consumer
+// (intake / grooming) provider+model selection. All admin-gated — there is no
+// consumer-agent surface for LLM config. Provider tokens are write-only: reads
+// expose presence only (`hasToken`), never the value; core's `addProvider` /
+// `updateProvider` store the token encrypted.
+//
+// The model picker (`listModels`) + non-blocking "test connection" land with the
+// dashboard UI in PR-B4b (they call out to the provider endpoint).
+
+import type { ConsumerConfigPatch, LlmProviderInput, LlmProviderPatch } from "@librarian/core";
+import {
+  LlmProviderInputSchema,
+  LlmProviderPatchSchema,
+  addProvider,
+  deleteProvider,
+  getProvider,
+  listProviders,
+  readConsumerConfig,
+  updateProvider,
+  writeConsumerConfig,
+} from "@librarian/core";
+import { z } from "zod";
+import { adminProcedure, router } from "./trpc.js";
+
+const ConsumerSchema = z.enum(["intake", "grooming"]);
+
+// Reuse core's patch schema (single source of truth) + the target id.
+const UpdateProviderSchema = LlmProviderPatchSchema.extend({ id: z.string().min(1) });
+
+const SetConsumerSchema = z.strictObject({
+  consumer: ConsumerSchema,
+  providerId: z.string().optional(),
+  model: z.string().optional(),
+  timeoutMs: z.number().optional(),
+});
+
+export const llmRouter = router({
+  // Named providers — list/get never include the token, only `hasToken`.
+  listProviders: adminProcedure.query(({ ctx }) => listProviders(ctx.store)),
+
+  addProvider: adminProcedure
+    .input(LlmProviderInputSchema)
+    // Cast at the validated boundary: Zod `.optional()` infers `T | undefined`,
+    // which the input type (optional-key, not undefined-value) rejects under
+    // exactOptionalPropertyTypes. The schema already validated the shape.
+    .mutation(({ ctx, input }) => addProvider(ctx.store, input as LlmProviderInput)),
+
+  updateProvider: adminProcedure.input(UpdateProviderSchema).mutation(({ ctx, input }) => {
+    const { id, ...patch } = input;
+    updateProvider(ctx.store, id, patch as LlmProviderPatch);
+    return getProvider(ctx.store, id);
+  }),
+
+  deleteProvider: adminProcedure
+    .input(z.strictObject({ id: z.string().min(1) }))
+    .mutation(({ ctx, input }) => {
+      deleteProvider(ctx.store, input.id);
+      return listProviders(ctx.store);
+    }),
+
+  // Per-consumer provider+model selection (intake / grooming).
+  consumerConfig: adminProcedure
+    .input(z.strictObject({ consumer: ConsumerSchema }))
+    .query(({ ctx, input }) => readConsumerConfig(ctx.store, input.consumer)),
+
+  setConsumerConfig: adminProcedure.input(SetConsumerSchema).mutation(({ ctx, input }) => {
+    const { consumer, ...patch } = input;
+    writeConsumerConfig(ctx.store, consumer, patch as ConsumerConfigPatch);
+    return readConsumerConfig(ctx.store, consumer);
+  }),
+});

--- a/packages/mcp-server/src/trpc/router.ts
+++ b/packages/mcp-server/src/trpc/router.ts
@@ -13,6 +13,7 @@ import { backupRouter } from "./backup.js";
 import { curatorRouter } from "./curator.js";
 import { handoffsRouter } from "./handoffs.js";
 import { healthRouter } from "./health.js";
+import { llmRouter } from "./llm.js";
 import { memoriesRouter } from "./memories.js";
 import { tokensRouter } from "./tokens.js";
 import { router } from "./trpc.js";
@@ -23,6 +24,7 @@ export const appRouter = router({
   curator: curatorRouter,
   handoffs: handoffsRouter,
   health: healthRouter,
+  llm: llmRouter,
   memories: memoriesRouter,
   tokens: tokensRouter,
 });

--- a/packages/mcp-server/tests/trpc/llm.test.ts
+++ b/packages/mcp-server/tests/trpc/llm.test.ts
@@ -1,0 +1,158 @@
+// LLM provider + per-consumer config admin tRPC tests (spec 042 §4). Spawns the
+// real HTTP bin and exercises the surface end to end: admin gating, provider CRUD
+// (token write-only — never returned), and per-consumer (intake/grooming) config
+// round-trip + independence.
+
+import { describe, expect, it } from "vitest";
+import { cleanupTempDir, makeTempDir, startHttpServer } from "../../../../test/helpers.js";
+
+interface TrpcOk<T> {
+  result: { data: T };
+}
+interface TrpcErr {
+  error: unknown;
+}
+interface ServerHandle {
+  url: string;
+  token: string;
+  stop: () => Promise<void>;
+}
+
+async function trpcGet<T>(server: ServerHandle, path: string, input?: unknown): Promise<T> {
+  const url = new URL(`${server.url}/trpc/${path}`);
+  if (input !== undefined) url.searchParams.set("input", JSON.stringify(input));
+  const response = await fetch(url, { headers: { authorization: `Bearer ${server.token}` } });
+  const json = (await response.json()) as TrpcOk<T> | TrpcErr;
+  if (response.status >= 400 || "error" in json) {
+    throw new Error(`trpc GET ${path} failed: ${JSON.stringify(json)}`);
+  }
+  return (json as TrpcOk<T>).result.data;
+}
+
+async function trpcPost<T>(server: ServerHandle, path: string, input?: unknown): Promise<T> {
+  const response = await fetch(`${server.url}/trpc/${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${server.token}` },
+    body: input === undefined ? undefined : JSON.stringify(input),
+  });
+  const json = (await response.json()) as TrpcOk<T> | TrpcErr;
+  if (response.status >= 400 || "error" in json) {
+    throw new Error(`trpc POST ${path} failed: ${JSON.stringify(json)}`);
+  }
+  return (json as TrpcOk<T>).result.data;
+}
+
+interface Provider {
+  id: string;
+  name: string;
+  endpoint: string;
+  hasToken: boolean;
+}
+
+interface ConsumerConfig {
+  consumer: string;
+  providerId: string;
+  providerExists: boolean;
+  endpoint: string;
+  model: string;
+  timeoutMs: number;
+  hasToken: boolean;
+  isOperational: boolean;
+}
+
+describe("tRPC llm provider surface", () => {
+  it("requires admin auth", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const response = await fetch(`${server.url}/trpc/llm.listProviders`);
+      expect(response.status).toBeGreaterThanOrEqual(400);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("round-trips provider CRUD without ever returning the token", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      expect(await trpcGet<Provider[]>(server, "llm.listProviders")).toEqual([]);
+
+      const created = await trpcPost<Provider>(server, "llm.addProvider", {
+        name: "OpenAI",
+        endpoint: "https://api.openai.com/v1",
+        token: "dummy-openai-token",
+      });
+      expect(created.name).toBe("OpenAI");
+      expect(created.hasToken).toBe(true);
+      // Lock the contract by shape, not just a fixture substring: no token field.
+      expect(created).not.toHaveProperty("token");
+      expect(Object.keys(created).sort()).toEqual(["endpoint", "hasToken", "id", "name"]);
+      expect(JSON.stringify(created)).not.toContain("dummy-openai-token");
+
+      const list = await trpcGet<Provider[]>(server, "llm.listProviders");
+      expect(list).toHaveLength(1);
+      expect(JSON.stringify(list)).not.toContain("dummy-openai-token");
+
+      const updated = await trpcPost<Provider>(server, "llm.updateProvider", {
+        id: created.id,
+        name: "OpenAI (prod)",
+      });
+      expect(updated.name).toBe("OpenAI (prod)");
+      expect(updated.id).toBe(created.id);
+
+      const afterDelete = await trpcPost<Provider[]>(server, "llm.deleteProvider", {
+        id: created.id,
+      });
+      expect(afterDelete).toEqual([]);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("round-trips per-consumer config and keeps intake + grooming independent", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const cheap = await trpcPost<Provider>(server, "llm.addProvider", {
+        name: "Cheap",
+        endpoint: "https://cheap.example/v1",
+        token: "dummy-cheap",
+      });
+      const strong = await trpcPost<Provider>(server, "llm.addProvider", {
+        name: "Strong",
+        endpoint: "https://strong.example/v1",
+        token: "dummy-strong",
+      });
+
+      await trpcPost<ConsumerConfig>(server, "llm.setConsumerConfig", {
+        consumer: "intake",
+        providerId: cheap.id,
+        model: "mini",
+      });
+      await trpcPost<ConsumerConfig>(server, "llm.setConsumerConfig", {
+        consumer: "grooming",
+        providerId: strong.id,
+        model: "max",
+      });
+
+      const intake = await trpcGet<ConsumerConfig>(server, "llm.consumerConfig", {
+        consumer: "intake",
+      });
+      const grooming = await trpcGet<ConsumerConfig>(server, "llm.consumerConfig", {
+        consumer: "grooming",
+      });
+      expect(intake.endpoint).toBe("https://cheap.example/v1");
+      expect(intake.model).toBe("mini");
+      expect(intake.isOperational).toBe(true);
+      expect(grooming.endpoint).toBe("https://strong.example/v1");
+      expect(grooming.model).toBe("max");
+      expect(grooming.isOperational).toBe(true);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+});


### PR DESCRIPTION
First slice of spec 042's dashboard surface (2A), per Plan 045. Backend tRPC only — builds on PR-B1/B2/B3.

> B4 (dashboard provider UI + legacy retirement) was split into **B4a** (this — backend tRPC), **B4b** (dashboard UI + model picker), **B4c** (retire legacy `curator.llm.*` + the single 042 CHANGELOG entry) to keep each PR shippable.

### What
Adds an `llm` admin router mounted on the app router:
- **`listProviders` / `addProvider` / `updateProvider` / `deleteProvider`** — CRUD over named providers. **Tokens are write-only** — reads expose only `hasToken`, never the value (asserted: the token string never appears in any response).
- **`consumerConfig` / `setConsumerConfig`** — read/write the per-consumer (`intake` / `grooming`) `{ providerId, model, timeoutMs }` selection.

All admin-gated, backed by the core helpers from PR-B1/B2.

### Not in this PR
The model picker (`listModels`) + non-blocking "test connection" call out to the provider endpoint, so they land with the dashboard UI in **B4b**. No user-visible surface yet → no CHANGELOG (lands with B4c).

### Tests
Integration test against the real HTTP bin: admin gating, provider CRUD with no token leak, intake/grooming per-consumer round-trip + independence. mcp-server suite green (111 passed); typecheck clean across all workspaces (incl. the dashboard's `AppRouter` import).

🤖 Generated with [Claude Code](https://claude.com/claude-code)