### PR TITLE
feat(dashboard): curator LLM provider dashboard UI (spec 042 PR-B4b)

### DIFF
--- a/apps/dashboard/app/curator/actions.ts
+++ b/apps/dashboard/app/curator/actions.ts
@@ -1,12 +1,35 @@
 "use server";
 
-import type { CuratorConfigPatch, CuratorTickResult } from "@librarian/core";
+import type {
+  ConsumerConfig,
+  ConsumerConfigPatch,
+  CuratorConfigPatch,
+  CuratorConsumer,
+  CuratorTickResult,
+  LlmProvider,
+  LlmProviderInput,
+  LlmProviderPatch,
+} from "@librarian/core";
 import { revalidatePath } from "next/cache";
 import { serverTRPC } from "@/lib/trpc-server";
 
 export type RunNowResult = { ok: true; result: CuratorTickResult } | { ok: false; error: string };
 
 export type SaveConfigResult = { ok: true } | { ok: false; error: string };
+
+// Provider mutations return the fresh provider list / consumer config so the
+// client can update without an extra round-trip; the page also revalidates.
+export type ProviderListResult =
+  | { ok: true; providers: LlmProvider[] }
+  | { ok: false; error: string };
+export type ConsumerConfigResult =
+  | { ok: true; config: ConsumerConfig }
+  | { ok: false; error: string };
+export type ModelsResult = { models: string[] };
+export type TestConnectionResult = { ok: boolean; error?: string };
+
+/** Inline `{ endpoint, token }` draft OR a saved `providerId` for a model probe. */
+export type ProbeInput = { providerId?: string; endpoint?: string; token?: string };
 
 function message(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -32,6 +55,79 @@ export async function saveCuratorConfigAction(
     await serverTRPC.curator.setConfig.mutate(patch);
     revalidatePath("/curator");
     return { ok: true };
+  } catch (error) {
+    return { ok: false, error: message(error) };
+  }
+}
+
+// --- LLM provider CRUD (spec 042 §4, B4b) -------------------------------------
+// The token is write-only: an empty/omitted token on add or update leaves the
+// stored secret untouched — the form never round-trips it.
+
+export async function addProviderAction(input: LlmProviderInput): Promise<ProviderListResult> {
+  try {
+    await serverTRPC.llm.addProvider.mutate(input);
+    const providers = await serverTRPC.llm.listProviders.query();
+    revalidatePath("/curator");
+    return { ok: true, providers };
+  } catch (error) {
+    return { ok: false, error: message(error) };
+  }
+}
+
+export async function updateProviderAction(
+  input: { id: string } & LlmProviderPatch,
+): Promise<ProviderListResult> {
+  try {
+    await serverTRPC.llm.updateProvider.mutate(input);
+    const providers = await serverTRPC.llm.listProviders.query();
+    revalidatePath("/curator");
+    return { ok: true, providers };
+  } catch (error) {
+    return { ok: false, error: message(error) };
+  }
+}
+
+export async function deleteProviderAction(id: string): Promise<ProviderListResult> {
+  try {
+    const providers = await serverTRPC.llm.deleteProvider.mutate({ id });
+    revalidatePath("/curator");
+    return { ok: true, providers };
+  } catch (error) {
+    return { ok: false, error: message(error) };
+  }
+}
+
+// --- Per-consumer (intake / grooming) provider+model selection ----------------
+
+export async function setConsumerConfigAction(
+  consumer: CuratorConsumer,
+  patch: ConsumerConfigPatch,
+): Promise<ConsumerConfigResult> {
+  try {
+    const config = await serverTRPC.llm.setConsumerConfig.mutate({ consumer, ...patch });
+    revalidatePath("/curator");
+    return { ok: true, config };
+  } catch (error) {
+    return { ok: false, error: message(error) };
+  }
+}
+
+// --- Model picker + connection probe (fail-soft on the server) ----------------
+
+export async function listModelsAction(input: ProbeInput): Promise<ModelsResult> {
+  try {
+    return await serverTRPC.llm.listModels.query(input);
+  } catch {
+    // Mirror the server's fail-soft contract: an unreachable proxy/server still
+    // lets the user fall back to typing a model name.
+    return { models: [] };
+  }
+}
+
+export async function testConnectionAction(input: ProbeInput): Promise<TestConnectionResult> {
+  try {
+    return await serverTRPC.llm.testConnection.query(input);
   } catch (error) {
     return { ok: false, error: message(error) };
   }

--- a/apps/dashboard/app/curator/page.tsx
+++ b/apps/dashboard/app/curator/page.tsx
@@ -1,9 +1,22 @@
-// Memory-curator admin cockpit (spec §7.1 / §13) — read-only v1 view: current
-// config + recent run history. Config editing and run-now land as follow-ups.
+// Memory-curator admin cockpit (spec §7.1 / §13 + 042 §4). Reads the current
+// curator config + run history, the named LLM providers, and the per-consumer
+// (intake / grooming) provider+model selection, and passes them to the client
+// components that manage them. Server component — all data is read via tRPC here.
 
-import { runCuratorNowAction, saveCuratorConfigAction } from "@/app/curator/actions";
+import {
+  addProviderAction,
+  deleteProviderAction,
+  listModelsAction,
+  runCuratorNowAction,
+  saveCuratorConfigAction,
+  setConsumerConfigAction,
+  testConnectionAction,
+  updateProviderAction,
+} from "@/app/curator/actions";
 import { CuratorConfigForm } from "@/components/curator/config-form";
 import { CuratorConfigSummary } from "@/components/curator/config-summary";
+import { ConsumerModelSelector } from "@/components/curator/consumer-model-selector";
+import { ProviderManager } from "@/components/curator/provider-manager";
 import { RunNowButton } from "@/components/curator/run-now-button";
 import { CuratorRunsTable } from "@/components/curator/runs-table";
 import { serverTRPC } from "@/lib/trpc-server";
@@ -13,11 +26,17 @@ export const dynamic = "force-dynamic";
 export default async function CuratorPage() {
   let config: Awaited<ReturnType<typeof serverTRPC.curator.config.query>> | null = null;
   let runs: Awaited<ReturnType<typeof serverTRPC.curator.runs.query>> = [];
+  let providers: Awaited<ReturnType<typeof serverTRPC.llm.listProviders.query>> = [];
+  let intake: Awaited<ReturnType<typeof serverTRPC.llm.consumerConfig.query>> | null = null;
+  let grooming: Awaited<ReturnType<typeof serverTRPC.llm.consumerConfig.query>> | null = null;
   let error: string | null = null;
   try {
-    [config, runs] = await Promise.all([
+    [config, runs, providers, intake, grooming] = await Promise.all([
       serverTRPC.curator.config.query(),
       serverTRPC.curator.runs.query({ limit: 50 }),
+      serverTRPC.llm.listProviders.query(),
+      serverTRPC.llm.consumerConfig.query({ consumer: "intake" }),
+      serverTRPC.llm.consumerConfig.query({ consumer: "grooming" }),
     ]);
   } catch (err) {
     error = err instanceof Error ? err.message : String(err);
@@ -32,6 +51,40 @@ export default async function CuratorPage() {
       {error ? <p className="text-sm text-destructive">{error}</p> : null}
       {config ? <CuratorConfigSummary config={config} /> : null}
       {config ? <CuratorConfigForm initial={config} onSave={saveCuratorConfigAction} /> : null}
+
+      <ProviderManager
+        initialProviders={providers}
+        actions={{
+          onAdd: addProviderAction,
+          onUpdate: updateProviderAction,
+          onDelete: deleteProviderAction,
+          onTest: testConnectionAction,
+        }}
+      />
+
+      {intake && grooming ? (
+        <section
+          className="flex flex-col gap-3 rounded-md border bg-card p-4"
+          aria-label="Per-consumer models"
+        >
+          <h2 className="font-semibold">Per-consumer models</h2>
+          <ConsumerModelSelector
+            consumer="intake"
+            config={intake}
+            providers={providers}
+            onSave={setConsumerConfigAction}
+            onListModels={listModelsAction}
+          />
+          <ConsumerModelSelector
+            consumer="grooming"
+            config={grooming}
+            providers={providers}
+            onSave={setConsumerConfigAction}
+            onListModels={listModelsAction}
+          />
+        </section>
+      ) : null}
+
       <section className="rounded-md border bg-card p-4" aria-label="Run history">
         <h2 className="mb-3 font-semibold">Recent runs</h2>
         <CuratorRunsTable runs={runs} />

--- a/apps/dashboard/components/curator/consumer-model-selector.tsx
+++ b/apps/dashboard/components/curator/consumer-model-selector.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+// Per-consumer (intake / grooming) provider + model selector (spec 042 §4, B4b).
+// A provider dropdown plus a model field. The model field is a dropdown populated
+// from `listModels` for the selected provider WITH a free-text fallback: when the
+// probe returns [] (unreachable / no token / non-listing endpoint) the user can
+// still type a model name, so the picker never blocks configuration.
+
+import type { ConsumerConfig, CuratorConsumer, LlmProvider } from "@librarian/core";
+import { useRouter } from "next/navigation";
+import { useEffect, useState, useTransition } from "react";
+import type { ConsumerConfigResult, ModelsResult } from "@/app/curator/actions";
+
+const inputClass = "rounded-md border bg-background px-2 py-1 font-mono text-sm";
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="flex flex-col gap-1 text-sm">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      {children}
+    </label>
+  );
+}
+
+const CONSUMER_LABEL: Record<CuratorConsumer, string> = {
+  intake: "Intake (consolidator)",
+  grooming: "Grooming (curator)",
+};
+
+export function ConsumerModelSelector({
+  consumer,
+  config,
+  providers,
+  onSave,
+  onListModels,
+}: {
+  consumer: CuratorConsumer;
+  config: ConsumerConfig;
+  providers: LlmProvider[];
+  onSave: (
+    consumer: CuratorConsumer,
+    patch: { providerId?: string; model?: string },
+  ) => Promise<ConsumerConfigResult>;
+  onListModels: (input: { providerId: string }) => Promise<ModelsResult>;
+}) {
+  const router = useRouter();
+  const [providerId, setProviderId] = useState(config.providerId);
+  const [model, setModel] = useState(config.model);
+  const [models, setModels] = useState<string[]>([]);
+  const [pending, startTransition] = useTransition();
+  const [status, setStatus] = useState<string | null>(null);
+
+  // Populate the model dropdown whenever a provider is selected. Fail-soft: [] on
+  // any error leaves only the free-text input, never blocking the form.
+  useEffect(() => {
+    let cancelled = false;
+    if (!providerId) {
+      setModels([]);
+      return;
+    }
+    void onListModels({ providerId }).then((result) => {
+      if (!cancelled) setModels(result.models);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [providerId, onListModels]);
+
+  const save = (event: React.FormEvent) => {
+    event.preventDefault();
+    startTransition(async () => {
+      const result = await onSave(consumer, { providerId, model });
+      setStatus(result.ok ? "Saved." : `Error: ${result.error}`);
+      if (result.ok) router.refresh();
+    });
+  };
+
+  // The current model isn't always in the listed set (free-text or a stale list);
+  // surface it as an extra option so the dropdown round-trips it.
+  const options = model && !models.includes(model) ? [model, ...models] : models;
+  const listId = `models-${consumer}`;
+
+  return (
+    <form
+      onSubmit={save}
+      className="flex flex-col gap-3 rounded-md border bg-background p-3"
+      aria-label={`${CONSUMER_LABEL[consumer]} model selection`}
+    >
+      <h3 className="text-sm font-medium">{CONSUMER_LABEL[consumer]}</h3>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Field label="Provider">
+          <select
+            className={inputClass}
+            value={providerId}
+            onChange={(e) => setProviderId(e.target.value)}
+            aria-label={`${consumer} provider`}
+          >
+            <option value="">— none —</option>
+            {providers.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.name}
+              </option>
+            ))}
+          </select>
+        </Field>
+        <Field label="Model (pick or type)">
+          {/* A datalist gives a dropdown of probed models while still accepting
+              free text — the listModels fallback the spec requires. */}
+          <input
+            className={inputClass}
+            list={listId}
+            value={model}
+            onChange={(e) => setModel(e.target.value)}
+            placeholder="gpt-4o-mini"
+            aria-label={`${consumer} model`}
+          />
+          <datalist id={listId}>
+            {options.map((m) => (
+              <option key={m} value={m} />
+            ))}
+          </datalist>
+        </Field>
+      </div>
+      <div className="flex items-center gap-3">
+        <button
+          type="submit"
+          disabled={pending}
+          className="rounded-md border bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground disabled:opacity-50"
+        >
+          {pending ? "Saving…" : "Save"}
+        </button>
+        {status ? <span className="text-sm text-muted-foreground">{status}</span> : null}
+        {!config.providerExists && config.providerId ? (
+          <span className="text-sm text-amber-600">Referenced provider was deleted.</span>
+        ) : null}
+      </div>
+    </form>
+  );
+}

--- a/apps/dashboard/components/curator/provider-manager.tsx
+++ b/apps/dashboard/components/curator/provider-manager.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+// Named LLM provider manager (spec 042 §4, B4b). List / add / edit / delete
+// providers. The token field is WRITE-ONLY and masked exactly like the curator
+// config-form's: an empty field leaves the stored token unchanged (the secret is
+// never round-tripped to the browser — reads expose `hasToken` only). A "Test"
+// button probes the endpoint without ever revealing the token.
+
+import type { LlmProvider } from "@librarian/core";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import type { ProviderListResult, TestConnectionResult } from "@/app/curator/actions";
+
+const inputClass = "rounded-md border bg-background px-2 py-1 font-mono text-sm";
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="flex flex-col gap-1 text-sm">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      {children}
+    </label>
+  );
+}
+
+export interface ProviderManagerActions {
+  onAdd: (input: { name: string; endpoint: string; token?: string }) => Promise<ProviderListResult>;
+  onUpdate: (input: {
+    id: string;
+    name?: string;
+    endpoint?: string;
+    token?: string;
+  }) => Promise<ProviderListResult>;
+  onDelete: (id: string) => Promise<ProviderListResult>;
+  onTest: (input: {
+    providerId?: string;
+    endpoint?: string;
+    token?: string;
+  }) => Promise<TestConnectionResult>;
+}
+
+export function ProviderManager({
+  initialProviders,
+  actions,
+}: {
+  initialProviders: LlmProvider[];
+  actions: ProviderManagerActions;
+}) {
+  const router = useRouter();
+  const [providers, setProviders] = useState<LlmProvider[]>(initialProviders);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [adding, setAdding] = useState(false);
+
+  const apply = (result: ProviderListResult) => {
+    if (result.ok) {
+      setProviders(result.providers);
+      setEditingId(null);
+      setAdding(false);
+      router.refresh();
+    }
+    return result;
+  };
+
+  return (
+    <section
+      className="flex flex-col gap-4 rounded-md border bg-card p-4"
+      aria-label="LLM providers"
+    >
+      <header className="flex items-center justify-between">
+        <h2 className="font-semibold">LLM providers</h2>
+        {!adding ? (
+          <button
+            type="button"
+            onClick={() => {
+              setAdding(true);
+              setEditingId(null);
+            }}
+            className="rounded-md border px-3 py-1.5 text-sm font-medium"
+          >
+            Add provider
+          </button>
+        ) : null}
+      </header>
+
+      {providers.length === 0 && !adding ? (
+        <p className="text-sm text-muted-foreground">
+          No providers yet. Add one to configure intake and grooming models.
+        </p>
+      ) : null}
+
+      <ul className="flex flex-col gap-2">
+        {providers.map((provider) =>
+          editingId === provider.id ? (
+            <li key={provider.id}>
+              <ProviderForm
+                initial={provider}
+                submitLabel="Save"
+                onSubmit={async (input) =>
+                  apply(await actions.onUpdate({ id: provider.id, ...input }))
+                }
+                onCancel={() => setEditingId(null)}
+                onTest={actions.onTest}
+              />
+            </li>
+          ) : (
+            <li
+              key={provider.id}
+              className="flex items-center justify-between gap-3 rounded-md border bg-background px-3 py-2"
+            >
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium">{provider.name}</p>
+                <p className="truncate font-mono text-xs text-muted-foreground">
+                  {provider.endpoint}
+                </p>
+              </div>
+              <div className="flex shrink-0 items-center gap-2 text-xs">
+                <span className={provider.hasToken ? "text-green-600" : "text-amber-600"}>
+                  {provider.hasToken ? "token set" : "no token"}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setEditingId(provider.id);
+                    setAdding(false);
+                  }}
+                  className="rounded-md border px-2 py-1"
+                >
+                  Edit
+                </button>
+                <DeleteButton onDelete={async () => apply(await actions.onDelete(provider.id))} />
+              </div>
+            </li>
+          ),
+        )}
+      </ul>
+
+      {adding ? (
+        <ProviderForm
+          submitLabel="Add"
+          onSubmit={async (input) => apply(await actions.onAdd(input))}
+          onCancel={() => setAdding(false)}
+          onTest={actions.onTest}
+        />
+      ) : null}
+    </section>
+  );
+}
+
+// Add/edit form. On edit, `initial` seeds name+endpoint; the token field is left
+// empty (placeholder reflects whether one is configured) and only sent when the
+// user types a new value — so the secret is never round-tripped.
+function ProviderForm({
+  initial,
+  submitLabel,
+  onSubmit,
+  onCancel,
+  onTest,
+}: {
+  initial?: LlmProvider;
+  submitLabel: string;
+  onSubmit: (input: {
+    name: string;
+    endpoint: string;
+    token?: string;
+  }) => Promise<ProviderListResult>;
+  onCancel: () => void;
+  onTest: ProviderManagerActions["onTest"];
+}) {
+  const [name, setName] = useState(initial?.name ?? "");
+  const [endpoint, setEndpoint] = useState(initial?.endpoint ?? "");
+  const [token, setToken] = useState("");
+  const [pending, startTransition] = useTransition();
+  const [testing, startTest] = useTransition();
+  const [status, setStatus] = useState<string | null>(null);
+
+  const submit = (event: React.FormEvent) => {
+    event.preventDefault();
+    startTransition(async () => {
+      const input: { name: string; endpoint: string; token?: string } = { name, endpoint };
+      // An empty token field leaves the stored token unchanged (never round-tripped).
+      if (token.length > 0) input.token = token;
+      const result = await onSubmit(input);
+      if (!result.ok) setStatus(`Error: ${result.error}`);
+    });
+  };
+
+  // Test the draft as typed (inline endpoint+token) when editing/creating, or the
+  // saved provider when no new token was entered.
+  const test = () =>
+    startTest(async () => {
+      setStatus("Testing…");
+      const probe =
+        initial && token.length === 0
+          ? { providerId: initial.id }
+          : { endpoint, ...(token ? { token } : {}) };
+      const result = await onTest(probe);
+      setStatus(
+        result.ok ? "Connection OK." : `Connection failed: ${result.error ?? "unreachable"}`,
+      );
+    });
+
+  return (
+    <form
+      onSubmit={submit}
+      className="flex flex-col gap-3 rounded-md border bg-background p-3"
+      aria-label={initial ? `Edit provider ${initial.name}` : "Add provider"}
+    >
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Field label="Name">
+          <input
+            className={inputClass}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="OpenAI"
+            required
+          />
+        </Field>
+        <Field label="Endpoint">
+          <input
+            className={inputClass}
+            value={endpoint}
+            onChange={(e) => setEndpoint(e.target.value)}
+            placeholder="https://api.openai.com/v1"
+            required
+          />
+        </Field>
+      </div>
+      <Field label="API token (blank = keep current)">
+        <input
+          className={inputClass}
+          type="password"
+          value={token}
+          placeholder={initial?.hasToken ? "•••••• (configured)" : "not set"}
+          onChange={(e) => setToken(e.target.value)}
+        />
+      </Field>
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="submit"
+          disabled={pending}
+          className="rounded-md border bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground disabled:opacity-50"
+        >
+          {pending ? "Saving…" : submitLabel}
+        </button>
+        <button
+          type="button"
+          onClick={test}
+          disabled={testing || endpoint.length === 0}
+          className="rounded-md border px-3 py-1.5 text-sm font-medium disabled:opacity-50"
+        >
+          {testing ? "Testing…" : "Test connection"}
+        </button>
+        <button type="button" onClick={onCancel} className="text-sm text-muted-foreground">
+          Cancel
+        </button>
+        {status ? <span className="text-sm text-muted-foreground">{status}</span> : null}
+      </div>
+    </form>
+  );
+}
+
+function DeleteButton({ onDelete }: { onDelete: () => Promise<ProviderListResult> }) {
+  const [pending, startTransition] = useTransition();
+  return (
+    <button
+      type="button"
+      onClick={() => startTransition(() => void onDelete())}
+      disabled={pending}
+      className="rounded-md border px-2 py-1 text-destructive disabled:opacity-50"
+    >
+      {pending ? "Deleting…" : "Delete"}
+    </button>
+  );
+}

--- a/apps/dashboard/e2e/curator-providers.spec.ts
+++ b/apps/dashboard/e2e/curator-providers.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "@playwright/test";
+
+// B4b: the LLM provider manager + per-consumer model picker, end to end through
+// the same-origin tRPC proxy and the real mcp-server llm router (auth is off in
+// the shared e2e server, so this exercises the UI + round-trip, not the login
+// gate — see tokens.spec.ts / A2 notes). The endpoint is an unreachable local
+// port so the listModels probe fails soft and the free-text model fallback is
+// what's under test — no real provider is contacted.
+const UNREACHABLE_ENDPOINT = "http://127.0.0.1:1/v1";
+
+test.describe("curator LLM providers", () => {
+  test("add → edit → delete a provider", async ({ page }) => {
+    const name = `e2e-provider-${Date.now()}`;
+    await page.goto("/curator");
+    await expect(page.getByRole("heading", { name: "Memory Curator", level: 1 })).toBeVisible();
+
+    const providers = page.getByRole("region", { name: "LLM providers" });
+    await providers.getByRole("button", { name: "Add provider" }).click();
+
+    const addForm = providers.getByRole("form", { name: "Add provider" });
+    await addForm.getByLabel("Name").fill(name);
+    await addForm.getByLabel("Endpoint").fill(UNREACHABLE_ENDPOINT);
+    await addForm.getByLabel(/API token/).fill("dummy-e2e-provider-token");
+    await addForm.getByRole("button", { name: "Add" }).click();
+
+    // The provider appears in the list with a "token set" marker (the secret is
+    // never echoed back — only its presence).
+    const row = providers.locator("li", { hasText: name });
+    await expect(row).toBeVisible();
+    await expect(row).toContainText("token set");
+
+    // Edit the name; the token field stays blank (keep current) so the secret is
+    // never round-tripped.
+    await row.getByRole("button", { name: "Edit" }).click();
+    const editForm = providers.getByRole("form", { name: new RegExp(`Edit provider ${name}`) });
+    const renamed = `${name}-edited`;
+    await editForm.getByLabel("Name").fill(renamed);
+    await editForm.getByRole("button", { name: "Save" }).click();
+    await expect(providers.locator("li", { hasText: renamed })).toBeVisible();
+
+    // Delete it.
+    const editedRow = providers.locator("li", { hasText: renamed });
+    await editedRow.getByRole("button", { name: "Delete" }).click();
+    await expect(providers.locator("li", { hasText: renamed })).toHaveCount(0);
+  });
+
+  test("model picker accepts free-text when listModels yields nothing", async ({ page }) => {
+    const name = `e2e-model-${Date.now()}`;
+    const model = "my-custom-model";
+    await page.goto("/curator");
+
+    // Create a provider whose unreachable endpoint makes listModels fail soft → [].
+    const providers = page.getByRole("region", { name: "LLM providers" });
+    await providers.getByRole("button", { name: "Add provider" }).click();
+    const addForm = providers.getByRole("form", { name: "Add provider" });
+    await addForm.getByLabel("Name").fill(name);
+    await addForm.getByLabel("Endpoint").fill(UNREACHABLE_ENDPOINT);
+    await addForm.getByLabel(/API token/).fill("dummy-e2e-model-token");
+    await addForm.getByRole("button", { name: "Add" }).click();
+    await expect(providers.locator("li", { hasText: name })).toBeVisible();
+
+    // Point intake at it and type a model name by hand — the datalist is empty
+    // (probe failed soft) but the free-text input still accepts the value.
+    const intake = page.getByRole("form", { name: /Intake.*model selection/ });
+    await intake.getByLabel("intake provider").selectOption({ label: name });
+    const modelInput = intake.getByLabel("intake model");
+    await modelInput.fill(model);
+    await intake.getByRole("button", { name: "Save" }).click();
+    await expect(intake.getByText("Saved.")).toBeVisible();
+
+    // Reload: the saved free-text model persisted (round-tripped through the store).
+    await page.reload();
+    const intakeAfter = page.getByRole("form", { name: /Intake.*model selection/ });
+    await expect(intakeAfter.getByLabel("intake model")).toHaveValue(model);
+  });
+});

--- a/packages/mcp-server/src/trpc/llm-models.ts
+++ b/packages/mcp-server/src/trpc/llm-models.ts
@@ -1,0 +1,112 @@
+// Provider `${endpoint}/models` probe for the dashboard model picker + "test
+// connection" (spec 042 §4, PR-B4b).
+//
+// Hard invariant (AGENTS.md): the bearer token travels ONLY in the Authorization
+// header. It must never appear in a URL, log, thrown error, or returned error
+// string. `redirect: "error"` forbids any 3xx so the token can't leak to another
+// origin; an AbortController timeout means a hung endpoint can't block the admin's
+// turn. Both helpers are fail-soft — they classify the failure into a short,
+// token-free message and never re-raise.
+
+const MODELS_TIMEOUT_MS = 10_000;
+
+/** Result of a non-blocking connection probe. `error` is always token-free. */
+export interface ProbeResult {
+  ok: boolean;
+  error?: string;
+}
+
+/**
+ * GET `${endpoint}/models` and return the model id list. Fail-soft: returns `[]`
+ * on any error (unreachable, auth failure, malformed body) so the picker falls
+ * back to free-text entry. Accepts the OpenAI `{ data: [{ id }] }` shape and a
+ * bare `string[]`.
+ */
+export async function fetchProviderModels(endpoint: string, token: string): Promise<string[]> {
+  const result = await getModels(endpoint, token);
+  return result.ok ? result.models : [];
+}
+
+/**
+ * Probe `${endpoint}/models` and report reachability without leaking the token.
+ * Never throws — the `error` string is built only from HTTP status or the
+ * transport error's own message, never from the request we sent.
+ */
+export async function probeProviderConnection(
+  endpoint: string,
+  token: string,
+): Promise<ProbeResult> {
+  const result = await getModels(endpoint, token);
+  if (result.ok) return { ok: true };
+  return { ok: false, error: result.error };
+}
+
+type GetModelsResult = { ok: true; models: string[] } | { ok: false; error: string };
+
+async function getModels(rawEndpoint: string, token: string): Promise<GetModelsResult> {
+  const endpoint = rawEndpoint.trim().replace(/\/+$/, "");
+  if (!endpoint) return { ok: false, error: "no endpoint configured" };
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), MODELS_TIMEOUT_MS);
+  try {
+    const headers: Record<string, string> = { accept: "application/json" };
+    // Only attach the header when a token exists; some self-hosted endpoints are open.
+    if (token) headers.authorization = `Bearer ${token}`;
+
+    let response: Response;
+    try {
+      response = await fetch(`${endpoint}/models`, {
+        method: "GET",
+        headers,
+        redirect: "error",
+        signal: controller.signal,
+      });
+    } catch (err) {
+      return { ok: false, error: transportError(err) };
+    }
+
+    if (!response.ok) {
+      // Status only — the response body may echo provider detail but never our token.
+      return { ok: false, error: `HTTP ${response.status}` };
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = await response.json();
+    } catch {
+      return { ok: false, error: "response was not valid JSON" };
+    }
+    return { ok: true, models: extractModelIds(parsed) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// Node's fetch rejects with a DOMException on abort, which does NOT extend Error
+// — match on `.name`. The error's own message (e.g. "ECONNREFUSED") is safe; it
+// never contains the request we sent.
+function transportError(err: unknown): string {
+  if (typeof err === "object" && err !== null && (err as { name?: string }).name === "AbortError") {
+    return `timed out after ${MODELS_TIMEOUT_MS}ms`;
+  }
+  return err instanceof Error ? err.message : "network error";
+}
+
+// Tolerate the OpenAI `{ data: [{ id }] }` shape and a bare `string[]`; ignore
+// anything malformed (yields []). Dedup + drop empties for a clean picker.
+function extractModelIds(parsed: unknown): string[] {
+  const raw = Array.isArray(parsed)
+    ? parsed
+    : isRecord(parsed) && Array.isArray(parsed.data)
+      ? parsed.data
+      : [];
+  const ids = raw
+    .map((entry) => (typeof entry === "string" ? entry : isRecord(entry) ? entry.id : null))
+    .filter((id): id is string => typeof id === "string" && id.length > 0);
+  return [...new Set(ids)];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/packages/mcp-server/src/trpc/llm.ts
+++ b/packages/mcp-server/src/trpc/llm.ts
@@ -6,10 +6,18 @@
 // expose presence only (`hasToken`), never the value; core's `addProvider` /
 // `updateProvider` store the token encrypted.
 //
-// The model picker (`listModels`) + non-blocking "test connection" land with the
-// dashboard UI in PR-B4b (they call out to the provider endpoint).
+// The model picker (`listModels`) + non-blocking "test connection" call out to
+// the provider's `${endpoint}/models`. Both are fail-soft (never throw) and the
+// bearer token travels solely in the Authorization header — never in a URL, log,
+// or returned error string (`redirect: "error"` so a 3xx can't leak it
+// cross-origin; an AbortController timeout so a hung endpoint can't block).
 
-import type { ConsumerConfigPatch, LlmProviderInput, LlmProviderPatch } from "@librarian/core";
+import type {
+  ConsumerConfigPatch,
+  InternalLibrarianStore,
+  LlmProviderInput,
+  LlmProviderPatch,
+} from "@librarian/core";
 import {
   LlmProviderInputSchema,
   LlmProviderPatchSchema,
@@ -18,13 +26,24 @@ import {
   getProvider,
   listProviders,
   readConsumerConfig,
+  resolveProviderToken,
   updateProvider,
   writeConsumerConfig,
 } from "@librarian/core";
 import { z } from "zod";
+import { fetchProviderModels, probeProviderConnection } from "./llm-models.js";
 import { adminProcedure, router } from "./trpc.js";
 
 const ConsumerSchema = z.enum(["intake", "grooming"]);
+
+// A model query may target an already-saved provider (token resolved from the
+// vault) OR an inline draft `{ endpoint, token }`, so the dashboard can test a
+// provider before saving it. `providerId` wins when both are supplied.
+const ProbeSchema = z.strictObject({
+  providerId: z.string().optional(),
+  endpoint: z.string().optional(),
+  token: z.string().optional(),
+});
 
 // Reuse core's patch schema (single source of truth) + the target id.
 const UpdateProviderSchema = LlmProviderPatchSchema.extend({ id: z.string().min(1) });
@@ -70,4 +89,45 @@ export const llmRouter = router({
     writeConsumerConfig(ctx.store, consumer, patch as ConsumerConfigPatch);
     return readConsumerConfig(ctx.store, consumer);
   }),
+
+  // Populate the model picker. Fail-soft: any error (unreachable endpoint, auth
+  // failure, malformed body) yields `[]` so the UI falls back to free-text entry.
+  listModels: adminProcedure.input(ProbeSchema).query(async ({ ctx, input }) => {
+    const target = resolveProbeTarget(ctx.store, input);
+    if (!target) return { models: [] };
+    return { models: await fetchProviderModels(target.endpoint, target.token) };
+  }),
+
+  // Non-blocking "test connection". Never throws; returns a plain ok/error result
+  // whose `error` string is built only from status/transport detail — never the token.
+  testConnection: adminProcedure.input(ProbeSchema).query(async ({ ctx, input }) => {
+    const target = resolveProbeTarget(ctx.store, input);
+    if (!target) return { ok: false, error: "no endpoint configured" };
+    return probeProviderConnection(target.endpoint, target.token);
+  }),
 });
+
+interface ProbeTarget {
+  endpoint: string;
+  token: string;
+}
+
+// Resolve the `{ endpoint, token }` to probe. A `providerId` reads the saved
+// endpoint + decrypts the stored token (the inline draft is ignored); otherwise
+// the inline draft is used. Returns null when no usable endpoint is available.
+function resolveProbeTarget(
+  store: InternalLibrarianStore,
+  input: z.infer<typeof ProbeSchema>,
+): ProbeTarget | null {
+  if (input.providerId) {
+    const provider = getProvider(store, input.providerId);
+    if (!provider?.endpoint) return null;
+    return {
+      endpoint: provider.endpoint,
+      token: resolveProviderToken(store, input.providerId) ?? "",
+    };
+  }
+  const endpoint = (input.endpoint ?? "").trim();
+  if (!endpoint) return null;
+  return { endpoint, token: input.token ?? "" };
+}

--- a/packages/mcp-server/src/trpc/llm.ts
+++ b/packages/mcp-server/src/trpc/llm.ts
@@ -122,10 +122,15 @@ function resolveProbeTarget(
   if (input.providerId) {
     const provider = getProvider(store, input.providerId);
     if (!provider?.endpoint) return null;
-    return {
-      endpoint: provider.endpoint,
-      token: resolveProviderToken(store, input.providerId) ?? "",
-    };
+    // Decrypting the token needs the master key; if it's absent the read throws.
+    // Probe the endpoint token-less rather than throwing out of a fail-soft query.
+    let token = "";
+    try {
+      token = resolveProviderToken(store, input.providerId) ?? "";
+    } catch {
+      token = "";
+    }
+    return { endpoint: provider.endpoint, token };
   }
   const endpoint = (input.endpoint ?? "").trim();
   if (!endpoint) return null;

--- a/packages/mcp-server/tests/trpc/llm.test.ts
+++ b/packages/mcp-server/tests/trpc/llm.test.ts
@@ -155,4 +155,79 @@ describe("tRPC llm provider surface", () => {
       cleanupTempDir(dataDir);
     }
   });
+
+  // An unreachable port (127.0.0.1:1) makes the outbound /models fetch fail fast.
+  // The token must never surface in the fail-soft result.
+  const UNREACHABLE = "http://127.0.0.1:1/v1";
+  const PROBE_TOKEN = "dummy-probe-secret";
+
+  it("listModels fails soft to [] on an unreachable endpoint and never leaks the token", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const result = await trpcGet<{ models: string[] }>(server, "llm.listModels", {
+        endpoint: UNREACHABLE,
+        token: PROBE_TOKEN,
+      });
+      expect(result).toEqual({ models: [] });
+      expect(JSON.stringify(result)).not.toContain(PROBE_TOKEN);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("testConnection returns {ok:false} with a token-free error on an unreachable endpoint", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const result = await trpcGet<{ ok: boolean; error?: string }>(server, "llm.testConnection", {
+        endpoint: UNREACHABLE,
+        token: PROBE_TOKEN,
+      });
+      expect(result.ok).toBe(false);
+      expect(result.error).toBeTruthy();
+      expect(JSON.stringify(result)).not.toContain(PROBE_TOKEN);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("listModels resolves a saved provider's token without exposing it, failing soft to []", async () => {
+    const dataDir = makeTempDir();
+    // A secret key is required for the stored provider token to round-trip.
+    // Assembled at runtime (64 hex chars) so no commit holds a key-shaped literal.
+    const secretKey = "0123456789abcdef".repeat(4);
+    const server = await startHttpServer({ dataDir, secretKey });
+    try {
+      const provider = await trpcPost<Provider>(server, "llm.addProvider", {
+        name: "Probe",
+        endpoint: UNREACHABLE,
+        token: PROBE_TOKEN,
+      });
+      const result = await trpcGet<{ models: string[] }>(server, "llm.listModels", {
+        providerId: provider.id,
+      });
+      expect(result).toEqual({ models: [] });
+      expect(JSON.stringify(result)).not.toContain(PROBE_TOKEN);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("model probes require admin auth", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const url = new URL(`${server.url}/trpc/llm.listModels`);
+      url.searchParams.set("input", JSON.stringify({ endpoint: UNREACHABLE }));
+      const response = await fetch(url);
+      expect(response.status).toBeGreaterThanOrEqual(400);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
 });


### PR DESCRIPTION
## Spec 042 PR-B4b — curator LLM provider dashboard UI

Builds the dashboard surface for the named-LLM-provider backend that landed in #314–#317. The whole 042 backend (the `llm` tRPC router: provider CRUD + per-consumer config, tokens write-only) was already merged; this PR adds the two outbound-network procedures it deferred plus the entire admin UI.

### What's in scope (the 4 parts)
1. **`llm.listModels` + `llm.testConnection`** (`packages/mcp-server/src/trpc/llm.ts` + new `llm-models.ts`). Both admin-gated and **fail-soft**: `listModels` → `{ models: string[] }` (`[]` on any error), `testConnection` → `{ ok, error? }` (never throws). They probe `${endpoint}/models` for either a saved `providerId` (token resolved from the vault) or an inline `{ endpoint, token }` draft, so the UI can test a provider *before* saving it.
   - **Security:** the bearer token travels **only** in the `Authorization` header — never a URL, log, or error string. `redirect: "error"` forbids a 3xx token leak; an AbortController 10s timeout stops a hung endpoint from blocking. Returned errors are built from HTTP status / transport detail only. Unit tests assert the token never appears in any result.
2. **Server actions** (`apps/dashboard/app/curator/actions.ts`) wrapping each procedure, revalidating `/curator` after mutations, token kept write-only.
3. **Components** (`apps/dashboard/components/curator/`): `provider-manager.tsx` (list/add/edit/delete with a masked, write-only token field — blank = keep current, mirroring `config-form.tsx` — and a non-blocking Test button) and `consumer-model-selector.tsx` (intake + grooming each get a provider dropdown + a model field backed by a `<datalist>` of probed models **with free-text fallback** when `listModels` returns `[]`). Wired into the curator page (server component).
4. **e2e** (`apps/dashboard/e2e/curator-providers.spec.ts`): provider add → edit → delete and the model-picker free-text fallback, mirroring `tokens.spec.ts`.

### Out of scope
B4c (retiring legacy `curator.llm.*`) and the single 042 CHANGELOG entry are a separate later PR — **no CHANGELOG entry here by design** (B4c owns the B1–B4 arc summary).

### Verification
- `pnpm typecheck`, `pnpm lint` clean across all workspaces; `pnpm -r build` clean (no `error TS`).
- Full vitest suite green (core 723, mcp-server 115, dashboard 175, cli 44, eval 39, root 22).
- Full Playwright e2e green (16/16, including the 2 new specs).

### Review fix folded in
`resolveProviderToken` decrypts via the master key and throws when it's absent — wrapped so the fail-soft probes degrade to a token-less request instead of throwing out of the query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
