### PR TITLE
refactor(core): retire legacy curator.llm config (spec 042 PR-B4c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ changes from this point forward are catalogued here.
 
 ## [Unreleased]
 
+### Added
+
+- **Dashboard-managed LLM providers with independent per-consumer model
+  selection.** The curator's LLM connection is no longer a single hard-coded
+  block — you now manage named LLM providers (name + endpoint + write-only API
+  token) on the Memory Curator page, and the two curator consumers, **intake**
+  (inbox consolidation) and **grooming** (memory curation), each pick their own
+  provider *and* model independently, so they can run on different models (and
+  providers) while reusing one stored connection. The model field offers a probed
+  dropdown of the provider's available models with a free-text fallback, and a
+  "Test connection" check (tokens are sent only as a `Bearer` header, never echoed
+  back). Existing installs are migrated automatically on the first curator/
+  consolidator run: the old single `curator.llm.*` config is converted one-time
+  into a `default` provider that both consumers point at, then the legacy config
+  is retired. The migration is fail-soft — if the master key is temporarily
+  unavailable it defers and retries on a later run, never losing your token.
+
 ### Removed
 
 - **Dashboard `/logs` and `/recall` pages removed.** Both rendered the

--- a/apps/dashboard/components/curator/config-form.tsx
+++ b/apps/dashboard/components/curator/config-form.tsx
@@ -28,11 +28,6 @@ export function CuratorConfigForm({
   const [status, setStatus] = useState<string | null>(null);
 
   const [enabled, setEnabled] = useState(initial.enabled);
-  const [provider, setProvider] = useState(initial.llm.provider);
-  const [endpoint, setEndpoint] = useState(initial.llm.endpoint);
-  const [model, setModel] = useState(initial.llm.model);
-  const [timeoutMs, setTimeoutMs] = useState(String(initial.llm.timeoutMs));
-  const [token, setToken] = useState("");
   const [level, setLevel] = useState<AutoApplyLevel>(initial.defaultAutoApply);
   const [confidence, setConfidence] = useState(String(initial.autoApplyConfidence));
   const [intervalMinutes, setIntervalMinutes] = useState(String(initial.intervalMinutes));
@@ -43,20 +38,14 @@ export function CuratorConfigForm({
     startTransition(async () => {
       const patch: CuratorConfigPatch = {
         enabled,
-        llm: { provider, endpoint, model, timeoutMs: Number(timeoutMs) },
         defaultAutoApply: level,
         autoApplyConfidence: Number(confidence),
         intervalMinutes: Number(intervalMinutes),
         promptAddendum: addendum,
       };
-      // An empty token field leaves the stored token unchanged (never round-tripped).
-      if (token.length > 0) patch.token = token;
       const result = await onSave(patch);
       setStatus(result.ok ? "Saved." : `Error: ${result.error}`);
-      if (result.ok) {
-        setToken("");
-        router.refresh();
-      }
+      if (result.ok) router.refresh();
     });
   };
 
@@ -71,47 +60,6 @@ export function CuratorConfigForm({
         <input type="checkbox" checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />
         Enable scheduled curation
       </label>
-      <div className="grid gap-3 sm:grid-cols-3">
-        <Field label="Provider">
-          <input
-            className={inputClass}
-            value={provider}
-            onChange={(e) => setProvider(e.target.value)}
-          />
-        </Field>
-        <Field label="Endpoint">
-          <input
-            className={inputClass}
-            value={endpoint}
-            onChange={(e) => setEndpoint(e.target.value)}
-          />
-        </Field>
-        <Field label="Model">
-          <input className={inputClass} value={model} onChange={(e) => setModel(e.target.value)} />
-        </Field>
-      </div>
-      <div className="grid gap-3 sm:grid-cols-[1fr_auto]">
-        <Field label="API token (blank = keep current)">
-          <input
-            className={inputClass}
-            type="password"
-            value={token}
-            placeholder={initial.hasToken ? "•••••• (configured)" : "not set"}
-            onChange={(e) => setToken(e.target.value)}
-          />
-        </Field>
-        <Field label="LLM request timeout (ms)">
-          <input
-            className={inputClass}
-            type="number"
-            min="1000"
-            max="600000"
-            step="1000"
-            value={timeoutMs}
-            onChange={(e) => setTimeoutMs(e.target.value)}
-          />
-        </Field>
-      </div>
       <div className="grid gap-3 sm:grid-cols-3">
         <Field label="Auto-apply">
           <select

--- a/apps/dashboard/components/curator/config-summary.tsx
+++ b/apps/dashboard/components/curator/config-summary.tsx
@@ -1,12 +1,12 @@
-// Read-only summary of the memory-curator config (spec §7.1 / §13). The token is
-// never shown — only whether one is configured (config.hasToken).
+// Read-only summary of the memory-curator's NON-LLM config (spec §7.1 / §13). The
+// LLM connection lives in the provider manager + per-consumer selectors below it.
 
 import type { CuratorConfig } from "@librarian/core";
 
 function statusOf(config: CuratorConfig): { label: string; tone: string } {
-  if (config.isOperational) return { label: "Operational", tone: "text-green-600" };
-  if (config.enabled) return { label: "Enabled — config incomplete", tone: "text-amber-600" };
-  return { label: "Disabled", tone: "text-muted-foreground" };
+  return config.enabled
+    ? { label: "Enabled", tone: "text-green-600" }
+    : { label: "Disabled", tone: "text-muted-foreground" };
 }
 
 function Row({ label, value }: { label: string; value: string }) {
@@ -27,10 +27,6 @@ export function CuratorConfigSummary({ config }: { config: CuratorConfig }) {
         <span className={`text-sm font-medium ${status.tone}`}>{status.label}</span>
       </header>
       <Row label="Schedule" value={`every ${config.intervalMinutes} minute(s)`} />
-      <Row label="Provider" value={config.llm.provider || "—"} />
-      <Row label="Endpoint" value={config.llm.endpoint || "—"} />
-      <Row label="Model" value={config.llm.model || "—"} />
-      <Row label="API token" value={config.hasToken ? "configured" : "not set"} />
       <Row label="Auto-apply" value={config.defaultAutoApply} />
       <Row label="Confidence threshold" value={String(config.autoApplyConfidence)} />
       <Row label="Prompt addendum" value={config.promptAddendum ? "set" : "—"} />

--- a/apps/dashboard/tests/components/curator/cockpit-actions.test.tsx
+++ b/apps/dashboard/tests/components/curator/cockpit-actions.test.tsx
@@ -48,43 +48,33 @@ describe("RunNowButton", () => {
 
 const config: CuratorConfig = {
   enabled: false,
-  llm: { provider: "openai", endpoint: "https://e/v1", model: "gpt-x", timeoutMs: 60_000 },
-  hasToken: true,
   promptAddendum: "",
   defaultAutoApply: "safe_only",
   autoApplyConfidence: 0.9,
   intervalMinutes: 60,
-  isLlmComplete: true,
-  isOperational: false,
 };
 
 describe("CuratorConfigForm", () => {
-  it("pre-fills from the current config and saves a patch without the token when left blank", async () => {
+  it("pre-fills from the current NON-LLM config and saves a patch (no LLM fields)", async () => {
     const onSave = vi.fn(async (_patch: CuratorConfigPatch) => ({ ok: true as const }));
     render(<CuratorConfigForm initial={config} onSave={onSave} />);
 
-    expect((screen.getByLabelText("Provider") as HTMLInputElement).value).toBe("openai");
-    expect((screen.getByLabelText("Model") as HTMLInputElement).value).toBe("gpt-x");
+    expect((screen.getByLabelText("Run every N minutes") as HTMLInputElement).value).toBe("60");
+    expect((screen.getByLabelText("Confidence (0–1)") as HTMLInputElement).value).toBe("0.9");
 
     await userEvent.click(screen.getByRole("button", { name: /save/i }));
     expect(onSave).toHaveBeenCalledTimes(1);
     const patch = onSave.mock.calls[0]![0];
     expect(patch).toMatchObject({
       enabled: false,
-      llm: { provider: "openai", endpoint: "https://e/v1", model: "gpt-x", timeoutMs: 60_000 },
       defaultAutoApply: "safe_only",
       autoApplyConfidence: 0.9,
       intervalMinutes: 60,
     });
-    expect("token" in patch).toBe(false); // blank token field → unchanged
+    // The LLM connection moved out of this form (provider manager + per-consumer
+    // selectors own it now) — the patch must carry no LLM/token keys.
+    expect("llm" in patch).toBe(false);
+    expect("token" in patch).toBe(false);
     expect(screen.getByText("Saved.")).toBeTruthy();
-  });
-
-  it("includes the token only when the field is filled", async () => {
-    const onSave = vi.fn(async (_patch: CuratorConfigPatch) => ({ ok: true as const }));
-    render(<CuratorConfigForm initial={config} onSave={onSave} />);
-    await userEvent.type(screen.getByLabelText(/API token/), "new-token-value");
-    await userEvent.click(screen.getByRole("button", { name: /save/i }));
-    expect(onSave.mock.calls[0]![0].token).toBe("new-token-value");
   });
 });

--- a/apps/dashboard/tests/components/curator/cockpit.test.tsx
+++ b/apps/dashboard/tests/components/curator/cockpit.test.tsx
@@ -7,14 +7,10 @@ import { CuratorRunsTable } from "@/components/curator/runs-table";
 function config(over: Partial<CuratorConfig> = {}): CuratorConfig {
   return {
     enabled: false,
-    llm: { provider: "", endpoint: "", model: "", timeoutMs: 60_000 },
-    hasToken: false,
     promptAddendum: "",
     defaultAutoApply: "safe_only",
     autoApplyConfidence: 0.9,
     intervalMinutes: 60,
-    isLlmComplete: false,
-    isOperational: false,
     ...over,
   };
 }
@@ -44,26 +40,14 @@ function run(over: Partial<CurationRun> = {}): CurationRun {
 }
 
 describe("CuratorConfigSummary", () => {
-  it("shows Disabled by default and never reveals the token", () => {
+  it("shows Disabled by default", () => {
     render(<CuratorConfigSummary config={config()} />);
     expect(screen.getByText("Disabled")).toBeTruthy();
-    expect(screen.getByText("not set")).toBeTruthy(); // token presence only, never a value
   });
 
-  it("shows Operational when enabled and the LLM config is complete", () => {
-    render(
-      <CuratorConfigSummary
-        config={config({
-          enabled: true,
-          hasToken: true,
-          isLlmComplete: true,
-          isOperational: true,
-          llm: { provider: "openai", endpoint: "https://e/v1", model: "gpt-x", timeoutMs: 60_000 },
-        })}
-      />,
-    );
-    expect(screen.getByText("Operational")).toBeTruthy();
-    expect(screen.getByText("configured")).toBeTruthy();
+  it("shows Enabled when scheduled curation is on", () => {
+    render(<CuratorConfigSummary config={config({ enabled: true })} />);
+    expect(screen.getByText("Enabled")).toBeTruthy();
   });
 });
 

--- a/packages/core/src/curator-config.ts
+++ b/packages/core/src/curator-config.ts
@@ -1,29 +1,17 @@
-// Curator LLM configuration (memory-curator spec §7.1), stored in the admin
-// settings/secret store. Operator-managed: enable flag, LLM connection
-// (provider/endpoint/token/model), prompt addendum, auto-apply posture, and
-// schedule. The token is a secret (encrypted by the settings store); the
-// readable config exposes only `hasToken`, never the value.
+// Curator configuration (memory-curator spec §7.1), stored in the admin
+// settings store. Operator-managed: enable flag, prompt addendum, auto-apply
+// posture, and schedule. The LLM connection no longer lives here — providers are
+// named + dashboard-managed (`llm-providers.ts`) and each consumer (intake /
+// grooming) picks its own provider+model (`curator-consumers.ts`). This config
+// carries only the curator's NON-LLM knobs.
 //
-// `readCuratorConfig` deliberately reads token PRESENCE from settings metadata
-// (no decryption), so it works without the master key — the admin cockpit can
-// render the configured state. Only the worker's `resolveCuratorToken` decrypts.
+// `readCuratorConfig` reads plain settings only, so it works without the master
+// key — the admin cockpit can always render the configured state.
 
 import { z } from "zod";
-import {
-  type LlmConnectionPatch,
-  type LlmConnectionReader,
-  type LlmConnectionWriter,
-  LlmConnectionPatchSchema,
-  llmConnectionKeys,
-  readLlmConnection,
-  resolveLlmToken,
-  writeLlmConnection,
-} from "./llm-connection.js";
+import type { LlmConnectionReader, LlmConnectionWriter } from "./llm-connection.js";
 
-// LLM-connection keys delegate to the shared helper (`curator.llm.*`);
-// curator-specific keys (enable flag, prompt addendum, auto-apply, schedule)
-// stay inline here.
-const LLM_KEYS = llmConnectionKeys("curator.llm");
+// Curator-specific keys (enable flag, prompt addendum, auto-apply, schedule).
 const KEYS = {
   enabled: "curator.enabled",
   promptAddendum: "curator.prompt_addendum",
@@ -54,25 +42,15 @@ const MAX_INTERVAL_MINUTES = 7 * 24 * 60; // one week
 
 export interface CuratorConfig {
   enabled: boolean;
-  llm: { provider: string; endpoint: string; model: string; timeoutMs: number };
-  /** Whether an LLM token is stored — never the value. */
-  hasToken: boolean;
   promptAddendum: string;
   defaultAutoApply: AutoApplyLevel;
   autoApplyConfidence: number;
   /** Whole minutes between scheduled runs (§12.4). */
   intervalMinutes: number;
-  /** provider + endpoint + model + token all present. */
-  isLlmComplete: boolean;
-  /** enabled AND the LLM config is complete (§7.1 — the scheduler gate). */
-  isOperational: boolean;
 }
 
 export interface CuratorConfigPatch {
   enabled?: boolean;
-  llm?: { provider?: string; endpoint?: string; model?: string; timeoutMs?: number };
-  /** Plaintext token; stored encrypted. Empty string clears it. */
-  token?: string;
   promptAddendum?: string;
   defaultAutoApply?: AutoApplyLevel;
   autoApplyConfidence?: number;
@@ -80,21 +58,18 @@ export interface CuratorConfigPatch {
 }
 
 // Input validation for the admin API. Permissive shape (all optional); the deeper
-// invariants — addendum ≤ 2 KB, confidence 0..1, interval ≥ 1, HH:MM — are
-// enforced by writeCuratorConfig, which is the single source of truth.
+// invariants — addendum ≤ 2 KB, confidence 0..1, interval ≥ 1 — are enforced by
+// writeCuratorConfig, which is the single source of truth.
 export const CuratorConfigPatchSchema = z.strictObject({
   enabled: z.boolean().optional(),
-  llm: LlmConnectionPatchSchema.optional(),
-  token: z.string().optional(),
   promptAddendum: z.string().optional(),
   defaultAutoApply: z.enum(["off", "safe_only", "high_confidence"]).optional(),
   autoApplyConfidence: z.number().optional(),
   intervalMinutes: z.number().optional(),
 });
 
-// The slices of the store this module needs. The LLM-connection block uses
-// the helper's reader/writer interfaces; curator-specific keys reuse the
-// same slice (it's a superset).
+// The slices of the store this module needs. Curator-specific keys are all plain
+// (non-secret) settings; we reuse the shared reader/writer interfaces.
 type ConfigReader = LlmConnectionReader;
 type ConfigWriter = LlmConnectionWriter;
 
@@ -110,17 +85,8 @@ function parseNumber(raw: string | null, fallback: number): number {
 }
 
 export function readCuratorConfig(store: ConfigReader): CuratorConfig {
-  const llm = readLlmConnection(store, LLM_KEYS);
-  const enabled = store.getSetting(KEYS.enabled) === "true";
   return {
-    enabled,
-    llm: {
-      provider: llm.provider,
-      endpoint: llm.endpoint,
-      model: llm.model,
-      timeoutMs: llm.timeoutMs,
-    },
-    hasToken: llm.hasToken,
+    enabled: store.getSetting(KEYS.enabled) === "true",
     promptAddendum: store.getSetting(KEYS.promptAddendum) ?? "",
     defaultAutoApply: parseAutoApply(store.getSetting(KEYS.defaultAutoApply)),
     autoApplyConfidence: parseNumber(
@@ -128,8 +94,6 @@ export function readCuratorConfig(store: ConfigReader): CuratorConfig {
       DEFAULT_CONFIDENCE,
     ),
     intervalMinutes: parseNumber(store.getSetting(KEYS.intervalMinutes), DEFAULT_INTERVAL_MINUTES),
-    isLlmComplete: llm.isComplete,
-    isOperational: enabled && llm.isComplete,
   };
 }
 
@@ -143,8 +107,7 @@ export function findLegacyScheduleKeys(store: ConfigReader): string[] {
 }
 
 export function writeCuratorConfig(store: ConfigWriter, patch: CuratorConfigPatch): void {
-  // Validate every curator-specific field before touching the store. The
-  // LLM-connection block is validated inside `writeLlmConnection`.
+  // Validate every curator-specific field before touching the store.
   if (patch.promptAddendum !== undefined) {
     if (Buffer.byteLength(patch.promptAddendum, "utf8") > MAX_ADDENDUM_BYTES) {
       throw new Error(`prompt addendum must be ≤ ${MAX_ADDENDUM_BYTES} bytes (~2 KB)`);
@@ -168,14 +131,6 @@ export function writeCuratorConfig(store: ConfigWriter, patch: CuratorConfigPatc
     }
   }
 
-  // LLM-connection block + token go through the shared helper, which validates
-  // timeoutMs bounds and encrypts the token.
-  if (patch.llm !== undefined || patch.token !== undefined) {
-    const llmPatch: LlmConnectionPatch & { token?: string } = { ...(patch.llm ?? {}) };
-    if (patch.token !== undefined) llmPatch.token = patch.token;
-    writeLlmConnection(store, LLM_KEYS, llmPatch);
-  }
-
   if (patch.enabled !== undefined) store.setSetting(KEYS.enabled, patch.enabled ? "true" : "false");
   if (patch.promptAddendum !== undefined)
     store.setSetting(KEYS.promptAddendum, patch.promptAddendum);
@@ -185,11 +140,4 @@ export function writeCuratorConfig(store: ConfigWriter, patch: CuratorConfigPatc
     store.setSetting(KEYS.autoApplyConfidence, String(patch.autoApplyConfidence));
   if (patch.intervalMinutes !== undefined)
     store.setSetting(KEYS.intervalMinutes, String(patch.intervalMinutes));
-}
-
-/** Decrypt the stored LLM token for the worker. Returns null when unset. Needs the master key. */
-export function resolveCuratorToken(store: {
-  getSetting: (key: string) => string | null;
-}): string | null {
-  return resolveLlmToken(store, LLM_KEYS);
 }

--- a/packages/core/src/curator-consumers.ts
+++ b/packages/core/src/curator-consumers.ts
@@ -152,9 +152,15 @@ export function resolveConsumerToken(
 /**
  * One-shot migration of a pre-existing `curator.llm.*` install: synthesise a
  * `default` provider from the legacy endpoint/token and point both consumers at
- * it with the legacy model + timeout. Idempotent — a no-op once any provider
- * exists. Returns whether it migrated. Leaves the legacy keys in place (the
- * cutover that retires them is PR-B3, when the consumers actually switch).
+ * it with the legacy model + timeout, then delete the legacy keys. Idempotent —
+ * a no-op once any provider exists or the legacy keys are gone. Returns whether
+ * it migrated.
+ *
+ * Deletion fires ONLY on the confirmed-success path — after the new provider +
+ * consumer config have been seeded. Every early `return false` (no providers
+ * needed, no endpoint, master key absent) bails out BEFORE any seed, so the
+ * legacy keys survive a deferral intact and no data is lost. NEVER delete before
+ * seeding or on the defer path.
  */
 export function migrateLegacyCuratorLlm(store: ConsumerStore): boolean {
   if (listProviderIds(store).length > 0) return false;
@@ -172,7 +178,7 @@ export function migrateLegacyCuratorLlm(store: ConsumerStore): boolean {
     // re-encrypt under the new provider. Defer the whole migration (retry next
     // tick when the key is back) rather than half-migrate a token-less provider —
     // migration is one-shot, so that would permanently drop the key. Fail-soft:
-    // never throw out of a tick.
+    // never throw out of a tick. The legacy keys are left untouched here.
     return false;
   }
   const created = addProvider(store, {
@@ -189,5 +195,11 @@ export function migrateLegacyCuratorLlm(store: ConsumerStore): boolean {
       ...(timeoutMs !== undefined ? { timeoutMs } : {}),
     });
   }
+
+  // Seed succeeded: retire the legacy `curator.llm.*` surface so it can't become
+  // a stale second source of truth. Safe to delete now — we've already read +
+  // re-encrypted the token under the new provider. Keeps the migration
+  // idempotent (a re-run finds nothing to migrate).
+  for (const key of Object.values(legacy)) store.deleteSetting(key);
   return true;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -172,7 +172,6 @@ export {
   type CuratorConfigPatch,
   CuratorConfigPatchSchema,
   readCuratorConfig,
-  resolveCuratorToken,
   writeCuratorConfig,
 } from "./curator-config.js";
 export {

--- a/packages/core/tests/curator-config.test.ts
+++ b/packages/core/tests/curator-config.test.ts
@@ -1,11 +1,10 @@
-// Curator LLM configuration (memory-curator spec §7.1) over the settings store.
+// Curator configuration (memory-curator spec §7.1) over the settings store.
 //
-// Operator-managed config: provider/endpoint/token/model + enable, prompt
-// addendum, auto-apply posture, schedule. The token is a secret (encrypted via
-// the settings store); the readable config never exposes it — only `hasToken`.
-// `readCuratorConfig` works WITHOUT the master key (token presence comes from
-// settings metadata), so the cockpit can render config; only the worker's
-// `resolveCuratorToken` needs the key.
+// Operator-managed NON-LLM config: enable flag, prompt addendum, auto-apply
+// posture, schedule. The LLM connection no longer lives here — providers are
+// named + dashboard-managed and each consumer picks its own (see
+// curator-consumers.test.ts). `readCuratorConfig` reads plain settings only, so
+// it always works without the master key.
 
 import fs from "node:fs";
 import os from "node:os";
@@ -15,21 +14,17 @@ import {
   createLibrarianStore,
   findLegacyScheduleKeys,
   readCuratorConfig,
-  resolveCuratorToken,
-  resolveSecretKey,
   writeCuratorConfig,
 } from "@librarian/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-
-const KEY = resolveSecretKey("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
 
 interface Scope {
   store: LibrarianStore;
   dataDir: string;
 }
 
-function open(dataDir: string, withKey = true): LibrarianStore {
-  return createLibrarianStore(withKey ? { dataDir, secretKey: KEY } : { dataDir });
+function open(dataDir: string): LibrarianStore {
+  return createLibrarianStore({ dataDir });
 }
 
 function scope(): Scope {
@@ -62,68 +57,31 @@ describe("curator config", () => {
     expect(cfg.enabled).toBe(false);
     expect(cfg.defaultAutoApply).toBe("safe_only");
     expect(cfg.autoApplyConfidence).toBeCloseTo(0.9);
-    expect(cfg.hasToken).toBe(false);
-    expect(cfg.isLlmComplete).toBe(false);
-    expect(cfg.isOperational).toBe(false);
-    // Matches curator-llm-client's DEFAULT_TIMEOUT_MS so unconfigured installs
-    // behave identically to before this field landed.
-    expect(cfg.llm.timeoutMs).toBe(60_000);
+    expect(cfg.intervalMinutes).toBe(60);
   });
 
-  it("round-trips a custom llm timeout and clamps invalid values", () => {
-    const { store } = s!;
-    writeCuratorConfig(store, { llm: { timeoutMs: 180_000 } });
-    expect(readCuratorConfig(store).llm.timeoutMs).toBe(180_000);
-    expect(() => writeCuratorConfig(store, { llm: { timeoutMs: 0 } })).toThrow(/timeout/);
-    expect(() => writeCuratorConfig(store, { llm: { timeoutMs: 1_000_000 } })).toThrow(/timeout/);
-    expect(() => writeCuratorConfig(store, { llm: { timeoutMs: 1.5 } })).toThrow(/timeout/);
-    // The earlier valid value is preserved when later writes are rejected.
-    expect(readCuratorConfig(store).llm.timeoutMs).toBe(180_000);
-  });
-
-  it("round-trips config and never exposes the token in the readable config", () => {
+  it("round-trips the non-LLM curator config", () => {
     const { store } = s!;
     writeCuratorConfig(store, {
       enabled: true,
-      llm: { provider: "openai", endpoint: "https://api.example.com/v1", model: "gpt-x" },
-      token: "dummy-llm-token",
       promptAddendum: "prefer merging over archiving",
+      defaultAutoApply: "high_confidence",
     });
     const cfg = readCuratorConfig(store);
-    expect(cfg.llm.provider).toBe("openai");
-    expect(cfg.llm.endpoint).toBe("https://api.example.com/v1");
-    expect(cfg.llm.model).toBe("gpt-x");
-    expect(cfg.hasToken).toBe(true);
-    expect(cfg.isLlmComplete).toBe(true);
-    expect(cfg.isOperational).toBe(true);
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.defaultAutoApply).toBe("high_confidence");
     expect(cfg.promptAddendum).toBe("prefer merging over archiving");
-    // The readable config object must not carry the token anywhere.
-    expect(JSON.stringify(cfg)).not.toContain("dummy-llm-token");
   });
 
-  it("reports hasToken WITHOUT the master key (cockpit render path)", () => {
+  it("reads the config WITHOUT the master key (cockpit render path)", () => {
     const { store, dataDir } = s!;
-    writeCuratorConfig(store, {
-      enabled: true,
-      llm: { provider: "openai", endpoint: "https://e", model: "m" },
-      token: "dummy-secret",
-    });
+    writeCuratorConfig(store, { enabled: true, promptAddendum: "x" });
     store.close();
-    const noKey = open(dataDir, false);
+    const noKey = open(dataDir);
     s!.store = noKey;
-    const cfg = readCuratorConfig(noKey); // must not throw despite the secret token
-    expect(cfg.hasToken).toBe(true);
-    expect(cfg.isOperational).toBe(true);
-  });
-
-  it("resolves the decrypted token for the worker", () => {
-    const { store } = s!;
-    writeCuratorConfig(store, { token: "dummy-worker-token" });
-    expect(resolveCuratorToken(store)).toBe("dummy-worker-token");
-  });
-
-  it("returns null token when none is configured", () => {
-    expect(resolveCuratorToken(s!.store)).toBeNull();
+    const cfg = readCuratorConfig(noKey); // plain settings only — must not need the key
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.promptAddendum).toBe("x");
   });
 
   it("validates the prompt addendum length (≤ 2 KB)", () => {

--- a/packages/core/tests/curator-consumers.test.ts
+++ b/packages/core/tests/curator-consumers.test.ts
@@ -185,8 +185,10 @@ describe("per-consumer LLM resolution", () => {
   });
 
   describe("legacy migration", () => {
+    const LEGACY_KEYS = llmConnectionKeys("curator.llm");
+
     function seedLegacy(store: LibrarianStore): void {
-      writeLlmConnection(store, llmConnectionKeys("curator.llm"), {
+      writeLlmConnection(store, LEGACY_KEYS, {
         provider: "openai",
         endpoint: "https://legacy.example/v1",
         model: "legacy-model",
@@ -195,7 +197,13 @@ describe("per-consumer LLM resolution", () => {
       });
     }
 
-    it("synthesises a `default` provider and points both consumers at it", () => {
+    /** True when ANY of the five legacy `curator.llm.*` keys is still present. */
+    function legacyKeysPresent(store: LibrarianStore): boolean {
+      const keys = store.listSettings().map((m) => m.key);
+      return Object.values(LEGACY_KEYS).some((k) => keys.includes(k));
+    }
+
+    it("synthesises a `default` provider, points both consumers at it, and deletes the legacy keys", () => {
       const { store } = s!;
       seedLegacy(store);
 
@@ -215,12 +223,18 @@ describe("per-consumer LLM resolution", () => {
         expect(cfg.isOperational).toBe(true);
         expect(resolveConsumerToken(store, c)).toBe("dummy-legacy-token");
       }
+
+      // The legacy surface is retired: every `curator.llm.*` key is gone once the
+      // new consumer config has been seeded from it (no double source of truth).
+      expect(legacyKeysPresent(store)).toBe(false);
     });
 
-    it("is idempotent — a second run is a no-op", () => {
+    it("is idempotent — a second run is a no-op (legacy keys already deleted)", () => {
       const { store } = s!;
       seedLegacy(store);
       expect(migrateLegacyCuratorLlm(store)).toBe(true);
+      expect(legacyKeysPresent(store)).toBe(false);
+      // Re-run finds no legacy keys AND a provider already exists -> no-op.
       expect(migrateLegacyCuratorLlm(store)).toBe(false);
       expect(listProviders(store)).toHaveLength(1);
     });
@@ -246,7 +260,7 @@ describe("per-consumer LLM resolution", () => {
       expect(listProviders(store)).toEqual([]);
     });
 
-    it("defers without throwing when a legacy token exists but the master key is absent", () => {
+    it("defers without throwing AND preserves the legacy keys when the master key is absent", () => {
       const { store, dataDir } = s!;
       seedLegacy(store); // endpoint + model + token
       store.close();
@@ -258,6 +272,10 @@ describe("per-consumer LLM resolution", () => {
         expect(() => migrateLegacyCuratorLlm(keyless)).not.toThrow();
         expect(migrateLegacyCuratorLlm(keyless)).toBe(false);
         expect(listProviders(keyless)).toEqual([]);
+        // CRITICAL — no data loss: the legacy keys MUST survive the deferral so a
+        // later tick (master key restored) can still migrate them. Deletion only
+        // ever fires on the confirmed-success path, after the seed.
+        expect(legacyKeysPresent(keyless)).toBe(true);
       } finally {
         keyless.close();
       }

--- a/packages/mcp-server/src/trpc/curator.ts
+++ b/packages/mcp-server/src/trpc/curator.ts
@@ -1,10 +1,11 @@
 // Memory-curator admin tRPC procedures (memory-curator spec §7.1 / §13).
 //
-// The admin cockpit's typed surface: read/update the curator config, read-only
-// run + operation observability, and the run-now control. All admin-gated — there
-// is deliberately NO consumer-agent surface for curation (§12). The config read
-// never exposes the token (only `hasToken`); writes go through core's
-// writeCuratorConfig, which validates and stores the token encrypted.
+// The admin cockpit's typed surface: read/update the curator's NON-LLM config
+// (enable flag, schedule, auto-apply posture, prompt addendum), read-only run +
+// operation observability, and the run-now control. All admin-gated — there is
+// deliberately NO consumer-agent surface for curation (§12). The LLM connection
+// is no longer part of this surface — named providers + per-consumer model
+// selection live under the `llm` router (042 §4).
 
 import type { CuratorConfigPatch, ListCurationRunsInput } from "@librarian/core";
 import {
@@ -23,11 +24,11 @@ const ListRunsInputSchema = z.strictObject({
 });
 
 export const curatorRouter = router({
-  // Current config (never includes the token — only hasToken).
+  // Current NON-LLM curator config.
   config: adminProcedure.query(({ ctx }) => readCuratorConfig(ctx.store)),
 
   // Update config; returns the fresh readable config. writeCuratorConfig validates
-  // (addendum size, confidence range, interval, HH:MM) and encrypts the token.
+  // (addendum size, confidence range, interval).
   setConfig: adminProcedure.input(CuratorConfigPatchSchema).mutation(({ ctx, input }) => {
     // Cast at the validated boundary: Zod `.optional()` infers `T | undefined`,
     // which the patch type (optional-key, not undefined-value) rejects under

--- a/packages/mcp-server/tests/trpc/curator.test.ts
+++ b/packages/mcp-server/tests/trpc/curator.test.ts
@@ -1,7 +1,7 @@
 // Memory-curator admin tRPC procedure tests (§7.1/§13). Spawns the real HTTP bin
-// and exercises the cockpit surface end to end: admin gating, config read/update
-// round-trip (no token — the encrypted-token path is covered by core), run
-// observability, and run-now (disabled config → no run).
+// and exercises the cockpit surface end to end: admin gating, NON-LLM config
+// read/update round-trip (the LLM connection lives under the `llm` router now),
+// run observability, and run-now (disabled config → no run).
 
 import { describe, expect, it } from "vitest";
 import { cleanupTempDir, makeTempDir, startHttpServer } from "../../../../test/helpers.js";
@@ -44,10 +44,9 @@ async function trpcPost<T>(server: ServerHandle, path: string, input?: unknown):
 
 interface CuratorConfig {
   enabled: boolean;
-  llm: { provider: string; endpoint: string; model: string };
-  hasToken: boolean;
   defaultAutoApply: string;
-  isOperational: boolean;
+  promptAddendum: string;
+  intervalMinutes: number;
 }
 
 describe("tRPC curator surface", () => {
@@ -85,18 +84,15 @@ describe("tRPC curator surface", () => {
       const before = await trpcGet<CuratorConfig>(server, "curator.config");
       expect(before.enabled).toBe(false);
       expect(before.defaultAutoApply).toBe("safe_only");
-      expect(before.isOperational).toBe(false);
 
       const after = await trpcPost<CuratorConfig>(server, "curator.setConfig", {
         enabled: true,
-        llm: { provider: "openai", endpoint: "https://api.example.com/v1", model: "gpt-x" },
         defaultAutoApply: "high_confidence",
         promptAddendum: "prefer merging",
       });
       expect(after.enabled).toBe(true);
-      expect(after.llm.model).toBe("gpt-x");
       expect(after.defaultAutoApply).toBe("high_confidence");
-      expect(after.hasToken).toBe(false); // no token set, no secret leak
+      expect(after.promptAddendum).toBe("prefer merging");
     } finally {
       await server.stop();
       cleanupTempDir(dataDir);


### PR DESCRIPTION
## What & why

The final PR of spec 042. The spec-042 world — named, dashboard-managed LLM
providers (`llm-providers.ts`) + independent per-consumer (intake/grooming)
provider+model selection (`curator-consumers.ts`) — has been live and merged
since B1–B4b (#314–#318). This PR retires the legacy single-block
`curator.llm.*` config that the new world replaced, and lands the single 042
`[Unreleased]` CHANGELOG entry for the whole B1–B4 arc.

## Changes

1. **`packages/core/src/curator-config.ts`** — dropped `CuratorConfig.llm`,
   `hasToken`, `isLlmComplete`, `isOperational`, the `resolveCuratorToken` export,
   and the `curator.llm.*` key plumbing (`LLM_KEYS`, `patch.llm`/`patch.token`).
   The config now carries only the curator's NON-LLM knobs (enable, schedule,
   auto-apply posture, prompt addendum) and reads plain settings only, so it
   never needs the master key. `CuratorConfigPatch` + Zod schema updated.
2. **`packages/mcp-server/src/trpc/curator.ts`** — the config read/write surface
   no longer carries `llm`/token. Per-consumer LLM config lives entirely under the
   `llm` router (`llm.consumerConfig`/`setConsumerConfig`).
3. **Dashboard `config-form.tsx` / `config-summary.tsx`** — removed the legacy
   provider/endpoint/model/token fields (now owned by `provider-manager.tsx` +
   `consumer-model-selector.tsx` from B4b); kept the non-LLM curator settings.
   Status badge is now Enabled/Disabled (LLM-completeness lives per-consumer).
4. **`migrateLegacyCuratorLlm`** — now **deletes** the legacy `curator.llm.*`
   keys, but **only on the confirmed-success path** (after the new provider +
   consumer config have been seeded). See the data-loss safety note below.
5. **CHANGELOG** — the single `[Unreleased]` entry for the whole 042 B1–B4 arc:
   dashboard-managed providers + independent per-consumer model selection + the
   one-time fail-soft migration.
6. Confirmed no other live reader of `curator.llm.*` remains. The only reader is
   `migrateLegacyCuratorLlm`, which reads the legacy keys to seed the new config
   and then deletes them. (B3 already cut the ticks over to `resolveConsumerToken`.)

## Migration data-loss safety (the #1 risk)

The migration is fail-soft and **defers** when the master key is absent (it can't
decrypt the legacy token to re-encrypt it under the new provider). The legacy-key
deletion fires **strictly after** both seed operations (`addProvider` +
`writeConsumerConfig` for both consumers) and **after all three early returns**
(providers already exist, no endpoint, master-key-absent defer). Every defer path
`return false`s before any seed runs, so a deferral leaves the legacy keys fully
intact — no data loss — and a later tick (key restored) still migrates them.
Neither seed call can throw on these inputs (`name:"default"` + a guarded
non-empty endpoint; the timeout is omitted when out of range), so a half-migrate
that strands the keys can't happen either.

New tests prove: (a) legacy keys gone after a successful migration, (b) master
key absent → migration defers AND leaves the legacy keys intact, (c) idempotent
on re-run.

## Verification

- `pnpm run typecheck` — clean across all 5 workspaces.
- `pnpm -r build` — clean, no `error TS` (incl. the Next.js dashboard build).
- `pnpm test` — exit 0; all suites green (core 80 files, mcp-server 19, dashboard 32, cli 5, consolidator-eval 5, root 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)