### PR TITLE
feat(core): intake decision log (spec 043 PR-1, Task C1)

### DIFF
--- a/packages/core/src/consolidator/consolidate.ts
+++ b/packages/core/src/consolidator/consolidate.ts
@@ -18,6 +18,11 @@ import {
   type ConsolidatorApplyStore,
   applyConsolidationPlan,
 } from "./apply.js";
+import {
+  type ConsolidationLogger,
+  type LogErrorSink,
+  recordConsolidationDecision,
+} from "./decision-log.js";
 import { judgeSubmission } from "./judge-step.js";
 import type { ConsolidationThresholds } from "./judge.js";
 import { navigateInbox } from "./navigate.js";
@@ -37,6 +42,15 @@ export interface ConsolidateInboxItemDeps {
   now?: () => number;
   /** Optional sink for a swallowed apply error (forwarded to applyConsolidationPlan). */
   onError?: (error: unknown) => void;
+  /**
+   * Optional intake decision-log writer (spec 043 C1) + the open run id to record
+   * this item's outcome against. Purely observational — every write is fail-soft
+   * (see decision-log.ts), so a throwing logger can never abort consolidation. The
+   * `logError` sink surfaces a swallowed log-write failure for debug only.
+   */
+  consolidationLog?: ConsolidationLogger;
+  consolidationRunId?: string;
+  logError?: LogErrorSink;
 }
 
 export type ConsolidateResult =
@@ -87,6 +101,18 @@ export async function consolidateInboxItem(
     ...(deps.onError ? { onError: deps.onError } : {}),
   };
   const outcome = applyConsolidationPlan(judged.plan, applyDeps);
+  // Observational decision-log row (spec 043 C1) — full-outcome coverage: applied,
+  // proposed, skipped AND failed/rejected items are all recorded. Fail-soft: a
+  // log-write throw is swallowed inside recordConsolidationDecision, so it can
+  // never change filing or abort the sweep. `claimed` is this item's source id.
+  recordConsolidationDecision(
+    deps.consolidationLog,
+    deps.consolidationRunId,
+    judged.plan,
+    outcome,
+    claimed,
+    deps.logError,
+  );
   // Complete on ANY outcome, including `rejected` — see the contract note above:
   // a rejection is terminal (won't be retried), so the item is removed.
   completeInboxItem(deps.vault, claimed);

--- a/packages/core/src/consolidator/decision-log.ts
+++ b/packages/core/src/consolidator/decision-log.ts
@@ -1,0 +1,148 @@
+// Consolidator decision-log writer (spec 043 C1). The fail-soft seam between the
+// intake pipeline (sweep + apply) and the `ConsolidationStore` sidecar.
+//
+// CRUCIAL CONTRACT: intake is the perf-sensitive ingestion path, and this log is
+// purely observational. A log-write failure must NEVER block or fail the sweep.
+// Every write goes through `safe()` here, which swallows ANY throw (surfacing it
+// only via the optional `onError` debug sink) and returns a sentinel. The sweep
+// proceeds and returns its normal summary even if the store throws on every call.
+//
+// The pipeline depends only on this narrow `ConsolidationLogger` surface (a
+// subset of `ConsolidationStore`'s write methods), so a test can inject a
+// throwing logger to pin the fail-soft guarantee without a real store.
+
+import { redactSecrets } from "../curator-redaction.js";
+import type {
+  CompleteConsolidationRunInput,
+  ConsolidationOperation,
+  ConsolidationRun,
+  CreateConsolidationRunInput,
+  FailConsolidationRunInput,
+  RecordConsolidationOperationInput,
+} from "../store/consolidation-store.js";
+import type { ConsolidationOutcome } from "./apply.js";
+import type { ConsolidationPlan } from "./judge.js";
+
+/** The write-only subset of `ConsolidationStore` the intake pipeline records to. */
+export interface ConsolidationLogger {
+  createConsolidationRun: (input: CreateConsolidationRunInput) => ConsolidationRun;
+  recordConsolidationOperation: (
+    input: RecordConsolidationOperationInput,
+  ) => ConsolidationOperation;
+  startConsolidationRun: (id: string) => ConsolidationRun;
+  completeConsolidationRun: (id: string, input?: CompleteConsolidationRunInput) => ConsolidationRun;
+  failConsolidationRun: (id: string, input: FailConsolidationRunInput) => ConsolidationRun;
+}
+
+/** Optional debug sink for a swallowed log-write error (never thrown onward). */
+export type LogErrorSink = (error: unknown) => void;
+
+/**
+ * Run `fn`, swallowing ANY throw so a log-write failure can never escape into the
+ * sweep. Returns `fn`'s result, or `undefined` when it threw. This is the single
+ * choke point that makes the decision log fail-soft — keep all writes behind it.
+ */
+function safe<T>(fn: () => T, onError?: LogErrorSink): T | undefined {
+  try {
+    return fn();
+  } catch (error) {
+    onError?.(error);
+    return undefined;
+  }
+}
+
+/**
+ * Open a consolidation run + mark it running, fail-soft. Returns the run id (for
+ * subsequent per-op + completion writes) or `undefined` if logging is off / the
+ * store threw — callers MUST treat `undefined` as "logging unavailable, skip it".
+ */
+export function openConsolidationRun(
+  logger: ConsolidationLogger | undefined,
+  input: CreateConsolidationRunInput,
+  onError?: LogErrorSink,
+): string | undefined {
+  if (!logger) return undefined;
+  const run = safe(() => logger.createConsolidationRun(input), onError);
+  if (!run) return undefined;
+  safe(() => logger.startConsolidationRun(run.id), onError);
+  return run.id;
+}
+
+/** Complete a consolidation run with its sweep summary, fail-soft (best-effort). */
+export function completeConsolidationRun(
+  logger: ConsolidationLogger | undefined,
+  runId: string | undefined,
+  input: CompleteConsolidationRunInput,
+  onError?: LogErrorSink,
+): void {
+  if (!logger || !runId) return;
+  safe(() => logger.completeConsolidationRun(runId, input), onError);
+}
+
+/** Fail a consolidation run with a value-free label, fail-soft (best-effort). */
+export function failConsolidationRun(
+  logger: ConsolidationLogger | undefined,
+  runId: string | undefined,
+  error: string,
+  onError?: LogErrorSink,
+): void {
+  if (!logger || !runId) return;
+  safe(() => logger.failConsolidationRun(runId, { error }), onError);
+}
+
+/** Map an apply `ConsolidationOutcome` to a decision-log `outcome`. */
+function outcomeOf(outcome: ConsolidationOutcome): RecordConsolidationOperationInput["outcome"] {
+  switch (outcome.kind) {
+    case "created":
+    case "augmented":
+    case "superseded":
+    case "archived":
+    case "created_new":
+      return "applied";
+    case "proposed":
+      return "proposed";
+    case "skipped":
+      return "skipped";
+    case "rejected":
+      return "failed";
+  }
+}
+
+/** The target memory id an outcome touched, when it has one. */
+function targetOf(outcome: ConsolidationOutcome): string | null {
+  return "id" in outcome ? outcome.id : null;
+}
+
+/**
+ * Record ONE per-item decision (the judged action + realised outcome + confidence
+ * + rationale + source/target id), fail-soft. Called for EVERY applied item — not
+ * just auto-applies — so skipped/proposed/failed rows are logged too (full
+ * coverage). The model's rationale is UNTRUSTED, so it is redacted before logging
+ * (same posture as apply.ts persisting it into the vault). The whole write —
+ * redaction included — is inside `safe`, so even a redaction throw can't escape.
+ */
+export function recordConsolidationDecision(
+  logger: ConsolidationLogger | undefined,
+  runId: string | undefined,
+  plan: ConsolidationPlan,
+  outcome: ConsolidationOutcome,
+  sourceId: string | null,
+  onError?: LogErrorSink,
+): void {
+  if (!logger || !runId) return;
+  // Everything that could throw — the outcome/target mapping, redaction, and the
+  // store write — is inside `safe`, so no part of recording an op can escape.
+  safe(
+    () =>
+      logger.recordConsolidationOperation({
+        run_id: runId,
+        action: plan.judgment.action,
+        outcome: outcomeOf(outcome),
+        confidence: plan.judgment.confidence,
+        rationale: redactSecrets(plan.judgment.rationale).redacted,
+        source_id: sourceId,
+        target_id: targetOf(outcome),
+      }),
+    onError,
+  );
+}

--- a/packages/core/src/consolidator/index.ts
+++ b/packages/core/src/consolidator/index.ts
@@ -43,3 +43,4 @@ export {
   consolidateInboxItem,
 } from "./consolidate.js";
 export { type ConsolidatorSweepDeps, type SweepSummary, runConsolidatorSweep } from "./sweep.js";
+export { type ConsolidationLogger, type LogErrorSink } from "./decision-log.js";

--- a/packages/core/src/consolidator/sweep.ts
+++ b/packages/core/src/consolidator/sweep.ts
@@ -10,6 +10,11 @@
 
 import { listInbox, releaseStaleClaims } from "../store/corpus/inbox.js";
 import { type ConsolidateInboxItemDeps, consolidateInboxItem } from "./consolidate.js";
+import {
+  type ConsolidationLogger,
+  completeConsolidationRun,
+  openConsolidationRun,
+} from "./decision-log.js";
 
 // A claim still in `.processing/` past this age is treated as a crashed worker
 // and reclaimed (matches the curator's lock TTL). With a serial single-process
@@ -19,6 +24,16 @@ const DEFAULT_LOCK_TTL_MS = 60 * 60_000; // 60 minutes
 export interface ConsolidatorSweepDeps extends ConsolidateInboxItemDeps {
   /** Claims older than this are reclaimed before the sweep (default 60 min). */
   lockTtlMs?: number;
+  /**
+   * Optional intake decision-log writer (spec 043 C1). When present, the sweep
+   * opens a run, records each item's outcome, and completes the run with the
+   * summary. Purely observational + fully fail-soft — a throwing logger never
+   * blocks or fails the sweep (see decision-log.ts). Omit it (the default) and
+   * filing behaviour is byte-identical to before this log existed.
+   */
+  consolidationLog?: ConsolidationLogger;
+  /** What opened this sweep (boot | tick | watcher | manual); recorded on the run. */
+  consolidationTrigger?: string;
 }
 
 export interface SweepSummary {
@@ -49,10 +64,23 @@ export async function runConsolidatorSweep(deps: ConsolidatorSweepDeps): Promise
     errored: 0,
   };
 
+  // Open a decision-log run (fail-soft: returns undefined if logging is off or the
+  // store threw, in which case every downstream log write is a no-op). `logError`
+  // surfaces swallowed log failures for debug; it never propagates.
+  const runId = openConsolidationRun(
+    deps.consolidationLog,
+    { trigger: deps.consolidationTrigger ?? "manual" },
+    deps.logError,
+  );
+  const itemDeps: ConsolidateInboxItemDeps = {
+    ...deps,
+    ...(runId !== undefined ? { consolidationRunId: runId } : {}),
+  };
+
   // Serial FIFO over the (reclaimed-inclusive) pending snapshot. One item at a time.
   for (const pendingPath of listInbox(deps.vault)) {
     try {
-      const result = await consolidateInboxItem(pendingPath, deps);
+      const result = await consolidateInboxItem(pendingPath, itemDeps);
       if (result.status === "consolidated") summary.consolidated++;
       else if (result.status === "judge_error") summary.judgeErrors++;
       else summary.claimedByOther++;
@@ -63,5 +91,20 @@ export async function runConsolidatorSweep(deps: ConsolidatorSweepDeps): Promise
       summary.errored++;
     }
   }
+
+  // Complete the run with the sweep summary (fail-soft, best-effort). A no-op when
+  // logging is off / the open failed.
+  completeConsolidationRun(
+    deps.consolidationLog,
+    runId,
+    {
+      summary: `consolidated ${summary.consolidated}, judgeErrors ${summary.judgeErrors}, claimedByOther ${summary.claimedByOther}, errored ${summary.errored}, reclaimed ${summary.reclaimed}`,
+      consolidated: summary.consolidated,
+      judge_errors: summary.judgeErrors,
+      errored: summary.errored,
+      reclaimed: summary.reclaimed,
+    },
+    deps.logError,
+  );
   return summary;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -117,6 +117,7 @@ export {
   type ConsolidationCandidates,
   type ConsolidationDecision,
   type ConsolidationJudgment,
+  type ConsolidationLogger,
   type ConsolidationOutcome,
   type ConsolidationPlan,
   type ConsolidationThresholds,
@@ -127,6 +128,7 @@ export {
   type JudgeSubmissionDeps,
   type JudgeSubmissionInput,
   type JudgeSubmissionResult,
+  type LogErrorSink,
   type NavigateDeps,
   type NavigateOptions,
   type ParsedConsolidationJudgment,
@@ -297,8 +299,10 @@ export {
   serializeMemoryDocument,
 } from "./store/markdown/index.js";
 export {
+  type JsonConsolidationStoreDeps,
   type JsonConversationStateStoreDeps,
   type JsonSettingsStoreDeps,
+  createJsonConsolidationStore,
   createJsonConversationStateStore,
   createJsonCurationStore,
   createJsonSettingsStore,
@@ -434,6 +438,16 @@ export {
   type ListCurationRunsInput,
   type RecordCurationOperationInput,
 } from "./store/curation-store.js";
+export {
+  type CompleteConsolidationRunInput,
+  type ConsolidationOperation,
+  type ConsolidationRun,
+  type ConsolidationStore,
+  type CreateConsolidationRunInput,
+  type FailConsolidationRunInput,
+  type ListConsolidationRunsInput,
+  type RecordConsolidationOperationInput,
+} from "./store/consolidation-store.js";
 export type { SettingMeta, SettingsStore } from "./store/settings-store.js";
 export type { ConversationStateStore } from "./store/conversation-state-store.js";
 export type { ConversationState, ConversationStatePatch } from "./schemas/conversation-state.js";

--- a/packages/core/src/store/consolidation-store.ts
+++ b/packages/core/src/store/consolidation-store.ts
@@ -1,0 +1,14 @@
+// Consolidation (intake) decision-log store — the run/operation types + the
+// `ConsolidationStore` contract live in `consolidation-types.ts`; re-exported from
+// this path so importers mirror the curation-store layering. The markdown backend
+// uses the sidecar `createJsonConsolidationStore`.
+export type {
+  CompleteConsolidationRunInput,
+  ConsolidationOperation,
+  ConsolidationRun,
+  ConsolidationStore,
+  CreateConsolidationRunInput,
+  FailConsolidationRunInput,
+  ListConsolidationRunsInput,
+  RecordConsolidationOperationInput,
+} from "./consolidation-types.js";

--- a/packages/core/src/store/consolidation-types.ts
+++ b/packages/core/src/store/consolidation-types.ts
@@ -1,0 +1,98 @@
+// Consolidation (intake) decision-log store — shared type contract (spec 043 C1).
+//
+// The intake pipeline's full-outcome decision log, mirroring grooming's
+// `CurationStore` run/operation shape (`curation-types.ts`) but for the
+// consolidator sweep. It is a purely observational sidecar: it records what the
+// intake judge decided + how each plan was applied (applied | proposed | skipped
+// | failed) and NEVER influences filing. The concrete JSON-sidecar implementation
+// lives in `sidecar/consolidation-store.ts`; the contract is re-exported from
+// `consolidation-store.ts` to match the curation-store layering.
+//
+// Unlike grooming, intake has no slice/evidence/scheduler seam (one submission at
+// a time, not a batched curation pass), so this store is deliberately the minimal
+// run + operation subset of `CurationStore` — no `gatherMemoryEvidence` /
+// `selectDueSlices` / `findRunningRun`.
+
+export interface CreateConsolidationRunInput {
+  trigger: string; // boot | tick | watcher | manual
+  status?: string; // defaults to "pending"
+}
+
+export interface ConsolidationRun {
+  id: string;
+  status: string;
+  trigger: string;
+  /** Items applied + completed (mirrors SweepSummary.consolidated). */
+  consolidated: number;
+  /** Items left claimed because the model output was unusable. */
+  judge_errors: number;
+  /** Items whose processing threw (LLM/transport). */
+  errored: number;
+  /** Stale claims returned to the pending queue before processing. */
+  reclaimed: number;
+  summary: string | null;
+  error: string | null;
+  created_at: string;
+  started_at: string | null;
+  completed_at: string | null;
+}
+
+export interface RecordConsolidationOperationInput {
+  run_id: string;
+  /** The judged action: noop | create | augment | supersede | archive | create_new. */
+  action: string;
+  /** The realised outcome of the plan. */
+  outcome: "applied" | "proposed" | "skipped" | "failed";
+  confidence: number;
+  /** A value-free rationale label (already redacted upstream — no secrets). */
+  rationale: string;
+  /** The submission/source identifier this op came from (e.g. the inbox item id). */
+  source_id?: string | null;
+  /** The target memory id when the action touched an existing doc. */
+  target_id?: string | null;
+}
+
+export interface ConsolidationOperation {
+  id: string;
+  run_id: string;
+  action: string;
+  outcome: string;
+  confidence: number;
+  rationale: string;
+  source_id: string | null;
+  target_id: string | null;
+}
+
+export interface ListConsolidationRunsInput {
+  status?: string;
+  trigger?: string;
+  /** Page size, defaulted to 50 and clamped to a 200 ceiling. */
+  limit?: number;
+}
+
+export interface CompleteConsolidationRunInput {
+  summary?: string | null;
+  consolidated?: number;
+  judge_errors?: number;
+  errored?: number;
+  reclaimed?: number;
+}
+
+export interface FailConsolidationRunInput {
+  /** A value-free error label (no secrets / untrusted content). */
+  error: string;
+}
+
+export interface ConsolidationStore {
+  createConsolidationRun: (input: CreateConsolidationRunInput) => ConsolidationRun;
+  getConsolidationRun: (id: string) => ConsolidationRun | null;
+  listConsolidationRuns: (input?: ListConsolidationRunsInput) => ConsolidationRun[];
+  recordConsolidationOperation: (
+    input: RecordConsolidationOperationInput,
+  ) => ConsolidationOperation;
+  getConsolidationOperations: (runId: string) => ConsolidationOperation[];
+  // Lifecycle transitions — mirror the curation store's run guards exactly.
+  startConsolidationRun: (id: string) => ConsolidationRun;
+  completeConsolidationRun: (id: string, input?: CompleteConsolidationRunInput) => ConsolidationRun;
+  failConsolidationRun: (id: string, input: FailConsolidationRunInput) => ConsolidationRun;
+}

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -1,4 +1,5 @@
 export * from "./memory-store.js";
 export * from "./curation-store.js";
+export * from "./consolidation-store.js";
 export * from "./settings-store.js";
 export * from "./handoff-store.js";

--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -8,6 +8,7 @@ import {
 import type { LlmClient } from "../curator-llm-client.js";
 import { createVaultCuratorMemorySource } from "../curator-source-vault.js";
 import { MemoryStatus } from "../schemas/common.js";
+import type { ConsolidationStore } from "./consolidation-store.js";
 import type { ConversationStateStore } from "./conversation-state-store.js";
 import {
   type InboxItemRef,
@@ -33,6 +34,7 @@ import { createMarkdownHandoffStore, createMarkdownMemoryStore } from "./markdow
 import type { Memory, MemoryStore } from "./memory-store.js";
 import type { SettingsStore } from "./settings-store.js";
 import {
+  createJsonConsolidationStore,
   createJsonConversationStateStore,
   createJsonCurationStore,
   createJsonSettingsStore,
@@ -61,7 +63,8 @@ export interface LibrarianStoreOptions {
   secretKey?: Buffer | null;
 }
 
-export interface LibrarianStore extends MemoryStore, CurationStore, SettingsStore {
+export interface LibrarianStore
+  extends MemoryStore, CurationStore, ConsolidationStore, SettingsStore {
   /** The storage backend (always "markdown" now SQLite is removed). */
   backend: "markdown";
   convState: ConversationStateStore;
@@ -109,6 +112,8 @@ export interface ConsolidateInboxOptions {
   lockTtlMs?: number;
   /** Per-item error sink — called for each item whose processing threw (LLM/transport). */
   onError?: (error: unknown) => void;
+  /** What opened this sweep (boot | tick | watcher | manual); recorded on the decision-log run. */
+  trigger?: string;
 }
 
 /** Actor id that owns consolidator writes (common-slice, system-owned). */
@@ -191,6 +196,12 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Libra
     filePath: path.join(dataDir, "curation-runs.json"),
     memorySource: createVaultCuratorMemorySource(markdownMemory),
   });
+  // Intake decision log (spec 043 C1) — the consolidator's full-outcome sidecar,
+  // paralleling curation-runs.json. Purely observational + fail-soft, so it never
+  // affects filing; the sweep wires it below.
+  const markdownConsolidation = createJsonConsolidationStore({
+    filePath: path.join(dataDir, "consolidation-runs.json"),
+  });
   // Index-backed recall, extracted so the consolidator's navigate step can
   // reuse the exact same recall the `recall` verb uses.
   const storeRecall = async (input: Record<string, unknown> = {}): Promise<Memory[]> => {
@@ -210,6 +221,7 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Libra
   return {
     ...markdownMemory,
     ...markdownCuration,
+    ...markdownConsolidation,
     ...jsonSettings,
     backend: "markdown",
     convState: jsonConvState,
@@ -236,6 +248,9 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Libra
         store: markdownMemory,
         actorId: CONSOLIDATOR_ACTOR_ID,
         llmClient: deps.llmClient,
+        // Observational decision log — fail-soft inside the sweep, never affects filing.
+        consolidationLog: markdownConsolidation,
+        consolidationTrigger: deps.trigger ?? "manual",
         ...(deps.thresholds ? { thresholds: deps.thresholds } : {}),
         ...(deps.lockTtlMs !== undefined ? { lockTtlMs: deps.lockTtlMs } : {}),
         ...(deps.onError ? { onError: deps.onError } : {}),

--- a/packages/core/src/store/sidecar/consolidation-store.ts
+++ b/packages/core/src/store/sidecar/consolidation-store.ts
@@ -1,0 +1,197 @@
+// JSON sidecar consolidation (intake) store (spec 043 C1). The intake pipeline's
+// full-outcome decision log, paralleling grooming's `createJsonCurationStore` /
+// `curation-runs.json`. Records, on a sidecar JSON file OUTSIDE the git vault, one
+// run per sweep + one operation row per filed item (action + outcome + confidence
+// + rationale + source/target id). Purely observational — the consolidator reads
+// nothing back from here, so a write failure never changes filing (the callers
+// wrap every write fail-soft; see sweep.ts / apply.ts).
+//
+// Same idioms as the curation sidecar: whole-file read/write per op (sweeps are
+// serial + low-cadence), corrupt-file degrades to empty, and the run lifecycle
+// guards mirror it exactly — start COALESCEs started_at; complete/fail only
+// transition a NON-terminal run so a late call can't resurrect a terminal run.
+
+import fs from "node:fs";
+import path from "node:path";
+import { makeId, nowIso } from "../../constants.js";
+import type {
+  CompleteConsolidationRunInput,
+  ConsolidationOperation,
+  ConsolidationRun,
+  ConsolidationStore,
+  CreateConsolidationRunInput,
+  FailConsolidationRunInput,
+  ListConsolidationRunsInput,
+  RecordConsolidationOperationInput,
+} from "../consolidation-store.js";
+
+interface ConsolidationData {
+  runs: Record<string, ConsolidationRun>;
+  operations: Record<string, ConsolidationOperation>;
+}
+
+export interface JsonConsolidationStoreDeps {
+  /** Sidecar file path, outside the git vault (e.g. `<data-dir>/consolidation-runs.json`). */
+  filePath: string;
+  now?: () => string;
+  generateId?: () => string;
+}
+
+const TERMINAL = new Set(["completed", "failed"]);
+
+// Newest-first by created_at, id as a deterministic tiebreak (mirrors the curation
+// store's `ORDER BY created_at DESC, id DESC`).
+function byCreatedDesc(a: ConsolidationRun, b: ConsolidationRun): number {
+  return b.created_at.localeCompare(a.created_at) || b.id.localeCompare(a.id);
+}
+
+export function createJsonConsolidationStore(deps: JsonConsolidationStoreDeps): ConsolidationStore {
+  const { filePath } = deps;
+  const now = deps.now ?? nowIso;
+  const newRunId = deps.generateId ?? (() => makeId("crun"));
+
+  function readAll(): ConsolidationData {
+    if (!fs.existsSync(filePath)) return { runs: {}, operations: {} };
+    try {
+      const parsed = JSON.parse(fs.readFileSync(filePath, "utf8")) as Partial<ConsolidationData>;
+      return {
+        runs: parsed.runs && typeof parsed.runs === "object" ? parsed.runs : {},
+        operations:
+          parsed.operations && typeof parsed.operations === "object" ? parsed.operations : {},
+      };
+    } catch {
+      // Corrupt file → start fresh. The decision log is advisory observability,
+      // not durable knowledge (filing has its own idempotency), so degrading-to-
+      // empty mirrors the curation sidecar.
+      return { runs: {}, operations: {} };
+    }
+  }
+
+  function writeAll(data: ConsolidationData): void {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+  }
+
+  function createConsolidationRun(input: CreateConsolidationRunInput): ConsolidationRun {
+    const id = newRunId();
+    const run: ConsolidationRun = {
+      id,
+      status: input.status ?? "pending",
+      trigger: input.trigger,
+      consolidated: 0,
+      judge_errors: 0,
+      errored: 0,
+      reclaimed: 0,
+      summary: null,
+      error: null,
+      created_at: now(),
+      started_at: null,
+      completed_at: null,
+    };
+    const data = readAll();
+    data.runs[id] = run;
+    writeAll(data);
+    return run;
+  }
+
+  function getConsolidationRun(id: string): ConsolidationRun | null {
+    return readAll().runs[id] ?? null;
+  }
+
+  function listConsolidationRuns(input: ListConsolidationRunsInput = {}): ConsolidationRun[] {
+    const limit = Math.min(Math.max(input.limit ?? 50, 1), 200);
+    return Object.values(readAll().runs)
+      .filter((r) => (input.status ? r.status === input.status : true))
+      .filter((r) => (input.trigger ? r.trigger === input.trigger : true))
+      .sort(byCreatedDesc)
+      .slice(0, limit);
+  }
+
+  function recordConsolidationOperation(
+    input: RecordConsolidationOperationInput,
+  ): ConsolidationOperation {
+    const id = makeId("cop");
+    const operation: ConsolidationOperation = {
+      id,
+      run_id: input.run_id,
+      action: input.action,
+      outcome: input.outcome,
+      confidence: input.confidence,
+      rationale: input.rationale,
+      source_id: input.source_id ?? null,
+      target_id: input.target_id ?? null,
+    };
+    const data = readAll();
+    data.operations[id] = operation;
+    writeAll(data);
+    return operation;
+  }
+
+  function getConsolidationOperations(runId: string): ConsolidationOperation[] {
+    return Object.values(readAll().operations)
+      .filter((op) => op.run_id === runId)
+      .sort((a, b) => a.id.localeCompare(b.id));
+  }
+
+  function requireRun(id: string): ConsolidationRun {
+    const run = getConsolidationRun(id);
+    if (!run) throw new Error(`No consolidation run found for id ${id}`);
+    return run;
+  }
+
+  function startConsolidationRun(id: string): ConsolidationRun {
+    const data = readAll();
+    const run = data.runs[id];
+    if (!run) throw new Error(`No consolidation run found for id ${id}`);
+    run.status = "running";
+    run.started_at = run.started_at ?? now(); // COALESCE — keep the original on restart
+    writeAll(data);
+    return run;
+  }
+
+  function completeConsolidationRun(
+    id: string,
+    input: CompleteConsolidationRunInput = {},
+  ): ConsolidationRun {
+    const data = readAll();
+    const run = data.runs[id];
+    if (!run) throw new Error(`No consolidation run found for id ${id}`);
+    // Only a non-terminal run transitions — a failed run can't be resurrected by a
+    // late completion (mirrors the curation store §10.1 guard).
+    if (!TERMINAL.has(run.status)) {
+      run.status = "completed";
+      run.completed_at = now();
+      run.summary = input.summary ?? null;
+      run.consolidated = input.consolidated ?? 0;
+      run.judge_errors = input.judge_errors ?? 0;
+      run.errored = input.errored ?? 0;
+      run.reclaimed = input.reclaimed ?? 0;
+      writeAll(data);
+    }
+    return requireRun(id);
+  }
+
+  function failConsolidationRun(id: string, input: FailConsolidationRunInput): ConsolidationRun {
+    const data = readAll();
+    const run = data.runs[id];
+    if (!run) throw new Error(`No consolidation run found for id ${id}`);
+    if (!TERMINAL.has(run.status)) {
+      run.status = "failed";
+      run.completed_at = now();
+      run.error = input.error;
+      writeAll(data);
+    }
+    return requireRun(id);
+  }
+
+  return {
+    createConsolidationRun,
+    getConsolidationRun,
+    listConsolidationRuns,
+    recordConsolidationOperation,
+    getConsolidationOperations,
+    startConsolidationRun,
+    completeConsolidationRun,
+    failConsolidationRun,
+  };
+}

--- a/packages/core/src/store/sidecar/index.ts
+++ b/packages/core/src/store/sidecar/index.ts
@@ -9,3 +9,7 @@ export {
 } from "./conversation-state-store.js";
 export { type JsonSettingsStoreDeps, createJsonSettingsStore } from "./settings-store.js";
 export { type JsonCurationStoreDeps, createJsonCurationStore } from "./curation-store.js";
+export {
+  type JsonConsolidationStoreDeps,
+  createJsonConsolidationStore,
+} from "./consolidation-store.js";

--- a/packages/core/tests/consolidator-decision-log.test.ts
+++ b/packages/core/tests/consolidator-decision-log.test.ts
@@ -1,0 +1,301 @@
+// Intake decision log (spec 043 C1). The consolidator sweep records a
+// full-outcome decision log (run + per-op rows) into the consolidation sidecar,
+// WITHOUT changing filing. These are the spec's acceptance criteria:
+//   1. a sweep that files N items leaves N logged operations queryable;
+//   2. a forced log-write failure does NOT fail the sweep;
+//   3. filing behaviour is byte-identical with and without logging.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type ConsolidationLogger,
+  type ConsolidationStore,
+  type ConsolidatorApplyStore,
+  type LlmClient,
+  type LlmCompletionRequest,
+  type Vault,
+  createJsonConsolidationStore,
+  createVault,
+  runConsolidatorSweep,
+  writeInbox,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let vault: Vault;
+let dataDir = "";
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-decision-log-"));
+  vault = createVault({ dataDir });
+});
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+const CREATE_JUDGMENT = JSON.stringify({
+  action: "create",
+  title: "T",
+  body: "B",
+  tags: [],
+  rationale: "novel topic",
+  confidence: 0.97,
+});
+
+// A judge that auto-applies an augment (confidence ≥ 0.95) against target m1.
+const AUGMENT_JUDGMENT = JSON.stringify({
+  action: "augment",
+  target_id: "m1",
+  addition: "more",
+  rationale: "weaves in",
+  confidence: 0.97,
+});
+
+// A mid-band augment (0.85–0.95) → routed to a PROPOSE (filed as a fresh proposed doc).
+const PROPOSE_JUDGMENT = JSON.stringify({
+  action: "augment",
+  target_id: "m1",
+  addition: "maybe",
+  rationale: "uncertain merge",
+  confidence: 0.9,
+});
+
+const NOOP_JUDGMENT = JSON.stringify({
+  action: "noop",
+  rationale: "duplicate",
+  confidence: 0.5,
+});
+
+function fakeStore(): ConsolidatorApplyStore {
+  let n = 0;
+  return {
+    createMemory: () => ({ memory: { id: `mem_${n++}` } }),
+    updateMemory: () => null,
+    archiveMemory: () => null,
+    // Return a stored memory so augment/supersede/archive targets exist.
+    getMemory: () => ({ title: "Existing", body: "Existing body." }),
+  };
+}
+
+function constantClient(content: string): LlmClient {
+  return { complete: async () => ({ content, model: "x", usage: null }) };
+}
+
+function deps(client: LlmClient, extra: Record<string, unknown> = {}) {
+  return {
+    vault,
+    recall: async () => [],
+    listActive: () => [],
+    llmClient: client,
+    store: fakeStore(),
+    actorId: "system-consolidator",
+    ...extra,
+  };
+}
+
+function write(text: string, ms: number, id: string) {
+  return writeInbox(vault, text, { now: () => ms, generateId: () => id });
+}
+
+function logStore(): ConsolidationStore {
+  return createJsonConsolidationStore({
+    filePath: path.join(dataDir, "consolidation-runs.json"),
+  });
+}
+
+describe("intake decision log — full-outcome coverage", () => {
+  it("a sweep that files N items leaves N logged operations queryable", async () => {
+    write("first", 1000, "a");
+    write("second", 1001, "b");
+    write("third", 1002, "c");
+    const store = logStore();
+
+    const summary = await runConsolidatorSweep(
+      deps(constantClient(CREATE_JUDGMENT), {
+        consolidationLog: store,
+        consolidationTrigger: "tick",
+      }),
+    );
+
+    expect(summary.consolidated).toBe(3);
+    const runs = store.listConsolidationRuns();
+    expect(runs).toHaveLength(1);
+    expect(runs[0]).toMatchObject({ trigger: "tick", status: "completed", consolidated: 3 });
+    const ops = store.getConsolidationOperations(runs[0]!.id);
+    expect(ops).toHaveLength(3); // N items → N logged operations
+    expect(ops.every((o) => o.outcome === "applied" && o.action === "create")).toBe(true);
+    expect(ops.every((o) => o.confidence === 0.97)).toBe(true);
+    expect(ops.every((o) => o.source_id?.startsWith("inbox/.processing/"))).toBe(true);
+  });
+
+  it("records every outcome — applied, proposed AND skipped — not just auto-applies", async () => {
+    write("create-me", 1000, "a");
+    write("propose-me", 1001, "b");
+    write("skip-me", 1002, "c");
+    const store = logStore();
+    // Route by submission text: create (applied), mid-band augment (proposed), noop (skipped).
+    const client: LlmClient = {
+      complete: async (req: LlmCompletionRequest) => {
+        const sub = req.messages[1]?.content ?? "";
+        if (sub.includes("propose-me"))
+          return { content: PROPOSE_JUDGMENT, model: "x", usage: null };
+        if (sub.includes("skip-me")) return { content: NOOP_JUDGMENT, model: "x", usage: null };
+        return { content: CREATE_JUDGMENT, model: "x", usage: null };
+      },
+    };
+
+    await runConsolidatorSweep(
+      deps(client, { consolidationLog: store, consolidationTrigger: "tick" }),
+    );
+
+    const ops = store.getConsolidationOperations(store.listConsolidationRuns()[0]!.id);
+    expect(ops.map((o) => o.outcome).sort()).toEqual(["applied", "proposed", "skipped"]);
+  });
+
+  it("logs the target_id for an applied augment", async () => {
+    write("augment-me", 1000, "a");
+    const store = logStore();
+    await runConsolidatorSweep(deps(constantClient(AUGMENT_JUDGMENT), { consolidationLog: store }));
+    const ops = store.getConsolidationOperations(store.listConsolidationRuns()[0]!.id);
+    expect(ops).toHaveLength(1);
+    expect(ops[0]).toMatchObject({ action: "augment", outcome: "applied", target_id: "m1" });
+  });
+
+  it("redacts a secret-shaped rationale before logging it", async () => {
+    write("create-me", 1000, "a");
+    const store = logStore();
+    // A model rationale carrying a `key = secret` assignment must be redacted in
+    // the log (the same known-format redactor apply.ts uses to scrub the vault).
+    // The literal is assembled at runtime so no secret-shaped string sits in source.
+    const secret = "s3cr3t-value-here";
+    const leaky = JSON.stringify({
+      action: "create",
+      title: "T",
+      body: "B",
+      tags: [],
+      rationale: `set ${"api_key"} = "${secret}" then file`,
+      confidence: 0.97,
+    });
+    await runConsolidatorSweep(deps(constantClient(leaky), { consolidationLog: store }));
+    const ops = store.getConsolidationOperations(store.listConsolidationRuns()[0]!.id);
+    expect(ops[0]?.rationale).not.toContain(secret);
+    expect(ops[0]?.rationale).toContain("[REDACTED:secret]");
+  });
+});
+
+describe("intake decision log — fail-soft (load-bearing)", () => {
+  // A logger whose every method throws — modelling a corrupt/locked sidecar.
+  function throwingLogger(): ConsolidationLogger {
+    const boom = (): never => {
+      throw new Error("log write failed");
+    };
+    return {
+      createConsolidationRun: boom,
+      recordConsolidationOperation: boom,
+      startConsolidationRun: boom,
+      completeConsolidationRun: boom,
+      failConsolidationRun: boom,
+    };
+  }
+
+  it("a forced log-write failure does NOT fail the sweep (sweep still completes + returns its summary)", async () => {
+    write("first", 1000, "a");
+    write("second", 1001, "b");
+    const logErrors: unknown[] = [];
+
+    const summary = await runConsolidatorSweep(
+      deps(constantClient(CREATE_JUDGMENT), {
+        consolidationLog: throwingLogger(),
+        consolidationTrigger: "tick",
+        logError: (e: unknown) => logErrors.push(e),
+      }),
+    );
+
+    // The sweep completed normally — both items filed — despite the logger throwing.
+    expect(summary.consolidated).toBe(2);
+    expect(summary.errored).toBe(0);
+    // The swallowed log failures were surfaced to the debug sink, never thrown.
+    expect(logErrors.length).toBeGreaterThan(0);
+  });
+
+  it("an operation-record throw on one item still files the rest of the batch", async () => {
+    write("first", 1000, "a");
+    write("second", 1001, "b");
+    write("third", 1002, "c");
+    // Only the per-op record throws; run open/complete succeed.
+    let calls = 0;
+    const logger: ConsolidationLogger = {
+      ...logStore(),
+      recordConsolidationOperation: () => {
+        calls++;
+        throw new Error("op write failed");
+      },
+    };
+
+    const summary = await runConsolidatorSweep(
+      deps(constantClient(CREATE_JUDGMENT), { consolidationLog: logger }),
+    );
+
+    expect(summary.consolidated).toBe(3); // all three filed despite every op-write throwing
+    expect(calls).toBe(3); // it was attempted for each
+  });
+});
+
+describe("intake decision log — byte-identical filing", () => {
+  it("produces the same sweep summary with and without a logger", async () => {
+    // Run A: no logger.
+    const a = await runConsolidatorSweep(deps(constantClient(CREATE_JUDGMENT)));
+    fs.rmSync(dataDir, { recursive: true, force: true });
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-decision-log-b-"));
+    vault = createVault({ dataDir });
+
+    // Run B: with a logger, identical inputs.
+    const store = logStore();
+    const b = await runConsolidatorSweep(
+      deps(constantClient(CREATE_JUDGMENT), { consolidationLog: store }),
+    );
+
+    // Both empty inboxes → identical no-op summary; the logger added a run but
+    // changed nothing about the (no-op) filing outcome.
+    expect(b).toEqual(a);
+  });
+
+  it("the filed memory is unchanged whether or not logging is on", async () => {
+    // With logging: capture what createMemory received.
+    const withLog: Record<string, unknown>[] = [];
+    const withLogStore: ConsolidatorApplyStore = {
+      createMemory: (input) => {
+        withLog.push(input);
+        return { memory: { id: "m" } };
+      },
+      updateMemory: () => null,
+      archiveMemory: () => null,
+      getMemory: () => null,
+    };
+    write("note one", 1000, "a");
+    await runConsolidatorSweep({
+      ...deps(constantClient(CREATE_JUDGMENT)),
+      store: withLogStore,
+      consolidationLog: logStore(),
+    });
+
+    // Reset vault + inbox, run the SAME submission with NO logger.
+    fs.rmSync(dataDir, { recursive: true, force: true });
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-decision-log-c-"));
+    vault = createVault({ dataDir });
+    const without: Record<string, unknown>[] = [];
+    const withoutStore: ConsolidatorApplyStore = {
+      createMemory: (input) => {
+        without.push(input);
+        return { memory: { id: "m" } };
+      },
+      updateMemory: () => null,
+      archiveMemory: () => null,
+      getMemory: () => null,
+    };
+    write("note one", 1000, "a");
+    await runConsolidatorSweep({ ...deps(constantClient(CREATE_JUDGMENT)), store: withoutStore });
+
+    expect(withLog).toEqual(without); // identical store mutation input
+  });
+});

--- a/packages/core/tests/store/consolidator-store-integration.test.ts
+++ b/packages/core/tests/store/consolidator-store-integration.test.ts
@@ -128,4 +128,38 @@ describe("LibrarianStore consolidator wiring (markdown)", () => {
     const anna = store.listMemories({ status: "active" }).memories.find((m) => m.title === "Anna");
     expect(anna).toMatchObject({ agent_id: "agent-a", project_key: "proj-x" });
   });
+
+  it("records an intake decision-log run + per-item op through the real store (spec 043 C1)", async () => {
+    store = createLibrarianStore({ dataDir, backend: "markdown" });
+    store.submitToInbox("Anna lives in Berlin.");
+    await store.consolidateInbox({
+      trigger: "tick",
+      llmClient: fakeClient(
+        JSON.stringify({
+          action: "create",
+          title: "Anna",
+          body: "Anna lives in Berlin.",
+          tags: ["person"],
+          rationale: "novel topic",
+          confidence: 0.97,
+        }),
+      ),
+    });
+
+    // The decision log is queryable from the same store — one run, one op, with
+    // the full outcome captured (filing itself is unchanged; this is observational).
+    const runs = store.listConsolidationRuns();
+    expect(runs).toHaveLength(1);
+    expect(runs[0]).toMatchObject({ trigger: "tick", status: "completed", consolidated: 1 });
+    const ops = store.getConsolidationOperations(runs[0]!.id);
+    expect(ops).toHaveLength(1);
+    expect(ops[0]).toMatchObject({
+      action: "create",
+      outcome: "applied",
+      confidence: 0.97,
+      rationale: "novel topic",
+    });
+    // And the sidecar landed OUTSIDE the git vault, like curation-runs.json.
+    expect(fs.existsSync(path.join(dataDir, "consolidation-runs.json"))).toBe(true);
+  });
 });

--- a/packages/core/tests/store/sidecar-consolidation-store.test.ts
+++ b/packages/core/tests/store/sidecar-consolidation-store.test.ts
@@ -1,0 +1,176 @@
+// JSON sidecar consolidation (intake) store (spec 043 C1). Mirrors the curation
+// sidecar test: run + operation round-trips, the run lifecycle guards (start
+// COALESCEs started_at; complete/fail only transition a non-terminal run),
+// corrupt-file degrade-to-empty, list filtering/ordering, and cross-instance
+// durability.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type CreateConsolidationRunInput,
+  type RecordConsolidationOperationInput,
+  createJsonConsolidationStore,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let dir = "";
+let tick = 0;
+const clock = () => `2026-06-01T00:00:${String(tick++).padStart(2, "0")}.000Z`;
+
+function makeStore() {
+  return createJsonConsolidationStore({
+    filePath: path.join(dir, "consolidation-runs.json"),
+    now: clock,
+  });
+}
+
+const run = (over: Partial<CreateConsolidationRunInput> = {}): CreateConsolidationRunInput => ({
+  trigger: "tick",
+  ...over,
+});
+
+const op = (
+  over: Partial<RecordConsolidationOperationInput> = {},
+): RecordConsolidationOperationInput => ({
+  run_id: "r1",
+  action: "create",
+  outcome: "applied",
+  confidence: 0.97,
+  rationale: "novel topic",
+  ...over,
+});
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-sidecar-consolidation-"));
+  tick = 0;
+});
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe("createJsonConsolidationStore — runs + operations", () => {
+  it("creates and reads back a run with defaulted counters", () => {
+    const store = makeStore();
+    const created = store.createConsolidationRun(run({ trigger: "boot" }));
+    expect(created).toMatchObject({
+      trigger: "boot",
+      status: "pending",
+      consolidated: 0,
+      judge_errors: 0,
+      errored: 0,
+      reclaimed: 0,
+      summary: null,
+      error: null,
+      started_at: null,
+      completed_at: null,
+    });
+    expect(store.getConsolidationRun(created.id)).toEqual(created);
+  });
+
+  it("records full-outcome operations (applied | proposed | skipped | failed)", () => {
+    const store = makeStore();
+    const r = store.createConsolidationRun(run());
+    store.recordConsolidationOperation(op({ run_id: r.id, outcome: "applied", action: "create" }));
+    store.recordConsolidationOperation(
+      op({ run_id: r.id, outcome: "proposed", action: "augment", target_id: "m1" }),
+    );
+    store.recordConsolidationOperation(op({ run_id: r.id, outcome: "skipped", action: "noop" }));
+    store.recordConsolidationOperation(
+      op({ run_id: r.id, outcome: "failed", action: "supersede", target_id: "m2" }),
+    );
+
+    const ops = store.getConsolidationOperations(r.id);
+    expect(ops).toHaveLength(4);
+    expect(ops.map((o) => o.outcome).sort()).toEqual(["applied", "failed", "proposed", "skipped"]);
+    const augment = ops.find((o) => o.action === "augment");
+    expect(augment).toMatchObject({ outcome: "proposed", target_id: "m1", source_id: null });
+  });
+
+  it("carries source_id + target_id through, defaulting absent ids to null", () => {
+    const store = makeStore();
+    const r = store.createConsolidationRun(run());
+    store.recordConsolidationOperation(
+      op({ run_id: r.id, source_id: "inbox/x.md", target_id: "mem_1" }),
+    );
+    const [stored] = store.getConsolidationOperations(r.id);
+    expect(stored).toMatchObject({ source_id: "inbox/x.md", target_id: "mem_1" });
+  });
+
+  it("start COALESCEs started_at across restarts", () => {
+    const store = makeStore();
+    const r = store.createConsolidationRun(run());
+    const first = store.startConsolidationRun(r.id);
+    expect(first.status).toBe("running");
+    expect(first.started_at).not.toBeNull();
+    const again = store.startConsolidationRun(r.id);
+    expect(again.started_at).toBe(first.started_at); // original kept
+  });
+
+  it("complete records the summary + counters and transitions to completed", () => {
+    const store = makeStore();
+    const r = store.createConsolidationRun(run());
+    store.startConsolidationRun(r.id);
+    const done = store.completeConsolidationRun(r.id, {
+      summary: "consolidated 2",
+      consolidated: 2,
+      judge_errors: 1,
+      errored: 0,
+      reclaimed: 3,
+    });
+    expect(done).toMatchObject({
+      status: "completed",
+      summary: "consolidated 2",
+      consolidated: 2,
+      judge_errors: 1,
+      reclaimed: 3,
+    });
+    expect(done.completed_at).not.toBeNull();
+  });
+
+  it("complete/fail only transition a NON-terminal run (no resurrection)", () => {
+    const store = makeStore();
+    const r = store.createConsolidationRun(run());
+    store.failConsolidationRun(r.id, { error: "boom" });
+    // A late completion can't resurrect a failed run.
+    const after = store.completeConsolidationRun(r.id, { summary: "late" });
+    expect(after.status).toBe("failed");
+    expect(after.summary).toBeNull();
+    expect(after.error).toBe("boom");
+  });
+
+  it("lists runs newest-first and filters by status/trigger", () => {
+    const store = makeStore();
+    const a = store.createConsolidationRun(run({ trigger: "boot" }));
+    const b = store.createConsolidationRun(run({ trigger: "tick" }));
+    store.completeConsolidationRun(b.id, { summary: "done" });
+
+    const all = store.listConsolidationRuns();
+    expect(all[0]?.id).toBe(b.id); // newest first (created later)
+    expect(all.map((r) => r.id)).toContain(a.id);
+
+    expect(store.listConsolidationRuns({ trigger: "boot" }).map((r) => r.id)).toEqual([a.id]);
+    expect(store.listConsolidationRuns({ status: "completed" }).map((r) => r.id)).toEqual([b.id]);
+  });
+
+  it("degrades a corrupt sidecar file to empty rather than throwing", () => {
+    const filePath = path.join(dir, "consolidation-runs.json");
+    fs.writeFileSync(filePath, "{ not json", "utf8");
+    const store = createJsonConsolidationStore({ filePath, now: clock });
+    expect(store.listConsolidationRuns()).toEqual([]);
+    // and a fresh write still works
+    const r = store.createConsolidationRun(run());
+    expect(store.getConsolidationRun(r.id)).not.toBeNull();
+  });
+
+  it("persists across store instances (sidecar durability)", () => {
+    const filePath = path.join(dir, "consolidation-runs.json");
+    const a = createJsonConsolidationStore({ filePath, now: clock });
+    const r = a.createConsolidationRun(run());
+    a.recordConsolidationOperation(op({ run_id: r.id }));
+
+    const b = createJsonConsolidationStore({ filePath, now: clock });
+    expect(b.getConsolidationRun(r.id)?.id).toBe(r.id);
+    expect(b.getConsolidationOperations(r.id)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## What

Gives the **intake (consolidator)** pipeline a full-outcome **decision log**, mirroring what **grooming (curation)** already has — a new `consolidation-runs` JSON sidecar paralleling grooming's `curation-runs.json`. This is foundational, purely observational plumbing for the later unified dashboard (C5) and the 2C self-improving loop. **It does not change filing behaviour at all.**

## The sidecar store

`consolidation-types.ts` + `consolidation-store.ts` + the sidecar `createJsonConsolidationStore` are a faithful, minimal mirror of the grooming sidecar (`sidecar/curation-store.ts`): same whole-file `readAll`/`writeAll`, same run lifecycle guards (`start` COALESCEs `started_at`; `complete`/`fail` only transition a **non-terminal** run so a late call can't resurrect a terminal run; corrupt file degrades to empty), same newest-first listing + 200 clamp.

The scheduler/evidence seam (slices / dueSlices / gatherMemoryEvidence) is deliberately **dropped** — intake has no scheduling, so the store is the minimal run + operation subset. Per-op rows capture **action, outcome (`applied` | `proposed` | `skipped` | `failed`), confidence, rationale, source id, target id**; the run row carries the sweep summary + counters.

## The two record sites

- `runConsolidatorSweep` (sweep.ts) opens a run at the start and completes it with the sweep summary at the end.
- `consolidateInboxItem` (consolidate.ts) records **each item's outcome** right after `applyConsolidationPlan` returns — at **full coverage**, not just auto-applies (proposed / skipped / failed rows are all recorded).

`applyConsolidationPlan` itself stays pure (no logging side-effect): the record happens at its call-site, which is where the source id (the inbox item) is available.

## Fail-soft (load-bearing)

Intake is the perf-sensitive ingestion path, so a **log-write failure must never block or fail the sweep**. Every log write flows through a single `safe()` choke point in `decision-log.ts` that swallows **any** throw (surfaced only via an optional debug sink, never re-thrown) — outcome mapping, secret redaction, and the store write are all inside it. A test injects a logger whose every method throws and asserts the sweep still files all items and returns its normal summary.

## Byte-identical filing

The logger is never read by the judge/navigate/apply path; recording happens strictly after the outcome is decided and feeds nothing back. When no logger is passed (the default), every log call is a guarded no-op. A test asserts `createMemory` receives identical input with and without the logger.

The model's rationale is **redacted** (same known-format redactor apply.ts uses to scrub the vault) before logging.

## Wiring

The sidecar is wired into the markdown `LibrarianStore` as `consolidation-runs.json` (outside the git vault, like `curation-runs.json`); `consolidateInbox` accepts an optional `trigger`.

## Tests (the spec's acceptance criteria)

- N filed items → N logged operations queryable from the new store.
- A forced log-write failure does not fail the sweep.
- Filing is byte-identical with and without the logger.
- Full-outcome coverage (applied / proposed / skipped rows all recorded) + rationale redaction + the real-store integration path.

Full `@librarian/core` suite green (739 tests); `pnpm -r build` clean (0 `error TS`).

No CHANGELOG entry: this is internal foundation with no user-visible surface (the log isn't shown until the C5 dashboard); the single user-visible 043 entry lands with the dashboard/rename PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)