### PR TITLE
feat(core): unified curator enablement settings + env migration (spec 043 PR-2, Task C2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,23 @@ changes from this point forward are catalogued here.
   is retired. The migration is fail-soft — if the master key is temporarily
   unavailable it defers and retries on a later run, never losing your token.
 
+### Changed
+
+- **Both curator jobs' enablement is now a dashboard setting; the
+  `LIBRARIAN_CONSOLIDATOR` env var is deprecated.** Grooming and intake are now
+  enabled/disabled from settings under the unified `curator.*` namespace
+  (`curator.grooming.enabled` / `curator.intake.enabled`) instead of the old
+  `curator.enabled` setting (grooming) and the `LIBRARIAN_CONSOLIDATOR`
+  environment variable (intake). Existing installs are migrated automatically on
+  the first boot — your exact enablement is preserved (grooming-on stays on,
+  `LIBRARIAN_CONSOLIDATOR=on` becomes intake-on) — and the migration is
+  idempotent and never overwrites a value you have since set. The setting is now
+  authoritative: `LIBRARIAN_CONSOLIDATOR` no longer controls intake (it only
+  seeds the setting once), so toggling intake from the dashboard takes effect.
+  **Action:** remove `LIBRARIAN_CONSOLIDATOR` from your environment — it logs a
+  deprecation warning on boot while still set, and will be removed in a future
+  release. (`LIBRARIAN_CONSOLIDATOR_TICK_MS`, the tick cadence, is unaffected.)
+
 ### Removed
 
 - **Dashboard `/logs` and `/recall` pages removed.** Both rendered the

--- a/packages/core/src/consolidator-tick.ts
+++ b/packages/core/src/consolidator-tick.ts
@@ -4,11 +4,11 @@
 // — intake and grooming each pick their own provider+model), builds the client
 // from it, and runs one inbox sweep via store.consolidateInbox.
 //
-// Enablement (the LIBRARIAN_CONSOLIDATOR opt-in) is decided by the caller (the
-// http boot only starts this scheduler when enabled), so the tick itself only
-// gates on a complete + decryptable LLM connection and a supporting backend. The
-// LLM client builder is injectable for testing; production defaults to the
-// OpenAI-compatible client.
+// Enablement (the `curator.intake.enabled` setting, spec 043 D-E) is decided by
+// the caller (the http boot only starts this scheduler when the setting is on),
+// so the tick itself only gates on a complete + decryptable LLM connection and a
+// supporting backend. The LLM client builder is injectable for testing;
+// production defaults to the OpenAI-compatible client.
 
 import type { ConsolidationThresholds, SweepSummary } from "./consolidator/index.js";
 import {
@@ -44,7 +44,7 @@ export async function runConsolidatorTick(
   // Preserve a pre-existing curator.llm.* install (idempotent once migrated).
   migrateLegacyCuratorLlm(store);
   // The intake job's own LLM connection — its enablement is the caller's
-  // LIBRARIAN_CONSOLIDATOR opt-in, not a curator flag.
+  // `curator.intake.enabled` setting (gated at the http boot), not read here.
   const llm = readConsumerConfig(store, "intake");
   if (!llm.isOperational) return { ran: false, reason: "incomplete_config" };
 

--- a/packages/core/src/curator-config.ts
+++ b/packages/core/src/curator-config.ts
@@ -12,13 +12,28 @@ import { z } from "zod";
 import type { LlmConnectionReader, LlmConnectionWriter } from "./llm-connection.js";
 
 // Curator-specific keys (enable flag, prompt addendum, auto-apply, schedule).
+// Grooming's enablement now lives under the unified `curator.grooming.enabled`
+// key (spec 043 D-E); the legacy `curator.enabled` is read once at migration
+// time and never again (see migrateCuratorEnablement / LEGACY_GROOMING_ENABLED_KEY).
 const KEYS = {
-  enabled: "curator.enabled",
+  enabled: "curator.grooming.enabled",
   promptAddendum: "curator.prompt_addendum",
   defaultAutoApply: "curator.default_auto_apply",
   autoApplyConfidence: "curator.auto_apply_confidence",
   intervalMinutes: "curator.interval_minutes",
 } as const;
+
+// Unified curator enablement keys (spec 043 D-E). BOTH jobs' on/off flags now
+// live under the `curator.*` namespace as dashboard-editable string settings
+// ("true"/"false"), replacing the two legacy sources:
+//   grooming: curator.enabled            (a setting)  → curator.grooming.enabled
+//   intake:   LIBRARIAN_CONSOLIDATOR env (an env var) → curator.intake.enabled
+export const GROOMING_ENABLED_KEY = "curator.grooming.enabled";
+export const INTAKE_ENABLED_KEY = "curator.intake.enabled";
+
+// The pre-043 grooming enablement setting. Read ONLY by migrateCuratorEnablement
+// to seed the new key once; the scheduler never reads it again.
+export const LEGACY_GROOMING_ENABLED_KEY = "curator.enabled";
 
 // Legacy keys retained only so a present value can be detected and logged at
 // boot (§12.4 disable-by-default cadence). They are no longer read by the
@@ -104,6 +119,61 @@ export function readCuratorConfig(store: ConfigReader): CuratorConfig {
  */
 export function findLegacyScheduleKeys(store: ConfigReader): string[] {
   return LEGACY_SCHEDULE_KEYS.filter((key) => store.getSetting(key) !== null);
+}
+
+/**
+ * Intake (consolidator) enablement, read from the unified `curator.intake.enabled`
+ * setting (spec 043 D-E). The setting is AUTHORITATIVE once present; the legacy
+ * `LIBRARIAN_CONSOLIDATOR` env var no longer gates the job — it only seeds this
+ * setting on first migration and triggers a deprecation warning while still set
+ * (see migrateCuratorEnablement). Default off. Reads plain settings only, so it
+ * works without the master key.
+ */
+export function isIntakeEnabled(store: ConfigReader): boolean {
+  return store.getSetting(INTAKE_ENABLED_KEY) === "true";
+}
+
+/**
+ * One-time, idempotent migration that seeds the unified enablement keys from the
+ * two legacy sources so an existing install keeps its EXACT enablement after the
+ * 043 upgrade (spec D-E). Safe to run on every boot/tick:
+ *
+ *  - `curator.grooming.enabled` ← `curator.enabled` (the legacy setting), ONLY
+ *    when `curator.grooming.enabled` is unset (never clobbers a value the user
+ *    has since set via the dashboard) AND the legacy key is present. A fresh
+ *    install with neither key leaves grooming unset → default off.
+ *  - `curator.intake.enabled` ← `LIBRARIAN_CONSOLIDATOR` (on/true), ONLY when
+ *    `curator.intake.enabled` is unset AND the env opts in. A fresh install or an
+ *    off/absent env leaves intake unset → default off.
+ *
+ * Precedence in the deprecation window: the SETTING is authoritative. The env's
+ * only roles are (a) seed-once here and (b) the deprecation warning emitted by
+ * the boot code while the var remains set. It must NOT override the setting, so
+ * toggling the dashboard off actually disables the job.
+ *
+ * `legacyIntakeEnv` is the raw `process.env.LIBRARIAN_CONSOLIDATOR` value, passed
+ * in by the mcp-server boundary (core never reads process.env). Omitted callers
+ * (e.g. the grooming tick) migrate grooming only — harmless, since intake is
+ * seeded at the http boot where the env is available.
+ */
+export function migrateCuratorEnablement(
+  store: ConfigReader & ConfigWriter,
+  options: { legacyIntakeEnv?: string } = {},
+): void {
+  // Grooming: seed once from the legacy setting, never clobbering an explicit value.
+  if (store.getSetting(GROOMING_ENABLED_KEY) === null) {
+    const legacy = store.getSetting(LEGACY_GROOMING_ENABLED_KEY);
+    if (legacy !== null) {
+      store.setSetting(GROOMING_ENABLED_KEY, legacy === "true" ? "true" : "false");
+    }
+  }
+  // Intake: seed once from the legacy env opt-in, never clobbering an explicit value.
+  if (store.getSetting(INTAKE_ENABLED_KEY) === null) {
+    const env = options.legacyIntakeEnv;
+    if (env === "on" || env === "true") {
+      store.setSetting(INTAKE_ENABLED_KEY, "true");
+    }
+  }
 }
 
 export function writeCuratorConfig(store: ConfigWriter, patch: CuratorConfigPatch): void {

--- a/packages/core/src/curator-consumers.ts
+++ b/packages/core/src/curator-consumers.ts
@@ -14,6 +14,7 @@
 // not-operational (inert, never throws) — the caller skips it.
 
 import { z } from "zod";
+import { GROOMING_ENABLED_KEY, INTAKE_ENABLED_KEY } from "./curator-config.js";
 import {
   type LlmConnectionReader,
   type LlmConnectionWriter,
@@ -36,6 +37,13 @@ const MAX_TIMEOUT_MS = 600_000;
 
 export interface ConsumerConfig {
   consumer: CuratorConsumer;
+  /**
+   * Whether this job is enabled, from the unified `curator.<consumer>.enabled`
+   * setting (spec 043 D-E). Default off. The setting is authoritative; the
+   * legacy sources (curator.enabled / LIBRARIAN_CONSOLIDATOR) only seed it once
+   * via migrateCuratorEnablement.
+   */
+  enabled: boolean;
   /** Referenced provider id; "" when unset. */
   providerId: string;
   /** Whether `providerId` resolves to an existing provider. */
@@ -51,6 +59,7 @@ export interface ConsumerConfig {
 }
 
 export interface ConsumerConfigPatch {
+  enabled?: boolean;
   providerId?: string;
   model?: string;
   timeoutMs?: number;
@@ -59,6 +68,7 @@ export interface ConsumerConfigPatch {
 // Permissive admin-patch shape; the timeout bound is enforced in
 // `writeConsumerConfig`, the single source of truth.
 export const ConsumerConfigPatchSchema = z.strictObject({
+  enabled: z.boolean().optional(),
   providerId: z.string().optional(),
   model: z.string().optional(),
   timeoutMs: z.number().optional(),
@@ -82,6 +92,13 @@ function consumerKeys(consumer: CuratorConsumer): ConsumerKeys {
   };
 }
 
+// The unified enablement key for a consumer (`curator.<consumer>.enabled`,
+// spec 043 D-E). Kept as fixed constants in curator-config.ts so the migration,
+// the http gate, and this per-consumer surface all agree.
+function enabledKey(consumer: CuratorConsumer): string {
+  return consumer === "intake" ? INTAKE_ENABLED_KEY : GROOMING_ENABLED_KEY;
+}
+
 // Bounded timeout parse: a valid in-range integer, else undefined. The read path
 // defaults; the migration omits (lets the consumer default). Clamping on read
 // means a hand-edited vault value can never feed a tick a 0/negative timeout.
@@ -101,6 +118,7 @@ export function readConsumerConfig(
   consumer: CuratorConsumer,
 ): ConsumerConfig {
   const keys = consumerKeys(consumer);
+  const enabled = store.getSetting(enabledKey(consumer)) === "true";
   const providerId = store.getSetting(keys.provider) ?? "";
   const model = store.getSetting(keys.model) ?? "";
   const timeoutMs = parseTimeoutMs(store.getSetting(keys.timeoutMs));
@@ -109,6 +127,7 @@ export function readConsumerConfig(
   const hasToken = provider?.hasToken ?? false;
   return {
     consumer,
+    enabled,
     providerId,
     providerExists,
     endpoint: provider?.endpoint ?? "",
@@ -134,6 +153,8 @@ export function writeConsumerConfig(
     }
   }
   const keys = consumerKeys(consumer);
+  if (patch.enabled !== undefined)
+    store.setSetting(enabledKey(consumer), patch.enabled ? "true" : "false");
   if (patch.providerId !== undefined) store.setSetting(keys.provider, patch.providerId);
   if (patch.model !== undefined) store.setSetting(keys.model, patch.model);
   if (patch.timeoutMs !== undefined) store.setSetting(keys.timeoutMs, String(patch.timeoutMs));

--- a/packages/core/src/curator-tick.ts
+++ b/packages/core/src/curator-tick.ts
@@ -10,7 +10,7 @@
 // the OpenAI-compatible client.
 
 import { SYSTEM_ACTOR_IDS } from "./caller-identity.js";
-import { readCuratorConfig } from "./curator-config.js";
+import { migrateCuratorEnablement, readCuratorConfig } from "./curator-config.js";
 import {
   migrateLegacyCuratorLlm,
   readConsumerConfig,
@@ -51,6 +51,10 @@ export async function runCuratorTick(options: CuratorTickOptions): Promise<Curat
   // Preserve a pre-existing curator.llm.* install: seed the per-consumer config
   // from it on first run (idempotent — a no-op once any provider exists).
   migrateLegacyCuratorLlm(store);
+  // Seed grooming's unified enablement key from the legacy curator.enabled
+  // setting (idempotent, no-clobber). Intake's env→setting seed runs at the http
+  // boot where LIBRARIAN_CONSOLIDATOR is available; this tick migrates grooming.
+  migrateCuratorEnablement(store);
   const config = readCuratorConfig(store);
   const llm = readConsumerConfig(store, "grooming");
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -173,6 +173,11 @@ export {
   type CuratorConfig,
   type CuratorConfigPatch,
   CuratorConfigPatchSchema,
+  GROOMING_ENABLED_KEY,
+  INTAKE_ENABLED_KEY,
+  isIntakeEnabled,
+  LEGACY_GROOMING_ENABLED_KEY,
+  migrateCuratorEnablement,
   readCuratorConfig,
   writeCuratorConfig,
 } from "./curator-config.js";

--- a/packages/core/tests/curator-consumers.test.ts
+++ b/packages/core/tests/curator-consumers.test.ts
@@ -86,6 +86,24 @@ describe("per-consumer LLM resolution", () => {
       store.setSetting("curator.intake.timeout_ms", "not-a-number");
       expect(readConsumerConfig(store, "intake").timeoutMs).toBe(60_000);
     });
+
+    it("round-trips the unified per-consumer enabled flag (spec 043 D-E)", () => {
+      const { store } = s!;
+      // Default off until explicitly enabled.
+      expect(readConsumerConfig(store, "intake").enabled).toBe(false);
+      expect(readConsumerConfig(store, "grooming").enabled).toBe(false);
+
+      writeConsumerConfig(store, "intake", { enabled: true });
+      expect(readConsumerConfig(store, "intake").enabled).toBe(true);
+      // The consumer surface and the unified setting key agree.
+      expect(store.getSetting("curator.intake.enabled")).toBe("true");
+      // Enabling intake does not enable grooming.
+      expect(readConsumerConfig(store, "grooming").enabled).toBe(false);
+
+      writeConsumerConfig(store, "intake", { enabled: false });
+      expect(readConsumerConfig(store, "intake").enabled).toBe(false);
+      expect(store.getSetting("curator.intake.enabled")).toBe("false");
+    });
   });
 
   describe("operational truth table", () => {

--- a/packages/core/tests/curator-enablement.test.ts
+++ b/packages/core/tests/curator-enablement.test.ts
@@ -1,0 +1,198 @@
+// Unified curator enablement + legacy migration (spec 043 D-E).
+//
+// Both curator jobs' on/off flags now live under the `curator.*` namespace as
+// dashboard-editable settings (curator.grooming.enabled / curator.intake.enabled),
+// replacing the two legacy sources (the curator.enabled setting for grooming and
+// the LIBRARIAN_CONSOLIDATOR env var for intake). migrateCuratorEnablement seeds
+// the new keys ONCE so an existing install keeps its exact enablement after the
+// upgrade, never clobbering a value the user has since set, and stays idempotent.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  GROOMING_ENABLED_KEY,
+  INTAKE_ENABLED_KEY,
+  LEGACY_GROOMING_ENABLED_KEY,
+  type LibrarianStore,
+  createLibrarianStore,
+  isIntakeEnabled,
+  migrateCuratorEnablement,
+  readCuratorConfig,
+  writeCuratorConfig,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+interface Scope {
+  store: LibrarianStore;
+  dataDir: string;
+}
+
+function open(dataDir: string): LibrarianStore {
+  return createLibrarianStore({ dataDir });
+}
+
+function scope(): Scope {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-enablement-"));
+  return { store: open(dataDir), dataDir };
+}
+
+function teardown(s: Scope | null): void {
+  if (!s) return;
+  try {
+    s.store.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(s.dataDir, { recursive: true, force: true });
+}
+
+describe("curator enablement migration (spec 043 D-E)", () => {
+  let s: Scope | null = null;
+  beforeEach(() => {
+    s = scope();
+  });
+  afterEach(() => {
+    teardown(s);
+    s = null;
+  });
+
+  // ── Acceptance: an old install keeps its EXACT enablement after upgrade ──────
+
+  it("preserves grooming-on: curator.enabled=true seeds curator.grooming.enabled=true", () => {
+    const { store } = s!;
+    store.setSetting(LEGACY_GROOMING_ENABLED_KEY, "true"); // pre-043 grooming on
+    expect(readCuratorConfig(store).enabled).toBe(false); // not yet migrated
+
+    migrateCuratorEnablement(store);
+
+    expect(store.getSetting(GROOMING_ENABLED_KEY)).toBe("true");
+    expect(readCuratorConfig(store).enabled).toBe(true);
+  });
+
+  it("preserves grooming-off: curator.enabled=false seeds curator.grooming.enabled=false", () => {
+    const { store } = s!;
+    store.setSetting(LEGACY_GROOMING_ENABLED_KEY, "false");
+
+    migrateCuratorEnablement(store);
+
+    expect(store.getSetting(GROOMING_ENABLED_KEY)).toBe("false");
+    expect(readCuratorConfig(store).enabled).toBe(false);
+  });
+
+  it("preserves intake-on: LIBRARIAN_CONSOLIDATOR=on seeds curator.intake.enabled=true", () => {
+    const { store } = s!;
+    expect(isIntakeEnabled(store)).toBe(false); // default off pre-migration
+
+    migrateCuratorEnablement(store, { legacyIntakeEnv: "on" });
+
+    expect(store.getSetting(INTAKE_ENABLED_KEY)).toBe("true");
+    expect(isIntakeEnabled(store)).toBe(true);
+  });
+
+  it("treats LIBRARIAN_CONSOLIDATOR=true the same as on", () => {
+    const { store } = s!;
+    migrateCuratorEnablement(store, { legacyIntakeEnv: "true" });
+    expect(isIntakeEnabled(store)).toBe(true);
+  });
+
+  // ── Acceptance: the setting is authoritative (toggle works) ─────────────────
+
+  it("lets the setting be toggled off even when the legacy env was on (setting wins)", () => {
+    const { store } = s!;
+    // Existing install: env on → migration seeds the setting on.
+    migrateCuratorEnablement(store, { legacyIntakeEnv: "on" });
+    expect(isIntakeEnabled(store)).toBe(true);
+
+    // User toggles intake OFF from the dashboard.
+    store.setSetting(INTAKE_ENABLED_KEY, "false");
+    expect(isIntakeEnabled(store)).toBe(false);
+
+    // A subsequent boot re-runs the migration with the env STILL set on — it must
+    // NOT re-enable intake (no-clobber). The setting stays authoritative.
+    migrateCuratorEnablement(store, { legacyIntakeEnv: "on" });
+    expect(isIntakeEnabled(store)).toBe(false);
+  });
+
+  it("lets grooming be toggled off after migrating from an on legacy setting", () => {
+    const { store } = s!;
+    store.setSetting(LEGACY_GROOMING_ENABLED_KEY, "true");
+    migrateCuratorEnablement(store);
+    expect(readCuratorConfig(store).enabled).toBe(true);
+
+    writeCuratorConfig(store, { enabled: false });
+    expect(readCuratorConfig(store).enabled).toBe(false);
+
+    // Re-running migration (legacy curator.enabled still "true") must not clobber.
+    migrateCuratorEnablement(store);
+    expect(readCuratorConfig(store).enabled).toBe(false);
+  });
+
+  // ── Acceptance: idempotent + never clobbers an explicit new-key value ────────
+
+  it("never clobbers an explicit curator.grooming.enabled value", () => {
+    const { store } = s!;
+    store.setSetting(GROOMING_ENABLED_KEY, "false"); // user set it off
+    store.setSetting(LEGACY_GROOMING_ENABLED_KEY, "true"); // legacy says on
+
+    migrateCuratorEnablement(store);
+
+    expect(store.getSetting(GROOMING_ENABLED_KEY)).toBe("false"); // explicit value preserved
+  });
+
+  it("never clobbers an explicit curator.intake.enabled value", () => {
+    const { store } = s!;
+    store.setSetting(INTAKE_ENABLED_KEY, "false"); // user set it off
+
+    migrateCuratorEnablement(store, { legacyIntakeEnv: "on" }); // legacy env says on
+
+    expect(store.getSetting(INTAKE_ENABLED_KEY)).toBe("false"); // explicit value preserved
+  });
+
+  it("is idempotent: re-running yields the same settings (no drift)", () => {
+    const { store } = s!;
+    store.setSetting(LEGACY_GROOMING_ENABLED_KEY, "true");
+
+    migrateCuratorEnablement(store, { legacyIntakeEnv: "on" });
+    const after1 = {
+      grooming: store.getSetting(GROOMING_ENABLED_KEY),
+      intake: store.getSetting(INTAKE_ENABLED_KEY),
+    };
+    migrateCuratorEnablement(store, { legacyIntakeEnv: "on" });
+    const after2 = {
+      grooming: store.getSetting(GROOMING_ENABLED_KEY),
+      intake: store.getSetting(INTAKE_ENABLED_KEY),
+    };
+
+    expect(after2).toEqual(after1);
+    expect(after2).toEqual({ grooming: "true", intake: "true" });
+  });
+
+  // ── Fresh install: no legacy sources → both jobs default off ─────────────────
+
+  it("leaves both keys unset on a fresh install (no legacy sources), defaulting off", () => {
+    const { store } = s!;
+    migrateCuratorEnablement(store); // no legacy setting, no env
+
+    expect(store.getSetting(GROOMING_ENABLED_KEY)).toBeNull();
+    expect(store.getSetting(INTAKE_ENABLED_KEY)).toBeNull();
+    expect(readCuratorConfig(store).enabled).toBe(false);
+    expect(isIntakeEnabled(store)).toBe(false);
+  });
+
+  it("does not seed intake when the env is off/absent", () => {
+    const { store } = s!;
+    migrateCuratorEnablement(store, { legacyIntakeEnv: "off" });
+    expect(store.getSetting(INTAKE_ENABLED_KEY)).toBeNull();
+    expect(isIntakeEnabled(store)).toBe(false);
+  });
+
+  // ── readCuratorConfig now round-trips through the unified grooming key ────────
+
+  it("writeCuratorConfig({enabled}) writes the unified grooming key", () => {
+    const { store } = s!;
+    writeCuratorConfig(store, { enabled: true });
+    expect(store.getSetting(GROOMING_ENABLED_KEY)).toBe("true");
+    expect(readCuratorConfig(store).enabled).toBe(true);
+  });
+});

--- a/packages/mcp-server/src/bin/http.ts
+++ b/packages/mcp-server/src/bin/http.ts
@@ -11,6 +11,7 @@ import {
   createLibrarianStore,
   createSerialScheduler,
   findLegacyScheduleKeys,
+  migrateCuratorEnablement,
   resolveBootCredentials,
   resolveDataDir,
   runBackupTick,
@@ -18,7 +19,11 @@ import {
   runCuratorTick,
   verifyAgentToken,
 } from "@librarian/core";
-import { isConsolidatorEnabled } from "../consolidator-config.js";
+import {
+  isConsolidatorEnabled,
+  isLegacyConsolidatorEnvSet,
+  legacyConsolidatorEnv,
+} from "../consolidator-config.js";
 import { type AuthConfig, AgentTokensError, parseAgentTokenMap, parseCsv } from "../http/auth.js";
 import { createHttpServer } from "../http/server.js";
 import { logger } from "../logging.js";
@@ -178,6 +183,29 @@ const server = createHttpServer({ store, auth, maxBodyBytes, secretKey });
   }
 }
 
+// Unified curator enablement migration (spec 043 D-E). Seed the new dashboard
+// settings from their legacy sources ONCE so an existing install keeps its exact
+// enablement after upgrade: curator.grooming.enabled ← curator.enabled,
+// curator.intake.enabled ← LIBRARIAN_CONSOLIDATOR. Idempotent + no-clobber — safe
+// every boot; the setting is authoritative thereafter. This is also where intake
+// gets its env seed (LIBRARIAN_CONSOLIDATOR is only visible at this boundary).
+const legacyIntakeEnv = legacyConsolidatorEnv();
+migrateCuratorEnablement(store, {
+  ...(legacyIntakeEnv !== undefined ? { legacyIntakeEnv } : {}),
+});
+
+// Deprecation notice: the LIBRARIAN_CONSOLIDATOR env opt-in is retired to a
+// seed-once role (above). It no longer gates intake — the dashboard setting
+// (curator.intake.enabled) is authoritative. Warn while the var remains set so
+// operators remove it and rely on the setting.
+if (isLegacyConsolidatorEnvSet()) {
+  logger.warn(
+    "LIBRARIAN_CONSOLIDATOR is deprecated and no longer controls intake. Its value was migrated " +
+      "to the dashboard setting (curator.intake.enabled) once; the setting is now authoritative. " +
+      "Remove the env var — toggle intake from the dashboard instead.",
+  );
+}
+
 // Memory-curator scheduler (§14): a serial tick that runs due slices on a cadence.
 // The tick self-gates on the admin config (disabled/incomplete → cheap no-op), so
 // it's safe to always start. Set LIBRARIAN_CURATOR_TICK_MS=0 to disable (e.g. when
@@ -215,13 +243,13 @@ const backupScheduler =
     : null;
 
 // Consolidator scheduler (spec 035 §F5): a serial tick that processes the inbox
-// (navigate→judge→apply) on a cadence. OPT-IN via LIBRARIAN_CONSOLIDATOR — the
-// inbox model ships gated (default off), reversible like the markdown cutover.
-// The tick self-gates on the shared LLM config + the markdown backend (cheap
-// no-op otherwise), so enabling it without a configured model is harmless.
-// Default 5-min cadence; the chokidar watcher (follow-on) makes processing
-// near-immediate. LIBRARIAN_CONSOLIDATOR_TICK_MS=0 disables the timer.
-const consolidatorEnabled = isConsolidatorEnabled();
+// (navigate→judge→apply) on a cadence. Enabled via the dashboard setting
+// `curator.intake.enabled` (spec 043 D-E) — the inbox model ships gated (default
+// off), reversible. The tick self-gates on the shared LLM config + the markdown
+// backend (cheap no-op otherwise), so enabling it without a configured model is
+// harmless. Default 5-min cadence; the chokidar watcher (follow-on) makes
+// processing near-immediate. LIBRARIAN_CONSOLIDATOR_TICK_MS=0 disables the timer.
+const consolidatorEnabled = isConsolidatorEnabled(store);
 const consolidatorTickMs = Number(process.env.LIBRARIAN_CONSOLIDATOR_TICK_MS ?? 5 * 60_000);
 const consolidatorScheduler =
   consolidatorEnabled && consolidatorTickMs > 0

--- a/packages/mcp-server/src/consolidator-config.ts
+++ b/packages/mcp-server/src/consolidator-config.ts
@@ -1,12 +1,39 @@
-// Consolidator enablement — the LIBRARIAN_CONSOLIDATOR opt-in (default off).
+// Consolidator (intake) enablement — now a dashboard-editable setting under the
+// unified curator namespace (`curator.intake.enabled`, spec 043 D-E). The legacy
+// `LIBRARIAN_CONSOLIDATOR` env opt-in is retired to a one-release deprecation:
+// it seeds the setting once on first migration and emits a deprecation warning
+// while still present, but it NO LONGER gates the job — the setting is
+// authoritative, so toggling it from the dashboard takes effect immediately.
 //
-// The inbox model (remember → inbox → async consolidation) ships gated, like the
-// markdown-backend cutover. Both the http scheduler (whether to start the tick +
-// boot-scan) and the `remember` verb (whether to route to the inbox) read this
-// single source of truth so they can't drift.
+// Both the http scheduler (whether to start the tick + boot-scan) and the
+// `remember` verb (whether to route to the inbox) read `isIntakeEnabled(store)`
+// so they can't drift.
 
-/** True when the consolidator is opted in via `LIBRARIAN_CONSOLIDATOR=on` (or `true`). */
-export function isConsolidatorEnabled(): boolean {
-  const value = process.env.LIBRARIAN_CONSOLIDATOR;
-  return value === "on" || value === "true";
+import { isIntakeEnabled } from "@librarian/core";
+import type { LibrarianStore } from "@librarian/core";
+
+/** The legacy env opt-in, retired to a seed-once + deprecation-warn role (043). */
+const LEGACY_CONSOLIDATOR_ENV = "LIBRARIAN_CONSOLIDATOR";
+
+/**
+ * True when intake is enabled via the unified `curator.intake.enabled` setting.
+ * The setting is authoritative; the legacy env is honoured only by seeding this
+ * setting at boot (see migrateCuratorEnablement) — never read here.
+ */
+export function isConsolidatorEnabled(store: LibrarianStore): boolean {
+  return isIntakeEnabled(store);
+}
+
+/** The raw legacy env value (for the one-time migration seed). */
+export function legacyConsolidatorEnv(): string | undefined {
+  return process.env[LEGACY_CONSOLIDATOR_ENV];
+}
+
+/**
+ * True when the deprecated `LIBRARIAN_CONSOLIDATOR` env var is still set (to any
+ * value). Boot code logs a one-line deprecation notice when this is true so
+ * operators learn to remove the env and rely on the dashboard setting instead.
+ */
+export function isLegacyConsolidatorEnvSet(): boolean {
+  return process.env[LEGACY_CONSOLIDATOR_ENV] !== undefined;
 }

--- a/packages/mcp-server/src/mcp/tools/remember.ts
+++ b/packages/mcp-server/src/mcp/tools/remember.ts
@@ -33,11 +33,12 @@ const remember: ToolDefinition = {
     // conv_id was a domain-routing signal, not a memory field.
     delete scoped.conv_id;
 
-    // Inbox cutover (opt-in): when the consolidator is enabled, `remember` is a
-    // fire-and-forget submission — stored raw in the inbox and filed
-    // asynchronously by the consolidator (navigate→judge→edit), preserving the
-    // submitter's scope via hints. Otherwise the legacy direct write.
-    if (isConsolidatorEnabled()) {
+    // Inbox cutover: when intake is enabled (the dashboard setting
+    // `curator.intake.enabled`, spec 043 D-E), `remember` is a fire-and-forget
+    // submission — stored raw in the inbox and filed asynchronously by the
+    // consolidator (navigate→judge→edit), preserving the submitter's scope via
+    // hints. Otherwise the legacy direct write.
+    if (isConsolidatorEnabled(store)) {
       const title = typeof scoped.title === "string" ? scoped.title : "";
       const body = typeof scoped.body === "string" ? scoped.body : "";
       const text = title ? `${title}\n\n${body}` : body;

--- a/packages/mcp-server/src/trpc/llm.ts
+++ b/packages/mcp-server/src/trpc/llm.ts
@@ -50,6 +50,10 @@ const UpdateProviderSchema = LlmProviderPatchSchema.extend({ id: z.string().min(
 
 const SetConsumerSchema = z.strictObject({
   consumer: ConsumerSchema,
+  // Unified job enablement (curator.<consumer>.enabled, spec 043 D-E). The
+  // dashboard (C5) toggles intake/grooming through here; the setting is
+  // authoritative over the legacy env/setting.
+  enabled: z.boolean().optional(),
   providerId: z.string().optional(),
   model: z.string().optional(),
   timeoutMs: z.number().optional(),

--- a/packages/mcp-server/tests/consolidator-config.test.ts
+++ b/packages/mcp-server/tests/consolidator-config.test.ts
@@ -1,0 +1,92 @@
+// Consolidator (intake) enablement seam (spec 043 D-E). Intake enablement now
+// reads the `curator.intake.enabled` setting (authoritative); the legacy
+// LIBRARIAN_CONSOLIDATOR env is retired to a seed-once + deprecation-warn role.
+// These tests pin the env→deprecation detection and the store-backed gate.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  INTAKE_ENABLED_KEY,
+  type LibrarianStore,
+  createLibrarianStore,
+  migrateCuratorEnablement,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  isConsolidatorEnabled,
+  isLegacyConsolidatorEnvSet,
+  legacyConsolidatorEnv,
+} from "../src/consolidator-config.js";
+
+let store: LibrarianStore | null = null;
+let dataDir = "";
+let savedEnv: string | undefined;
+
+function makeStore(): LibrarianStore {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-consolidator-cfg-"));
+  store = createLibrarianStore({ dataDir });
+  return store;
+}
+
+beforeEach(() => {
+  savedEnv = process.env.LIBRARIAN_CONSOLIDATOR;
+  delete process.env.LIBRARIAN_CONSOLIDATOR;
+});
+
+afterEach(() => {
+  try {
+    store?.close();
+  } catch {
+    /* ignore */
+  }
+  if (dataDir) fs.rmSync(dataDir, { recursive: true, force: true });
+  store = null;
+  dataDir = "";
+  if (savedEnv === undefined) delete process.env.LIBRARIAN_CONSOLIDATOR;
+  else process.env.LIBRARIAN_CONSOLIDATOR = savedEnv;
+});
+
+describe("consolidator-config (intake enablement seam, spec 043 D-E)", () => {
+  it("isConsolidatorEnabled reads the setting, not the env", () => {
+    const s = makeStore();
+    // Env on, setting unset → still off (the env no longer gates the job).
+    process.env.LIBRARIAN_CONSOLIDATOR = "on";
+    expect(isConsolidatorEnabled(s)).toBe(false);
+
+    s.setSetting(INTAKE_ENABLED_KEY, "true");
+    expect(isConsolidatorEnabled(s)).toBe(true);
+
+    // Setting authoritative: env on but setting off → off.
+    s.setSetting(INTAKE_ENABLED_KEY, "false");
+    expect(isConsolidatorEnabled(s)).toBe(false);
+  });
+
+  it("boot-style migration seeds the setting from the env, then the setting wins", () => {
+    const s = makeStore();
+    process.env.LIBRARIAN_CONSOLIDATOR = "on";
+
+    migrateCuratorEnablement(s, { legacyIntakeEnv: legacyConsolidatorEnv() });
+    expect(isConsolidatorEnabled(s)).toBe(true); // exact enablement preserved
+
+    // Operator toggles off; re-running boot migration must not re-enable.
+    s.setSetting(INTAKE_ENABLED_KEY, "false");
+    migrateCuratorEnablement(s, { legacyIntakeEnv: legacyConsolidatorEnv() });
+    expect(isConsolidatorEnabled(s)).toBe(false);
+  });
+
+  it("detects the deprecated env var while it is set (drives the boot warning)", () => {
+    expect(isLegacyConsolidatorEnvSet()).toBe(false);
+    process.env.LIBRARIAN_CONSOLIDATOR = "on";
+    expect(isLegacyConsolidatorEnvSet()).toBe(true);
+    expect(legacyConsolidatorEnv()).toBe("on");
+
+    // Set to anything (even "off") still counts as present → deprecation warn fires.
+    process.env.LIBRARIAN_CONSOLIDATOR = "off";
+    expect(isLegacyConsolidatorEnvSet()).toBe(true);
+
+    delete process.env.LIBRARIAN_CONSOLIDATOR;
+    expect(isLegacyConsolidatorEnvSet()).toBe(false);
+    expect(legacyConsolidatorEnv()).toBeUndefined();
+  });
+});

--- a/packages/mcp-server/tests/consolidator-config.test.ts
+++ b/packages/mcp-server/tests/consolidator-config.test.ts
@@ -13,11 +13,15 @@ import {
   migrateCuratorEnablement,
 } from "@librarian/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+// Import the compiled module: vitest externalizes packages/mcp-server/{src,dist}
+// (see vitest.config.ts), so a `../src/*.ts` import hits Node's loader, which
+// cannot load .ts. Other internal-module tests (e.g. http/db-tokens) import from
+// dist for the same reason; dist is built before test:vitest runs.
 import {
   isConsolidatorEnabled,
   isLegacyConsolidatorEnvSet,
   legacyConsolidatorEnv,
-} from "../src/consolidator-config.js";
+} from "../dist/consolidator-config.js";
 
 let store: LibrarianStore | null = null;
 let dataDir = "";

--- a/packages/mcp-server/tests/mcp/remember-cutover.test.ts
+++ b/packages/mcp-server/tests/mcp/remember-cutover.test.ts
@@ -1,22 +1,21 @@
 // remember verb — inbox cutover routing (plan 036 Phase 4 / spec 035 §F5).
-// When LIBRARIAN_CONSOLIDATOR is on AND the store is on the markdown backend,
-// `remember` is a fire-and-forget submission to the consolidator inbox;
-// otherwise it writes directly via createMemory (the legacy path, unchanged by
-// default). Dispatched through handleMcpPayload over a real store.
+// When intake is enabled (the `curator.intake.enabled` setting, spec 043 D-E)
+// AND the store is on the markdown backend, `remember` is a fire-and-forget
+// submission to the consolidator inbox; otherwise it writes directly via
+// createMemory (the legacy path, unchanged by default). Dispatched through
+// handleMcpPayload over a real store.
 
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { type LibrarianStore, createLibrarianStore } from "@librarian/core";
+import { INTAKE_ENABLED_KEY, type LibrarianStore, createLibrarianStore } from "@librarian/core";
 import { handleMcpPayload } from "@librarian/mcp-server";
 import { afterEach, describe, expect, it } from "vitest";
 
 let store: LibrarianStore | null = null;
 let dataDir = "";
-let savedFlag: string | undefined;
 
 function makeStore(): void {
-  savedFlag = process.env.LIBRARIAN_CONSOLIDATOR;
   dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-remember-"));
   store = createLibrarianStore({ dataDir });
 }
@@ -29,8 +28,6 @@ afterEach(() => {
   }
   if (dataDir) fs.rmSync(dataDir, { recursive: true, force: true });
   store = null;
-  if (savedFlag === undefined) delete process.env.LIBRARIAN_CONSOLIDATOR;
-  else process.env.LIBRARIAN_CONSOLIDATOR = savedFlag;
 });
 
 type CallResult = { result: { content: { text: string }[] } };
@@ -44,9 +41,9 @@ const remember = (args: Record<string, unknown>): Promise<unknown> =>
 const text = (res: unknown): string => (res as CallResult).result.content[0]!.text;
 
 describe("remember verb — inbox cutover routing", () => {
-  it("submits to the inbox (not a memory) when the consolidator is on + markdown", async () => {
+  it("submits to the inbox (not a memory) when intake is enabled + markdown", async () => {
     makeStore();
-    process.env.LIBRARIAN_CONSOLIDATOR = "on";
+    store!.setSetting(INTAKE_ENABLED_KEY, "true");
 
     const res = await remember({ title: "Anna", body: "moved to Berlin", agent_id: "agent-a" });
 
@@ -59,9 +56,20 @@ describe("remember verb — inbox cutover routing", () => {
     expect(inboxFiles).toHaveLength(1);
   });
 
-  it("writes directly (createMemory) when the consolidator is off — the default", async () => {
+  it("writes directly (createMemory) when intake is off — the default", async () => {
     makeStore();
-    delete process.env.LIBRARIAN_CONSOLIDATOR;
+    // curator.intake.enabled unset → default off.
+
+    const res = await remember({ title: "T", body: "B", agent_id: "agent-a" });
+
+    expect(text(res)).toMatch(/Memory saved/);
+    expect(store!.listMemories({ status: "active" }).total).toBe(1);
+  });
+
+  it("respects the setting toggled off even after it was on", async () => {
+    makeStore();
+    store!.setSetting(INTAKE_ENABLED_KEY, "true");
+    store!.setSetting(INTAKE_ENABLED_KEY, "false");
 
     const res = await remember({ title: "T", body: "B", agent_id: "agent-a" });
 
@@ -71,7 +79,7 @@ describe("remember verb — inbox cutover routing", () => {
 
   it("falls through to a direct write for an empty submission (no empty inbox item to loop on)", async () => {
     makeStore();
-    process.env.LIBRARIAN_CONSOLIDATOR = "on";
+    store!.setSetting(INTAKE_ENABLED_KEY, "true");
 
     // No title and no body → nothing to consolidate.
     const res = await remember({ agent_id: "agent-a" });

--- a/scripts/seed/import.mjs
+++ b/scripts/seed/import.mjs
@@ -84,8 +84,9 @@ if (values.wipe && !values.yes) {
 // Absolute so the vault's path-escape guard doesn't trip on a relative root.
 const dataDir = path.resolve(dataDirArg);
 
-// `remember` routes to the inbox (→ consolidator) only when this is on.
-process.env.LIBRARIAN_CONSOLIDATOR = "on";
+// `remember` routes to the inbox (→ consolidator) only when intake is enabled.
+// runSeedImport sets the `curator.intake.enabled` setting on the store (spec 043
+// D-E) — no env opt-in needed here anymore.
 
 const { secretKey } = resolveBootCredentials({
   env: process.env,

--- a/scripts/seed/lib.mjs
+++ b/scripts/seed/lib.mjs
@@ -219,6 +219,12 @@ export async function runSeedImport({
 }) {
   const summary = { wiped: [], referencesCopied: 0, remembered: 0, sweep: null };
 
+  // Intake enablement is now the `curator.intake.enabled` setting (spec 043 D-E),
+  // not the LIBRARIAN_CONSOLIDATOR env. Turn it on for this store so `remember`
+  // routes submissions to the inbox; the explicit consolidateInbox below drains
+  // it (this script runs in-process with no scheduler). Idempotent.
+  store.setSetting("curator.intake.enabled", "true");
+
   if (wipe) summary.wiped = wipeVaultKnowledge(vaultRoot);
 
   const { memoryFiles, referenceFiles } = routeSourceDir(sourceDir);

--- a/test/seed-import.test.ts
+++ b/test/seed-import.test.ts
@@ -8,7 +8,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { type InternalLibrarianStore, createLibrarianStore } from "@librarian/core";
+import {
+  INTAKE_ENABLED_KEY,
+  type InternalLibrarianStore,
+  createLibrarianStore,
+} from "@librarian/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -117,11 +121,8 @@ describe("seed lib — runSeedImport (end to end, scripted consolidator)", () =>
   let dataDir = "";
   let sourceDir = "";
   let store: InternalLibrarianStore | null = null;
-  let savedFlag: string | undefined;
 
   beforeEach(() => {
-    savedFlag = process.env.LIBRARIAN_CONSOLIDATOR;
-    process.env.LIBRARIAN_CONSOLIDATOR = "on"; // remember → inbox
     dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-seed-data-"));
     sourceDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-seed-src-"));
     fs.mkdirSync(path.join(sourceDir, "memories"), { recursive: true });
@@ -132,6 +133,9 @@ describe("seed lib — runSeedImport (end to end, scripted consolidator)", () =>
     );
     fs.writeFileSync(path.join(sourceDir, "references", "AI", "note.md"), "# Background\nlong doc");
     store = createLibrarianStore({ dataDir, backend: "markdown" });
+    // Intake enablement is now the `curator.intake.enabled` setting (spec 043
+    // D-E), not the LIBRARIAN_CONSOLIDATOR env — route remember → inbox.
+    store.setSetting(INTAKE_ENABLED_KEY, "true");
   });
   afterEach(() => {
     try {
@@ -141,8 +145,6 @@ describe("seed lib — runSeedImport (end to end, scripted consolidator)", () =>
     }
     fs.rmSync(dataDir, { recursive: true, force: true });
     fs.rmSync(sourceDir, { recursive: true, force: true });
-    if (savedFlag === undefined) delete process.env.LIBRARIAN_CONSOLIDATOR;
-    else process.env.LIBRARIAN_CONSOLIDATOR = savedFlag;
   });
 
   it("copies references verbatim and grooms memories through the consolidator", async () => {


### PR DESCRIPTION
## Spec 043 PR-2 (Task C2) — unified curator enablement + env migration (decision D-E)

Moves **both** curator jobs' enablement into dashboard-editable settings under the
unified `curator.*` namespace and migrates the two legacy enablement sources.

### The two migrations
| Job | Legacy source | New setting |
|---|---|---|
| Grooming | `curator.enabled` (a setting) | `curator.grooming.enabled` |
| Intake | `LIBRARIAN_CONSOLIDATOR` (an env var) | `curator.intake.enabled` |

`migrateCuratorEnablement(store, { legacyIntakeEnv })` (in `packages/core/src/curator-config.ts`)
seeds the new keys **once** from the legacy sources so an existing install keeps its
**exact** enablement after upgrade. It is **idempotent** and **never clobbers** a value the
user has since set.

- **Grooming seed** (`curator.enabled` → `curator.grooming.enabled`) is pure store→store —
  runs at the start of `runCuratorTick` (mirroring 042's `migrateLegacyCuratorLlm`) and at
  http boot.
- **Intake seed** (`LIBRARIAN_CONSOLIDATOR` → `curator.intake.enabled`) needs the env, which
  is only visible at the mcp-server boundary, so it runs at the http boot (`bin/http.ts`).
  Core never reads `process.env` — the value is injected as `legacyIntakeEnv`.

### Precedence in the deprecation window
The **setting is authoritative once it exists.** `LIBRARIAN_CONSOLIDATOR`'s only roles are
(a) to seed `curator.intake.enabled` on first migration and (b) to emit a **deprecation
warning** whenever it is still set. It does **not** override the setting — so toggling intake
off from the dashboard takes effect even while the env remains present. `isConsolidatorEnabled(store)`
/ `isIntakeEnabled(store)` read only the setting. (`LIBRARIAN_CONSOLIDATOR_TICK_MS`, the tick
cadence, is unaffected.)

### Gating + back-end surface
- The http consolidator scheduler + boot-scan and the `remember` verb gate on `isIntakeEnabled(store)`.
- `CuratorConfig.enabled` (grooming, via the `curator` router) and the per-consumer config
  (`ConsumerConfig.enabled` + `llm.consumerConfig`/`setConsumerConfig`) carry the new keys so
  config read/write surfaces both enablement flags for C5's dashboard toggles.

### Acceptance criteria (all covered by tests + verified at a real boot)
- An old env/setting install keeps its exact enablement after upgrade.
- Toggling either dashboard setting enables/disables that job (setting authoritative).
- The deprecation warning fires while `LIBRARIAN_CONSOLIDATOR` is still set.
- Migration is idempotent and never clobbers an explicit new-key value.

### Tests
- `packages/core/tests/curator-enablement.test.ts` (new) — the four acceptance criteria.
- `packages/mcp-server/tests/consolidator-config.test.ts` (new) — the env→setting seam + deprecation detection.
- Updated `curator-consumers.test.ts`, `remember-cutover.test.ts`, `seed-import.test.ts` to the setting.

Full suite green (core 752, mcp-server 119, dashboard 174, root 22), `pnpm -r build`,
typecheck, lint, and `pnpm smoke` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)