### PR TITLE
feat(core): triggered grooming — retire cron for post-intake threshold (spec 043 PR-3, Task C3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,17 @@ changes from this point forward are catalogued here.
   deprecation warning on boot while still set, and will be removed in a future
   release. (`LIBRARIAN_CONSOLIDATOR_TICK_MS`, the tick cadence, is unaffected.)
 
+- **Grooming no longer runs on a wall-clock cron — it is triggered.** Memory
+  grooming (curation) previously ran on a timer; it now runs only when you click
+  **Run now** or when intake has changed enough memories to warrant it. After an
+  intake sweep, if intake has created/augmented/superseded at least
+  `curator.grooming.trigger_threshold` memories (default 20) since the last groom,
+  one grooming run is enqueued — rate-limited so it never auto-runs within
+  `curator.grooming.debounce_minutes` (default 60, seeded once from your old
+  `curator.interval_minutes`) of the previous one. Due-slice idempotency is
+  unchanged, so a triggered groom still only reprocesses slices whose input
+  actually changed. The wall-clock cron (`LIBRARIAN_CURATOR_TICK_MS`) is retired.
+
 ### Removed
 
 - **Dashboard `/logs` and `/recall` pages removed.** Both rendered the

--- a/apps/dashboard/tests/components/curator/cockpit-actions.test.tsx
+++ b/apps/dashboard/tests/components/curator/cockpit-actions.test.tsx
@@ -52,6 +52,8 @@ const config: CuratorConfig = {
   defaultAutoApply: "safe_only",
   autoApplyConfidence: 0.9,
   intervalMinutes: 60,
+  triggerThreshold: 20,
+  debounceMinutes: 60,
 };
 
 describe("CuratorConfigForm", () => {

--- a/apps/dashboard/tests/components/curator/cockpit.test.tsx
+++ b/apps/dashboard/tests/components/curator/cockpit.test.tsx
@@ -11,6 +11,8 @@ function config(over: Partial<CuratorConfig> = {}): CuratorConfig {
     defaultAutoApply: "safe_only",
     autoApplyConfidence: 0.9,
     intervalMinutes: 60,
+    triggerThreshold: 20,
+    debounceMinutes: 60,
     ...over,
   };
 }

--- a/packages/core/src/consolidator-tick.ts
+++ b/packages/core/src/consolidator-tick.ts
@@ -17,6 +17,7 @@ import {
   resolveConsumerToken,
 } from "./curator-consumers.js";
 import { type LlmClient, createCuratorLlmClient } from "./curator-llm-client.js";
+import { maybeTriggerGroomingAfterIntake } from "./grooming-trigger.js";
 import type { LibrarianStore } from "./store/librarian-store.js";
 
 export type ConsolidatorTickSkipReason = "incomplete_config" | "no_token";
@@ -35,6 +36,15 @@ export interface ConsolidatorTickOptions {
     conn: { endpoint: string; model: string; timeoutMs: number },
     token: string,
   ) => LlmClient;
+  /**
+   * Post-intake grooming trigger (spec 043 D-A). After the sweep + decision log,
+   * check the threshold/debounce and enqueue a `post_intake` groom if armed. Default
+   * on; set false to suppress (e.g. when a separate process owns grooming). The hook
+   * is fail-soft — it can never fail the sweep. Injectable for tests.
+   */
+  triggerGrooming?: boolean | ((store: LibrarianStore) => Promise<unknown>);
+  /** Trigger evaluation time (debounce math); defaults to now. Mostly for tests. */
+  now?: Date;
 }
 
 export async function runConsolidatorTick(
@@ -74,5 +84,26 @@ export async function runConsolidatorTick(
     ...(options.thresholds ? { thresholds: options.thresholds } : {}),
     ...(options.lockTtlMs !== undefined ? { lockTtlMs: options.lockTtlMs } : {}),
   });
+
+  // Post-intake grooming trigger (spec 043 D-A) — the natural seam: the sweep is done
+  // and its C1 decision log is written, so the applied-op count is complete. Fail-soft
+  // by contract (intake is the hot path — AGENTS.md "never block the user's turn"): the
+  // hook swallows its own errors, and we still guard the call so nothing here can fail
+  // the sweep that already succeeded.
+  if (options.triggerGrooming !== false) {
+    try {
+      await maybeTriggerGroomingAfterIntake({
+        store,
+        ...(options.now !== undefined ? { now: options.now } : {}),
+        ...(typeof options.triggerGrooming === "function"
+          ? { runGroom: options.triggerGrooming }
+          : {}),
+      });
+    } catch {
+      /* unreachable — maybeTriggerGroomingAfterIntake is itself fail-soft — but the
+         sweep must never fail on the trigger, belt-and-braces. */
+    }
+  }
+
   return { ran: true, summary };
 }

--- a/packages/core/src/curator-config.ts
+++ b/packages/core/src/curator-config.ts
@@ -21,6 +21,13 @@ const KEYS = {
   defaultAutoApply: "curator.default_auto_apply",
   autoApplyConfidence: "curator.auto_apply_confidence",
   intervalMinutes: "curator.interval_minutes",
+  // Post-intake threshold trigger (spec 043 D-A/D-D). Grooming no longer runs on a
+  // wall-clock cron — it's triggered after an intake sweep crosses a threshold:
+  triggerThreshold: "curator.grooming.trigger_threshold",
+  // The repurposed interval (D-A): a debounce FLOOR, not a cadence — never
+  // auto-trigger a groom within this many minutes of the last one. Seeded from the
+  // legacy curator.interval_minutes at migration (see migrateCuratorEnablement).
+  debounceMinutes: "curator.grooming.debounce_minutes",
 } as const;
 
 // Unified curator enablement keys (spec 043 D-E). BOTH jobs' on/off flags now
@@ -55,13 +62,40 @@ const DEFAULT_INTERVAL_MINUTES = 60;
 const MIN_INTERVAL_MINUTES = 1;
 const MAX_INTERVAL_MINUTES = 7 * 24 * 60; // one week
 
+// Post-intake threshold trigger defaults (spec 043 D-A/D-D).
+//
+// trigger_threshold = the number of memories created/augmented/superseded by intake
+// since the last groom that arms one grooming run. Default 20: a meaningful burst of
+// new knowledge (a session's worth of ingestion) without grooming after every trickle.
+// debounce_minutes = the repurposed interval default (60) — at most one auto-groom per
+// hour regardless of how many sweeps cross the threshold.
+const DEFAULT_TRIGGER_THRESHOLD = 20;
+const MIN_TRIGGER_THRESHOLD = 1;
+const DEFAULT_DEBOUNCE_MINUTES = DEFAULT_INTERVAL_MINUTES;
+const MIN_DEBOUNCE_MINUTES = MIN_INTERVAL_MINUTES;
+const MAX_DEBOUNCE_MINUTES = MAX_INTERVAL_MINUTES;
+
 export interface CuratorConfig {
   enabled: boolean;
   promptAddendum: string;
   defaultAutoApply: AutoApplyLevel;
   autoApplyConfidence: number;
-  /** Whole minutes between scheduled runs (§12.4). */
+  /**
+   * Legacy whole-minutes interval (§12.4). Retired as a cadence (D-A removed the
+   * wall-clock cron); kept on the config for back-compat + as the seed source for
+   * debounceMinutes. The trigger uses debounceMinutes, not this.
+   */
   intervalMinutes: number;
+  /**
+   * Post-intake threshold (spec 043 D-A): the count of memories created/augmented/
+   * superseded by intake since the last groom that arms one grooming run.
+   */
+  triggerThreshold: number;
+  /**
+   * Debounce floor in whole minutes (spec 043 D-A): never auto-trigger a groom
+   * within this window of the last one. Seeded from the legacy intervalMinutes.
+   */
+  debounceMinutes: number;
 }
 
 export interface CuratorConfigPatch {
@@ -70,6 +104,8 @@ export interface CuratorConfigPatch {
   defaultAutoApply?: AutoApplyLevel;
   autoApplyConfidence?: number;
   intervalMinutes?: number;
+  triggerThreshold?: number;
+  debounceMinutes?: number;
 }
 
 // Input validation for the admin API. Permissive shape (all optional); the deeper
@@ -81,6 +117,8 @@ export const CuratorConfigPatchSchema = z.strictObject({
   defaultAutoApply: z.enum(["off", "safe_only", "high_confidence"]).optional(),
   autoApplyConfidence: z.number().optional(),
   intervalMinutes: z.number().optional(),
+  triggerThreshold: z.number().optional(),
+  debounceMinutes: z.number().optional(),
 });
 
 // The slices of the store this module needs. Curator-specific keys are all plain
@@ -109,6 +147,11 @@ export function readCuratorConfig(store: ConfigReader): CuratorConfig {
       DEFAULT_CONFIDENCE,
     ),
     intervalMinutes: parseNumber(store.getSetting(KEYS.intervalMinutes), DEFAULT_INTERVAL_MINUTES),
+    triggerThreshold: parseNumber(
+      store.getSetting(KEYS.triggerThreshold),
+      DEFAULT_TRIGGER_THRESHOLD,
+    ),
+    debounceMinutes: parseNumber(store.getSetting(KEYS.debounceMinutes), DEFAULT_DEBOUNCE_MINUTES),
   };
 }
 
@@ -174,6 +217,18 @@ export function migrateCuratorEnablement(
       store.setSetting(INTAKE_ENABLED_KEY, "true");
     }
   }
+  // Debounce floor (spec 043 D-A): the cron is retired and curator.interval_minutes
+  // is repurposed as the auto-trigger debounce. Seed curator.grooming.debounce_minutes
+  // from the legacy interval ONCE so an install's existing cadence becomes its debounce
+  // floor; never clobber an explicit debounce value (same seed-once/no-clobber pattern
+  // as the enablement keys). A fresh install with no interval leaves debounce unset →
+  // the DEFAULT_DEBOUNCE_MINUTES default.
+  if (store.getSetting(KEYS.debounceMinutes) === null) {
+    const legacyInterval = store.getSetting(KEYS.intervalMinutes);
+    if (legacyInterval !== null) {
+      store.setSetting(KEYS.debounceMinutes, legacyInterval);
+    }
+  }
 }
 
 export function writeCuratorConfig(store: ConfigWriter, patch: CuratorConfigPatch): void {
@@ -200,6 +255,20 @@ export function writeCuratorConfig(store: ConfigWriter, patch: CuratorConfigPatc
       );
     }
   }
+  if (patch.triggerThreshold !== undefined) {
+    const t = patch.triggerThreshold;
+    if (!Number.isInteger(t) || t < MIN_TRIGGER_THRESHOLD) {
+      throw new Error(`trigger_threshold must be an integer ≥ ${MIN_TRIGGER_THRESHOLD}`);
+    }
+  }
+  if (patch.debounceMinutes !== undefined) {
+    const m = patch.debounceMinutes;
+    if (!Number.isInteger(m) || m < MIN_DEBOUNCE_MINUTES || m > MAX_DEBOUNCE_MINUTES) {
+      throw new Error(
+        `debounce_minutes must be an integer between ${MIN_DEBOUNCE_MINUTES} and ${MAX_DEBOUNCE_MINUTES} (1 minute and one week)`,
+      );
+    }
+  }
 
   if (patch.enabled !== undefined) store.setSetting(KEYS.enabled, patch.enabled ? "true" : "false");
   if (patch.promptAddendum !== undefined)
@@ -210,4 +279,8 @@ export function writeCuratorConfig(store: ConfigWriter, patch: CuratorConfigPatc
     store.setSetting(KEYS.autoApplyConfidence, String(patch.autoApplyConfidence));
   if (patch.intervalMinutes !== undefined)
     store.setSetting(KEYS.intervalMinutes, String(patch.intervalMinutes));
+  if (patch.triggerThreshold !== undefined)
+    store.setSetting(KEYS.triggerThreshold, String(patch.triggerThreshold));
+  if (patch.debounceMinutes !== undefined)
+    store.setSetting(KEYS.debounceMinutes, String(patch.debounceMinutes));
 }

--- a/packages/core/src/curator-enqueue.ts
+++ b/packages/core/src/curator-enqueue.ts
@@ -29,9 +29,14 @@ import type { RunCurationCaps } from "./curator-worker.js";
 import { runCuration } from "./curator-worker.js";
 import type { LibrarianStore } from "./store/librarian-store.js";
 
-// The only valid run triggers (§12). schedule = the clock; manual = admin run-now;
-// maintenance = trusted internal code. No agent-reachable trigger exists.
-export type CuratorTrigger = "schedule" | "manual" | "maintenance";
+// The only valid run triggers (§12). manual = admin run-now; maintenance = trusted
+// internal code; post_intake = the spec 043 D-A threshold trigger (a groom enqueued
+// after an intake sweep crosses curator.grooming.trigger_threshold). schedule is the
+// retired wall-clock cron — kept as the historical default of runCuratorTick /
+// runDueCuration so existing call-sites and run records don't churn, but nothing
+// schedules on a timer any more (043 D-A removed the curator createSerialScheduler).
+// No agent-reachable trigger exists.
+export type CuratorTrigger = "schedule" | "manual" | "maintenance" | "post_intake";
 
 // A run still "running" past this age is treated as a crashed-worker lock and
 // reclaimed. Set well above the worst-case run time so a live run is never

--- a/packages/core/src/grooming-trigger.ts
+++ b/packages/core/src/grooming-trigger.ts
@@ -1,0 +1,127 @@
+// Post-intake grooming trigger (spec 043 D-A/D-D). Grooming no longer runs on a
+// wall-clock cron — it is TRIGGERED. Besides the admin `runNow` (manual), the one
+// automatic trigger is this: after an intake (consolidator) sweep completes and its
+// decision log is written, count the memories intake created/augmented/superseded
+// since the last groom; if that count ≥ `curator.grooming.trigger_threshold` AND we
+// are outside the `curator.grooming.debounce_minutes` window of the last groom,
+// enqueue EXACTLY ONE grooming run tagged `trigger:"post_intake"`.
+//
+// `runCuratorTick` + the due-slice input-hash idempotency are unchanged, so a
+// triggered groom only runs the slices whose input actually changed — repeated
+// triggers on unchanged input are cheap no-ops. The debounce is a rate-limit (a
+// floor between auto-groom enqueues), NOT a scheduler.
+//
+// This module is the pure decision (`evaluateGroomingTrigger`) plus a fail-soft
+// driver (`maybeTriggerGroomingAfterIntake`) the consolidator tick calls. The hook
+// is fail-soft by contract: per AGENTS.md intake is the hot path, so a trigger or
+// enqueue failure must NEVER fail the sweep — it logs and moves on.
+
+import { readCuratorConfig } from "./curator-config.js";
+import { runCuratorTick } from "./curator-tick.js";
+import type { CurationStore } from "./store/curation-store.js";
+import type { LibrarianStore } from "./store/librarian-store.js";
+
+/** The reference time of the last groom (the newest curation run's created_at). */
+type LastGroomReader = Pick<CurationStore, "listCurationRuns">;
+
+export interface GroomingTriggerInputs {
+  /** curator.grooming.trigger_threshold — the armed count (≥ 1). */
+  threshold: number;
+  /** curator.grooming.debounce_minutes — the auto-trigger floor (≥ 1). */
+  debounceMinutes: number;
+  /** Created_at of the most recent grooming run, or null if none ever ran. */
+  lastGroomAt: string | null;
+  /** Applied intake ops recorded since `lastGroomAt` (exclusive). */
+  appliedSinceLastGroom: number;
+  /** The moment we're evaluating at (the just-finished sweep's completion time). */
+  now: Date;
+}
+
+export type GroomingTriggerDecision =
+  | { trigger: true }
+  | { trigger: false; reason: "below_threshold" | "debounced" };
+
+/**
+ * The pure threshold + debounce arithmetic. Triggers iff the applied-op count has
+ * reached the threshold AND we are outside the debounce window of the last groom.
+ * Debounce is checked first only for a clearer `reason`; both must hold.
+ *
+ * Debounce boundary: a groom exactly `debounceMinutes` after the last is allowed
+ * (the window is `[lastGroomAt, lastGroomAt + debounceMinutes)` — `<` not `≤`), so
+ * the floor is "at least N minutes apart". No prior groom (`lastGroomAt === null`)
+ * means the debounce never applies.
+ */
+export function evaluateGroomingTrigger(input: GroomingTriggerInputs): GroomingTriggerDecision {
+  if (input.appliedSinceLastGroom < input.threshold) {
+    return { trigger: false, reason: "below_threshold" };
+  }
+  if (input.lastGroomAt !== null) {
+    const elapsedMs = input.now.getTime() - new Date(input.lastGroomAt).getTime();
+    const windowMs = input.debounceMinutes * 60_000;
+    // Guard a malformed timestamp (NaN) by treating it as "outside the window" —
+    // failing open here is safe (the threshold already gated us) and avoids
+    // suppressing a legitimate groom on a corrupt log entry.
+    if (Number.isFinite(elapsedMs) && elapsedMs < windowMs) {
+      return { trigger: false, reason: "debounced" };
+    }
+  }
+  return { trigger: true };
+}
+
+export interface MaybeTriggerGroomingOptions {
+  store: LibrarianStore;
+  /** Evaluation time; defaults to now. The sweep just completed, so ~now is correct. */
+  now?: Date;
+  /** Surfaced for debug only — never rethrown (the hook is fail-soft). */
+  onError?: (error: unknown) => void;
+  /** Injectable groom runner (defaults to runCuratorTick) — for tests. */
+  runGroom?: (store: LibrarianStore) => Promise<unknown>;
+}
+
+export type MaybeTriggerGroomingResult =
+  | { triggered: true }
+  | { triggered: false; reason: "below_threshold" | "debounced" | "error" };
+
+/**
+ * Fail-soft post-intake hook: read the config + the last-groom time + the applied-op
+ * count, decide via `evaluateGroomingTrigger`, and enqueue ONE grooming run when
+ * armed. Any failure (read, decide, or enqueue) is swallowed → `{triggered:false,
+ * reason:"error"}` so it can NEVER fail the intake sweep that called it.
+ *
+ * The groom is awaited so a synchronous test sees the run; in production the
+ * consolidator tick already awaits the whole sweep, and the groom's own due-slice
+ * idempotency keeps it cheap.
+ */
+export async function maybeTriggerGroomingAfterIntake(
+  options: MaybeTriggerGroomingOptions,
+): Promise<MaybeTriggerGroomingResult> {
+  const { store } = options;
+  try {
+    const config = readCuratorConfig(store);
+    const lastGroomAt = lastGroomTimestamp(store);
+    const appliedSinceLastGroom = store.countAppliedOperationsSince(lastGroomAt);
+
+    const decision = evaluateGroomingTrigger({
+      threshold: config.triggerThreshold,
+      debounceMinutes: config.debounceMinutes,
+      lastGroomAt,
+      appliedSinceLastGroom,
+      now: options.now ?? new Date(),
+    });
+    if (!decision.trigger) return { triggered: false, reason: decision.reason };
+
+    const runGroom =
+      options.runGroom ??
+      ((s: LibrarianStore) => runCuratorTick({ store: s, trigger: "post_intake" }));
+    await runGroom(store);
+    return { triggered: true };
+  } catch (error) {
+    options.onError?.(error);
+    return { triggered: false, reason: "error" };
+  }
+}
+
+/** Newest grooming run's created_at, or null when none has ever run. */
+function lastGroomTimestamp(store: LastGroomReader): string | null {
+  return store.listCurationRuns({ limit: 1 })[0]?.created_at ?? null;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -89,6 +89,14 @@ export {
   runConsolidatorTick,
 } from "./consolidator-tick.js";
 export {
+  type GroomingTriggerDecision,
+  type GroomingTriggerInputs,
+  type MaybeTriggerGroomingOptions,
+  type MaybeTriggerGroomingResult,
+  evaluateGroomingTrigger,
+  maybeTriggerGroomingAfterIntake,
+} from "./grooming-trigger.js";
+export {
   type SerialScheduler,
   type SerialSchedulerOptions,
   createSerialScheduler,

--- a/packages/core/src/store/consolidation-types.ts
+++ b/packages/core/src/store/consolidation-types.ts
@@ -91,6 +91,16 @@ export interface ConsolidationStore {
     input: RecordConsolidationOperationInput,
   ) => ConsolidationOperation;
   getConsolidationOperations: (runId: string) => ConsolidationOperation[];
+  /**
+   * Count `applied` intake operations recorded since `sinceIso` (exclusive) — the
+   * memories intake actually created/augmented/superseded after the last groom.
+   * Drives grooming's post-intake threshold trigger (spec 043 D-A). Membership is
+   * by the OWNING RUN's created_at: an op counts when its run was created strictly
+   * after `sinceIso`. `null` (no prior groom) counts every applied op. Only
+   * `applied` ops — proposed/skipped/failed didn't change the corpus, so they don't
+   * arm a groom.
+   */
+  countAppliedOperationsSince: (sinceIso: string | null) => number;
   // Lifecycle transitions — mirror the curation store's run guards exactly.
   startConsolidationRun: (id: string) => ConsolidationRun;
   completeConsolidationRun: (id: string, input?: CompleteConsolidationRunInput) => ConsolidationRun;

--- a/packages/core/src/store/sidecar/consolidation-store.ts
+++ b/packages/core/src/store/sidecar/consolidation-store.ts
@@ -133,6 +133,20 @@ export function createJsonConsolidationStore(deps: JsonConsolidationStoreDeps): 
       .sort((a, b) => a.id.localeCompare(b.id));
   }
 
+  function countAppliedOperationsSince(sinceIso: string | null): number {
+    const { runs, operations } = readAll();
+    // An op's time is its owning run's created_at (ops carry no timestamp; the sweep
+    // that produced them is the natural time unit, and grooming is enqueued only
+    // AFTER a sweep's log is written, so the run boundary is clean — no double-count
+    // and no off-by-one at the groom timestamp, which we exclude via strict `>`).
+    return Object.values(operations).filter((op) => {
+      if (op.outcome !== "applied") return false;
+      const createdAt = runs[op.run_id]?.created_at;
+      if (createdAt === undefined) return false; // orphan op (run pruned) — don't count
+      return sinceIso === null || createdAt > sinceIso;
+    }).length;
+  }
+
   function requireRun(id: string): ConsolidationRun {
     const run = getConsolidationRun(id);
     if (!run) throw new Error(`No consolidation run found for id ${id}`);
@@ -190,6 +204,7 @@ export function createJsonConsolidationStore(deps: JsonConsolidationStoreDeps): 
     listConsolidationRuns,
     recordConsolidationOperation,
     getConsolidationOperations,
+    countAppliedOperationsSince,
     startConsolidationRun,
     completeConsolidationRun,
     failConsolidationRun,

--- a/packages/core/tests/consolidator-grooming-trigger.test.ts
+++ b/packages/core/tests/consolidator-grooming-trigger.test.ts
@@ -1,0 +1,239 @@
+// Post-intake grooming trigger — integration (spec 043 D-A). Grooming no longer
+// runs on a wall-clock cron; after an intake sweep crosses
+// curator.grooming.trigger_threshold (and outside the debounce window of the last
+// groom), runConsolidatorTick enqueues exactly ONE grooming run tagged
+// `trigger:"post_intake"`. These tests drive the REAL store: a real intake sweep
+// files real memories, the real countAppliedOperationsSince + config + last-groom
+// timestamp decide, and a real post_intake curation run is recorded. The grooming
+// LLM is a network-free injected no-op so no provider is contacted.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type LibrarianStore,
+  type LlmClient,
+  addProvider,
+  createLibrarianStore,
+  resolveSecretKey,
+  runConsolidatorTick,
+  runCuratorTick,
+  writeConsumerConfig,
+  writeCuratorConfig,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Assemble the 64-hex master key at runtime — no secret-shaped literal in source.
+const KEY = resolveSecretKey("0123456789abcdef".repeat(4));
+
+let store: LibrarianStore | null = null;
+let dataDir = "";
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-groom-trigger-"));
+  store = createLibrarianStore({ dataDir, backend: "markdown", secretKey: KEY });
+});
+afterEach(() => {
+  try {
+    store?.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  store = null;
+});
+
+// An intake judge that files every submission as a fresh `create` (auto-applied at
+// confidence ≥ 0.95 → an `applied` op in the decision log).
+function createIntakeClient(): LlmClient {
+  let n = 0;
+  return {
+    complete: async () => {
+      n += 1;
+      return {
+        content: JSON.stringify({
+          action: "create",
+          title: `Topic ${n}`,
+          body: `Body ${n}.`,
+          tags: [],
+          rationale: "novel topic",
+          confidence: 0.97,
+        }),
+        model: "m",
+        usage: null,
+      };
+    },
+  };
+}
+
+// A grooming judge that proposes nothing — the run still records (a real post_intake
+// curation run), but it makes no corpus change. Network-free.
+const groomingNoOpClient: LlmClient = {
+  complete: async () => ({ content: JSON.stringify({ operations: [] }), model: "m", usage: null }),
+};
+
+function configureIntake() {
+  const provider = addProvider(store!, {
+    name: "intake-provider",
+    endpoint: "https://intake.example/v1",
+    token: "dummy-intake-token",
+  });
+  writeConsumerConfig(store!, "intake", { providerId: provider.id, model: "gpt-x" });
+}
+
+function configureGrooming() {
+  const provider = addProvider(store!, {
+    name: "grooming-provider",
+    endpoint: "https://grooming.example/v1",
+    token: "dummy-grooming-token",
+  });
+  writeConsumerConfig(store!, "grooming", { providerId: provider.id, model: "gpt-y" });
+  writeCuratorConfig(store!, { enabled: true });
+}
+
+// Seed a common-project memory so grooming has a due slice to run.
+function seedMemory() {
+  store!.createMemory({
+    agent_id: "agent-a",
+    title: "seed",
+    body: "seed body",
+    category: "lessons",
+    visibility: "common",
+    scope: "project",
+    project_key: "proj-x",
+    priority: "normal",
+    confidence: "working",
+  });
+}
+
+// A groom ENQUEUE spy: one call == one triggered groom (one runCuratorTick), which
+// is the unit the spec means by "exactly one grooming run". A single enqueue may run
+// several due slices (so several curation-run ROWS); the trigger fires once. We assert
+// on the enqueue count, and separately that the resulting runs are tagged post_intake.
+function groomSpy() {
+  return vi.fn((s: LibrarianStore) =>
+    runCuratorTick({ store: s, trigger: "post_intake", buildClient: () => groomingNoOpClient }),
+  );
+}
+
+// Run an intake sweep that files `count` items, routing grooming through the
+// network-free no-op client (via the injected triggerGrooming runner). `now` is the
+// trigger's debounce-evaluation time (defaults to real now).
+async function sweepFiling(
+  count: number,
+  runGroom: (s: LibrarianStore) => Promise<unknown>,
+  now?: Date,
+) {
+  for (let i = 0; i < count; i += 1) store!.submitToInbox(`Submission ${i} ${Math.random()}`);
+  return runConsolidatorTick({
+    store: store!,
+    buildClient: () => createIntakeClient(),
+    triggerGrooming: runGroom,
+    ...(now ? { now } : {}),
+  });
+}
+
+function postIntakeRuns() {
+  return store!.listCurationRuns().filter((r) => r.trigger === "post_intake");
+}
+
+describe("post-intake grooming trigger — threshold", () => {
+  it("an intake burst crossing the threshold triggers grooming exactly once", async () => {
+    seedMemory();
+    configureIntake();
+    configureGrooming();
+    writeCuratorConfig(store!, { triggerThreshold: 3, debounceMinutes: 60 });
+
+    const groom = groomSpy();
+    const result = await sweepFiling(3, groom);
+
+    expect(result).toMatchObject({ ran: true, summary: { consolidated: 3 } });
+    // Exactly one enqueue — the trigger fired once.
+    expect(groom).toHaveBeenCalledTimes(1);
+    // …and every grooming run it produced is tagged post_intake.
+    expect(postIntakeRuns().length).toBeGreaterThanOrEqual(1);
+    expect(store!.listCurationRuns().every((r) => r.trigger === "post_intake")).toBe(true);
+  });
+
+  it("a sub-threshold intake burst does NOT trigger grooming", async () => {
+    seedMemory();
+    configureIntake();
+    configureGrooming();
+    writeCuratorConfig(store!, { triggerThreshold: 5, debounceMinutes: 60 });
+
+    const groom = groomSpy();
+    await sweepFiling(2, groom); // below the threshold of 5
+
+    expect(groom).not.toHaveBeenCalled();
+    expect(postIntakeRuns()).toHaveLength(0);
+  });
+});
+
+describe("post-intake grooming trigger — debounce", () => {
+  it("suppresses a second trigger within the debounce window", async () => {
+    seedMemory();
+    configureIntake();
+    configureGrooming();
+    writeCuratorConfig(store!, { triggerThreshold: 2, debounceMinutes: 60 });
+
+    const groom = groomSpy();
+    // First burst → one enqueue.
+    await sweepFiling(2, groom);
+    expect(groom).toHaveBeenCalledTimes(1);
+
+    // Second burst immediately after, still inside the 60-min debounce → suppressed.
+    await sweepFiling(2, groom);
+    expect(groom).toHaveBeenCalledTimes(1); // still one — no second enqueue
+  });
+
+  it("allows a second trigger once the debounce window has elapsed", async () => {
+    seedMemory();
+    configureIntake();
+    configureGrooming();
+    writeCuratorConfig(store!, { triggerThreshold: 2, debounceMinutes: 1 });
+
+    const groom = groomSpy();
+    await sweepFiling(2, groom);
+    expect(groom).toHaveBeenCalledTimes(1);
+
+    // A second armed burst, evaluated 5 minutes later (> the 1-min debounce floor).
+    await sweepFiling(2, groom, new Date(Date.now() + 5 * 60_000));
+    expect(groom).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("post-intake grooming trigger — fail-soft (intake is the hot path)", () => {
+  it("a throwing grooming trigger does NOT fail the intake sweep", async () => {
+    configureIntake();
+    configureGrooming();
+    writeCuratorConfig(store!, { triggerThreshold: 1 });
+    store!.submitToInbox("a submission");
+
+    const result = await runConsolidatorTick({
+      store: store!,
+      buildClient: () => createIntakeClient(),
+      triggerGrooming: () => {
+        throw new Error("groom enqueue boom");
+      },
+    });
+
+    // The sweep still succeeded — the trigger failure was swallowed.
+    expect(result).toMatchObject({ ran: true, summary: { consolidated: 1 } });
+  });
+
+  it("can be disabled entirely (triggerGrooming:false) — no groom enqueued", async () => {
+    seedMemory();
+    configureIntake();
+    configureGrooming();
+    writeCuratorConfig(store!, { triggerThreshold: 1 });
+    store!.submitToInbox("a submission");
+
+    await runConsolidatorTick({
+      store: store!,
+      buildClient: () => createIntakeClient(),
+      triggerGrooming: false, // explicitly off — no groom, even above threshold
+    });
+
+    expect(postIntakeRuns()).toHaveLength(0);
+  });
+});

--- a/packages/core/tests/curator-config.test.ts
+++ b/packages/core/tests/curator-config.test.ts
@@ -58,6 +58,28 @@ describe("curator config", () => {
     expect(cfg.defaultAutoApply).toBe("safe_only");
     expect(cfg.autoApplyConfidence).toBeCloseTo(0.9);
     expect(cfg.intervalMinutes).toBe(60);
+    // Post-intake trigger defaults (spec 043 D-A): a 20-op threshold + a 60-min
+    // debounce floor (the repurposed interval default).
+    expect(cfg.triggerThreshold).toBe(20);
+    expect(cfg.debounceMinutes).toBe(60);
+  });
+
+  it("round-trips trigger_threshold and rejects invalid values (≥ 1 integer)", () => {
+    const { store } = s!;
+    writeCuratorConfig(store, { triggerThreshold: 5 });
+    expect(readCuratorConfig(store).triggerThreshold).toBe(5);
+    expect(() => writeCuratorConfig(store, { triggerThreshold: 0 })).toThrow(/threshold/i);
+    expect(() => writeCuratorConfig(store, { triggerThreshold: -1 })).toThrow(/threshold/i);
+    expect(() => writeCuratorConfig(store, { triggerThreshold: 2.5 })).toThrow(/threshold/i);
+  });
+
+  it("round-trips debounce_minutes and clamps invalid values (1..one week)", () => {
+    const { store } = s!;
+    writeCuratorConfig(store, { debounceMinutes: 30 });
+    expect(readCuratorConfig(store).debounceMinutes).toBe(30);
+    expect(() => writeCuratorConfig(store, { debounceMinutes: 0 })).toThrow(/debounce/i);
+    expect(() => writeCuratorConfig(store, { debounceMinutes: 10 * 24 * 60 })).toThrow(/debounce/i);
+    expect(() => writeCuratorConfig(store, { debounceMinutes: 1.5 })).toThrow(/debounce/i);
   });
 
   it("round-trips the non-LLM curator config", () => {

--- a/packages/core/tests/curator-enablement.test.ts
+++ b/packages/core/tests/curator-enablement.test.ts
@@ -195,4 +195,36 @@ describe("curator enablement migration (spec 043 D-E)", () => {
     expect(store.getSetting(GROOMING_ENABLED_KEY)).toBe("true");
     expect(readCuratorConfig(store).enabled).toBe(true);
   });
+
+  // ── Debounce seed: the repurposed interval becomes the auto-trigger floor (D-A) ──
+
+  it("seeds curator.grooming.debounce_minutes from the legacy interval_minutes", () => {
+    const { store } = s!;
+    store.setSetting("curator.interval_minutes", "45"); // an install's existing cadence
+    expect(readCuratorConfig(store).debounceMinutes).toBe(60); // not yet migrated → default
+
+    migrateCuratorEnablement(store);
+
+    expect(store.getSetting("curator.grooming.debounce_minutes")).toBe("45");
+    expect(readCuratorConfig(store).debounceMinutes).toBe(45);
+  });
+
+  it("never clobbers an explicit debounce value, and is idempotent", () => {
+    const { store } = s!;
+    store.setSetting("curator.interval_minutes", "45");
+    writeCuratorConfig(store, { debounceMinutes: 90 }); // user set it explicitly
+
+    migrateCuratorEnablement(store);
+    expect(readCuratorConfig(store).debounceMinutes).toBe(90); // preserved
+
+    migrateCuratorEnablement(store); // re-run → no drift
+    expect(readCuratorConfig(store).debounceMinutes).toBe(90);
+  });
+
+  it("leaves debounce unset (default) on a fresh install with no legacy interval", () => {
+    const { store } = s!;
+    migrateCuratorEnablement(store);
+    expect(store.getSetting("curator.grooming.debounce_minutes")).toBeNull();
+    expect(readCuratorConfig(store).debounceMinutes).toBe(60); // default
+  });
 });

--- a/packages/core/tests/grooming-trigger.test.ts
+++ b/packages/core/tests/grooming-trigger.test.ts
@@ -1,0 +1,95 @@
+// Post-intake grooming trigger arithmetic (spec 043 D-A). The pure decision:
+// trigger a groom iff applied-intake-ops-since-last-groom ≥ threshold AND we are
+// outside the debounce window of the last groom. These are the unit tests for the
+// threshold + debounce math; the integration (an intake burst triggers grooming
+// exactly once) lives in consolidator-grooming-trigger.test.ts.
+
+import { type GroomingTriggerInputs, evaluateGroomingTrigger } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+const base = (over: Partial<GroomingTriggerInputs> = {}): GroomingTriggerInputs => ({
+  threshold: 20,
+  debounceMinutes: 60,
+  lastGroomAt: null,
+  appliedSinceLastGroom: 0,
+  now: new Date("2026-06-06T12:00:00.000Z"),
+  ...over,
+});
+
+describe("evaluateGroomingTrigger — threshold", () => {
+  it("does not trigger below the threshold", () => {
+    expect(evaluateGroomingTrigger(base({ appliedSinceLastGroom: 19 }))).toEqual({
+      trigger: false,
+      reason: "below_threshold",
+    });
+  });
+
+  it("triggers exactly at the threshold (≥, no prior groom)", () => {
+    expect(evaluateGroomingTrigger(base({ appliedSinceLastGroom: 20 }))).toEqual({ trigger: true });
+  });
+
+  it("triggers above the threshold", () => {
+    expect(evaluateGroomingTrigger(base({ appliedSinceLastGroom: 100 }))).toEqual({
+      trigger: true,
+    });
+  });
+
+  it("honours a custom threshold", () => {
+    expect(evaluateGroomingTrigger(base({ threshold: 5, appliedSinceLastGroom: 4 }))).toMatchObject(
+      { trigger: false },
+    );
+    expect(evaluateGroomingTrigger(base({ threshold: 5, appliedSinceLastGroom: 5 }))).toEqual({
+      trigger: true,
+    });
+  });
+});
+
+describe("evaluateGroomingTrigger — debounce", () => {
+  const lastGroomAt = "2026-06-06T11:30:00.000Z"; // 30 min before `now`
+
+  it("suppresses a second trigger inside the debounce window", () => {
+    // 30 min since the last groom, debounce 60 → still inside the window.
+    expect(
+      evaluateGroomingTrigger(
+        base({ appliedSinceLastGroom: 100, lastGroomAt, debounceMinutes: 60 }),
+      ),
+    ).toEqual({ trigger: false, reason: "debounced" });
+  });
+
+  it("allows a trigger once the debounce window has elapsed", () => {
+    // 30 min since the last groom, debounce 30 → exactly at the floor, allowed (< not ≤).
+    expect(
+      evaluateGroomingTrigger(
+        base({ appliedSinceLastGroom: 100, lastGroomAt, debounceMinutes: 30 }),
+      ),
+    ).toEqual({ trigger: true });
+  });
+
+  it("allows a trigger well past the debounce window", () => {
+    expect(
+      evaluateGroomingTrigger(
+        base({ appliedSinceLastGroom: 100, lastGroomAt, debounceMinutes: 10 }),
+      ),
+    ).toEqual({ trigger: true });
+  });
+
+  it("never debounces when there is no prior groom", () => {
+    expect(
+      evaluateGroomingTrigger(base({ appliedSinceLastGroom: 100, lastGroomAt: null })),
+    ).toEqual({ trigger: true });
+  });
+
+  it("checks the threshold first: below threshold reports below_threshold even inside the window", () => {
+    expect(
+      evaluateGroomingTrigger(base({ appliedSinceLastGroom: 1, lastGroomAt, debounceMinutes: 60 })),
+    ).toEqual({ trigger: false, reason: "below_threshold" });
+  });
+
+  it("fails open on a malformed last-groom timestamp (does not suppress)", () => {
+    expect(
+      evaluateGroomingTrigger(
+        base({ appliedSinceLastGroom: 100, lastGroomAt: "not-a-date", debounceMinutes: 60 }),
+      ),
+    ).toEqual({ trigger: true });
+  });
+});

--- a/packages/core/tests/store/sidecar-consolidation-store.test.ts
+++ b/packages/core/tests/store/sidecar-consolidation-store.test.ts
@@ -163,6 +163,44 @@ describe("createJsonConsolidationStore — runs + operations", () => {
     expect(store.getConsolidationRun(r.id)).not.toBeNull();
   });
 
+  // ── countAppliedOperationsSince — drives the post-intake groom trigger (043 D-A) ──
+
+  it("counts only APPLIED ops, ignoring proposed/skipped/failed", () => {
+    const store = makeStore();
+    const r = store.createConsolidationRun(run());
+    store.recordConsolidationOperation(op({ run_id: r.id, outcome: "applied" }));
+    store.recordConsolidationOperation(op({ run_id: r.id, outcome: "applied" }));
+    store.recordConsolidationOperation(op({ run_id: r.id, outcome: "proposed" }));
+    store.recordConsolidationOperation(op({ run_id: r.id, outcome: "skipped" }));
+    store.recordConsolidationOperation(op({ run_id: r.id, outcome: "failed" }));
+
+    expect(store.countAppliedOperationsSince(null)).toBe(2);
+  });
+
+  it("counts ops only from runs created strictly AFTER the cutoff (no off-by-one at the boundary)", () => {
+    const store = makeStore();
+    // The clock advances per write; capture the boundary between two runs.
+    const before = store.createConsolidationRun(run()); // created_at tick 0
+    store.recordConsolidationOperation(op({ run_id: before.id, outcome: "applied" }));
+    const boundary = before.created_at; // = the groom's reference timestamp
+    const after = store.createConsolidationRun(run()); // created later than `boundary`
+    store.recordConsolidationOperation(op({ run_id: after.id, outcome: "applied" }));
+    store.recordConsolidationOperation(op({ run_id: after.id, outcome: "applied" }));
+
+    // Strictly-after: the op in `before` (created AT the boundary) is excluded.
+    expect(store.countAppliedOperationsSince(boundary)).toBe(2);
+    // A null cutoff counts everything.
+    expect(store.countAppliedOperationsSince(null)).toBe(3);
+  });
+
+  it("returns 0 when nothing applied since the cutoff", () => {
+    const store = makeStore();
+    const r = store.createConsolidationRun(run());
+    store.recordConsolidationOperation(op({ run_id: r.id, outcome: "applied" }));
+    // Cutoff in the future → no run is strictly after it.
+    expect(store.countAppliedOperationsSince("2099-01-01T00:00:00.000Z")).toBe(0);
+  });
+
   it("persists across store instances (sidecar durability)", () => {
     const filePath = path.join(dir, "consolidation-runs.json");
     const a = createJsonConsolidationStore({ filePath, now: clock });

--- a/packages/mcp-server/src/bin/http.ts
+++ b/packages/mcp-server/src/bin/http.ts
@@ -16,7 +16,6 @@ import {
   resolveDataDir,
   runBackupTick,
   runConsolidatorTick,
-  runCuratorTick,
   verifyAgentToken,
 } from "@librarian/core";
 import {
@@ -206,20 +205,13 @@ if (isLegacyConsolidatorEnvSet()) {
   );
 }
 
-// Memory-curator scheduler (§14): a serial tick that runs due slices on a cadence.
-// The tick self-gates on the admin config (disabled/incomplete → cheap no-op), so
-// it's safe to always start. Set LIBRARIAN_CURATOR_TICK_MS=0 to disable (e.g. when
-// a separate worker process owns curation). Default hourly; the per-slice
-// interval (curator.interval_minutes) is enforced inside the tick.
-const curatorTickMs = Number(process.env.LIBRARIAN_CURATOR_TICK_MS ?? 60 * 60_000);
-const curatorScheduler =
-  curatorTickMs > 0
-    ? createSerialScheduler({
-        task: () => runCuratorTick({ store }),
-        intervalMs: curatorTickMs,
-        onError: (error) => logger.error({ err: error }, "curator tick failed"),
-      })
-    : null;
+// Memory-curator scheduler: RETIRED (spec 043 D-A). Grooming no longer runs on a
+// wall-clock cron. It is triggered instead — by admin `runNow` (trpc/curator.ts) and
+// by the post-intake threshold (after an intake sweep crosses
+// curator.grooming.trigger_threshold; see grooming-trigger.ts, wired into
+// runConsolidatorTick). Due-slice input-hash idempotency is unchanged, so a triggered
+// groom only runs the slices whose input actually changed. The intake/backup
+// schedulers below are unaffected.
 
 // Scheduled backups: the tick self-gates on the dashboard-managed config
 // (`backup.schedule.*`) — disabled → cheap no-op — and runs a backup once the
@@ -261,7 +253,6 @@ const consolidatorScheduler =
     : null;
 
 server.listen(port, host, () => {
-  curatorScheduler?.start();
   backupScheduler?.start();
   consolidatorScheduler?.start();
   // Boot scan: process anything left in the inbox from a previous run, before
@@ -284,7 +275,6 @@ server.listen(port, host, () => {
 });
 
 function shutdown(): void {
-  curatorScheduler?.stop();
   backupScheduler?.stop();
   // Stop the consolidator timer before closing the store — a tick writes through
   // the same store, so it must not fire after store.close() (parity with above).


### PR DESCRIPTION
## Spec 043 PR-3 (Task C3) — retire the grooming cron → post-intake threshold trigger (decisions D-A + D-D)

Grooming no longer runs on a wall-clock cron. It is now **triggered**:
1. **admin `runNow`** (unchanged), and
2. a new **post-intake threshold trigger** — after a consolidator sweep + its decision-log write, count the memories intake *applied* (created/augmented/superseded) since the last groom (from the C1 `consolidation-runs` log); if that count ≥ `curator.grooming.trigger_threshold` **and** we're outside the `curator.grooming.debounce_minutes` window of the last groom, enqueue exactly one grooming run tagged `trigger:"post_intake"`.

### What changed
- **Removed** the grooming `createSerialScheduler` (`LIBRARIAN_CURATOR_TICK_MS`) from `bin/http.ts` — **only** that scheduler; the consolidator (intake) and backup schedulers are untouched.
- **New** `grooming-trigger.ts`: a pure `evaluateGroomingTrigger` (threshold + debounce arithmetic) + a **fail-soft** `maybeTriggerGroomingAfterIntake` driver. Per AGENTS.md (intake is the hot path), the hook can **never** fail the sweep — any read/decide/enqueue error is swallowed.
- **New config** under the unified `curator.grooming.*` namespace: `trigger_threshold` (default 20) + `debounce_minutes` (default 60, **seeded once** from the legacy `curator.interval_minutes`, no-clobber — same pattern as the C2 enablement migration).
- `CuratorTrigger` gains `"post_intake"`. `runConsolidatorTick` calls the hook at the natural seam (after the sweep + log), with an injectable `triggerGrooming` for tests.
- Due-slice input-hash idempotency is unchanged — a triggered groom only reprocesses slices whose input actually changed.

### Tests
- `grooming-trigger.test.ts` — threshold arms / debounce suppresses / boundary / null-last-groom / NaN-fails-open.
- `consolidator-grooming-trigger.test.ts` — integration: an intake burst triggers grooming exactly once; a second sweep within the debounce window does not.
- Full suite green locally: core 775 (+1 skip), mcp-server 119, dashboard 174; `pnpm -r build` clean (no `error TS`).

### Provenance note
Implementation was produced by an autonomous build agent whose shared-tree session was interrupted by a concurrent agent (a git-checkout race) before it committed. The work was salvaged intact onto this branch; the orchestrator then ran the full suite + build, conducted the multi-axis review (no Critical/Important findings), and added the CHANGELOG entry the interrupted run hadn't reached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)