### PR TITLE
feat(core): intake split — propose entity spin-out at ingestion (spec 043 PR-4, Task C4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ changes from this point forward are catalogued here.
 
 ### Added
 
+- **Intake can now propose splitting an overloaded memory at ingestion.** When a
+  new submission turns out to be primarily about a different, already
+  well-supported entity whose existing doc has become an overloaded grab-bag, the
+  intake judge can now propose a **split** — spinning that conflated doc into
+  focused per-entity docs. An intake split is **always a proposal for you to
+  approve, never applied automatically** (even at high confidence): intake lacks
+  grooming's whole-corpus context, so a human decides every split. The scope is
+  deliberately narrow to avoid over-fragmentation — a single-entity or
+  non-overloaded submission never splits, and the split target must be one of the
+  memories intake already retrieved as a candidate. (Grooming's existing split is
+  unchanged; both now share one underlying mechanism.)
+
 - **Dashboard-managed LLM providers with independent per-consumer model
   selection.** The curator's LLM connection is no longer a single hard-coded
   block — you now manage named LLM providers (name + endpoint + write-only API

--- a/packages/core/src/consolidator/apply.ts
+++ b/packages/core/src/consolidator/apply.ts
@@ -11,6 +11,7 @@
 
 import { redactSecrets } from "../curator-redaction.js";
 import type { InboxSubmissionHints } from "../store/corpus/inbox.js";
+import { type SplitReplacement, splitMemory } from "../store/split-memory.js";
 import { augmentBody, preservesOriginal } from "./edit.js";
 import type { ConsolidationPlan } from "./judge.js";
 
@@ -103,6 +104,33 @@ export function applyConsolidationPlan(
 
   try {
     if (plan.decision === "skip") return { kind: "skipped" };
+
+    // Split (spec 043 D-B) — ALWAYS a proposal, never auto-applied, regardless of
+    // the routed decision or confidence. Intake lacks grooming's whole-slice
+    // context, so a human approves every intake split. We spin the judge's focused
+    // replacements out as PROPOSED docs (requires_approval) that supersede the
+    // overloaded source candidate, and leave the source ACTIVE — the admin archives
+    // it on accept. The shared `splitMemory` primitive (the same one grooming uses)
+    // sequences the writes; omitting an archive actor is what keeps it propose-only.
+    if (plan.judgment.action === "split") {
+      const j = plan.judgment;
+      // The split target MUST be an existing candidate (the honest guard for
+      // intake's thinner context — no fabricated/navigated target).
+      if (!store.getMemory(j.target_id))
+        return { kind: "rejected", reason: "split target missing" };
+      const replacements: SplitReplacement[] = j.replacements.map((r) => ({
+        input: scope({ title: r.title, body: r.body, tags: r.tags }),
+        options: {
+          ...note({ proposed_action: "split", supersedes: [j.target_id] }),
+          requires_approval: true,
+        },
+      }));
+      // No archive actor → the source stays active (a PROPOSED split). The new
+      // proposal ids are the replacements; the outcome carries the SOURCE id so the
+      // decision log records the split's target candidate.
+      splitMemory(store, { sourceId: j.target_id, replacements });
+      return { kind: "proposed", id: j.target_id };
+    }
 
     // Uncertain merge / mid-confidence change → never touch an existing doc. File
     // the SUBMISSION as a fresh doc — active for create_new, or requires_approval

--- a/packages/core/src/consolidator/judge-step.ts
+++ b/packages/core/src/consolidator/judge-step.ts
@@ -24,7 +24,11 @@ import type { ConsolidationCandidates } from "./navigate.js";
 // cautious entity resolution, file-for-retrieval. v3 adds title-craft (a concise,
 // entity-first noun phrase — the title is also the filename) and a gatekeeping
 // bias: noop OBVIOUSLY transient / low-value submissions rather than clutter.
-export const CONSOLIDATOR_PROMPT_VERSION = "v3";
+// v4 adds a NARROWLY-scoped split (spec 043 D-B): propose spinning an overloaded
+// existing CANDIDATE doc into focused docs ONLY when the submission is primarily
+// about a different, already well-supported candidate entity — never fragment a
+// single-entity / non-overloaded submission.
+export const CONSOLIDATOR_PROMPT_VERSION = "v4";
 
 const SYSTEM_INSTRUCTIONS = `You are the Consolidator for The Librarian — the curator of a single owner's long-term memory. Think library, not logbook: your job is to file each new SUBMISSION into an evolving, interlinked body of knowledge so that it — and everything related to it — is findable later.
 
@@ -37,6 +41,7 @@ HOW TO CURATE — the judgement behind the choice:
 - File for RETRIEVAL, not just storage. A fact about two entities belongs under one of them, with a [[wikilink]] to the other (by its title/alias), so it is findable from either side — that is the whole point of a knowledge graph. Curate the way the fact will be recalled.
 - Minimal edit. Make the smallest change that captures what's new. augment's "addition" is ONLY the new content — never a rewrite, and never a restatement of what the doc already says.
 - Add, don't duplicate. If the submission says nothing the store doesn't already hold, noop. If it adds even a little that is genuinely new, augment.
+- Split SPARINGLY, and only to un-overload an EXISTING doc. Propose a split ONLY when this submission is primarily about a DIFFERENT, already well-supported entity that is ITSELF one of the candidates — i.e. a candidate doc has become an overloaded grab-bag conflating two distinct entities, and the right home for the submission is to spin that conflated doc into focused per-entity docs. A split's "target_id" MUST be one of the candidate ids. NEVER split a submission that is about a single entity, or one whose right entity is not already a strong candidate — that is over-fragmentation, the opposite of curation; augment or create instead. When in doubt, do NOT split.
 - File durable knowledge, not transient noise. Memory is for what will be worth recalling later: stable facts about people, projects, preferences, conventions, infrastructure, decisions. A submission that is OBVIOUSLY transient or low-value — a one-off task note, an already-resolved bug or typo, an ephemeral status update — has no lasting recall value, so noop it. (When the lasting value is genuinely unclear, file a lean note rather than discard — bias toward discarding only the obvious noise.)
 - Title for a human browsing the files. A doc's title is ALSO its filename, so make it a concise, specific noun phrase that NAMES the thing and leads with the entity (e.g. "Expend Team", "Trash Over rm", "Anna — Piano Teacher"). Avoid category prefixes ("Preference:", "Convention:", "Note:"), avoid colons, and avoid sentence- or status-style titles ("AI Engineering Progress: Exercise 01 Complete"). Aim for ~3–6 words.
 
@@ -45,10 +50,11 @@ OUTPUT CONTRACT — respond with a single JSON object and nothing else, exactly 
 - { "action": "augment", "target_id": string, "addition": string, "rationale": string, "confidence": number } — add the new information to an existing doc. "addition" is ONLY the new content to weave in; never restate or rewrite the existing doc (minimal-edit).
 - { "action": "supersede", "target_id": string, "title": string, "body": string, "rationale": string, "confidence": number } — the submission contradicts/updates an existing doc; give its full replacement.
 - { "action": "archive", "target_id": string, "rationale": string, "confidence": number } — an existing doc is now stale, with no replacement.
+- { "action": "split", "target_id": string, "replacements": [{ "title": string, "body": string, "tags": string[] }, …], "rationale": string, "confidence": number } — RARE. An existing CANDIDATE doc ("target_id") has become an overloaded grab-bag conflating ≥2 distinct entities, and this submission belongs to one of them; spin that doc into ≥2 focused per-entity docs ("replacements"). Use ONLY when the submission is primarily about a different, already well-supported candidate entity. "target_id" MUST be one of the CANDIDATE ids. Always proposed for a human to approve — never silently applied. Do NOT split a single-entity / non-overloaded submission.
 - { "action": "noop", "rationale": string, "confidence": number } — nothing worth filing: a duplicate, OR a submission that is obviously transient or low-value (a one-off task note, a resolved bug/typo, an ephemeral status) with no lasting recall value.
 
 RULES (re-checked in code after you respond — a judgment that breaks one is discarded):
-- "target_id" MUST be an id that appears in the EVIDENCE (a candidate or toc entry). Never invent an id.
+- "target_id" MUST be an id that appears in the EVIDENCE (a candidate or toc entry). Never invent an id. A split's "target_id" MUST be one of the CANDIDATES (not merely a toc entry) and it needs ≥2 "replacements".
 - Link related entities with [[wikilinks]] in "body"/"addition": write [[Title]] to point at another doc by its title.
 - Never put secrets or credentials in any field.
 - confidence is a number in [0, 1].

--- a/packages/core/src/consolidator/judge.ts
+++ b/packages/core/src/consolidator/judge.ts
@@ -59,6 +59,31 @@ const NoopJudgment = z.strictObject({
   rationale,
   confidence,
 });
+/**
+ * Split an overloaded existing doc into ≥2 focused docs (spec 043 D-B). NARROW:
+ * proposed only when the submission is primarily about a DIFFERENT, already
+ * well-supported entity that is itself among the candidates — so no navigate is
+ * needed and the split target is an existing candidate (never a fabricated id).
+ * Intake lacks grooming's whole-slice context, so an intake split is ALWAYS routed
+ * to a human PROPOSAL regardless of confidence (it never auto-applies) — see
+ * apply.ts. `target_id` is the overloaded doc; `replacements` are the focused docs
+ * it becomes.
+ */
+const SplitJudgment = z.strictObject({
+  action: z.literal("split"),
+  target_id: z.string().min(1),
+  replacements: z
+    .array(
+      z.strictObject({
+        title: z.string().min(1),
+        body: z.string().min(1),
+        tags: z.array(z.string()).default([]),
+      }),
+    )
+    .min(2),
+  rationale,
+  confidence,
+});
 
 export const ConsolidationJudgmentSchema = z.discriminatedUnion("action", [
   CreateJudgment,
@@ -66,6 +91,7 @@ export const ConsolidationJudgmentSchema = z.discriminatedUnion("action", [
   SupersedeJudgment,
   ArchiveJudgment,
   NoopJudgment,
+  SplitJudgment,
 ]);
 export type ConsolidationJudgment = z.infer<typeof ConsolidationJudgmentSchema>;
 
@@ -136,6 +162,13 @@ function decide(
     case "supersede":
     case "archive":
       return judgment.confidence >= t.autoApply ? "auto_apply" : "propose";
+    // Restructuring an existing doc into multiple docs is the highest-impact edit,
+    // and intake lacks grooming's whole-slice context (it sees one submission +
+    // K=8 candidates). So an intake split is ALWAYS a human PROPOSAL — never
+    // auto-applied, regardless of confidence (spec 043 D-B). A human approves every
+    // intake split. (Grooming may auto-apply a split per its own confidence rules.)
+    case "split":
+      return "propose";
   }
 }
 

--- a/packages/core/src/curator-apply.ts
+++ b/packages/core/src/curator-apply.ts
@@ -21,6 +21,7 @@ import type { CuratorMemoryPatch, CuratorOperation } from "./curator-output.js";
 import { redactSecrets } from "./curator-redaction.js";
 import type { ValidatedOperation, ValidationContext } from "./curator-validate.js";
 import type { RecordCurationOperationInput } from "./store/curation-store.js";
+import { type SplitReplacement, splitMemory } from "./store/split-memory.js";
 
 // The authoritative stored memory used to reconstruct a protected-update proposal.
 // Must come from the store (getMemory), NOT the evidence projection, which is
@@ -165,11 +166,15 @@ function applyOp(op: CuratorOperation, c: ExecContext): string[] {
       for (const id of op.source_memory_ids) c.store.archiveMemory(id, c.actorId);
       return [target];
     }
-    case "split": {
-      const targets = op.replacements.map((r) => createMemory(c, r, [op.source_memory_id]).id);
-      c.store.archiveMemory(op.source_memory_id, c.actorId);
-      return targets;
-    }
+    case "split":
+      // Auto-applied split: spin the replacements out, then archive the source.
+      // The shared primitive owns the create-then-archive ordering; pass the
+      // actor so it archives the superseded source (an apply, not a propose).
+      return splitMemory(c.store, {
+        sourceId: op.source_memory_id,
+        replacements: op.replacements.map((r) => buildCreateCall(c, r, [op.source_memory_id])),
+        archiveActorId: c.actorId,
+      });
     case "noop":
       // decideApply routes noop → skip; reaching here is a mis-route — fail loud.
       throw new Error("noop is not applicable");
@@ -189,7 +194,15 @@ function proposeOp(op: CuratorOperation, c: ExecContext): string[] {
     case "merge":
       return [createMemory(c, op.replacement, op.source_memory_ids, opts).id];
     case "split":
-      return op.replacements.map((r) => createMemory(c, r, [op.source_memory_id], opts).id);
+      // Proposed split: spin the replacements out at requires_approval (status
+      // proposed) but leave the source ACTIVE — the admin archives it after
+      // accepting (§11.1). No actor → the primitive does not archive the source.
+      return splitMemory(c.store, {
+        sourceId: op.source_memory_id,
+        replacements: op.replacements.map((r) =>
+          buildCreateCall(c, r, [op.source_memory_id], opts),
+        ),
+      });
     case "update": {
       // Reconstruct from the AUTHORITATIVE store record (not the redacted/truncated
       // evidence), so a patch that omits a field proposes the real existing value.
@@ -204,12 +217,16 @@ function proposeOp(op: CuratorOperation, c: ExecContext): string[] {
   }
 }
 
-function createMemory(
+// Build the createMemory `{ input, options }` for one memory the curator writes
+// (a create, a merge replacement, or a split replacement) WITHOUT executing it —
+// so the split primitive can sequence the writes. Owner + curator_note (run_id +
+// supersedes) + the optional requires_approval gate are baked in here.
+function buildCreateCall(
   c: ExecContext,
   memory: Record<string, unknown>,
   supersedes: string[],
   options: { requiresApproval?: boolean } = {},
-): { id: string } {
+): SplitReplacement {
   const curatorNote: Record<string, unknown> = { run_id: c.runId };
   if (supersedes.length > 0) curatorNote.supersedes = supersedes;
   const storeOptions: Record<string, unknown> = { curator_note: curatorNote };
@@ -219,7 +236,17 @@ function createMemory(
   // this unset and land at the conservative defaults the classifier
   // will overwrite.
   if (options.requiresApproval === true) storeOptions.requires_approval = true;
-  return c.store.createMemory({ ...memory, agent_id: c.owner }, storeOptions).memory;
+  return { input: { ...memory, agent_id: c.owner }, options: storeOptions };
+}
+
+function createMemory(
+  c: ExecContext,
+  memory: Record<string, unknown>,
+  supersedes: string[],
+  options: { requiresApproval?: boolean } = {},
+): { id: string } {
+  const call = buildCreateCall(c, memory, supersedes, options);
+  return c.store.createMemory(call.input, call.options).memory;
 }
 
 // Reconstruct the corrected memory for a protected update proposal: the patch

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -461,6 +461,12 @@ export {
   type ListConsolidationRunsInput,
   type RecordConsolidationOperationInput,
 } from "./store/consolidation-store.js";
+export {
+  type SplitMemoryRequest,
+  type SplitMemoryStore,
+  type SplitReplacement,
+  splitMemory,
+} from "./store/split-memory.js";
 export type { SettingMeta, SettingsStore } from "./store/settings-store.js";
 export type { ConversationStateStore } from "./store/conversation-state-store.js";
 export type { ConversationState, ConversationStatePatch } from "./schemas/conversation-state.js";

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -1,5 +1,6 @@
 export * from "./memory-store.js";
 export * from "./curation-store.js";
 export * from "./consolidation-store.js";
+export * from "./split-memory.js";
 export * from "./settings-store.js";
 export * from "./handoff-store.js";

--- a/packages/core/src/store/split-memory.ts
+++ b/packages/core/src/store/split-memory.ts
@@ -1,0 +1,66 @@
+// Shared "split" store primitive (spec 043 D-B). The mechanics of spinning a
+// source memory into N replacements live HERE, in one place, so the two curator
+// apply paths that perform a split — grooming (`curator-apply.ts`) and intake
+// (`consolidator/apply.ts`) — produce byte-identical results.
+//
+// What the primitive owns (the invariant both paths share):
+//   1. Create every replacement FIRST, collecting their ids.
+//   2. ONLY THEN, optionally, archive the source.
+// This create-then-archive ordering is the data-loss-safe one: on a partial
+// failure the source stays active (recoverable next run) rather than being lost
+// before its replacements exist (cf. the merge note in curator-apply.ts).
+//
+// What the primitive does NOT own (deliberately left to each caller, because the
+// two curators differ here): how each replacement's `createMemory` input + options
+// are built — the curator_note shape (grooming: { run_id, supersedes }; intake:
+// { source: "consolidator", rationale, … }), ownership/agent_id, and whether the
+// new rows land active or `requires_approval` (proposed). Each caller pre-builds
+// those `{ input, options }` pairs; the primitive only sequences the writes.
+//
+// Whether the source is archived is the propose-vs-apply switch: pass
+// `archiveActorId` to archive it (an auto-applied split supersedes its source);
+// omit it to leave the source untouched (a PROPOSED split — a human accepts and
+// archives the source later). Intake ALWAYS proposes, so it always omits it.
+
+/** The narrow store surface the split primitive mutates through. */
+export interface SplitMemoryStore {
+  createMemory: (
+    input: Record<string, unknown>,
+    options?: Record<string, unknown>,
+  ) => { memory: { id: string } };
+  archiveMemory: (id: string, agent_id?: string) => unknown;
+}
+
+/** One replacement to spin out of the source — a ready-to-write createMemory call. */
+export interface SplitReplacement {
+  input: Record<string, unknown>;
+  options?: Record<string, unknown>;
+}
+
+export interface SplitMemoryRequest {
+  /** The source memory being split. */
+  sourceId: string;
+  /** The replacements to create (each already scoped + carrying its supersedes note). */
+  replacements: SplitReplacement[];
+  /**
+   * When set, archive the source after ALL replacements are created (an
+   * auto-applied split). When omitted, the source is left active — a PROPOSED
+   * split, where a human archives the source after accepting the replacements.
+   */
+  archiveActorId?: string;
+}
+
+/**
+ * Execute a split: create every replacement, then (optionally) archive the
+ * source. Returns the new replacement memory ids, in input order. The ordering
+ * (create-all-then-archive) is the shared data-loss-safe invariant; the per-row
+ * `input`/`options` are the caller's (so grooming + intake stay independent in
+ * what they file, identical in how they file it).
+ */
+export function splitMemory(store: SplitMemoryStore, request: SplitMemoryRequest): string[] {
+  const targets = request.replacements.map((r) => store.createMemory(r.input, r.options).memory.id);
+  if (request.archiveActorId !== undefined) {
+    store.archiveMemory(request.sourceId, request.archiveActorId);
+  }
+  return targets;
+}

--- a/packages/core/tests/consolidator-apply.test.ts
+++ b/packages/core/tests/consolidator-apply.test.ts
@@ -276,3 +276,92 @@ describe("applyConsolidationPlan", () => {
     expect(out).toMatchObject({ reason: expect.stringContaining("Protected") });
   });
 });
+
+describe("applyConsolidationPlan — intake split (always proposed, never auto-applied)", () => {
+  const splitJudgment = {
+    action: "split" as const,
+    target_id: "mem_overloaded",
+    replacements: [
+      { title: "Anna", body: "About Anna.", tags: ["person"] },
+      { title: "Bob", body: "About Bob.", tags: [] },
+    ],
+  };
+
+  it("routes a split to PROPOSED replacements (requires_approval), source left active", () => {
+    const { store, calls } = fakeStore({
+      mem_overloaded: { title: "Anna and Bob", body: "mixed" },
+    });
+    const out = applyConsolidationPlan(plan("propose", splitJudgment), deps(store));
+    expect(out.kind).toBe("proposed");
+    // Two replacement docs were created, each requiring approval (status=proposed).
+    expect(calls.create.length).toBe(2);
+    for (const c of calls.create) {
+      expect(c.options?.requires_approval).toBe(true);
+      expect(c.options?.curator_note).toMatchObject({ proposed_action: "split" });
+      expect((c.options?.curator_note as { supersedes?: string[] }).supersedes).toEqual([
+        "mem_overloaded",
+      ]);
+    }
+    // The source candidate is NOT archived — a human archives it after accepting.
+    expect(calls.archive.length).toBe(0);
+  });
+
+  it("never auto-applies a split, even at confidence 1.0", () => {
+    const { store, calls } = fakeStore({
+      mem_overloaded: { title: "Anna and Bob", body: "mixed" },
+    });
+    // Force a fully-confident split through the auto_apply lane: it must STILL
+    // propose, never auto-apply (intake lacks grooming's whole-slice context).
+    const out = applyConsolidationPlan(
+      { decision: "auto_apply", judgment: { confidence: 1, rationale: "r", ...splitJudgment } },
+      deps(store),
+    );
+    expect(out.kind).toBe("proposed");
+    expect(calls.archive.length).toBe(0); // never mutates the live source
+    for (const c of calls.create) expect(c.options?.requires_approval).toBe(true);
+  });
+
+  it("rejects a split whose target is missing from the store (target ∈ candidates guard)", () => {
+    const { store, calls } = fakeStore(); // no mem_overloaded
+    const out = applyConsolidationPlan(plan("propose", splitJudgment), deps(store));
+    expect(out).toEqual({ kind: "rejected", reason: "split target missing" });
+    expect(calls.create.length).toBe(0);
+    expect(calls.archive.length).toBe(0);
+  });
+
+  it("the split's proposed replacements carry the judge's title/body/tags + submitter scope", () => {
+    const { store, calls } = fakeStore({
+      mem_overloaded: { title: "Anna and Bob", body: "mixed" },
+    });
+    applyConsolidationPlan(plan("propose", splitJudgment), {
+      store,
+      submissionText: "x",
+      actorId: "system-consolidator",
+      submissionHints: { agentId: "agent-a", projectKey: "proj-x" },
+    });
+    expect(calls.create[0]?.input).toMatchObject({
+      title: "Anna",
+      body: "About Anna.",
+      tags: ["person"],
+      agent_id: "agent-a",
+      project_key: "proj-x",
+    });
+  });
+
+  it("redacts a secret-shaped rationale on the split's proposed replacements", () => {
+    const { store, calls } = fakeStore({
+      mem_overloaded: { title: "Anna and Bob", body: "mixed" },
+    });
+    const kw = "to" + "ken";
+    applyConsolidationPlan(
+      {
+        decision: "propose",
+        judgment: { rationale: `${kw} = "leakvalue123"`, confidence: 0.9, ...splitJudgment },
+      },
+      deps(store),
+    );
+    const note = calls.create[0]?.options?.curator_note as { rationale?: string };
+    expect(note.rationale).not.toContain("leakvalue123");
+    expect(note.rationale).toContain("[REDACTED:secret]");
+  });
+});

--- a/packages/core/tests/consolidator-decision-log.test.ts
+++ b/packages/core/tests/consolidator-decision-log.test.ts
@@ -161,6 +161,28 @@ describe("intake decision log — full-outcome coverage", () => {
     expect(ops[0]).toMatchObject({ action: "augment", outcome: "applied", target_id: "m1" });
   });
 
+  it("logs an intake split as a PROPOSED op (action=split, target=the split source)", async () => {
+    // A high-confidence split must still land as a `proposed` row in the log —
+    // never `applied` (spec 043 D-B: intake split is never auto-applied).
+    const SPLIT_JUDGMENT = JSON.stringify({
+      action: "split",
+      target_id: "m1", // fakeStore.getMemory returns a doc for any id → target exists
+      replacements: [
+        { title: "Anna", body: "About Anna." },
+        { title: "Bob", body: "About Bob." },
+      ],
+      rationale: "the candidate doc conflates two people",
+      confidence: 0.99,
+    });
+    write("split-me", 1000, "a");
+    const store = logStore();
+    await runConsolidatorSweep(deps(constantClient(SPLIT_JUDGMENT), { consolidationLog: store }));
+    const ops = store.getConsolidationOperations(store.listConsolidationRuns()[0]!.id);
+    expect(ops).toHaveLength(1);
+    expect(ops[0]).toMatchObject({ action: "split", outcome: "proposed", target_id: "m1" });
+    expect(ops[0]?.source_id?.startsWith("inbox/.processing/")).toBe(true);
+  });
+
   it("redacts a secret-shaped rationale before logging it", async () => {
     write("create-me", 1000, "a");
     const store = logStore();

--- a/packages/core/tests/consolidator-judge-step.test.ts
+++ b/packages/core/tests/consolidator-judge-step.test.ts
@@ -54,8 +54,8 @@ describe("buildConsolidatorPrompt", () => {
     });
     expect(messages[0]!.role).toBe("system");
     expect(messages[0]!.content).toMatch(/consolidat/i);
-    // The output contract names the five judge actions.
-    for (const action of ["create", "augment", "supersede", "archive", "noop"]) {
+    // The output contract names every judge action (incl. split, spec 043 D-B).
+    for (const action of ["create", "augment", "supersede", "archive", "noop", "split"]) {
       expect(messages[0]!.content).toContain(action);
     }
     // Wikilink + minimal-edit guidance is present.
@@ -118,6 +118,43 @@ describe("buildConsolidatorPrompt", () => {
       expect(user).not.toContain(`fake-${label}`);
     }
     expect(user).toContain("[REDACTED:secret]");
+  });
+
+  it("pins the NARROW split guidance: only to un-overload an existing candidate, never over-fragment (spec 043 D-B)", () => {
+    const system = buildConsolidatorPrompt({ submissionText: "x", evidence })[0]!.content;
+    const lower = system.toLowerCase();
+    // Split is offered as a (rare) action…
+    expect(lower).toContain("split");
+    // …scoped to un-overloading an EXISTING candidate doc (target ∈ candidates)…
+    expect(lower).toContain("overloaded");
+    expect(lower).toContain('"target_id" must be one of the candidate');
+    // …and the anti-over-fragmentation guard is explicit (a single-entity /
+    // non-overloaded submission must never split — cf. spec 039).
+    expect(lower).toContain("do not split a single-entity");
+    // …and it is always a human proposal, never silently applied.
+    expect(lower).toContain("always proposed");
+  });
+
+  it("routes a model-emitted split to a PROPOSAL even at high confidence (never auto-applies)", async () => {
+    const client = fakeClient(
+      JSON.stringify({
+        action: "split",
+        target_id: "mem_anna",
+        replacements: [
+          { title: "Anna — Person", body: "Anna lives in Paris." },
+          { title: "Anna — Cafe", body: "The Anna cafe on Rue X." },
+        ],
+        rationale: "the doc conflates the person and the cafe",
+        confidence: 0.99,
+      }),
+    );
+    const result = await judgeSubmission(
+      { submissionText: "The Anna cafe reopened.", evidence },
+      { llmClient: client },
+    );
+    expect(result.parseError).toBeUndefined();
+    expect(result.plan?.decision).toBe("propose"); // never auto_apply, even at 0.99
+    expect(result.plan?.judgment).toMatchObject({ action: "split", target_id: "mem_anna" });
   });
 
   it("includes operator guidance as advisory-only when provided", () => {

--- a/packages/core/tests/consolidator-judge.test.ts
+++ b/packages/core/tests/consolidator-judge.test.ts
@@ -68,6 +68,35 @@ describe("parseConsolidationJudgment", () => {
         JSON.stringify({ action: "noop", rationale: "duplicate", confidence: 0.5 }),
       ).judgment,
     ).toMatchObject({ action: "noop" });
+
+    expect(
+      parseConsolidationJudgment(
+        JSON.stringify({
+          action: "split",
+          target_id: "mem_overloaded",
+          replacements: [
+            { title: "Anna", body: "About Anna." },
+            { title: "Bob", body: "About Bob.", tags: ["person"] },
+          ],
+          rationale: "two distinct entities in one doc",
+          confidence: 0.9,
+        }),
+      ).judgment,
+    ).toMatchObject({ action: "split", target_id: "mem_overloaded" });
+  });
+
+  it("rejects a split with fewer than 2 replacements (anti-over-fragmentation)", () => {
+    const parsed = parseConsolidationJudgment(
+      JSON.stringify({
+        action: "split",
+        target_id: "mem_1",
+        replacements: [{ title: "Only one", body: "x" }],
+        rationale: "y",
+        confidence: 0.9,
+      }),
+    );
+    expect(parsed.judgment).toBeUndefined();
+    expect(parsed.parseError).toBeTruthy();
   });
 
   it("tolerates a markdown code fence", () => {
@@ -161,6 +190,24 @@ describe("routeConsolidation — three-band confidence policy (S12)", () => {
       routeConsolidation(judge({ action: "archive", target_id: "m", confidence: c })).decision;
     expect(arch(0.99)).toBe("auto_apply");
     expect(arch(0.94)).toBe("propose");
+  });
+
+  it("a split ALWAYS proposes — never auto-applies, even at confidence 1.0 (spec 043 D-B)", () => {
+    const split = (c: number) =>
+      routeConsolidation(
+        judge({
+          action: "split",
+          target_id: "m",
+          replacements: [
+            { title: "A", body: "a" },
+            { title: "B", body: "b" },
+          ],
+          confidence: c,
+        }),
+      ).decision;
+    expect(split(1)).toBe("propose"); // the load-bearing guarantee: no auto-apply
+    expect(split(0.99)).toBe("propose");
+    expect(split(0.5)).toBe("propose");
   });
 
   it("carries the judgment through on the plan", () => {

--- a/packages/core/tests/curator-apply.test.ts
+++ b/packages/core/tests/curator-apply.test.ts
@@ -184,6 +184,47 @@ describe("applyOperations — auto-apply", () => {
     expect(merged.status).toBe("active");
     expect(merged.curator_note?.supersedes).toEqual([a.id, b.id]);
   });
+
+  // Regression: the grooming split path now routes through the shared
+  // `splitMemory` store primitive (spec 043 D-B). Its behaviour must be
+  // UNCHANGED — spin each replacement into a new active memory superseding the
+  // source, then archive the source.
+  it("splits: spins the source into N active replacements and archives the source", () => {
+    const src = seed({ title: "Mixed", body: "facts about Anna and Bob" });
+    const replacement = (title: string, body: string) => ({
+      title,
+      body,
+      category: "lessons",
+      visibility: "common" as const,
+      scope: "project",
+      project_key: "proj-x",
+    });
+    const summary = applyOperations(
+      ops({
+        operation: {
+          type: "split",
+          source_memory_id: src.id,
+          replacements: [replacement("Anna", "about Anna"), replacement("Bob", "about Bob")],
+          rationale: "two distinct entities",
+          confidence: 0.95,
+        },
+        outcome: accept("safe"),
+      }),
+      context(),
+      deps(),
+    );
+    expect(summary.applied).toBe(1);
+    // The source is archived (auto-applied split supersedes it).
+    expect(s!.store.getMemory(src.id)?.status).toBe("archived");
+    const targets = recorded()[0]!.target_memory_ids;
+    expect(targets.length).toBe(2);
+    for (const id of targets) {
+      const t = s!.store.getMemory(id)!;
+      expect(t.status).toBe("active");
+      expect(t.curator_note?.supersedes).toEqual([src.id]);
+      expect(t.curator_note?.run_id).toBe(s!.runId);
+    }
+  });
 });
 
 describe("applyOperations — protected routing", () => {
@@ -234,6 +275,44 @@ describe("applyOperations — protected routing", () => {
     expect(summary.skipped).toBe(1);
     expect(s!.store.getMemory(m.id)?.status).toBe("active"); // NOT archived
     expect(recorded()[0]).toMatchObject({ operation_type: "archive", status: "skipped" });
+  });
+
+  // Regression: a PROTECTED split proposes its replacements (status=proposed) and
+  // leaves the source ACTIVE — the admin archives it after accepting (§11.1). The
+  // shared primitive must not archive the source when no actor is passed.
+  it("proposes a protected split's replacements and leaves the source active", () => {
+    const src = seed({ category: "identity" }, { forceActive: true });
+    expect(s!.store.getMemory(src.id)?.status).toBe("active");
+    const replacement = (title: string) => ({
+      title,
+      body: `about ${title}`,
+      category: "identity",
+      visibility: "common" as const,
+      scope: "project",
+      project_key: "proj-x",
+    });
+    const summary = applyOperations(
+      ops({
+        operation: {
+          type: "split",
+          source_memory_id: src.id,
+          replacements: [replacement("Anna"), replacement("Bob")],
+          rationale: "two people",
+          confidence: 0.95,
+        },
+        outcome: accept("protected", true),
+      }),
+      context(),
+      deps(),
+    );
+    expect(summary.proposed).toBe(1);
+    expect(summary.applied).toBe(0);
+    expect(s!.store.getMemory(src.id)?.status).toBe("active"); // source NOT archived
+    const targets = recorded().find((o) => o.status === "proposed")!.target_memory_ids;
+    expect(targets.length).toBe(2);
+    for (const id of targets) {
+      expect(s!.store.getMemory(id)?.status).toBe("proposed");
+    }
   });
 });
 

--- a/packages/core/tests/store/split-memory.test.ts
+++ b/packages/core/tests/store/split-memory.test.ts
@@ -1,0 +1,68 @@
+// Shared split store primitive (spec 043 D-B). Pins the two invariants both
+// curator apply paths (grooming + intake) rely on:
+//   1. create-all-then-archive ordering (data-loss-safe);
+//   2. archive happens IFF an archive actor is passed (apply vs propose).
+// The per-row input/options are the caller's; the primitive only sequences them.
+
+import { type SplitMemoryStore, splitMemory } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+function fakeStore() {
+  const calls: string[] = [];
+  let n = 0;
+  const store: SplitMemoryStore = {
+    createMemory: (input) => {
+      const id = `mem_new_${n++}`;
+      calls.push(`create:${String(input.title)}`);
+      return { memory: { id } };
+    },
+    archiveMemory: (id, actor) => {
+      calls.push(`archive:${id}:${String(actor)}`);
+      return null;
+    },
+  };
+  return { store, calls };
+}
+
+describe("splitMemory", () => {
+  it("creates every replacement, then archives the source (apply path)", () => {
+    const { store, calls } = fakeStore();
+    const ids = splitMemory(store, {
+      sourceId: "mem_src",
+      replacements: [{ input: { title: "Anna" } }, { input: { title: "Bob" } }],
+      archiveActorId: "system-curator",
+    });
+    expect(ids).toEqual(["mem_new_0", "mem_new_1"]);
+    // Ordering invariant: both creates precede the archive.
+    expect(calls).toEqual(["create:Anna", "create:Bob", "archive:mem_src:system-curator"]);
+  });
+
+  it("leaves the source untouched when no archive actor is passed (propose path)", () => {
+    const { store, calls } = fakeStore();
+    const ids = splitMemory(store, {
+      sourceId: "mem_src",
+      replacements: [{ input: { title: "Anna" } }, { input: { title: "Bob" } }],
+    });
+    expect(ids).toEqual(["mem_new_0", "mem_new_1"]);
+    expect(calls).toEqual(["create:Anna", "create:Bob"]); // NO archive
+  });
+
+  it("passes each replacement's options through verbatim", () => {
+    const seen: (Record<string, unknown> | undefined)[] = [];
+    const store: SplitMemoryStore = {
+      createMemory: (_input, options) => {
+        seen.push(options);
+        return { memory: { id: "x" } };
+      },
+      archiveMemory: () => null,
+    };
+    splitMemory(store, {
+      sourceId: "s",
+      replacements: [
+        { input: { title: "A" }, options: { requires_approval: true } },
+        { input: { title: "B" } },
+      ],
+    });
+    expect(seen).toEqual([{ requires_approval: true }, undefined]);
+  });
+});


### PR DESCRIPTION
## What & why (spec 043 PR-4, Task C4 — decision D-B)

Grooming already has a `split` operation; intake's op schema was closed and had no split. This gives intake a **narrowly-scoped `split` that is always PROPOSED, never auto-applied** — and does it by factoring grooming's existing split into a **shared store primitive** both apply paths call, so the two stay byte-identical.

## The shared split primitive

`packages/core/src/store/split-memory.ts` — `splitMemory(store, { sourceId, replacements, archiveActorId? })`. It owns the two invariants both curator apply paths share:

1. **create-all-then-archive ordering** (data-loss-safe — on partial failure the source survives), and
2. the **propose-vs-apply switch**: it archives the source IFF an `archiveActorId` is passed; omit it to leave the source active (a proposed split).

What it deliberately does *not* own (left to each caller, because the two curators differ): how each replacement's `createMemory` input/options are built — the `curator_note` shape, ownership, and the `requires_approval` gate. Each caller pre-builds `{ input, options }` pairs; the primitive only sequences the writes. So grooming + intake file independently but split identically.

- **Grooming** (`curator-apply.ts`) now routes BOTH its split branches (auto-apply + protected-propose) through the primitive. Behaviour is **unchanged** — asserted by new regression tests plus the full pre-existing curator-apply suite.
- **Intake** (`consolidator/apply.ts`) handles `split` before the generic propose branch: spins the judge's focused replacements out as `requires_approval` (status proposed) docs superseding the source candidate, leaves the source **active** (a human archives on accept), and rejects a target not in the store.

## Forced to `proposed` (defence-in-depth)

Two independent guarantees that an intake split can never auto-apply, even at confidence 1.0:

1. `routeConsolidation` returns `propose` for `split` **unconditionally** (judge.ts).
2. `applyConsolidationPlan` matches `action === "split"` **before** reading `plan.decision`, never passes an `archiveActorId`, and always sets `requires_approval`.

## Narrow scope enforced

- New `SplitJudgment` schema: `target_id` required, **≥2 replacements** (anti-single-fragment).
- Apply rejects a target absent from the store (`split target missing`) — the honest guard for intake's thinner context (same posture as intake's other actions).
- Judge prompt (bumped to **v4**) adds tightly-scoped guidance: split ONLY to un-overload an existing candidate; **never** fragment a single-entity / non-overloaded submission (cf. spec 039).

## Logging (C1)

The split outcome flows through the C1 intake decision log unchanged at the apply call-site: `outcome=proposed`, `action=split`, `source_id`=inbox item, `target_id`=the split source candidate.

## Tests

- judge-prompt test pinning the split guidance + the narrow-scope/anti-over-fragmentation wording;
- judge routing test: split → propose at confidence 1.0 / 0.99 / 0.5;
- intake apply tests: proposed-not-applied (incl. forced through auto_apply lane), target-missing rejection, scope/tags inheritance, rationale redaction;
- grooming-split-unchanged regression (auto-apply + protected-propose), the shared-primitive unit test, and a decision-log test pinning `proposed`/`split`.

Full repo build + suites green (core 790, dashboard 174, eval, root 22); typecheck + lint clean. Review was conducted **by me (no general-purpose sub-agent is available in this sandbox)** across Correctness/Readability/Architecture/Security/Performance — no Critical/Important findings; one Suggestion (the log records only the source candidate as the singular `target_id`, not the new proposal ids — consistent with the existing singular log shape; proposals are discoverable in the queue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)