### PR TITLE
feat(mcp-server): intake tRPC router for the unified curator dashboard (spec 043 PR-5a, Task C5a)

### DIFF
--- a/packages/core/src/curator-config.ts
+++ b/packages/core/src/curator-config.ts
@@ -177,6 +177,17 @@ export function isIntakeEnabled(store: ConfigReader): boolean {
 }
 
 /**
+ * Set intake (consolidator) enablement (spec 043 D-E / PR-5a). Writes the unified
+ * `curator.intake.enabled` setting — the AUTHORITATIVE source `isIntakeEnabled`
+ * reads — as the canonical "true"/"false" string, mirroring how grooming's enable
+ * flag is written in `writeCuratorConfig`. This is the intake counterpart of that
+ * grooming write: the unified curator dashboard's Intake toggle calls it.
+ */
+export function setIntakeEnabled(store: ConfigWriter, enabled: boolean): void {
+  store.setSetting(INTAKE_ENABLED_KEY, enabled ? "true" : "false");
+}
+
+/**
  * One-time, idempotent migration that seeds the unified enablement keys from the
  * two legacy sources so an existing install keeps its EXACT enablement after the
  * 043 upgrade (spec D-E). Safe to run on every boot/tick:

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -187,6 +187,7 @@ export {
   LEGACY_GROOMING_ENABLED_KEY,
   migrateCuratorEnablement,
   readCuratorConfig,
+  setIntakeEnabled,
   writeCuratorConfig,
 } from "./curator-config.js";
 export {

--- a/packages/core/tests/curator-enablement.test.ts
+++ b/packages/core/tests/curator-enablement.test.ts
@@ -19,6 +19,7 @@ import {
   isIntakeEnabled,
   migrateCuratorEnablement,
   readCuratorConfig,
+  setIntakeEnabled,
   writeCuratorConfig,
 } from "@librarian/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -194,6 +195,21 @@ describe("curator enablement migration (spec 043 D-E)", () => {
     writeCuratorConfig(store, { enabled: true });
     expect(store.getSetting(GROOMING_ENABLED_KEY)).toBe("true");
     expect(readCuratorConfig(store).enabled).toBe(true);
+  });
+
+  // ── setIntakeEnabled: the intake counterpart of writeCuratorConfig({enabled}) (PR-5a) ──
+
+  it("setIntakeEnabled writes the unified intake key and round-trips via isIntakeEnabled", () => {
+    const { store } = s!;
+    expect(isIntakeEnabled(store)).toBe(false); // default off
+
+    setIntakeEnabled(store, true);
+    expect(store.getSetting(INTAKE_ENABLED_KEY)).toBe("true");
+    expect(isIntakeEnabled(store)).toBe(true);
+
+    setIntakeEnabled(store, false);
+    expect(store.getSetting(INTAKE_ENABLED_KEY)).toBe("false");
+    expect(isIntakeEnabled(store)).toBe(false);
   });
 
   // ── Debounce seed: the repurposed interval becomes the auto-trigger floor (D-A) ──

--- a/packages/mcp-server/src/trpc/intake.ts
+++ b/packages/mcp-server/src/trpc/intake.ts
@@ -1,0 +1,92 @@
+// Intake (consolidator) admin tRPC procedures (spec 043 PR-5a / Task C5a).
+//
+// The parallel of the grooming `curatorRouter` (curator.ts), adapted for intake —
+// so the unified curator dashboard (C5b) can render an Intake section with the
+// same shape it already has for grooming: enablement + the per-consumer
+// operational view (read-only here), run + per-operation observability over the
+// C1 consolidation decision log, and an admin run-now.
+//
+// All admin-gated — there is deliberately NO consumer-agent surface for intake
+// control. This router is read-only aggregation for the dashboard's Intake
+// section; the provider/model WRITE surface is the existing `llm.setConsumerConfig`
+// (not duplicated here). The one write `setConfig` owns is the intake enablement
+// toggle (`curator.intake.enabled`).
+
+import type {
+  ConsolidatorTickResult,
+  LibrarianStore,
+  ListConsolidationRunsInput,
+} from "@librarian/core";
+import {
+  isIntakeEnabled,
+  readConsumerConfig,
+  runConsolidatorTick,
+  setIntakeEnabled,
+} from "@librarian/core";
+import { z } from "zod";
+import { adminProcedure, router } from "./trpc.js";
+
+// Mirror grooming's `runs` input (curator.ts ListRunsInputSchema), matching the
+// C1 ListConsolidationRunsInput shape. All optional; the store clamps `limit`.
+const ListRunsInputSchema = z.strictObject({
+  status: z.string().optional(),
+  trigger: z.string().optional(),
+  limit: z.number().int().positive().max(200).optional(),
+});
+
+// Intake's configured state in one read: the enablement flag (authoritative
+// `curator.intake.enabled` setting) + the per-consumer operational view (provider/
+// model/operational flags). The token is never part of this — `readConsumerConfig`
+// returns presence-only `hasToken`, never the secret.
+function readIntakeConfig(store: LibrarianStore) {
+  return {
+    enabled: isIntakeEnabled(store),
+    consumer: readConsumerConfig(store, "intake"),
+  };
+}
+
+// Run-now widens the tick result with a `disabled` skip — the enablement gate the
+// router applies on top of the (enablement-agnostic) consolidator tick, mirroring
+// grooming's CuratorTickSkipReason which already carries "disabled".
+type RunNowResult = ConsolidatorTickResult | { ran: false; reason: "disabled" };
+
+export const intakeRouter = router({
+  // Intake's configured state (enablement + the read-only per-consumer view).
+  config: adminProcedure.query(({ ctx }) => readIntakeConfig(ctx.store)),
+
+  // Toggle intake enablement; returns the fresh readable config. The setting is
+  // authoritative (spec 043 D-E) — toggling off actually disables the job.
+  setConfig: adminProcedure
+    .input(z.strictObject({ enabled: z.boolean() }))
+    .mutation(({ ctx, input }) => {
+      setIntakeEnabled(ctx.store, input.enabled);
+      return readIntakeConfig(ctx.store);
+    }),
+
+  // Observability: consolidation run history (most recent first) + per-run ops,
+  // over the C1 decision log (LibrarianStore extends ConsolidationStore).
+  runs: adminProcedure
+    .input(ListRunsInputSchema.optional())
+    .query(({ ctx, input }) =>
+      ctx.store.listConsolidationRuns((input ?? {}) as ListConsolidationRunsInput),
+    ),
+
+  runOperations: adminProcedure
+    .input(z.strictObject({ runId: z.string().min(1) }))
+    .query(({ ctx, input }) => ctx.store.getConsolidationOperations(input.runId)),
+
+  // Admin run-now: force one inbox sweep. Mirrors grooming's run-now posture —
+  // gated on enablement (the setting is authoritative), then runs the tick. Unlike
+  // grooming there is no input-hash/debounce skip inside the intake sweep to bypass
+  // (it always processes the whole inbox), so an enabled run-now is already a forced
+  // sweep — it files queued items even though intake's scheduler never starts while
+  // disabled. NB: an enabled intake sweep can also fire the C3 post-intake grooming
+  // trigger (runConsolidatorTick's default), so an admin run-now may, like a
+  // scheduled tick, arm a groom if the threshold/debounce allow — intentional and
+  // consistent with the scheduled path.
+  runNow: adminProcedure.mutation(({ ctx }): Promise<RunNowResult> | RunNowResult =>
+    isIntakeEnabled(ctx.store)
+      ? runConsolidatorTick({ store: ctx.store })
+      : { ran: false, reason: "disabled" },
+  ),
+});

--- a/packages/mcp-server/src/trpc/router.ts
+++ b/packages/mcp-server/src/trpc/router.ts
@@ -13,6 +13,7 @@ import { backupRouter } from "./backup.js";
 import { curatorRouter } from "./curator.js";
 import { handoffsRouter } from "./handoffs.js";
 import { healthRouter } from "./health.js";
+import { intakeRouter } from "./intake.js";
 import { llmRouter } from "./llm.js";
 import { memoriesRouter } from "./memories.js";
 import { tokensRouter } from "./tokens.js";
@@ -24,6 +25,7 @@ export const appRouter = router({
   curator: curatorRouter,
   handoffs: handoffsRouter,
   health: healthRouter,
+  intake: intakeRouter,
   llm: llmRouter,
   memories: memoriesRouter,
   tokens: tokensRouter,

--- a/packages/mcp-server/tests/trpc/intake.test.ts
+++ b/packages/mcp-server/tests/trpc/intake.test.ts
@@ -1,0 +1,261 @@
+// Intake (consolidator) admin tRPC procedure tests (spec 043 PR-5a / Task C5a).
+// The parallel of the grooming `curator` router for the unified dashboard's Intake
+// section: admin gating on every procedure, the read-only `config` aggregation +
+// the `setConfig` enablement toggle round-trip, run/operation observability over
+// the C1 consolidation decision log, and the `runNow` sweep trigger.
+//
+// `runs`/`runOperations` are exercised by pre-seeding the consolidation-runs.json
+// sidecar (created by a store on the same dataDir before the server boots, then
+// read back through the router). `runNow` drives a REAL end-to-end sweep against a
+// local stub LLM server, proving the admin trigger files an inbox item even when
+// the scheduled tick would otherwise never have started (intake default-disabled).
+
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { createLibrarianStore } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanupTempDir, makeTempDir, startHttpServer } from "../../../../test/helpers.js";
+
+interface TrpcOk<T> {
+  result: { data: T };
+}
+interface TrpcErr {
+  error: unknown;
+}
+interface ServerHandle {
+  url: string;
+  token: string;
+  stop: () => Promise<void>;
+}
+
+async function trpcGet<T>(server: ServerHandle, path: string, input?: unknown): Promise<T> {
+  const url = new URL(`${server.url}/trpc/${path}`);
+  if (input !== undefined) url.searchParams.set("input", JSON.stringify(input));
+  const response = await fetch(url, { headers: { authorization: `Bearer ${server.token}` } });
+  const json = (await response.json()) as TrpcOk<T> | TrpcErr;
+  if (response.status >= 400 || "error" in json) {
+    throw new Error(`trpc GET ${path} failed: ${JSON.stringify(json)}`);
+  }
+  return (json as TrpcOk<T>).result.data;
+}
+
+async function trpcPost<T>(server: ServerHandle, path: string, input?: unknown): Promise<T> {
+  const response = await fetch(`${server.url}/trpc/${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${server.token}` },
+    body: input === undefined ? undefined : JSON.stringify(input),
+  });
+  const json = (await response.json()) as TrpcOk<T> | TrpcErr;
+  if (response.status >= 400 || "error" in json) {
+    throw new Error(`trpc POST ${path} failed: ${JSON.stringify(json)}`);
+  }
+  return (json as TrpcOk<T>).result.data;
+}
+
+interface IntakeConfig {
+  enabled: boolean;
+  consumer: {
+    providerId: string;
+    providerExists: boolean;
+    model: string;
+    isOperational: boolean;
+  };
+}
+
+interface ConsolidationRun {
+  id: string;
+  status: string;
+  trigger: string;
+  consolidated: number;
+}
+interface ConsolidationOperation {
+  id: string;
+  run_id: string;
+  action: string;
+  outcome: string;
+}
+
+// A minimal OpenAI-compatible chat-completions stub the curator LLM client can
+// talk to. Returns one fixed `create` judgment so a sweep files exactly one memory.
+function startStubLlm(): Promise<{ url: string; stop: () => Promise<void> }> {
+  const judgment = JSON.stringify({
+    action: "create",
+    title: "Anna",
+    body: "Anna lives in Berlin.",
+    tags: [],
+    rationale: "novel",
+    confidence: 0.97,
+  });
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      let body = "";
+      req.on("data", (c) => (body += c));
+      req.on("end", () => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ choices: [{ message: { content: judgment } }] }));
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({
+        url: `http://127.0.0.1:${port}/v1`,
+        stop: () => new Promise((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
+describe("tRPC intake surface", () => {
+  let dataDir = "";
+  beforeEach(() => {
+    dataDir = makeTempDir();
+  });
+  afterEach(() => {
+    cleanupTempDir(dataDir);
+  });
+
+  it("admin-gates every procedure (401/err without an admin bearer)", async () => {
+    const server = await startHttpServer({ dataDir });
+    try {
+      const reads = ["intake.config", "intake.runs"];
+      for (const path of reads) {
+        const response = await fetch(`${server.url}/trpc/${path}`); // no Authorization
+        expect(response.status, path).toBeGreaterThanOrEqual(400);
+      }
+      const opsUrl = new URL(`${server.url}/trpc/intake.runOperations`);
+      opsUrl.searchParams.set("input", JSON.stringify({ runId: "x" }));
+      expect((await fetch(opsUrl)).status).toBeGreaterThanOrEqual(400);
+
+      // Mutations: unauthenticated AND a non-admin (agent) token are both rejected.
+      for (const path of ["intake.setConfig", "intake.runNow"]) {
+        const unauthed = await fetch(`${server.url}/trpc/${path}`, { method: "POST" });
+        expect(unauthed.status, path).toBeGreaterThanOrEqual(400);
+        const agent = await fetch(`${server.url}/trpc/${path}`, {
+          method: "POST",
+          headers: { "content-type": "application/json", authorization: "Bearer agent-token" },
+          body: path.endsWith("setConfig") ? JSON.stringify({ enabled: true }) : undefined,
+        });
+        expect(agent.status, `${path} agent`).toBeGreaterThanOrEqual(400);
+      }
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("config round-trips the intake enablement toggle (default off, authoritative)", async () => {
+    const server = await startHttpServer({ dataDir });
+    try {
+      const before = await trpcGet<IntakeConfig>(server, "intake.config");
+      expect(before.enabled).toBe(false);
+      expect(before.consumer.isOperational).toBe(false);
+
+      const enabled = await trpcPost<IntakeConfig>(server, "intake.setConfig", { enabled: true });
+      expect(enabled.enabled).toBe(true);
+      expect(await trpcGet<IntakeConfig>(server, "intake.config").then((c) => c.enabled)).toBe(
+        true,
+      );
+
+      const disabled = await trpcPost<IntakeConfig>(server, "intake.setConfig", { enabled: false });
+      expect(disabled.enabled).toBe(false);
+      expect(await trpcGet<IntakeConfig>(server, "intake.config").then((c) => c.enabled)).toBe(
+        false,
+      );
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("runs + runOperations expose the consolidation decision log through the router", async () => {
+    // Seed the sidecar log via a store on the same dataDir BEFORE the server boots.
+    const seed = createLibrarianStore({ dataDir });
+    const run = seed.createConsolidationRun({ trigger: "manual" });
+    seed.startConsolidationRun(run.id);
+    seed.recordConsolidationOperation({
+      run_id: run.id,
+      action: "create",
+      outcome: "applied",
+      confidence: 0.97,
+      rationale: "novel",
+      source_id: "inbox-1",
+      target_id: "mem_1",
+    });
+    seed.completeConsolidationRun(run.id, { summary: "consolidated 1", consolidated: 1 });
+    seed.close();
+
+    const server = await startHttpServer({ dataDir });
+    try {
+      const runs = await trpcGet<ConsolidationRun[]>(server, "intake.runs");
+      expect(runs).toHaveLength(1);
+      expect(runs[0]?.id).toBe(run.id);
+      expect(runs[0]?.consolidated).toBe(1);
+      expect(runs[0]?.status).toBe("completed");
+
+      const ops = await trpcGet<ConsolidationOperation[]>(server, "intake.runOperations", {
+        runId: run.id,
+      });
+      expect(ops).toHaveLength(1);
+      expect(ops[0]?.action).toBe("create");
+      expect(ops[0]?.outcome).toBe("applied");
+
+      // A limit of 0-rows query path still works (no runs for an unknown id).
+      const none = await trpcGet<ConsolidationOperation[]>(server, "intake.runOperations", {
+        runId: "does-not-exist",
+      });
+      expect(none).toEqual([]);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("runNow drives a real sweep that files an inbox item (even though intake ships disabled)", async () => {
+    // A real, decryptable provider token requires the master key. Assembled at
+    // runtime so no key-shaped literal lands in committed source.
+    const secretKey = "0123456789abcdef".repeat(4);
+    const stub = await startStubLlm();
+    // Seed one inbox item via a store on the same dataDir before boot.
+    const seed = createLibrarianStore({ dataDir, secretKey: Buffer.from(secretKey, "hex") });
+    seed.submitToInbox("Anna moved to Berlin.");
+    seed.close();
+
+    const server = await startHttpServer({ dataDir, secretKey });
+    try {
+      // Configure the intake consumer to point at the stub LLM, and enable intake.
+      const provider = await trpcPost<{ id: string }>(server, "llm.addProvider", {
+        name: "stub",
+        endpoint: stub.url,
+        token: "dummy-stub-token",
+      });
+      await trpcPost(server, "llm.setConsumerConfig", {
+        consumer: "intake",
+        providerId: provider.id,
+        model: "gpt-x",
+      });
+      await trpcPost(server, "intake.setConfig", { enabled: true });
+
+      const result = await trpcPost<{ ran: boolean; summary?: { consolidated: number } }>(
+        server,
+        "intake.runNow",
+      );
+      expect(result.ran).toBe(true);
+      expect(result.summary?.consolidated).toBe(1);
+
+      // The sweep wrote a run row queryable through the router.
+      const runs = await trpcGet<ConsolidationRun[]>(server, "intake.runs");
+      expect(runs.length).toBeGreaterThanOrEqual(1);
+      expect(runs[0]?.consolidated).toBe(1);
+    } finally {
+      await server.stop();
+      await stub.stop();
+    }
+  });
+
+  it("runNow no-ops with a reason when intake is disabled (setting is authoritative)", async () => {
+    const server = await startHttpServer({ dataDir });
+    try {
+      const result = await trpcPost<{ ran: boolean; reason?: string }>(server, "intake.runNow");
+      expect(result).toEqual({ ran: false, reason: "disabled" });
+    } finally {
+      await server.stop();
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds an `intake` tRPC router (`packages/mcp-server/src/trpc/intake.ts`, registered as `intake:` in `router.ts`) — the backend half of spec 043 PR-5 (Task C5), parallel to the grooming `curatorRouter`. The unified curator dashboard's Intake section (C5b) consumes it so it has the same shape grooming already has.

All **five procedures are admin-gated**:

| Procedure | Kind | Behaviour |
|---|---|---|
| `config` | query | Intake's configured state in one read: `{ enabled: isIntakeEnabled(store), consumer: readConsumerConfig(store,"intake") }` — the authoritative `curator.intake.enabled` flag + the read-only per-consumer operational view (provider/model/operational flags). |
| `setConfig` | mutation | Toggle intake enablement (`{ enabled: boolean }`); returns the fresh `config`. Setting is authoritative (C2). |
| `runs` | query | Consolidation run history (`store.listConsolidationRuns`, the C1 decision log). |
| `runOperations` | query | Per-run consolidation operations (`store.getConsolidationOperations`). |
| `runNow` | mutation | Admin-triggered inbox sweep — enablement-gated, then `runConsolidatorTick({ store })`. |

It is a thin, faithful mirror of `curatorRouter`: it reuses core functions and store methods, reimplements no store logic, and does **not** touch the grooming router (C6 owns naming consistency).

## New core writer

`setIntakeEnabled(store, enabled)` added next to `isIntakeEnabled` in `packages/core/src/curator-config.ts` and exported from `index.ts` — the intake counterpart of grooming's `writeCuratorConfig({ enabled })` write (`curator.intake.enabled` = `"true"`/`"false"`). The provider/model **write** surface stays the existing `llm.setConsumerConfig` (not duplicated); `config` here is read-only aggregation plus this one enablement toggle.

## run-now ↔ grooming-trigger

`runConsolidatorTick` defaults its post-intake grooming trigger ON, so an **enabled** admin run-now can also fire the C3 grooming trigger if the threshold/debounce allow — identical to the scheduled path (the http boot calls `runConsolidatorTick({ store })` with the same defaults). Intentional and consistent; both the sweep and the trigger are fail-soft, so run-now can never wedge state. The run-now disabled-gate mirrors grooming's (`{ ran: false, reason: "disabled" }` when off) and keeps the setting-authoritative invariant.

## Tests (TDD, RED→GREEN)

`packages/mcp-server/tests/trpc/intake.test.ts` spawns the real HTTP bin via `startHttpServer({ dataDir })`:
- admin-gating on every procedure (unauthenticated reads + agent-token mutations both rejected),
- `config` round-trip (default off → on → back to off),
- `runs`/`runOperations` via a pre-seeded `consolidation-runs.json` sidecar,
- a **real end-to-end run-now sweep** against a local OpenAI-compatible stub LLM (files one inbox item), proving it works when the scheduled tick would otherwise never have started,
- the disabled run-now no-op.

Plus a focused `setIntakeEnabled` unit test in `curator-enablement.test.ts`. Full suite + `pnpm -r build` are green (no `error TS`); lint clean.

## UI is C5b

This is backend plumbing with **no user-facing surface yet** — the user-visible unified-dashboard change (and its CHANGELOG entry) lands with C5b (the UI). No CHANGELOG entry here, no `apps/dashboard/**` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)