### PR TITLE
feat(dashboard): unified curator dashboard — intake + grooming sections (spec 043 PR-5b, Task C5b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ changes from this point forward are catalogued here.
 
 ### Added
 
+- **Unified Memory Curator dashboard — one page, two jobs.** The Memory Curator
+  page now presents both curator jobs side by side in clear **Intake** and
+  **Grooming** sections, each with its own enablement toggle, model
+  configuration, recent-run history, and a run-now button. Shared LLM provider
+  management lives once, above both sections (it serves both jobs). The Intake
+  section makes consolidation **observable for the first time**: each run expands
+  to reveal its decisions — the action taken, whether it was applied, proposed,
+  skipped, or failed, the confidence, and the rationale — so you can see exactly
+  what intake did with each new submission. Run-now clearly reports when nothing
+  ran and why (disabled / incomplete config / no token). Everything stays
+  admin-only.
+
 - **Intake can now propose splitting an overloaded memory at ingestion.** When a
   new submission turns out to be primarily about a different, already
   well-supported entity whose existing doc has become an overloaded grab-bag, the

--- a/apps/dashboard/app/curator/actions.ts
+++ b/apps/dashboard/app/curator/actions.ts
@@ -1,6 +1,8 @@
 "use server";
 
 import type {
+  ConsolidationOperation,
+  ConsolidatorTickResult,
   ConsumerConfig,
   ConsumerConfigPatch,
   CuratorConfigPatch,
@@ -15,7 +17,17 @@ import { serverTRPC } from "@/lib/trpc-server";
 
 export type RunNowResult = { ok: true; result: CuratorTickResult } | { ok: false; error: string };
 
+// Intake run-now widens the tick result with a router-applied `disabled` skip.
+type IntakeRunResult = ConsolidatorTickResult | { ran: false; reason: "disabled" };
+export type RunIntakeNowResult =
+  | { ok: true; result: IntakeRunResult }
+  | { ok: false; error: string };
+
 export type SaveConfigResult = { ok: true } | { ok: false; error: string };
+
+export type LoadOperationsResult =
+  | { ok: true; operations: ConsolidationOperation[] }
+  | { ok: false; error: string };
 
 // Provider mutations return the fresh provider list / consumer config so the
 // client can update without an extra round-trip; the page also revalidates.
@@ -128,6 +140,48 @@ export async function listModelsAction(input: ProbeInput): Promise<ModelsResult>
 export async function testConnectionAction(input: ProbeInput): Promise<TestConnectionResult> {
   try {
     return await serverTRPC.llm.testConnection.query(input);
+  } catch (error) {
+    return { ok: false, error: message(error) };
+  }
+}
+
+// --- Intake (consolidator) section (spec 043 C5b) -----------------------------
+// Mirrors the grooming actions above against the C5a `intake` router. The intake
+// job owns only an enablement toggle here (provider/model is the shared
+// per-consumer selector); its runs are the C1 consolidation decision log.
+
+// Admin run-now: force one inbox sweep. Surfaces the {ran:false,reason} skip
+// states (disabled / incomplete_config / no_token) to the caller, never swallows.
+export async function runIntakeNowAction(): Promise<RunIntakeNowResult> {
+  try {
+    const result = await serverTRPC.intake.runNow.mutate();
+    revalidatePath("/curator");
+    return { ok: true, result };
+  } catch (error) {
+    return { ok: false, error: message(error) };
+  }
+}
+
+// Toggle intake enablement (`curator.intake.enabled`). The setting is
+// authoritative (spec 043 D-E) — toggling off actually disables the job.
+export async function setIntakeConfigAction(input: {
+  enabled: boolean;
+}): Promise<SaveConfigResult> {
+  try {
+    await serverTRPC.intake.setConfig.mutate(input);
+    revalidatePath("/curator");
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: message(error) };
+  }
+}
+
+// Lazy per-run drill-down: the C1 decisions (action/outcome/confidence/rationale)
+// for one consolidation run, fetched on demand when an admin expands the row.
+export async function loadIntakeOperationsAction(runId: string): Promise<LoadOperationsResult> {
+  try {
+    const operations = await serverTRPC.intake.runOperations.query({ runId });
+    return { ok: true, operations };
   } catch (error) {
     return { ok: false, error: message(error) };
   }

--- a/apps/dashboard/app/curator/page.tsx
+++ b/apps/dashboard/app/curator/page.tsx
@@ -1,23 +1,34 @@
-// Memory-curator admin cockpit (spec §7.1 / §13 + 042 §4). Reads the current
-// curator config + run history, the named LLM providers, and the per-consumer
-// (intake / grooming) provider+model selection, and passes them to the client
-// components that manage them. Server component — all data is read via tRPC here.
+// Unified memory-curator admin cockpit (spec 043 §7.1 / §13 + 042 §4 + C5b). ONE
+// page, TWO jobs in clear parallel sections — Intake (inbox consolidation) and
+// Grooming (memory curation). Each section carries: enablement, model/config,
+// recent runs, and run-now. Shared LLM provider management (it serves both jobs)
+// lives in its own area, not duplicated per section. Server component — all data
+// is read via tRPC here and passed to the client controls.
 
 import {
   addProviderAction,
   deleteProviderAction,
   listModelsAction,
+  loadIntakeOperationsAction,
   runCuratorNowAction,
+  runIntakeNowAction,
   saveCuratorConfigAction,
   setConsumerConfigAction,
+  setIntakeConfigAction,
   testConnectionAction,
   updateProviderAction,
 } from "@/app/curator/actions";
 import { CuratorConfigForm } from "@/components/curator/config-form";
 import { CuratorConfigSummary } from "@/components/curator/config-summary";
 import { ConsumerModelSelector } from "@/components/curator/consumer-model-selector";
+import { IntakeConfigForm } from "@/components/curator/intake-config-form";
+import { IntakeRunsTable } from "@/components/curator/intake-runs-table";
 import { ProviderManager } from "@/components/curator/provider-manager";
-import { RunNowButton } from "@/components/curator/run-now-button";
+import {
+  RunNowButton,
+  renderGroomingResult,
+  renderIntakeResult,
+} from "@/components/curator/run-now-button";
 import { CuratorRunsTable } from "@/components/curator/runs-table";
 import { serverTRPC } from "@/lib/trpc-server";
 
@@ -27,31 +38,39 @@ export default async function CuratorPage() {
   let config: Awaited<ReturnType<typeof serverTRPC.curator.config.query>> | null = null;
   let runs: Awaited<ReturnType<typeof serverTRPC.curator.runs.query>> = [];
   let providers: Awaited<ReturnType<typeof serverTRPC.llm.listProviders.query>> = [];
-  let intake: Awaited<ReturnType<typeof serverTRPC.llm.consumerConfig.query>> | null = null;
+  let intakeConfig: Awaited<ReturnType<typeof serverTRPC.intake.config.query>> | null = null;
+  let intakeRuns: Awaited<ReturnType<typeof serverTRPC.intake.runs.query>> = [];
+  let intakeConsumer: Awaited<ReturnType<typeof serverTRPC.llm.consumerConfig.query>> | null = null;
   let grooming: Awaited<ReturnType<typeof serverTRPC.llm.consumerConfig.query>> | null = null;
   let error: string | null = null;
   try {
-    [config, runs, providers, intake, grooming] = await Promise.all([
-      serverTRPC.curator.config.query(),
-      serverTRPC.curator.runs.query({ limit: 50 }),
-      serverTRPC.llm.listProviders.query(),
-      serverTRPC.llm.consumerConfig.query({ consumer: "intake" }),
-      serverTRPC.llm.consumerConfig.query({ consumer: "grooming" }),
-    ]);
+    [config, runs, providers, intakeConfig, intakeRuns, intakeConsumer, grooming] =
+      await Promise.all([
+        serverTRPC.curator.config.query(),
+        serverTRPC.curator.runs.query({ limit: 50 }),
+        serverTRPC.llm.listProviders.query(),
+        serverTRPC.intake.config.query(),
+        serverTRPC.intake.runs.query({ limit: 50 }),
+        serverTRPC.llm.consumerConfig.query({ consumer: "intake" }),
+        serverTRPC.llm.consumerConfig.query({ consumer: "grooming" }),
+      ]);
   } catch (err) {
     error = err instanceof Error ? err.message : String(err);
   }
 
   return (
-    <main className="flex flex-col gap-6 p-6">
-      <header className="flex items-center justify-between">
+    <main className="flex flex-col gap-8 p-6">
+      <header>
         <h1 className="text-2xl font-semibold tracking-tight">Memory Curator</h1>
-        <RunNowButton onRun={runCuratorNowAction} />
+        <p className="mt-1 text-sm text-muted-foreground">
+          Two jobs keep the corpus healthy: <strong>Intake</strong> consolidates new submissions in
+          the inbox; <strong>Grooming</strong> curates the existing corpus.
+        </p>
       </header>
       {error ? <p className="text-sm text-destructive">{error}</p> : null}
-      {config ? <CuratorConfigSummary config={config} /> : null}
-      {config ? <CuratorConfigForm initial={config} onSave={saveCuratorConfigAction} /> : null}
 
+      {/* Shared LLM providers — serves both jobs, so it lives once, above the
+          per-job sections. */}
       <ProviderManager
         initialProviders={providers}
         actions={{
@@ -62,32 +81,73 @@ export default async function CuratorPage() {
         }}
       />
 
-      {intake && grooming ? (
-        <section
-          className="flex flex-col gap-3 rounded-md border bg-card p-4"
-          aria-label="Per-consumer models"
-        >
-          <h2 className="font-semibold">Per-consumer models</h2>
-          <ConsumerModelSelector
-            consumer="intake"
-            config={intake}
-            providers={providers}
-            onSave={setConsumerConfigAction}
-            onListModels={listModelsAction}
+      {/* --- Intake -------------------------------------------------------- */}
+      <section className="flex flex-col gap-4" aria-label="Intake">
+        <header className="flex items-center justify-between border-b pb-2">
+          <h2 className="text-xl font-semibold">Intake</h2>
+          <RunNowButton
+            onRun={runIntakeNowAction}
+            renderResult={renderIntakeResult}
+            label="Run intake now"
+            ariaLabel="Run intake now"
           />
-          <ConsumerModelSelector
-            consumer="grooming"
-            config={grooming}
-            providers={providers}
-            onSave={setConsumerConfigAction}
-            onListModels={listModelsAction}
-          />
+        </header>
+        {intakeConfig ? (
+          <IntakeConfigForm enabled={intakeConfig.enabled} onSave={setIntakeConfigAction} />
+        ) : null}
+        {intakeConsumer ? (
+          <section
+            className="flex flex-col gap-3 rounded-md border bg-card p-4"
+            aria-label="Intake model"
+          >
+            <h3 className="font-semibold">Model</h3>
+            <ConsumerModelSelector
+              consumer="intake"
+              config={intakeConsumer}
+              providers={providers}
+              onSave={setConsumerConfigAction}
+              onListModels={listModelsAction}
+            />
+          </section>
+        ) : null}
+        <section className="rounded-md border bg-card p-4" aria-label="Intake run history">
+          <h3 className="mb-3 font-semibold">Recent runs</h3>
+          <IntakeRunsTable runs={intakeRuns} onLoadOperations={loadIntakeOperationsAction} />
         </section>
-      ) : null}
+      </section>
 
-      <section className="rounded-md border bg-card p-4" aria-label="Run history">
-        <h2 className="mb-3 font-semibold">Recent runs</h2>
-        <CuratorRunsTable runs={runs} />
+      {/* --- Grooming ------------------------------------------------------ */}
+      <section className="flex flex-col gap-4" aria-label="Grooming">
+        <header className="flex items-center justify-between border-b pb-2">
+          <h2 className="text-xl font-semibold">Grooming</h2>
+          <RunNowButton
+            onRun={runCuratorNowAction}
+            renderResult={renderGroomingResult}
+            label="Run grooming now"
+            ariaLabel="Run grooming now"
+          />
+        </header>
+        {config ? <CuratorConfigSummary config={config} /> : null}
+        {config ? <CuratorConfigForm initial={config} onSave={saveCuratorConfigAction} /> : null}
+        {grooming ? (
+          <section
+            className="flex flex-col gap-3 rounded-md border bg-card p-4"
+            aria-label="Grooming model"
+          >
+            <h3 className="font-semibold">Model</h3>
+            <ConsumerModelSelector
+              consumer="grooming"
+              config={grooming}
+              providers={providers}
+              onSave={setConsumerConfigAction}
+              onListModels={listModelsAction}
+            />
+          </section>
+        ) : null}
+        <section className="rounded-md border bg-card p-4" aria-label="Grooming run history">
+          <h3 className="mb-3 font-semibold">Recent runs</h3>
+          <CuratorRunsTable runs={runs} />
+        </section>
       </section>
     </main>
   );

--- a/apps/dashboard/components/curator/intake-config-form.tsx
+++ b/apps/dashboard/components/curator/intake-config-form.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+// Intake enablement toggle (spec 043 C5b). Intake has no grooming-specific knobs
+// (auto-apply level / confidence / schedule live on grooming) — its only job-level
+// setting here is on/off (`curator.intake.enabled`). Provider/model is the shared
+// per-consumer selector. Mirrors the grooming config form's save UX.
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import type { SaveConfigResult } from "@/app/curator/actions";
+
+export function IntakeConfigForm({
+  enabled: initialEnabled,
+  onSave,
+}: {
+  enabled: boolean;
+  onSave: (input: { enabled: boolean }) => Promise<SaveConfigResult>;
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [status, setStatus] = useState<string | null>(null);
+  const [enabled, setEnabled] = useState(initialEnabled);
+
+  const submit = (event: React.FormEvent) => {
+    event.preventDefault();
+    startTransition(async () => {
+      const result = await onSave({ enabled });
+      setStatus(result.ok ? "Saved." : `Error: ${result.error}`);
+      if (result.ok) router.refresh();
+    });
+  };
+
+  return (
+    <form
+      onSubmit={submit}
+      className="flex flex-col gap-4 rounded-md border bg-card p-4"
+      aria-label="Intake configuration form"
+    >
+      <h3 className="font-semibold">Enablement</h3>
+      <label className="flex items-center gap-2 text-sm">
+        <input type="checkbox" checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />
+        Enable inbox consolidation (intake)
+      </label>
+      <div className="flex items-center gap-3">
+        <button
+          type="submit"
+          disabled={pending}
+          className="rounded-md border bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground disabled:opacity-50"
+        >
+          {pending ? "Saving…" : "Save"}
+        </button>
+        {status ? <span className="text-sm text-muted-foreground">{status}</span> : null}
+      </div>
+    </form>
+  );
+}

--- a/apps/dashboard/components/curator/intake-runs-table.tsx
+++ b/apps/dashboard/components/curator/intake-runs-table.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+// Read-only intake (consolidation) decision history (spec 043 C1 / C5b). Unlike
+// grooming's runs table (token/model-centric per curation pass), an intake run is
+// a whole-inbox sweep whose VALUE is the C1 decision log — what the judge decided
+// for each item and how it was realised. So each run row expands to reveal its
+// per-operation decisions: action / outcome / confidence / rationale (loaded on
+// demand to keep the page payload small). source/target ids are shown so an admin
+// can trace a decision back to the inbox item + the memory it touched.
+
+import type { ConsolidationOperation, ConsolidationRun } from "@librarian/core";
+import { useState, useTransition } from "react";
+import type { LoadOperationsResult } from "@/app/curator/actions";
+
+function fmt(ts: string | null): string {
+  return ts ? new Date(ts).toLocaleString() : "—";
+}
+
+const outcomeTone: Record<string, string> = {
+  applied: "text-green-600",
+  proposed: "text-blue-600",
+  skipped: "text-muted-foreground",
+  failed: "text-destructive",
+};
+
+function OperationsDetail({ operations }: { operations: ConsolidationOperation[] }) {
+  if (operations.length === 0) {
+    return <p className="px-2 py-2 text-sm text-muted-foreground">No decisions recorded.</p>;
+  }
+  return (
+    <table className="w-full text-left text-xs" aria-label="Intake decisions">
+      <thead className="text-muted-foreground">
+        <tr>
+          <th className="py-1 pr-4 font-medium">Action</th>
+          <th className="py-1 pr-4 font-medium">Outcome</th>
+          <th className="py-1 pr-4 font-medium">Confidence</th>
+          <th className="py-1 pr-4 font-medium">Rationale</th>
+          <th className="py-1 pr-4 font-medium">Source</th>
+          <th className="py-1 font-medium">Target</th>
+        </tr>
+      </thead>
+      <tbody>
+        {operations.map((op) => (
+          <tr key={op.id} className="border-t align-top">
+            <td className="py-1 pr-4 font-mono">{op.action}</td>
+            <td className={`py-1 pr-4 font-medium ${outcomeTone[op.outcome] ?? ""}`}>
+              {op.outcome}
+            </td>
+            <td className="py-1 pr-4 font-mono">{op.confidence.toFixed(2)}</td>
+            <td className="py-1 pr-4">{op.rationale || "—"}</td>
+            <td className="py-1 pr-4 font-mono">{op.source_id ?? "—"}</td>
+            <td className="py-1 font-mono">{op.target_id ?? "—"}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function RunRow({
+  run,
+  onLoadOperations,
+}: {
+  run: ConsolidationRun;
+  onLoadOperations: (runId: string) => Promise<LoadOperationsResult>;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [operations, setOperations] = useState<ConsolidationOperation[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const toggle = () => {
+    const next = !expanded;
+    setExpanded(next);
+    // Lazy-load the decisions the first time this run is opened.
+    if (next && operations === null && !pending) {
+      startTransition(async () => {
+        const result = await onLoadOperations(run.id);
+        if (result.ok) setOperations(result.operations);
+        else setError(result.error);
+      });
+    }
+  };
+
+  return (
+    <>
+      <tr className="border-t align-top">
+        <td className="py-2 pr-4">
+          <button
+            type="button"
+            onClick={toggle}
+            aria-expanded={expanded}
+            aria-label={`${expanded ? "Hide" : "Show"} decisions for run ${run.id}`}
+            className="text-left underline-offset-2 hover:underline"
+          >
+            {expanded ? "▾" : "▸"} {run.trigger}
+          </button>
+        </td>
+        <td className="py-2 pr-4">{run.status}</td>
+        <td className="py-2 pr-4 font-mono text-xs">{fmt(run.started_at)}</td>
+        <td className="py-2 pr-4">{run.summary ?? run.error ?? "—"}</td>
+        <td className="py-2 font-mono text-xs">{run.consolidated}</td>
+      </tr>
+      {expanded ? (
+        <tr className="border-t bg-background/50">
+          <td colSpan={5} className="px-2 py-1">
+            {pending ? (
+              <p className="px-2 py-2 text-sm text-muted-foreground">Loading decisions…</p>
+            ) : error ? (
+              <p className="px-2 py-2 text-sm text-destructive">Error: {error}</p>
+            ) : operations ? (
+              <OperationsDetail operations={operations} />
+            ) : null}
+          </td>
+        </tr>
+      ) : null}
+    </>
+  );
+}
+
+export function IntakeRunsTable({
+  runs,
+  onLoadOperations,
+}: {
+  runs: ConsolidationRun[];
+  onLoadOperations: (runId: string) => Promise<LoadOperationsResult>;
+}) {
+  if (runs.length === 0) {
+    return <p className="text-sm text-muted-foreground">No intake runs yet.</p>;
+  }
+  return (
+    <table className="w-full text-left text-sm" aria-label="Intake runs">
+      <thead className="text-xs text-muted-foreground">
+        <tr>
+          <th className="py-2 pr-4 font-medium">Trigger</th>
+          <th className="py-2 pr-4 font-medium">Status</th>
+          <th className="py-2 pr-4 font-medium">Started</th>
+          <th className="py-2 pr-4 font-medium">Summary</th>
+          <th className="py-2 font-medium">Consolidated</th>
+        </tr>
+      </thead>
+      <tbody>
+        {runs.map((run) => (
+          <RunRow key={run.id} run={run} onLoadOperations={onLoadOperations} />
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/apps/dashboard/components/curator/run-now-button.tsx
+++ b/apps/dashboard/components/curator/run-now-button.tsx
@@ -1,10 +1,52 @@
 "use client";
 
+import type { ConsolidatorTickResult, CuratorTickResult } from "@librarian/core";
 import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
-import type { RunNowResult } from "@/app/curator/actions";
 
-export function RunNowButton({ onRun }: { onRun: () => Promise<RunNowResult> }) {
+// --- Result renderers (pure, shape-specific) ----------------------------------
+// The {ran:false,reason} skip states are turned into an explicit human notice so
+// an admin sees *why* nothing ran (disabled / incomplete config / no token).
+
+const skipLabel = (reason: string) => `Skipped — ${reason.replace(/_/g, " ")}.`;
+
+/** Grooming tick: N of M due slice(s) curated, or a skip reason. */
+export function renderGroomingResult(result: CuratorTickResult): string {
+  return result.ran
+    ? `Ran — ${result.summary.ran} of ${result.summary.due} due slice(s) curated.`
+    : skipLabel(result.reason);
+}
+
+/** Intake sweep: items consolidated this sweep, or a skip reason. */
+export function renderIntakeResult(
+  result: ConsolidatorTickResult | { ran: false; reason: "disabled" },
+): string {
+  return result.ran
+    ? `Ran — ${result.summary.consolidated} item(s) consolidated.`
+    : skipLabel(result.reason);
+}
+
+// A run-now result is either an error or a job-specific result object. The button
+// is shape-agnostic: each section supplies a `renderResult` that turns its own
+// success/skip result into a human message, so one button drives both the
+// grooming tick (CuratorTickResult) and the intake sweep (ConsolidatorTickResult)
+// without leaking either shape here. The {ran:false,reason} skip states are
+// surfaced via that renderer, never swallowed.
+export type RunActionResult<R> = { ok: true; result: R } | { ok: false; error: string };
+
+const defaultLabel = "Run now";
+
+export function RunNowButton<R>({
+  onRun,
+  renderResult,
+  label = defaultLabel,
+  ariaLabel,
+}: {
+  onRun: () => Promise<RunActionResult<R>>;
+  renderResult: (result: R) => string;
+  label?: string;
+  ariaLabel?: string;
+}) {
   const [pending, startTransition] = useTransition();
   const [message, setMessage] = useState<string | null>(null);
   const router = useRouter();
@@ -16,12 +58,7 @@ export function RunNowButton({ onRun }: { onRun: () => Promise<RunNowResult> }) 
         setMessage(`Error: ${res.error}`);
         return;
       }
-      const r = res.result;
-      setMessage(
-        r.ran
-          ? `Ran — ${r.summary.ran} of ${r.summary.due} due slice(s) curated.`
-          : `Skipped — ${r.reason.replace(/_/g, " ")}.`,
-      );
+      setMessage(renderResult(res.result));
       router.refresh();
     });
 
@@ -31,9 +68,10 @@ export function RunNowButton({ onRun }: { onRun: () => Promise<RunNowResult> }) 
         type="button"
         onClick={run}
         disabled={pending}
+        aria-label={ariaLabel ?? label}
         className="rounded-md border bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground disabled:opacity-50"
       >
-        {pending ? "Running…" : "Run now"}
+        {pending ? "Running…" : label}
       </button>
       {message ? <span className="text-sm text-muted-foreground">{message}</span> : null}
     </div>

--- a/apps/dashboard/e2e/curator-sections.spec.ts
+++ b/apps/dashboard/e2e/curator-sections.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test } from "@playwright/test";
+
+// C5b: the unified curator dashboard — ONE page, TWO parallel sections (Intake +
+// Grooming), each with enablement, model config, recent runs, and run-now. This
+// exercises the UI + the round-trip through the same-origin tRPC proxy and the
+// real mcp-server intake/curator routers (auth is off in the shared e2e server,
+// so this covers the controls + wiring, not the login gate — see global-setup.ts).
+//
+// No LLM provider is configured in the e2e store, so an intake run-now returns a
+// {ran:false, reason:"disabled"|"incomplete_config"|...} skip — the test asserts
+// that skip is SURFACED to the admin (not swallowed), which is the load-bearing
+// C5b behaviour.
+
+test.describe("unified curator dashboard", () => {
+  test("both Intake and Grooming sections are present with their controls", async ({ page }) => {
+    await page.goto("/curator");
+    await expect(page.getByRole("heading", { name: "Memory Curator", level: 1 })).toBeVisible();
+
+    const intake = page.getByRole("region", { name: "Intake", exact: true });
+    const grooming = page.getByRole("region", { name: "Grooming", exact: true });
+
+    // Each section is a clearly-labelled area with its own heading + run-now +
+    // model controls + recent-runs.
+    await expect(intake.getByRole("heading", { name: "Intake", level: 2 })).toBeVisible();
+    await expect(grooming.getByRole("heading", { name: "Grooming", level: 2 })).toBeVisible();
+
+    await expect(intake.getByRole("button", { name: "Run intake now" })).toBeVisible();
+    await expect(grooming.getByRole("button", { name: "Run grooming now" })).toBeVisible();
+
+    await expect(intake.getByRole("region", { name: "Intake run history" })).toBeVisible();
+    await expect(grooming.getByRole("region", { name: "Grooming run history" })).toBeVisible();
+
+    // Shared provider management lives once, outside the per-job sections.
+    await expect(page.getByRole("region", { name: "LLM providers" })).toBeVisible();
+  });
+
+  test("intake enablement toggles and persists", async ({ page }) => {
+    await page.goto("/curator");
+    const intake = page.getByRole("region", { name: "Intake", exact: true });
+    const form = intake.getByRole("form", { name: "Intake configuration form" });
+    const toggle = form.getByRole("checkbox");
+
+    // Read the current state, flip it, save, and confirm it persisted on reload.
+    const before = await toggle.isChecked();
+    await toggle.setChecked(!before);
+    await form.getByRole("button", { name: "Save" }).click();
+    await expect(form.getByText("Saved.")).toBeVisible();
+
+    await page.reload();
+    const intakeAfter = page.getByRole("region", { name: "Intake", exact: true });
+    const toggleAfter = intakeAfter
+      .getByRole("form", { name: "Intake configuration form" })
+      .getByRole("checkbox");
+    await expect(toggleAfter).toBeChecked({ checked: !before });
+
+    // Restore the original state so the shared e2e store isn't left mutated.
+    await toggleAfter.setChecked(before);
+    await intakeAfter
+      .getByRole("form", { name: "Intake configuration form" })
+      .getByRole("button", {
+        name: "Save",
+      })
+      .click();
+    await expect(
+      intakeAfter.getByRole("form", { name: "Intake configuration form" }).getByText("Saved."),
+    ).toBeVisible();
+  });
+
+  test("intake run-now surfaces a skip reason when intake can't run", async ({ page }) => {
+    await page.goto("/curator");
+    const intake = page.getByRole("region", { name: "Intake", exact: true });
+
+    // Ensure intake is disabled so run-now deterministically reports a skip.
+    const form = intake.getByRole("form", { name: "Intake configuration form" });
+    const toggle = form.getByRole("checkbox");
+    if (await toggle.isChecked()) {
+      await toggle.setChecked(false);
+      await form.getByRole("button", { name: "Save" }).click();
+      await expect(form.getByText("Saved.")).toBeVisible();
+    }
+
+    await intake.getByRole("button", { name: "Run intake now" }).click();
+    // The {ran:false,reason} state is shown, never swallowed.
+    await expect(intake.getByText(/Skipped — /)).toBeVisible();
+  });
+
+  test("grooming run-now is operable and reports a result", async ({ page }) => {
+    await page.goto("/curator");
+    const grooming = page.getByRole("region", { name: "Grooming", exact: true });
+    await grooming.getByRole("button", { name: "Run grooming now" }).click();
+    // With no provider configured the tick skips; either way the result is shown.
+    await expect(grooming.getByText(/Ran — |Skipped — |Error: /)).toBeVisible();
+  });
+});

--- a/apps/dashboard/tests/components/curator/cockpit-actions.test.tsx
+++ b/apps/dashboard/tests/components/curator/cockpit-actions.test.tsx
@@ -3,7 +3,11 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { CuratorConfigForm } from "@/components/curator/config-form";
-import { RunNowButton } from "@/components/curator/run-now-button";
+import {
+  RunNowButton,
+  renderGroomingResult,
+  renderIntakeResult,
+} from "@/components/curator/run-now-button";
 
 vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
 
@@ -22,7 +26,7 @@ describe("RunNowButton", () => {
       ok: true as const,
       result: { ran: true as const, summary },
     }));
-    render(<RunNowButton onRun={onRun} />);
+    render(<RunNowButton onRun={onRun} renderResult={renderGroomingResult} />);
     await userEvent.click(screen.getByRole("button", { name: /run now/i }));
     expect(onRun).toHaveBeenCalledTimes(1);
     expect(screen.getByText(/Ran — 2 of 2 due/)).toBeTruthy();
@@ -33,16 +37,45 @@ describe("RunNowButton", () => {
       ok: true as const,
       result: { ran: false as const, reason: "disabled" as const },
     }));
-    render(<RunNowButton onRun={onRun} />);
+    render(<RunNowButton onRun={onRun} renderResult={renderGroomingResult} />);
     await userEvent.click(screen.getByRole("button", { name: /run now/i }));
     expect(screen.getByText(/Skipped — disabled/)).toBeTruthy();
   });
 
   it("surfaces an error", async () => {
     const onRun = vi.fn(async () => ({ ok: false as const, error: "nope" }));
-    render(<RunNowButton onRun={onRun} />);
+    render(<RunNowButton onRun={onRun} renderResult={renderGroomingResult} />);
     await userEvent.click(screen.getByRole("button", { name: /run now/i }));
     expect(screen.getByText(/Error: nope/)).toBeTruthy();
+  });
+
+  it("renders an intake sweep result with a custom label and renderer", async () => {
+    const onRun = vi.fn(async () => ({
+      ok: true as const,
+      result: {
+        ran: true as const,
+        summary: {
+          reclaimed: 0,
+          consolidated: 3,
+          judgeErrors: 0,
+          claimedByOther: 0,
+          errored: 0,
+        },
+      },
+    }));
+    render(<RunNowButton onRun={onRun} renderResult={renderIntakeResult} label="Run intake now" />);
+    await userEvent.click(screen.getByRole("button", { name: /run intake now/i }));
+    expect(screen.getByText(/Ran — 3 item\(s\) consolidated/)).toBeTruthy();
+  });
+
+  it("surfaces an intake disabled skip (not swallowed)", async () => {
+    const onRun = vi.fn(async () => ({
+      ok: true as const,
+      result: { ran: false as const, reason: "disabled" as const },
+    }));
+    render(<RunNowButton onRun={onRun} renderResult={renderIntakeResult} label="Run intake now" />);
+    await userEvent.click(screen.getByRole("button", { name: /run intake now/i }));
+    expect(screen.getByText(/Skipped — disabled/)).toBeTruthy();
   });
 });
 

--- a/apps/dashboard/tests/components/curator/intake.test.tsx
+++ b/apps/dashboard/tests/components/curator/intake.test.tsx
@@ -1,0 +1,104 @@
+import type { ConsolidationOperation, ConsolidationRun } from "@librarian/core";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { IntakeConfigForm } from "@/components/curator/intake-config-form";
+import { IntakeRunsTable } from "@/components/curator/intake-runs-table";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
+
+function run(over: Partial<ConsolidationRun> = {}): ConsolidationRun {
+  return {
+    id: "crun_1",
+    status: "completed",
+    trigger: "manual",
+    consolidated: 2,
+    judge_errors: 0,
+    errored: 0,
+    reclaimed: 0,
+    summary: "consolidated 2",
+    error: null,
+    created_at: "2026-05-24T00:00:00.000Z",
+    started_at: "2026-05-24T00:00:00.000Z",
+    completed_at: "2026-05-24T00:01:00.000Z",
+    ...over,
+  };
+}
+
+function op(over: Partial<ConsolidationOperation> = {}): ConsolidationOperation {
+  return {
+    id: "cop_1",
+    run_id: "crun_1",
+    action: "augment",
+    outcome: "applied",
+    confidence: 0.88,
+    rationale: "extends existing doc",
+    source_id: "inbox/item-1",
+    target_id: "mem_42",
+    ...over,
+  };
+}
+
+describe("IntakeConfigForm", () => {
+  it("reflects the current enabled state and saves a toggle", async () => {
+    const onSave = vi.fn(async (_input: { enabled: boolean }) => ({ ok: true as const }));
+    render(<IntakeConfigForm enabled={false} onSave={onSave} />);
+
+    const toggle = screen.getByRole("checkbox");
+    expect((toggle as HTMLInputElement).checked).toBe(false);
+    await userEvent.click(toggle);
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave.mock.calls[0]![0]).toEqual({ enabled: true });
+    expect(screen.getByText("Saved.")).toBeTruthy();
+  });
+
+  it("surfaces a save error", async () => {
+    const onSave = vi.fn(async () => ({ ok: false as const, error: "boom" }));
+    render(<IntakeConfigForm enabled={true} onSave={onSave} />);
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+    expect(screen.getByText(/Error: boom/)).toBeTruthy();
+  });
+});
+
+describe("IntakeRunsTable", () => {
+  it("renders an empty state with no runs", () => {
+    render(<IntakeRunsTable runs={[]} onLoadOperations={vi.fn()} />);
+    expect(screen.getByText(/no intake runs/i)).toBeTruthy();
+  });
+
+  it("renders a run row with its summary and consolidated count", () => {
+    render(<IntakeRunsTable runs={[run()]} onLoadOperations={vi.fn()} />);
+    expect(screen.getByText("consolidated 2")).toBeTruthy();
+    // The trigger label sits inside the expand toggle (alongside its ▸ marker).
+    expect(screen.getByRole("button", { name: /show decisions for run crun_1/i })).toBeTruthy();
+  });
+
+  it("lazily loads and shows the C1 decisions when a run is expanded", async () => {
+    const onLoadOperations = vi.fn(async (_runId: string) => ({
+      ok: true as const,
+      operations: [op()],
+    }));
+    render(<IntakeRunsTable runs={[run()]} onLoadOperations={onLoadOperations} />);
+
+    // Not loaded until expanded.
+    expect(onLoadOperations).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole("button", { name: /show decisions/i }));
+    expect(onLoadOperations).toHaveBeenCalledWith("crun_1");
+
+    // The decision detail is visible: action / outcome / confidence / rationale.
+    expect(await screen.findByText("augment")).toBeTruthy();
+    expect(screen.getByText("applied")).toBeTruthy();
+    expect(screen.getByText("0.88")).toBeTruthy();
+    expect(screen.getByText("extends existing doc")).toBeTruthy();
+  });
+
+  it("surfaces an operations load error", async () => {
+    const onLoadOperations = vi.fn(async () => ({ ok: false as const, error: "nope" }));
+    render(<IntakeRunsTable runs={[run()]} onLoadOperations={onLoadOperations} />);
+    await userEvent.click(screen.getByRole("button", { name: /show decisions/i }));
+    expect(await screen.findByText(/Error: nope/)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## What & why

The user-visible payoff of the 043 curator arc. Restructures `/curator` into **ONE page with two clear, visually parallel sections — Intake and Grooming** — each carrying its own enablement toggle, model config, recent-run history, and run-now. The backend (C1–C5a) was all merged; this is the UI that surfaces it.

Before, `/curator` was grooming-centric with provider/model management mixed in and intake had no dashboard presence at all. After:

- **Shared LLM provider management** lives once, above both sections (it serves both jobs — not duplicated per section).
- **Intake** section: enablement toggle, model selector, and — for the first time — **observable consolidation history**.
- **Grooming** section: keeps all its existing controls (config summary/form, model selector, runs table, run-now).

## The Intake section consumes the C5a `intake` router (all `adminProcedure`)

- `IntakeConfigForm` → `intake.setConfig` (enablement on/off; intake has no grooming-specific knobs).
- `ConsumerModelSelector` (reused, already wired for `consumer:"intake"`) → provider/model.
- `IntakeRunsTable` renders the C1 consolidation decision log (`intake.runs`). **Each run row expands to lazily reveal its per-operation decisions** — action / outcome (applied·proposed·skipped·failed) / confidence / rationale / source / target — via `intake.runOperations`. This makes intake's decisions observable for the first time.
- `RunNowButton` (generalised) → `intake.runNow`, **surfacing the `{ran:false, reason}` skip states** (disabled / incomplete_config / no_token) to the admin rather than swallowing them.

## How the runs-table was handled

Grooming's runs (`CurationRun`, token/model-centric, flat) and intake's runs (`ConsolidationRun` + lazy-loaded `ConsolidationOperation` drill-down) genuinely differ in shape and presentation, so I added a focused `IntakeRunsTable` sibling rather than overloading grooming's table with conditional branches. They share no duplicated logic beyond a trivial date formatter — this is the more maintainable choice over a union-typed table. The `RunNowButton` *was* generalised (one shape-agnostic component taking a `renderResult`), since its skip/error UX is identical across both jobs.

## Safety

- No backend/router changes; no new public surface. Everything stays **admin-only**.
- **No token/secret is ever rendered**: the intake consumer view is presence-only (`hasToken`), the page passes only `enabled` to the toggle, and the decision log's rationale is redacted upstream (C1).

## Tests

- Component tests: `IntakeConfigForm` (toggle + save + error), `IntakeRunsTable` (empty / row / lazy decision drill-down / load error), `RunNowButton` generic intake + grooming renderers incl. surfaced skip states.
- Playwright e2e (`curator-sections.spec.ts`): both sections present with their controls, intake enablement toggles + persists, intake run-now surfaces a skip reason, grooming run-now operable. Existing `curator-providers.spec.ts` still passes against the restructured page.
- Full `pnpm test`, `pnpm -r build`, `pnpm typecheck`, `pnpm lint` all green locally.

## Review

No general-purpose review sub-agent is available in this sandbox, so I conducted the multi-axis review myself (Correctness / Readability / Architecture / Security / Performance), with emphasis on: admin-only (no public data exposure), no token/secret rendered, the `{ran:false,reason}` states surfaced not swallowed, and accessible/parallel section structure. No Critical/Important findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)