### PR TITLE
chore(curator): rename user-facing surfaces + docs + cleanup (spec 043 PR-6, Task C6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,13 @@ changes from this point forward are catalogued here.
 
 ### Changed
 
+- **Consistent "one curator, two jobs" naming across the product.** User-facing
+  surfaces now describe a single curator doing two jobs — **Intake** (consolidates
+  new submissions) and **Grooming** (tends the existing corpus) — rather than
+  exposing the older internal "consolidator" name. The dashboard model labels,
+  the `remember` queued-for-consolidation reply, the agent skill doc, and the
+  README curator section are updated to match. No behaviour change.
+
 - **Both curator jobs' enablement is now a dashboard setting; the
   `LIBRARIAN_CONSOLIDATOR` env var is deprecated.** Grooming and intake are now
   enabled/disabled from settings under the unified `curator.*` namespace

--- a/README.md
+++ b/README.md
@@ -114,8 +114,10 @@ That's it — memory tools and the handoff surface are live.
 - **Cross-harness handoffs** — `/handoff` packages the work in a five-section
   document; `/takeover` claims it atomically in another agent / harness; `/learn`
   promotes lessons from the conversation into memory proposals.
-- **Memory curator** — an optional scheduled LLM pass that grooms memory
-  (dedupe, archive stale, refine), configured and observed from the dashboard.
+- **Memory curator** — one curator doing two jobs: **Intake** consolidates new
+  submissions as they arrive, **Grooming** tends the existing corpus (dedupe,
+  archive stale, refine). Both are optional LLM passes, configured and observed
+  from the unified **Curator** dashboard.
 - **Dashboard** — a Next.js admin cockpit (Memories, Handoffs, Proposals,
   Archive, Analytics, Curator, Backups) with a ⌘K command palette.
 
@@ -232,11 +234,35 @@ project / cwd / harness scope flags.
 
 ## Memory curator
 
-The curator is an **optional, scheduled LLM pass** that grooms the memory store
-— deduping, archiving stale entries, refining wording — configured and observed
-from the dashboard **Curator** cockpit (`/curator`). The curator's LLM API
-token is encrypted at rest with `LIBRARIAN_SECRET_KEY`. Spec:
-[`docs/specs/done/013-memory-curator-spec.md`](./docs/specs/done/013-memory-curator-spec.md).
+One curator does **two jobs**, configured and observed from a single dashboard
+**Curator** cockpit (`/curator`) with parallel **Intake** and **Grooming**
+sections (shared LLM provider management above both):
+
+- **Intake** consolidates each new submission as it lands in the inbox —
+  augment / create / supersede / archive an existing entry, or propose a `split`
+  of an overloaded one (split is always proposed, never auto-applied). Intake's
+  decisions are observable per-run in the dashboard.
+- **Grooming** tends the existing corpus (dedupe, archive stale, refine).
+  Grooming is **triggered, not scheduled**: it runs from the dashboard's
+  *Run now* and automatically after an intake sweep pushes enough new material
+  past `curator.grooming.trigger_threshold` (rate-limited by
+  `curator.grooming.debounce_minutes`). The old wall-clock cron
+  (`LIBRARIAN_CURATOR_TICK_MS`) is retired.
+
+Each job is enabled independently from the dashboard
+(`curator.grooming.enabled` / `curator.intake.enabled`). The curator's LLM API
+token is encrypted at rest with `LIBRARIAN_SECRET_KEY`.
+
+> **Deprecation:** the `LIBRARIAN_CONSOLIDATOR` env opt-in is deprecated. On
+> first boot it seeds `curator.intake.enabled` once and logs a warning; the
+> dashboard setting is authoritative thereafter. Remove the env var and toggle
+> intake from the dashboard — it will be removed in a future release.
+> (`LIBRARIAN_CONSOLIDATOR_TICK_MS`, the intake tick cadence, is unaffected.)
+
+Spec:
+[`docs/specs/043-curator-unification-spec.md`](./docs/specs/043-curator-unification-spec.md)
+(builds on
+[`docs/specs/done/013-memory-curator-spec.md`](./docs/specs/done/013-memory-curator-spec.md)).
 
 ## Agent skill
 

--- a/apps/dashboard/app/curator/actions.ts
+++ b/apps/dashboard/app/curator/actions.ts
@@ -145,7 +145,7 @@ export async function testConnectionAction(input: ProbeInput): Promise<TestConne
   }
 }
 
-// --- Intake (consolidator) section (spec 043 C5b) -----------------------------
+// --- Intake section (spec 043 C5b) --------------------------------------------
 // Mirrors the grooming actions above against the C5a `intake` router. The intake
 // job owns only an enablement toggle here (provider/model is the shared
 // per-consumer selector); its runs are the C1 consolidation decision log.

--- a/apps/dashboard/components/curator/consumer-model-selector.tsx
+++ b/apps/dashboard/components/curator/consumer-model-selector.tsx
@@ -23,8 +23,8 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
 }
 
 const CONSUMER_LABEL: Record<CuratorConsumer, string> = {
-  intake: "Intake (consolidator)",
-  grooming: "Grooming (curator)",
+  intake: "Intake",
+  grooming: "Grooming",
 };
 
 export function ConsumerModelSelector({

--- a/packages/core/src/curator-tick.ts
+++ b/packages/core/src/curator-tick.ts
@@ -1,10 +1,11 @@
-// Curator tick (spec §12 + §14) — the config-driven entrypoint the server-side
-// scheduler calls on a (serial) timer, and the admin run-now action calls with a
-// manual trigger. Reads the admin config, gates on it, builds the LLM client from
-// it, and runs all due slices via runDueCuration as the system-memory-curator
-// actor. It never runs unless curation is enabled AND the LLM config is complete
-// AND the token can be decrypted (the scheduler must never run on an incomplete
-// config, §7.1).
+// Curator tick (spec §12 + §14) — the config-driven entrypoint for grooming.
+// Grooming is triggered, not scheduled (the wall-clock cron was retired in spec
+// 043 D-A): this runs from the admin run-now action ("manual" trigger) and from
+// the post-intake threshold trigger ("post_intake"; see grooming-trigger.ts).
+// Reads the admin config, gates on it, builds the LLM client from it, and runs
+// all due slices via runDueCuration as the system-memory-curator actor. It never
+// runs unless grooming is enabled AND the LLM config is complete AND the token
+// can be decrypted (it must never run on an incomplete config, §7.1).
 //
 // The LLM client builder is injectable for testing; in production it defaults to
 // the OpenAI-compatible client.

--- a/packages/mcp-server/src/mcp/tools/remember.ts
+++ b/packages/mcp-server/src/mcp/tools/remember.ts
@@ -49,7 +49,7 @@ const remember: ToolDefinition = {
       if (text.trim()) {
         store.submitToInbox(text, submissionHints(scoped));
         return textResult(
-          "Noted — queued for consolidation. The consolidator will file it into your memory shortly.",
+          "Noted — queued for consolidation. The curator will file it into your memory shortly.",
         );
       }
     }

--- a/skills/use-the-librarian/SKILL.md
+++ b/skills/use-the-librarian/SKILL.md
@@ -174,13 +174,13 @@ Use `remember` for active technical, project, environment, tool, lesson, people,
 
 Use `propose_memory` for protected or user-review-worthy memories.
 
-Write the smallest useful memory. You do **not** need to `recall` or search for existing memories first to avoid duplicates — the curator/consolidator de-duplicates, merges, and supersedes for you, asynchronously.
+Write the smallest useful memory. You do **not** need to `recall` or search for existing memories first to avoid duplicates — the curator de-duplicates, merges, and supersedes for you, asynchronously.
 
 ## Consolidation is automatic
 
-When the consolidator is enabled, `remember` is fire-and-forget: it returns `queued for consolidation` (no `duplicates` list), and the curator later navigates, judges, merges, and supersedes your submission as it grooms the corpus. You do not hand-consolidate.
+When the curator's intake is enabled, `remember` is fire-and-forget: it returns `queued for consolidation` (no `duplicates` list), and the curator later navigates, judges, merges, and supersedes your submission as it grooms the corpus. You do not hand-consolidate.
 
-On a legacy install with the consolidator off, `remember` saves directly and may return a `duplicates` list — that's informational, never a refusal. You generally don't need to act on it; reserve `update_memory` / `verify_memory result=outdated` for genuine corrections (see below), not as a manual dedup pass. (The `resolve_conflict` verb is retired.)
+On an install with intake off, `remember` saves directly and may return a `duplicates` list — that's informational, never a refusal. You generally don't need to act on it; reserve `update_memory` / `verify_memory result=outdated` for genuine corrections (see below), not as a manual dedup pass. (The `resolve_conflict` verb is retired.)
 
 ## Update and Verify
 
@@ -263,7 +263,7 @@ Keep it brief.
 
 - `start_context`: required task-start context
 - `recall`: targeted search
-- `remember`: submit a memory. With the consolidator on it's queued for async consolidation (the curator dedupes/merges); otherwise it saves directly. Protected categories become proposals.
+- `remember`: submit a memory. With the curator's intake on it's queued for async consolidation (the curator dedupes/merges); otherwise it saves directly. Protected categories become proposals.
 - `propose_memory`: submit protected or review-worthy memory
 - `update_memory`: edit while preserving history
 - `verify_memory`: useful (+1), not_useful (-1), outdated (archive)


### PR DESCRIPTION
Final PR of spec 043 (curator unification). Makes the user-facing naming consistent with the **"one curator, two jobs"** model (Intake + Grooming) and tidies up residue. Strings a human *sees* only — code identifiers, file names, the `@librarian/consolidator-eval` package, and the `curator.*` / `curator.intake.*` setting keys all stay (renaming them would be large, risky churn and is out of scope).

## User-facing renames
- **Dashboard** per-consumer model labels: `Intake (consolidator)` → **Intake**, `Grooming (curator)` → **Grooming** (`consumer-model-selector.tsx`). The page headings, nav, run-now buttons, and section regions already said Intake/Grooming (C5b) — this clears the last straggler.
- **`remember` queued reply** (returned to the agent/user): "The **consolidator** will file it" → "The **curator** will file it" (keeps the test-asserted `queued for consolidation`).
- **Agent skill doc** (`SKILL.md`): consolidator → curator / "the curator's intake".

## Doc updates
- **README "Memory curator" section + feature bullet** rewritten for the two-job reality:
  - Grooming is **triggered, not cron** — admin *Run now* + post-intake threshold (`curator.grooming.trigger_threshold`, rate-limited by `curator.grooming.debounce_minutes`); the wall-clock `LIBRARIAN_CURATOR_TICK_MS` cron is retired.
  - The **unified two-job dashboard** (one `/curator` page, Intake + Grooming, shared provider management); intake decisions observable per-run.
  - Intake's proposed-only **`split`** is enumerated.
  - Independent enablement settings (`curator.grooming.enabled` / `curator.intake.enabled`); the **`LIBRARIAN_CONSOLIDATOR` deprecation** (seeds the setting once + warns; removed in a future release) — with the `LIBRARIAN_CONSOLIDATOR_TICK_MS` carve-out (unaffected).
  - Spec link updated to the active 043 spec.

## Residue removed
- **`curator-tick.ts` header**: dropped the stale "the server-side scheduler calls on a (serial) timer" claim — provably false post-C3 (the only callers are admin `runNow` and the post-intake trigger; grep-verified). Rewritten to describe the triggered model.
- **classifier residue**: the `llm-connection.ts` lines the spec flagged were already cleaned by B1 — verified clean. The remaining `classifier` mentions are load-bearing explanatory references to the classifier-worker concept (Section 4d.3, the policy-boolean source of truth) — left untouched per "don't touch what you don't understand."
- **retired-cron wiring**: the `http.ts` grooming-cron retirement comment (C3) and `curator-enqueue.ts` "schedule" rationale are accurate + load-bearing — left. No leftover dead `LIBRARIAN_CURATOR_TICK_MS` wiring exists.

## CHANGELOG
Added a brief `### Changed` entry for the naming consistency (the `remember` reply + skill doc are agent-user-facing strings that genuinely changed text). The feature entries (unified dashboard, triggered grooming, deprecation, split) were already landed by C1–C5b.

## Verification
- **No behaviour change**: judges' prompts/op schemas, routers, stores, and the grooming/intake control flow are untouched (string/comment/doc edits only).
- Full suite green (core 791, mcp-server 124, dashboard 182, cli 44, consolidator-eval 39, root 22); **6/6 curator e2e** green; typecheck / lint / `pnpm -r build` (incl. Next.js) clean (no `error TS`).
- User-facing "consolidator" grep is clean (dashboard labels, docs prose, help, titles); remaining hits are code identifiers / the eval package / the env-var name / operator server-log strings / the maintainer-only seed tool — all in-scope to keep.

**Spec 043 is complete with this PR (C1–C6 all merged).**

Review was conducted **by me** (no general-purpose Task/Agent review sub-agent is available in this sandbox — confirmed again, as in C1–C5b). No Critical/Important/Suggestion findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)