### PR TITLE
feat(core): curator addenda as committed vault files (spec 044 PR-1, Task D1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,15 @@ changes from this point forward are catalogued here.
 
 ### Changed
 
+- **The curator's prompt addendum is now a git-versioned vault file.** Each
+  curator job's advisory prompt addendum moves out of a single overwritten
+  setting into a committed vault file (`<vault>/.curator/grooming-addendum.md`,
+  and `intake-addendum.md` for intake), so edits get git history, diff, and
+  revert for free. An existing install's `curator.prompt_addendum` is migrated
+  into the grooming file **byte-for-byte automatically on first start** and the
+  old setting is retired — no operator action needed. (The dashboard editor for
+  these files arrives in a later increment of this release.)
+
 - **Consistent "one curator, two jobs" naming across the product.** User-facing
   surfaces now describe a single curator doing two jobs — **Intake** (consolidates
   new submissions) and **Grooming** (tends the existing corpus) — rather than

--- a/apps/dashboard/components/curator/config-form.tsx
+++ b/apps/dashboard/components/curator/config-form.tsx
@@ -31,7 +31,6 @@ export function CuratorConfigForm({
   const [level, setLevel] = useState<AutoApplyLevel>(initial.defaultAutoApply);
   const [confidence, setConfidence] = useState(String(initial.autoApplyConfidence));
   const [intervalMinutes, setIntervalMinutes] = useState(String(initial.intervalMinutes));
-  const [addendum, setAddendum] = useState(initial.promptAddendum);
 
   const submit = (event: React.FormEvent) => {
     event.preventDefault();
@@ -41,7 +40,6 @@ export function CuratorConfigForm({
         defaultAutoApply: level,
         autoApplyConfidence: Number(confidence),
         intervalMinutes: Number(intervalMinutes),
-        promptAddendum: addendum,
       };
       const result = await onSave(patch);
       setStatus(result.ok ? "Saved." : `Error: ${result.error}`);
@@ -94,14 +92,6 @@ export function CuratorConfigForm({
           />
         </Field>
       </div>
-      <Field label="Prompt addendum (advisory, ≤ 2 KB)">
-        <textarea
-          className={inputClass}
-          rows={3}
-          value={addendum}
-          onChange={(e) => setAddendum(e.target.value)}
-        />
-      </Field>
       <div className="flex items-center gap-3">
         <button
           type="submit"

--- a/apps/dashboard/components/curator/config-summary.tsx
+++ b/apps/dashboard/components/curator/config-summary.tsx
@@ -29,7 +29,6 @@ export function CuratorConfigSummary({ config }: { config: CuratorConfig }) {
       <Row label="Schedule" value={`every ${config.intervalMinutes} minute(s)`} />
       <Row label="Auto-apply" value={config.defaultAutoApply} />
       <Row label="Confidence threshold" value={String(config.autoApplyConfidence)} />
-      <Row label="Prompt addendum" value={config.promptAddendum ? "set" : "—"} />
     </section>
   );
 }

--- a/apps/dashboard/tests/components/curator/cockpit-actions.test.tsx
+++ b/apps/dashboard/tests/components/curator/cockpit-actions.test.tsx
@@ -81,7 +81,6 @@ describe("RunNowButton", () => {
 
 const config: CuratorConfig = {
   enabled: false,
-  promptAddendum: "",
   defaultAutoApply: "safe_only",
   autoApplyConfidence: 0.9,
   intervalMinutes: 60,
@@ -110,6 +109,9 @@ describe("CuratorConfigForm", () => {
     // selectors own it now) — the patch must carry no LLM/token keys.
     expect("llm" in patch).toBe(false);
     expect("token" in patch).toBe(false);
+    // The prompt addendum left this form too (spec 044 D-1 — it's a committed
+    // vault file now; its dashboard editor is D7), so the patch must not set it.
+    expect("promptAddendum" in patch).toBe(false);
     expect(screen.getByText("Saved.")).toBeTruthy();
   });
 });

--- a/apps/dashboard/tests/components/curator/cockpit.test.tsx
+++ b/apps/dashboard/tests/components/curator/cockpit.test.tsx
@@ -7,7 +7,6 @@ import { CuratorRunsTable } from "@/components/curator/runs-table";
 function config(over: Partial<CuratorConfig> = {}): CuratorConfig {
   return {
     enabled: false,
-    promptAddendum: "",
     defaultAutoApply: "safe_only",
     autoApplyConfidence: 0.9,
     intervalMinutes: 60,

--- a/packages/core/src/curator-addendum.ts
+++ b/packages/core/src/curator-addendum.ts
@@ -1,0 +1,100 @@
+// Curator prompt addenda as committed vault files (spec 044 D-1 / 2C).
+//
+// Each curator job (intake / grooming) has a prompt addendum the admin uses to
+// teach THIS install's curator its owner's preferences. Pre-044 the addendum was
+// a single blind-overwritten setting (`curator.prompt_addendum`, grooming-only,
+// no history); 044 moves BOTH jobs' addenda into git-committed vault files
+// (`.curator/<job>-addendum.md`) so 2C's self-improvement loop can diff / revert /
+// roll them back by git hash. The version IS the file's last-touching commit hash
+// (load-bearing for later PRs: D3 tags proposals with it + rolls back via
+// `git checkout <hash>`).
+//
+// The file read/write/commit + version lives on the store layer (it owns the
+// vault + the git committer); these thin helpers expose it behind a focused
+// interface and own the one-time migration off the retired setting.
+
+import type { CuratorConsumer } from "./curator-consumers.js";
+import type { SettingsStore } from "./store/settings-store.js";
+
+/** A curator job — the same two consumers the LLM config + enablement key over. */
+export type CuratorJob = CuratorConsumer;
+
+/** A job's addendum content + its git version (the last-touching commit hash). */
+export interface JobAddendum {
+  /** The addendum text (empty string when the file is absent — fail-soft). */
+  content: string;
+  /** The commit hash that last touched the file, or null when it has no history. */
+  version: string | null;
+}
+
+/**
+ * The store slice the addendum helpers need: the committed-file read/write (which
+ * the LibrarianStore implements over the vault + git) plus settings for the
+ * one-time migration off the legacy setting.
+ */
+export interface AddendumStore extends SettingsStore {
+  readAddendum: (job: CuratorJob) => JobAddendum;
+  writeAddendum: (job: CuratorJob, content: string) => JobAddendum;
+}
+
+// The pre-044 grooming addendum setting. Read ONLY by migrateCuratorAddendum to
+// seed grooming-addendum.md once; the curator never reads it again (it's retired
+// at migration time, exactly like the C2 enablement migration).
+export const LEGACY_PROMPT_ADDENDUM_KEY = "curator.prompt_addendum";
+
+/**
+ * Read a curator job's prompt addendum from its committed vault file (spec 044
+ * D-1). Fail-soft: a missing file returns `{ content: "", version: null }` — the
+ * fresh-install default, identical to the pre-044 empty-setting behaviour. The
+ * version is the file's last-touching commit hash (stable; null until committed).
+ */
+export function readJobAddendum(store: AddendumStore, job: CuratorJob): JobAddendum {
+  return store.readAddendum(job);
+}
+
+/**
+ * Write a curator job's prompt addendum to its committed vault file AND commit it
+ * (spec 044 D-1), so the change is versioned + appears in `git log`. Returns the
+ * post-write record (content + the new version hash).
+ */
+export function setJobAddendum(
+  store: AddendumStore,
+  job: CuratorJob,
+  content: string,
+): JobAddendum {
+  return store.writeAddendum(job, content);
+}
+
+/**
+ * One-time, idempotent, no-clobber migration that moves the legacy grooming
+ * addendum setting (`curator.prompt_addendum`) into the committed
+ * `.curator/grooming-addendum.md` file so an existing install keeps its EXACT
+ * addendum after the 044 upgrade, now git-versioned (spec 044 D-1). Safe to run
+ * on every boot/tick — mirrors C2's migrateCuratorEnablement / C3's debounce seed:
+ *
+ *  - If `grooming-addendum.md` does NOT yet exist AND the legacy setting IS
+ *    present, write the setting's value BYTE-FOR-BYTE into the file + commit it.
+ *    No-clobber: an already-present file (e.g. an admin edit after a prior
+ *    migration) is left untouched.
+ *  - Retire the legacy setting unconditionally once observed, so it can never
+ *    re-seed a later edit. A fresh install with no setting leaves the file absent
+ *    → readJobAddendum returns "" (today's behaviour).
+ *
+ * Intake had no legacy addendum source (intake never consumed an addendum
+ * pre-044), so this migrates grooming only; intake's file is created on first
+ * write (D2 wires intake to read it).
+ */
+export function migrateCuratorAddendum(store: AddendumStore): void {
+  const legacy = store.getSetting(LEGACY_PROMPT_ADDENDUM_KEY);
+  if (legacy === null) return; // fresh install (or already migrated) — nothing to do.
+
+  // No-clobber: only seed when there is no destination file at all. Guarding on
+  // BOTH content and version (not just version) keeps a hand-placed but not-yet-
+  // committed file safe too — never overwrite an addendum the admin already has.
+  const existing = store.readAddendum("grooming");
+  if (existing.content === "" && existing.version === null) {
+    store.writeAddendum("grooming", legacy);
+  }
+  // Retire the setting regardless — it must never re-seed an edited file later.
+  store.deleteSetting(LEGACY_PROMPT_ADDENDUM_KEY);
+}

--- a/packages/core/src/curator-config.ts
+++ b/packages/core/src/curator-config.ts
@@ -1,9 +1,11 @@
 // Curator configuration (memory-curator spec §7.1), stored in the admin
-// settings store. Operator-managed: enable flag, prompt addendum, auto-apply
-// posture, and schedule. The LLM connection no longer lives here — providers are
-// named + dashboard-managed (`llm-providers.ts`) and each consumer (intake /
-// grooming) picks its own provider+model (`curator-consumers.ts`). This config
-// carries only the curator's NON-LLM knobs.
+// settings store. Operator-managed: enable flag, auto-apply posture, and
+// schedule. The LLM connection no longer lives here — providers are named +
+// dashboard-managed (`llm-providers.ts`) and each consumer (intake / grooming)
+// picks its own provider+model (`curator-consumers.ts`). The prompt addendum
+// likewise left this config in spec 044 D-1 — both jobs' addenda are now
+// git-committed vault files (`curator-addendum.ts`), versioned by commit hash.
+// This config carries only the curator's NON-LLM, NON-addendum knobs.
 //
 // `readCuratorConfig` reads plain settings only, so it works without the master
 // key — the admin cockpit can always render the configured state.
@@ -11,13 +13,12 @@
 import { z } from "zod";
 import type { LlmConnectionReader, LlmConnectionWriter } from "./llm-connection.js";
 
-// Curator-specific keys (enable flag, prompt addendum, auto-apply, schedule).
-// Grooming's enablement now lives under the unified `curator.grooming.enabled`
-// key (spec 043 D-E); the legacy `curator.enabled` is read once at migration
-// time and never again (see migrateCuratorEnablement / LEGACY_GROOMING_ENABLED_KEY).
+// Curator-specific keys (enable flag, auto-apply, schedule). Grooming's
+// enablement now lives under the unified `curator.grooming.enabled` key (spec
+// 043 D-E); the legacy `curator.enabled` is read once at migration time and
+// never again (see migrateCuratorEnablement / LEGACY_GROOMING_ENABLED_KEY).
 const KEYS = {
   enabled: "curator.grooming.enabled",
-  promptAddendum: "curator.prompt_addendum",
   defaultAutoApply: "curator.default_auto_apply",
   autoApplyConfidence: "curator.auto_apply_confidence",
   intervalMinutes: "curator.interval_minutes",
@@ -53,7 +54,6 @@ export const LEGACY_SCHEDULE_KEYS = [
 
 export type AutoApplyLevel = "off" | "safe_only" | "high_confidence";
 const AUTO_APPLY_LEVELS: readonly AutoApplyLevel[] = ["off", "safe_only", "high_confidence"];
-const MAX_ADDENDUM_BYTES = 2048; // §7.1: addendum is length-bounded (~2 KB)
 
 // Spec defaults (§7.2 / §12.4).
 const DEFAULT_AUTO_APPLY: AutoApplyLevel = "safe_only";
@@ -77,7 +77,6 @@ const MAX_DEBOUNCE_MINUTES = MAX_INTERVAL_MINUTES;
 
 export interface CuratorConfig {
   enabled: boolean;
-  promptAddendum: string;
   defaultAutoApply: AutoApplyLevel;
   autoApplyConfidence: number;
   /**
@@ -100,7 +99,6 @@ export interface CuratorConfig {
 
 export interface CuratorConfigPatch {
   enabled?: boolean;
-  promptAddendum?: string;
   defaultAutoApply?: AutoApplyLevel;
   autoApplyConfidence?: number;
   intervalMinutes?: number;
@@ -109,11 +107,10 @@ export interface CuratorConfigPatch {
 }
 
 // Input validation for the admin API. Permissive shape (all optional); the deeper
-// invariants — addendum ≤ 2 KB, confidence 0..1, interval ≥ 1 — are enforced by
+// invariants — confidence 0..1, interval ≥ 1 — are enforced by
 // writeCuratorConfig, which is the single source of truth.
 export const CuratorConfigPatchSchema = z.strictObject({
   enabled: z.boolean().optional(),
-  promptAddendum: z.string().optional(),
   defaultAutoApply: z.enum(["off", "safe_only", "high_confidence"]).optional(),
   autoApplyConfidence: z.number().optional(),
   intervalMinutes: z.number().optional(),
@@ -140,7 +137,6 @@ function parseNumber(raw: string | null, fallback: number): number {
 export function readCuratorConfig(store: ConfigReader): CuratorConfig {
   return {
     enabled: store.getSetting(KEYS.enabled) === "true",
-    promptAddendum: store.getSetting(KEYS.promptAddendum) ?? "",
     defaultAutoApply: parseAutoApply(store.getSetting(KEYS.defaultAutoApply)),
     autoApplyConfidence: parseNumber(
       store.getSetting(KEYS.autoApplyConfidence),
@@ -244,11 +240,6 @@ export function migrateCuratorEnablement(
 
 export function writeCuratorConfig(store: ConfigWriter, patch: CuratorConfigPatch): void {
   // Validate every curator-specific field before touching the store.
-  if (patch.promptAddendum !== undefined) {
-    if (Buffer.byteLength(patch.promptAddendum, "utf8") > MAX_ADDENDUM_BYTES) {
-      throw new Error(`prompt addendum must be ≤ ${MAX_ADDENDUM_BYTES} bytes (~2 KB)`);
-    }
-  }
   if (patch.defaultAutoApply !== undefined && !AUTO_APPLY_LEVELS.includes(patch.defaultAutoApply)) {
     throw new Error(`invalid default_auto_apply level: ${patch.defaultAutoApply}`);
   }
@@ -282,8 +273,6 @@ export function writeCuratorConfig(store: ConfigWriter, patch: CuratorConfigPatc
   }
 
   if (patch.enabled !== undefined) store.setSetting(KEYS.enabled, patch.enabled ? "true" : "false");
-  if (patch.promptAddendum !== undefined)
-    store.setSetting(KEYS.promptAddendum, patch.promptAddendum);
   if (patch.defaultAutoApply !== undefined)
     store.setSetting(KEYS.defaultAutoApply, patch.defaultAutoApply);
   if (patch.autoApplyConfidence !== undefined)

--- a/packages/core/src/curator-tick.ts
+++ b/packages/core/src/curator-tick.ts
@@ -11,6 +11,7 @@
 // the OpenAI-compatible client.
 
 import { SYSTEM_ACTOR_IDS } from "./caller-identity.js";
+import { migrateCuratorAddendum, readJobAddendum } from "./curator-addendum.js";
 import { migrateCuratorEnablement, readCuratorConfig } from "./curator-config.js";
 import {
   migrateLegacyCuratorLlm,
@@ -56,6 +57,9 @@ export async function runCuratorTick(options: CuratorTickOptions): Promise<Curat
   // setting (idempotent, no-clobber). Intake's env→setting seed runs at the http
   // boot where LIBRARIAN_CONSOLIDATOR is available; this tick migrates grooming.
   migrateCuratorEnablement(store);
+  // Move the legacy curator.prompt_addendum setting into the committed
+  // grooming-addendum.md vault file once (spec 044 D-1; idempotent, no-clobber).
+  migrateCuratorAddendum(store);
   const config = readCuratorConfig(store);
   const llm = readConsumerConfig(store, "grooming");
 
@@ -92,7 +96,9 @@ export async function runCuratorTick(options: CuratorTickOptions): Promise<Curat
     ),
     actorId: SYSTEM_ACTOR_IDS.memoryCurator,
     policy: { level: config.defaultAutoApply, confidenceThreshold: config.autoApplyConfidence },
-    promptAddendum: config.promptAddendum,
+    // The grooming addendum now lives in a git-committed vault file (spec 044
+    // D-1); read it from there (fail-soft "" when the file is absent).
+    promptAddendum: readJobAddendum(store, "grooming").content,
     model: { provider: llm.providerId, name: llm.model },
     trigger: options.trigger ?? "schedule",
     ...(options.bypassSkip !== undefined ? { bypassSkip: options.bypassSkip } : {}),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -191,6 +191,15 @@ export {
   writeCuratorConfig,
 } from "./curator-config.js";
 export {
+  type AddendumStore,
+  type CuratorJob,
+  type JobAddendum,
+  LEGACY_PROMPT_ADDENDUM_KEY,
+  migrateCuratorAddendum,
+  readJobAddendum,
+  setJobAddendum,
+} from "./curator-addendum.js";
+export {
   type LlmConnection,
   type LlmConnectionKeys,
   type LlmConnectionPatch,
@@ -344,10 +353,12 @@ export {
 export { type MemoryWriteVerdict, routeMemoryWrite } from "./store/memory-routing.js";
 export type { Memory, MemoryStore } from "./store/memory-store.js";
 export {
+  type AddendumRecord,
   type ConsolidateInboxOptions,
   type InternalLibrarianStore,
   type LibrarianStore,
   type LibrarianStoreOptions,
+  addendumPath,
   createLibrarianStore,
   resolveDataDir,
 } from "./store/librarian-store.js";

--- a/packages/core/src/store/git/sync-git-ops.ts
+++ b/packages/core/src/store/git/sync-git-ops.ts
@@ -34,6 +34,13 @@ export interface SyncGitOps {
   commitAll(message: string): string | null;
   /** Current HEAD hash, or `null` on a repo with no commits yet. */
   head(): string | null;
+  /**
+   * The full hash of the most recent commit that touched `relPath`, or `null`
+   * when the path has no history yet (never committed, or a commitless repo).
+   * Used as the addendum's version (spec 044 D-1): a stable hash later PRs tag
+   * proposals with and `git checkout` to roll back.
+   */
+  lastCommitFor(relPath: string): string | null;
   /** Commit subjects, newest first (empty on a repo with no commits). */
   log(): string[];
   isRepo(): boolean;
@@ -107,6 +114,14 @@ export function createSyncGitOps(opts: { cwd: string }): SyncGitOps {
     return tryGit(["rev-parse", "HEAD"])?.trim() ?? null;
   }
 
+  function lastCommitFor(relPath: string): string | null {
+    // `-1 --format=%H -- <path>` prints the newest touching commit's hash, or
+    // empty (exit 0) when the path has no history; tryGit also absorbs the
+    // commitless-repo case (exit non-zero) → null.
+    const out = tryGit(["log", "-1", "--format=%H", "--", relPath])?.trim();
+    return out ? out : null;
+  }
+
   function log(): string[] {
     const out = tryGit(["log", "--format=%s"]);
     if (out === null) return []; // no commits yet
@@ -124,7 +139,7 @@ export function createSyncGitOps(opts: { cwd: string }): SyncGitOps {
     );
   }
 
-  return { init, commitAll, head, log, isRepo, push };
+  return { init, commitAll, head, lastCommitFor, log, isRepo, push };
 }
 
 /**

--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -5,6 +5,7 @@ import {
   type SweepSummary,
   runConsolidatorSweep,
 } from "../consolidator/index.js";
+import type { CuratorConsumer } from "../curator-consumers.js";
 import type { LlmClient } from "../curator-llm-client.js";
 import { createVaultCuratorMemorySource } from "../curator-source-vault.js";
 import { MemoryStatus } from "../schemas/common.js";
@@ -102,6 +103,37 @@ export interface LibrarianStore
    * hash, or null if the vault has no commits yet.
    */
   pushVaultBackup(auth: GitPushAuth): string | null;
+  /**
+   * Read a curator job's prompt addendum from its committed vault file
+   * (`.curator/<job>-addendum.md`, spec 044 D-1). Fail-soft: a missing file
+   * returns `{ content: "", version: null }` (never throws). `version` is the
+   * git commit hash that last touched the file — load-bearing for 2C's
+   * self-improvement loop (proposal tagging + git rollback); null until the file
+   * has history.
+   */
+  readAddendum(job: CuratorConsumer): AddendumRecord;
+  /**
+   * Write a curator job's prompt addendum to its committed vault file AND commit
+   * it (spec 044 D-1), so it is versioned + appears in `git log`. Returns the
+   * post-write record (content + the new version hash).
+   */
+  writeAddendum(job: CuratorConsumer, content: string): AddendumRecord;
+}
+
+/** A curator job's addendum content + its git version (spec 044 D-1). */
+export interface AddendumRecord {
+  /** The addendum text (empty string when the file is absent — fail-soft). */
+  content: string;
+  /** The commit hash that last touched the file, or null when it has no history. */
+  version: string | null;
+}
+
+/**
+ * Vault-relative path of a job's committed addendum file (spec 044 D-1):
+ * `.curator/intake-addendum.md` / `.curator/grooming-addendum.md`.
+ */
+export function addendumPath(job: CuratorConsumer): string {
+  return `.curator/${job}-addendum.md`;
 }
 
 /** Options for `LibrarianStore.consolidateInbox`. */
@@ -278,6 +310,23 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Libra
       if (!head) return null;
       git.push(auth);
       return head;
+    },
+    // Curator addenda live as committed vault files (spec 044 D-1): same
+    // write+commit primitive as memory/handoff, read back as raw text (no
+    // frontmatter), versioned by the file's last-touching commit hash.
+    readAddendum: (job) => {
+      const rel = addendumPath(job);
+      const content = vault.tryReadText(rel) ?? "";
+      // The version is meaningful only when the file actually exists on disk;
+      // lastCommitFor would otherwise return null anyway, but skip the git call.
+      const version = vault.exists(rel) ? git.lastCommitFor(rel) : null;
+      return { content, version };
+    },
+    writeAddendum: (job, content) => {
+      const rel = addendumPath(job);
+      vault.writeText(rel, content);
+      commit(`curator: addendum ${job}`);
+      return { content, version: git.lastCommitFor(rel) };
     },
   };
 }

--- a/packages/core/tests/curator-addendum.test.ts
+++ b/packages/core/tests/curator-addendum.test.ts
@@ -1,0 +1,203 @@
+// Curator addenda as committed vault files (spec 044 D-1 / PR-1).
+//
+// Both jobs' prompt addenda move from the single `curator.prompt_addendum`
+// setting into git-committed vault files (`<vault>/.curator/intake-addendum.md`,
+// `grooming-addendum.md`) so 2C's self-improvement loop can version + roll them
+// back by git hash. This pins:
+//   - readJobAddendum is fail-soft (missing file → "", null version, no throw)
+//     and returns a stable commit hash once the file is committed;
+//   - setJobAddendum writes the file AND commits it (it appears in git log);
+//   - migrateCuratorAddendum moves curator.prompt_addendum → grooming-addendum.md
+//     byte-for-byte, commits it, retires the setting; idempotent + no-clobber;
+//     a fresh install (no setting) leaves the file absent → "".
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type LibrarianStore,
+  createLibrarianStore,
+  migrateCuratorAddendum,
+  readJobAddendum,
+  setJobAddendum,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+interface Scope {
+  store: LibrarianStore;
+  dataDir: string;
+}
+
+const LEGACY_ADDENDUM_KEY = "curator.prompt_addendum";
+
+function open(dataDir: string): LibrarianStore {
+  return createLibrarianStore({ dataDir });
+}
+
+function scope(): Scope {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-addendum-"));
+  return { store: open(dataDir), dataDir };
+}
+
+function teardown(s: Scope | null): void {
+  if (!s) return;
+  try {
+    s.store.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(s.dataDir, { recursive: true, force: true });
+}
+
+/** The git log subjects for the vault repo (newest first). */
+function vaultLog(dataDir: string): string[] {
+  const vaultRoot = path.join(dataDir, "vault");
+  try {
+    return execGit(vaultRoot, ["log", "--format=%s"]).split("\n").filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+/** Vault-relative paths tracked by git (i.e. files that are actually committed). */
+function vaultTracked(dataDir: string): string[] {
+  const vaultRoot = path.join(dataDir, "vault");
+  try {
+    return execGit(vaultRoot, ["ls-files"]).split("\n").filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function execGit(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).toString();
+}
+
+describe("curator addenda as committed vault files (spec 044 D-1)", () => {
+  let s: Scope | null = null;
+  beforeEach(() => {
+    s = scope();
+  });
+  afterEach(() => {
+    teardown(s);
+    s = null;
+  });
+
+  // ── readJobAddendum: fail-soft empty on a fresh install ──────────────────────
+
+  it("returns an empty addendum + null version when the file does not exist", () => {
+    const { store } = s!;
+    expect(readJobAddendum(store, "grooming")).toEqual({ content: "", version: null });
+    expect(readJobAddendum(store, "intake")).toEqual({ content: "", version: null });
+  });
+
+  // ── setJobAddendum: writes the file AND commits it ───────────────────────────
+
+  it("setJobAddendum writes the file, commits it, and exposes a stable version hash", () => {
+    const { store, dataDir } = s!;
+    setJobAddendum(store, "grooming", "prefer merging over archiving");
+
+    const file = path.join(dataDir, "vault", ".curator", "grooming-addendum.md");
+    expect(fs.readFileSync(file, "utf8")).toBe("prefer merging over archiving");
+
+    const got = readJobAddendum(store, "grooming");
+    expect(got.content).toBe("prefer merging over archiving");
+    expect(got.version).toMatch(/^[0-9a-f]{40}$/); // a real commit hash
+
+    // The write is a real git commit: the file is tracked + there's an addendum commit.
+    expect(vaultTracked(dataDir)).toContain(".curator/grooming-addendum.md");
+    expect(vaultLog(dataDir).some((m) => /addendum grooming/.test(m))).toBe(true);
+  });
+
+  it("writes each job to its own file independently", () => {
+    const { store, dataDir } = s!;
+    setJobAddendum(store, "intake", "intake guidance");
+    setJobAddendum(store, "grooming", "grooming guidance");
+
+    expect(readJobAddendum(store, "intake").content).toBe("intake guidance");
+    expect(readJobAddendum(store, "grooming").content).toBe("grooming guidance");
+    expect(fs.existsSync(path.join(dataDir, "vault", ".curator", "intake-addendum.md"))).toBe(true);
+    expect(fs.existsSync(path.join(dataDir, "vault", ".curator", "grooming-addendum.md"))).toBe(
+      true,
+    );
+  });
+
+  it("the version hash changes when the addendum is re-written", () => {
+    const { store } = s!;
+    setJobAddendum(store, "grooming", "v1");
+    const v1 = readJobAddendum(store, "grooming").version;
+    setJobAddendum(store, "grooming", "v2");
+    const v2 = readJobAddendum(store, "grooming").version;
+    expect(v1).not.toBeNull();
+    expect(v2).not.toBeNull();
+    expect(v2).not.toBe(v1);
+  });
+
+  // ── Migration: curator.prompt_addendum → grooming-addendum.md, byte-for-byte ─
+
+  it("migrates the legacy setting into grooming-addendum.md byte-for-byte and retires the setting", () => {
+    const { store, dataDir } = s!;
+    const legacy = "Existing operator guidance: prefer condensing.\nKeep it tight.";
+    store.setSetting(LEGACY_ADDENDUM_KEY, legacy);
+
+    migrateCuratorAddendum(store);
+
+    // File holds the EXACT bytes the setting held.
+    const file = path.join(dataDir, "vault", ".curator", "grooming-addendum.md");
+    expect(fs.readFileSync(file, "utf8")).toBe(legacy);
+    expect(readJobAddendum(store, "grooming").content).toBe(legacy);
+
+    // The legacy setting is gone.
+    expect(store.getSetting(LEGACY_ADDENDUM_KEY)).toBeNull();
+
+    // The migrated file is committed (tracked + in git log) and has a version.
+    expect(vaultTracked(dataDir)).toContain(".curator/grooming-addendum.md");
+    expect(vaultLog(dataDir).some((m) => /addendum grooming/.test(m))).toBe(true);
+    expect(readJobAddendum(store, "grooming").version).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  it("a fresh install with no legacy setting leaves the addendum absent → empty", () => {
+    const { store } = s!;
+    migrateCuratorAddendum(store);
+    expect(readJobAddendum(store, "grooming")).toEqual({ content: "", version: null });
+    expect(store.getSetting(LEGACY_ADDENDUM_KEY)).toBeNull();
+  });
+
+  it("does not touch the intake addendum during migration", () => {
+    const { store } = s!;
+    store.setSetting(LEGACY_ADDENDUM_KEY, "grooming-only guidance");
+    migrateCuratorAddendum(store);
+    expect(readJobAddendum(store, "intake")).toEqual({ content: "", version: null });
+  });
+
+  // ── Migration: idempotent + no-clobber ───────────────────────────────────────
+
+  it("is idempotent: re-running does not re-create or change the file", () => {
+    const { store } = s!;
+    store.setSetting(LEGACY_ADDENDUM_KEY, "original");
+    migrateCuratorAddendum(store);
+    const v1 = readJobAddendum(store, "grooming").version;
+
+    // The setting is already retired, so a second run is a no-op (no legacy value).
+    migrateCuratorAddendum(store);
+    const v2 = readJobAddendum(store, "grooming").version;
+    expect(v2).toBe(v1);
+    expect(readJobAddendum(store, "grooming").content).toBe("original");
+  });
+
+  it("no-clobber: never overwrites an existing edited grooming-addendum.md", () => {
+    const { store } = s!;
+    // The file already exists (the admin edited it after a prior migration).
+    setJobAddendum(store, "grooming", "edited by admin");
+    // A stale legacy setting is somehow still present.
+    store.setSetting(LEGACY_ADDENDUM_KEY, "legacy value");
+
+    migrateCuratorAddendum(store);
+
+    // The edited file wins; the migration must not clobber it.
+    expect(readJobAddendum(store, "grooming").content).toBe("edited by admin");
+    // The stale legacy setting is retired regardless (it must never re-seed later).
+    expect(store.getSetting(LEGACY_ADDENDUM_KEY)).toBeNull();
+  });
+});

--- a/packages/core/tests/curator-config.test.ts
+++ b/packages/core/tests/curator-config.test.ts
@@ -1,7 +1,9 @@
 // Curator configuration (memory-curator spec §7.1) over the settings store.
 //
-// Operator-managed NON-LLM config: enable flag, prompt addendum, auto-apply
-// posture, schedule. The LLM connection no longer lives here — providers are
+// Operator-managed NON-LLM config: enable flag, auto-apply posture, schedule.
+// The prompt addendum left this config in spec 044 D-1 (it's a committed vault
+// file now; see curator-addendum.test.ts). The LLM connection no longer lives
+// here either — providers are
 // named + dashboard-managed and each consumer picks its own (see
 // curator-consumers.test.ts). `readCuratorConfig` reads plain settings only, so
 // it always works without the master key.
@@ -86,29 +88,21 @@ describe("curator config", () => {
     const { store } = s!;
     writeCuratorConfig(store, {
       enabled: true,
-      promptAddendum: "prefer merging over archiving",
       defaultAutoApply: "high_confidence",
     });
     const cfg = readCuratorConfig(store);
     expect(cfg.enabled).toBe(true);
     expect(cfg.defaultAutoApply).toBe("high_confidence");
-    expect(cfg.promptAddendum).toBe("prefer merging over archiving");
   });
 
   it("reads the config WITHOUT the master key (cockpit render path)", () => {
     const { store, dataDir } = s!;
-    writeCuratorConfig(store, { enabled: true, promptAddendum: "x" });
+    writeCuratorConfig(store, { enabled: true });
     store.close();
     const noKey = open(dataDir);
     s!.store = noKey;
     const cfg = readCuratorConfig(noKey); // plain settings only — must not need the key
     expect(cfg.enabled).toBe(true);
-    expect(cfg.promptAddendum).toBe("x");
-  });
-
-  it("validates the prompt addendum length (≤ 2 KB)", () => {
-    const { store } = s!;
-    expect(() => writeCuratorConfig(store, { promptAddendum: "x".repeat(2049) })).toThrow(/2/);
   });
 
   it("round-trips intervalMinutes and clamps invalid values", () => {

--- a/packages/core/tests/curator-tick.test.ts
+++ b/packages/core/tests/curator-tick.test.ts
@@ -9,10 +9,12 @@ import path from "node:path";
 import {
   type LibrarianStore,
   type LlmClient,
+  type LlmCompletionRequest,
   addProvider,
   createLibrarianStore,
   resolveSecretKey,
   runCuratorTick,
+  setJobAddendum,
   writeConsumerConfig,
   writeCuratorConfig,
 } from "@librarian/core";
@@ -97,6 +99,48 @@ describe("runCuratorTick — operational", () => {
       "dummy-decrypted-token",
     );
     if (result.ran) expect(result.summary.ran).toBeGreaterThanOrEqual(1);
+  });
+
+  it("feeds the grooming addendum from the committed vault file into the prompt (spec 044 D-1)", async () => {
+    seedMemory();
+    writeCuratorConfig(store!, { enabled: true });
+    configureGrooming({ token: "dummy-decrypted-token" });
+    // The addendum lives in the committed vault file now, not a setting.
+    setJobAddendum(store!, "grooming", "MARKER-ADDENDUM prefer merging over archiving");
+
+    let capturedPrompt = "";
+    const capturingClient: LlmClient = {
+      complete: async (request: LlmCompletionRequest) => {
+        capturedPrompt = request.messages.map((m) => m.content).join("\n");
+        return { content: JSON.stringify({ operations: [] }), model: "m", usage: null };
+      },
+    };
+
+    const result = await runCuratorTick({ store: store!, buildClient: () => capturingClient });
+
+    expect(result.ran).toBe(true);
+    // The file's content reached the grooming prompt (it's the OPERATOR GUIDANCE block).
+    expect(capturedPrompt).toContain("MARKER-ADDENDUM prefer merging over archiving");
+  });
+
+  it("omits the operator-guidance block when the grooming addendum file is absent", async () => {
+    seedMemory();
+    writeCuratorConfig(store!, { enabled: true });
+    configureGrooming({ token: "dummy-decrypted-token" });
+    // No addendum file written → fail-soft empty → today's behaviour (no guidance).
+
+    let capturedPrompt = "";
+    const capturingClient: LlmClient = {
+      complete: async (request: LlmCompletionRequest) => {
+        capturedPrompt = request.messages.map((m) => m.content).join("\n");
+        return { content: JSON.stringify({ operations: [] }), model: "m", usage: null };
+      },
+    };
+
+    const result = await runCuratorTick({ store: store!, buildClient: () => capturingClient });
+
+    expect(result.ran).toBe(true);
+    expect(capturedPrompt).not.toContain("OPERATOR GUIDANCE");
   });
 });
 

--- a/packages/mcp-server/src/bin/http.ts
+++ b/packages/mcp-server/src/bin/http.ts
@@ -11,6 +11,7 @@ import {
   createLibrarianStore,
   createSerialScheduler,
   findLegacyScheduleKeys,
+  migrateCuratorAddendum,
   migrateCuratorEnablement,
   resolveBootCredentials,
   resolveDataDir,
@@ -192,6 +193,13 @@ const legacyIntakeEnv = legacyConsolidatorEnv();
 migrateCuratorEnablement(store, {
   ...(legacyIntakeEnv !== undefined ? { legacyIntakeEnv } : {}),
 });
+
+// Curator addendum migration (spec 044 D-1). Move the legacy
+// `curator.prompt_addendum` setting into the committed `.curator/grooming-addendum.md`
+// vault file ONCE so an existing install keeps its addendum byte-for-byte, now
+// git-versioned, then retire the setting. Idempotent + no-clobber — safe every boot.
+// Mirrored at the start of runCuratorTick so any entry point converges.
+migrateCuratorAddendum(store);
 
 // Deprecation notice: the LIBRARIAN_CONSOLIDATOR env opt-in is retired to a
 // seed-once role (above). It no longer gates intake — the dashboard setting

--- a/packages/mcp-server/src/trpc/curator.ts
+++ b/packages/mcp-server/src/trpc/curator.ts
@@ -1,11 +1,13 @@
 // Memory-curator admin tRPC procedures (memory-curator spec §7.1 / §13).
 //
 // The admin cockpit's typed surface: read/update the curator's NON-LLM config
-// (enable flag, schedule, auto-apply posture, prompt addendum), read-only run +
-// operation observability, and the run-now control. All admin-gated — there is
+// (enable flag, schedule, auto-apply posture), read-only run + operation
+// observability, and the run-now control. All admin-gated — there is
 // deliberately NO consumer-agent surface for curation (§12). The LLM connection
 // is no longer part of this surface — named providers + per-consumer model
-// selection live under the `llm` router (042 §4).
+// selection live under the `llm` router (042 §4). The prompt addendum left this
+// surface in spec 044 D-1 — it's a committed vault file now (its dashboard editor
+// is D7); this router no longer reads or writes it.
 
 import type { CuratorConfigPatch, ListCurationRunsInput } from "@librarian/core";
 import {

--- a/packages/mcp-server/tests/trpc/curator.test.ts
+++ b/packages/mcp-server/tests/trpc/curator.test.ts
@@ -45,7 +45,6 @@ async function trpcPost<T>(server: ServerHandle, path: string, input?: unknown):
 interface CuratorConfig {
   enabled: boolean;
   defaultAutoApply: string;
-  promptAddendum: string;
   intervalMinutes: number;
 }
 
@@ -88,11 +87,9 @@ describe("tRPC curator surface", () => {
       const after = await trpcPost<CuratorConfig>(server, "curator.setConfig", {
         enabled: true,
         defaultAutoApply: "high_confidence",
-        promptAddendum: "prefer merging",
       });
       expect(after.enabled).toBe(true);
       expect(after.defaultAutoApply).toBe("high_confidence");
-      expect(after.promptAddendum).toBe("prefer merging");
     } finally {
       await server.stop();
       cleanupTempDir(dataDir);


### PR DESCRIPTION
## What

First PR of spec 044 (2C, self-improving curator). Moves **both** curator jobs' prompt addenda out of the single, blind-overwritten `curator.prompt_addendum` setting into **git-committed vault files** so 2C's self-improvement loop can version, diff, and roll them back by commit hash (spec decision **D-1**).

- `<vault>/.curator/grooming-addendum.md`
- `<vault>/.curator/intake-addendum.md`

## How

- **Store layer owns the read/write/commit + version** (a faithful sibling of the memory/handoff store pattern). New `LibrarianStore.readAddendum(job)` / `writeAddendum(job, content)` write via `vault.writeText` then `commit("curator: addendum <job>")`, and read fail-soft via `vault.tryReadText` (missing file → `""`). The **version is the file's last-touching commit hash**, exposed by a new `SyncGitOps.lastCommitFor(relPath)` (`git log -1 --format=%H -- <rel>`; null when the file has no history). Thin core helpers `readJobAddendum` / `setJobAddendum` / `migrateCuratorAddendum` (new `curator-addendum.ts`) operate on a focused `AddendumStore` interface the store satisfies.

- **Byte-for-byte migration that retires the setting.** `migrateCuratorAddendum(store)`: if `curator.prompt_addendum` is present, write its value **verbatim** into `grooming-addendum.md`, commit it (it appears in `git log`), then **delete the legacy setting**. Idempotent + **no-clobber** (never overwrites an already-present/edited file — guards on both content and version). A fresh install with no setting leaves the file absent → `readJobAddendum` returns `""` (today's behaviour). Runs at the start of `runCuratorTick` **and** at HTTP boot, mirroring the C2 enablement migration.

- **Grooming rewired** to read its addendum from the file. `promptAddendum` removed from `CuratorConfig` / `CuratorConfigPatch` / the Zod schema / `readCuratorConfig` / `writeCuratorConfig` / the `KEYS.promptAddendum` key (retired). The dashboard addendum textarea is removed (its file-based editor lands in D7).

## Out of scope (later 044 PRs)

Intake does not consume its addendum yet (D2). No under-evaluation/force-propose (D3), dry-run (D4), admin mutations (D5), chat (D6), dashboard editor (D7), or big docs (D8).

## Tests

TDD (RED→GREEN). New `curator-addendum.test.ts` (real temp vault + git): fail-soft empty, write+commit + stable hash, per-job files, version-changes-on-rewrite, migration byte-for-byte + setting-retired + tracked-in-git-log, fresh-install-empty, intake-untouched, idempotent, no-clobber. Two new `curator-tick` cases pin grooming feeding the file's content into the actual LLM prompt and producing no OPERATOR GUIDANCE when the file is absent. Full suite green (core 801, mcp-server 124, dashboard 182) + `pnpm -r build` / typecheck / lint clean.

## CHANGELOG

One brief `### Changed` `[Unreleased]` note — the storage move is operator-facing (an existing addendum is auto-migrated byte-for-byte and the setting retired; the textarea is gone until D7). The big user-visible 044 entry lands in D8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)