### PR TITLE
feat(core): intake consumes its prompt addendum (spec 044 PR-2, Task D2)

### DIFF
--- a/packages/core/src/consolidator-tick.ts
+++ b/packages/core/src/consolidator-tick.ts
@@ -11,6 +11,7 @@
 // production defaults to the OpenAI-compatible client.
 
 import type { ConsolidationThresholds, SweepSummary } from "./consolidator/index.js";
+import { readJobAddendum } from "./curator-addendum.js";
 import {
   migrateLegacyCuratorLlm,
   readConsumerConfig,
@@ -76,6 +77,11 @@ export async function runConsolidatorTick(
         timeoutMs: conn.timeoutMs,
       }));
 
+  // The intake prompt addendum lives in a git-committed vault file (spec 044 D-1);
+  // read it ONCE here (the sweep level), not per inbox item — intake is the hot
+  // path. Fail-soft "" when the file is absent → today's behaviour (no guidance).
+  const promptAddendum = readJobAddendum(store, "intake").content;
+
   const summary = await store.consolidateInbox({
     llmClient: buildClient(
       { endpoint: llm.endpoint, model: llm.model, timeoutMs: llm.timeoutMs },
@@ -83,6 +89,7 @@ export async function runConsolidatorTick(
     ),
     ...(options.thresholds ? { thresholds: options.thresholds } : {}),
     ...(options.lockTtlMs !== undefined ? { lockTtlMs: options.lockTtlMs } : {}),
+    ...(promptAddendum ? { promptAddendum } : {}),
   });
 
   // Post-intake grooming trigger (spec 043 D-A) — the natural seam: the sweep is done

--- a/packages/core/src/consolidator/consolidate.ts
+++ b/packages/core/src/consolidator/consolidate.ts
@@ -38,6 +38,14 @@ export interface ConsolidateInboxItemDeps {
   /** Actor id that owns consolidator writes (e.g. "system-consolidator"). */
   actorId: string;
   thresholds?: ConsolidationThresholds;
+  /**
+   * Optional operator steering for the judge prompt (spec 044 D-2). Read ONCE per
+   * sweep from the committed intake addendum file (`readJobAddendum(store,"intake")`)
+   * and threaded down via deps — never re-read per item (intake is the hot path).
+   * Redacted + framed as advisory-only by the judge step; empty/absent → today's
+   * behaviour (no OPERATOR GUIDANCE block).
+   */
+  promptAddendum?: string;
   /** Clock (epoch ms) for the atomic claim; defaults to Date.now via the inbox. */
   now?: () => number;
   /** Optional sink for a swallowed apply error (forwarded to applyConsolidationPlan). */
@@ -83,7 +91,11 @@ export async function consolidateInboxItem(
     listActive: deps.listActive,
   });
   const judged = await judgeSubmission(
-    { submissionText: item.text, evidence },
+    {
+      submissionText: item.text,
+      evidence,
+      ...(deps.promptAddendum ? { promptAddendum: deps.promptAddendum } : {}),
+    },
     { llmClient: deps.llmClient, ...(deps.thresholds ? { thresholds: deps.thresholds } : {}) },
   );
   if (!judged.plan) {

--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -146,6 +146,12 @@ export interface ConsolidateInboxOptions {
   onError?: (error: unknown) => void;
   /** What opened this sweep (boot | tick | watcher | manual); recorded on the decision-log run. */
   trigger?: string;
+  /**
+   * Operator steering for the judge prompt (spec 044 D-2), read ONCE per sweep by
+   * the caller (`readJobAddendum(store,"intake").content`) and threaded into every
+   * item's judge call. Empty/absent → today's behaviour (no OPERATOR GUIDANCE).
+   */
+  promptAddendum?: string;
 }
 
 /** Actor id that owns consolidator writes (common-slice, system-owned). */
@@ -286,6 +292,7 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Libra
         ...(deps.thresholds ? { thresholds: deps.thresholds } : {}),
         ...(deps.lockTtlMs !== undefined ? { lockTtlMs: deps.lockTtlMs } : {}),
         ...(deps.onError ? { onError: deps.onError } : {}),
+        ...(deps.promptAddendum ? { promptAddendum: deps.promptAddendum } : {}),
       });
       // The apply path commits per memory write; commit once more to capture
       // the inbox claim/complete moves a no-op or judge-error sweep leaves

--- a/packages/core/tests/consolidator-consolidate.test.ts
+++ b/packages/core/tests/consolidator-consolidate.test.ts
@@ -171,6 +171,67 @@ describe("consolidateInboxItem", () => {
     expect(listInbox(vault)).toEqual([]); // completed
   });
 
+  it("threads a deps-supplied promptAddendum into the judge prompt (spec 044 D-2, once-per-sweep)", async () => {
+    // The addendum is read ONCE at the sweep/tick and threaded down through deps;
+    // consolidateInboxItem passes it into judgeSubmission so it reaches the prompt
+    // (the OPERATOR GUIDANCE block) — it is NOT re-read per item here.
+    const ref = writeInbox(vault, "some fact", { now: () => 1000, generateId: () => "inbox_a" });
+    const { store } = fakeStore();
+    let capturedPrompt = "";
+    const capturingClient: LlmClient = {
+      complete: async (request) => {
+        capturedPrompt = request.messages.map((m) => m.content).join("\n");
+        return {
+          content: JSON.stringify({
+            action: "create",
+            title: "X",
+            body: "Y",
+            tags: [],
+            rationale: "novel",
+            confidence: 0.97,
+          }),
+          model: "gpt-x",
+          usage: null,
+        };
+      },
+    };
+
+    const result = await consolidateInboxItem(ref.relPath, {
+      ...baseDeps(store, capturingClient),
+      promptAddendum: "MARKER-ADDENDUM steer the filing",
+    });
+
+    expect(result).toMatchObject({ status: "consolidated" });
+    expect(capturedPrompt).toContain("MARKER-ADDENDUM steer the filing");
+  });
+
+  it("emits no operator-guidance block when no promptAddendum is supplied (today's behaviour)", async () => {
+    const ref = writeInbox(vault, "some fact", { now: () => 1000, generateId: () => "inbox_a" });
+    const { store } = fakeStore();
+    let capturedPrompt = "";
+    const capturingClient: LlmClient = {
+      complete: async (request) => {
+        capturedPrompt = request.messages.map((m) => m.content).join("\n");
+        return {
+          content: JSON.stringify({
+            action: "create",
+            title: "X",
+            body: "Y",
+            tags: [],
+            rationale: "novel",
+            confidence: 0.97,
+          }),
+          model: "gpt-x",
+          usage: null,
+        };
+      },
+    };
+
+    await consolidateInboxItem(ref.relPath, baseDeps(store, capturingClient));
+
+    expect(capturedPrompt).not.toContain("OPERATOR GUIDANCE");
+  });
+
   it("completes (removes) the item even when apply rejects — a rejection is terminal", async () => {
     const ref = writeInbox(vault, "archive that", { now: () => 1000, generateId: () => "inbox_a" });
     const { store } = fakeStore(); // empty → the archive target is missing → rejected

--- a/packages/core/tests/consolidator-tick.test.ts
+++ b/packages/core/tests/consolidator-tick.test.ts
@@ -9,10 +9,12 @@ import path from "node:path";
 import {
   type LibrarianStore,
   type LlmClient,
+  type LlmCompletionRequest,
   addProvider,
   createLibrarianStore,
   resolveSecretKey,
   runConsolidatorTick,
+  setJobAddendum,
   writeConsumerConfig,
 } from "@librarian/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -105,5 +107,69 @@ describe("runConsolidatorTick — operational", () => {
     expect(
       store!.searchMemories({ query: "Anna", status: "active" }).map((m) => m.title),
     ).toContain("Anna");
+  });
+
+  it("feeds the intake addendum from the committed vault file into the prompt (spec 044 D-2)", async () => {
+    configureLlm();
+    store!.submitToInbox("Anna moved to Berlin.");
+    // The intake addendum lives in the committed vault file (spec 044 D-1); it is
+    // read ONCE per sweep at the tick and threaded down into each item's judge call.
+    setJobAddendum(store!, "intake", "MARKER-ADDENDUM prefer the lessons folder");
+
+    let capturedPrompt = "";
+    const capturingClient: LlmClient = {
+      complete: async (request: LlmCompletionRequest) => {
+        capturedPrompt = request.messages.map((m) => m.content).join("\n");
+        return {
+          content: JSON.stringify({
+            action: "create",
+            title: "Anna",
+            body: "Anna lives in Berlin.",
+            tags: [],
+            rationale: "novel",
+            confidence: 0.97,
+          }),
+          model: "m",
+          usage: null,
+        };
+      },
+    };
+
+    const result = await runConsolidatorTick({ store: store!, buildClient: () => capturingClient });
+
+    expect(result).toMatchObject({ ran: true });
+    // The file's content reached the intake prompt (the OPERATOR GUIDANCE block).
+    expect(capturedPrompt).toContain("MARKER-ADDENDUM prefer the lessons folder");
+  });
+
+  it("omits the operator-guidance block when the intake addendum file is absent (today's behaviour)", async () => {
+    configureLlm();
+    store!.submitToInbox("Anna moved to Berlin.");
+    // No intake addendum file written → fail-soft empty → byte-identical prompt to
+    // before D2 (no OPERATOR GUIDANCE block).
+
+    let capturedPrompt = "";
+    const capturingClient: LlmClient = {
+      complete: async (request: LlmCompletionRequest) => {
+        capturedPrompt = request.messages.map((m) => m.content).join("\n");
+        return {
+          content: JSON.stringify({
+            action: "create",
+            title: "Anna",
+            body: "Anna lives in Berlin.",
+            tags: [],
+            rationale: "novel",
+            confidence: 0.97,
+          }),
+          model: "m",
+          usage: null,
+        };
+      },
+    };
+
+    const result = await runConsolidatorTick({ store: store!, buildClient: () => capturingClient });
+
+    expect(result).toMatchObject({ ran: true });
+    expect(capturedPrompt).not.toContain("OPERATOR GUIDANCE");
   });
 });


### PR DESCRIPTION
## What

D1 (#327) created the committed intake addendum file (`.curator/intake-addendum.md`) and `readJobAddendum(store, "intake")`, but the live intake sweep still **omitted** the addendum when it built the judge prompt — so a non-empty intake addendum had no effect (the I5 gap). This PR wires it through so a non-empty intake addendum actually shapes intake's filing decisions.

## How — the threading path (deps → judgeSubmission → judge-step)

`runConsolidatorTick` reads `readJobAddendum(store, "intake").content` **once per sweep** (the tick level — where the store is available, and the natural seam since intake is the perf-sensitive hot path), then threads the resulting string down:

```
runConsolidatorTick  (reads addendum ONCE)
  → store.consolidateInbox({ promptAddendum })          (ConsolidateInboxOptions)
  → runConsolidatorSweep                                (flows via its existing ...deps spread)
  → consolidateInboxItem  (ConsolidateInboxItemDeps.promptAddendum)
  → judgeSubmission({ promptAddendum })
  → buildConsolidatorPrompt  (the redacted, advisory-only OPERATOR GUIDANCE block)
```

`buildConsolidatorPrompt` / `JudgeSubmissionInput` already accepted `promptAddendum?` (it trims + redacts it into the OPERATOR GUIDANCE block) — the judge layer was ready; the gap was purely the upstream threading. This mirrors exactly how grooming reads its addendum in `runCuratorTick`.

### Once-per-sweep (not per item)
The addendum is identical for every inbox item in a sweep, and intake is the hot path. It is read **once** at the tick and carried through deps to each item's judge call — never re-read per inbox item.

### Fail-soft + empty-addendum unchanged
`readJobAddendum` is fail-soft (returns `""` when the file is absent — no throwing path added). Every hop uses a conditional spread (`...(x ? { promptAddendum: x } : {})`, `exactOptionalPropertyTypes`-safe), so an empty/absent addendum yields a **byte-identical** prompt to before D2 (no OPERATOR GUIDANCE block).

## Tests (TDD, RED → GREEN)
- A non-empty intake addendum (committed via `setJobAddendum`) measurably reaches the intake judge prompt — real-store tick test with a capturing LLM client.
- A deps-supplied `promptAddendum` reaches the judge call — pins that the value is **threaded via deps**, not read per item.
- An absent intake addendum emits **no** OPERATOR GUIDANCE block (today's behaviour).

Full suite green (core 805/+1 skip, mcp-server 124, dashboard 182, cli 44, consolidator-eval 39, root 22) + `pnpm -r build` + typecheck + lint all clean (no `error TS`).

## CHANGELOG
Deferred to the single user-visible 044 entry in D8 — this is internal plumbing closing the I5 gap, and there is no UI to set the intake addendum yet (the file editor is D7), so no operator surface changes here.

## Out of scope (later 044 PRs)
No under-evaluation/force-propose (D3), dry-run (D4), admin mutations (D5), chat (D6), dashboard (D7). The judge prompt's content/structure is unchanged beyond the addendum flowing in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)