### PR TITLE
feat(core): under-evaluation force-propose + addendum status/tagging (spec 044 PR-3a, Task D3a)

### DIFF
--- a/packages/core/src/consolidator-tick.ts
+++ b/packages/core/src/consolidator-tick.ts
@@ -11,12 +11,13 @@
 // production defaults to the OpenAI-compatible client.
 
 import type { ConsolidationThresholds, SweepSummary } from "./consolidator/index.js";
-import { readJobAddendum } from "./curator-addendum.js";
+import { readAddendumStatus, readJobAddendum } from "./curator-addendum.js";
 import {
   migrateLegacyCuratorLlm,
   readConsumerConfig,
   resolveConsumerToken,
 } from "./curator-consumers.js";
+import { forceProposeDeps } from "./curator-force-propose.js";
 import { type LlmClient, createCuratorLlmClient } from "./curator-llm-client.js";
 import { maybeTriggerGroomingAfterIntake } from "./grooming-trigger.js";
 import type { LibrarianStore } from "./store/librarian-store.js";
@@ -90,6 +91,10 @@ export async function runConsolidatorTick(
     ...(options.thresholds ? { thresholds: options.thresholds } : {}),
     ...(options.lockTtlMs !== undefined ? { lockTtlMs: options.lockTtlMs } : {}),
     ...(promptAddendum ? { promptAddendum } : {}),
+    // Under-evaluation force-propose (spec 044 D-3): read the intake addendum status
+    // ONCE here (same seam as the addendum content). When under_evaluation, no item
+    // auto-applies and proposals are tagged. Accepted (default) → unchanged.
+    ...forceProposeDeps(readAddendumStatus(store, "intake")),
   });
 
   // Post-intake grooming trigger (spec 043 D-A) — the natural seam: the sweep is done

--- a/packages/core/src/consolidator/apply.ts
+++ b/packages/core/src/consolidator/apply.ts
@@ -9,6 +9,7 @@
 // augment write; a store rejection (e.g. a protected target) is caught and
 // returned as `rejected`, never thrown, so one bad item can't abort a batch.
 
+import { tagAddendumVersion } from "../curator-force-propose.js";
 import { redactSecrets } from "../curator-redaction.js";
 import type { InboxSubmissionHints } from "../store/corpus/inbox.js";
 import { type SplitReplacement, splitMemory } from "../store/split-memory.js";
@@ -45,6 +46,19 @@ export interface ApplyConsolidationDeps {
    * / archive) keep the target's own scope and ignore these.
    */
   submissionHints?: InboxSubmissionHints;
+  /**
+   * Under-evaluation force-propose (spec 044 D-3). When true, the intake addendum
+   * is being evaluated: NO op auto-applies — a would-be auto-apply is routed to a
+   * PROPOSAL and a would-be auto-archive is SKIPPED (archive is not proposable).
+   * Default false → byte-identical to the accepted path (the regression guard).
+   */
+  underEvaluation?: boolean;
+  /**
+   * The addendum version (git hash) being evaluated; stamped onto every proposal
+   * produced while `underEvaluation` (spec 044 D-3) so D3b can find the batch.
+   * Only meaningful with `underEvaluation`; ignored otherwise.
+   */
+  addendumVersion?: string | null;
   /** Optional sink for a swallowed store error, so a real bug stays observable. */
   onError?: (error: unknown) => void;
 }
@@ -93,17 +107,60 @@ export function applyConsolidationPlan(
     return out;
   };
   // The model's rationale is untrusted (could carry a hallucinated secret) and is
-  // persisted into the vault + git history — redact it, like the curator does.
-  const note = (extra: Record<string, unknown> = {}): Record<string, unknown> => ({
-    curator_note: {
+  // persisted into the vault + git history — redact it, like the curator does. While
+  // the intake addendum is under_evaluation (spec 044 D-3), tag every produced
+  // proposal with the addendum version being evaluated so D3b can find the batch
+  // (no-op tag when accepted / no version → byte-identical accepted-path note).
+  const note = (extra: Record<string, unknown> = {}): Record<string, unknown> => {
+    const curator_note: Record<string, unknown> = {
       source: "consolidator",
       rationale: redactSecrets(plan.judgment.rationale).redacted,
       ...extra,
-    },
-  });
+    };
+    if (deps.underEvaluation) tagAddendumVersion(curator_note, deps.addendumVersion);
+    return { curator_note };
+  };
+
+  // File the raw SUBMISSION as a fresh doc (the shared body of the create_new /
+  // propose / force-propose lanes). `proposedAction` set → a PROPOSED doc
+  // (requires_approval → status proposed, awaiting review) carrying the judge's
+  // intended action; null → an active create_new. The judgment's title/target are
+  // intentionally dropped — a human (or a later pass) decides filing from the raw
+  // submission, never a low-confidence/under-eval merge.
+  const proposeSubmission = (proposedAction: string | null): ConsolidationOutcome => {
+    const proposed = proposedAction !== null;
+    const options = note(proposed ? { proposed_action: proposedAction } : {});
+    if (proposed) options.requires_approval = true;
+    const input = scope({ title: deriveTitle(submissionText), body: submissionText });
+    if (hints?.tags) input.tags = hints.tags; // the raw submission's tags (no judge tags here)
+    const { memory } = store.createMemory(input, options);
+    return { kind: proposed ? "proposed" : "created_new", id: memory.id };
+  };
 
   try {
     if (plan.decision === "skip") return { kind: "skipped" };
+
+    // Under-evaluation force-propose (spec 044 D-3). The intake addendum is being
+    // evaluated, so NOTHING auto-applies regardless of the routed decision or
+    // confidence. Both the auto_apply lane AND create_new (which would land an
+    // ACTIVE doc) are re-routed to a PROPOSAL of the raw submission, EXCEPT a
+    // would-be auto-ARCHIVE which is SKIPPED — archive (and noop) are not proposable
+    // (the archive wrinkle). `split` is already always-proposed (below); the
+    // existing `propose` decision already files for review (left unchanged). Defence-
+    // in-depth like C4's split: even at confidence 1.0 an under-eval op never
+    // auto-applies.
+    if (
+      deps.underEvaluation &&
+      (plan.decision === "auto_apply" || plan.decision === "create_new")
+    ) {
+      if (plan.judgment.action === "archive" || plan.judgment.action === "noop") {
+        return { kind: "skipped" };
+      }
+      if (plan.judgment.action !== "split") {
+        return proposeSubmission(plan.judgment.action);
+      }
+      // split falls through to its always-proposed handling below (it's tagged there).
+    }
 
     // Split (spec 043 D-B) — ALWAYS a proposal, never auto-applied, regardless of
     // the routed decision or confidence. Intake lacks grooming's whole-slice
@@ -133,19 +190,11 @@ export function applyConsolidationPlan(
     }
 
     // Uncertain merge / mid-confidence change → never touch an existing doc. File
-    // the SUBMISSION as a fresh doc — active for create_new, or requires_approval
-    // (→ status proposed, awaiting human review) for propose. The judgment's
-    // addition/title/target are intentionally dropped on this branch: a human (or
-    // a later pass) decides filing from the raw submission, never a low-confidence
-    // merge. requires_approval is the store's signal that lands it at status=proposed.
+    // the SUBMISSION as a fresh doc — active for create_new, or proposed (awaiting
+    // human review) for propose. requires_approval is the store's signal that lands
+    // a proposed doc at status=proposed.
     if (plan.decision === "create_new" || plan.decision === "propose") {
-      const proposed = plan.decision === "propose";
-      const options = note(proposed ? { proposed_action: plan.judgment.action } : {});
-      if (proposed) options.requires_approval = true;
-      const input = scope({ title: deriveTitle(submissionText), body: submissionText });
-      if (hints?.tags) input.tags = hints.tags; // the raw submission's tags (no judge tags here)
-      const { memory } = store.createMemory(input, options);
-      return { kind: proposed ? "proposed" : "created_new", id: memory.id };
+      return proposeSubmission(plan.decision === "propose" ? plan.judgment.action : null);
     }
 
     // auto_apply — execute the judged action directly.

--- a/packages/core/src/consolidator/consolidate.ts
+++ b/packages/core/src/consolidator/consolidate.ts
@@ -46,6 +46,15 @@ export interface ConsolidateInboxItemDeps {
    * behaviour (no OPERATOR GUIDANCE block).
    */
   promptAddendum?: string;
+  /**
+   * Under-evaluation force-propose (spec 044 D-3). When true, the intake addendum is
+   * being evaluated, so no item auto-applies: a would-be auto-apply is routed to a
+   * PROPOSAL and a would-be auto-archive is SKIPPED. Read ONCE per sweep + threaded
+   * via deps (intake is the hot path); default false → byte-identical to before D3a.
+   */
+  underEvaluation?: boolean;
+  /** The addendum version (git hash) under evaluation; tags produced proposals. */
+  addendumVersion?: string | null;
   /** Clock (epoch ms) for the atomic claim; defaults to Date.now via the inbox. */
   now?: () => number;
   /** Optional sink for a swallowed apply error (forwarded to applyConsolidationPlan). */
@@ -110,6 +119,9 @@ export async function consolidateInboxItem(
     submissionText: item.text,
     actorId: deps.actorId,
     submissionHints: item.hints, // carry the submitter's scope/ownership onto new memories
+    ...(deps.underEvaluation
+      ? { underEvaluation: true, addendumVersion: deps.addendumVersion }
+      : {}),
     ...(deps.onError ? { onError: deps.onError } : {}),
   };
   const outcome = applyConsolidationPlan(judged.plan, applyDeps);

--- a/packages/core/src/curator-addendum.ts
+++ b/packages/core/src/curator-addendum.ts
@@ -28,6 +28,29 @@ export interface JobAddendum {
 }
 
 /**
+ * A curator job's addendum evaluation state (spec 044 D-3 / decision D-3).
+ *
+ *  - `accepted` (the DEFAULT when unset): the addendum is proven; the curator
+ *    auto-applies as normal — byte-identical to pre-D3 behaviour.
+ *  - `under_evaluation`: the addendum was freshly changed; the curator force-
+ *    proposes every would-be auto-apply (and skips would-be auto-archives) and
+ *    tags each proposal with `evalVersion`, so the batch can be accepted or
+ *    rolled back wholesale once the admin has reviewed it.
+ */
+export type AddendumStatus = "accepted" | "under_evaluation";
+
+/** A job's addendum evaluation state + the version being evaluated. */
+export interface AddendumStatusRecord {
+  /** The evaluation state; defaults to "accepted" when the setting is unset. */
+  status: AddendumStatus;
+  /**
+   * The git hash of the addendum version under evaluation (the file's last-
+   * touching commit), or null when accepted / no version was captured.
+   */
+  evalVersion: string | null;
+}
+
+/**
  * The store slice the addendum helpers need: the committed-file read/write (which
  * the LibrarianStore implements over the vault + git) plus settings for the
  * one-time migration off the legacy setting.
@@ -41,6 +64,17 @@ export interface AddendumStore extends SettingsStore {
 // seed grooming-addendum.md once; the curator never reads it again (it's retired
 // at migration time, exactly like the C2 enablement migration).
 export const LEGACY_PROMPT_ADDENDUM_KEY = "curator.prompt_addendum";
+
+// Per-job addendum evaluation settings (spec 044 D-3), in the unified
+// `curator.<job>.*` namespace alongside enablement (`curator.<job>.enabled`) —
+// mirrors the C2/C3 key conventions. Both are plain (non-secret) string settings.
+const ADDENDUM_STATUS_KEY = (job: CuratorJob): string => `curator.${job}.addendum_status`;
+const ADDENDUM_EVAL_VERSION_KEY = (job: CuratorJob): string =>
+  `curator.${job}.addendum_eval_version`;
+
+// The only persisted status value other than the default; an unset/unknown value
+// reads as "accepted" so existing installs are unchanged (the regression guard).
+const UNDER_EVALUATION = "under_evaluation";
 
 /**
  * Read a curator job's prompt addendum from its committed vault file (spec 044
@@ -63,6 +97,55 @@ export function setJobAddendum(
   content: string,
 ): JobAddendum {
   return store.writeAddendum(job, content);
+}
+
+/**
+ * Read a curator job's addendum evaluation state (spec 044 D-3). Unset (the
+ * fresh-install default) reads as `{ status: "accepted", evalVersion: null }`, so
+ * the curator auto-applies as before D3 — the load-bearing regression default.
+ * Any non-"under_evaluation" value also reads as accepted (fail-safe: an unknown
+ * value never silently force-proposes). The evalVersion is only meaningful while
+ * under_evaluation; it's returned null when accepted.
+ */
+export function readAddendumStatus(store: AddendumStore, job: CuratorJob): AddendumStatusRecord {
+  const raw = store.getSetting(ADDENDUM_STATUS_KEY(job));
+  if (raw !== UNDER_EVALUATION) return { status: "accepted", evalVersion: null };
+  return {
+    status: "under_evaluation",
+    evalVersion: store.getSetting(ADDENDUM_EVAL_VERSION_KEY(job)),
+  };
+}
+
+/**
+ * Set a curator job's addendum evaluation state (spec 044 D-3). The two operations
+ * D3b's admin tRPC drives:
+ *
+ *  - "begin evaluation": `setAddendumStatus(store, job, "under_evaluation")` —
+ *    captures the CURRENT addendum version (via D1's `readJobAddendum().version`)
+ *    as the eval version automatically, unless an explicit `evalVersion` is given.
+ *    From now on the job force-proposes (see curator-force-propose.ts) and tags
+ *    every proposal with this version.
+ *  - "end evaluation": `setAddendumStatus(store, job, "accepted")` — clears the
+ *    eval version and resumes auto-apply (Accept / Roll-back land here).
+ */
+export function setAddendumStatus(
+  store: AddendumStore,
+  job: CuratorJob,
+  status: AddendumStatus,
+  evalVersion?: string | null,
+): void {
+  if (status === "accepted") {
+    store.setSetting(ADDENDUM_STATUS_KEY(job), "accepted");
+    store.deleteSetting(ADDENDUM_EVAL_VERSION_KEY(job));
+    return;
+  }
+  // Entering evaluation: pin the version being evaluated. An explicit arg wins
+  // (D3b's Re-evaluate may pass a specific hash); otherwise capture the current
+  // addendum version (D1) — the natural "begin evaluation" primitive.
+  const version = evalVersion !== undefined ? evalVersion : store.readAddendum(job).version;
+  store.setSetting(ADDENDUM_STATUS_KEY(job), UNDER_EVALUATION);
+  if (version) store.setSetting(ADDENDUM_EVAL_VERSION_KEY(job), version);
+  else store.deleteSetting(ADDENDUM_EVAL_VERSION_KEY(job));
 }
 
 /**

--- a/packages/core/src/curator-apply.ts
+++ b/packages/core/src/curator-apply.ts
@@ -16,7 +16,8 @@
 //   - Every operation (applied / proposed / skipped / failed) is recorded for the
 //     admin audit; the recorded rationale is redacted as defence-in-depth.
 
-import { type ApplyPolicy, decideApply } from "./curator-apply-policy.js";
+import { type ApplyDecision, type ApplyPolicy, decideApply } from "./curator-apply-policy.js";
+import { tagAddendumVersion, underEvaluationRoute } from "./curator-force-propose.js";
 import type { CuratorMemoryPatch, CuratorOperation } from "./curator-output.js";
 import { redactSecrets } from "./curator-redaction.js";
 import type { ValidatedOperation, ValidationContext } from "./curator-validate.js";
@@ -61,6 +62,19 @@ export interface ApplyDeps {
   /** Curator actor id for common-slice writes (e.g. "system-memory-curator"). */
   actorId: string;
   policy: ApplyPolicy;
+  /**
+   * Under-evaluation force-propose (spec 044 D-3). When true, the grooming addendum
+   * is being evaluated: NO op auto-applies — a would-be auto-apply is routed to a
+   * PROPOSAL and a would-be auto-archive is SKIPPED (archive is not proposable).
+   * Default false → byte-identical to before D3a (the regression guard).
+   */
+  underEvaluation?: boolean;
+  /**
+   * The addendum version (git hash) being evaluated; stamped onto every proposal
+   * produced while `underEvaluation` (spec 044 D-3) so D3b can find the batch. Only
+   * meaningful with `underEvaluation`; ignored otherwise.
+   */
+  addendumVersion?: string | null;
   /** Optional sink for swallowed execution errors (keeps the audit row content-free). */
   onError?: (error: unknown, operation: CuratorOperation) => void;
 }
@@ -77,6 +91,8 @@ interface ExecContext {
   runId: string;
   actorId: string;
   owner: string;
+  /** Set while the grooming addendum is under_evaluation — tags every proposal. */
+  addendumVersion?: string | null;
 }
 
 export function applyOperations(
@@ -93,6 +109,8 @@ export function applyOperations(
     runId: deps.runId,
     actorId: deps.actorId,
     owner,
+    // Carried so proposals produced under_evaluation are tagged (no-op when accepted).
+    ...(deps.underEvaluation ? { addendumVersion: deps.addendumVersion } : {}),
   };
 
   const summary: ApplySummary = { applied: 0, proposed: 0, skipped: 0, failed: 0 };
@@ -106,7 +124,13 @@ export function applyOperations(
     }
     // Accepted ops passed the §10.5 content guards, so their payload is safe to record.
     const payload = operationPayload(operation);
-    const decision = decideApply(operation, outcome, deps.policy);
+    // Under-evaluation force-propose (spec 044 D-3): while the grooming addendum is
+    // being evaluated, divert a would-be auto-apply to `propose` and a would-be
+    // auto-ARCHIVE to `skip` (archive is not proposable — the wrinkle). `propose`/
+    // `skip` pass through unchanged, so a protected-propose stays propose. When
+    // accepted (the default), the route is the identity → byte-identical to before.
+    const routed = decideApply(operation, outcome, deps.policy);
+    const decision = deps.underEvaluation ? forcePropose(routed, operation.type) : routed;
     if (decision === "skip") {
       record(deps, operation, "skipped", outcome.risk, operation.rationale, [], payload);
       summary.skipped++;
@@ -146,6 +170,17 @@ export function applyOperations(
     }
   }
   return summary;
+}
+
+// Adapt the grooming ApplyDecision to the shared under-evaluation routing rule
+// (spec 044 D-3). `auto_apply` is the only would-be apply; the shared rule diverts
+// a pure-archive auto-apply to skip and everything else to propose (and never
+// returns "apply" for an under-eval op). `propose`/`skip` pass through unchanged.
+function forcePropose(decision: ApplyDecision, type: CuratorOperation["type"]): ApplyDecision {
+  if (decision !== "auto_apply") return decision;
+  const routed = underEvaluationRoute("apply", type === "archive");
+  // routed is "propose" | "skip" for a would-be apply — both valid ApplyDecisions.
+  return routed === "skip" ? "skip" : "propose";
 }
 
 // Auto-apply a non-protected operation; returns the target memory ids.
@@ -229,13 +264,19 @@ function buildCreateCall(
 ): SplitReplacement {
   const curatorNote: Record<string, unknown> = { run_id: c.runId };
   if (supersedes.length > 0) curatorNote.supersedes = supersedes;
-  const storeOptions: Record<string, unknown> = { curator_note: curatorNote };
   // Section 4d.3 — the curator emits requires_approval=true on
   // protected creates so the store can drop the legacy
   // category-based gate. Auto-apply paths (non-protected ops) leave
   // this unset and land at the conservative defaults the classifier
   // will overwrite.
-  if (options.requiresApproval === true) storeOptions.requires_approval = true;
+  const isProposal = options.requiresApproval === true;
+  // Tag PROPOSALS produced while the grooming addendum is under_evaluation with the
+  // version being evaluated (spec 044 D-3), so D3b finds the batch. Gated on
+  // isProposal so an auto-applied write is never tagged (defence-in-depth — under
+  // evaluation an op never auto-applies anyway). No-op when accepted / no version.
+  if (isProposal) tagAddendumVersion(curatorNote, c.addendumVersion);
+  const storeOptions: Record<string, unknown> = { curator_note: curatorNote };
+  if (isProposal) storeOptions.requires_approval = true;
   return { input: { ...memory, agent_id: c.owner }, options: storeOptions };
 }
 

--- a/packages/core/src/curator-enqueue.ts
+++ b/packages/core/src/curator-enqueue.ts
@@ -52,6 +52,10 @@ export interface RunDueCurationOptions {
   actorId: string;
   policy: ApplyPolicy;
   promptAddendum?: string;
+  /** Under-evaluation force-propose (spec 044 D-3); see RunCurationOptions. */
+  underEvaluation?: boolean;
+  /** The addendum version (git hash) under evaluation; tags produced proposals. */
+  addendumVersion?: string | null;
   model: { provider: string; name: string };
   caps?: RunCurationCaps;
   /** Default "schedule". */
@@ -110,6 +114,9 @@ export async function runDueCuration(
         actorId: options.actorId,
         policy: options.policy,
         model: options.model,
+        ...(options.underEvaluation
+          ? { underEvaluation: true, addendumVersion: options.addendumVersion }
+          : {}),
         ...(options.promptAddendum !== undefined ? { promptAddendum: options.promptAddendum } : {}),
         ...(options.caps !== undefined ? { caps: options.caps } : {}),
         ...(options.bypassSkip !== undefined ? { bypassSkip: options.bypassSkip } : {}),

--- a/packages/core/src/curator-force-propose.ts
+++ b/packages/core/src/curator-force-propose.ts
@@ -1,0 +1,78 @@
+// Under-evaluation force-propose (spec 044 D-3 / decision D-3). When a curator
+// job's prompt addendum has been freshly changed it goes "under evaluation": the
+// curator must NOT auto-apply decisions made under the unproven addendum. Instead
+// it forces every would-be auto-apply to a PROPOSAL (for human review) and tags
+// it with the addendum version, so the whole batch can later be accepted or rolled
+// back wholesale (the admin tRPC that drives that is D3b).
+//
+// Two apply paths consume this (intake `applyConsolidationPlan` + grooming
+// `applyOperations`). They have genuinely different op/decision models, so this
+// module owns ONLY the small shared ROUTING RULE both share — the transform from
+// a normal routing terminal to its under-evaluation equivalent — plus the shared
+// "tag the proposal with the eval version" primitive. Each path keeps its own
+// op-specific execution.
+//
+// The rule (decision D-3), applied ONLY while a job is under_evaluation:
+//   - an op that WOULD auto-apply (create/merge/update/supersede/augment/split/…)
+//     is routed to `propose` instead — exactly the existing propose path;
+//   - the ARCHIVE WRINKLE: an op that would auto-ARCHIVE is `skip`ped (recorded as
+//     skipped), NOT proposed — archive (and noop) are not proposable;
+//   - a `propose` stays `propose`, a `skip`/`noop` stays `skip`.
+// When the job is `accepted` (the default), the transform is the IDENTITY — so the
+// accepted path is byte-identical to before D3a (the load-bearing regression).
+
+/**
+ * The three routing terminals both apply paths reduce to. `apply` = mutate live
+ * memory now; `propose` = file a proposal for human review; `skip` = do nothing.
+ * Archive is modelled as `apply` with `isArchive: true` so the rule can divert it
+ * to `skip` (the archive wrinkle) rather than `propose`.
+ */
+export type ForcePropose = "apply" | "propose" | "skip";
+
+/**
+ * Map a normal routing terminal to its under-evaluation equivalent (decision D-3).
+ *
+ * @param terminal what the op WOULD do under the proven (accepted) addendum.
+ * @param isArchive true when the would-be apply is an auto-archive (the wrinkle).
+ *
+ * Identity for `propose`/`skip`. An `apply` becomes `propose`, EXCEPT an auto-
+ * archive becomes `skip` (archive is not proposable). Call this ONLY when the job
+ * is under_evaluation; when accepted, use the original terminal unchanged.
+ */
+export function underEvaluationRoute(terminal: ForcePropose, isArchive: boolean): ForcePropose {
+  if (terminal !== "apply") return terminal; // propose / skip pass through unchanged
+  return isArchive ? "skip" : "propose"; // archive → skip; everything else → propose
+}
+
+/**
+ * Stamp the addendum eval version onto a curator_note record so D3b's Accept /
+ * Roll-back / Re-evaluate can find every proposal produced under this addendum
+ * version. exactOptionalPropertyTypes-safe: a null/empty version adds NO key (so
+ * the tag never appears on an accepted-path proposal). Mutates + returns the note.
+ */
+export function tagAddendumVersion(
+  note: Record<string, unknown>,
+  evalVersion: string | null | undefined,
+): Record<string, unknown> {
+  if (evalVersion) note.addendum_version = evalVersion;
+  return note;
+}
+
+/**
+ * Translate a job's addendum evaluation state into the apply-path deps spread that
+ * turns force-propose on (spec 044 D-3). Both ticks read the status ONCE per
+ * sweep/tick and spread this into the apply caller:
+ *
+ *  - accepted (the default) → `{}` (no key): byte-identical to before D3a.
+ *  - under_evaluation → `{ underEvaluation: true, addendumVersion }`.
+ *
+ * exactOptionalPropertyTypes-safe (the accepted branch adds nothing).
+ */
+export function forceProposeDeps(state: {
+  status: "accepted" | "under_evaluation";
+  evalVersion: string | null;
+}): { underEvaluation?: true; addendumVersion?: string | null } {
+  return state.status === "under_evaluation"
+    ? { underEvaluation: true, addendumVersion: state.evalVersion }
+    : {};
+}

--- a/packages/core/src/curator-tick.ts
+++ b/packages/core/src/curator-tick.ts
@@ -11,7 +11,7 @@
 // the OpenAI-compatible client.
 
 import { SYSTEM_ACTOR_IDS } from "./caller-identity.js";
-import { migrateCuratorAddendum, readJobAddendum } from "./curator-addendum.js";
+import { migrateCuratorAddendum, readAddendumStatus, readJobAddendum } from "./curator-addendum.js";
 import { migrateCuratorEnablement, readCuratorConfig } from "./curator-config.js";
 import {
   migrateLegacyCuratorLlm,
@@ -23,6 +23,7 @@ import {
   type RunDueCurationSummary,
   runDueCuration,
 } from "./curator-enqueue.js";
+import { forceProposeDeps } from "./curator-force-propose.js";
 import { type LlmClient, createCuratorLlmClient } from "./curator-llm-client.js";
 import type { RunCurationCaps } from "./curator-worker.js";
 import type { LibrarianStore } from "./store/librarian-store.js";
@@ -99,6 +100,11 @@ export async function runCuratorTick(options: CuratorTickOptions): Promise<Curat
     // The grooming addendum now lives in a git-committed vault file (spec 044
     // D-1); read it from there (fail-soft "" when the file is absent).
     promptAddendum: readJobAddendum(store, "grooming").content,
+    // Under-evaluation force-propose (spec 044 D-3): read the addendum status ONCE
+    // per tick (the natural seam, store available). When under_evaluation, no op
+    // auto-applies and proposals are tagged with the eval version. Accepted (the
+    // default) → byte-identical to before D3a.
+    ...forceProposeDeps(readAddendumStatus(store, "grooming")),
     model: { provider: llm.providerId, name: llm.model },
     trigger: options.trigger ?? "schedule",
     ...(options.bypassSkip !== undefined ? { bypassSkip: options.bypassSkip } : {}),

--- a/packages/core/src/curator-worker.ts
+++ b/packages/core/src/curator-worker.ts
@@ -37,6 +37,15 @@ export interface RunCurationOptions {
   actorId: string;
   policy: ApplyPolicy;
   promptAddendum?: string;
+  /**
+   * Under-evaluation force-propose (spec 044 D-3): when true, the grooming addendum
+   * is being evaluated, so no op auto-applies (would-be applies → proposals,
+   * would-be archives → skipped) and proposals are tagged with `addendumVersion`.
+   * Default false → byte-identical to before D3a.
+   */
+  underEvaluation?: boolean;
+  /** The addendum version (git hash) under evaluation; tags produced proposals. */
+  addendumVersion?: string | null;
   /** Recorded on the run for observability. */
   model: { provider: string; name: string };
   caps?: RunCurationCaps;
@@ -125,6 +134,9 @@ export async function runCuration(
       runId: run.id,
       actorId: options.actorId,
       policy: options.policy,
+      ...(options.underEvaluation
+        ? { underEvaluation: true, addendumVersion: options.addendumVersion }
+        : {}),
     });
 
     return store.completeCurationRun(run.id, {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -191,14 +191,24 @@ export {
   writeCuratorConfig,
 } from "./curator-config.js";
 export {
+  type AddendumStatus,
+  type AddendumStatusRecord,
   type AddendumStore,
   type CuratorJob,
   type JobAddendum,
   LEGACY_PROMPT_ADDENDUM_KEY,
   migrateCuratorAddendum,
+  readAddendumStatus,
   readJobAddendum,
+  setAddendumStatus,
   setJobAddendum,
 } from "./curator-addendum.js";
+export {
+  type ForcePropose,
+  forceProposeDeps,
+  tagAddendumVersion,
+  underEvaluationRoute,
+} from "./curator-force-propose.js";
 export {
   type LlmConnection,
   type LlmConnectionKeys,

--- a/packages/core/src/schemas/memory.ts
+++ b/packages/core/src/schemas/memory.ts
@@ -20,6 +20,11 @@ export const CuratorNoteSchema = z.object({
   supersedes: z.array(z.string()).optional(),
   run_id: z.string().optional(),
   operation_id: z.string().optional(),
+  // The addendum version (git hash) under which this proposal was produced while
+  // the job was "under evaluation" (spec 044 D-3). D3b's Accept / Roll-back /
+  // Re-evaluate find this batch of proposals by this tag. Set ONLY on proposals
+  // produced under_evaluation; absent on every accepted-path write.
+  addendum_version: z.string().optional(),
 });
 export type CuratorNote = z.infer<typeof CuratorNoteSchema>;
 

--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -152,6 +152,15 @@ export interface ConsolidateInboxOptions {
    * item's judge call. Empty/absent → today's behaviour (no OPERATOR GUIDANCE).
    */
   promptAddendum?: string;
+  /**
+   * Under-evaluation force-propose (spec 044 D-3): when true, the intake addendum is
+   * being evaluated, so no item auto-applies (would-be applies → proposals, would-be
+   * archives → skipped) and proposals are tagged with `addendumVersion`. Read ONCE
+   * per sweep by the caller; default false → byte-identical to before D3a.
+   */
+  underEvaluation?: boolean;
+  /** The addendum version (git hash) under evaluation; tags produced proposals. */
+  addendumVersion?: string | null;
 }
 
 /** Actor id that owns consolidator writes (common-slice, system-owned). */
@@ -293,6 +302,9 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Libra
         ...(deps.lockTtlMs !== undefined ? { lockTtlMs: deps.lockTtlMs } : {}),
         ...(deps.onError ? { onError: deps.onError } : {}),
         ...(deps.promptAddendum ? { promptAddendum: deps.promptAddendum } : {}),
+        ...(deps.underEvaluation
+          ? { underEvaluation: true, addendumVersion: deps.addendumVersion }
+          : {}),
       });
       // The apply path commits per memory write; commit once more to capture
       // the inbox claim/complete moves a no-op or judge-error sweep leaves

--- a/packages/core/tests/consolidator-apply.test.ts
+++ b/packages/core/tests/consolidator-apply.test.ts
@@ -365,3 +365,170 @@ describe("applyConsolidationPlan — intake split (always proposed, never auto-a
     expect(note.rationale).toContain("[REDACTED:secret]");
   });
 });
+
+// ── Under-evaluation force-propose (spec 044 D-3) ────────────────────────────
+//
+// While the intake addendum is under_evaluation, NO op auto-applies: a would-be
+// auto-apply is routed to a PROPOSAL (tagged with the eval version) and a would-be
+// auto-archive is SKIPPED (archive is not proposable — the wrinkle). noop stays
+// noop. When accepted (the default) behaviour is byte-identical to before D3a.
+describe("applyConsolidationPlan — under_evaluation force-propose (spec 044 D-3)", () => {
+  const evalDeps = (store: ConsolidatorApplyStore, submissionText = "Anna moved to Berlin.") => ({
+    store,
+    submissionText,
+    actorId: "system-consolidator",
+    underEvaluation: true,
+    addendumVersion: "abc123def",
+  });
+
+  it("auto_apply create → PROPOSED (not created), tagged with the eval version", () => {
+    const { store, calls } = fakeStore();
+    const out = applyConsolidationPlan(
+      plan("auto_apply", { action: "create", title: "Anna", body: "Lives in Berlin.", tags: [] }),
+      evalDeps(store),
+    );
+    expect(out).toMatchObject({ kind: "proposed" }); // NOT "created"
+    expect(calls.create[0]?.options?.requires_approval).toBe(true);
+    expect(calls.create[0]?.options?.curator_note).toMatchObject({
+      proposed_action: "create",
+      addendum_version: "abc123def",
+    });
+    // The submission is filed as-is (the judge's curated title/body are dropped on
+    // the propose lane — a human decides from the raw submission).
+    expect(calls.create[0]?.input).toMatchObject({ body: "Anna moved to Berlin." });
+  });
+
+  it("auto_apply augment → PROPOSED (target untouched), tagged", () => {
+    const { store, calls } = fakeStore({ mem_anna: { title: "Anna", body: "Lives in Paris." } });
+    const out = applyConsolidationPlan(
+      plan("auto_apply", { action: "augment", target_id: "mem_anna", addition: "moved" }),
+      evalDeps(store),
+    );
+    expect(out).toMatchObject({ kind: "proposed" });
+    expect(calls.update.length).toBe(0); // the existing doc is NOT mutated
+    expect(calls.create[0]?.options?.curator_note).toMatchObject({
+      proposed_action: "augment",
+      addendum_version: "abc123def",
+    });
+  });
+
+  it("auto_apply supersede → PROPOSED (target untouched), tagged", () => {
+    const { store, calls } = fakeStore({ mem_anna: { title: "Anna", body: "Works at Globex." } });
+    const out = applyConsolidationPlan(
+      plan("auto_apply", { action: "supersede", target_id: "mem_anna", title: "t", body: "b" }),
+      evalDeps(store),
+    );
+    expect(out).toMatchObject({ kind: "proposed" });
+    expect(calls.update.length).toBe(0);
+    expect(calls.create[0]?.options?.curator_note).toMatchObject({
+      proposed_action: "supersede",
+      addendum_version: "abc123def",
+    });
+  });
+
+  it("auto_apply archive → SKIPPED, not proposed (the archive wrinkle)", () => {
+    const { store, calls } = fakeStore({ mem_old: { title: "Old", body: "Stale." } });
+    const out = applyConsolidationPlan(
+      plan("auto_apply", { action: "archive", target_id: "mem_old" }),
+      evalDeps(store),
+    );
+    expect(out).toEqual({ kind: "skipped" }); // NOT proposed, NOT archived
+    expect(calls.archive.length).toBe(0);
+    expect(calls.create.length).toBe(0);
+  });
+
+  it("create_new (a would-be ACTIVE doc) → PROPOSED, tagged", () => {
+    const { store, calls } = fakeStore();
+    const out = applyConsolidationPlan(
+      plan("create_new", { action: "augment", target_id: "x", addition: "a" }),
+      evalDeps(store, "A fresh fact."),
+    );
+    expect(out).toMatchObject({ kind: "proposed" }); // NOT created_new (active)
+    expect(calls.create[0]?.options?.requires_approval).toBe(true);
+    expect(calls.create[0]?.options?.curator_note).toMatchObject({ addendum_version: "abc123def" });
+  });
+
+  it("split stays PROPOSED and is tagged with the eval version", () => {
+    const { store, calls } = fakeStore({ mem_overloaded: { title: "A and B", body: "mixed" } });
+    const out = applyConsolidationPlan(
+      plan("propose", {
+        action: "split",
+        target_id: "mem_overloaded",
+        replacements: [
+          { title: "A", body: "about a", tags: [] },
+          { title: "B", body: "about b", tags: [] },
+        ],
+      }),
+      evalDeps(store),
+    );
+    expect(out).toMatchObject({ kind: "proposed" });
+    expect(calls.archive.length).toBe(0); // source stays active (a proposed split)
+    expect(calls.create[0]?.options?.curator_note).toMatchObject({
+      proposed_action: "split",
+      addendum_version: "abc123def",
+    });
+  });
+
+  it("noop / skip stays skipped (nothing proposed)", () => {
+    const { store, calls } = fakeStore();
+    expect(applyConsolidationPlan(plan("skip", { action: "noop" }), evalDeps(store))).toEqual({
+      kind: "skipped",
+    });
+    expect(calls.create.length).toBe(0);
+  });
+
+  it("even at confidence 1.0 a create never auto-applies under evaluation (defence-in-depth)", () => {
+    const { store, calls } = fakeStore();
+    const out = applyConsolidationPlan(
+      plan("auto_apply", {
+        action: "create",
+        title: "T",
+        body: "B",
+        tags: [],
+        confidence: 1,
+      }),
+      evalDeps(store),
+    );
+    expect(out).toMatchObject({ kind: "proposed" });
+    expect(calls.create[0]?.options?.requires_approval).toBe(true);
+  });
+
+  it("under_evaluation without a version tags nothing (no addendum_version key)", () => {
+    const { store, calls } = fakeStore();
+    applyConsolidationPlan(
+      plan("auto_apply", { action: "create", title: "T", body: "B", tags: [] }),
+      {
+        store,
+        submissionText: "x",
+        actorId: "system-consolidator",
+        underEvaluation: true,
+        addendumVersion: null,
+      },
+    );
+    const note = calls.create[0]?.options?.curator_note as Record<string, unknown>;
+    expect(note).not.toHaveProperty("addendum_version");
+    expect(note).toMatchObject({ proposed_action: "create" }); // still force-proposed
+  });
+
+  it("accepted (default, underEvaluation absent) is byte-identical: auto_apply still applies", () => {
+    const { store, calls } = fakeStore();
+    // No underEvaluation flag → the accepted path.
+    const created = applyConsolidationPlan(
+      plan("auto_apply", { action: "create", title: "Anna", body: "Lives in Paris.", tags: [] }),
+      deps(store),
+    );
+    expect(created).toMatchObject({ kind: "created" });
+    const note = calls.create[0]?.options?.curator_note as Record<string, unknown>;
+    expect(note).not.toHaveProperty("addendum_version"); // never tagged on the accepted path
+
+    // ...and auto_apply archive still archives.
+    const a = fakeStore({ mem_old: { title: "Old", body: "Stale." } });
+    expect(
+      applyConsolidationPlan(
+        plan("auto_apply", { action: "archive", target_id: "mem_old" }),
+        deps(a.store),
+      ),
+    ).toEqual({ kind: "archived", id: "mem_old" });
+    expect(a.calls.archive).toEqual(["mem_old"]);
+  });
+});

--- a/packages/core/tests/consolidator-consolidate.test.ts
+++ b/packages/core/tests/consolidator-consolidate.test.ts
@@ -232,6 +232,47 @@ describe("consolidateInboxItem", () => {
     expect(capturedPrompt).not.toContain("OPERATOR GUIDANCE");
   });
 
+  it("threads deps-supplied underEvaluation into apply: force-proposes + tags (spec 044 D-3)", async () => {
+    // The status is read ONCE at the sweep/tick and threaded via deps; a would-be
+    // auto-apply create lands as a PROPOSAL tagged with the eval version — proving
+    // the wiring reaches applyConsolidationPlan, not just a unit test of apply.
+    const ref = writeInbox(vault, "Anna moved to Berlin.", {
+      now: () => 1000,
+      generateId: () => "inbox_a",
+    });
+    // An options-capturing store (the shared fakeStore drops options).
+    let createdOptions: Record<string, unknown> | undefined;
+    const store: ConsolidatorApplyStore = {
+      createMemory: (_input, options) => {
+        createdOptions = options;
+        return { memory: { id: "mem_p" } };
+      },
+      updateMemory: () => null,
+      archiveMemory: () => null,
+      getMemory: () => null,
+    };
+    const client = fakeClient(
+      JSON.stringify({
+        action: "create",
+        title: "Anna",
+        body: "Anna lives in Berlin.",
+        tags: [],
+        rationale: "novel",
+        confidence: 0.99,
+      }),
+    );
+
+    const result = await consolidateInboxItem(ref.relPath, {
+      ...baseDeps(store, client),
+      underEvaluation: true,
+      addendumVersion: "evalhash999",
+    });
+
+    expect(result).toMatchObject({ status: "consolidated", outcome: { kind: "proposed" } });
+    expect(createdOptions?.requires_approval).toBe(true);
+    expect(createdOptions?.curator_note).toMatchObject({ addendum_version: "evalhash999" });
+  });
+
   it("completes (removes) the item even when apply rejects — a rejection is terminal", async () => {
     const ref = writeInbox(vault, "archive that", { now: () => 1000, generateId: () => "inbox_a" });
     const { store } = fakeStore(); // empty → the archive target is missing → rejected

--- a/packages/core/tests/consolidator-tick.test.ts
+++ b/packages/core/tests/consolidator-tick.test.ts
@@ -14,6 +14,7 @@ import {
   createLibrarianStore,
   resolveSecretKey,
   runConsolidatorTick,
+  setAddendumStatus,
   setJobAddendum,
   writeConsumerConfig,
 } from "@librarian/core";
@@ -140,6 +141,29 @@ describe("runConsolidatorTick — operational", () => {
     expect(result).toMatchObject({ ran: true });
     // The file's content reached the intake prompt (the OPERATOR GUIDANCE block).
     expect(capturedPrompt).toContain("MARKER-ADDENDUM prefer the lessons folder");
+  });
+
+  it("force-proposes (no auto-apply) while the intake addendum is under_evaluation (spec 044 D-3)", async () => {
+    configureLlm();
+    setJobAddendum(store!, "intake", "freshly changed guidance");
+    setAddendumStatus(store!, "intake", "under_evaluation");
+    const evalVersion = store!.readAddendum("intake").version;
+    store!.submitToInbox("Anna moved to Berlin.");
+
+    // The judge would auto-apply a high-confidence create; under evaluation it must
+    // land as a PROPOSED memory, NOT an active one — proven end-to-end through the tick.
+    const result = await runConsolidatorTick({
+      store: store!,
+      buildClient: () => createJudgmentClient(),
+    });
+    expect(result).toMatchObject({ ran: true, summary: { consolidated: 1 } });
+
+    // Nothing active was created…
+    expect(store!.searchMemories({ query: "Anna", status: "active" })).toEqual([]);
+    // …it's a proposal, tagged with the eval version.
+    const proposed = store!.searchMemories({ query: "Anna", status: "proposed" });
+    expect(proposed.length).toBe(1);
+    expect(proposed[0]?.curator_note?.addendum_version).toBe(evalVersion);
   });
 
   it("omits the operator-guidance block when the intake addendum file is absent (today's behaviour)", async () => {

--- a/packages/core/tests/curator-addendum.test.ts
+++ b/packages/core/tests/curator-addendum.test.ts
@@ -19,7 +19,9 @@ import {
   type LibrarianStore,
   createLibrarianStore,
   migrateCuratorAddendum,
+  readAddendumStatus,
   readJobAddendum,
+  setAddendumStatus,
   setJobAddendum,
 } from "@librarian/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -199,5 +201,82 @@ describe("curator addenda as committed vault files (spec 044 D-1)", () => {
     expect(readJobAddendum(store, "grooming").content).toBe("edited by admin");
     // The stale legacy setting is retired regardless (it must never re-seed later).
     expect(store.getSetting(LEGACY_ADDENDUM_KEY)).toBeNull();
+  });
+});
+
+describe("addendum evaluation status round-trip (spec 044 D-3)", () => {
+  let s: Scope | null = null;
+  beforeEach(() => {
+    s = scope();
+  });
+  afterEach(() => {
+    teardown(s);
+    s = null;
+  });
+
+  it("defaults to accepted + null version when unset (the regression default)", () => {
+    const { store } = s!;
+    expect(readAddendumStatus(store, "grooming")).toEqual({
+      status: "accepted",
+      evalVersion: null,
+    });
+    expect(readAddendumStatus(store, "intake")).toEqual({ status: "accepted", evalVersion: null });
+  });
+
+  it("begin evaluation captures the CURRENT addendum version automatically", () => {
+    const { store } = s!;
+    const written = setJobAddendum(store, "grooming", "prefer merging");
+    expect(written.version).not.toBeNull();
+
+    setAddendumStatus(store, "grooming", "under_evaluation");
+
+    const got = readAddendumStatus(store, "grooming");
+    expect(got.status).toBe("under_evaluation");
+    expect(got.evalVersion).toBe(written.version); // the D1 version is pinned
+  });
+
+  it("an explicit evalVersion arg wins over the current addendum version", () => {
+    const { store } = s!;
+    setJobAddendum(store, "intake", "some guidance");
+    setAddendumStatus(store, "intake", "under_evaluation", "deadbeefcafe");
+    expect(readAddendumStatus(store, "intake")).toEqual({
+      status: "under_evaluation",
+      evalVersion: "deadbeefcafe",
+    });
+  });
+
+  it("end evaluation (accepted) clears the eval version and resumes the default", () => {
+    const { store } = s!;
+    setJobAddendum(store, "grooming", "x");
+    setAddendumStatus(store, "grooming", "under_evaluation");
+    expect(readAddendumStatus(store, "grooming").status).toBe("under_evaluation");
+
+    setAddendumStatus(store, "grooming", "accepted");
+    expect(readAddendumStatus(store, "grooming")).toEqual({
+      status: "accepted",
+      evalVersion: null,
+    });
+  });
+
+  it("per-job: intake under_evaluation does not affect grooming (and vice versa)", () => {
+    const { store } = s!;
+    setJobAddendum(store, "intake", "intake guidance");
+    setAddendumStatus(store, "intake", "under_evaluation");
+
+    expect(readAddendumStatus(store, "intake").status).toBe("under_evaluation");
+    expect(readAddendumStatus(store, "grooming")).toEqual({
+      status: "accepted",
+      evalVersion: null,
+    });
+  });
+
+  it("entering evaluation with no committed addendum leaves evalVersion null", () => {
+    const { store } = s!;
+    // No setJobAddendum → the file is absent → version null.
+    setAddendumStatus(store, "grooming", "under_evaluation");
+    expect(readAddendumStatus(store, "grooming")).toEqual({
+      status: "under_evaluation",
+      evalVersion: null,
+    });
   });
 });

--- a/packages/core/tests/curator-apply.test.ts
+++ b/packages/core/tests/curator-apply.test.ts
@@ -457,3 +457,255 @@ describe("applyOperations — skips + rejects mutate nothing", () => {
     expect(s!.store.getMemory(m.id)?.status).toBe("active");
   });
 });
+
+// ── Under-evaluation force-propose (spec 044 D-3) ────────────────────────────
+//
+// While the grooming addendum is under_evaluation, NO non-protected op auto-
+// applies: a would-be auto-apply is routed to a PROPOSAL (tagged with the eval
+// version) and a would-be auto-archive is SKIPPED (archive is not proposable —
+// the wrinkle). Protected ops already route to propose/skip and are unchanged.
+// When accepted (the default) behaviour is byte-identical to before D3a.
+describe("applyOperations — under_evaluation force-propose (spec 044 D-3)", () => {
+  // high_confidence so EVERY non-protected op would otherwise auto-apply.
+  function evalDeps(addendumVersion: string | null = "evalhash123") {
+    return {
+      store: s!.store,
+      runId: s!.runId,
+      actorId: "system-memory-curator",
+      policy: policy("high_confidence"),
+      underEvaluation: true as const,
+      addendumVersion,
+    };
+  }
+
+  it("a would-be auto-apply create is PROPOSED (not applied) and tagged", () => {
+    const summary = applyOperations(
+      ops({
+        operation: {
+          type: "create",
+          memory: {
+            title: "New",
+            body: "the body",
+            category: "lessons",
+            visibility: "common",
+            scope: "project",
+            project_key: "proj-x",
+          },
+          rationale: "durable",
+          confidence: 0.99,
+        },
+        outcome: accept("normal"),
+      }),
+      context(),
+      evalDeps(),
+    );
+    expect(summary.proposed).toBe(1);
+    expect(summary.applied).toBe(0);
+    const op = recorded().find((o) => o.status === "proposed")!;
+    const proposal = s!.store.getMemory(op.target_memory_ids[0]!)!;
+    expect(proposal.status).toBe("proposed");
+    expect(proposal.curator_note?.addendum_version).toBe("evalhash123");
+    expect(proposal.curator_note?.run_id).toBe(s!.runId);
+  });
+
+  it("a would-be auto-apply update is PROPOSED, the source untouched, tagged", () => {
+    const m = seed({ title: "Orig", body: "orig body" });
+    const summary = applyOperations(
+      ops({
+        operation: {
+          type: "update",
+          source_memory_id: m.id,
+          patch: { title: "Edited" },
+          rationale: "edit",
+          confidence: 0.99,
+        },
+        outcome: accept("normal"),
+      }),
+      context(),
+      evalDeps(),
+    );
+    expect(summary.proposed).toBe(1);
+    expect(summary.applied).toBe(0);
+    expect(s!.store.getMemory(m.id)?.title).toBe("Orig"); // source NOT mutated
+    const op = recorded().find((o) => o.status === "proposed")!;
+    const proposal = s!.store.getMemory(op.target_memory_ids[0]!)!;
+    expect(proposal.title).toBe("Edited"); // reconstructed from the authoritative record
+    expect(proposal.curator_note?.addendum_version).toBe("evalhash123");
+    expect(proposal.curator_note?.supersedes).toEqual([m.id]);
+  });
+
+  it("a would-be auto-apply merge is PROPOSED, sources stay active, tagged", () => {
+    const a = seed({ title: "A", body: "same" });
+    const b = seed({ title: "B", body: "same" });
+    const summary = applyOperations(
+      ops({
+        operation: {
+          type: "merge",
+          source_memory_ids: [a.id, b.id],
+          replacement: {
+            title: "Merged",
+            body: "merged body",
+            category: "lessons",
+            visibility: "common",
+            scope: "project",
+            project_key: "proj-x",
+          },
+          rationale: "dups",
+          confidence: 0.99,
+        },
+        outcome: accept("safe"),
+      }),
+      context(),
+      evalDeps(),
+    );
+    expect(summary.proposed).toBe(1);
+    expect(summary.applied).toBe(0);
+    // The would-be-archived sources stay ACTIVE (a proposal, not an apply).
+    expect(s!.store.getMemory(a.id)?.status).toBe("active");
+    expect(s!.store.getMemory(b.id)?.status).toBe("active");
+    const op = recorded().find((o) => o.status === "proposed")!;
+    expect(s!.store.getMemory(op.target_memory_ids[0]!)?.curator_note?.addendum_version).toBe(
+      "evalhash123",
+    );
+  });
+
+  it("a would-be auto-apply split is PROPOSED, source stays active, tagged", () => {
+    const src = seed({ title: "Mixed", body: "Anna and Bob" });
+    const replacement = (title: string) => ({
+      title,
+      body: `about ${title}`,
+      category: "lessons",
+      visibility: "common" as const,
+      scope: "project",
+      project_key: "proj-x",
+    });
+    const summary = applyOperations(
+      ops({
+        operation: {
+          type: "split",
+          source_memory_id: src.id,
+          replacements: [replacement("Anna"), replacement("Bob")],
+          rationale: "two entities",
+          confidence: 0.99,
+        },
+        outcome: accept("safe"),
+      }),
+      context(),
+      evalDeps(),
+    );
+    expect(summary.proposed).toBe(1);
+    expect(summary.applied).toBe(0);
+    expect(s!.store.getMemory(src.id)?.status).toBe("active"); // source NOT archived
+    const targets = recorded().find((o) => o.status === "proposed")!.target_memory_ids;
+    expect(targets.length).toBe(2);
+    for (const id of targets) {
+      const t = s!.store.getMemory(id)!;
+      expect(t.status).toBe("proposed");
+      expect(t.curator_note?.addendum_version).toBe("evalhash123");
+    }
+  });
+
+  it("a would-be auto-ARCHIVE is SKIPPED, not proposed (the archive wrinkle)", () => {
+    const m = seed();
+    const summary = applyOperations(
+      ops({
+        operation: {
+          type: "archive",
+          source_memory_ids: [m.id],
+          rationale: "dup",
+          confidence: 0.99,
+        },
+        outcome: accept("safe"),
+      }),
+      context(),
+      evalDeps(),
+    );
+    expect(summary.skipped).toBe(1);
+    expect(summary.proposed).toBe(0);
+    expect(summary.applied).toBe(0);
+    expect(s!.store.getMemory(m.id)?.status).toBe("active"); // NOT archived
+    expect(recorded()[0]).toMatchObject({ operation_type: "archive", status: "skipped" });
+  });
+
+  it("a noop stays skipped under evaluation (nothing proposed)", () => {
+    const m = seed();
+    const summary = applyOperations(
+      ops({
+        operation: { type: "noop", source_memory_ids: [m.id], rationale: "ok", confidence: 0.99 },
+        outcome: accept("safe"),
+      }),
+      context(),
+      evalDeps(),
+    );
+    expect(summary.skipped).toBe(1);
+    expect(summary.proposed).toBe(0);
+  });
+
+  it("under_evaluation without a version produces a proposal with NO addendum_version key", () => {
+    const summary = applyOperations(
+      ops({
+        operation: {
+          type: "create",
+          memory: {
+            title: "New",
+            body: "b",
+            category: "lessons",
+            visibility: "common",
+            scope: "project",
+            project_key: "proj-x",
+          },
+          rationale: "d",
+          confidence: 0.99,
+        },
+        outcome: accept("normal"),
+      }),
+      context(),
+      evalDeps(null),
+    );
+    expect(summary.proposed).toBe(1);
+    const op = recorded().find((o) => o.status === "proposed")!;
+    const note = s!.store.getMemory(op.target_memory_ids[0]!)!.curator_note!;
+    expect(note).not.toHaveProperty("addendum_version");
+  });
+
+  it("ACCEPTED (default, no underEvaluation) is byte-identical: auto-apply still applies + archives", () => {
+    // create auto-applies (active, no addendum_version tag).
+    const createSummary = applyOperations(
+      ops({
+        operation: {
+          type: "create",
+          memory: {
+            title: "New",
+            body: "b",
+            category: "lessons",
+            visibility: "common",
+            scope: "project",
+            project_key: "proj-x",
+          },
+          rationale: "d",
+          confidence: 0.99,
+        },
+        outcome: accept("normal"),
+      }),
+      context(),
+      deps(), // high_confidence, NO underEvaluation
+    );
+    expect(createSummary.applied).toBe(1);
+    const created = s!.store.getMemory(recorded()[0]!.target_memory_ids[0]!)!;
+    expect(created.status).toBe("active");
+    expect(created.curator_note).not.toHaveProperty("addendum_version");
+
+    // archive still archives.
+    const m = seed();
+    const archiveSummary = applyOperations(
+      ops({
+        operation: { type: "archive", source_memory_ids: [m.id], rationale: "x", confidence: 0.99 },
+        outcome: accept("safe"),
+      }),
+      context(),
+      deps(),
+    );
+    expect(archiveSummary.applied).toBe(1);
+    expect(s!.store.getMemory(m.id)?.status).toBe("archived");
+  });
+});

--- a/packages/core/tests/curator-force-propose.test.ts
+++ b/packages/core/tests/curator-force-propose.test.ts
@@ -1,0 +1,72 @@
+// Under-evaluation force-propose routing rule (spec 044 D-3). The small shared
+// decision both apply paths reduce to: while a job is under_evaluation, divert a
+// would-be auto-apply to a proposal and a would-be auto-archive to a skip; tag the
+// produced proposals with the addendum eval version. Pure functions, no store.
+
+import { forceProposeDeps, tagAddendumVersion, underEvaluationRoute } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+describe("underEvaluationRoute (spec 044 D-3)", () => {
+  it("routes a would-be apply to propose (not archive)", () => {
+    expect(underEvaluationRoute("apply", false)).toBe("propose");
+  });
+
+  it("routes a would-be auto-ARCHIVE to skip — the archive wrinkle", () => {
+    expect(underEvaluationRoute("apply", true)).toBe("skip");
+  });
+
+  it("passes a propose through unchanged (a protected-propose stays propose)", () => {
+    expect(underEvaluationRoute("propose", false)).toBe("propose");
+    expect(underEvaluationRoute("propose", true)).toBe("propose");
+  });
+
+  it("passes a skip through unchanged", () => {
+    expect(underEvaluationRoute("skip", false)).toBe("skip");
+    expect(underEvaluationRoute("skip", true)).toBe("skip");
+  });
+
+  it("never returns 'apply' for an under-eval op (nothing auto-applies)", () => {
+    expect(underEvaluationRoute("apply", false)).not.toBe("apply");
+    expect(underEvaluationRoute("apply", true)).not.toBe("apply");
+  });
+});
+
+describe("tagAddendumVersion (spec 044 D-3)", () => {
+  it("stamps the version onto the note", () => {
+    expect(tagAddendumVersion({}, "abc123")).toEqual({ addendum_version: "abc123" });
+  });
+
+  it("adds NO key for a null/empty/undefined version (accepted-path note unchanged)", () => {
+    expect(tagAddendumVersion({}, null)).toEqual({});
+    expect(tagAddendumVersion({}, undefined)).toEqual({});
+    expect(tagAddendumVersion({}, "")).toEqual({});
+  });
+
+  it("preserves existing keys", () => {
+    expect(tagAddendumVersion({ run_id: "r" }, "v")).toEqual({
+      run_id: "r",
+      addendum_version: "v",
+    });
+  });
+});
+
+describe("forceProposeDeps (spec 044 D-3)", () => {
+  it("accepted → an empty spread (byte-identical to before D3a)", () => {
+    expect(forceProposeDeps({ status: "accepted", evalVersion: null })).toEqual({});
+    expect(forceProposeDeps({ status: "accepted", evalVersion: "ignored" })).toEqual({});
+  });
+
+  it("under_evaluation → turns force-propose on with the eval version", () => {
+    expect(forceProposeDeps({ status: "under_evaluation", evalVersion: "v1" })).toEqual({
+      underEvaluation: true,
+      addendumVersion: "v1",
+    });
+  });
+
+  it("under_evaluation with a null version still turns force-propose on", () => {
+    expect(forceProposeDeps({ status: "under_evaluation", evalVersion: null })).toEqual({
+      underEvaluation: true,
+      addendumVersion: null,
+    });
+  });
+});

--- a/packages/core/tests/curator-tick.test.ts
+++ b/packages/core/tests/curator-tick.test.ts
@@ -14,6 +14,7 @@ import {
   createLibrarianStore,
   resolveSecretKey,
   runCuratorTick,
+  setAddendumStatus,
   setJobAddendum,
   writeConsumerConfig,
   writeCuratorConfig,
@@ -121,6 +122,51 @@ describe("runCuratorTick — operational", () => {
     expect(result.ran).toBe(true);
     // The file's content reached the grooming prompt (it's the OPERATOR GUIDANCE block).
     expect(capturedPrompt).toContain("MARKER-ADDENDUM prefer merging over archiving");
+  });
+
+  it("force-proposes (no auto-apply) while the grooming addendum is under_evaluation (spec 044 D-3)", async () => {
+    seedMemory();
+    // high_confidence so the create would otherwise auto-apply to active.
+    writeCuratorConfig(store!, { enabled: true, defaultAutoApply: "high_confidence" });
+    configureGrooming({ token: "dummy-decrypted-token" });
+    setJobAddendum(store!, "grooming", "freshly changed guidance");
+    setAddendumStatus(store!, "grooming", "under_evaluation");
+    const evalVersion = store!.readAddendum("grooming").version;
+
+    // The grooming LLM emits a high-confidence create that would auto-apply.
+    const createClient: LlmClient = {
+      complete: async () => ({
+        content: JSON.stringify({
+          operations: [
+            {
+              type: "create",
+              memory: {
+                title: "Curator fact",
+                body: "a durable lesson",
+                category: "lessons",
+                visibility: "common",
+                scope: "project",
+                project_key: "proj-x",
+              },
+              rationale: "novel durable lesson",
+              confidence: 0.99,
+            },
+          ],
+        }),
+        model: "m",
+        usage: null,
+      }),
+    };
+
+    const result = await runCuratorTick({ store: store!, buildClient: () => createClient });
+    expect(result.ran).toBe(true);
+
+    // Nothing active was created by the curator…
+    expect(store!.searchMemories({ query: "Curator", status: "active" })).toEqual([]);
+    // …it's a proposal, tagged with the eval version.
+    const proposed = store!.searchMemories({ query: "Curator", status: "proposed" });
+    expect(proposed.length).toBe(1);
+    expect(proposed[0]?.curator_note?.addendum_version).toBe(evalVersion);
   });
 
   it("omits the operator-guidance block when the grooming addendum file is absent", async () => {


### PR DESCRIPTION
## What & why

When a curator job's prompt addendum is **freshly changed** it goes **"under evaluation"** (spec 044 decision D-3): the curator must NOT auto-apply decisions made under the unproven addendum. Instead it **force-proposes** them for human review and **tags** them with the addendum version, so the whole batch can later be accepted or rolled back wholesale.

This PR is **D3a — the core behaviour**. The admin tRPC (Accept / Roll-back / Re-evaluate) that *drives* this state is **D3b** (next).

## What's in here

### 1. Per-job status/version settings (unified `curator.<job>.*` namespace)
- `curator.<job>.addendum_status ∈ {accepted, under_evaluation}` — defaults to **accepted** when unset (so existing installs are unchanged).
- `curator.<job>.addendum_eval_version` — the D1 git hash of the addendum version being evaluated.
- Core readers + writers next to D1's addendum helpers (`curator-addendum.ts`): `readAddendumStatus(store, job)` → `{status, evalVersion}` and `setAddendumStatus(store, job, status, evalVersion?)`. Entering evaluation captures the **current** addendum version (D1's `readAddendum(job).version`) automatically unless an explicit version is passed; ending evaluation clears it. Exported from `index.ts` for D3b.

### 2. Force-propose in BOTH apply paths
Intake (`consolidator/apply.ts` `applyConsolidationPlan`) and grooming (`curator-apply.ts` `applyOperations`). While `under_evaluation`:
- a would-be **auto-apply** (create/merge/update/supersede/augment/split/create_new) is routed to a **proposal**;
- **the archive wrinkle:** a would-be **auto-archive** is **skipped** (recorded `skipped`), NOT proposed — archive and `noop` are not proposable;
- C4's intake `split` stays proposed (already not an auto-apply); grooming's protected-propose stays propose.
- **Defence-in-depth** like C4's split: even at confidence 1.0 an under-eval op never auto-applies.

The small shared **routing rule** + the **tag** primitive live in the new pure `curator-force-propose.ts` (`underEvaluationRoute`, `tagAddendumVersion`, `forceProposeDeps`); each apply path keeps its own op execution — the two judges' models are **not** merged.

### 3. Proposal tagging
Every proposal produced while `under_evaluation` carries `curator_note.addendum_version = <eval version>` (added `addendum_version?: string` to `CuratorNoteSchema`). The grooming tag is gated on `isProposal` so an auto-applied write can never be tagged.

### 4. Threading + logging
The status is read **once per sweep/tick** and threaded via deps (the D2 pattern); the only production callers of `consolidateInbox` / `runDueCuration` are the two ticks, so the read is consistent across every entry point (http boot scheduler/scan, intake+grooming tRPC run-now, post-intake trigger). Force-proposed ops log `outcome=proposed`, force-skipped archives log `outcome=skipped` through the existing C1/grooming log call-sites (no log-site edits needed).

## Accepted-path is byte-identical (the load-bearing regression guard)
Every change is gated behind `deps.underEvaluation`. When `accepted` (default/unset): the decision is unchanged, no eval-version is carried, and the note adds no key → identical writes. Pinned by explicit "ACCEPTED is byte-identical" regression tests on **both** paths (auto-apply still applies, auto-archive still archives, no `addendum_version` key) plus the entire pre-existing apply suites staying green.

## Tests (TDD, +96)
- `curator-force-propose.test.ts` (the pure rule), `curator-addendum.test.ts` (+6 status round-trip), intake + grooming apply force-propose/archive-skip/tagging blocks, deps-threading through `consolidateInboxItem`, and **end-to-end** through the real `runConsolidatorTick` / `runCuratorTick` against a real store (high-confidence create lands `status=proposed` not active, tagged with the real committed eval version).
- Full suite green: core 843 (+1 skip), mcp-server 124, cli 44, dashboard 182, root 22. `pnpm -r build` + typecheck + lint clean.

## CHANGELOG
Deferred to D8's single 044 entry — D3a is pure core plumbing with no operator-facing surface (no operator can trigger `under_evaluation` until the D3b admin tRPC / D7 dashboard).

## Review
No general-purpose review sub-agent is available in this sandbox (confirmed via ToolSearch, as on every prior task), so I conducted the multi-axis review myself — emphasis on the four called-out axes: accepted-path byte-identical, archive→skip (not propose), no auto-apply at high confidence, and the version tag on every under-eval proposal. No Critical/Important findings; one self-applied tightening (gate the grooming tag on `isProposal`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)