### PR TITLE
feat(mcp-server): admin accept + roll-back for addendum evaluation (spec 044 PR-3b, Task D3b)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -368,6 +368,7 @@ export {
   type InternalLibrarianStore,
   type LibrarianStore,
   type LibrarianStoreOptions,
+  type RollbackAddendumResult,
   addendumPath,
   createLibrarianStore,
   resolveDataDir,

--- a/packages/core/src/store/git/sync-git-ops.ts
+++ b/packages/core/src/store/git/sync-git-ops.ts
@@ -41,6 +41,22 @@ export interface SyncGitOps {
    * proposals with and `git checkout` to roll back.
    */
   lastCommitFor(relPath: string): string | null;
+  /**
+   * The full hashes of every commit that touched `relPath`, newest first (empty
+   * when the path has no history). The first element is the file's current
+   * version, the second its prior version — the spec 044 D-3b roll-back uses
+   * `commitsFor(rel)[1]` to find the commit to restore the addendum to.
+   */
+  commitsFor(relPath: string): string[];
+  /**
+   * Restore a SINGLE file to its content at `commitHash`, leaving every other
+   * file (committed or dirty) in the working tree untouched (spec 044 D-3b roll-
+   * back). This is `git checkout <hash> -- <relPath>`: path-scoped on purpose —
+   * the vault is the live shared working tree, so a broad checkout that could
+   * clobber unrelated uncommitted state is forbidden. The restored content is left
+   * staged + in the working tree; the caller commits it. Returns void.
+   */
+  checkoutFile(relPath: string, commitHash: string): void;
   /** Commit subjects, newest first (empty on a repo with no commits). */
   log(): string[];
   isRepo(): boolean;
@@ -122,6 +138,22 @@ export function createSyncGitOps(opts: { cwd: string }): SyncGitOps {
     return out ? out : null;
   }
 
+  function commitsFor(relPath: string): string[] {
+    // `--format=%H -- <path>` prints every touching commit's hash newest-first,
+    // or empty (exit 0) when the path has no history; tryGit also absorbs the
+    // commitless-repo case (exit non-zero) → [].
+    const out = tryGit(["log", "--format=%H", "--", relPath]);
+    if (out === null) return [];
+    return out.split("\n").filter((line) => line.length > 0);
+  }
+
+  function checkoutFile(relPath: string, commitHash: string): void {
+    // `checkout <hash> -- <relPath>` restores ONLY that path from that commit; the
+    // `--` separates the pathspec so a path that looks like a ref can't be
+    // misread, and no other working-tree file (committed or dirty) is touched.
+    git(["checkout", commitHash, "--", relPath]);
+  }
+
   function log(): string[] {
     const out = tryGit(["log", "--format=%s"]);
     if (out === null) return []; // no commits yet
@@ -139,7 +171,7 @@ export function createSyncGitOps(opts: { cwd: string }): SyncGitOps {
     );
   }
 
-  return { init, commitAll, head, lastCommitFor, log, isRepo, push };
+  return { init, commitAll, head, lastCommitFor, commitsFor, checkoutFile, log, isRepo, push };
 }
 
 /**

--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -118,6 +118,17 @@ export interface LibrarianStore
    * post-write record (content + the new version hash).
    */
   writeAddendum(job: CuratorConsumer, content: string): AddendumRecord;
+  /**
+   * Roll a curator job's addendum back to its PRIOR committed version (spec 044
+   * D-3b roll-back): restore the file to the commit before its current one in the
+   * file's own git history, then COMMIT the restoration so the roll-back is itself
+   * a revertable commit. Edge cases:
+   *   - only one committed version → restore to empty (the pre-existence state),
+   *     committed (`restored: true`);
+   *   - no committed version at all → safe no-op (`restored: false`, version null).
+   * Surgical: touches ONLY this job's addendum file, never other vault state.
+   */
+  rollbackAddendum(job: CuratorConsumer): RollbackAddendumResult;
 }
 
 /** A curator job's addendum content + its git version (spec 044 D-1). */
@@ -125,6 +136,14 @@ export interface AddendumRecord {
   /** The addendum text (empty string when the file is absent — fail-soft). */
   content: string;
   /** The commit hash that last touched the file, or null when it has no history. */
+  version: string | null;
+}
+
+/** The outcome of a `rollbackAddendum` (spec 044 D-3b). */
+export interface RollbackAddendumResult {
+  /** True when a restoration commit was made (prior version OR empty); false on a no-op. */
+  restored: boolean;
+  /** The new HEAD commit hash for the file after the roll-back, or null on a no-op. */
   version: string | null;
 }
 
@@ -346,6 +365,29 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Libra
       vault.writeText(rel, content);
       commit(`curator: addendum ${job}`);
       return { content, version: git.lastCommitFor(rel) };
+    },
+    rollbackAddendum: (job) => {
+      const rel = addendumPath(job);
+      // The file's own commit history, newest-first. [0] = current version,
+      // [1] = the prior version we roll back to (spec 044 D-3b).
+      const history = git.commitsFor(rel);
+      if (history.length === 0) {
+        // Never committed — nothing to roll back. Safe no-op.
+        return { restored: false, version: null };
+      }
+      const prior = history[1];
+      if (prior) {
+        // Restore ONLY this file to its prior committed content (surgical — the
+        // vault is the live shared tree), then commit the restoration so it is a
+        // revertable commit at the head of the file's history.
+        git.checkoutFile(rel, prior);
+      } else {
+        // Single committed version → no prior content to restore to. Roll back to
+        // the pre-existence state by clearing the file, still committed.
+        vault.writeText(rel, "");
+      }
+      commit(`curator: rollback ${job}`);
+      return { restored: true, version: git.lastCommitFor(rel) };
     },
   };
 }

--- a/packages/core/tests/curator-addendum.test.ts
+++ b/packages/core/tests/curator-addendum.test.ts
@@ -280,3 +280,74 @@ describe("addendum evaluation status round-trip (spec 044 D-3)", () => {
     });
   });
 });
+
+describe("addendum roll-back to the prior committed version (spec 044 D-3b)", () => {
+  let s: Scope | null = null;
+  beforeEach(() => {
+    s = scope();
+  });
+  afterEach(() => {
+    teardown(s);
+    s = null;
+  });
+
+  it("restores the addendum file to its prior committed content and records a NEW commit", () => {
+    const { store, dataDir } = s!;
+    const v1 = setJobAddendum(store, "grooming", "v1 guidance");
+    const v2 = setJobAddendum(store, "grooming", "v2 guidance (under evaluation)");
+    expect(v2.version).not.toBe(v1.version);
+
+    const result = store.rollbackAddendum("grooming");
+
+    // The file content is restored to v1.
+    expect(readJobAddendum(store, "grooming").content).toBe("v1 guidance");
+    const file = path.join(dataDir, "vault", ".curator", "grooming-addendum.md");
+    expect(fs.readFileSync(file, "utf8")).toBe("v1 guidance");
+
+    // The restoration is itself a NEW commit (revertable), distinct from v1/v2.
+    expect(result.restored).toBe(true);
+    expect(result.version).toMatch(/^[0-9a-f]{40}$/);
+    expect(result.version).not.toBe(v1.version);
+    expect(result.version).not.toBe(v2.version);
+    expect(readJobAddendum(store, "grooming").version).toBe(result.version);
+
+    // The new commit is at the head of the file's history and mentions roll-back.
+    expect(vaultLog(dataDir).some((m) => /rollback grooming/.test(m))).toBe(true);
+    expect(vaultLog(dataDir)[0]).toMatch(/rollback grooming/);
+  });
+
+  it("rolling back a single-version addendum safely restores it to empty", () => {
+    const { store, dataDir } = s!;
+    const v1 = setJobAddendum(store, "grooming", "only ever version");
+
+    const result = store.rollbackAddendum("grooming");
+
+    // No prior version → restore to the pre-existence state (empty content).
+    expect(readJobAddendum(store, "grooming").content).toBe("");
+    expect(result.restored).toBe(true);
+    expect(result.version).not.toBe(v1.version);
+    // The empty restoration is a real commit recorded in the log.
+    expect(vaultLog(dataDir).some((m) => /rollback grooming/.test(m))).toBe(true);
+  });
+
+  it("rolling back with no committed addendum is a safe no-op", () => {
+    const { store } = s!;
+    const result = store.rollbackAddendum("grooming");
+    expect(result.restored).toBe(false);
+    expect(result.version).toBeNull();
+    expect(readJobAddendum(store, "grooming")).toEqual({ content: "", version: null });
+  });
+
+  it("rolls back ONLY the target job's addendum, leaving the other job untouched", () => {
+    const { store } = s!;
+    setJobAddendum(store, "intake", "intake v1");
+    setJobAddendum(store, "intake", "intake v2");
+    setJobAddendum(store, "grooming", "grooming v1");
+    setJobAddendum(store, "grooming", "grooming v2");
+
+    store.rollbackAddendum("grooming");
+
+    expect(readJobAddendum(store, "grooming").content).toBe("grooming v1");
+    expect(readJobAddendum(store, "intake").content).toBe("intake v2"); // untouched
+  });
+});

--- a/packages/core/tests/store/git/sync-git-ops.test.ts
+++ b/packages/core/tests/store/git/sync-git-ops.test.ts
@@ -108,6 +108,55 @@ describe("sync git-ops", () => {
     expect(git.log()).toEqual(["remove a", "add a"]);
   });
 
+  it("commitsFor lists a file's touching commits newest-first (and is empty for an unknown path)", () => {
+    const git = createSyncGitOps({ cwd });
+    git.init();
+    write("a.md", "v1\n");
+    const c1 = git.commitAll("a v1");
+    write("b.md", "other\n"); // a commit that does NOT touch a.md
+    git.commitAll("b v1");
+    write("a.md", "v2\n");
+    const c2 = git.commitAll("a v2");
+
+    // Newest-first, only the commits that actually touched a.md (b's commit is excluded).
+    expect(git.commitsFor("a.md")).toEqual([c2, c1]);
+    expect(git.commitsFor("never.md")).toEqual([]);
+  });
+
+  it("checkoutFile restores ONE file to a prior commit without disturbing other files", () => {
+    const git = createSyncGitOps({ cwd });
+    git.init();
+    write("a.md", "v1\n");
+    const c1 = git.commitAll("a v1");
+    write("a.md", "v2\n");
+    write("b.md", "b-current\n");
+    git.commitAll("a v2 + b");
+
+    // Restore a.md to its v1 content; b.md (and any other working-tree file) untouched.
+    git.checkoutFile("a.md", c1!);
+
+    expect(fs.readFileSync(path.join(cwd, "a.md"), "utf8")).toBe("v1\n");
+    expect(fs.readFileSync(path.join(cwd, "b.md"), "utf8")).toBe("b-current\n");
+  });
+
+  it("checkoutFile leaves uncommitted edits to OTHER files intact (surgical, not a broad checkout)", () => {
+    const git = createSyncGitOps({ cwd });
+    git.init();
+    write("addendum.md", "v1\n");
+    const c1 = git.commitAll("addendum v1");
+    write("addendum.md", "v2\n");
+    git.commitAll("addendum v2");
+
+    // A dirty, UNCOMMITTED edit to an unrelated vault file (the live shared tree).
+    write("memory.md", "uncommitted work\n");
+
+    git.checkoutFile("addendum.md", c1!);
+
+    expect(fs.readFileSync(path.join(cwd, "addendum.md"), "utf8")).toBe("v1\n");
+    // The unrelated uncommitted edit must survive — checkoutFile is path-scoped.
+    expect(fs.readFileSync(path.join(cwd, "memory.md"), "utf8")).toBe("uncommitted work\n");
+  });
+
   it("push delivers HEAD to a remote branch without persisting a named remote or the token", () => {
     const git = createSyncGitOps({ cwd });
     git.init();

--- a/packages/mcp-server/src/trpc/addendum.ts
+++ b/packages/mcp-server/src/trpc/addendum.ts
@@ -1,0 +1,58 @@
+// Addendum evaluation lifecycle admin tRPC procedures (spec 044 PR-3b / Task D3b).
+//
+// When an admin changes a curator job's prompt addendum it goes "under evaluation"
+// (spec 044 D-3): the curator force-proposes every would-be auto-apply (D3a) so the
+// admin can review the batch before trusting the new addendum. This router exposes
+// the two simpler lifecycle actions that END an evaluation:
+//
+//   - accept: the new addendum is good — set status back to `accepted` so the
+//     curator auto-applies again. (setAddendumStatus clears the eval version.)
+//   - rollback: the new addendum is bad — restore the addendum file to its PRIOR
+//     committed version (undo the under-evaluation change) + commit the
+//     restoration (revertable), then set status → accepted.
+//
+// PLACEMENT: a single shared `addendum` router keyed by `{ job }` rather than
+// parallel mutations on each of the per-job `curator` (grooming) + `intake`
+// routers. The lifecycle is byte-identical per job (both call the same core
+// `setAddendumStatus` / `store.rollbackAddendum` keyed by the job), so duplicating
+// it onto two routers would be pure repetition. The per-job routers stay split
+// because their OTHER concerns (config shape, runs/ops, run-now) genuinely differ;
+// this one does not. (The "Re-evaluate proposals" action — D3c — will join here.)
+//
+// All admin-gated — there is deliberately NO consumer-agent surface for curation.
+// The dashboard buttons that call these land in D7.
+
+import type { CuratorJob } from "@librarian/core";
+import { readAddendumStatus, setAddendumStatus } from "@librarian/core";
+import { z } from "zod";
+import { adminProcedure, router } from "./trpc.js";
+
+// The two curator jobs, the same `{ job }` key the addendum status is namespaced
+// over (`curator.<job>.addendum_status`).
+const JobInputSchema = z.strictObject({ job: z.enum(["intake", "grooming"]) });
+
+export const addendumRouter = router({
+  // Accept the addendum under evaluation: resume auto-apply by setting status back
+  // to `accepted` (which clears the eval version). Returns the fresh status.
+  accept: adminProcedure.input(JobInputSchema).mutation(({ ctx, input }) => {
+    const job: CuratorJob = input.job;
+    setAddendumStatus(ctx.store, job, "accepted");
+    return readAddendumStatus(ctx.store, job);
+  }),
+
+  // Roll back the addendum under evaluation: restore the file to its prior
+  // committed version (committed as a revertable roll-back commit), then set status
+  // → accepted so auto-apply resumes against the restored addendum. Returns the
+  // fresh status plus the roll-back outcome (whether a restoration commit was made
+  // and the restored version hash).
+  rollback: adminProcedure.input(JobInputSchema).mutation(({ ctx, input }) => {
+    const job: CuratorJob = input.job;
+    const rollback = ctx.store.rollbackAddendum(job);
+    setAddendumStatus(ctx.store, job, "accepted");
+    return {
+      ...readAddendumStatus(ctx.store, job),
+      restored: rollback.restored,
+      restoredVersion: rollback.version,
+    };
+  }),
+});

--- a/packages/mcp-server/src/trpc/router.ts
+++ b/packages/mcp-server/src/trpc/router.ts
@@ -8,6 +8,7 @@
 // rest of the session subsystem. D16 — the `domains` router is retired
 // with the rest of the domain model.
 
+import { addendumRouter } from "./addendum.js";
 import { authRouter } from "./auth.js";
 import { backupRouter } from "./backup.js";
 import { curatorRouter } from "./curator.js";
@@ -20,6 +21,7 @@ import { tokensRouter } from "./tokens.js";
 import { router } from "./trpc.js";
 
 export const appRouter = router({
+  addendum: addendumRouter,
   auth: authRouter,
   backup: backupRouter,
   curator: curatorRouter,

--- a/packages/mcp-server/tests/trpc/addendum.test.ts
+++ b/packages/mcp-server/tests/trpc/addendum.test.ts
@@ -1,0 +1,195 @@
+// Addendum evaluation lifecycle admin tRPC tests (spec 044 PR-3b / Task D3b).
+//
+// The two simpler admin lifecycle actions that drive D3a's under-evaluation state
+// back to accepted, both keyed by `{ job }` (intake | grooming):
+//   - accept: status `under_evaluation` → `accepted`, eval version cleared, so the
+//     curator auto-applies again (auto-apply resumes);
+//   - rollback: restore the addendum file to its PRIOR committed version + commit
+//     the restoration, then status → accepted.
+// Both are admin-gated (rejected without an admin bearer). The router is a single
+// shared `addendum` router keyed by `{ job }` — the lifecycle is identical per job,
+// unlike the per-job `curator`/`intake` routers whose other concerns genuinely
+// differ. Tests pre-seed addendum state via a store on the same dataDir before boot
+// and read back the file + git log to assert the roll-back recorded a new commit.
+
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import {
+  createLibrarianStore,
+  forceProposeDeps,
+  readAddendumStatus,
+  setAddendumStatus,
+  setJobAddendum,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanupTempDir, makeTempDir, startHttpServer } from "../../../../test/helpers.js";
+
+interface TrpcOk<T> {
+  result: { data: T };
+}
+interface TrpcErr {
+  error: unknown;
+}
+interface ServerHandle {
+  url: string;
+  token: string;
+  stop: () => Promise<void>;
+}
+
+async function trpcPost<T>(server: ServerHandle, path: string, input?: unknown): Promise<T> {
+  const response = await fetch(`${server.url}/trpc/${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${server.token}` },
+    body: input === undefined ? undefined : JSON.stringify(input),
+  });
+  const json = (await response.json()) as TrpcOk<T> | TrpcErr;
+  if (response.status >= 400 || "error" in json) {
+    throw new Error(`trpc POST ${path} failed: ${JSON.stringify(json)}`);
+  }
+  return (json as TrpcOk<T>).result.data;
+}
+
+interface StatusResult {
+  status: string;
+  evalVersion: string | null;
+}
+interface RollbackResult extends StatusResult {
+  restored: boolean;
+  restoredVersion: string | null;
+}
+
+const vaultLog = (dataDir: string): string[] =>
+  execFileSync("git", ["log", "--format=%s"], {
+    cwd: path.join(dataDir, "vault"),
+    encoding: "utf8",
+  })
+    .split("\n")
+    .filter(Boolean);
+
+describe("tRPC addendum evaluation lifecycle surface (spec 044 D3b)", () => {
+  let dataDir = "";
+  beforeEach(() => {
+    dataDir = makeTempDir();
+  });
+  afterEach(() => {
+    cleanupTempDir(dataDir);
+  });
+
+  it("admin-gates accept + rollback (rejected without an admin bearer)", async () => {
+    const server = await startHttpServer({ dataDir });
+    try {
+      for (const proc of ["addendum.accept", "addendum.rollback"]) {
+        const unauthed = await fetch(`${server.url}/trpc/${proc}`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ job: "grooming" }),
+        });
+        expect(unauthed.status, proc).toBeGreaterThanOrEqual(400);
+
+        const agent = await fetch(`${server.url}/trpc/${proc}`, {
+          method: "POST",
+          headers: { "content-type": "application/json", authorization: "Bearer agent-token" },
+          body: JSON.stringify({ job: "grooming" }),
+        });
+        expect(agent.status, `${proc} agent`).toBeGreaterThanOrEqual(400);
+      }
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("accept moves under_evaluation → accepted, clears the eval version, resumes auto-apply", async () => {
+    // Seed: grooming addendum committed + put under evaluation.
+    const seed = createLibrarianStore({ dataDir });
+    setJobAddendum(seed, "grooming", "v1 guidance");
+    setAddendumStatus(seed, "grooming", "under_evaluation");
+    expect(readAddendumStatus(seed, "grooming").status).toBe("under_evaluation");
+    // While under evaluation the curator force-proposes (non-empty deps).
+    expect(forceProposeDeps(readAddendumStatus(seed, "grooming"))).not.toEqual({});
+    seed.close();
+
+    const server = await startHttpServer({ dataDir });
+    try {
+      const result = await trpcPost<StatusResult>(server, "addendum.accept", { job: "grooming" });
+      expect(result).toEqual({ status: "accepted", evalVersion: null });
+    } finally {
+      await server.stop();
+    }
+
+    // Re-open the store and confirm auto-apply resumes: accepted → empty force-
+    // propose deps, i.e. the curator no longer force-proposes (byte-identical to
+    // the pre-D3a path).
+    const after = createLibrarianStore({ dataDir });
+    try {
+      const status = readAddendumStatus(after, "grooming");
+      expect(status).toEqual({ status: "accepted", evalVersion: null });
+      expect(forceProposeDeps(status)).toEqual({});
+    } finally {
+      after.close();
+    }
+  });
+
+  it("rollback restores the prior committed addendum, records a new commit, and accepts", async () => {
+    const seed = createLibrarianStore({ dataDir });
+    const v1 = setJobAddendum(seed, "grooming", "v1 guidance");
+    setJobAddendum(seed, "grooming", "v2 guidance (under evaluation)");
+    setAddendumStatus(seed, "grooming", "under_evaluation");
+    seed.close();
+
+    const server = await startHttpServer({ dataDir });
+    try {
+      const result = await trpcPost<RollbackResult>(server, "addendum.rollback", {
+        job: "grooming",
+      });
+      expect(result.status).toBe("accepted");
+      expect(result.evalVersion).toBeNull();
+      expect(result.restored).toBe(true);
+      expect(result.restoredVersion).toMatch(/^[0-9a-f]{40}$/);
+      expect(result.restoredVersion).not.toBe(v1.version);
+    } finally {
+      await server.stop();
+    }
+
+    // The file is restored to v1 content, a new roll-back commit is recorded, and
+    // status is accepted (auto-apply resumes).
+    const after = createLibrarianStore({ dataDir });
+    try {
+      expect(after.readAddendum("grooming").content).toBe("v1 guidance");
+      expect(readAddendumStatus(after, "grooming")).toEqual({
+        status: "accepted",
+        evalVersion: null,
+      });
+    } finally {
+      after.close();
+    }
+    expect(vaultLog(dataDir).some((m) => /rollback grooming/.test(m))).toBe(true);
+  });
+
+  it("rollback is keyed by job — accepts/rolls back ONLY the named job", async () => {
+    const seed = createLibrarianStore({ dataDir });
+    setJobAddendum(seed, "intake", "intake v1");
+    setJobAddendum(seed, "intake", "intake v2");
+    setAddendumStatus(seed, "intake", "under_evaluation");
+    setJobAddendum(seed, "grooming", "grooming v1");
+    setAddendumStatus(seed, "grooming", "under_evaluation");
+    seed.close();
+
+    const server = await startHttpServer({ dataDir });
+    try {
+      await trpcPost<RollbackResult>(server, "addendum.rollback", { job: "intake" });
+    } finally {
+      await server.stop();
+    }
+
+    const after = createLibrarianStore({ dataDir });
+    try {
+      expect(after.readAddendum("intake").content).toBe("intake v1"); // rolled back
+      expect(readAddendumStatus(after, "intake").status).toBe("accepted");
+      // Grooming is untouched: still under evaluation, content unchanged.
+      expect(after.readAddendum("grooming").content).toBe("grooming v1");
+      expect(readAddendumStatus(after, "grooming").status).toBe("under_evaluation");
+    } finally {
+      after.close();
+    }
+  });
+});


### PR DESCRIPTION
## Spec 044 PR-3b (Task D3b): admin Accept + Roll-back for addendum evaluation

Part of the self-improving curator arc (spec 044). D3a shipped the under-evaluation
**force-propose** core (status + proposal tagging + both apply paths). D3b adds the
two simpler admin lifecycle actions that END an evaluation, plus the git primitive
roll-back needs. (D3c — "Re-evaluate proposals" — is next.)

### What this adds

**Accept** (`addendum.accept({job})`): the new addendum is good — set status back to
`accepted` so the curator auto-applies again. `setAddendumStatus(store, job,
"accepted")` clears the eval version (D3a). Returns the fresh `{status, evalVersion}`.

**Roll-back** (`addendum.rollback({job})`): the new addendum is bad — restore the
addendum vault file to its **prior committed version** (undo the under-evaluation
change), **commit** the restoration (so the roll-back is itself a revertable
commit), then set status → `accepted`. Returns `{status, evalVersion, restored,
restoredVersion}`.

### The `checkoutFile` primitive

`SyncGitOps` gains `checkoutFile(relPath, commitHash)` = `git checkout <hash> --
<relPath>` — **path-scoped**: it restores ONLY that file from that commit, leaving
every other working-tree file (committed **or** dirty) untouched. The vault is the
live shared working tree, so a broad checkout that could clobber unrelated
uncommitted state is forbidden; the `--` separates the pathspec so a path that looks
like a ref can't be misread. Also adds `commitsFor(relPath)` (a file's touching
commits, newest-first) so roll-back can find the prior version (`commitsFor(rel)[1]`).

### `rollbackAddendum` store method

A faithful sibling of D1's addendum I/O on the `LibrarianStore`:
- **prior version exists** → `checkoutFile` to it;
- **single committed version** (no prior) → restore to **empty** (the pre-existence
  state), still committed;
- **never committed** → safe no-op (`{restored:false, version:null}`).
Then commits `curator: rollback <job>`.

### tRPC placement

A single shared **`addendum`** router keyed by `{job}` (registered in `router.ts`),
**not** parallel mutations on the per-job `curator`/`intake` routers. The
Accept/Roll-back lifecycle is byte-identical per job (both just call core
`setAddendumStatus` / `store.rollbackAddendum` keyed by the job), so duplicating it
across two routers would be pure repetition. The per-job routers stay split because
their other concerns (config shape, runs/ops, run-now) genuinely differ; this one
does not. D3c's "Re-evaluate" will join this same router. Both mutations are
`adminProcedure` (admin-gated).

### Tests (TDD, RED→GREEN)

- **core** (`sync-git-ops.test.ts`): `commitsFor` lists only touching commits;
  `checkoutFile` restores one file without disturbing others; `checkoutFile` leaves
  **uncommitted** edits to other files intact (the shared-vault axis).
- **core** (`curator-addendum.test.ts`): `rollbackAddendum` restores prior content +
  records a new commit; single-version → empty; never-committed → no-op; per-job
  isolation.
- **mcp-server** (`trpc/addendum.test.ts`, real HTTP bin): Accept moves
  under_evaluation → accepted + clears eval version + **resumes auto-apply**
  (`forceProposeDeps` becomes `{}`); Roll-back restores prior content + new commit +
  accepts; both **admin-gated** (unauth + agent-token rejected); keyed by job.

### CHANGELOG

Deferred to D8's single 044 entry — these are admin endpoints with no UI yet (the
buttons are D7), and no operator can reach `under_evaluation` via any UI surface yet
either, so D3b changes no operator-facing surface today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
