### PR TITLE
feat(mcp-server): re-evaluate grooming proposals for an addendum version (spec 044 PR-3c, Task D3c)

### DIFF
--- a/packages/core/src/curator-reevaluate.ts
+++ b/packages/core/src/curator-reevaluate.ts
@@ -1,0 +1,198 @@
+// Re-evaluate grooming proposals for an addendum version (spec 044 D-3 / decision
+// D-3, the "Re-evaluate proposals" escape hatch — Task D3c).
+//
+// While a grooming addendum is `under_evaluation` the curator force-proposes every
+// would-be auto-apply (D3a) and tags each proposal `curator_note.addendum_version
+// = <the eval version git hash>`. If the admin keeps editing the addendum (a new
+// commit → a new eval version), the proposals tagged with the EARLIER version go
+// stale. "Re-evaluate proposals" is the batch escape hatch: it discards exactly
+// that version's stale grooming proposals and re-runs grooming over their slices
+// under the CURRENT addendum, producing a fresh, re-tagged batch.
+//
+// GROOMING ONLY. Spec 044 ("what's there"): grooming's input is the replayable
+// corpus (curator-evidence / curator-source-vault), but the intake input (the
+// inbox) is CONSUMED on apply — not replayable. So an intake proposal has no
+// original judge input to re-run; there is deliberately no intake re-evaluate
+// (mirrors why intake has no dry-run in D4). The tRPC layer returns an
+// `intake_not_replayable` result for `job: "intake"` rather than calling this.
+//
+// MECHANISM (reuses the real grooming pipeline — NOT a parallel judging path):
+//   1. read the grooming eval version (readAddendumStatus); no version / no tagged
+//      proposals → a clean no-op `{ reEvaluated: true, count: 0 }`;
+//   2. derive the DISTINCT slices the tagged proposals belong to (via the store's
+//      own slice enumeration + evidence — so the partitioning never diverges from
+//      what a real grooming run would see), so ONLY those slices are re-judged (no
+//      collateral re-judging of unrelated slices);
+//   3. gate exactly like the tick (enabled / operational config / decryptable
+//      token) — if grooming can't run we DON'T discard anything (fail-soft: never
+//      leave the admin with the stale proposals gone AND no fresh batch);
+//   4. ARCHIVE the stale tagged proposals (the discard mechanism — the same status
+//      transition the admin's "reject" gives an unwanted proposal; no stale
+//      duplicate is left behind), then run `runCuration` over each affected slice
+//      with `bypassSkip` (force a fresh run) and the CURRENT force-propose deps, so
+//      fresh proposals land at `proposed` re-tagged with the current eval version.
+//   Each slice's re-run is fail-soft (one slice's failure never wedges the batch);
+//   the stale-proposal discard only happens for slices we actually re-run.
+
+import { SYSTEM_ACTOR_IDS } from "./caller-identity.js";
+import { readAddendumStatus, readJobAddendum } from "./curator-addendum.js";
+import { readCuratorConfig } from "./curator-config.js";
+import { readConsumerConfig, resolveConsumerToken } from "./curator-consumers.js";
+import type { EvidenceSlice } from "./curator-evidence.js";
+import { forceProposeDeps } from "./curator-force-propose.js";
+import { type LlmClient, createCuratorLlmClient } from "./curator-llm-client.js";
+import { type RunCurationCaps, runCuration } from "./curator-worker.js";
+import { MemoryStatus } from "./schemas/common.js";
+import type { LibrarianStore } from "./store/librarian-store.js";
+import type { Memory } from "./store/memory-store.js";
+
+/** Why a re-evaluate could not run (mirrors CuratorTickSkipReason). */
+export type ReEvaluateSkipReason = "disabled" | "incomplete_config" | "no_token";
+
+/**
+ * The outcome of `reEvaluateGroomingProposals`.
+ *  - `{ reEvaluated: true, count }`: ran (count = the stale proposals discarded +
+ *    re-judged; 0 is a clean no-op — nothing was tagged with the eval version).
+ *  - `{ reEvaluated: false, reason }`: grooming isn't runnable, so NOTHING was
+ *    discarded (fail-soft) — the admin still has the stale batch to act on.
+ */
+export type ReEvaluateResult =
+  | { reEvaluated: true; count: number }
+  | { reEvaluated: false; reason: ReEvaluateSkipReason };
+
+export interface ReEvaluateGroomingOptions {
+  store: LibrarianStore;
+  now?: Date;
+  caps?: RunCurationCaps;
+  /** Injectable LLM client builder (defaults to the OpenAI-compatible client). */
+  buildClient?: (
+    conn: { endpoint: string; model: string; timeoutMs: number },
+    token: string,
+  ) => LlmClient;
+}
+
+const DEFAULT_MAX_MEMORIES = 200;
+
+/** A proposal tagged with the eval version we're re-evaluating. */
+function isTaggedProposal(memory: Memory, evalVersion: string): boolean {
+  return (
+    memory.status === MemoryStatus.Proposed &&
+    typeof memory.curator_note === "object" &&
+    memory.curator_note !== null &&
+    (memory.curator_note as Record<string, unknown>).addendum_version === evalVersion
+  );
+}
+
+/**
+ * Re-evaluate the grooming proposals tagged with the current eval version: discard
+ * them and re-run grooming over their slices under the current addendum, producing
+ * a fresh batch. See the module header for the full contract. Intake is handled at
+ * the tRPC boundary (not replayable) and never reaches here.
+ */
+export async function reEvaluateGroomingProposals(
+  options: ReEvaluateGroomingOptions,
+): Promise<ReEvaluateResult> {
+  const { store } = options;
+  const status = readAddendumStatus(store, "grooming");
+  const evalVersion = status.evalVersion;
+
+  // No eval version pinned → nothing was tagged → clean no-op. (Also the case
+  // after Accept, which clears the version: re-judging is moot.)
+  if (!evalVersion) return { reEvaluated: true, count: 0 };
+
+  // Find the proposals tagged with this version. The memory store has no
+  // curator_note filter, so list proposals and filter in-memory.
+  const tagged = store
+    .listAll({ status: MemoryStatus.Proposed })
+    .filter((m) => isTaggedProposal(m, evalVersion));
+  if (tagged.length === 0) return { reEvaluated: true, count: 0 };
+
+  // Derive the DISTINCT slices the tagged proposals belong to BEFORE we discard
+  // them (an archived proposal leaves its slice's evidence). Use the store's own
+  // slice enumeration + evidence so the partitioning matches a real grooming run
+  // exactly — never re-derive a slice from a memory's raw fields.
+  const taggedIds = new Set(tagged.map((m) => m.id));
+  const caps = options.caps ?? {};
+  const maxMemories = caps.maxMemories ?? DEFAULT_MAX_MEMORIES;
+  const affected: EvidenceSlice[] = [];
+  for (const slice of store.listCuratorSlices()) {
+    const evidence = store.gatherMemoryEvidence(slice, {
+      maxMemories,
+      ...(caps.maxBodyChars !== undefined ? { maxBodyChars: caps.maxBodyChars } : {}),
+    });
+    if (evidence.proposedMemories.some((m) => taggedIds.has(m.id))) affected.push(slice);
+  }
+
+  // Gate exactly like the tick. If grooming can't run we must NOT discard the
+  // stale proposals (fail-soft: never leave the admin with neither the stale batch
+  // NOR a fresh one). Returned reason mirrors runCuratorTick's skip reasons.
+  const config = readCuratorConfig(store);
+  const llm = readConsumerConfig(store, "grooming");
+  if (!config.enabled) return { reEvaluated: false, reason: "disabled" };
+  if (!llm.isOperational) return { reEvaluated: false, reason: "incomplete_config" };
+  let token: string | null;
+  try {
+    token = resolveConsumerToken(store, "grooming");
+  } catch {
+    return { reEvaluated: false, reason: "no_token" };
+  }
+  if (!token) return { reEvaluated: false, reason: "no_token" };
+
+  const buildClient =
+    options.buildClient ??
+    ((conn, secret) =>
+      createCuratorLlmClient({
+        endpoint: conn.endpoint,
+        token: secret,
+        model: conn.model,
+        timeoutMs: conn.timeoutMs,
+      }));
+  const llmClient = buildClient(
+    { endpoint: llm.endpoint, model: llm.model, timeoutMs: llm.timeoutMs },
+    token,
+  );
+
+  // Discard the stale tagged proposals (the same archived transition "reject"
+  // gives an unwanted proposal), so the re-run never leaves a stale duplicate.
+  // Fail-soft per proposal — a single archive failure must not wedge the batch.
+  for (const proposal of tagged) {
+    try {
+      store.archiveMemory(proposal.id, SYSTEM_ACTOR_IDS.memoryCurator);
+    } catch {
+      /* fail-soft: leave this one; the re-run still refreshes the slice */
+    }
+  }
+
+  // Re-run grooming over each affected slice under the CURRENT addendum. Reuse the
+  // real worker (judge → validate → apply): `bypassSkip` forces a fresh run past
+  // the input-hash idempotency, and the force-propose deps re-tag fresh proposals
+  // with the current eval version (no auto-apply while under_evaluation). Fail-soft
+  // per slice — one slice's failure never aborts the rest.
+  const promptAddendum = readJobAddendum(store, "grooming").content;
+  // `status` is still under_evaluation (we don't change it here — Accept/Roll-back
+  // do), so these deps re-tag fresh proposals with the SAME eval version.
+  const forceProp = forceProposeDeps(status);
+  for (const slice of affected) {
+    try {
+      await runCuration(slice, {
+        store,
+        llmClient,
+        trigger: "manual",
+        actorId: SYSTEM_ACTOR_IDS.memoryCurator,
+        policy: {
+          level: config.defaultAutoApply,
+          confidenceThreshold: config.autoApplyConfidence,
+        },
+        model: { provider: llm.providerId, name: llm.model },
+        bypassSkip: true,
+        ...(promptAddendum !== "" ? { promptAddendum } : {}),
+        ...forceProp,
+        ...(caps.maxMemories !== undefined || caps.maxBodyChars !== undefined ? { caps } : {}),
+      });
+    } catch {
+      /* fail-soft: a slice's re-run failure never wedges the batch */
+    }
+  }
+
+  return { reEvaluated: true, count: tagged.length };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -83,6 +83,12 @@ export {
   runCuratorTick,
 } from "./curator-tick.js";
 export {
+  type ReEvaluateGroomingOptions,
+  type ReEvaluateResult,
+  type ReEvaluateSkipReason,
+  reEvaluateGroomingProposals,
+} from "./curator-reevaluate.js";
+export {
   type ConsolidatorTickOptions,
   type ConsolidatorTickResult,
   type ConsolidatorTickSkipReason,

--- a/packages/core/tests/curator-reevaluate.test.ts
+++ b/packages/core/tests/curator-reevaluate.test.ts
@@ -1,0 +1,344 @@
+// Re-evaluate grooming proposals (spec 044 D-3 / Task D3c). The batch escape hatch
+// that discards the proposals tagged with the current eval version and re-runs
+// grooming over their slices under the CURRENT addendum, producing a fresh batch.
+//
+// Network-free: a scripted LLM client makes the re-judge deterministic plumbing.
+// Verifies: only the tagged version's proposals are touched (a DIFFERENT version's
+// proposal + active memories are untouched); a fresh batch replaces the stale one
+// (no stale duplicate); no eval version / none tagged → clean no-op; grooming not
+// runnable → fail-soft (nothing discarded); partial failure on one slice doesn't
+// wedge the rest.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type LibrarianStore,
+  type LlmClient,
+  type Memory,
+  addProvider,
+  createLibrarianStore,
+  reEvaluateGroomingProposals,
+  resolveSecretKey,
+  setAddendumStatus,
+  setJobAddendum,
+  writeConsumerConfig,
+  writeCuratorConfig,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// Assemble the 64-hex key at runtime — no secret-shaped literal in source (GitGuardian).
+const KEY = resolveSecretKey("0123456789abcdef".repeat(4));
+
+let store: LibrarianStore | null = null;
+let dataDir = "";
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-reeval-"));
+  store = createLibrarianStore({ dataDir, secretKey: KEY });
+});
+afterEach(() => {
+  try {
+    store?.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  store = null;
+});
+
+// An LLM client that emits a single high-confidence create (would auto-apply when
+// accepted; force-proposed while under_evaluation). `title` makes each run's
+// proposal findable.
+function createEmittingClient(title: string, body = "a durable lesson"): LlmClient {
+  return {
+    complete: async () => ({
+      content: JSON.stringify({
+        operations: [
+          {
+            type: "create",
+            memory: {
+              title,
+              body,
+              category: "lessons",
+              visibility: "common",
+              scope: "project",
+              project_key: "proj-x",
+            },
+            rationale: "novel durable lesson",
+            confidence: 0.99,
+          },
+        ],
+      }),
+      model: "m",
+      usage: null,
+    }),
+  };
+}
+
+const noOpClient: LlmClient = {
+  complete: async () => ({ content: JSON.stringify({ operations: [] }), model: "m", usage: null }),
+};
+
+function seedActive(title: string, projectKey = "proj-x") {
+  store!.createMemory({
+    agent_id: "agent-a",
+    title,
+    body: "b",
+    category: "lessons",
+    visibility: "common",
+    scope: "project",
+    project_key: projectKey,
+    priority: "normal",
+    confidence: "working",
+  });
+}
+
+function configureGrooming(opts: { token?: string } = {}) {
+  const provider = addProvider(store!, {
+    name: "default",
+    endpoint: "https://api.example.com/v1",
+    ...(opts.token !== undefined ? { token: opts.token } : {}),
+  });
+  writeConsumerConfig(store!, "grooming", { providerId: provider.id, model: "gpt-x" });
+}
+
+// Put grooming under evaluation against a freshly-committed addendum and return the
+// pinned eval version (git hash).
+function beginEvaluation(addendum: string): string {
+  setJobAddendum(store!, "grooming", addendum);
+  setAddendumStatus(store!, "grooming", "under_evaluation");
+  const version = store!.readAddendum("grooming").version;
+  if (!version) throw new Error("expected an eval version");
+  return version;
+}
+
+// Exact title lookup (searchMemories is fuzzy keyword matching — too loose to assert
+// precise presence/absence of a specific titled memory).
+function byTitle(title: string, status: string): Memory[] {
+  return store!.listAll({ status }).filter((m) => m.title === title);
+}
+
+describe("reEvaluateGroomingProposals — clean no-ops", () => {
+  it("returns { reEvaluated: true, count: 0 } when no addendum is under evaluation", async () => {
+    seedActive("Active fact");
+    writeCuratorConfig(store!, { enabled: true });
+    configureGrooming({ token: "dummy-decrypted-token" });
+
+    const result = await reEvaluateGroomingProposals({
+      store: store!,
+      buildClient: () => noOpClient,
+    });
+    expect(result).toEqual({ reEvaluated: true, count: 0 });
+  });
+
+  it("returns count 0 when under evaluation but nothing is tagged with the version", async () => {
+    seedActive("Active fact");
+    writeCuratorConfig(store!, { enabled: true });
+    configureGrooming({ token: "dummy-decrypted-token" });
+    beginEvaluation("fresh guidance"); // version pinned, but no tagged proposals exist
+
+    const result = await reEvaluateGroomingProposals({
+      store: store!,
+      buildClient: () => noOpClient,
+    });
+    expect(result).toEqual({ reEvaluated: true, count: 0 });
+  });
+});
+
+describe("reEvaluateGroomingProposals — fail-soft gating", () => {
+  it("does not discard the stale batch when grooming is disabled", async () => {
+    seedActive("Active fact");
+    writeCuratorConfig(store!, { enabled: true });
+    configureGrooming({ token: "dummy-decrypted-token" });
+    const version = beginEvaluation("v1 guidance");
+    // Hand-seed a tagged proposal (as a grooming run under eval would).
+    store!.createMemory(
+      {
+        agent_id: "agent-a",
+        title: "Stale proposal",
+        body: "stale",
+        category: "lessons",
+        visibility: "common",
+        scope: "project",
+        project_key: "proj-x",
+      },
+      { requires_approval: true, curator_note: { addendum_version: version } },
+    );
+    // Now DISABLE grooming.
+    writeCuratorConfig(store!, { enabled: false });
+
+    const result = await reEvaluateGroomingProposals({
+      store: store!,
+      buildClient: () => noOpClient,
+    });
+    expect(result).toEqual({ reEvaluated: false, reason: "disabled" });
+    // The stale proposal is STILL there — nothing was discarded.
+    expect(byTitle("Stale proposal", "proposed").length).toBe(1);
+  });
+
+  it("does not discard the stale batch when the token can't be decrypted", async () => {
+    seedActive("Active fact");
+    writeCuratorConfig(store!, { enabled: true });
+    configureGrooming({ token: "dummy-secret" });
+    const version = beginEvaluation("v1 guidance");
+    store!.createMemory(
+      {
+        agent_id: "agent-a",
+        title: "Stale proposal",
+        body: "stale",
+        category: "lessons",
+        visibility: "common",
+        scope: "project",
+        project_key: "proj-x",
+      },
+      { requires_approval: true, curator_note: { addendum_version: version } },
+    );
+    store!.close();
+    // Reopen WITHOUT the master key → the token can't be decrypted.
+    store = createLibrarianStore({ dataDir });
+
+    const result = await reEvaluateGroomingProposals({
+      store: store!,
+      buildClient: () => noOpClient,
+    });
+    expect(result).toEqual({ reEvaluated: false, reason: "no_token" });
+    expect(byTitle("Stale proposal", "proposed").length).toBe(1);
+  });
+});
+
+describe("reEvaluateGroomingProposals — re-judges only the tagged version", () => {
+  it("discards the tagged batch and produces a fresh re-tagged batch (no stale duplicate)", async () => {
+    seedActive("Active fact");
+    writeCuratorConfig(store!, { enabled: true, defaultAutoApply: "high_confidence" });
+    configureGrooming({ token: "dummy-decrypted-token" });
+    const version = beginEvaluation("v1 guidance");
+    // Seed a stale tagged proposal in the proj-x slice.
+    store!.createMemory(
+      {
+        agent_id: "agent-a",
+        title: "Stale curator proposal",
+        body: "stale body",
+        category: "lessons",
+        visibility: "common",
+        scope: "project",
+        project_key: "proj-x",
+      },
+      { requires_approval: true, curator_note: { addendum_version: version } },
+    );
+
+    // Re-evaluate: the re-run emits a FRESH create.
+    const result = await reEvaluateGroomingProposals({
+      store: store!,
+      buildClient: () => createEmittingClient("Fresh curator proposal"),
+    });
+    expect(result).toEqual({ reEvaluated: true, count: 1 });
+
+    // The stale proposal is gone (archived — discarded).
+    expect(byTitle("Stale curator proposal", "proposed")).toEqual([]);
+    // A fresh proposal exists, re-tagged with the (still-current) eval version.
+    const fresh = byTitle("Fresh curator proposal", "proposed");
+    expect(fresh.length).toBe(1);
+    expect(fresh[0]?.curator_note?.addendum_version).toBe(version);
+    // Nothing was auto-applied to active (under evaluation forces propose).
+    expect(byTitle("Fresh curator proposal", "active")).toEqual([]);
+  });
+
+  it("leaves proposals tagged with a DIFFERENT version untouched", async () => {
+    seedActive("Active fact");
+    writeCuratorConfig(store!, { enabled: true, defaultAutoApply: "high_confidence" });
+    configureGrooming({ token: "dummy-decrypted-token" });
+    const version = beginEvaluation("v2 guidance");
+    // A proposal tagged with the CURRENT version (will be discarded + refreshed).
+    store!.createMemory(
+      {
+        agent_id: "agent-a",
+        title: "Current version proposal",
+        body: "x",
+        category: "lessons",
+        visibility: "common",
+        scope: "project",
+        project_key: "proj-x",
+      },
+      { requires_approval: true, curator_note: { addendum_version: version } },
+    );
+    // A proposal tagged with a DIFFERENT (older) version — must NOT be touched.
+    store!.createMemory(
+      {
+        agent_id: "agent-a",
+        title: "Old version proposal",
+        body: "y",
+        category: "lessons",
+        visibility: "common",
+        scope: "project",
+        project_key: "proj-x",
+      },
+      { requires_approval: true, curator_note: { addendum_version: "deadbeefdeadbeef" } },
+    );
+
+    const result = await reEvaluateGroomingProposals({
+      store: store!,
+      buildClient: () => createEmittingClient("Fresh version proposal"),
+    });
+    expect(result).toEqual({ reEvaluated: true, count: 1 });
+
+    // The different-version proposal survived untouched (still proposed).
+    const other = byTitle("Old version proposal", "proposed");
+    expect(other.length).toBe(1);
+    expect(other[0]?.curator_note?.addendum_version).toBe("deadbeefdeadbeef");
+    // The current-version proposal was discarded (refreshed).
+    expect(byTitle("Current version proposal", "proposed")).toEqual([]);
+    // The active corpus is untouched (still active, not archived).
+    expect(byTitle("Active fact", "active").length).toBe(1);
+  });
+});
+
+describe("reEvaluateGroomingProposals — partial-failure fail-soft", () => {
+  it("a re-judge failure on one slice does not wedge the batch or corrupt state", async () => {
+    // Two slices: proj-x and proj-y, each with an active memory + a tagged proposal.
+    seedActive("Active X", "proj-x");
+    seedActive("Active Y", "proj-y");
+    writeCuratorConfig(store!, { enabled: true, defaultAutoApply: "high_confidence" });
+    configureGrooming({ token: "dummy-decrypted-token" });
+    const version = beginEvaluation("v1 guidance");
+    for (const pk of ["proj-x", "proj-y"]) {
+      store!.createMemory(
+        {
+          agent_id: "agent-a",
+          title: `Stale ${pk}`,
+          body: "stale",
+          category: "lessons",
+          visibility: "common",
+          scope: "project",
+          project_key: pk,
+        },
+        { requires_approval: true, curator_note: { addendum_version: version } },
+      );
+    }
+
+    // A client that THROWS for the proj-y slice (its active memory is "Active Y")
+    // but succeeds for proj-x. The worker swallows the per-slice failure.
+    const flakyClient: LlmClient = {
+      complete: async (request) => {
+        const prompt = request.messages.map((m) => m.content).join("\n");
+        if (prompt.includes("Active Y")) throw new Error("simulated judge failure");
+        return createEmittingClient("Fresh X").complete(request);
+      },
+    };
+
+    const result = await reEvaluateGroomingProposals({
+      store: store!,
+      buildClient: () => flakyClient,
+    });
+    // Still reports the full batch (both stale proposals discarded + attempted).
+    expect(result).toEqual({ reEvaluated: true, count: 2 });
+
+    // proj-x refreshed; both stale proposals discarded; no crash.
+    expect(byTitle("Fresh X", "proposed").length).toBe(1);
+    expect(byTitle("Stale proj-x", "proposed")).toEqual([]);
+    expect(byTitle("Stale proj-y", "proposed")).toEqual([]);
+    // Active corpus intact in both slices.
+    expect(byTitle("Active X", "active").length).toBe(1);
+    expect(byTitle("Active Y", "active").length).toBe(1);
+  });
+});

--- a/packages/mcp-server/src/trpc/addendum.ts
+++ b/packages/mcp-server/src/trpc/addendum.ts
@@ -1,4 +1,4 @@
-// Addendum evaluation lifecycle admin tRPC procedures (spec 044 PR-3b / Task D3b).
+// Addendum evaluation lifecycle admin tRPC procedures (spec 044 PR-3b/3c / D3b+D3c).
 //
 // When an admin changes a curator job's prompt addendum it goes "under evaluation"
 // (spec 044 D-3): the curator force-proposes every would-be auto-apply (D3a) so the
@@ -17,15 +17,32 @@
 // `setAddendumStatus` / `store.rollbackAddendum` keyed by the job), so duplicating
 // it onto two routers would be pure repetition. The per-job routers stay split
 // because their OTHER concerns (config shape, runs/ops, run-now) genuinely differ;
-// this one does not. (The "Re-evaluate proposals" action — D3c — will join here.)
+// this one does not.
+//
+// The third action — "Re-evaluate proposals" (D3c) — also lives here, but is
+// GROOMING ONLY: it batch re-judges the proposals tagged with the current eval
+// version, discarding the stale batch and re-running grooming over their slices
+// under the current addendum (the escape hatch when the admin keeps editing the
+// addendum and earlier-version proposals go stale). Intake has no re-evaluate: the
+// intake input (the inbox) is consumed on apply — not replayable (spec 044 "what's
+// there"), so an intake proposal has no original judge input to re-run (the same
+// reason intake has no dry-run in D4). For `job: "intake"` the mutation returns a
+// clear `intake_not_replayable` result rather than attempting any re-judge.
 //
 // All admin-gated — there is deliberately NO consumer-agent surface for curation.
 // The dashboard buttons that call these land in D7.
 
-import type { CuratorJob } from "@librarian/core";
-import { readAddendumStatus, setAddendumStatus } from "@librarian/core";
+import type { CuratorJob, ReEvaluateResult } from "@librarian/core";
+import {
+  readAddendumStatus,
+  reEvaluateGroomingProposals,
+  setAddendumStatus,
+} from "@librarian/core";
 import { z } from "zod";
 import { adminProcedure, router } from "./trpc.js";
+
+/** The mutation summary returned by `reEvaluate` (grooming runs; intake is unsupported). */
+type ReEvaluateSummary = ReEvaluateResult | { reEvaluated: false; reason: "intake_not_replayable" };
 
 // The two curator jobs, the same `{ job }` key the addendum status is namespaced
 // over (`curator.<job>.addendum_status`).
@@ -55,4 +72,21 @@ export const addendumRouter = router({
       restoredVersion: rollback.version,
     };
   }),
+
+  // Re-evaluate the proposals tagged with the addendum's current eval version
+  // (GROOMING ONLY). Grooming: discard that version's stale proposals and re-run
+  // grooming over their slices under the current addendum, producing a fresh,
+  // re-tagged batch (the escape hatch — see the module header). Intake: NOT
+  // replayable (the inbox is consumed on apply), so return a clear unsupported
+  // result rather than attempting any re-judge. Returns a summary.
+  reEvaluate: adminProcedure
+    .input(JobInputSchema)
+    .mutation(async ({ ctx, input }): Promise<ReEvaluateSummary> => {
+      if (input.job === "intake") {
+        // Intake input is consumed on apply — there is no original submission to
+        // re-judge. The D7 dashboard simply won't offer the button for intake.
+        return { reEvaluated: false, reason: "intake_not_replayable" };
+      }
+      return reEvaluateGroomingProposals({ store: ctx.store });
+    }),
 });

--- a/packages/mcp-server/tests/trpc/addendum.test.ts
+++ b/packages/mcp-server/tests/trpc/addendum.test.ts
@@ -1,28 +1,45 @@
-// Addendum evaluation lifecycle admin tRPC tests (spec 044 PR-3b / Task D3b).
+// Addendum evaluation lifecycle admin tRPC tests (spec 044 PR-3b/3c / Tasks D3b+D3c).
 //
-// The two simpler admin lifecycle actions that drive D3a's under-evaluation state
-// back to accepted, both keyed by `{ job }` (intake | grooming):
+// The admin lifecycle actions that drive D3a's under-evaluation state, keyed by
+// `{ job }` (intake | grooming):
 //   - accept: status `under_evaluation` → `accepted`, eval version cleared, so the
 //     curator auto-applies again (auto-apply resumes);
 //   - rollback: restore the addendum file to its PRIOR committed version + commit
 //     the restoration, then status → accepted.
-// Both are admin-gated (rejected without an admin bearer). The router is a single
+//   - reEvaluate (D3c, GROOMING ONLY): discard the proposals tagged with the current
+//     eval version and re-run grooming over their slices under the current addendum,
+//     producing a fresh batch. Intake returns `intake_not_replayable` (the inbox is
+//     consumed on apply — there is no original submission to re-judge).
+// All are admin-gated (rejected without an admin bearer). The router is a single
 // shared `addendum` router keyed by `{ job }` — the lifecycle is identical per job,
 // unlike the per-job `curator`/`intake` routers whose other concerns genuinely
 // differ. Tests pre-seed addendum state via a store on the same dataDir before boot
-// and read back the file + git log to assert the roll-back recorded a new commit.
+// and read back the file + git log to assert the roll-back recorded a new commit;
+// the grooming re-evaluate test drives a REAL run against a local stub LLM.
 
 import { execFileSync } from "node:child_process";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
 import path from "node:path";
 import {
+  addProvider,
   createLibrarianStore,
   forceProposeDeps,
   readAddendumStatus,
+  resolveSecretKey,
   setAddendumStatus,
   setJobAddendum,
+  writeConsumerConfig,
+  writeCuratorConfig,
 } from "@librarian/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { cleanupTempDir, makeTempDir, startHttpServer } from "../../../../test/helpers.js";
+
+// The grooming re-evaluate test encrypts a provider token, so the seed store and
+// the server must share a master key. Assemble the 64-hex key + Buffer at runtime —
+// no secret-shaped literal in source (GitGuardian).
+const SECRET_KEY_HEX = "0123456789abcdef".repeat(4);
+const SECRET_KEY = resolveSecretKey(SECRET_KEY_HEX);
 
 interface TrpcOk<T> {
   result: { data: T };
@@ -57,6 +74,9 @@ interface RollbackResult extends StatusResult {
   restored: boolean;
   restoredVersion: string | null;
 }
+type ReEvaluateSummary =
+  | { reEvaluated: true; count: number }
+  | { reEvaluated: false; reason: string };
 
 const vaultLog = (dataDir: string): string[] =>
   execFileSync("git", ["log", "--format=%s"], {
@@ -66,7 +86,47 @@ const vaultLog = (dataDir: string): string[] =>
     .split("\n")
     .filter(Boolean);
 
-describe("tRPC addendum evaluation lifecycle surface (spec 044 D3b)", () => {
+// A minimal OpenAI-compatible chat-completions stub the curator LLM client can talk
+// to. Returns one fixed grooming `create` op so a re-evaluate run files exactly one
+// fresh proposal (forced to `proposed` under evaluation).
+function startStubLlm(): Promise<{ url: string; stop: () => Promise<void> }> {
+  const completion = JSON.stringify({
+    operations: [
+      {
+        type: "create",
+        memory: {
+          title: "Fresh reeval proposal",
+          body: "a durable lesson",
+          category: "lessons",
+          visibility: "common",
+          scope: "project",
+          project_key: "proj-x",
+        },
+        rationale: "novel durable lesson",
+        confidence: 0.99,
+      },
+    ],
+  });
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      let body = "";
+      req.on("data", (c) => (body += c));
+      req.on("end", () => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ choices: [{ message: { content: completion } }] }));
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({
+        url: `http://127.0.0.1:${port}/v1`,
+        stop: () => new Promise((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
+describe("tRPC addendum evaluation lifecycle surface (spec 044 D3b+D3c)", () => {
   let dataDir = "";
   beforeEach(() => {
     dataDir = makeTempDir();
@@ -78,7 +138,7 @@ describe("tRPC addendum evaluation lifecycle surface (spec 044 D3b)", () => {
   it("admin-gates accept + rollback (rejected without an admin bearer)", async () => {
     const server = await startHttpServer({ dataDir });
     try {
-      for (const proc of ["addendum.accept", "addendum.rollback"]) {
+      for (const proc of ["addendum.accept", "addendum.rollback", "addendum.reEvaluate"]) {
         const unauthed = await fetch(`${server.url}/trpc/${proc}`, {
           method: "POST",
           headers: { "content-type": "application/json" },
@@ -188,6 +248,87 @@ describe("tRPC addendum evaluation lifecycle surface (spec 044 D3b)", () => {
       // Grooming is untouched: still under evaluation, content unchanged.
       expect(after.readAddendum("grooming").content).toBe("grooming v1");
       expect(readAddendumStatus(after, "grooming").status).toBe("under_evaluation");
+    } finally {
+      after.close();
+    }
+  });
+
+  it("reEvaluate is unsupported for intake (not replayable — the inbox is consumed)", async () => {
+    const server = await startHttpServer({ dataDir });
+    try {
+      const result = await trpcPost<ReEvaluateSummary>(server, "addendum.reEvaluate", {
+        job: "intake",
+      });
+      expect(result).toEqual({ reEvaluated: false, reason: "intake_not_replayable" });
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("reEvaluate (grooming) discards the tagged batch and re-runs grooming for a fresh one", async () => {
+    const stub = await startStubLlm();
+    // Seed: grooming enabled + pointed at the stub, an active memory, a tagged stale
+    // proposal, and grooming under evaluation against a committed addendum. The seed
+    // store shares the server's master key so the provider token round-trips.
+    const seed = createLibrarianStore({ dataDir, secretKey: SECRET_KEY });
+    writeCuratorConfig(seed, { enabled: true, defaultAutoApply: "high_confidence" });
+    const provider = addProvider(seed, {
+      name: "stub",
+      endpoint: stub.url,
+      token: "dummy-stub-token",
+    });
+    writeConsumerConfig(seed, "grooming", { providerId: provider.id, model: "gpt-x" });
+    seed.createMemory({
+      agent_id: "agent-a",
+      title: "Active anchor",
+      body: "b",
+      category: "lessons",
+      visibility: "common",
+      scope: "project",
+      project_key: "proj-x",
+      priority: "normal",
+      confidence: "working",
+    });
+    setJobAddendum(seed, "grooming", "v1 guidance under evaluation");
+    setAddendumStatus(seed, "grooming", "under_evaluation");
+    const version = seed.readAddendum("grooming").version;
+    seed.createMemory(
+      {
+        agent_id: "agent-a",
+        title: "Stale curator proposal",
+        body: "stale",
+        category: "lessons",
+        visibility: "common",
+        scope: "project",
+        project_key: "proj-x",
+      },
+      { requires_approval: true, curator_note: { addendum_version: version } },
+    );
+    seed.close();
+
+    const server = await startHttpServer({ dataDir, secretKey: SECRET_KEY_HEX });
+    try {
+      const result = await trpcPost<ReEvaluateSummary>(server, "addendum.reEvaluate", {
+        job: "grooming",
+      });
+      expect(result).toEqual({ reEvaluated: true, count: 1 });
+    } finally {
+      await server.stop();
+      await stub.stop();
+    }
+
+    // The stale proposal is discarded; a fresh one (from the stub) replaces it,
+    // re-tagged with the current eval version; nothing was auto-applied to active.
+    const after = createLibrarianStore({ dataDir });
+    try {
+      const proposed = after.listAll({ status: "proposed" });
+      expect(proposed.some((m) => m.title === "Stale curator proposal")).toBe(false);
+      const fresh = proposed.filter((m) => m.title === "Fresh reeval proposal");
+      expect(fresh).toHaveLength(1);
+      expect(fresh[0]?.curator_note?.addendum_version).toBe(version);
+      expect(
+        after.listAll({ status: "active" }).some((m) => m.title === "Fresh reeval proposal"),
+      ).toBe(false);
     } finally {
       after.close();
     }


### PR DESCRIPTION
## What

Adds the third addendum-evaluation admin action — **"Re-evaluate proposals"** — to the shared `addendum` tRPC router (spec 044 decision D-3, the escape hatch). Completes Task **D3** (a/b/c).

**GROOMING ONLY — batch re-judge.** While a grooming addendum is `under_evaluation` the curator force-proposes every would-be auto-apply (D3a) and tags each proposal `curator_note.addendum_version = <eval version git hash>`. If the admin keeps editing the addendum (each edit commits a new version), the proposals tagged with an EARLIER version go stale. Re-evaluate discards exactly *that version's* stale grooming proposals and re-runs grooming over their slices under the **current** addendum, producing a fresh, re-tagged batch.

## Re-judge mechanism — reuses the REAL grooming pipeline (not a parallel judging path)

New core driver `reEvaluateGroomingProposals` (`packages/core/src/curator-reevaluate.ts`) is a thin orchestration:
1. read the grooming eval version (`readAddendumStatus`); no version / no tagged proposals → clean no-op `{ reEvaluated: true, count: 0 }`;
2. find the tagged proposals (`listAll({status: proposed})` + in-memory `curator_note.addendum_version === evalVersion` filter — the store has no curator_note filter);
3. derive the **distinct affected slices** via the store's own slice enumeration + evidence (`listCuratorSlices` / `gatherMemoryEvidence`), so partitioning matches a real grooming run and **only slices containing a tagged proposal are re-judged** (no collateral re-judging of unrelated slices);
4. gate exactly like `runCuratorTick` (enabled / operational config / decryptable token);
5. **archive** the stale tagged proposals, then re-run `runCuration` per affected slice with `bypassSkip` + the current force-propose deps (D3a) — fresh proposals land at `proposed`, re-tagged with the current version.

Grooming is slice-based (not proposal-based), so re-running the affected slices is the faithful "re-judge against the current addendum" the spec asks for — consistent with a normal grooming run (same judge → validate → apply path). Active memories are never mutated (under_evaluation forces propose; nothing auto-applies).

## How stale proposals are handled

The stale tagged proposals are **archived** (the same status transition a "reject" gives an unwanted proposal) **before** the re-run, so no stale duplicate is left behind. The discard only happens when grooming can actually run — fail-soft never leaves the admin with neither the stale batch nor a fresh one.

## Intake-unsupported rationale

The intake input (the inbox) is **consumed on apply — not replayable** (spec 044 "what's there"), so an intake proposal has no original submission to re-judge (the same reason intake has no dry-run in D4). For `job: "intake"` the mutation returns `{ reEvaluated: false, reason: "intake_not_replayable" }` and never attempts a re-judge; the D7 dashboard simply won't offer the button.

## Fail-soft

Per-proposal archive and per-slice re-run are each `try/catch` — one failure never wedges the batch or corrupts state.

## Admin-gating

`reEvaluate` is `adminProcedure`; no token is ever rendered/returned.

## Tests (TDD, RED→GREEN)

- `packages/core/tests/curator-reevaluate.test.ts` (7) — clean no-ops; fail-soft gating (disabled / undecryptable token → nothing discarded); re-judges only the tagged version (different-version proposal + active corpus untouched; no stale duplicate); partial-failure fail-soft (one slice throws, the rest still refresh). Network-free via scripted LLM clients.
- `packages/mcp-server/tests/trpc/addendum.test.ts` (+2) — admin-gating (`addendum.reEvaluate` added to the loop); intake unsupported; a REAL grooming re-evaluate end-to-end against a local stub LLM.

Full suite + `pnpm -r build` + typecheck + lint all clean.

**CHANGELOG:** deferred to D8's single 044 entry (the Re-evaluate *button* is D7; no operator-facing surface lands here — consistent with D2/D3a/D3b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)