### PR TITLE
feat(core): grooming dry-run over the corpus with a candidate addendum (spec 044 PR-4, Task D4)

### DIFF
--- a/packages/core/src/curator-apply.ts
+++ b/packages/core/src/curator-apply.ts
@@ -17,7 +17,7 @@
 //     admin audit; the recorded rationale is redacted as defence-in-depth.
 
 import { type ApplyDecision, type ApplyPolicy, decideApply } from "./curator-apply-policy.js";
-import { tagAddendumVersion, underEvaluationRoute } from "./curator-force-propose.js";
+import { tagAddendumVersion, tagDryRun, underEvaluationRoute } from "./curator-force-propose.js";
 import type { CuratorMemoryPatch, CuratorOperation } from "./curator-output.js";
 import { redactSecrets } from "./curator-redaction.js";
 import type { ValidatedOperation, ValidationContext } from "./curator-validate.js";
@@ -75,6 +75,17 @@ export interface ApplyDeps {
    * meaningful with `underEvaluation`; ignored otherwise.
    */
   addendumVersion?: string | null;
+  /**
+   * Grooming dry-run (spec 044 D-4). When true this run is a CANDIDATE-addendum dry-
+   * run: it force-proposes exactly like `underEvaluation` (nothing auto-applies),
+   * but tags each proposal `dry_run` (+ `dryRunCandidate`) instead of an
+   * addendum_version, so the throwaway batch is distinguishable from a real run. The
+   * candidate addendum reaches the prompt via `promptAddendum`; it is NEVER written
+   * to the vault. `dryRun` implies force-propose; set it WITHOUT `underEvaluation`.
+   */
+  dryRun?: boolean;
+  /** A label for the dry-run candidate (e.g. "candidate v2" / a hash); tags proposals. */
+  dryRunCandidate?: string | null;
   /** Optional sink for swallowed execution errors (keeps the audit row content-free). */
   onError?: (error: unknown, operation: CuratorOperation) => void;
 }
@@ -93,6 +104,10 @@ interface ExecContext {
   owner: string;
   /** Set while the grooming addendum is under_evaluation — tags every proposal. */
   addendumVersion?: string | null;
+  /** Set for a grooming dry-run (spec 044 D-4) — tags every proposal `dry_run`. */
+  dryRun?: boolean;
+  /** The dry-run candidate label; tags proposals alongside `dry_run`. */
+  dryRunCandidate?: string | null;
 }
 
 export function applyOperations(
@@ -104,6 +119,9 @@ export function applyOperations(
     context.slice.kind === "agent_private" && context.slice.agentId
       ? context.slice.agentId
       : deps.actorId;
+  // Force-propose is on while the addendum is under_evaluation (D3a) OR for a dry-run
+  // (D4) — both routes mean "no op auto-applies". They tag proposals differently.
+  const forceProp = deps.underEvaluation === true || deps.dryRun === true;
   const exec: ExecContext = {
     store: deps.store,
     runId: deps.runId,
@@ -111,6 +129,8 @@ export function applyOperations(
     owner,
     // Carried so proposals produced under_evaluation are tagged (no-op when accepted).
     ...(deps.underEvaluation ? { addendumVersion: deps.addendumVersion } : {}),
+    // Carried so dry-run proposals are tagged distinctly (no addendum_version).
+    ...(deps.dryRun ? { dryRun: true, dryRunCandidate: deps.dryRunCandidate } : {}),
   };
 
   const summary: ApplySummary = { applied: 0, proposed: 0, skipped: 0, failed: 0 };
@@ -130,7 +150,7 @@ export function applyOperations(
     // `skip` pass through unchanged, so a protected-propose stays propose. When
     // accepted (the default), the route is the identity → byte-identical to before.
     const routed = decideApply(operation, outcome, deps.policy);
-    const decision = deps.underEvaluation ? forcePropose(routed, operation.type) : routed;
+    const decision = forceProp ? forcePropose(routed, operation.type) : routed;
     if (decision === "skip") {
       record(deps, operation, "skipped", outcome.risk, operation.rationale, [], payload);
       summary.skipped++;
@@ -275,6 +295,11 @@ function buildCreateCall(
   // isProposal so an auto-applied write is never tagged (defence-in-depth — under
   // evaluation an op never auto-applies anyway). No-op when accepted / no version.
   if (isProposal) tagAddendumVersion(curatorNote, c.addendumVersion);
+  // Tag PROPOSALS produced by a dry-run (spec 044 D-4) so the throwaway batch is
+  // distinguishable from real proposals. Mutually exclusive with addendum_version:
+  // a dry-run runs a CANDIDATE addendum, never a committed eval version. Gated on
+  // isProposal (a dry-run never auto-applies anyway). No-op for a non-dry run.
+  if (isProposal && c.dryRun) tagDryRun(curatorNote, c.dryRunCandidate);
   const storeOptions: Record<string, unknown> = { curator_note: curatorNote };
   if (isProposal) storeOptions.requires_approval = true;
   return { input: { ...memory, agent_id: c.owner }, options: storeOptions };

--- a/packages/core/src/curator-dry-run.ts
+++ b/packages/core/src/curator-dry-run.ts
@@ -1,0 +1,156 @@
+// Grooming dry-run over the corpus with a candidate addendum (spec 044 D-4 /
+// decision D-4, the "see what a new addendum would do before committing it" tool).
+//
+// Before an admin commits a new grooming addendum they want to SEE what it would
+// do. A dry-run runs a CANDIDATE (uncommitted) addendum over the existing corpus
+// in propose-mode, producing a reviewable batch of proposals WITHOUT committing the
+// candidate addendum live and WITHOUT auto-applying anything.
+//
+// GROOMING ONLY. The intake input (the inbox) is consumed on apply — not replayable
+// (spec 044 "what's there"), so there is deliberately no intake dry-run (the same
+// reason intake has no re-evaluate in D3c). This module is grooming-hardcoded; the
+// tRPC layer never offers a dry-run for intake.
+//
+// This is the same DRIVER SHAPE as D3c's `reEvaluateGroomingProposals` (a per-slice
+// `runCuration` over the real grooming worker with force-propose deps), with two
+// deliberate differences:
+//   1. it threads the CANDIDATE addendum string into the prompt (as `promptAddendum`
+//      — the prompt builder redacts it) instead of the committed `readJobAddendum`;
+//      the candidate is NEVER written to the vault (in-memory only — a dry-run must
+//      not change the live grooming-addendum.md, its status, or its version);
+//   2. it tags proposals `dry_run` (+ a candidate label) instead of an
+//      addendum_version, so the throwaway batch is distinguishable from real
+//      proposals (the D7 dashboard filters them; they can be discarded freely).
+//
+// FORCE-PROPOSE IS UNCONDITIONAL. A dry-run forces every op to a proposal and auto-
+// archives to skip — nothing auto-applies, ever, even at confidence 1.0 (defence-in-
+// depth). This is independent of the job's real `addendum_status`: a dry-run is a
+// pure preview and changes no live state.
+//
+// SCOPE:
+//   - a `slice` is given → run that ONE slice synchronously and return fast (the
+//     latency-sensitive "dry-run this slice" path);
+//   - no `slice` → run every slice that has curatable content ("dry-run everything").
+//     Each slice's run is fail-soft (one slice's failure never wedges the rest); the
+//     tRPC layer runs the whole-corpus variant as background work.
+
+import { SYSTEM_ACTOR_IDS } from "./caller-identity.js";
+import { readCuratorConfig } from "./curator-config.js";
+import { readConsumerConfig, resolveConsumerToken } from "./curator-consumers.js";
+import type { EvidenceSlice } from "./curator-evidence.js";
+import { type LlmClient, createCuratorLlmClient } from "./curator-llm-client.js";
+import { type RunCurationCaps, runCuration } from "./curator-worker.js";
+import type { LibrarianStore } from "./store/librarian-store.js";
+
+/** Why a dry-run could not run (mirrors CuratorTickSkipReason). */
+export type DryRunSkipReason = "disabled" | "incomplete_config" | "no_token";
+
+/**
+ * The outcome of `dryRunGrooming`.
+ *  - `{ ran: true, scope, slicesRun }`: ran; `scope` is "slice" (one slice) or
+ *    "corpus" (all slices), `slicesRun` = how many slices were actually judged.
+ *  - `{ ran: false, reason }`: grooming isn't runnable (disabled / incomplete
+ *    config / no token) — nothing was proposed.
+ */
+export type DryRunResult =
+  | { ran: true; scope: "slice" | "corpus"; slicesRun: number }
+  | { ran: false; reason: DryRunSkipReason };
+
+export interface DryRunGroomingOptions {
+  store: LibrarianStore;
+  /** The candidate (uncommitted) addendum — threaded into the prompt, never written. */
+  candidateAddendum: string;
+  /**
+   * An optional label for the candidate batch (e.g. "candidate v2" / a hash); tags
+   * every dry-run proposal so a batch can be identified. Caller-supplied.
+   */
+  candidateLabel?: string;
+  /** Dry-run ONE slice (synchronous, fast). Omit to dry-run the whole corpus. */
+  slice?: EvidenceSlice;
+  caps?: RunCurationCaps;
+  /** Injectable LLM client builder (defaults to the OpenAI-compatible client). */
+  buildClient?: (
+    conn: { endpoint: string; model: string; timeoutMs: number },
+    token: string,
+  ) => LlmClient;
+}
+
+/**
+ * Run a candidate grooming addendum over the corpus (or one slice) in propose-mode,
+ * producing a reviewable batch tagged `dry_run` — WITHOUT committing the candidate
+ * addendum and WITHOUT auto-applying anything. See the module header for the full
+ * contract. Grooming only.
+ */
+export async function dryRunGrooming(options: DryRunGroomingOptions): Promise<DryRunResult> {
+  const { store, candidateAddendum } = options;
+
+  // Gate exactly like the tick (enabled / operational config / decryptable token).
+  // A dry-run never runs on a non-runnable grooming config (§7.1).
+  const config = readCuratorConfig(store);
+  const llm = readConsumerConfig(store, "grooming");
+  if (!config.enabled) return { ran: false, reason: "disabled" };
+  if (!llm.isOperational) return { ran: false, reason: "incomplete_config" };
+  let token: string | null;
+  try {
+    token = resolveConsumerToken(store, "grooming");
+  } catch {
+    return { ran: false, reason: "no_token" };
+  }
+  if (!token) return { ran: false, reason: "no_token" };
+
+  const buildClient =
+    options.buildClient ??
+    ((conn, secret) =>
+      createCuratorLlmClient({
+        endpoint: conn.endpoint,
+        token: secret,
+        model: conn.model,
+        timeoutMs: conn.timeoutMs,
+      }));
+  const llmClient = buildClient(
+    { endpoint: llm.endpoint, model: llm.model, timeoutMs: llm.timeoutMs },
+    token,
+  );
+
+  const slices = options.slice ? [options.slice] : store.listCuratorSlices();
+  const caps = options.caps;
+
+  // Run the candidate over each slice via the REAL worker (judge → validate →
+  // apply): `bypassSkip` forces a fresh run past the input-hash idempotency, the
+  // candidate addendum reaches the prompt via `promptAddendum` (redacted there,
+  // never written to the vault), and `dryRun` force-proposes every op (nothing auto-
+  // applies) + tags each proposal `dry_run` (+ the candidate label). Fail-soft per
+  // slice — one slice's failure never aborts the rest (load-bearing for the whole-
+  // corpus background path).
+  let slicesRun = 0;
+  for (const slice of slices) {
+    try {
+      await runCuration(slice, {
+        store,
+        llmClient,
+        trigger: "manual",
+        actorId: SYSTEM_ACTOR_IDS.memoryCurator,
+        policy: {
+          level: config.defaultAutoApply,
+          confidenceThreshold: config.autoApplyConfidence,
+        },
+        model: { provider: llm.providerId, name: llm.model },
+        bypassSkip: true,
+        // The candidate addendum is in-memory only — passed to the prompt, NEVER
+        // written to grooming-addendum.md (the load-bearing dry-run invariant).
+        ...(candidateAddendum !== "" ? { promptAddendum: candidateAddendum } : {}),
+        // Force-propose unconditionally + tag dry-run (no addendum_version).
+        dryRun: true,
+        ...(options.candidateLabel !== undefined
+          ? { dryRunCandidate: options.candidateLabel }
+          : {}),
+        ...(caps !== undefined ? { caps } : {}),
+      });
+      slicesRun++;
+    } catch {
+      /* fail-soft: a slice's dry-run failure never wedges the batch */
+    }
+  }
+
+  return { ran: true, scope: options.slice ? "slice" : "corpus", slicesRun };
+}

--- a/packages/core/src/curator-force-propose.ts
+++ b/packages/core/src/curator-force-propose.ts
@@ -59,6 +59,24 @@ export function tagAddendumVersion(
 }
 
 /**
+ * Mark a curator_note record as produced by a grooming DRY-RUN (spec 044 D-4) so
+ * the D7 dashboard can distinguish + discard throwaway dry-run proposals. A dry-
+ * run runs a CANDIDATE (uncommitted) addendum over the corpus in propose-mode —
+ * its proposals must never look like real ones. exactOptionalPropertyTypes-safe:
+ * `dry_run` is set only when true; the candidate label only when non-empty. A dry-
+ * run proposal is NEVER tagged with an addendum_version (that's committed
+ * evaluation). Mutates + returns the note.
+ */
+export function tagDryRun(
+  note: Record<string, unknown>,
+  candidateLabel: string | null | undefined,
+): Record<string, unknown> {
+  note.dry_run = true;
+  if (candidateLabel) note.dry_run_candidate = candidateLabel;
+  return note;
+}
+
+/**
  * Translate a job's addendum evaluation state into the apply-path deps spread that
  * turns force-propose on (spec 044 D-3). Both ticks read the status ONCE per
  * sweep/tick and spread this into the apply caller:

--- a/packages/core/src/curator-worker.ts
+++ b/packages/core/src/curator-worker.ts
@@ -46,6 +46,15 @@ export interface RunCurationOptions {
   underEvaluation?: boolean;
   /** The addendum version (git hash) under evaluation; tags produced proposals. */
   addendumVersion?: string | null;
+  /**
+   * Grooming dry-run (spec 044 D-4): when true this run uses a CANDIDATE addendum
+   * (passed via `promptAddendum`, never written to the vault) and force-proposes
+   * every op (nothing auto-applies), tagging proposals `dry_run` (+ `dryRunCandidate`)
+   * instead of an addendum version. Independent of `underEvaluation`.
+   */
+  dryRun?: boolean;
+  /** The dry-run candidate label (e.g. "candidate v2"); tags produced proposals. */
+  dryRunCandidate?: string | null;
   /** Recorded on the run for observability. */
   model: { provider: string; name: string };
   caps?: RunCurationCaps;
@@ -137,6 +146,7 @@ export async function runCuration(
       ...(options.underEvaluation
         ? { underEvaluation: true, addendumVersion: options.addendumVersion }
         : {}),
+      ...(options.dryRun ? { dryRun: true, dryRunCandidate: options.dryRunCandidate } : {}),
     });
 
     return store.completeCurationRun(run.id, {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -89,6 +89,12 @@ export {
   reEvaluateGroomingProposals,
 } from "./curator-reevaluate.js";
 export {
+  type DryRunGroomingOptions,
+  type DryRunResult,
+  type DryRunSkipReason,
+  dryRunGrooming,
+} from "./curator-dry-run.js";
+export {
   type ConsolidatorTickOptions,
   type ConsolidatorTickResult,
   type ConsolidatorTickSkipReason,
@@ -213,6 +219,7 @@ export {
   type ForcePropose,
   forceProposeDeps,
   tagAddendumVersion,
+  tagDryRun,
   underEvaluationRoute,
 } from "./curator-force-propose.js";
 export {

--- a/packages/core/src/schemas/memory.ts
+++ b/packages/core/src/schemas/memory.ts
@@ -25,6 +25,15 @@ export const CuratorNoteSchema = z.object({
   // Re-evaluate find this batch of proposals by this tag. Set ONLY on proposals
   // produced under_evaluation; absent on every accepted-path write.
   addendum_version: z.string().optional(),
+  // Dry-run marker (spec 044 D-4). Set ONLY on proposals produced by a grooming
+  // dry-run — a candidate (uncommitted) addendum run over the corpus in propose-
+  // mode. These are throwaway: the D7 dashboard filters them and they can be
+  // discarded without affecting live state. Distinct from `addendum_version`
+  // (which is committed-evaluation tagging); a dry-run proposal is NEVER tagged
+  // with an addendum_version. `dry_run_candidate` is the candidate label (e.g.
+  // "candidate v2" / a hash) so a batch can be identified.
+  dry_run: z.boolean().optional(),
+  dry_run_candidate: z.string().optional(),
 });
 export type CuratorNote = z.infer<typeof CuratorNoteSchema>;
 

--- a/packages/core/tests/curator-dry-run.test.ts
+++ b/packages/core/tests/curator-dry-run.test.ts
@@ -1,0 +1,344 @@
+// Grooming dry-run over the corpus with a candidate addendum (spec 044 D-4 / Task
+// D4). Before an admin commits a new grooming addendum they want to SEE what it
+// would do: run a CANDIDATE (uncommitted) addendum over the existing corpus in
+// propose-mode, producing a reviewable batch of proposals WITHOUT committing the
+// candidate addendum live and WITHOUT auto-applying anything.
+//
+// Network-free: a scripted LLM client makes the dry-run deterministic plumbing.
+// Verifies: the candidate text reaches the prompt (capturing client); the live
+// grooming-addendum.md file + status + version are UNCHANGED after a dry-run (the
+// load-bearing invariant); nothing auto-applies even at confidence 1.0; proposals
+// carry the dry-run tag (+ candidate label) and NOT addendum_version; a single
+// slice runs synchronously; the whole-corpus path runs every affected slice.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type LibrarianStore,
+  type LlmClient,
+  type Memory,
+  addProvider,
+  createLibrarianStore,
+  dryRunGrooming,
+  readAddendumStatus,
+  resolveSecretKey,
+  setAddendumStatus,
+  setJobAddendum,
+  writeConsumerConfig,
+  writeCuratorConfig,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// Assemble the 64-hex key at runtime — no secret-shaped literal in source (GitGuardian).
+const KEY = resolveSecretKey("0123456789abcdef".repeat(4));
+
+let store: LibrarianStore | null = null;
+let dataDir = "";
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-dryrun-"));
+  store = createLibrarianStore({ dataDir, secretKey: KEY });
+});
+afterEach(() => {
+  try {
+    store?.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  store = null;
+});
+
+// An LLM client that emits one high-confidence create (would auto-apply when
+// accepted; force-proposed under a dry-run). `title` makes the proposal findable;
+// `projectKey` matches the slice so the create isn't rejected as cross-boundary.
+function createEmittingClient(title: string, projectKey = "proj-x"): LlmClient {
+  return {
+    complete: async () => ({
+      content: JSON.stringify({
+        operations: [
+          {
+            type: "create",
+            memory: {
+              title,
+              body: "a durable lesson",
+              category: "lessons",
+              visibility: "common",
+              scope: "project",
+              project_key: projectKey,
+            },
+            rationale: "novel durable lesson",
+            confidence: 1.0,
+          },
+        ],
+      }),
+      model: "m",
+      usage: null,
+    }),
+  };
+}
+
+function seedActive(title: string, projectKey = "proj-x") {
+  store!.createMemory({
+    agent_id: "agent-a",
+    title,
+    body: "b",
+    category: "lessons",
+    visibility: "common",
+    scope: "project",
+    project_key: projectKey,
+    priority: "normal",
+    confidence: "working",
+  });
+}
+
+function configureGrooming(opts: { token?: string } = {}) {
+  const provider = addProvider(store!, {
+    name: "default",
+    endpoint: "https://api.example.com/v1",
+    ...(opts.token !== undefined ? { token: opts.token } : {}),
+  });
+  writeConsumerConfig(store!, "grooming", { providerId: provider.id, model: "gpt-x" });
+}
+
+function byTitle(title: string, status: string): Memory[] {
+  return store!.listAll({ status }).filter((m) => m.title === title);
+}
+
+describe("dryRunGrooming — candidate addendum is never committed (the load-bearing invariant)", () => {
+  it("leaves the live grooming addendum file, status, and version unchanged", async () => {
+    seedActive("Active fact");
+    writeCuratorConfig(store!, { enabled: true, defaultAutoApply: "high_confidence" });
+    configureGrooming({ token: "dummy-decrypted-token" });
+    // A committed, accepted live addendum.
+    setJobAddendum(store!, "grooming", "LIVE committed guidance");
+    const before = store!.readAddendum("grooming");
+    const statusBefore = readAddendumStatus(store!, "grooming");
+
+    const result = await dryRunGrooming({
+      store: store!,
+      candidateAddendum: "CANDIDATE uncommitted guidance",
+      buildClient: () => createEmittingClient("Dry-run proposal"),
+    });
+    expect(result.ran).toBe(true);
+
+    // The live file is byte-for-byte unchanged; status + version untouched.
+    const after = store!.readAddendum("grooming");
+    expect(after.content).toBe("LIVE committed guidance");
+    expect(after.version).toBe(before.version);
+    expect(readAddendumStatus(store!, "grooming")).toEqual(statusBefore);
+    expect(readAddendumStatus(store!, "grooming").status).toBe("accepted");
+  });
+});
+
+describe("dryRunGrooming — slice dry-run is synchronous + the candidate reaches the prompt", () => {
+  it("runs one slice and the candidate addendum text reaches the LLM prompt", async () => {
+    seedActive("Active fact");
+    writeCuratorConfig(store!, { enabled: true, defaultAutoApply: "high_confidence" });
+    configureGrooming({ token: "dummy-decrypted-token" });
+
+    let seenPrompt = "";
+    const capturingClient: LlmClient = {
+      complete: async (request) => {
+        seenPrompt = request.messages.map((m) => m.content).join("\n");
+        return createEmittingClient("Dry-run proposal").complete(request);
+      },
+    };
+
+    const result = await dryRunGrooming({
+      store: store!,
+      candidateAddendum: "CANDIDATE steering: prefer concise lessons",
+      slice: { kind: "common_project", projectKey: "proj-x" },
+      buildClient: () => capturingClient,
+    });
+    expect(result).toMatchObject({ ran: true, scope: "slice" });
+    // The candidate text reached the prompt (redacted-passthrough — no secrets here).
+    expect(seenPrompt).toContain("CANDIDATE steering: prefer concise lessons");
+    expect(seenPrompt).toContain("OPERATOR GUIDANCE");
+  });
+});
+
+describe("dryRunGrooming — proposals are tagged dry-run, nothing auto-applies", () => {
+  it("forces every op to a proposal tagged dry-run (+ candidate label), even at confidence 1.0", async () => {
+    seedActive("Active fact");
+    writeCuratorConfig(store!, { enabled: true, defaultAutoApply: "high_confidence" });
+    configureGrooming({ token: "dummy-decrypted-token" });
+
+    await dryRunGrooming({
+      store: store!,
+      candidateAddendum: "CANDIDATE guidance",
+      candidateLabel: "candidate v2",
+      slice: { kind: "common_project", projectKey: "proj-x" },
+      buildClient: () => createEmittingClient("Dry-run proposal"),
+    });
+
+    // The high-confidence create landed as a PROPOSAL, never active.
+    const proposed = byTitle("Dry-run proposal", "proposed");
+    expect(proposed).toHaveLength(1);
+    expect(byTitle("Dry-run proposal", "active")).toEqual([]);
+    // Tagged dry-run + candidate label; NOT tagged with an addendum_version.
+    const note = proposed[0]?.curator_note as Record<string, unknown> | null | undefined;
+    expect(note?.dry_run).toBe(true);
+    expect(note?.dry_run_candidate).toBe("candidate v2");
+    expect(note?.addendum_version).toBeUndefined();
+  });
+
+  it("dry-run proposals are distinguishable from a real grooming run's proposals", async () => {
+    // A dry-run proposal carries dry_run; a normal (non-dry-run) run does not.
+    // Use the store's own grooming run via runCuration semantics indirectly: assert
+    // the dry-run tag is present here and absent on a hand-seeded plain proposal.
+    seedActive("Active fact");
+    writeCuratorConfig(store!, { enabled: true, defaultAutoApply: "high_confidence" });
+    configureGrooming({ token: "dummy-decrypted-token" });
+
+    // A plain proposal (no dry-run tag) as a real grooming run would produce.
+    store!.createMemory(
+      {
+        agent_id: "agent-a",
+        title: "Real proposal",
+        body: "x",
+        category: "lessons",
+        visibility: "common",
+        scope: "project",
+        project_key: "proj-x",
+      },
+      { requires_approval: true, curator_note: { run_id: "r1" } },
+    );
+
+    await dryRunGrooming({
+      store: store!,
+      candidateAddendum: "CANDIDATE guidance",
+      slice: { kind: "common_project", projectKey: "proj-x" },
+      buildClient: () => createEmittingClient("Dry-run proposal"),
+    });
+
+    const real = byTitle("Real proposal", "proposed");
+    expect(real).toHaveLength(1);
+    const realNote = real[0]?.curator_note as Record<string, unknown> | null | undefined;
+    expect(realNote?.dry_run).toBeUndefined();
+
+    const dry = byTitle("Dry-run proposal", "proposed");
+    const dryNote = dry[0]?.curator_note as Record<string, unknown> | null | undefined;
+    expect(dryNote?.dry_run).toBe(true);
+  });
+});
+
+describe("dryRunGrooming — whole-corpus path", () => {
+  it("runs every slice that has curatable content (no slice given)", async () => {
+    seedActive("Active X", "proj-x");
+    seedActive("Active Y", "proj-y");
+    writeCuratorConfig(store!, { enabled: true, defaultAutoApply: "high_confidence" });
+    configureGrooming({ token: "dummy-decrypted-token" });
+
+    // Emit a slice-specific proposal so we can confirm BOTH slices were judged.
+    const client: LlmClient = {
+      complete: async (request) => {
+        const prompt = request.messages.map((m) => m.content).join("\n");
+        const isX = prompt.includes("Active X");
+        return createEmittingClient(
+          isX ? "Dry-run X" : "Dry-run Y",
+          isX ? "proj-x" : "proj-y",
+        ).complete(request);
+      },
+    };
+
+    const result = await dryRunGrooming({
+      store: store!,
+      candidateAddendum: "CANDIDATE guidance",
+      buildClient: () => client,
+    });
+    expect(result).toMatchObject({ ran: true, scope: "corpus" });
+    expect(byTitle("Dry-run X", "proposed").length).toBe(1);
+    expect(byTitle("Dry-run Y", "proposed").length).toBe(1);
+    // Active corpus untouched (nothing auto-applied / archived).
+    expect(byTitle("Active X", "active").length).toBe(1);
+    expect(byTitle("Active Y", "active").length).toBe(1);
+  });
+
+  it("is fail-soft: one slice's failure never wedges the rest", async () => {
+    seedActive("Active X", "proj-x");
+    seedActive("Active Y", "proj-y");
+    writeCuratorConfig(store!, { enabled: true, defaultAutoApply: "high_confidence" });
+    configureGrooming({ token: "dummy-decrypted-token" });
+
+    const flakyClient: LlmClient = {
+      complete: async (request) => {
+        const prompt = request.messages.map((m) => m.content).join("\n");
+        if (prompt.includes("Active Y")) throw new Error("simulated judge failure");
+        return createEmittingClient("Dry-run X").complete(request);
+      },
+    };
+
+    const result = await dryRunGrooming({
+      store: store!,
+      candidateAddendum: "CANDIDATE guidance",
+      buildClient: () => flakyClient,
+    });
+    expect(result.ran).toBe(true);
+    // proj-x still produced a proposal despite proj-y throwing.
+    expect(byTitle("Dry-run X", "proposed").length).toBe(1);
+  });
+});
+
+describe("dryRunGrooming — fail-soft gating", () => {
+  it("does not run when grooming is disabled", async () => {
+    seedActive("Active fact");
+    writeCuratorConfig(store!, { enabled: false });
+    configureGrooming({ token: "dummy-decrypted-token" });
+
+    const result = await dryRunGrooming({
+      store: store!,
+      candidateAddendum: "CANDIDATE guidance",
+      slice: { kind: "common_project", projectKey: "proj-x" },
+      buildClient: () => createEmittingClient("Dry-run proposal"),
+    });
+    expect(result).toEqual({ ran: false, reason: "disabled" });
+  });
+
+  it("does not run when the token can't be decrypted", async () => {
+    seedActive("Active fact");
+    writeCuratorConfig(store!, { enabled: true });
+    configureGrooming({ token: "dummy-secret" });
+    store!.close();
+    store = createLibrarianStore({ dataDir }); // reopen without the master key
+
+    const result = await dryRunGrooming({
+      store: store!,
+      candidateAddendum: "CANDIDATE guidance",
+      slice: { kind: "common_project", projectKey: "proj-x" },
+      buildClient: () => createEmittingClient("Dry-run proposal"),
+    });
+    expect(result).toEqual({ ran: false, reason: "no_token" });
+  });
+});
+
+// Independence from the job's real addendum_status: even with grooming under
+// evaluation, a dry-run does not change that state and still force-proposes.
+describe("dryRunGrooming — independent of the job's addendum_status", () => {
+  it("does not change addendum_status and never auto-applies", async () => {
+    seedActive("Active fact");
+    writeCuratorConfig(store!, { enabled: true, defaultAutoApply: "high_confidence" });
+    configureGrooming({ token: "dummy-decrypted-token" });
+    setJobAddendum(store!, "grooming", "LIVE guidance");
+    setAddendumStatus(store!, "grooming", "under_evaluation");
+    const before = readAddendumStatus(store!, "grooming");
+
+    await dryRunGrooming({
+      store: store!,
+      candidateAddendum: "CANDIDATE guidance",
+      slice: { kind: "common_project", projectKey: "proj-x" },
+      buildClient: () => createEmittingClient("Dry-run proposal"),
+    });
+
+    // Status (incl. the eval version) is unchanged by the dry-run.
+    expect(readAddendumStatus(store!, "grooming")).toEqual(before);
+    // The dry-run proposal is tagged dry-run, NOT with the live eval version.
+    const note = byTitle("Dry-run proposal", "proposed")[0]?.curator_note as
+      | Record<string, unknown>
+      | null
+      | undefined;
+    expect(note?.dry_run).toBe(true);
+    expect(note?.addendum_version).toBeUndefined();
+  });
+});

--- a/packages/mcp-server/src/trpc/curator.ts
+++ b/packages/mcp-server/src/trpc/curator.ts
@@ -9,20 +9,41 @@
 // surface in spec 044 D-1 — it's a committed vault file now (its dashboard editor
 // is D7); this router no longer reads or writes it.
 
-import type { CuratorConfigPatch, ListCurationRunsInput } from "@librarian/core";
+import type { CuratorConfigPatch, EvidenceSlice, ListCurationRunsInput } from "@librarian/core";
 import {
   CuratorConfigPatchSchema,
+  dryRunGrooming,
   readCuratorConfig,
   runCuratorTick,
   writeCuratorConfig,
 } from "@librarian/core";
 import { z } from "zod";
+import { logger } from "../logging.js";
 import { adminProcedure, router } from "./trpc.js";
 
 const ListRunsInputSchema = z.strictObject({
   status: z.string().optional(),
   trigger: z.string().optional(),
   limit: z.number().int().positive().max(200).optional(),
+});
+
+// A slice key for the "dry-run this slice" path: the EvidenceSlice shape (kind +
+// the one identifier that kind needs). projectKey is required for common_project,
+// agentId for agent_private; common_global needs neither. Kept structural rather
+// than a string key so the dashboard can build it from the slice it already shows.
+const SliceKeySchema = z.strictObject({
+  kind: z.enum(["common_project", "common_global", "agent_private"]),
+  projectKey: z.string().min(1).optional(),
+  agentId: z.string().min(1).optional(),
+});
+
+// Input for curator.dryRunGrooming. The candidate is the UNCOMMITTED addendum text
+// to preview; candidateLabel tags the throwaway batch; slice (optional) runs ONE
+// slice synchronously (fast), else the whole corpus runs in the background.
+const DryRunGroomingInputSchema = z.strictObject({
+  candidateAddendum: z.string(),
+  candidateLabel: z.string().min(1).optional(),
+  slice: SliceKeySchema.optional(),
 });
 
 export const curatorRouter = router({
@@ -53,4 +74,50 @@ export const curatorRouter = router({
   runNow: adminProcedure.mutation(({ ctx }) =>
     runCuratorTick({ store: ctx.store, trigger: "manual", bypassSkip: true }),
   ),
+
+  // Grooming dry-run (spec 044 D-4): preview what a CANDIDATE (uncommitted) addendum
+  // would do over the corpus, in propose-mode, WITHOUT committing the candidate live
+  // and WITHOUT auto-applying anything. The candidate is threaded into the prompt
+  // (redacted there) and NEVER written to the vault — the live addendum file/status/
+  // version are untouched. Proposals are tagged dry-run (discardable). GROOMING ONLY
+  // — intake input is consumed on apply (not replayable), so there is no intake dry-
+  // run (the same reason intake has no re-evaluate). The dashboard buttons are D7.
+  //
+  // Two scopes:
+  //  - slice given → run that ONE slice SYNCHRONOUSLY and return the result (the
+  //    latency-sensitive "dry-run this slice" path the spec calls out as fast);
+  //  - no slice → "dry-run everything" can be slow, so it must NOT block the request:
+  //    run it as fire-and-forget background work and return a `{ started: true }` ack
+  //    immediately. CAVEAT: there is NO progress handle — the admin polls the runs/
+  //    proposals to see results. A failure in the background run is fail-soft (logged
+  //    via the shared logger, never crashes the server).
+  dryRunGrooming: adminProcedure
+    .input(DryRunGroomingInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (input.slice) {
+        // Fast path: one slice, synchronous — the admin awaits the result.
+        const slice: EvidenceSlice = {
+          kind: input.slice.kind,
+          ...(input.slice.projectKey !== undefined ? { projectKey: input.slice.projectKey } : {}),
+          ...(input.slice.agentId !== undefined ? { agentId: input.slice.agentId } : {}),
+        };
+        return dryRunGrooming({
+          store: ctx.store,
+          candidateAddendum: input.candidateAddendum,
+          ...(input.candidateLabel !== undefined ? { candidateLabel: input.candidateLabel } : {}),
+          slice,
+        });
+      }
+      // Whole-corpus path: fire-and-forget so the request returns fast. The run is
+      // fail-soft inside `dryRunGrooming` (per-slice try/catch); we also guard the
+      // promise so a top-level rejection (gating throw etc.) is logged, never unhandled.
+      void dryRunGrooming({
+        store: ctx.store,
+        candidateAddendum: input.candidateAddendum,
+        ...(input.candidateLabel !== undefined ? { candidateLabel: input.candidateLabel } : {}),
+      }).catch((error: unknown) => {
+        logger.error({ err: error }, "background grooming dry-run failed");
+      });
+      return { started: true };
+    }),
 });

--- a/packages/mcp-server/tests/trpc/curator-dry-run.test.ts
+++ b/packages/mcp-server/tests/trpc/curator-dry-run.test.ts
@@ -1,0 +1,229 @@
+// Grooming dry-run admin tRPC tests (spec 044 PR-4 / Task D4).
+//
+// `curator.dryRunGrooming` runs a CANDIDATE (uncommitted) grooming addendum over
+// the corpus (or one slice) in propose-mode, producing a reviewable batch tagged
+// dry-run — WITHOUT committing the candidate live and WITHOUT auto-applying:
+//   - slice given → run that ONE slice synchronously and return fast (the latency-
+//     sensitive path); the candidate addendum reaches the prompt;
+//   - no slice → run the whole corpus as background work, returning a started ack
+//     immediately (no progress handle — fire-and-forget, fail-soft).
+// Admin-gated (rejected without an admin bearer). INTAKE HAS NO DRY-RUN.
+//
+// The slice test drives a REAL run against a local OpenAI-compatible stub LLM; the
+// seed store + server share a runtime-assembled 64-hex master key so the provider
+// token round-trips.
+
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import {
+  addProvider,
+  createLibrarianStore,
+  readAddendumStatus,
+  resolveSecretKey,
+  writeConsumerConfig,
+  writeCuratorConfig,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanupTempDir, makeTempDir, startHttpServer } from "../../../../test/helpers.js";
+
+// Assemble the 64-hex key + Buffer at runtime — no secret-shaped literal (GitGuardian).
+const SECRET_KEY_HEX = "0123456789abcdef".repeat(4);
+const SECRET_KEY = resolveSecretKey(SECRET_KEY_HEX);
+
+interface TrpcOk<T> {
+  result: { data: T };
+}
+interface TrpcErr {
+  error: unknown;
+}
+interface ServerHandle {
+  url: string;
+  token: string;
+  stop: () => Promise<void>;
+}
+
+async function trpcPost<T>(server: ServerHandle, path: string, input?: unknown): Promise<T> {
+  const response = await fetch(`${server.url}/trpc/${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${server.token}` },
+    body: input === undefined ? undefined : JSON.stringify(input),
+  });
+  const json = (await response.json()) as TrpcOk<T> | TrpcErr;
+  if (response.status >= 400 || "error" in json) {
+    throw new Error(`trpc POST ${path} failed: ${JSON.stringify(json)}`);
+  }
+  return (json as TrpcOk<T>).result.data;
+}
+
+interface DryRunSliceResult {
+  ran: boolean;
+  scope?: string;
+}
+interface DryRunCorpusAck {
+  started: boolean;
+}
+
+// A minimal OpenAI-compatible stub that records every prompt it sees and returns one
+// fixed grooming `create` op so a slice dry-run files exactly one fresh proposal.
+function startStubLlm(): Promise<{
+  url: string;
+  prompts: string[];
+  stop: () => Promise<void>;
+}> {
+  const prompts: string[] = [];
+  const completion = JSON.stringify({
+    operations: [
+      {
+        type: "create",
+        memory: {
+          title: "Dry-run candidate proposal",
+          body: "a durable lesson",
+          category: "lessons",
+          visibility: "common",
+          scope: "project",
+          project_key: "proj-x",
+        },
+        rationale: "novel durable lesson",
+        confidence: 0.99,
+      },
+    ],
+  });
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      let body = "";
+      req.on("data", (c) => (body += c));
+      req.on("end", () => {
+        prompts.push(body);
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ choices: [{ message: { content: completion } }] }));
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({
+        url: `http://127.0.0.1:${port}/v1`,
+        prompts,
+        stop: () => new Promise((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
+function seedGrooming(dataDir: string, stubUrl: string) {
+  const seed = createLibrarianStore({ dataDir, secretKey: SECRET_KEY });
+  writeCuratorConfig(seed, { enabled: true, defaultAutoApply: "high_confidence" });
+  const provider = addProvider(seed, {
+    name: "stub",
+    endpoint: stubUrl,
+    token: "dummy-stub-token",
+  });
+  writeConsumerConfig(seed, "grooming", { providerId: provider.id, model: "gpt-x" });
+  seed.createMemory({
+    agent_id: "agent-a",
+    title: "Active anchor",
+    body: "b",
+    category: "lessons",
+    visibility: "common",
+    scope: "project",
+    project_key: "proj-x",
+    priority: "normal",
+    confidence: "working",
+  });
+  seed.close();
+}
+
+describe("tRPC curator.dryRunGrooming (spec 044 D4)", () => {
+  let dataDir = "";
+  beforeEach(() => {
+    dataDir = makeTempDir();
+  });
+  afterEach(() => {
+    cleanupTempDir(dataDir);
+  });
+
+  it("admin-gates dryRunGrooming (rejected without an admin bearer)", async () => {
+    const server = await startHttpServer({ dataDir });
+    try {
+      const unauthed = await fetch(`${server.url}/trpc/curator.dryRunGrooming`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ candidateAddendum: "x" }),
+      });
+      expect(unauthed.status).toBeGreaterThanOrEqual(400);
+
+      const agent = await fetch(`${server.url}/trpc/curator.dryRunGrooming`, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: "Bearer agent-token" },
+        body: JSON.stringify({ candidateAddendum: "x" }),
+      });
+      expect(agent.status).toBeGreaterThanOrEqual(400);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("slice dry-run runs synchronously: candidate reaches the prompt, proposal tagged dry-run, live addendum untouched", async () => {
+    const stub = await startStubLlm();
+    seedGrooming(dataDir, stub.url);
+
+    const server = await startHttpServer({ dataDir, secretKey: SECRET_KEY_HEX });
+    try {
+      const result = await trpcPost<DryRunSliceResult>(server, "curator.dryRunGrooming", {
+        candidateAddendum: "CANDIDATE steering: prefer concise lessons",
+        candidateLabel: "candidate v9",
+        slice: { kind: "common_project", projectKey: "proj-x" },
+      });
+      expect(result).toMatchObject({ ran: true, scope: "slice" });
+    } finally {
+      await server.stop();
+      await stub.stop();
+    }
+
+    // The candidate text reached the prompt (redacted-passthrough, no secrets).
+    expect(stub.prompts.some((p) => p.includes("CANDIDATE steering: prefer concise lessons"))).toBe(
+      true,
+    );
+
+    // A fresh dry-run proposal was filed, tagged dry-run (+ candidate label); the
+    // live grooming addendum is untouched (never committed) and nothing went active.
+    const after = createLibrarianStore({ dataDir });
+    try {
+      const proposed = after.listAll({ status: "proposed" });
+      const fresh = proposed.filter((m) => m.title === "Dry-run candidate proposal");
+      expect(fresh).toHaveLength(1);
+      const note = fresh[0]?.curator_note as Record<string, unknown> | null | undefined;
+      expect(note?.dry_run).toBe(true);
+      expect(note?.dry_run_candidate).toBe("candidate v9");
+      expect(note?.addendum_version).toBeUndefined();
+      // Nothing auto-applied to active.
+      expect(
+        after.listAll({ status: "active" }).some((m) => m.title === "Dry-run candidate proposal"),
+      ).toBe(false);
+      // The live addendum file is still absent/empty + accepted (never committed).
+      expect(after.readAddendum("grooming").content).toBe("");
+      expect(readAddendumStatus(after, "grooming")).toEqual({
+        status: "accepted",
+        evalVersion: null,
+      });
+    } finally {
+      after.close();
+    }
+  });
+
+  it("whole-corpus dry-run returns a started ack immediately (background, fail-soft)", async () => {
+    const stub = await startStubLlm();
+    seedGrooming(dataDir, stub.url);
+
+    const server = await startHttpServer({ dataDir, secretKey: SECRET_KEY_HEX });
+    try {
+      const result = await trpcPost<DryRunCorpusAck>(server, "curator.dryRunGrooming", {
+        candidateAddendum: "CANDIDATE whole-corpus guidance",
+      });
+      // Fire-and-forget: the request returns a started ack without awaiting the run.
+      expect(result).toEqual({ started: true });
+    } finally {
+      await server.stop();
+      await stub.stop();
+    }
+  });
+});


### PR DESCRIPTION
## What & why

Before an admin commits a new grooming addendum, they want to SEE what it would do. This adds a **dry-run**: run a **candidate (uncommitted)** addendum over the existing corpus in **propose-mode**, producing a reviewable batch of proposals **without committing the candidate live and without auto-applying anything** (spec 044 decision D-4).

This is the same driver shape as D3c's `reEvaluateGroomingProposals` (a per-slice `runCuration` over the real grooming worker), with two deliberate differences: it threads a **candidate addendum string** into the prompt instead of the committed file, and it tags proposals **dry-run** instead of with a committed eval version.

## How the candidate threads in without committing (the invariant)

`dryRunGrooming` (`packages/core/src/curator-dry-run.ts`) passes the candidate **only** as `promptAddendum` to `runCuration` — the prompt builder redacts it before it reaches the model. The driver **never** calls `setJobAddendum`/`writeAddendum`/`setAddendumStatus`, so the live `grooming-addendum.md`, its status, and its version are all **untouched**. This is the load-bearing invariant and is tested explicitly (core + tRPC): after a dry-run the live file is byte-for-byte unchanged and the status stays `accepted` (and an `under_evaluation` status is left untouched too).

## Propose-mode — nothing auto-applies

`dryRun` reuses D3a's force-propose routing **unconditionally** (independent of the job's real `addendum_status`): every would-be auto-apply becomes a proposal and a would-be auto-archive is skipped — nothing auto-applies, **ever**, even at confidence 1.0. Proposals are tagged `curator_note.dry_run` (+ a `dry_run_candidate` label) and **never** `addendum_version`, so the throwaway batch is distinguishable from real proposals (the D7 dashboard filters them).

## Slice-fast vs everything-background

`curator.dryRunGrooming` (admin tRPC, input `{ candidateAddendum, candidateLabel?, slice? }`):
- **slice given → "dry-run this slice"**: run that ONE slice **synchronously** and return fast (the latency-sensitive path).
- **no slice → "dry-run everything"**: runs the whole corpus as **fire-and-forget** background work, returning `{ started: true }` immediately. **Caveat:** there is no progress handle (the repo has no durable background-job infra — grooming itself is a serial in-process tick); the admin polls the runs/proposals. The background run is **fail-soft** — per-slice `try/catch` in the driver plus a top-level `.catch` that logs via the shared logger and never crashes the server.

## Intake has no dry-run

The inbox is consumed on apply (not replayable), so there is deliberately no intake dry-run — same reason intake has no re-evaluate (D3c). `dryRunGrooming` is grooming-only and the endpoint lives on the grooming `curator` router.

## Tests (TDD, scripted/stub LLM for determinism)

- core `curator-dry-run.test.ts` (9): candidate-never-committed invariant; slice synchronous + candidate reaches the prompt; force-propose at conf 1.0 + dry-run tag (no `addendum_version`); distinguishable from a real proposal; whole-corpus runs every slice + fail-soft; gating; independent of `addendum_status`.
- mcp-server `curator-dry-run.test.ts` (3): admin-gating; slice dry-run end-to-end against a local OpenAI-compatible stub (candidate in the prompt, proposal tagged, live addendum untouched); whole-corpus returns `{ started: true }`.

Full suite green + `pnpm -r build` + typecheck + lint clean. CHANGELOG deferred to D8's single 044 entry (the dry-run buttons are D7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)