### PR TITLE
feat(core): shared merge/split/update primitives + admin mutations (spec 044 PR-5a, Task D5a)

### DIFF
--- a/packages/core/src/curator-apply.ts
+++ b/packages/core/src/curator-apply.ts
@@ -22,6 +22,7 @@ import type { CuratorMemoryPatch, CuratorOperation } from "./curator-output.js";
 import { redactSecrets } from "./curator-redaction.js";
 import type { ValidatedOperation, ValidationContext } from "./curator-validate.js";
 import type { RecordCurationOperationInput } from "./store/curation-store.js";
+import { mergeMemory } from "./store/merge-memory.js";
 import { type SplitReplacement, splitMemory } from "./store/split-memory.js";
 
 // The authoritative stored memory used to reconstruct a protected-update proposal.
@@ -214,13 +215,19 @@ function applyOp(op: CuratorOperation, c: ExecContext): string[] {
     case "update":
       c.store.updateMemory(op.source_memory_id, op.patch, c.actorId);
       return [op.source_memory_id];
-    case "merge": {
-      // Create-then-archive: on partial failure the duplicate stays active
-      // (recoverable next run) rather than losing the source (data loss).
-      const target = createMemory(c, op.replacement, op.source_memory_ids).id;
-      for (const id of op.source_memory_ids) c.store.archiveMemory(id, c.actorId);
-      return [target];
-    }
+    case "merge":
+      // Auto-applied merge: spin up the merged replacement, then archive the
+      // sources. The shared primitive owns the create-then-archive ordering (on a
+      // partial failure the duplicate stays active rather than losing a source);
+      // pass the actor so it archives the superseded sources (an apply, not a
+      // propose). Sibling of the split case below (N→1 vs 1→N).
+      return [
+        mergeMemory(c.store, {
+          replacement: buildCreateCall(c, op.replacement, op.source_memory_ids),
+          sourceIds: op.source_memory_ids,
+          archiveActorId: c.actorId,
+        }),
+      ];
     case "split":
       // Auto-applied split: spin the replacements out, then archive the source.
       // The shared primitive owns the create-then-archive ordering; pass the
@@ -247,7 +254,15 @@ function proposeOp(op: CuratorOperation, c: ExecContext): string[] {
     case "create":
       return [createMemory(c, op.memory, [], opts).id];
     case "merge":
-      return [createMemory(c, op.replacement, op.source_memory_ids, opts).id];
+      // Proposed merge: spin up the merged replacement at requires_approval (status
+      // proposed) but leave the sources ACTIVE — the admin archives them after
+      // accepting (§11.1). No actor → the primitive does not archive the sources.
+      return [
+        mergeMemory(c.store, {
+          replacement: buildCreateCall(c, op.replacement, op.source_memory_ids, opts),
+          sourceIds: op.source_memory_ids,
+        }),
+      ];
     case "split":
       // Proposed split: spin the replacements out at requires_approval (status
       // proposed) but leave the source ACTIVE — the admin archives it after

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -503,6 +503,11 @@ export {
   type SplitReplacement,
   splitMemory,
 } from "./store/split-memory.js";
+export {
+  type MergeMemoryRequest,
+  type MergeMemoryStore,
+  mergeMemory,
+} from "./store/merge-memory.js";
 export type { SettingMeta, SettingsStore } from "./store/settings-store.js";
 export type { ConversationStateStore } from "./store/conversation-state-store.js";
 export type { ConversationState, ConversationStatePatch } from "./schemas/conversation-state.js";

--- a/packages/core/src/store/merge-memory.ts
+++ b/packages/core/src/store/merge-memory.ts
@@ -1,0 +1,61 @@
+// Shared "merge" store primitive (spec 044 D-5a). The mechanics of merging N
+// source memories into ONE replacement live HERE, in one place, so the curator
+// run path (`curator-apply.ts`) and a NEW admin path (`memories.merge` tRPC) that
+// both perform a merge produce byte-identical results. It is the sibling of
+// `splitMemory` (split-memory.ts): split is 1→N, merge is N→1.
+//
+// What the primitive owns (the invariant both paths share):
+//   1. Create the merged replacement FIRST, capturing its id.
+//   2. ONLY THEN, optionally, archive every source.
+// This create-then-archive ordering is the data-loss-safe one (it mirrors split's,
+// and the inline merge it replaces): on a partial failure the merged duplicate
+// stays active (recoverable next run) rather than losing a source before its
+// replacement exists.
+//
+// What the primitive does NOT own (deliberately left to the caller, because the
+// two paths differ here): how the replacement's `createMemory` input + options are
+// built — the curator_note shape (run path: { run_id, supersedes }; admin:
+// { source: "admin-chat", supersedes }), ownership/agent_id, and whether the new
+// row lands active or `requires_approval` (proposed). Each caller pre-builds that
+// `{ input, options }` pair; the primitive only sequences the writes. The
+// `supersedes = sourceIds` note belongs on the replacement and so is the caller's
+// responsibility — same as split.
+//
+// Whether the sources are archived is the propose-vs-apply switch: pass
+// `archiveActorId` to archive them (an auto-applied merge supersedes its sources);
+// omit it to leave them active (a PROPOSED merge — a human accepts and archives the
+// sources later).
+
+import type { SplitMemoryStore, SplitReplacement } from "./split-memory.js";
+
+/** The narrow store surface the merge primitive mutates through (same as split). */
+export type MergeMemoryStore = SplitMemoryStore;
+
+export interface MergeMemoryRequest {
+  /** The merged target to create — a ready-to-write createMemory call. */
+  replacement: SplitReplacement;
+  /** The source memories being merged away (carried on the replacement's supersedes). */
+  sourceIds: string[];
+  /**
+   * When set, archive every source AFTER the replacement is created (an auto-
+   * applied merge). When omitted, the sources are left active — a PROPOSED merge,
+   * where a human archives the sources after accepting the replacement.
+   */
+  archiveActorId?: string;
+}
+
+/**
+ * Execute a merge: create the merged replacement, then (optionally) archive every
+ * source. Returns the new merged memory id. The ordering (create-then-archive) is
+ * the shared data-loss-safe invariant; the replacement's `input`/`options` are the
+ * caller's (so the run path + admin path stay independent in what they file,
+ * identical in how they file it).
+ */
+export function mergeMemory(store: MergeMemoryStore, request: MergeMemoryRequest): string {
+  const target = store.createMemory(request.replacement.input, request.replacement.options).memory
+    .id;
+  if (request.archiveActorId !== undefined) {
+    for (const id of request.sourceIds) store.archiveMemory(id, request.archiveActorId);
+  }
+  return target;
+}

--- a/packages/core/tests/curator-apply.test.ts
+++ b/packages/core/tests/curator-apply.test.ts
@@ -153,6 +153,10 @@ describe("applyOperations — auto-apply", () => {
     expect(created.curator_note?.run_id).toBe(s!.runId);
   });
 
+  // Regression (spec 044 D-5a): the grooming merge path now routes through the
+  // shared `mergeMemory` store primitive (the sibling of `splitMemory`). Its
+  // behaviour must be UNCHANGED — create the merged replacement (superseding the
+  // sources, carrying the run_id), then archive every source.
   it("merges: creates the replacement and archives the sources atomically", () => {
     const a = seed({ title: "A", body: "same" });
     const b = seed({ title: "B", body: "same" });
@@ -183,6 +187,7 @@ describe("applyOperations — auto-apply", () => {
     const merged = s!.store.getMemory(recorded()[0]!.target_memory_ids[0]!)!;
     expect(merged.status).toBe("active");
     expect(merged.curator_note?.supersedes).toEqual([a.id, b.id]);
+    expect(merged.curator_note?.run_id).toBe(s!.runId); // provenance unchanged by the refactor
   });
 
   // Regression: the grooming split path now routes through the shared

--- a/packages/core/tests/store/merge-memory.test.ts
+++ b/packages/core/tests/store/merge-memory.test.ts
@@ -1,0 +1,69 @@
+// Shared merge store primitive (spec 044 D-5a). Sibling of splitMemory: pins the
+// two invariants both merge paths (curator run + admin) rely on:
+//   1. create-replacement-then-archive-sources ordering (data-loss-safe);
+//   2. sources archived IFF an archive actor is passed (apply vs propose).
+// The replacement's input/options are the caller's; the primitive only sequences.
+
+import { type MergeMemoryStore, mergeMemory } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+function fakeStore() {
+  const calls: string[] = [];
+  let n = 0;
+  const store: MergeMemoryStore = {
+    createMemory: (input) => {
+      const id = `mem_new_${n++}`;
+      calls.push(`create:${String(input.title)}`);
+      return { memory: { id } };
+    },
+    archiveMemory: (id, actor) => {
+      calls.push(`archive:${id}:${String(actor)}`);
+      return null;
+    },
+  };
+  return { store, calls };
+}
+
+describe("mergeMemory", () => {
+  it("creates the replacement, then archives every source (apply path)", () => {
+    const { store, calls } = fakeStore();
+    const id = mergeMemory(store, {
+      replacement: { input: { title: "Merged" } },
+      sourceIds: ["mem_a", "mem_b"],
+      archiveActorId: "system-curator",
+    });
+    expect(id).toBe("mem_new_0");
+    // Ordering invariant: the create precedes BOTH archives.
+    expect(calls).toEqual([
+      "create:Merged",
+      "archive:mem_a:system-curator",
+      "archive:mem_b:system-curator",
+    ]);
+  });
+
+  it("leaves the sources untouched when no archive actor is passed (propose path)", () => {
+    const { store, calls } = fakeStore();
+    const id = mergeMemory(store, {
+      replacement: { input: { title: "Merged" } },
+      sourceIds: ["mem_a", "mem_b"],
+    });
+    expect(id).toBe("mem_new_0");
+    expect(calls).toEqual(["create:Merged"]); // NO archives
+  });
+
+  it("passes the replacement's options through verbatim", () => {
+    let seen: Record<string, unknown> | undefined;
+    const store: MergeMemoryStore = {
+      createMemory: (_input, options) => {
+        seen = options;
+        return { memory: { id: "x" } };
+      },
+      archiveMemory: () => null,
+    };
+    mergeMemory(store, {
+      replacement: { input: { title: "M" }, options: { requires_approval: true } },
+      sourceIds: ["s1", "s2"],
+    });
+    expect(seen).toEqual({ requires_approval: true });
+  });
+});

--- a/packages/mcp-server/src/trpc/memories.ts
+++ b/packages/mcp-server/src/trpc/memories.ts
@@ -13,7 +13,13 @@
 // follow-up; the casts at this boundary are safe because the Zod input
 // schemas validate before the cast runs.
 
-import { DEFAULT_AGENT_ID, SYSTEM_ACTOR_IDS } from "@librarian/core";
+import {
+  DEFAULT_AGENT_ID,
+  type SplitReplacement,
+  SYSTEM_ACTOR_IDS,
+  mergeMemory,
+  splitMemory,
+} from "@librarian/core";
 import {
   MemoryInputSchema,
   MemoryPatchSchema,
@@ -115,6 +121,25 @@ const DistinctValuesInputSchema = z.object({
   include_archived: z.boolean().optional(),
 });
 
+// Admin mutation primitives (spec 044 D-5a). merge/split let an admin fix the
+// corpus OUTSIDE a curation run, calling the SAME shared store primitives
+// (mergeMemory / splitMemory) the curator run path uses. The replacement(s) carry
+// the curator's MemoryInput shape (title/body/category/…); ownership + provenance
+// are stamped server-side, never taken from the request.
+const MergeMemoryInputSchema = z.object({
+  // ≥2 sources — merging fewer than two is a no-op/rename, not a merge.
+  source_ids: z.array(z.string().min(1)).min(2),
+  replacement: MemoryInputSchema,
+  agent_id: z.string().optional(),
+});
+
+const SplitMemoryInputSchema = z.object({
+  source_id: z.string().min(1),
+  // ≥2 replacements — splitting into one is a no-op/rename, not a split.
+  replacements: z.array(MemoryInputSchema).min(2),
+  agent_id: z.string().optional(),
+});
+
 const ApproveProposalInputSchema = z.object({
   id: z.string().min(1),
   patch: MemoryPatchSchema.optional(),
@@ -147,6 +172,22 @@ function rethrowAsNotFound<T>(fn: () => T, message: string): T {
     }
     throw error;
   }
+}
+
+// Build the createMemory `{ input, options }` for one memory an admin merge/split
+// writes (spec 044 D-5a) — the admin analogue of curator-apply.ts's
+// `buildCreateCall`. Owner + curator_note (provenance source="admin-chat" +
+// supersedes) are stamped server-side. The note's `source` key marks these as
+// admin-initiated (not a curation run); `supersedes` records what the new memory
+// replaces, so the corpus's provenance graph stays intact.
+function adminCreateCall(
+  memory: Record<string, unknown>,
+  supersedes: string[],
+  owner: string,
+): SplitReplacement {
+  const curatorNote: Record<string, unknown> = { source: "admin-chat" };
+  if (supersedes.length > 0) curatorNote.supersedes = supersedes;
+  return { input: { ...memory, agent_id: owner }, options: { curator_note: curatorNote } };
 }
 
 export const memoriesRouter = router({
@@ -203,6 +244,44 @@ export const memoriesRouter = router({
           "Memory not found",
         ) as unknown as MemoryShape,
     ),
+
+  // Admin merge (spec 044 D-5a): collapse N sources into one target OUTSIDE a
+  // curation run. Calls the SAME shared `mergeMemory` primitive the curator run
+  // path uses (curator-apply.ts) — create the merged target (superseding the
+  // sources, tagged provenance source="admin-chat"), then archive every source.
+  // Passing the actor archives the sources (an admin merge auto-applies — there's
+  // no run to defer to). Each store mutation lands a git commit (revertable).
+  merge: adminProcedure.input(MergeMemoryInputSchema).mutation(({ ctx, input }) => {
+    const actor = input.agent_id ?? DASHBOARD_AGENT_ID;
+    const id = rethrowAsNotFound(
+      () =>
+        mergeMemory(ctx.store, {
+          replacement: adminCreateCall(input.replacement, input.source_ids, actor),
+          sourceIds: input.source_ids,
+          archiveActorId: actor,
+        }),
+      "Memory not found",
+    );
+    return ctx.store.getMemory(id) as unknown as MemoryShape;
+  }),
+
+  // Admin split (spec 044 D-5a): spin one source into N replacements OUTSIDE a
+  // curation run. Calls the SAME shared `splitMemory` primitive the curator run
+  // path uses — create every replacement (each superseding the source, tagged
+  // source="admin-chat"), then archive the source. Returns the new ids.
+  split: adminProcedure.input(SplitMemoryInputSchema).mutation(({ ctx, input }) => {
+    const actor = input.agent_id ?? DASHBOARD_AGENT_ID;
+    const ids = rethrowAsNotFound(
+      () =>
+        splitMemory(ctx.store, {
+          sourceId: input.source_id,
+          replacements: input.replacements.map((r) => adminCreateCall(r, [input.source_id], actor)),
+          archiveActorId: actor,
+        }),
+      "Memory not found",
+    );
+    return { ids };
+  }),
 
   bulkUpdate: adminProcedure.input(BulkUpdateMemoryInputSchema).mutation(({ ctx, input }) => {
     const patch: { agent_id?: string; project_key?: string } = {};

--- a/packages/mcp-server/tests/trpc/memories.test.ts
+++ b/packages/mcp-server/tests/trpc/memories.test.ts
@@ -4,9 +4,39 @@
 // admin gating, list/aggregates, related (incl. 404), full CRUD
 // (create/update/delete), proposal approve/reject, and recall.
 
+import { spawnSync } from "node:child_process";
 import { createLibrarianStore } from "@librarian/core";
 import { describe, expect, it } from "vitest";
 import { cleanupTempDir, makeTempDir, startHttpServer } from "../../../../test/helpers.js";
+
+// The data dir's vault is a git repo; every store mutation lands a commit. Read
+// the subject lines so a test can assert a mutation was committed (revertable).
+function gitLog(dataDir: string): string[] {
+  const result = spawnSync("git", ["-C", `${dataDir}/vault`, "log", "--format=%s"], {
+    encoding: "utf8",
+  });
+  return result.stdout.split("\n").filter((l) => l.length > 0);
+}
+
+// Read a memory's curator_note (the provenance record) from the data dir, by
+// opening a fresh store — the HTTP server runs in a separate process.
+function curatorNote(dataDir: string, id: string): Record<string, unknown> | null | undefined {
+  const store = createLibrarianStore({ dataDir });
+  try {
+    return store.getMemory(id)?.curator_note as Record<string, unknown> | null | undefined;
+  } finally {
+    store.close();
+  }
+}
+
+function memoryStatus(dataDir: string, id: string): string | undefined {
+  const store = createLibrarianStore({ dataDir });
+  try {
+    return store.getMemory(id)?.status;
+  } finally {
+    store.close();
+  }
+}
 
 interface TrpcOk<T> {
   result: { data: T };
@@ -443,6 +473,114 @@ describe("tRPC memories surface", () => {
         expect(response.status).toBe(404);
         const json = (await response.json()) as TrpcErr;
         expect(json.error?.data?.code).toBe("NOT_FOUND");
+      }
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+});
+
+// Admin mutation primitives (spec 044 D-5a). merge/split/update run OUTSIDE a
+// curation run (an admin fixing the corpus directly), call the SAME shared store
+// primitives the curator run path uses, tag provenance `curator_note.source =
+// "admin-chat"`, and each lands a git commit (revertable). Admin-gated.
+describe("tRPC admin mutation primitives (spec 044 D-5a)", () => {
+  it("memories.merge merges N sources into one target, tags admin-chat, commits", async () => {
+    const dataDir = makeTempDir();
+    const a = seedMemory(dataDir, { title: "Dup A", body: "same fact" });
+    const b = seedMemory(dataDir, { title: "Dup B", body: "same fact" });
+    const server = await startHttpServer({ dataDir });
+    try {
+      const merged = await trpcPost<MemoryRow>(server, "memories.merge", {
+        source_ids: [a.id, b.id],
+        replacement: { title: "Merged fact", body: "the merged fact", category: "lessons" },
+      });
+      expect(merged.title).toBe("Merged fact");
+      expect(merged.status).toBe("active");
+      // Sources archived (an admin merge auto-applies — there's no run to defer to).
+      expect(memoryStatus(dataDir, a.id)).toBe("archived");
+      expect(memoryStatus(dataDir, b.id)).toBe("archived");
+      // Provenance: supersedes the sources + tagged admin-chat.
+      const note = curatorNote(dataDir, merged.id);
+      expect(note?.supersedes).toEqual([a.id, b.id]);
+      expect(note?.source).toBe("admin-chat");
+      // Committed (revertable): the create + both archives are in git history.
+      const log = gitLog(dataDir);
+      expect(log.some((s) => s.includes(`store ${merged.id}`))).toBe(true);
+      expect(log.some((s) => s.includes(`archive ${a.id}`))).toBe(true);
+      expect(log.some((s) => s.includes(`archive ${b.id}`))).toBe(true);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("memories.split spins one source into N replacements, tags admin-chat, commits", async () => {
+    const dataDir = makeTempDir();
+    const src = seedMemory(dataDir, { title: "Overloaded", body: "facts about Anna and Bob" });
+    const server = await startHttpServer({ dataDir });
+    try {
+      const result = await trpcPost<{ ids: string[] }>(server, "memories.split", {
+        source_id: src.id,
+        replacements: [
+          { title: "Anna", body: "about Anna", category: "lessons" },
+          { title: "Bob", body: "about Bob", category: "lessons" },
+        ],
+      });
+      expect(result.ids).toHaveLength(2);
+      // Source archived (an admin split auto-applies).
+      expect(memoryStatus(dataDir, src.id)).toBe("archived");
+      for (const id of result.ids) {
+        expect(memoryStatus(dataDir, id)).toBe("active");
+        const note = curatorNote(dataDir, id);
+        expect(note?.supersedes).toEqual([src.id]);
+        expect(note?.source).toBe("admin-chat");
+      }
+      const log = gitLog(dataDir);
+      expect(log.some((s) => s.includes(`archive ${src.id}`))).toBe(true);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("memories.update patches a memory in place (the shared update routine), commits", async () => {
+    const dataDir = makeTempDir();
+    const m = seedMemory(dataDir, { title: "Stale", body: "old body" });
+    const server = await startHttpServer({ dataDir });
+    try {
+      const updated = await trpcPost<MemoryRow>(server, "memories.update", {
+        id: m.id,
+        patch: { body: "corrected body" },
+      });
+      expect(updated.body).toBe("corrected body");
+      expect(updated.status).toBe("active"); // in place, not superseded
+      const log = gitLog(dataDir);
+      expect(log.some((s) => s.includes(`update ${m.id}`))).toBe(true);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("merge / split reject unauthenticated callers (admin-gated)", async () => {
+    const dataDir = makeTempDir();
+    const m = seedMemory(dataDir, { title: "Protected by gate" });
+    const server = await startHttpServer({ dataDir });
+    try {
+      for (const [path, body] of [
+        ["memories.merge", { source_ids: [m.id, m.id], replacement: { title: "X", body: "y" } }],
+        ["memories.split", { source_id: m.id, replacements: [{ title: "A" }, { title: "B" }] }],
+      ] as const) {
+        const response = await fetch(`${server.url}/trpc/${path}`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        expect(response.status).toBe(401);
+        const json = (await response.json()) as TrpcErr;
+        expect(json.error?.data?.code).toBe("UNAUTHORIZED");
       }
     } finally {
       await server.stop();


### PR DESCRIPTION
## Summary

Spec 044 PR-5 (Task D5) is "admin mutation primitives incl. reverse-a-groom". It's Large, so it's split — **this is D5a**: factor merge/split/update into shared store primitives that the curator run path and a new admin path both call, then expose merge/split/update as admin tRPC mutations. (`unmerge` / reverse-a-groom is D5b.)

### The factoring

- **`mergeMemory` store primitive** (`packages/core/src/store/merge-memory.ts`) — the N→1 sibling of the existing `splitMemory` (1→N). It owns the data-loss-safe **create-then-archive** ordering (on partial failure the merged duplicate stays active rather than losing a source); the caller pre-builds the merged replacement's `{ input, options }` (so the `curator_note` shape stays the caller's). Sources are archived **iff** an `archiveActorId` is passed — the apply-vs-propose switch, exactly like `splitMemory`.
- **`update` needs no new primitive** — `store.updateMemory` is *already* the shared routine the run path's auto-apply and the admin `memories.update` both call. Manufacturing a forwarding wrapper would have added a parallel path for nothing.

### Run path uses the primitives (byte-identical)

`curator-apply.ts` now routes **both** merge cases (auto-apply + protected-propose) through `mergeMemory`, replacing the inline create+archive. The extraction is mechanical: same `buildCreateCall`, same archive loop/actor/order, same return shape. Proven by the **untouched existing apply suite** (merge auto-apply, merge partial-failure ordering, merge-under-evaluation propose, and the byte-identical accepted-path regression) plus an added assertion that the merged target's `run_id` provenance is unchanged.

### Admin merge/split/update (admin-chat)

Added admin-gated `merge` / `split` mutations to `memoriesRouter` (where the admin memory mutations already live, using the reserved `dashboard-admin` actor). Each:
- works **outside a curation run** (an admin fixing the corpus directly),
- calls the **SAME shared primitive** the run path uses (`mergeMemory` / `splitMemory`; update via `store.updateMemory`),
- tags new memories `curator_note.source = "admin-chat"` + `supersedes`,
- **auto-applies** (passing the actor archives the superseded source(s) — there's no run to defer to),
- lands a **git commit** per store mutation (revertable).

`curator_note` is intentionally not patchable in place (`cleanPatch` strips it by design), so an in-place `update`'s admin provenance is the `dashboard-admin` actor + the commit; `merge`/`split` create new rows through the trusted channel and so carry the `admin-chat` tag directly.

## Tests (TDD, RED→GREEN)

- **core** `tests/store/merge-memory.test.ts` (3) — create-then-archive ordering, archive-iff-actor, options pass-through.
- **core** `tests/curator-apply.test.ts` — existing suite stays green (the byte-identical regression guard) + a run-path merge-provenance assertion.
- **mcp-server** `tests/trpc/memories.test.ts` (4, real HTTP bin) — admin merge/split/update each work standalone, produce the expected corpus change, tag `admin-chat`, land a git commit; merge/split reject unauthenticated callers (admin-gated).

Full `pnpm test` green; `pnpm -r build` + lint clean (no `error TS`).

## Out of scope (later tasks)

No `unmerge` (D5b), no chat (D6), no dashboard UI/buttons (D7), no docs (D8). The CHANGELOG entry is deferred to D8's single 044 entry — consistent with D2/D3/D4 — since these endpoints have no operator-facing surface until D7 builds the buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)