### PR TITLE
feat(core): unmerge / reverse-a-groom admin mutation (spec 044 PR-5b, Task D5b)

### DIFF
--- a/packages/core/src/store/markdown/markdown-memory-store.ts
+++ b/packages/core/src/store/markdown/markdown-memory-store.ts
@@ -246,6 +246,22 @@ export function createMarkdownMemoryStore(deps: MarkdownMemoryStoreDeps): Memory
     );
   }
 
+  // The narrow inverse of archiveMemory (spec 044 D-5b): restore an archived
+  // memory to Active. Used by the admin `unmerge` mutation to un-archive the
+  // sources a bad merge collapsed. Mirrors archiveMemory's shape exactly —
+  // status transition + updated_at + commit — and is idempotent (an
+  // already-active memory is returned unchanged, no commit).
+  function unarchiveMemory(id: string, agent_id: string = DEFAULT_AGENT_ID): Memory | null {
+    void agent_id;
+    const existing = getMemory(id);
+    if (!existing) throw new Error(`No memory found for id ${id}`);
+    if (existing.status === MemoryStatus.Active) return existing; // idempotent
+    return persist(
+      { ...existing, status: MemoryStatus.Active, updated_at: now() },
+      `memory: unarchive ${id}`,
+    );
+  }
+
   function verifyMemory(
     id: string,
     result: string,
@@ -565,6 +581,7 @@ export function createMarkdownMemoryStore(deps: MarkdownMemoryStoreDeps): Memory
     getRelated,
     updateMemory,
     archiveMemory,
+    unarchiveMemory,
     verifyMemory,
     approveProposal,
     recordRecall,

--- a/packages/core/src/store/memory-types.ts
+++ b/packages/core/src/store/memory-types.ts
@@ -114,6 +114,9 @@ export interface MemoryStore {
   countMemoriesByAgentId: () => { agent_id: string; count: number }[];
   listMemoryIdsByAgentId: (agentId: string) => string[];
   archiveMemory: (id: string, agent_id?: string) => Memory | null;
+  // The narrow inverse of archiveMemory (spec 044 D-5b): restore an archived
+  // memory to Active (idempotent on an already-active row). Drives admin unmerge.
+  unarchiveMemory: (id: string, agent_id?: string) => Memory | null;
   verifyMemory: (id: string, result: string, note?: string, agent_id?: string) => Memory | null;
   recordRecall: (memories: Memory[], agent_id?: string, query?: string) => void;
   approveProposal: (

--- a/packages/core/tests/store/markdown/markdown-memory-mutations.test.ts
+++ b/packages/core/tests/store/markdown/markdown-memory-mutations.test.ts
@@ -118,6 +118,27 @@ describe("markdown MemoryStore — archiveMemory", () => {
   });
 });
 
+describe("markdown MemoryStore — unarchiveMemory", () => {
+  it("restores an archived memory to active and bumps updated_at", () => {
+    const { store, seed } = setup();
+    seed({ id: "m", status: "archived" });
+    const restored = store.unarchiveMemory("m");
+    expect(restored!.status).toBe("active");
+    expect(restored!.updated_at).toBe(NOW);
+  });
+
+  it("is idempotent on an already-active memory (no-op)", () => {
+    const { store, seed } = setup();
+    seed({ id: "m", status: "active" });
+    expect(store.unarchiveMemory("m")!.status).toBe("active"); // already active → no-op
+  });
+
+  it("throws for an unknown id", () => {
+    const { store } = setup();
+    expect(() => store.unarchiveMemory("ghost")).toThrow(/No memory found/);
+  });
+});
+
 describe("markdown MemoryStore — verifyMemory", () => {
   it("nudges usefulness +1 / -1 and clamps to ±3", () => {
     const { store, seed } = setup();

--- a/packages/core/tests/store/markdown/markdown-store-git.test.ts
+++ b/packages/core/tests/store/markdown/markdown-store-git.test.ts
@@ -66,4 +66,17 @@ describe("markdown store + git — commit per write", () => {
       `memory: store ${memory.id}`,
     ]);
   });
+
+  it("unarchiveMemory records its own commit (revertable), idempotent on already-active", () => {
+    const { git, store } = setup();
+    const { memory } = store.createMemory({ agent_id: "codex", title: "t", body: "b" });
+    store.archiveMemory(memory.id);
+    const beforeUnarchive = git.log().length;
+    store.unarchiveMemory(memory.id);
+    expect(git.log()[0]).toBe(`memory: unarchive ${memory.id}`);
+    expect(git.log().length).toBe(beforeUnarchive + 1);
+    // Already active → no-op, no new commit.
+    store.unarchiveMemory(memory.id);
+    expect(git.log().length).toBe(beforeUnarchive + 1);
+  });
 });

--- a/packages/mcp-server/src/trpc/memories.ts
+++ b/packages/mcp-server/src/trpc/memories.ts
@@ -140,6 +140,12 @@ const SplitMemoryInputSchema = z.object({
   agent_id: z.string().optional(),
 });
 
+// unmerge (spec 044 D-5b) — `id` is the MERGED target whose merge to reverse.
+const UnmergeMemoryInputSchema = z.object({
+  id: z.string().min(1),
+  agent_id: z.string().optional(),
+});
+
 const ApproveProposalInputSchema = z.object({
   id: z.string().min(1),
   patch: MemoryPatchSchema.optional(),
@@ -281,6 +287,47 @@ export const memoriesRouter = router({
       "Memory not found",
     );
     return { ids };
+  }),
+
+  // Admin unmerge / reverse-a-groom (spec 044 D-5b): undo a bad merge. Given the
+  // MERGED target's id, read its `curator_note.supersedes` (the source ids the
+  // merge collapsed), un-archive every source (restore to active), then archive
+  // the merged target. The ordering is data-loss-safe: sources are RESTORED
+  // BEFORE the target is archived, so a partial failure can never leave the whole
+  // group archived. A memory with no superseded sources is not a merge result —
+  // we error rather than silently archive it (which would just lose the row).
+  // Each transition lands a git commit (revertable). The provenance of these
+  // status transitions is the `dashboard-admin` actor + the commit (curator_note
+  // is not patchable in place — same invariant D-5a documented for archive).
+  unmerge: adminProcedure.input(UnmergeMemoryInputSchema).mutation(({ ctx, input }) => {
+    const actor = input.agent_id ?? DASHBOARD_AGENT_ID;
+    const target = rethrowAsNotFound(() => {
+      const found = ctx.store.getMemory(input.id);
+      if (!found) throw new Error(`No memory found for id ${input.id}`);
+      return found;
+    }, "Memory not found") as unknown as MemoryShape;
+
+    const note = (target.curator_note ?? {}) as Record<string, unknown>;
+    const rawSupersedes = note.supersedes;
+    const supersedes = Array.isArray(rawSupersedes)
+      ? rawSupersedes.filter((s): s is string => typeof s === "string" && s.length > 0)
+      : [];
+    if (supersedes.length === 0) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: `Memory ${input.id} is not a merge result — it has no superseded sources to restore.`,
+      });
+    }
+
+    // Data-loss-safe ordering: restore every source FIRST, then archive the target.
+    for (const sourceId of supersedes) {
+      rethrowAsNotFound(
+        () => ctx.store.unarchiveMemory(sourceId, actor),
+        `Superseded source ${sourceId} not found`,
+      );
+    }
+    ctx.store.archiveMemory(input.id, actor);
+    return { restored: supersedes, archived: input.id };
   }),
 
   bulkUpdate: adminProcedure.input(BulkUpdateMemoryInputSchema).mutation(({ ctx, input }) => {

--- a/packages/mcp-server/tests/trpc/memories.test.ts
+++ b/packages/mcp-server/tests/trpc/memories.test.ts
@@ -588,3 +588,146 @@ describe("tRPC admin mutation primitives (spec 044 D-5a)", () => {
     }
   });
 });
+
+// unmerge / reverse-a-groom (spec 044 D-5b). Given a merged target, read its
+// curator_note.supersedes (the source ids it replaced), un-archive those sources
+// (restore them to active), and archive the merged target — reversing a bad merge.
+// Restore-sources-before-archive-target is the data-loss-safe ordering. Each
+// transition lands a git commit (revertable). Admin-gated.
+describe("tRPC unmerge / reverse-a-groom (spec 044 D-5b)", () => {
+  it("reverses a merge: restores the sources to active and archives the target", async () => {
+    const dataDir = makeTempDir();
+    const a = seedMemory(dataDir, { title: "Dup A", body: "same fact" });
+    const b = seedMemory(dataDir, { title: "Dup B", body: "same fact" });
+    const server = await startHttpServer({ dataDir });
+    try {
+      // Merge first (the bad merge): sources archived, target active.
+      const merged = await trpcPost<MemoryRow>(server, "memories.merge", {
+        source_ids: [a.id, b.id],
+        replacement: { title: "Merged fact", body: "the merged fact", category: "lessons" },
+      });
+      expect(memoryStatus(dataDir, a.id)).toBe("archived");
+      expect(memoryStatus(dataDir, b.id)).toBe("archived");
+      expect(memoryStatus(dataDir, merged.id)).toBe("active");
+
+      // Now unmerge it.
+      const result = await trpcPost<{ restored: string[]; archived: string }>(
+        server,
+        "memories.unmerge",
+        { id: merged.id },
+      );
+      expect(result.restored).toEqual([a.id, b.id]);
+      expect(result.archived).toBe(merged.id);
+
+      // Sources are active again; the merged target is archived.
+      expect(memoryStatus(dataDir, a.id)).toBe("active");
+      expect(memoryStatus(dataDir, b.id)).toBe("active");
+      expect(memoryStatus(dataDir, merged.id)).toBe("archived");
+
+      // Each transition is committed (revertable): the un-archives, then the archive.
+      const log = gitLog(dataDir);
+      expect(log.some((s) => s.includes(`unarchive ${a.id}`))).toBe(true);
+      expect(log.some((s) => s.includes(`unarchive ${b.id}`))).toBe(true);
+      expect(log.some((s) => s.includes(`archive ${merged.id}`))).toBe(true);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("restores sources BEFORE archiving the target (no data loss on partial failure)", async () => {
+    const dataDir = makeTempDir();
+    const a = seedMemory(dataDir, { title: "Dup A", body: "same fact" });
+    const b = seedMemory(dataDir, { title: "Dup B", body: "same fact" });
+    const server = await startHttpServer({ dataDir });
+    try {
+      const merged = await trpcPost<MemoryRow>(server, "memories.merge", {
+        source_ids: [a.id, b.id],
+        replacement: { title: "Merged fact", body: "the merged fact", category: "lessons" },
+      });
+      await trpcPost(server, "memories.unmerge", { id: merged.id });
+      // The data-loss-safe invariant: at no point are ALL of {sources, target}
+      // archived. After unmerge the sources are restored; even if the final
+      // archive of the target had failed, the sources would already be active —
+      // so a partial failure can never leave the whole group archived.
+      const sourcesActive =
+        memoryStatus(dataDir, a.id) === "active" && memoryStatus(dataDir, b.id) === "active";
+      expect(sourcesActive).toBe(true);
+      // The un-archive commits land before the target's archive commit (ordering).
+      const log = gitLog(dataDir); // newest-first
+      const archiveTargetIdx = log.findIndex((s) => s.includes(`archive ${merged.id}`));
+      const unarchiveAIdx = log.findIndex((s) => s.includes(`unarchive ${a.id}`));
+      const unarchiveBIdx = log.findIndex((s) => s.includes(`unarchive ${b.id}`));
+      // newest-first → a smaller index is a LATER commit; the target archive is
+      // the newest of the three (smallest index).
+      expect(archiveTargetIdx).toBeLessThan(unarchiveAIdx);
+      expect(archiveTargetIdx).toBeLessThan(unarchiveBIdx);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("returns a clear error for a memory with no superseded sources (not a merge result)", async () => {
+    const dataDir = makeTempDir();
+    const m = seedMemory(dataDir, { title: "Plain memory", body: "not a merge result" });
+    const server = await startHttpServer({ dataDir });
+    try {
+      const response = await fetch(`${server.url}/trpc/memories.unmerge`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${server.token}`,
+        },
+        body: JSON.stringify({ id: m.id }),
+      });
+      expect(response.status).toBeGreaterThanOrEqual(400);
+      const json = (await response.json()) as TrpcErr;
+      expect(json.error?.message).toMatch(/not a merge result|no superseded sources/i);
+      // No corpus change: the memory is untouched (still active).
+      expect(memoryStatus(dataDir, m.id)).toBe("active");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("returns NOT_FOUND for an unknown id", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const response = await fetch(`${server.url}/trpc/memories.unmerge`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${server.token}`,
+        },
+        body: JSON.stringify({ id: "mem_does_not_exist" }),
+      });
+      const json = (await response.json()) as TrpcErr;
+      expect(json.error?.data?.code).toBe("NOT_FOUND");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("rejects unauthenticated callers (admin-gated)", async () => {
+    const dataDir = makeTempDir();
+    const m = seedMemory(dataDir, { title: "Protected by gate" });
+    const server = await startHttpServer({ dataDir });
+    try {
+      const response = await fetch(`${server.url}/trpc/memories.unmerge`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: m.id }),
+      });
+      expect(response.status).toBe(401);
+      const json = (await response.json()) as TrpcErr;
+      expect(json.error?.data?.code).toBe("UNAUTHORIZED");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+});


### PR DESCRIPTION
## What

Net-new admin mutation that **reverses a bad merge** (spec 044 decision D-7). A merge archived N source memories and created one merged target; `unmerge` restores the sources and archives the target.

### `unarchiveMemory(id, actor)` store method
The narrow inverse of `archiveMemory` — there was no un-archive path today (`updateMemory` refuses status changes, `approveProposal` only un-proposes). It mirrors `archiveMemory` exactly: status Archived→Active, bumps `updated_at`, commits `memory: unarchive <id>`, and is idempotent (already-active → no-op, no commit). Declared on the store interface (`memory-types.ts`) and implemented in the markdown store.

### `unmerge` admin tRPC mutation (`memoriesRouter`, sibling of D5a's merge/split)
Input `{ id }` (the merged target). Flow:
1. `getMemory(id)` → read `curator_note.supersedes` (the source ids the merge collapsed).
2. If absent/empty (not a merge result) → **clear `BAD_REQUEST` error** ("memory `<id>` is not a merge result — it has no superseded sources to restore"), no corpus change. We error rather than silently archive into a destructive no-op.
3. **Un-archive each source FIRST, then archive the merged target** — the data-loss-safe ordering. A partial failure can never leave the whole group archived (a missing source 404s before the target is archived).

Returns `{ restored: string[], archived: string }`. Admin-gated (`adminProcedure`); each transition lands a git commit (revertable). Provenance of the status transitions is the `dashboard-admin` actor + the commit message (`curator_note` is not patchable in place — the same invariant D-5a documented for archive transitions).

## Out of scope
The unmerge **button** is D7 (dashboard). No chat (D6), no docs (D8). CHANGELOG deferred to D8's single 044 entry (consistent with D2–D5a — no operator-facing surface reaches this endpoint yet).

## Tests (TDD, RED→GREEN)
- **Core** (`markdown-memory-mutations.test.ts`, `markdown-store-git.test.ts`): `unarchiveMemory` round-trip Archived→Active, idempotent on already-active (no new commit), throws on unknown id, commit in `git log`.
- **mcp-server** (`memories.test.ts`, real HTTP bin): unmerge reverses a merge (sources active, target archived, commits asserted); restore-before-archive ordering (via git-log commit order); not-a-merge error (no corpus change); NOT_FOUND for unknown id; admin-gating (401 unauthenticated).

Full `pnpm test` green; `pnpm -r build` + typecheck + lint clean.

## Review
Self-conducted (no general-purpose review sub-agent in this sandbox) across: (a) restore-before-archive ordering, (b) not-a-merge guard, (c) unarchive mirrors archive, (d) admin-gating, (e) each transition commits — all pinned by tests; no Critical/Important findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)