### PR TITLE
feat(core): curator.chat per-consumer LLM config with grooming fallback (spec 044 PR-6a, Task D6a)

### DIFF
--- a/packages/core/src/curator-consumers.ts
+++ b/packages/core/src/curator-consumers.ts
@@ -28,20 +28,42 @@ import {
   resolveProviderToken,
 } from "./llm-providers.js";
 
+// The two scheduled/triggered curator JOBS that consume an LLM. This is the
+// job-iteration type AND list: enablement (`curator.<job>.enabled`), the legacy
+// migration, the addendum files, and the schedulers all key off it. Adding a new
+// member here makes the codebase treat it as a runnable job — do NOT add `chat`.
 export type CuratorConsumer = "intake" | "grooming";
 export const CURATOR_CONSUMERS: readonly CuratorConsumer[] = ["intake", "grooming"];
+
+// The CONFIG-ONLY superset of LLM consumers (spec 044 D-8). `chat` is the
+// interactive curator chat endpoint's LLM (D6b) — it has its OWN
+// `curator.chat.{provider,model,timeout_ms}` config but, unlike the two jobs, NO
+// enablement key, NO legacy migration, and NO scheduler. It is deliberately a
+// SEPARATE type from `CuratorConsumer` (not a widening) so the job-only paths —
+// `enabledKey`, `migrateLegacyCuratorLlm`'s `CURATOR_CONSUMERS` loop, the
+// addendum store methods — stay typed to jobs and can never silently start
+// treating `chat` as a job. Only the per-consumer config surface
+// (`readConsumerConfig` / `writeConsumerConfig` / `resolveConsumerToken`) widens
+// to `LlmConsumer`.
+export type LlmConsumer = CuratorConsumer | "chat";
+
+// When the `chat` consumer's own config is unset, it resolves WHOLE-CONSUMER from
+// this job's config (spec 044 D-8): provider + model + token + timeout. Set
+// chat's own provider to override the fallback entirely.
+const CHAT_FALLBACK_CONSUMER: CuratorConsumer = "grooming";
 
 const DEFAULT_TIMEOUT_MS = 60_000;
 const MIN_TIMEOUT_MS = 1_000;
 const MAX_TIMEOUT_MS = 600_000;
 
 export interface ConsumerConfig {
-  consumer: CuratorConsumer;
+  consumer: LlmConsumer;
   /**
    * Whether this job is enabled, from the unified `curator.<consumer>.enabled`
    * setting (spec 043 D-E). Default off. The setting is authoritative; the
    * legacy sources (curator.enabled / LIBRARIAN_CONSOLIDATOR) only seed it once
-   * via migrateCuratorEnablement.
+   * via migrateCuratorEnablement. ALWAYS `false` for the config-only `chat`
+   * consumer — it is not a job and has no enablement key.
    */
   enabled: boolean;
   /** Referenced provider id; "" when unset. */
@@ -83,7 +105,7 @@ interface ConsumerKeys {
   timeoutMs: string;
 }
 
-function consumerKeys(consumer: CuratorConsumer): ConsumerKeys {
+function consumerKeys(consumer: LlmConsumer): ConsumerKeys {
   const prefix = `curator.${consumer}`;
   return {
     provider: `${prefix}.provider`,
@@ -112,13 +134,31 @@ function parseTimeoutMs(raw: string | null): number {
   return boundedTimeout(raw) ?? DEFAULT_TIMEOUT_MS;
 }
 
-/** Read a consumer's resolved config, joined with its referenced provider. Never throws. */
-export function readConsumerConfig(
-  store: ConsumerReader,
-  consumer: CuratorConsumer,
-): ConsumerConfig {
+/**
+ * Read a consumer's resolved config, joined with its referenced provider. Never
+ * throws.
+ *
+ * The config-only `chat` consumer (spec 044 D-8) falls back WHOLE-CONSUMER to the
+ * grooming consumer when its OWN provider is unset: with no `curator.chat.provider`
+ * set, chat resolves entirely from grooming (provider + model + timeout, and
+ * `resolveConsumerToken` mirrors this). Once chat's own provider IS set, chat's
+ * own model/timeout/token win — there is no per-field mixing. `chat` is never a
+ * job, so its resolved `enabled` is always `false`.
+ */
+export function readConsumerConfig(store: ConsumerReader, consumer: LlmConsumer): ConsumerConfig {
+  // chat with no own provider configured -> resolve the grooming consumer instead,
+  // but keep `consumer: "chat"` so the caller knows which config it requested.
+  if (consumer === "chat" && (store.getSetting(consumerKeys("chat").provider) ?? "") === "") {
+    return {
+      ...readConsumerConfig(store, CHAT_FALLBACK_CONSUMER),
+      consumer: "chat",
+      enabled: false,
+    };
+  }
+
   const keys = consumerKeys(consumer);
-  const enabled = store.getSetting(enabledKey(consumer)) === "true";
+  // `chat` has no enablement key (it is not a job) -> always false.
+  const enabled = consumer !== "chat" && store.getSetting(enabledKey(consumer)) === "true";
   const providerId = store.getSetting(keys.provider) ?? "";
   const model = store.getSetting(keys.model) ?? "";
   const timeoutMs = parseTimeoutMs(store.getSetting(keys.timeoutMs));
@@ -138,10 +178,14 @@ export function readConsumerConfig(
   };
 }
 
-/** Patch a consumer's provider/model/timeout. Validates the timeout bound. */
+/**
+ * Patch a consumer's provider/model/timeout. Validates the timeout bound. The
+ * config-only `chat` consumer has NO enablement key (it is not a job), so a
+ * `patch.enabled` for `chat` is rejected — chat can never be enabled/disabled.
+ */
 export function writeConsumerConfig(
   store: ConsumerStore,
-  consumer: CuratorConsumer,
+  consumer: LlmConsumer,
   patch: ConsumerConfigPatch,
 ): void {
   if (patch.timeoutMs !== undefined) {
@@ -153,19 +197,31 @@ export function writeConsumerConfig(
     }
   }
   const keys = consumerKeys(consumer);
-  if (patch.enabled !== undefined)
+  if (patch.enabled !== undefined) {
+    if (consumer === "chat") {
+      throw new Error("curator.chat has no enablement — chat is an endpoint, not a job");
+    }
     store.setSetting(enabledKey(consumer), patch.enabled ? "true" : "false");
+  }
   if (patch.providerId !== undefined) store.setSetting(keys.provider, patch.providerId);
   if (patch.model !== undefined) store.setSetting(keys.model, patch.model);
   if (patch.timeoutMs !== undefined) store.setSetting(keys.timeoutMs, String(patch.timeoutMs));
 }
 
-/** Decrypt the token of the provider a consumer references. Null when unset/missing. Needs the master key. */
-export function resolveConsumerToken(
-  store: ConsumerReader,
-  consumer: CuratorConsumer,
-): string | null {
-  const providerId = store.getSetting(consumerKeys(consumer).provider) ?? "";
+/**
+ * Decrypt the token of the provider a consumer references. Null when
+ * unset/missing. Needs the master key.
+ *
+ * Mirrors `readConsumerConfig`'s grooming fallback for `chat` (spec 044 D-8): an
+ * unconfigured chat consumer resolves grooming's token, so the chat endpoint runs
+ * on grooming's provider until it is given its own.
+ */
+export function resolveConsumerToken(store: ConsumerReader, consumer: LlmConsumer): string | null {
+  const target =
+    consumer === "chat" && (store.getSetting(consumerKeys("chat").provider) ?? "") === ""
+      ? CHAT_FALLBACK_CONSUMER
+      : consumer;
+  const providerId = store.getSetting(consumerKeys(target).provider) ?? "";
   if (!providerId) return null;
   return resolveProviderToken(store, providerId);
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -252,6 +252,7 @@ export {
   type ConsumerConfig,
   type ConsumerConfigPatch,
   type CuratorConsumer,
+  type LlmConsumer,
   CURATOR_CONSUMERS,
   ConsumerConfigPatchSchema,
   migrateLegacyCuratorLlm,

--- a/packages/core/tests/curator-consumers.test.ts
+++ b/packages/core/tests/curator-consumers.test.ts
@@ -9,6 +9,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
+  CURATOR_CONSUMERS,
   type LibrarianStore,
   addProvider,
   createLibrarianStore,
@@ -199,6 +200,172 @@ describe("per-consumer LLM resolution", () => {
         /timeout/i,
       );
       expect(() => writeConsumerConfig(store, "intake", { timeoutMs: 1.5 })).toThrow(/timeout/i);
+    });
+  });
+
+  // The `chat` consumer (spec 044 D-8): a third, CONFIG-ONLY LLM consumer for the
+  // interactive curator chat endpoint (D6b). It is NOT a job — no enablement key,
+  // no scheduler, no legacy migration. When its own config is unset it falls back
+  // WHOLE-CONSUMER to the grooming consumer (provider + model + token + timeout).
+  describe("chat consumer (config-only, grooming fallback)", () => {
+    it("round-trips its own provider/model/timeout", () => {
+      const { store } = s!;
+      const p = addProvider(store, {
+        name: "ChatProvider",
+        endpoint: "https://chat.example/v1",
+        token: "dummy-chat-token",
+      });
+      writeConsumerConfig(store, "chat", {
+        providerId: p.id,
+        model: "chat-model",
+        timeoutMs: 30_000,
+      });
+
+      const cfg = readConsumerConfig(store, "chat");
+      expect(cfg.consumer).toBe("chat");
+      expect(cfg.providerId).toBe(p.id);
+      expect(cfg.endpoint).toBe("https://chat.example/v1");
+      expect(cfg.model).toBe("chat-model");
+      expect(cfg.timeoutMs).toBe(30_000);
+      expect(cfg.hasToken).toBe(true);
+      expect(cfg.isOperational).toBe(true);
+      // The writes land under the `curator.chat.*` namespace.
+      expect(store.getSetting("curator.chat.provider")).toBe(p.id);
+      expect(store.getSetting("curator.chat.model")).toBe("chat-model");
+      expect(store.getSetting("curator.chat.timeout_ms")).toBe("30000");
+    });
+
+    it("the token is write-only — only presence (hasToken) is read back", () => {
+      const { store } = s!;
+      const p = addProvider(store, {
+        name: "ChatP",
+        endpoint: "https://c.example/v1",
+        token: "dummy-chat-secret",
+      });
+      writeConsumerConfig(store, "chat", { providerId: p.id, model: "m" });
+      const cfg = readConsumerConfig(store, "chat");
+      expect(cfg.hasToken).toBe(true);
+      // The resolved view never carries the token value itself.
+      expect(JSON.stringify(cfg)).not.toContain("dummy-chat-secret");
+    });
+
+    it("falls back WHOLE-CONSUMER to grooming when chat's own config is unset", () => {
+      const { store } = s!;
+      const groom = addProvider(store, {
+        name: "Groom",
+        endpoint: "https://groom.example/v1",
+        token: "dummy-groom-token",
+      });
+      writeConsumerConfig(store, "grooming", {
+        providerId: groom.id,
+        model: "groom-model",
+        timeoutMs: 42_000,
+      });
+
+      // chat is entirely unset -> resolves from grooming (provider/model/token/timeout).
+      const cfg = readConsumerConfig(store, "chat");
+      expect(cfg.consumer).toBe("chat");
+      expect(cfg.providerId).toBe(groom.id);
+      expect(cfg.endpoint).toBe("https://groom.example/v1");
+      expect(cfg.model).toBe("groom-model");
+      expect(cfg.timeoutMs).toBe(42_000);
+      expect(cfg.hasToken).toBe(true);
+      expect(cfg.isOperational).toBe(true);
+      // The token resolves from grooming's provider too.
+      expect(resolveConsumerToken(store, "chat")).toBe("dummy-groom-token");
+    });
+
+    it("uses chat's OWN config (not grooming's) once chat's provider is set", () => {
+      const { store } = s!;
+      const groom = addProvider(store, {
+        name: "Groom",
+        endpoint: "https://groom.example/v1",
+        token: "dummy-groom-token",
+      });
+      const chat = addProvider(store, {
+        name: "Chat",
+        endpoint: "https://chat.example/v1",
+        token: "dummy-chat-own",
+      });
+      writeConsumerConfig(store, "grooming", {
+        providerId: groom.id,
+        model: "groom-model",
+        timeoutMs: 42_000,
+      });
+      writeConsumerConfig(store, "chat", {
+        providerId: chat.id,
+        model: "chat-model",
+        timeoutMs: 30_000,
+      });
+
+      const cfg = readConsumerConfig(store, "chat");
+      expect(cfg.providerId).toBe(chat.id);
+      expect(cfg.endpoint).toBe("https://chat.example/v1");
+      expect(cfg.model).toBe("chat-model");
+      expect(cfg.timeoutMs).toBe(30_000);
+      expect(resolveConsumerToken(store, "chat")).toBe("dummy-chat-own");
+    });
+
+    it("falls back for resolveConsumerToken when chat is unset but grooming is set", () => {
+      const { store } = s!;
+      const groom = addProvider(store, {
+        name: "Groom",
+        endpoint: "https://groom.example/v1",
+        token: "dummy-groom-token",
+      });
+      writeConsumerConfig(store, "grooming", { providerId: groom.id, model: "m" });
+      expect(resolveConsumerToken(store, "chat")).toBe("dummy-groom-token");
+    });
+
+    it("resolves inert (not operational) when neither chat nor grooming is configured", () => {
+      const { store } = s!;
+      const cfg = readConsumerConfig(store, "chat");
+      expect(cfg.consumer).toBe("chat");
+      expect(cfg.providerId).toBe("");
+      expect(cfg.providerExists).toBe(false);
+      expect(cfg.isOperational).toBe(false);
+      expect(resolveConsumerToken(store, "chat")).toBeNull();
+    });
+
+    it("is NOT a job: not in CURATOR_CONSUMERS and has no enablement key", () => {
+      const { store } = s!;
+      // The job-iteration list must stay intake+grooming only.
+      expect(CURATOR_CONSUMERS).toEqual(["intake", "grooming"]);
+      expect(CURATOR_CONSUMERS).not.toContain("chat");
+
+      // chat has no enablement key; its resolved config never reports enabled.
+      writeConsumerConfig(store, "chat", { providerId: "p", model: "m" });
+      expect(readConsumerConfig(store, "chat").enabled).toBe(false);
+      // No `curator.chat.enabled` setting is ever written.
+      expect(store.getSetting("curator.chat.enabled")).toBeNull();
+    });
+
+    it("rejects an attempt to enable/disable chat (it has no enablement)", () => {
+      const { store } = s!;
+      expect(() => writeConsumerConfig(store, "chat", { enabled: true })).toThrow(/enablement/i);
+      expect(() => writeConsumerConfig(store, "chat", { enabled: false })).toThrow(/enablement/i);
+      // The rejection fires before any write -> no chat enablement key materialises.
+      expect(store.getSetting("curator.chat.enabled")).toBeNull();
+    });
+
+    it("migrateLegacyCuratorLlm does NOT seed a chat config (chat is not a job)", () => {
+      const { store } = s!;
+      writeLlmConnection(store, llmConnectionKeys("curator.llm"), {
+        provider: "openai",
+        endpoint: "https://legacy.example/v1",
+        model: "legacy-model",
+        timeoutMs: 45_000,
+        token: "dummy-legacy-token",
+      });
+      expect(migrateLegacyCuratorLlm(store)).toBe(true);
+      // Migration seeds intake + grooming only — never chat's own keys.
+      expect(store.getSetting("curator.chat.provider")).toBeNull();
+      expect(store.getSetting("curator.chat.model")).toBeNull();
+      expect(store.getSetting("curator.chat.timeout_ms")).toBeNull();
+      // But chat still RESOLVES (via the grooming fallback) to the migrated config.
+      const cfg = readConsumerConfig(store, "chat");
+      expect(cfg.model).toBe("legacy-model");
+      expect(cfg.isOperational).toBe(true);
     });
   });
 

--- a/packages/mcp-server/src/trpc/llm.ts
+++ b/packages/mcp-server/src/trpc/llm.ts
@@ -1,8 +1,8 @@
 // LLM provider + per-consumer model config admin tRPC (spec 042 §4).
 //
 // The admin cockpit's typed surface for named LLM providers and the per-consumer
-// (intake / grooming) provider+model selection. All admin-gated — there is no
-// consumer-agent surface for LLM config. Provider tokens are write-only: reads
+// (intake / grooming / chat) provider+model selection. All admin-gated — there is
+// no consumer-agent surface for LLM config. Provider tokens are write-only: reads
 // expose presence only (`hasToken`), never the value; core's `addProvider` /
 // `updateProvider` store the token encrypted.
 //
@@ -34,7 +34,13 @@ import { z } from "zod";
 import { fetchProviderModels, probeProviderConnection } from "./llm-models.js";
 import { adminProcedure, router } from "./trpc.js";
 
-const ConsumerSchema = z.enum(["intake", "grooming"]);
+// The per-consumer LLM config surface covers the two curator JOBS (intake /
+// grooming) PLUS the config-only `chat` consumer (spec 044 D-8) — D6b's curator
+// chat endpoint's LLM, which falls back to the grooming consumer when its own
+// config is unset (handled in core's readConsumerConfig / resolveConsumerToken).
+// `chat` has no enablement, so a `setConsumerConfig({consumer:"chat", enabled})`
+// is rejected at the core boundary.
+const ConsumerSchema = z.enum(["intake", "grooming", "chat"]);
 
 // A model query may target an already-saved provider (token resolved from the
 // vault) OR an inline draft `{ endpoint, token }`, so the dashboard can test a
@@ -83,7 +89,9 @@ export const llmRouter = router({
       return listProviders(ctx.store);
     }),
 
-  // Per-consumer provider+model selection (intake / grooming).
+  // Per-consumer provider+model selection (intake / grooming / chat). Reading
+  // the `chat` consumer returns its grooming-fallback-resolved view when chat's
+  // own config is unset (spec 044 D-8).
   consumerConfig: adminProcedure
     .input(z.strictObject({ consumer: ConsumerSchema }))
     .query(({ ctx, input }) => readConsumerConfig(ctx.store, input.consumer)),

--- a/packages/mcp-server/tests/trpc/llm.test.ts
+++ b/packages/mcp-server/tests/trpc/llm.test.ts
@@ -156,6 +156,116 @@ describe("tRPC llm provider surface", () => {
     }
   });
 
+  it("exposes the chat consumer: round-trips its own config (spec 044 D-8)", async () => {
+    const dataDir = makeTempDir();
+    const secretKey = "0123456789abcdef".repeat(4);
+    const server = await startHttpServer({ dataDir, secretKey });
+    try {
+      const chatProvider = await trpcPost<Provider>(server, "llm.addProvider", {
+        name: "ChatProvider",
+        endpoint: "https://chat.example/v1",
+        token: "dummy-chat-token",
+      });
+
+      const written = await trpcPost<ConsumerConfig>(server, "llm.setConsumerConfig", {
+        consumer: "chat",
+        providerId: chatProvider.id,
+        model: "chat-model",
+        timeoutMs: 30_000,
+      });
+      expect(written.consumer).toBe("chat");
+      expect(written.model).toBe("chat-model");
+      expect(written.isOperational).toBe(true);
+      // The token is never returned, only its presence.
+      expect(written.hasToken).toBe(true);
+      expect(JSON.stringify(written)).not.toContain("dummy-chat-token");
+
+      const read = await trpcGet<ConsumerConfig>(server, "llm.consumerConfig", {
+        consumer: "chat",
+      });
+      expect(read.consumer).toBe("chat");
+      expect(read.endpoint).toBe("https://chat.example/v1");
+      expect(read.model).toBe("chat-model");
+      expect(read.timeoutMs).toBe(30_000);
+      expect(read.isOperational).toBe(true);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("chat consumer falls back to grooming's config when chat's own is unset (spec 044 D-8)", async () => {
+    const dataDir = makeTempDir();
+    const secretKey = "0123456789abcdef".repeat(4);
+    const server = await startHttpServer({ dataDir, secretKey });
+    try {
+      const groom = await trpcPost<Provider>(server, "llm.addProvider", {
+        name: "Groom",
+        endpoint: "https://groom.example/v1",
+        token: "dummy-groom-token",
+      });
+      await trpcPost<ConsumerConfig>(server, "llm.setConsumerConfig", {
+        consumer: "grooming",
+        providerId: groom.id,
+        model: "groom-model",
+        timeoutMs: 42_000,
+      });
+
+      // chat unset -> resolves whole-consumer from grooming.
+      const chat = await trpcGet<ConsumerConfig>(server, "llm.consumerConfig", {
+        consumer: "chat",
+      });
+      expect(chat.consumer).toBe("chat");
+      expect(chat.endpoint).toBe("https://groom.example/v1");
+      expect(chat.model).toBe("groom-model");
+      expect(chat.timeoutMs).toBe(42_000);
+      expect(chat.isOperational).toBe(true);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("rejects an unknown consumer for read and write", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const readUrl = new URL(`${server.url}/trpc/llm.consumerConfig`);
+      readUrl.searchParams.set("input", JSON.stringify({ consumer: "bogus" }));
+      const readResp = await fetch(readUrl, {
+        headers: { authorization: `Bearer ${server.token}` },
+      });
+      expect(readResp.status).toBeGreaterThanOrEqual(400);
+
+      const writeResp = await fetch(`${server.url}/trpc/llm.setConsumerConfig`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${server.token}`,
+        },
+        body: JSON.stringify({ consumer: "bogus", model: "x" }),
+      });
+      expect(writeResp.status).toBeGreaterThanOrEqual(400);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("the chat consumer config is admin-gated", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const url = new URL(`${server.url}/trpc/llm.consumerConfig`);
+      url.searchParams.set("input", JSON.stringify({ consumer: "chat" }));
+      const response = await fetch(url);
+      expect(response.status).toBeGreaterThanOrEqual(400);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
   // An unreachable port (127.0.0.1:1) makes the outbound /models fetch fail fast.
   // The token must never surface in the fail-soft result.
   const UNREACHABLE = "http://127.0.0.1:1/v1";


### PR DESCRIPTION
## What

Adds a **third, config-only LLM consumer `chat`** for the upcoming curator chat endpoint (Task D6b), alongside the two curator jobs `intake` + `grooming`. This is **D6a** — the split-out config half of spec 044 PR-6 (Task D6). **No chat endpoint** lands here (that's D6b).

## The 3rd consumer

`curator.chat.{provider,model,timeout_ms}` (+ token) — a per-consumer LLM config exactly like `intake`/`grooming`'s (spec 042 B2), but **config-only, not a runnable job**.

### Config-only, NOT a job

`intake`/`grooming` are scheduled/triggered jobs (enablement key, legacy migration, schedulers). `chat` is an interactive endpoint, so:

- **Type model = a separate superset `LlmConsumer = CuratorConsumer | "chat"`**, NOT a widening of `CuratorConsumer`. The JOB type `CuratorConsumer` and the job-iteration list `CURATOR_CONSUMERS` stay `intake`+`grooming` only — so every job-only path that reuses `CuratorConsumer` (the addendum store methods, `enabledKey`, `migrateLegacyCuratorLlm`'s loop, the schedulers) stays typed to jobs and can never silently treat `chat` as a job. Only the three per-consumer config functions widen to `LlmConsumer`.
- **No enablement:** `writeConsumerConfig` rejects `{consumer:"chat", enabled}`; chat's resolved `enabled` is always `false`; no `curator.chat.enabled` key is ever written.
- **No migration:** `migrateLegacyCuratorLlm` iterates the unchanged `CURATOR_CONSUMERS` and never seeds `curator.chat.*`.
- **No scheduler** references chat.

### Grooming fallback (spec 044 D-8)

**Whole-consumer fallback.** When `curator.chat.provider` is unset, `readConsumerConfig(store,"chat")` and `resolveConsumerToken(store,"chat")` resolve chat **entirely from the grooming consumer** (provider + model + token + timeout, tagged `consumer:"chat"`). Once chat's own provider is set, chat's own config wins entirely (no per-field mixing).

### tRPC exposure

`ConsumerSchema` in `trpc/llm.ts` widened to `z.enum(["intake","grooming","chat"])`, so D7's dashboard can read/write the chat consumer via the existing `llm.consumerConfig` / `llm.setConsumerConfig`. Token stays **write-only** (presence only on read). Admin-gated. Unknown consumers rejected.

## Tests (TDD, RED→GREEN)

- core `curator-consumers.test.ts` (+10): own-config round-trip; token write-only; whole-consumer grooming fallback; chat-own-wins; token fallback; inert-when-neither-set; not-a-job (`CURATOR_CONSUMERS` + no enabled key); migration-doesn't-seed-chat; reject chat enable/disable.
- mcp-server `trpc/llm.test.ts` (+4): chat own-config round-trip via real HTTP; chat grooming fallback; unknown-consumer rejected (read+write); chat admin-gated.

Full `pnpm test` green, `pnpm -r build` + typecheck + lint clean.

## Out of scope (D6b/D7/D8)

No `curator.chat` endpoint, no dashboard UI, no CHANGELOG entry (deferred to D8's single 044 entry — no operator-facing surface yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)