### PR TITLE
feat(dashboard): curator chat UI + lifecycle controls (spec 044 PR-7, Task D7)

### DIFF
--- a/apps/dashboard/app/curator/actions.ts
+++ b/apps/dashboard/app/curator/actions.ts
@@ -1,18 +1,22 @@
 "use server";
 
 import type {
+  ChatResponse,
   ConsolidationOperation,
   ConsolidatorTickResult,
   ConsumerConfig,
   ConsumerConfigPatch,
   CuratorConfigPatch,
   CuratorConsumer,
+  CuratorJob,
   CuratorTickResult,
   LlmProvider,
   LlmProviderInput,
   LlmProviderPatch,
+  ProposedAction,
 } from "@librarian/core";
 import { revalidatePath } from "next/cache";
+import type { RouterInputs } from "@/components/memories/types";
 import { serverTRPC } from "@/lib/trpc-server";
 
 export type RunNowResult = { ok: true; result: CuratorTickResult } | { ok: false; error: string };
@@ -182,6 +186,162 @@ export async function loadIntakeOperationsAction(runId: string): Promise<LoadOpe
   try {
     const operations = await serverTRPC.intake.runOperations.query({ runId });
     return { ok: true, operations };
+  } catch (error) {
+    return { ok: false, error: message(error) };
+  }
+}
+
+// --- Curator chat (spec 044 D-7 / decisions D-5/6/9/11) -----------------------
+// The whole 2C self-improvement loop surfaced in the dashboard: discuss a memory
+// (or the corpus) with the curator, accept its proposed fixes, and drive the
+// addendum-evaluation lifecycle.
+
+export type ChatResult = { ok: true; response: ChatResponse } | { ok: false; error: string };
+
+// One chat turn: send the conversation so far (+ an optional memory to ground in,
+// + an optional job) and get back exactly ONE response (NO streaming). The panel
+// keeps the messages array client-side and appends. A non-operational chat LLM
+// surfaces a clear error ("configure the chat/grooming LLM first").
+export async function chatAction(input: {
+  messages: { role: "system" | "user" | "assistant"; content: string }[];
+  memoryId?: string;
+  job?: CuratorJob;
+}): Promise<ChatResult> {
+  try {
+    const response = await serverTRPC.curator.chat.mutate({
+      messages: input.messages,
+      ...(input.memoryId ? { memoryId: input.memoryId } : {}),
+      ...(input.job ? { job: input.job } : {}),
+    });
+    return { ok: true, response };
+  } catch (error) {
+    return { ok: false, error: message(error) };
+  }
+}
+
+// Confirm a proposed action (human-in-the-loop). The chat NEVER auto-runs an
+// action; the admin clicks Confirm and ONLY THEN does the matching D5 memory
+// mutation run. The action's `type` selects the mutation; the rest of the action
+// IS that mutation's input (the proposed-action schema mirrors the D5 inputs
+// exactly), so we drop `type` and pass the rest straight through.
+export type ConfirmActionResult = { ok: true } | { ok: false; error: string };
+
+export async function confirmActionAction(action: ProposedAction): Promise<ConfirmActionResult> {
+  try {
+    const { type, ...input } = action;
+    switch (type) {
+      case "merge":
+        await serverTRPC.memories.merge.mutate(input as RouterInputs["memories"]["merge"]);
+        break;
+      case "split":
+        await serverTRPC.memories.split.mutate(input as RouterInputs["memories"]["split"]);
+        break;
+      case "update":
+        await serverTRPC.memories.update.mutate(input as RouterInputs["memories"]["update"]);
+        break;
+      case "unmerge":
+        await serverTRPC.memories.unmerge.mutate(input as RouterInputs["memories"]["unmerge"]);
+        break;
+    }
+    revalidatePath("/curator");
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: message(error) };
+  }
+}
+
+// --- Addendum lifecycle (spec 044 D-3/D-4) ------------------------------------
+
+export type AddendumState = {
+  content: string;
+  version: string | null;
+  status: "accepted" | "under_evaluation";
+  evalVersion: string | null;
+};
+export type AddendumStateResult =
+  | { ok: true; addendum: AddendumState }
+  | { ok: false; error: string };
+
+// Commit a new addendum draft for a job — it goes UNDER EVALUATION (the curator
+// force-proposes until accepted). Works whether or not the job is enabled (D-11):
+// the edit commits and takes effect when the job next runs. The 2 KB cap is the
+// hard backstop (setJobAddendum throws over-cap); surfaced as an error here.
+export async function setAddendumAction(input: {
+  job: CuratorJob;
+  content: string;
+}): Promise<AddendumStateResult> {
+  try {
+    const addendum = await serverTRPC.addendum.set.mutate(input);
+    revalidatePath("/curator");
+    return { ok: true, addendum };
+  } catch (error) {
+    return { ok: false, error: message(error) };
+  }
+}
+
+// Accept the addendum under evaluation: resume auto-apply.
+export async function acceptAddendumAction(input: {
+  job: CuratorJob;
+}): Promise<AddendumStateResult> {
+  try {
+    const status = await serverTRPC.addendum.accept.mutate(input);
+    const current = await serverTRPC.addendum.get.query(input);
+    revalidatePath("/curator");
+    return { ok: true, addendum: { ...current, ...status } };
+  } catch (error) {
+    return { ok: false, error: message(error) };
+  }
+}
+
+// Roll back the addendum under evaluation to its prior committed version.
+export async function rollbackAddendumAction(input: {
+  job: CuratorJob;
+}): Promise<AddendumStateResult> {
+  try {
+    await serverTRPC.addendum.rollback.mutate(input);
+    const current = await serverTRPC.addendum.get.query(input);
+    revalidatePath("/curator");
+    return { ok: true, addendum: current };
+  } catch (error) {
+    return { ok: false, error: message(error) };
+  }
+}
+
+// Re-evaluate the proposals tagged with the current eval version (GROOMING ONLY —
+// intake is not replayable). Returns the summary so the admin sees the count.
+export type ReEvaluateResult =
+  | { ok: true; result: Awaited<ReturnType<typeof serverTRPC.addendum.reEvaluate.mutate>> }
+  | { ok: false; error: string };
+
+export async function reEvaluateAddendumAction(input: {
+  job: CuratorJob;
+}): Promise<ReEvaluateResult> {
+  try {
+    const result = await serverTRPC.addendum.reEvaluate.mutate(input);
+    revalidatePath("/curator");
+    return { ok: true, result };
+  } catch (error) {
+    return { ok: false, error: message(error) };
+  }
+}
+
+// Dry-run grooming with a CANDIDATE (uncommitted) addendum (GROOMING ONLY). With
+// no slice it runs the whole corpus in the background and returns `{started:true}`
+// immediately; the admin polls the runs/proposals for results.
+type DryRunMutationResult = Awaited<ReturnType<typeof serverTRPC.curator.dryRunGrooming.mutate>>;
+export type DryRunActionResult =
+  | { ok: true; result: DryRunMutationResult }
+  | { ok: false; error: string };
+
+export async function dryRunGroomingAction(input: {
+  candidateAddendum: string;
+}): Promise<DryRunActionResult> {
+  try {
+    const result = await serverTRPC.curator.dryRunGrooming.mutate({
+      candidateAddendum: input.candidateAddendum,
+    });
+    revalidatePath("/curator");
+    return { ok: true, result };
   } catch (error) {
     return { ok: false, error: message(error) };
   }

--- a/apps/dashboard/app/curator/page.tsx
+++ b/apps/dashboard/app/curator/page.tsx
@@ -6,18 +6,26 @@
 // is read via tRPC here and passed to the client controls.
 
 import {
+  acceptAddendumAction,
   addProviderAction,
+  chatAction,
+  confirmActionAction,
   deleteProviderAction,
+  dryRunGroomingAction,
   listModelsAction,
   loadIntakeOperationsAction,
+  reEvaluateAddendumAction,
+  rollbackAddendumAction,
   runCuratorNowAction,
   runIntakeNowAction,
   saveCuratorConfigAction,
+  setAddendumAction,
   setConsumerConfigAction,
   setIntakeConfigAction,
   testConnectionAction,
   updateProviderAction,
 } from "@/app/curator/actions";
+import { CuratorChatWorkspace } from "@/components/curator/chat-workspace";
 import { CuratorConfigForm } from "@/components/curator/config-form";
 import { CuratorConfigSummary } from "@/components/curator/config-summary";
 import { ConsumerModelSelector } from "@/components/curator/consumer-model-selector";
@@ -42,18 +50,31 @@ export default async function CuratorPage() {
   let intakeRuns: Awaited<ReturnType<typeof serverTRPC.intake.runs.query>> = [];
   let intakeConsumer: Awaited<ReturnType<typeof serverTRPC.llm.consumerConfig.query>> | null = null;
   let grooming: Awaited<ReturnType<typeof serverTRPC.llm.consumerConfig.query>> | null = null;
+  let groomingAddendum: Awaited<ReturnType<typeof serverTRPC.addendum.get.query>> | null = null;
+  let intakeAddendum: Awaited<ReturnType<typeof serverTRPC.addendum.get.query>> | null = null;
   let error: string | null = null;
   try {
-    [config, runs, providers, intakeConfig, intakeRuns, intakeConsumer, grooming] =
-      await Promise.all([
-        serverTRPC.curator.config.query(),
-        serverTRPC.curator.runs.query({ limit: 50 }),
-        serverTRPC.llm.listProviders.query(),
-        serverTRPC.intake.config.query(),
-        serverTRPC.intake.runs.query({ limit: 50 }),
-        serverTRPC.llm.consumerConfig.query({ consumer: "intake" }),
-        serverTRPC.llm.consumerConfig.query({ consumer: "grooming" }),
-      ]);
+    [
+      config,
+      runs,
+      providers,
+      intakeConfig,
+      intakeRuns,
+      intakeConsumer,
+      grooming,
+      groomingAddendum,
+      intakeAddendum,
+    ] = await Promise.all([
+      serverTRPC.curator.config.query(),
+      serverTRPC.curator.runs.query({ limit: 50 }),
+      serverTRPC.llm.listProviders.query(),
+      serverTRPC.intake.config.query(),
+      serverTRPC.intake.runs.query({ limit: 50 }),
+      serverTRPC.llm.consumerConfig.query({ consumer: "intake" }),
+      serverTRPC.llm.consumerConfig.query({ consumer: "grooming" }),
+      serverTRPC.addendum.get.query({ job: "grooming" }),
+      serverTRPC.addendum.get.query({ job: "intake" }),
+    ]);
   } catch (err) {
     error = err instanceof Error ? err.message : String(err);
   }
@@ -68,6 +89,48 @@ export default async function CuratorPage() {
         </p>
       </header>
       {error ? <p className="text-sm text-destructive">{error}</p> : null}
+
+      {/* Curator chat workspace (spec 044 D-7): discuss a job/the corpus with the
+          curator, accept proposed fixes, draft an addendum, and drive the
+          addendum-evaluation lifecycle. The chat proposes; the admin confirms. */}
+      {groomingAddendum && intakeAddendum ? (
+        <section className="flex flex-col gap-3" aria-label="Curator chat">
+          <header className="border-b pb-2">
+            <h2 className="text-xl font-semibold">Chat &amp; addendum</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Discuss the corpus with the curator and teach it via the addendum. Proposed fixes are
+              applied only when you confirm them — nothing runs automatically.
+            </p>
+          </header>
+          <CuratorChatWorkspace
+            jobs={{
+              grooming: {
+                content: groomingAddendum.content,
+                version: groomingAddendum.version,
+                status: groomingAddendum.status,
+                evalVersion: groomingAddendum.evalVersion,
+                enabled: config?.enabled ?? false,
+              },
+              intake: {
+                content: intakeAddendum.content,
+                version: intakeAddendum.version,
+                status: intakeAddendum.status,
+                evalVersion: intakeAddendum.evalVersion,
+                enabled: intakeConfig?.enabled ?? false,
+              },
+            }}
+            actions={{
+              onChat: chatAction,
+              onConfirmAction: confirmActionAction,
+              onSetAddendum: setAddendumAction,
+              onAccept: acceptAddendumAction,
+              onRollback: rollbackAddendumAction,
+              onReEvaluate: reEvaluateAddendumAction,
+              onDryRun: dryRunGroomingAction,
+            }}
+          />
+        </section>
+      ) : null}
 
       {/* Shared LLM providers — serves both jobs, so it lives once, above the
           per-job sections. */}

--- a/apps/dashboard/components/curator/addendum-lifecycle.tsx
+++ b/apps/dashboard/components/curator/addendum-lifecycle.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+// Addendum-evaluation lifecycle controls (spec 044 D-7 / decisions D-3/4/11). Sits
+// in a curator job's section and drives the under-evaluation lifecycle:
+//
+//   - Accept (D3)      — the new addendum is good; resume auto-apply.
+//   - Roll-back (D3)   — the new addendum is bad; restore the prior committed one.
+//   - Re-evaluate (D3c, GROOMING ONLY) — batch re-judge the tagged proposals.
+//   - Dry-run (D4, GROOMING ONLY)      — preview the current candidate over the
+//     corpus WITHOUT committing it (background; the admin polls runs/proposals).
+//
+// Re-evaluate + Dry-run are NOT rendered for intake (the inbox is consumed on
+// apply — not replayable). The Accept/Roll-back lifecycle applies to both jobs.
+//
+// DISABLED-JOB MESSAGING (D-11): when the job is disabled the chat + addendum
+// editor still work (edits commit and take effect when the job is re-enabled), but
+// the probation/dry-run controls are INERT with a clear message — never hidden
+// silently. Accept/Roll-back stay live (they just flip a status the next enabled
+// run reads).
+
+import type { CuratorJob } from "@librarian/core";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import type {
+  AddendumStateResult,
+  DryRunActionResult,
+  ReEvaluateResult,
+} from "@/app/curator/actions";
+
+const buttonClass =
+  "rounded-md border px-3 py-1.5 text-sm font-medium hover:bg-accent disabled:opacity-50";
+
+export function AddendumLifecycle({
+  job,
+  status,
+  evalVersion,
+  enabled,
+  candidate,
+  onAccept,
+  onRollback,
+  onReEvaluate,
+  onDryRun,
+}: {
+  job: CuratorJob;
+  status: "accepted" | "under_evaluation";
+  evalVersion: string | null;
+  enabled: boolean;
+  // The current addendum draft (right pane) — dry-run previews THIS candidate.
+  candidate: string;
+  onAccept: (input: { job: CuratorJob }) => Promise<AddendumStateResult>;
+  onRollback: (input: { job: CuratorJob }) => Promise<AddendumStateResult>;
+  onReEvaluate: (input: { job: CuratorJob }) => Promise<ReEvaluateResult>;
+  onDryRun: (input: { candidateAddendum: string }) => Promise<DryRunActionResult>;
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [notice, setNotice] = useState<string | null>(null);
+  // Grooming has the dry-run + re-evaluate escape hatches; intake does not.
+  const isGrooming = job === "grooming";
+  const underEvaluation = status === "under_evaluation";
+
+  const run = <R,>(action: () => Promise<R>, describe: (result: R) => string) =>
+    startTransition(async () => {
+      setNotice(null);
+      const result = await action();
+      setNotice(describe(result));
+      router.refresh();
+    });
+
+  return (
+    <section
+      className="flex flex-col gap-3 rounded-md border bg-card p-4"
+      aria-label={`${job === "grooming" ? "Grooming" : "Intake"} addendum lifecycle`}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <h3 className="font-semibold">Addendum status</h3>
+        <span
+          className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+            underEvaluation
+              ? "bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-200"
+              : "bg-emerald-100 text-emerald-900 dark:bg-emerald-900/30 dark:text-emerald-200"
+          }`}
+        >
+          {underEvaluation ? "under evaluation" : "accepted"}
+          {underEvaluation && evalVersion ? ` · ${evalVersion.slice(0, 7)}` : ""}
+        </span>
+      </div>
+
+      {underEvaluation ? (
+        <p className="text-xs text-muted-foreground">
+          The {job} curator is force-proposing every would-be auto-apply until you accept (or roll
+          back) this addendum version.
+        </p>
+      ) : (
+        <p className="text-xs text-muted-foreground">
+          The {job} addendum is accepted — the curator auto-applies as configured.
+        </p>
+      )}
+
+      {!enabled ? (
+        <p
+          className="rounded-md border border-amber-300/50 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:bg-amber-900/20 dark:text-amber-200"
+          role="status"
+        >
+          {job === "grooming" ? "Grooming" : "Intake"} is disabled — enable it to dry-run /
+          evaluate. The chat and addendum editor still work; your edits commit and take effect when
+          the job is re-enabled.
+        </p>
+      ) : null}
+
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          className={buttonClass}
+          disabled={pending || !underEvaluation}
+          onClick={() =>
+            run(
+              () => onAccept({ job }),
+              (r) => (r.ok ? "Accepted — auto-apply resumes." : `Error: ${r.error}`),
+            )
+          }
+        >
+          Accept
+        </button>
+        <button
+          type="button"
+          className={buttonClass}
+          disabled={pending || !underEvaluation}
+          onClick={() =>
+            run(
+              () => onRollback({ job }),
+              (r) => (r.ok ? "Rolled back to the prior addendum." : `Error: ${r.error}`),
+            )
+          }
+        >
+          Roll back
+        </button>
+        {isGrooming ? (
+          <>
+            <button
+              type="button"
+              className={buttonClass}
+              disabled={pending || !enabled}
+              title={enabled ? undefined : "Grooming is disabled — enable it to dry-run."}
+              onClick={() =>
+                run(
+                  () => onDryRun({ candidateAddendum: candidate }),
+                  (r) =>
+                    r.ok
+                      ? "started" in r.result
+                        ? "Dry-run started over the corpus — check Recent runs / proposals."
+                        : r.result.ran
+                          ? `Dry-run ran ${r.result.slicesRun} slice(s).`
+                          : `Dry-run skipped — ${r.result.reason.replace(/_/g, " ")}.`
+                      : `Error: ${r.error}`,
+                )
+              }
+            >
+              Dry-run candidate
+            </button>
+            <button
+              type="button"
+              className={buttonClass}
+              disabled={pending || !enabled || !underEvaluation}
+              title={enabled ? undefined : "Grooming is disabled — enable it to evaluate."}
+              onClick={() =>
+                run(
+                  () => onReEvaluate({ job }),
+                  (r) =>
+                    r.ok
+                      ? r.result.reEvaluated
+                        ? `Re-evaluated — ${r.result.count} proposal(s) refreshed.`
+                        : `Re-evaluate skipped — ${r.result.reason.replace(/_/g, " ")}.`
+                      : `Error: ${r.error}`,
+                )
+              }
+            >
+              Re-evaluate proposals
+            </button>
+          </>
+        ) : null}
+      </div>
+      {notice ? <p className="text-sm text-muted-foreground">{notice}</p> : null}
+    </section>
+  );
+}

--- a/apps/dashboard/components/curator/chat-panel.tsx
+++ b/apps/dashboard/components/curator/chat-panel.tsx
@@ -1,0 +1,320 @@
+"use client";
+
+// Curator chat panel (spec 044 D-7 / decisions D-5/6/9/11). Surfaces the whole 2C
+// self-improvement loop: discuss a memory (or the corpus) with the curator LLM,
+// accept its proposed fixes, and draft an addendum.
+//
+// SPLIT SCREEN: the conversation lives on the LEFT, an addendum-draft editor on
+// the RIGHT. The panel keeps the messages array CLIENT-SIDE — each turn sends the
+// whole array and appends the single response (request/response, NO streaming).
+//
+// THREE response kinds (the `ChatResponse` discriminated union):
+//   - message        → prose, rendered inline.
+//   - proposed_action → a CONFIRM CARD. The chat NEVER auto-runs an action; the
+//     admin clicks Confirm and only THEN does the matching D5 memory mutation run
+//     (human-in-the-loop, load-bearing).
+//   - addendum_edit  → populates the right-pane addendum draft with the candidate;
+//     `over_limit` shows a clear "still over 2 KB" notice (the write backstop
+//     rejects >2 KB anyway).
+
+import type { ChatJob, ChatResponse, ProposedAction } from "@librarian/core";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import type { AddendumStateResult, ChatResult, ConfirmActionResult } from "@/app/curator/actions";
+
+type Role = "system" | "user" | "assistant";
+interface ChatMessage {
+  role: Role;
+  content: string;
+}
+
+// A rendered conversation entry: a user/curator message, OR a proposed-action card
+// awaiting the admin's confirm. (addendum_edit drives the right pane, not the log.)
+type Entry =
+  | { kind: "text"; role: "user" | "assistant"; text: string }
+  | { kind: "action"; action: ProposedAction };
+
+export function ChatPanel({
+  onChat,
+  onConfirmAction,
+  onSetAddendum,
+  memoryId,
+  memoryTitle,
+  job = "grooming",
+  initialAddendum = "",
+  draft: controlledDraft,
+  onDraftChange,
+}: {
+  onChat: (input: {
+    messages: ChatMessage[];
+    memoryId?: string;
+    job?: ChatJob;
+  }) => Promise<ChatResult>;
+  onConfirmAction: (action: ProposedAction) => Promise<ConfirmActionResult>;
+  onSetAddendum: (input: { job: ChatJob; content: string }) => Promise<AddendumStateResult>;
+  memoryId?: string;
+  memoryTitle?: string;
+  job?: ChatJob;
+  initialAddendum?: string;
+  // The addendum draft can be lifted up (the curator workspace shares it with the
+  // lifecycle controls' dry-run). When uncontrolled, the panel owns it internally.
+  draft?: string;
+  onDraftChange?: (next: string) => void;
+}) {
+  const router = useRouter();
+  // The full conversation sent to the server each turn (request/response, no stream).
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [entries, setEntries] = useState<Entry[]>([]);
+  const [input, setInput] = useState("");
+  const [chatError, setChatError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  // Right pane: the addendum draft + its commit state. Controlled (lifted up) when
+  // `draft`/`onDraftChange` are provided, else internal.
+  const [internalDraft, setInternalDraft] = useState(initialAddendum);
+  const draft = controlledDraft ?? internalDraft;
+  const setDraft = (next: string) => {
+    if (onDraftChange) onDraftChange(next);
+    else setInternalDraft(next);
+  };
+  const [overLimit, setOverLimit] = useState(false);
+  const [addendumStatus, setAddendumStatus] = useState<string | null>(null);
+  const [committing, startCommit] = useTransition();
+
+  const send = () => {
+    const content = input.trim();
+    if (!content || pending) return;
+    const next = [...messages, { role: "user" as const, content }];
+    setMessages(next);
+    setEntries((e) => [...e, { kind: "text", role: "user", text: content }]);
+    setInput("");
+    setChatError(null);
+    startTransition(async () => {
+      const res = await onChat({
+        messages: next,
+        ...(memoryId ? { memoryId } : {}),
+        job,
+      });
+      if (!res.ok) {
+        setChatError(res.error);
+        return;
+      }
+      applyResponse(res.response, next);
+    });
+  };
+
+  const applyResponse = (response: ChatResponse, sent: ChatMessage[]) => {
+    switch (response.kind) {
+      case "message":
+        setMessages([...sent, { role: "assistant", content: response.text }]);
+        setEntries((e) => [...e, { kind: "text", role: "assistant", text: response.text }]);
+        break;
+      case "proposed_action":
+        // The model's turn is the action; keep the assistant aware of it for context.
+        setMessages([...sent, { role: "assistant", content: JSON.stringify(response) }]);
+        setEntries((e) => [...e, { kind: "action", action: response.action }]);
+        break;
+      case "addendum_edit":
+        setMessages([...sent, { role: "assistant", content: JSON.stringify(response) }]);
+        setDraft(response.candidate);
+        setOverLimit(response.over_limit === true);
+        setAddendumStatus(null);
+        setEntries((e) => [
+          ...e,
+          {
+            kind: "text",
+            role: "assistant",
+            text: "I've drafted addendum guidance — review it in the editor on the right.",
+          },
+        ]);
+        break;
+    }
+  };
+
+  const confirm = (action: ProposedAction) =>
+    startTransition(async () => {
+      const res = await onConfirmAction(action);
+      setEntries((e) => [
+        ...e,
+        {
+          kind: "text",
+          role: "assistant",
+          text: res.ok ? `Confirmed — the ${action.type} was applied.` : `Failed: ${res.error}`,
+        },
+      ]);
+      if (res.ok) router.refresh();
+    });
+
+  const commitAddendum = () =>
+    startCommit(async () => {
+      const res = await onSetAddendum({ job, content: draft });
+      if (res.ok) {
+        setAddendumStatus(
+          `Committed — ${job} addendum is now under evaluation (curator will propose, not auto-apply, until you accept).`,
+        );
+        setOverLimit(false);
+        router.refresh();
+      } else {
+        setAddendumStatus(`Error: ${res.error}`);
+      }
+    });
+
+  return (
+    <section
+      className="grid gap-4 rounded-md border bg-card p-4 lg:grid-cols-2"
+      aria-label="Curator chat"
+    >
+      {/* --- Conversation (left) --------------------------------------------- */}
+      <div className="flex min-w-0 flex-col gap-3">
+        <header>
+          <h3 className="font-semibold">Chat with the curator</h3>
+          {memoryId ? (
+            <p className="text-xs text-muted-foreground">
+              Grounded in {memoryTitle ? <strong>{memoryTitle}</strong> : "memory"} (
+              <code>{memoryId}</code>)
+            </p>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              General {job} conversation — no specific memory.
+            </p>
+          )}
+        </header>
+
+        <ol className="flex min-h-[160px] flex-col gap-2" aria-label="Conversation">
+          {entries.length === 0 ? (
+            <li className="text-sm text-muted-foreground">
+              Ask a question or request a fix. The curator proposes; you confirm.
+            </li>
+          ) : null}
+          {entries.map((entry, i) =>
+            entry.kind === "text" ? (
+              <li
+                key={i}
+                className={`rounded-md border p-2 text-sm ${
+                  entry.role === "user" ? "bg-muted/40" : "bg-background"
+                }`}
+              >
+                <span className="mr-1 text-xs font-medium text-muted-foreground">
+                  {entry.role === "user" ? "You" : "Curator"}:
+                </span>
+                <span className="whitespace-pre-wrap">{entry.text}</span>
+              </li>
+            ) : (
+              <li key={i}>
+                <ProposedActionCard
+                  action={entry.action}
+                  onConfirm={() => confirm(entry.action)}
+                  disabled={pending}
+                />
+              </li>
+            ),
+          )}
+        </ol>
+
+        {chatError ? (
+          <p className="text-sm text-destructive" role="alert">
+            {chatError}
+          </p>
+        ) : null}
+
+        <div className="flex items-end gap-2">
+          <textarea
+            aria-label="Message the curator"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                e.preventDefault();
+                send();
+              }
+            }}
+            placeholder="Ask the curator…"
+            className="min-h-[60px] flex-1 rounded-md border border-input bg-background p-2 text-sm"
+          />
+          <button
+            type="button"
+            onClick={send}
+            disabled={pending || input.trim() === ""}
+            className="rounded-md border bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground disabled:opacity-50"
+          >
+            {pending ? "Sending…" : "Send"}
+          </button>
+        </div>
+      </div>
+
+      {/* --- Addendum draft (right) ------------------------------------------ */}
+      <div className="flex min-w-0 flex-col gap-2 border-t pt-4 lg:border-l lg:border-t-0 lg:pl-4 lg:pt-0">
+        <header>
+          <h3 className="font-semibold">Addendum draft ({job})</h3>
+          <p className="text-xs text-muted-foreground">
+            Operator guidance for the {job} curator. Committing puts it under evaluation.
+          </p>
+        </header>
+        <textarea
+          aria-label="Addendum draft"
+          value={draft}
+          onChange={(e) => {
+            setDraft(e.target.value);
+            setOverLimit(false);
+            setAddendumStatus(null);
+          }}
+          placeholder="The curator's addendum suggestions appear here — or write your own."
+          className="min-h-[200px] flex-1 rounded-md border border-input bg-background p-2 font-mono text-sm"
+        />
+        {overLimit ? (
+          <p className="text-sm text-destructive" role="alert">
+            That candidate is still over 2 KB — shorten it before committing (the write will reject
+            anything over 2 KB).
+          </p>
+        ) : null}
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={commitAddendum}
+            disabled={committing}
+            className="rounded-md border bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground disabled:opacity-50"
+          >
+            {committing ? "Committing…" : "Commit addendum"}
+          </button>
+          {addendumStatus ? (
+            <span className="text-sm text-muted-foreground">{addendumStatus}</span>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// A proposed fix-now action awaiting the admin's confirm. The chat NEVER runs it;
+// the action's `type` + payload IS the matching D5 mutation input.
+function ProposedActionCard({
+  action,
+  onConfirm,
+  disabled,
+}: {
+  action: ProposedAction;
+  onConfirm: () => void;
+  disabled: boolean;
+}) {
+  return (
+    <div className="rounded-md border border-primary/40 bg-primary/5 p-3 text-sm">
+      <p className="font-medium">
+        Proposed fix: <span className="uppercase">{action.type}</span>
+      </p>
+      <pre className="mt-2 max-h-48 overflow-auto whitespace-pre-wrap break-words rounded bg-background p-2 text-xs">
+        {JSON.stringify(action, null, 2)}
+      </pre>
+      <p className="mt-2 text-xs text-muted-foreground">
+        Review the change above. Nothing runs until you confirm.
+      </p>
+      <button
+        type="button"
+        onClick={onConfirm}
+        disabled={disabled}
+        className="mt-2 rounded-md border bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground disabled:opacity-50"
+      >
+        Confirm &amp; apply
+      </button>
+    </div>
+  );
+}

--- a/apps/dashboard/components/curator/chat-workspace.tsx
+++ b/apps/dashboard/components/curator/chat-workspace.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+// The curator chat workspace (spec 044 D-7). The general fresh-chat entry on the
+// curator page: a job picker (intake / grooming) over the split-screen chat panel
+// (chat left, addendum draft right), with the addendum-evaluation lifecycle
+// controls (Accept / Roll-back / Dry-run / Re-evaluate) below.
+//
+// The addendum DRAFT is lifted up here so it's SHARED between the chat panel's
+// editor and the lifecycle's Dry-run (which previews the current candidate). The
+// picked job selects which addendum state + enablement the lifecycle shows; the
+// draft resets to that job's committed text when the job changes.
+
+import type { CuratorJob } from "@librarian/core";
+import { useState } from "react";
+import { AddendumLifecycle } from "./addendum-lifecycle";
+import { ChatPanel } from "./chat-panel";
+import type {
+  acceptAddendumAction,
+  chatAction,
+  confirmActionAction,
+  dryRunGroomingAction,
+  reEvaluateAddendumAction,
+  rollbackAddendumAction,
+  setAddendumAction,
+} from "@/app/curator/actions";
+
+export interface JobAddendumState {
+  content: string;
+  version: string | null;
+  status: "accepted" | "under_evaluation";
+  evalVersion: string | null;
+  enabled: boolean;
+}
+
+export interface ChatWorkspaceActions {
+  onChat: typeof chatAction;
+  onConfirmAction: typeof confirmActionAction;
+  onSetAddendum: typeof setAddendumAction;
+  onAccept: typeof acceptAddendumAction;
+  onRollback: typeof rollbackAddendumAction;
+  onReEvaluate: typeof reEvaluateAddendumAction;
+  onDryRun: typeof dryRunGroomingAction;
+}
+
+export function CuratorChatWorkspace({
+  jobs,
+  actions,
+}: {
+  // Per-job addendum + enablement state, read server-side on the curator page.
+  jobs: Record<CuratorJob, JobAddendumState>;
+  actions: ChatWorkspaceActions;
+}) {
+  const [job, setJob] = useState<CuratorJob>("grooming");
+  const current = jobs[job];
+  const [draft, setDraft] = useState(current.content);
+
+  const pickJob = (next: CuratorJob) => {
+    setJob(next);
+    setDraft(jobs[next].content);
+  };
+
+  return (
+    <section className="flex flex-col gap-4" aria-label="Curator chat workspace">
+      <div className="flex items-center gap-3">
+        <span className="text-sm font-medium">Discuss with the curator about:</span>
+        <label className="text-sm">
+          <span className="sr-only">Curator job</span>
+          <select
+            aria-label="Curator job"
+            value={job}
+            onChange={(e) => pickJob(e.target.value as CuratorJob)}
+            className="rounded-md border bg-background px-2 py-1 text-sm"
+          >
+            <option value="grooming">Grooming (the existing corpus)</option>
+            <option value="intake">Intake (the inbox)</option>
+          </select>
+        </label>
+      </div>
+
+      <ChatPanel
+        key={job}
+        job={job}
+        onChat={actions.onChat}
+        onConfirmAction={actions.onConfirmAction}
+        onSetAddendum={actions.onSetAddendum}
+        draft={draft}
+        onDraftChange={setDraft}
+      />
+
+      <AddendumLifecycle
+        job={job}
+        status={current.status}
+        evalVersion={current.evalVersion}
+        enabled={current.enabled}
+        candidate={draft}
+        onAccept={actions.onAccept}
+        onRollback={actions.onRollback}
+        onReEvaluate={actions.onReEvaluate}
+        onDryRun={actions.onDryRun}
+      />
+    </section>
+  );
+}

--- a/apps/dashboard/components/curator/discuss-memory-button.tsx
+++ b/apps/dashboard/components/curator/discuss-memory-button.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+// "Discuss this memory" — the per-memory entry point to the curator chat (spec
+// 044 D-7). Opens the split-screen chat panel in a dialog, PRE-POPULATED with the
+// memory id (its content is grounded server-side; the job is inferred from the
+// memory's decision history when unset). The admin can ask about the memory or
+// request a fix-now action (which is proposed, never auto-run).
+//
+// The actions are passed in (server actions wired by the page/parent) so this stays
+// a thin client wrapper around ChatPanel.
+
+import { useState } from "react";
+import { ChatPanel } from "./chat-panel";
+import type { chatAction, confirmActionAction, setAddendumAction } from "@/app/curator/actions";
+import { Button } from "@/components/ui-v2/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui-v2/dialog";
+
+export function DiscussMemoryButton({
+  memoryId,
+  memoryTitle,
+  onChat,
+  onConfirmAction,
+  onSetAddendum,
+  variant = "outline",
+}: {
+  memoryId: string;
+  memoryTitle?: string;
+  onChat: typeof chatAction;
+  onConfirmAction: typeof confirmActionAction;
+  onSetAddendum: typeof setAddendumAction;
+  variant?: "outline" | "ghost" | "primary";
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button variant={variant} onClick={() => setOpen(true)}>
+        Discuss this memory
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-h-[90vh] max-w-5xl overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Discuss with the curator</DialogTitle>
+          </DialogHeader>
+          <ChatPanel
+            memoryId={memoryId}
+            {...(memoryTitle ? { memoryTitle } : {})}
+            onChat={onChat}
+            onConfirmAction={onConfirmAction}
+            onSetAddendum={onSetAddendum}
+          />
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/dashboard/components/memories/detail-panel.tsx
+++ b/apps/dashboard/components/memories/detail-panel.tsx
@@ -3,6 +3,8 @@
 import { useState, useTransition } from "react";
 import type { MemoryRow } from "./types";
 import { archiveMemoryAction, updateMemoryAction } from "@/app/(memories)/actions";
+import { chatAction, confirmActionAction, setAddendumAction } from "@/app/curator/actions";
+import { DiscussMemoryButton } from "@/components/curator/discuss-memory-button";
 import { Button } from "@/components/ui-v2/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui-v2/dialog";
 import { Input } from "@/components/ui-v2/input";
@@ -95,10 +97,17 @@ export function MemoryDetailPanel({ memory, onClose, onMutated }: Props) {
               id: <code>{memory.id}</code>
             </p>
             {error ? <p className="text-sm text-destructive">{error}</p> : null}
-            <div className="flex gap-2">
+            <div className="flex flex-wrap gap-2">
               <Button variant="outline" onClick={() => setEditing(true)}>
                 Edit
               </Button>
+              <DiscussMemoryButton
+                memoryId={memory.id}
+                {...(memory.title ? { memoryTitle: memory.title } : {})}
+                onChat={chatAction}
+                onConfirmAction={confirmActionAction}
+                onSetAddendum={setAddendumAction}
+              />
               <Button
                 variant="primary"
                 disabled={pending}

--- a/apps/dashboard/e2e/curator-chat.spec.ts
+++ b/apps/dashboard/e2e/curator-chat.spec.ts
@@ -1,0 +1,235 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { expect, request, test, type APIRequestContext } from "@playwright/test";
+import { createTestMemory } from "./fixtures";
+
+// Spec 044 D-7 — the dashboard curator chat UI + entry points + lifecycle controls.
+//
+// This runs against the shared e2e mcp-server (auth off). The chat turn needs a
+// deterministic LLM, so the proposed-action test starts a LOCAL OpenAI-compatible
+// stub, configures the curator chat/grooming provider to point at it (the server
+// encrypts the token with its own master key, so it round-trips within this run),
+// and scripts the completion. The entry-point + lifecycle tests need no LLM (the
+// lifecycle is driven over real addendum tRPC; entry points just open the panel).
+//
+// LOAD-BEARING: a proposed_action is PROPOSED, never auto-run — the test asserts
+// the memory is unchanged until the admin clicks Confirm, then changed after.
+
+const SERVER_URL = process.env.LIBRARIAN_E2E_SERVER_URL ?? "http://127.0.0.1:3838";
+const ADMIN_TOKEN = process.env.LIBRARIAN_E2E_ADMIN_TOKEN ?? "e2e-admin-token";
+
+async function adminContext(): Promise<APIRequestContext> {
+  return request.newContext({
+    baseURL: SERVER_URL,
+    extraHTTPHeaders: { Authorization: `Bearer ${ADMIN_TOKEN}` },
+  });
+}
+
+async function trpc<T>(ctx: APIRequestContext, procedure: string, input: unknown): Promise<T> {
+  const response = await ctx.post(`/trpc/${procedure}`, {
+    data: input as object,
+    headers: { "content-type": "application/json" },
+  });
+  if (!response.ok()) {
+    throw new Error(`tRPC ${procedure} failed: ${response.status()} ${await response.text()}`);
+  }
+  const body = (await response.json()) as { result?: { data?: T } };
+  return body.result?.data as T;
+}
+
+// tRPC QUERY procedures (memories.list / addendum.get) must use GET with the
+// input in the `input` query param.
+async function trpcQuery<T>(ctx: APIRequestContext, procedure: string, input: unknown): Promise<T> {
+  const response = await ctx.get(`/trpc/${procedure}`, {
+    params: { input: JSON.stringify(input) },
+  });
+  if (!response.ok()) {
+    throw new Error(`tRPC ${procedure} failed: ${response.status()} ${await response.text()}`);
+  }
+  const body = (await response.json()) as { result?: { data?: T } };
+  return body.result?.data as T;
+}
+
+// A minimal OpenAI-compatible chat-completions stub the curator chat client talks
+// to. Returns a single fixed completion (a JSON ChatResponse) for every request.
+function startStubLlm(completion: string): Promise<{ url: string; stop: () => Promise<void> }> {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      let body = "";
+      req.on("data", (c) => (body += c));
+      req.on("end", () => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ choices: [{ message: { content: completion } }] }));
+      });
+    });
+    // 0.0.0.0 so the in-process mcp-server (on 127.0.0.1) can reach it.
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({
+        url: `http://127.0.0.1:${port}/v1`,
+        stop: () => new Promise((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
+test.describe("curator chat — entry points", () => {
+  test("the general fresh-chat entry on the curator page opens the chat + job picker", async ({
+    page,
+  }) => {
+    await page.goto("/curator");
+    const chat = page.getByRole("region", { name: "Curator chat workspace" });
+    await expect(chat).toBeVisible();
+    // The job picker (intake / grooming) is present.
+    await expect(chat.getByRole("combobox", { name: "Curator job" })).toBeVisible();
+    // The split-screen chat panel + addendum draft editor are present.
+    await expect(chat.getByRole("textbox", { name: /message the curator/i })).toBeVisible();
+    await expect(chat.getByRole("textbox", { name: /addendum draft/i })).toBeVisible();
+  });
+
+  test("'Discuss this memory' on a memory opens the chat pre-populated with the memory", async ({
+    page,
+  }) => {
+    const { id } = await createTestMemory("Chat entry memory", "discuss me");
+    await page.goto("/");
+    await page.getByRole("button", { name: /Chat entry memory/ }).click();
+    await page.getByRole("button", { name: "Discuss this memory" }).click();
+    // The chat dialog opens grounded in the memory id.
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText(id)).toBeVisible();
+    await expect(dialog.getByRole("textbox", { name: /message the curator/i })).toBeVisible();
+  });
+});
+
+test.describe("curator chat — proposed action (propose, confirm, never auto-run)", () => {
+  test("a proposed update is NOT applied until the admin confirms, then it applies", async ({
+    page,
+  }) => {
+    const { id } = await createTestMemory("Original title", "body to keep");
+
+    // Script the chat to propose an `update` action against this memory.
+    const stub = await startStubLlm(
+      JSON.stringify({
+        kind: "proposed_action",
+        action: { type: "update", id, patch: { title: "Curator-fixed title" } },
+      }),
+    );
+    const ctx = await adminContext();
+    let providerId = "";
+    try {
+      // Point the chat consumer at the stub via a named provider (grooming fallback
+      // would also work; we set chat directly).
+      const provider = await trpc<{ id: string }>(ctx, "llm.addProvider", {
+        name: "e2e-chat-stub",
+        endpoint: stub.url,
+        token: "dummy-stub-token",
+      });
+      providerId = provider.id;
+      await trpc(ctx, "llm.setConsumerConfig", {
+        consumer: "chat",
+        providerId: provider.id,
+        model: "gpt-stub",
+      });
+
+      await page.goto("/curator");
+      const chat = page.getByRole("region", { name: "Curator chat workspace" });
+      await chat.getByRole("textbox", { name: /message the curator/i }).fill("fix the title");
+      await chat.getByRole("button", { name: "Send" }).click();
+
+      // The proposed action is shown for confirmation — NOT auto-applied.
+      const confirm = chat.getByRole("button", { name: /confirm/i });
+      await expect(confirm).toBeVisible();
+
+      // The memory is still its original title (nothing ran yet — propose, not run).
+      const before = await trpcQuery<{ memories: { id: string; title: string }[] }>(
+        ctx,
+        "memories.list",
+        { status: "active", limit: 200 },
+      );
+      expect(before.memories.find((m) => m.id === id)?.title).toBe("Original title");
+
+      // Now confirm — the update runs.
+      await confirm.click();
+      await expect(chat.getByText(/Confirmed — the update was applied/i)).toBeVisible();
+
+      const after = await trpcQuery<{ memories: { id: string; title: string }[] }>(
+        ctx,
+        "memories.list",
+        { status: "active", limit: 200 },
+      );
+      expect(after.memories.find((m) => m.id === id)?.title).toBe("Curator-fixed title");
+    } finally {
+      // Clean up: clear the chat consumer config + delete the stub provider so
+      // other specs see no leftover provider (the suite shares one store).
+      await trpc(ctx, "llm.setConsumerConfig", {
+        consumer: "chat",
+        providerId: "",
+        model: "",
+      }).catch(() => {});
+      if (providerId) await trpc(ctx, "llm.deleteProvider", { id: providerId }).catch(() => {});
+      await ctx.dispose();
+      await stub.stop();
+    }
+  });
+});
+
+test.describe("curator chat — addendum lifecycle (Accept / Roll-back)", () => {
+  test("an under-evaluation grooming addendum can be accepted from the dashboard", async ({
+    page,
+  }) => {
+    const ctx = await adminContext();
+    try {
+      // Seed: commit a grooming addendum (this puts it under evaluation).
+      await trpc(ctx, "addendum.set", { job: "grooming", content: "e2e accept guidance" });
+      let state = await trpcQuery<{ status: string }>(ctx, "addendum.get", { job: "grooming" });
+      expect(state.status).toBe("under_evaluation");
+
+      await page.goto("/curator");
+      const chat = page.getByRole("region", { name: "Curator chat workspace" });
+      const lifecycle = chat.getByRole("region", { name: "Grooming addendum lifecycle" });
+      // Grooming is the default picked job; the lifecycle status badge shows it.
+      await expect(lifecycle.getByText(/under evaluation/i).first()).toBeVisible();
+
+      await lifecycle.getByRole("button", { name: "Accept" }).click();
+      await expect(chat.getByText(/Accepted — auto-apply resumes/i)).toBeVisible();
+
+      // The status persisted.
+      state = await trpcQuery<{ status: string }>(ctx, "addendum.get", { job: "grooming" });
+      expect(state.status).toBe("accepted");
+    } finally {
+      await ctx.dispose();
+    }
+  });
+
+  test("an under-evaluation grooming addendum can be rolled back from the dashboard", async ({
+    page,
+  }) => {
+    const ctx = await adminContext();
+    try {
+      // Seed two versions, leaving grooming under evaluation against v2.
+      await trpc(ctx, "addendum.set", { job: "grooming", content: "rollback v1" });
+      await trpc(ctx, "addendum.accept", { job: "grooming" });
+      await trpc(ctx, "addendum.set", { job: "grooming", content: "rollback v2 (bad)" });
+      let state = await trpcQuery<{ status: string; content: string }>(ctx, "addendum.get", {
+        job: "grooming",
+      });
+      expect(state.status).toBe("under_evaluation");
+      expect(state.content).toBe("rollback v2 (bad)");
+
+      await page.goto("/curator");
+      const chat = page.getByRole("region", { name: "Curator chat workspace" });
+      const lifecycle = chat.getByRole("region", { name: "Grooming addendum lifecycle" });
+      await lifecycle.getByRole("button", { name: "Roll back" }).click();
+      await expect(chat.getByText(/Rolled back to the prior addendum/i)).toBeVisible();
+
+      state = await trpcQuery<{ status: string; content: string }>(ctx, "addendum.get", {
+        job: "grooming",
+      });
+      expect(state.status).toBe("accepted");
+      expect(state.content).toBe("rollback v1");
+    } finally {
+      await ctx.dispose();
+    }
+  });
+});

--- a/apps/dashboard/tests/components/curator/addendum-lifecycle.test.tsx
+++ b/apps/dashboard/tests/components/curator/addendum-lifecycle.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { AddendumLifecycle } from "@/components/curator/addendum-lifecycle";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
+
+const okAddendum = vi.fn(async () => ({
+  ok: true as const,
+  addendum: { content: "x", version: "v", status: "accepted" as const, evalVersion: null },
+}));
+const okReEvaluate = vi.fn(async () => ({
+  ok: true as const,
+  result: { reEvaluated: true as const, count: 2 },
+}));
+const okDryRun = vi.fn(async () => ({ ok: true as const, result: { started: true as const } }));
+
+function renderLifecycle(over: Partial<Parameters<typeof AddendumLifecycle>[0]> = {}) {
+  render(
+    <AddendumLifecycle
+      job="grooming"
+      status="accepted"
+      evalVersion={null}
+      enabled
+      candidate=""
+      onAccept={okAddendum}
+      onRollback={okAddendum}
+      onReEvaluate={okReEvaluate}
+      onDryRun={okDryRun}
+      {...over}
+    />,
+  );
+}
+
+describe("AddendumLifecycle", () => {
+  it("shows the accepted status + version", () => {
+    renderLifecycle({ status: "accepted", evalVersion: null });
+    expect(screen.getAllByText(/accepted/i).length).toBeGreaterThan(0);
+  });
+
+  it("shows the under-evaluation status with the version when evaluating", () => {
+    renderLifecycle({ status: "under_evaluation", evalVersion: "abcdef0" });
+    expect(screen.getByText(/under evaluation/i)).toBeTruthy();
+    expect(screen.getByText(/abcdef0/)).toBeTruthy();
+  });
+
+  it("drives Accept (D3)", async () => {
+    renderLifecycle({ status: "under_evaluation", evalVersion: "v1" });
+    await userEvent.click(screen.getByRole("button", { name: /accept/i }));
+    await waitFor(() => expect(okAddendum).toHaveBeenCalledWith({ job: "grooming" }));
+  });
+
+  it("drives Roll-back (D3)", async () => {
+    const onRollback = vi.fn(async () => ({
+      ok: true as const,
+      addendum: { content: "x", version: "v", status: "accepted" as const, evalVersion: null },
+    }));
+    renderLifecycle({ status: "under_evaluation", evalVersion: "v1", onRollback });
+    await userEvent.click(screen.getByRole("button", { name: /roll.?back/i }));
+    await waitFor(() => expect(onRollback).toHaveBeenCalledWith({ job: "grooming" }));
+  });
+
+  it("drives Re-evaluate (D3c, grooming) with the count surfaced", async () => {
+    const onReEvaluate = vi.fn(async () => ({
+      ok: true as const,
+      result: { reEvaluated: true as const, count: 3 },
+    }));
+    renderLifecycle({ status: "under_evaluation", evalVersion: "v1", onReEvaluate });
+    await userEvent.click(screen.getByRole("button", { name: /re-?evaluate/i }));
+    await waitFor(() => expect(onReEvaluate).toHaveBeenCalledWith({ job: "grooming" }));
+    await waitFor(() => expect(screen.getByText(/3/)).toBeTruthy());
+  });
+
+  it("drives Dry-run (D4) with the current candidate addendum", async () => {
+    const onDryRun = vi.fn(async () => ({ ok: true as const, result: { started: true as const } }));
+    renderLifecycle({ candidate: "draft guidance", onDryRun });
+    await userEvent.click(screen.getByRole("button", { name: /dry.?run/i }));
+    await waitFor(() =>
+      expect(onDryRun).toHaveBeenCalledWith({ candidateAddendum: "draft guidance" }),
+    );
+  });
+
+  it("does NOT render Dry-run or Re-evaluate for intake (grooming-only)", () => {
+    renderLifecycle({ job: "intake", status: "under_evaluation", evalVersion: "v1" });
+    expect(screen.queryByRole("button", { name: /dry.?run/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /re-?evaluate/i })).toBeNull();
+    // Accept + Roll-back still exist for intake.
+    expect(screen.getByRole("button", { name: /accept/i })).toBeTruthy();
+  });
+
+  it("makes the probation/dry-run controls INERT with a clear message when the job is disabled (D-11)", async () => {
+    renderLifecycle({ enabled: false, candidate: "draft", status: "under_evaluation" });
+    expect(screen.getByText(/disabled/i)).toBeTruthy();
+    // Dry-run / re-evaluate are inert (disabled) when the job is off.
+    const dryRun = screen.getByRole("button", { name: /dry.?run/i });
+    expect(dryRun).toBeDisabled();
+    const reEval = screen.getByRole("button", { name: /re-?evaluate/i });
+    expect(reEval).toBeDisabled();
+  });
+});

--- a/apps/dashboard/tests/components/curator/chat-panel.test.tsx
+++ b/apps/dashboard/tests/components/curator/chat-panel.test.tsx
@@ -1,0 +1,157 @@
+import type { ChatResponse, ProposedAction } from "@librarian/core";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ChatPanel } from "@/components/curator/chat-panel";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
+
+// A stub chat action that returns a scripted response, recording what it was sent.
+function scriptedChat(response: ChatResponse) {
+  const calls: { messages: { role: string; content: string }[] }[] = [];
+  const action = vi.fn(async (input: { messages: { role: string; content: string }[] }) => {
+    calls.push({ messages: input.messages });
+    return { ok: true as const, response };
+  });
+  return { action, calls };
+}
+
+const noopConfirm = vi.fn(async () => ({ ok: true as const }));
+const noopSetAddendum = vi.fn(async () => ({
+  ok: true as const,
+  addendum: {
+    content: "x",
+    version: "v",
+    status: "under_evaluation" as const,
+    evalVersion: "v",
+  },
+}));
+
+function renderPanel(over: Partial<Parameters<typeof ChatPanel>[0]> = {}) {
+  const chat = scriptedChat({ kind: "message", text: "Hello from the curator." });
+  render(
+    <ChatPanel
+      onChat={chat.action}
+      onConfirmAction={noopConfirm}
+      onSetAddendum={noopSetAddendum}
+      {...over}
+    />,
+  );
+  return chat;
+}
+
+describe("ChatPanel", () => {
+  it("sends a turn and renders a prose message response", async () => {
+    const chat = renderPanel();
+    await userEvent.type(screen.getByRole("textbox", { name: /message/i }), "hi");
+    await userEvent.click(screen.getByRole("button", { name: /send/i }));
+    await waitFor(() => expect(screen.getByText("Hello from the curator.")).toBeTruthy());
+    expect(chat.action).toHaveBeenCalledTimes(1);
+    // The user's message is appended to the array sent to the server.
+    expect(chat.calls[0]!.messages.at(-1)).toEqual({ role: "user", content: "hi" });
+  });
+
+  it("renders a proposed_action as a Confirm card and does NOT auto-execute it", async () => {
+    const action: ProposedAction = {
+      type: "update",
+      id: "mem-1",
+      patch: { title: "Fixed title" },
+    };
+    renderPanel({ onChat: scriptedChat({ kind: "proposed_action", action }).action });
+    await userEvent.type(screen.getByRole("textbox", { name: /message/i }), "fix it");
+    await userEvent.click(screen.getByRole("button", { name: /send/i }));
+
+    // The action is shown for review with an explicit Confirm — never auto-run.
+    await waitFor(() => expect(screen.getByText(/proposed fix/i)).toBeTruthy());
+    const confirm = screen.getByRole("button", { name: /confirm/i });
+    expect(confirm).toBeTruthy();
+    // Human-in-the-loop: the mutation has NOT run until the admin confirms.
+    expect(noopConfirm).not.toHaveBeenCalled();
+  });
+
+  it("calls the confirm action with the proposed action only when the admin clicks Confirm", async () => {
+    const action: ProposedAction = { type: "unmerge", id: "mem-merged" };
+    const onConfirmAction = vi.fn(async () => ({ ok: true as const }));
+    renderPanel({
+      onChat: scriptedChat({ kind: "proposed_action", action }).action,
+      onConfirmAction,
+    });
+    await userEvent.type(screen.getByRole("textbox", { name: /message/i }), "undo");
+    await userEvent.click(screen.getByRole("button", { name: /send/i }));
+    await userEvent.click(await screen.findByRole("button", { name: /confirm/i }));
+    await waitFor(() => expect(onConfirmAction).toHaveBeenCalledTimes(1));
+    expect(onConfirmAction).toHaveBeenCalledWith(action);
+  });
+
+  it("populates the addendum draft from an addendum_edit response", async () => {
+    renderPanel({
+      onChat: scriptedChat({
+        kind: "addendum_edit",
+        job: "grooming",
+        candidate: "Prefer keeping project-scoped lessons separate.",
+      }).action,
+    });
+    await userEvent.type(screen.getByRole("textbox", { name: /message/i }), "suggest a rule");
+    await userEvent.click(screen.getByRole("button", { name: /send/i }));
+    const draft = (await screen.findByRole("textbox", {
+      name: /addendum draft/i,
+    })) as HTMLTextAreaElement;
+    await waitFor(() =>
+      expect(draft.value).toBe("Prefer keeping project-scoped lessons separate."),
+    );
+  });
+
+  it("warns when an addendum_edit candidate is still over the 2 KB limit", async () => {
+    renderPanel({
+      onChat: scriptedChat({
+        kind: "addendum_edit",
+        job: "grooming",
+        candidate: "way too long",
+        over_limit: true,
+      }).action,
+    });
+    await userEvent.type(screen.getByRole("textbox", { name: /message/i }), "rule");
+    await userEvent.click(screen.getByRole("button", { name: /send/i }));
+    await waitFor(() => expect(screen.getByText(/still over 2 KB/i)).toBeTruthy());
+  });
+
+  it("surfaces a chat error (e.g. non-operational LLM) without crashing", async () => {
+    const onChat = vi.fn(async () => ({
+      ok: false as const,
+      error: "The chat LLM is not configured.",
+    }));
+    renderPanel({ onChat });
+    await userEvent.type(screen.getByRole("textbox", { name: /message/i }), "hi");
+    await userEvent.click(screen.getByRole("button", { name: /send/i }));
+    await waitFor(() => expect(screen.getByText(/not configured/i)).toBeTruthy());
+  });
+
+  it("seeds the conversation with the memory context when given a memory", async () => {
+    const chat = renderPanel({ memoryId: "mem-42", memoryTitle: "Some memory" });
+    // The memory id is visible so the admin knows what's grounded.
+    expect(screen.getByText(/mem-42/)).toBeTruthy();
+    await userEvent.type(screen.getByRole("textbox", { name: /message/i }), "what is this?");
+    await userEvent.click(screen.getByRole("button", { name: /send/i }));
+    await waitFor(() => expect(chat.action).toHaveBeenCalled());
+  });
+
+  it("commits the addendum draft only on an explicit Commit click", async () => {
+    const onSetAddendum = vi.fn(async () => ({
+      ok: true as const,
+      addendum: {
+        content: "rule",
+        version: "v2",
+        status: "under_evaluation" as const,
+        evalVersion: "v2",
+      },
+    }));
+    renderPanel({ onSetAddendum, initialAddendum: "existing rule" });
+    const draft = screen.getByRole("textbox", { name: /addendum draft/i });
+    await userEvent.clear(draft);
+    await userEvent.type(draft, "rule");
+    expect(onSetAddendum).not.toHaveBeenCalled();
+    await userEvent.click(screen.getByRole("button", { name: /commit addendum/i }));
+    await waitFor(() => expect(onSetAddendum).toHaveBeenCalledTimes(1));
+    expect(onSetAddendum).toHaveBeenCalledWith({ job: "grooming", content: "rule" });
+  });
+});

--- a/packages/mcp-server/src/trpc/addendum.ts
+++ b/packages/mcp-server/src/trpc/addendum.ts
@@ -35,8 +35,10 @@
 import type { CuratorJob, ReEvaluateResult } from "@librarian/core";
 import {
   readAddendumStatus,
+  readJobAddendum,
   reEvaluateGroomingProposals,
   setAddendumStatus,
+  setJobAddendum,
 } from "@librarian/core";
 import { z } from "zod";
 import { adminProcedure, router } from "./trpc.js";
@@ -48,7 +50,42 @@ type ReEvaluateSummary = ReEvaluateResult | { reEvaluated: false; reason: "intak
 // over (`curator.<job>.addendum_status`).
 const JobInputSchema = z.strictObject({ job: z.enum(["intake", "grooming"]) });
 
+// Set-addendum input: the new committed addendum text for a job. The hard 2 KB
+// cap is enforced by core's setJobAddendum (which throws over the limit) — the
+// dashboard editor + chat condense loop sit in front of it as soft guards.
+const SetAddendumInputSchema = z.strictObject({
+  job: z.enum(["intake", "grooming"]),
+  content: z.string(),
+});
+
+/** The combined addendum read shape the dashboard editor renders (D7). */
+function addendumState(ctx: { store: Parameters<typeof readJobAddendum>[0] }, job: CuratorJob) {
+  const { content, version } = readJobAddendum(ctx.store, job);
+  const { status, evalVersion } = readAddendumStatus(ctx.store, job);
+  return { content, version, status, evalVersion };
+}
+
 export const addendumRouter = router({
+  // Read a job's committed addendum text + its git version + its evaluation status
+  // (accepted / under_evaluation) and the version under evaluation. The D7
+  // dashboard editor populates from this and shows the lifecycle state.
+  get: adminProcedure
+    .input(JobInputSchema)
+    .query(({ ctx, input }) => addendumState(ctx, input.job)),
+
+  // Commit a new addendum draft for a job and put it UNDER EVALUATION (spec 044
+  // D-3): a freshly-changed addendum is not yet trusted, so the curator force-
+  // proposes every would-be auto-apply until the admin Accepts (or Rolls back).
+  // The change effect is the same whether the job is enabled or not — the addendum
+  // takes effect when the job next runs (D-11: the editor still works for a
+  // disabled job). The 2 KB cap is enforced by setJobAddendum (throws over-cap).
+  set: adminProcedure.input(SetAddendumInputSchema).mutation(({ ctx, input }) => {
+    const job: CuratorJob = input.job;
+    setJobAddendum(ctx.store, job, input.content);
+    setAddendumStatus(ctx.store, job, "under_evaluation");
+    return addendumState(ctx, job);
+  }),
+
   // Accept the addendum under evaluation: resume auto-apply by setting status back
   // to `accepted` (which clears the eval version). Returns the fresh status.
   accept: adminProcedure.input(JobInputSchema).mutation(({ ctx, input }) => {

--- a/packages/mcp-server/tests/trpc/addendum.test.ts
+++ b/packages/mcp-server/tests/trpc/addendum.test.ts
@@ -66,6 +66,19 @@ async function trpcPost<T>(server: ServerHandle, path: string, input?: unknown):
   return (json as TrpcOk<T>).result.data;
 }
 
+async function trpcGet<T>(server: ServerHandle, path: string, input: unknown): Promise<T> {
+  const query = `input=${encodeURIComponent(JSON.stringify(input))}`;
+  const response = await fetch(`${server.url}/trpc/${path}?${query}`, {
+    method: "GET",
+    headers: { authorization: `Bearer ${server.token}` },
+  });
+  const json = (await response.json()) as TrpcOk<T> | TrpcErr;
+  if (response.status >= 400 || "error" in json) {
+    throw new Error(`trpc GET ${path} failed: ${JSON.stringify(json)}`);
+  }
+  return (json as TrpcOk<T>).result.data;
+}
+
 interface StatusResult {
   status: string;
   evalVersion: string | null;
@@ -331,6 +344,98 @@ describe("tRPC addendum evaluation lifecycle surface (spec 044 D3b+D3c)", () => 
       ).toBe(false);
     } finally {
       after.close();
+    }
+  });
+
+  it("admin-gates get + set (rejected without an admin bearer)", async () => {
+    const server = await startHttpServer({ dataDir });
+    try {
+      const unauthedGet = await fetch(`${server.url}/trpc/addendum.get?input=`, {
+        method: "GET",
+      });
+      expect(unauthedGet.status).toBeGreaterThanOrEqual(400);
+
+      const unauthedSet = await fetch(`${server.url}/trpc/addendum.set`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ job: "grooming", content: "x" }),
+      });
+      expect(unauthedSet.status).toBeGreaterThanOrEqual(400);
+
+      const agentSet = await fetch(`${server.url}/trpc/addendum.set`, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: "Bearer agent-token" },
+        body: JSON.stringify({ job: "grooming", content: "x" }),
+      });
+      expect(agentSet.status).toBeGreaterThanOrEqual(400);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("set commits a new addendum and puts the job UNDER EVALUATION; get reads it back", async () => {
+    const server = await startHttpServer({ dataDir });
+    try {
+      const result = await trpcPost<{
+        content: string;
+        version: string | null;
+        status: string;
+        evalVersion: string | null;
+      }>(server, "addendum.set", { job: "grooming", content: "be conservative" });
+      expect(result.content).toBe("be conservative");
+      expect(result.version).toMatch(/^[0-9a-f]{40}$/);
+      // A freshly-changed addendum goes under evaluation (the curator force-proposes).
+      expect(result.status).toBe("under_evaluation");
+      expect(result.evalVersion).toBe(result.version);
+    } finally {
+      await server.stop();
+    }
+
+    // The change is committed to the vault and the status persists.
+    const after = createLibrarianStore({ dataDir });
+    try {
+      expect(after.readAddendum("grooming").content).toBe("be conservative");
+      expect(readAddendumStatus(after, "grooming").status).toBe("under_evaluation");
+    } finally {
+      after.close();
+    }
+    expect(vaultLog(dataDir).some((m) => /grooming/.test(m))).toBe(true);
+  });
+
+  it("set rejects an addendum over the 2 KB cap (the hard write backstop)", async () => {
+    const server = await startHttpServer({ dataDir });
+    try {
+      const tooBig = "x".repeat(2049);
+      const response = await fetch(`${server.url}/trpc/addendum.set`, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: `Bearer ${server.token}` },
+        body: JSON.stringify({ job: "grooming", content: tooBig }),
+      });
+      expect(response.status).toBeGreaterThanOrEqual(400);
+      const body = await response.text();
+      expect(body).toMatch(/2048|2 KB|bytes/i);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("get returns the fresh-install default for an unset addendum", async () => {
+    const server = await startHttpServer({ dataDir });
+    try {
+      const result = await trpcGet<{
+        content: string;
+        version: string | null;
+        status: string;
+        evalVersion: string | null;
+      }>(server, "addendum.get", { job: "intake" });
+      expect(result).toEqual({
+        content: "",
+        version: null,
+        status: "accepted",
+        evalVersion: null,
+      });
+    } finally {
+      await server.stop();
     }
   });
 });


### PR DESCRIPTION
Surfaces the whole 2C self-improvement loop in the dashboard: chat with the curator about a memory (or the corpus), accept its proposed fixes, draft an addendum, and manage the addendum-evaluation lifecycle.

## What's built (`apps/dashboard/`)
- **Split-screen chat panel** (`components/curator/chat-panel.tsx`): conversation on the left, an addendum-draft editor on the right. Keeps the messages array client-side (request/response, NO streaming — send the array, get one response, append). Renders the three `ChatResponse` kinds:
  - `message` → prose.
  - `proposed_action` → a **Confirm card**. **PROPOSE, NEVER AUTO-EXECUTE (human-in-the-loop):** the action is shown for review; only an explicit Confirm runs the matching D5 mutation. Confirm does `const { type, ...input } = action; memories[type](input)` — i.e. `memories.merge/split/update/unmerge` — because the proposed-action schema mirrors the D5 mutation inputs exactly. The UI never auto-runs an action.
  - `addendum_edit` → populates the right-pane draft with the candidate; an `over_limit` candidate shows a clear "still over 2 KB — shorten before committing" notice (the write backstop rejects >2 KB anyway).
- **Entry points:** a **"Discuss this memory"** button on the memory detail panel (opens the chat pre-populated with the memory id; the job is inferred server-side) + a **general fresh-chat entry** on the curator page with an intake/grooming **job picker**.
- **Lifecycle controls** (`components/curator/addendum-lifecycle.tsx`): **Accept** / **Roll-back** (both jobs) + **Dry-run** / **Re-evaluate** (grooming-only) wired to `addendum.accept` / `addendum.rollback` / `curator.dryRunGrooming` / `addendum.reEvaluate`. Shows the addendum status (accepted / under_evaluation) + version.
- **Disabled-job messaging (D-11):** when a job is disabled the **chat + addendum editor still work** (edits commit and take effect when the job is re-enabled), but the **probation/dry-run controls are inert with a clear message** ("enable it to dry-run / evaluate") — never hidden silently.
- **Server actions** (`app/curator/actions.ts`): chat, confirm-action, accept, rollback, re-evaluate, dry-run, set-addendum — all mirror the existing `{ok}|{ok:false,error}` + `message()` + `revalidatePath` pattern. The curator page's reads stay parallelised.

## Thin tRPC added
The addendum content/status had no read/write tRPC. Added two admin-gated procedures to the existing `addendum` router (no existing behaviour changed): `get` (content + git version + status + evalVersion) and `set` (commit a new addendum draft → under evaluation; the hard 2 KB cap throws over-cap, the write backstop).

## Tests
- Component: `chat-panel.test.tsx` (8 — incl. propose-not-auto-execute, addendum-edit populates the draft, over-2 KB notice), `addendum-lifecycle.test.tsx` (8 — Accept/Roll-back/Dry-run/Re-evaluate, grooming-only gating, disabled-job inert).
- mcp-server tRPC: `addendum.test.ts` (+4 — get/set round-trip, under-evaluation on set, admin-gating, 2 KB write backstop).
- Playwright e2e: `curator-chat.spec.ts` (5 — both entry points open the chat; a proposed update is NOT applied until Confirm, then applies; Accept/Roll-back drive the lifecycle; the proposed-action turn uses a scripted OpenAI-compatible stub).

Full `pnpm test` + `pnpm -r build` + typecheck + lint clean; the full 25-test Playwright e2e suite passes locally.

CHANGELOG deferred to D8's single user-visible 044 entry (covers the whole D1–D7 arc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)