### PR TITLE
docs(curator): document the self-improving loop + 044 CHANGELOG (spec 044 PR-8, Task D8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,32 @@ changes from this point forward are catalogued here.
 
 ### Added
 
+- **The curator now self-improves under your supervision.** You can teach each
+  curator job — **Intake** and **Grooming** — by editing its **prompt addendum**,
+  a per-job vault file (`<vault>/.curator/grooming-addendum.md` and
+  `intake-addendum.md`) that is **git-versioned**, so every edit gets diff,
+  revert, and backup for free; an existing install's old single
+  `curator.prompt_addendum` is migrated into the grooming file byte-for-byte and
+  retired automatically. **Both jobs now consume their addendum on the live
+  path** (intake previously didn't). Editing an addendum puts that job **under
+  evaluation**: every operation it would have auto-applied is instead **proposed**
+  for your review (auto-archives are skipped), tagged with the addendum version,
+  until you **Accept** (resume auto-apply), **Roll back** (`git checkout` the
+  prior version), or — for grooming — **Re-evaluate** that version's proposals.
+  Grooming can also **dry-run** a candidate addendum over the whole corpus or a
+  single slice in propose-mode **without committing it live**. A new **curator
+  chat** (a "discuss this memory" button on each memory row plus a general entry)
+  grounds in a memory and its decision history and can **propose** a fix-now
+  mutation — **merge / split / update / unmerge** (unmerge reverses a bad groom)
+  — or an addendum edit, which **you confirm** with an explicit button: the
+  curator proposes, never executes on its own. There is **no automated evaluation
+  gate** — the addendum is **advisory** (the curator's hard, safety, and
+  structural rules stay code-re-checked regardless of it), and the guards are a
+  human judging real results, a 2 KB addendum cap (soft in-chat condense + hard
+  write backstop), the under-evaluation lifecycle, and dry-run. Everything is
+  **admin-only** — there is no agent-facing surface and recall/navigate are
+  untouched.
+
 - **Unified Memory Curator dashboard — one page, two jobs.** The Memory Curator
   page now presents both curator jobs side by side in clear **Intake** and
   **Grooming** sections, each with its own enablement toggle, model
@@ -60,8 +86,9 @@ changes from this point forward are catalogued here.
   and `intake-addendum.md` for intake), so edits get git history, diff, and
   revert for free. An existing install's `curator.prompt_addendum` is migrated
   into the grooming file **byte-for-byte automatically on first start** and the
-  old setting is retired — no operator action needed. (The dashboard editor for
-  these files arrives in a later increment of this release.)
+  old setting is retired — no operator action needed. (Editing these files, the
+  under-evaluation lifecycle, dry-run, and the curator chat are described under
+  the self-improving-curator entry in **Added** above.)
 
 - **Consistent "one curator, two jobs" naming across the product.** User-facing
   surfaces now describe a single curator doing two jobs — **Intake** (consolidates

--- a/README.md
+++ b/README.md
@@ -259,9 +259,73 @@ token is encrypted at rest with `LIBRARIAN_SECRET_KEY`.
 > intake from the dashboard — it will be removed in a future release.
 > (`LIBRARIAN_CONSOLIDATOR_TICK_MS`, the intake tick cadence, is unaffected.)
 
+### Tuning the curator — the self-improving loop
+
+The curator improves through use. An admin teaches each job by editing its
+**prompt addendum**, watches the results on real memories, and either keeps the
+change or reverts it. Everything below is **admin-only** — there is no
+agent-facing surface, and `recall` / navigate are untouched.
+
+**Per-job addendum files (git-versioned).** Each job's prompt addendum is a
+committed vault file — `<vault>/.curator/grooming-addendum.md` and
+`intake-addendum.md` — appended to that job's judge prompt as **advisory**
+guidance. Because it lives in git you get diff, revert, and backup for free, and
+its **version is the file's git commit hash**. An existing install's old
+`curator.prompt_addendum` setting is migrated into `grooming-addendum.md`
+byte-for-byte on first start, then the setting is retired. **Both jobs consume
+their addendum on the live path** — grooming and intake alike (the intake side
+was a gap that is now closed).
+
+**Under-evaluation lifecycle.** Editing an addendum (from the dashboard editor or
+the chat) commits the file and puts that job **under evaluation**: every
+operation it would have applied is instead **proposed** for your review (auto-
+applies become proposals; auto-archives are skipped), and each proposal is tagged
+with the addendum version. You judge the real proposals, then choose:
+
+- **Accept** — the addendum is good; auto-apply resumes.
+- **Roll back** — the addendum is bad; `git checkout` restores the prior
+  committed version and auto-apply resumes on it.
+- **Re-evaluate** (grooming only) — batch re-judge that version's outstanding
+  proposals (the escape hatch). Intake has none — the inbox is consumed on apply
+  and isn't replayable.
+
+**Grooming dry-run.** Before committing a candidate addendum live, preview it:
+grooming can run the candidate over the whole corpus (background) or a single
+slice (fast) in **propose-mode without committing it**, producing a reviewable
+batch tagged as a dry-run. Intake has no dry-run for the same reason it has no
+re-evaluate — its inbox isn't replayable.
+
+**Curator chat.** A dashboard chat — a **"discuss this memory"** entry on each
+memory row plus a **general** entry — grounds the conversation in the memory and
+its decision history. It can **propose** a fix-now mutation (merge / split /
+update / **unmerge**) or an addendum edit, and the admin **confirms** each with an
+explicit button: the curator proposes, it never executes against the live store
+on its own (human-in-the-loop). A co-authored addendum over **2 KB** triggers a
+soft **condense** turn (rewrite tighter, preserving load-bearing rules) rather
+than failing; the file write hard-rejects anything over 2 KB as a backstop.
+
+**How it's kept safe — the admin judges real results.** There is **no automated
+evaluation gate**. The addendum is **advisory only**: the curator's hard, safety,
+and structural rules stay **code-re-checked regardless of what the addendum
+says**, so an addendum can shape judgement but never override an invariant. The
+guards are deliberately simple and human-centred:
+
+1. **Code re-check** of the hard/safety/structural rules on every operation,
+   independent of the addendum.
+2. The **2 KB cap** (soft condense + hard write backstop) keeps an addendum from
+   growing into an unbounded second prompt.
+3. The **under-evaluation lifecycle** — a freshly edited addendum force-proposes
+   until you accept it, so nothing it changes auto-applies unseen.
+4. **Dry-run** — preview a candidate over real corpus before it ever goes live.
+
+You read the actual proposals the change produced and decide; the loop is tuned
+by a human judging real results, not by a metric.
+
 Spec:
 [`docs/specs/043-curator-unification-spec.md`](./docs/specs/043-curator-unification-spec.md)
-(builds on
+and
+[`docs/specs/044-self-improving-curator-spec.md`](./docs/specs/044-self-improving-curator-spec.md)
+(building on
 [`docs/specs/done/013-memory-curator-spec.md`](./docs/specs/done/013-memory-curator-spec.md)).
 
 ## Agent skill

--- a/apps/dashboard/components/curator/addendum-lifecycle.tsx
+++ b/apps/dashboard/components/curator/addendum-lifecycle.tsx
@@ -58,6 +58,10 @@ export function AddendumLifecycle({
   // Grooming has the dry-run + re-evaluate escape hatches; intake does not.
   const isGrooming = job === "grooming";
   const underEvaluation = status === "under_evaluation";
+  // The committed vault file this lifecycle governs (D-1): "grooming-addendum.md"
+  // / "intake-addendum.md". Surface its name so the badge reads in the spec's
+  // "grooming-addendum vN — under evaluation" shape.
+  const addendumName = `${job}-addendum`;
 
   const run = <R,>(action: () => Promise<R>, describe: (result: R) => string) =>
     startTransition(async () => {
@@ -73,7 +77,12 @@ export function AddendumLifecycle({
       aria-label={`${job === "grooming" ? "Grooming" : "Intake"} addendum lifecycle`}
     >
       <div className="flex items-center justify-between gap-2">
-        <h3 className="font-semibold">Addendum status</h3>
+        <h3 className="font-semibold">
+          <span className="font-mono">{addendumName}</span>
+          {underEvaluation && evalVersion ? (
+            <span className="text-muted-foreground"> v{evalVersion.slice(0, 7)}</span>
+          ) : null}
+        </h3>
         <span
           className={`rounded-full px-2 py-0.5 text-xs font-medium ${
             underEvaluation
@@ -82,7 +91,6 @@ export function AddendumLifecycle({
           }`}
         >
           {underEvaluation ? "under evaluation" : "accepted"}
-          {underEvaluation && evalVersion ? ` · ${evalVersion.slice(0, 7)}` : ""}
         </span>
       </div>
 

--- a/apps/dashboard/tests/components/curator/addendum-lifecycle.test.tsx
+++ b/apps/dashboard/tests/components/curator/addendum-lifecycle.test.tsx
@@ -44,6 +44,19 @@ describe("AddendumLifecycle", () => {
     expect(screen.getByText(/abcdef0/)).toBeTruthy();
   });
 
+  it("names the addendum file in the spec's 'name vN — status' shape", () => {
+    renderLifecycle({ job: "grooming", status: "under_evaluation", evalVersion: "abcdef0123" });
+    // "grooming-addendum vabcdef0 — under evaluation"
+    expect(screen.getByText("grooming-addendum")).toBeTruthy();
+    expect(screen.getByText(/vabcdef0/)).toBeTruthy();
+    expect(screen.getByText(/under evaluation/i)).toBeTruthy();
+  });
+
+  it("names the intake addendum file for the intake job", () => {
+    renderLifecycle({ job: "intake", status: "accepted", evalVersion: null });
+    expect(screen.getByText("intake-addendum")).toBeTruthy();
+  });
+
   it("drives Accept (D3)", async () => {
     renderLifecycle({ status: "under_evaluation", evalVersion: "v1" });
     await userEvent.click(screen.getByRole("button", { name: /accept/i }));


### PR DESCRIPTION
Final PR of **spec 044 (self-improving curator)**. The 2C self-improvement loop was fully built across D1–D7 (#327–#337); D8 documents it, lands the single user-visible 044 CHANGELOG entry, and polishes the dashboard addendum-status badge into the spec's `grooming-addendum vN — under evaluation` shape. No behaviour change.

## Docs — README "Memory curator" section
New **"Tuning the curator — the self-improving loop"** subsection:
- **Git-versioned per-job addendum files** (`<vault>/.curator/grooming-addendum.md` + `intake-addendum.md`) — diff/revert/backup for free, version = file's git commit hash; old `curator.prompt_addendum` migrated byte-for-byte then retired.
- **Both jobs consume their addendum on the live path** (the intake I5 gap, now closed).
- **Under-evaluation lifecycle** — editing an addendum force-proposes (auto-archives skipped), tagged with the version; **Accept** / **Roll back** (git checkout) / **Re-evaluate** (grooming only).
- **Grooming dry-run** — preview a candidate over the corpus/a slice in propose-mode without committing it live (intake has none — inbox not replayable).
- **Curator chat** — "discuss this memory" + general entry; proposes a fix-now mutation (merge/split/update/**unmerge**) or an addendum edit, which the admin **confirms** (propose-never-execute); 2 KB soft condense + hard write backstop.
- **The human-judges-real-results model + the guards (D-4), stated explicitly:** NO automated eval gate; the addendum is **advisory** (hard/safety/structural rules stay code-re-checked regardless); guards = code re-check + 2 KB cap + under-evaluation + dry-run. **Admin-only**; recall/navigate untouched.
- Links the live 044 spec.

## CHANGELOG — the single 044 `[Unreleased]` entry
One cohesive **Added** entry covering the whole D1–D7 arc (git-versioned per-job addenda + auto-migration, intake consuming its addendum, the under-evaluation accept/rollback/re-evaluate lifecycle, grooming dry-run, admin merge/split/update/**unmerge**, and the curator chat with propose-and-confirm). The prior D1 **Changed** addendum entry drops its now-obsolete "editor arrives later" caveat and cross-references the Added entry (no duplication; 042/043 entries untouched).

## Surfacing — confirmed + polished
D7's `components/curator/addendum-lifecycle.tsx` already showed accepted / under_evaluation + version. Polished into the spec's **"name vN — status"** shape: the heading now names the file (`grooming-addendum` / `intake-addendum`) + `vN`, and the badge carries the status. Component tests pin the new shape; existing `/under evaluation/`, `/accepted/`, version assertions stay green.

## Verification
`pnpm test` (full suite — dashboard 200, root 22, all packages green, 0 `error TS`), `pnpm -r build` incl. the dashboard Next.js build, `pnpm typecheck`, `pnpm lint` — all green. Review conducted by me (no Task/Agent sub-agent in this sandbox, as in every prior D-task): every claim verified against shipped code (judge-step.ts advisory + code-re-check, migration, force-propose, dryRunGrooming, unmerge, addendum.set→under_evaluation); no aspirational docs; README contract holds; no behaviour change beyond the cosmetic badge.

**After this, spec 044 — and the entire 042+043+044 curator arc — is COMPLETE.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)