### PR TITLE
feat(core): awareness primer setting + admin field (spec 041 PR-1, Task A1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ changes from this point forward are catalogued here.
 
 ### Added
 
+- **Awareness primer — a dashboard-editable note that tells every agent it has
+  durable memory.** A new admin setting (**Settings → Awareness primer**) holds a
+  short, server-sourced note (shipped with a sensible default, pre-filled) that
+  will be injected **every turn on every harness** — reminding the model that The
+  Librarian exists and which verbs to reach for (`recall` before asking,
+  `remember` / `/learn` to save). Editing it changes what the next turn sees with
+  no plugin redeploy; **clearing it to empty disables the primer**. (This lands
+  the setting and admin field; the per-turn injection ships in a follow-up.)
+
 - **The curator now self-improves under your supervision.** You can teach each
   curator job — **Intake** and **Grooming** — by editing its **prompt addendum**,
   a per-job vault file (`<vault>/.curator/grooming-addendum.md` and

--- a/apps/dashboard/app/settings/actions.ts
+++ b/apps/dashboard/app/settings/actions.ts
@@ -1,0 +1,25 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { serverTRPC } from "@/lib/trpc-server";
+
+// Server actions for the settings home (spec 041 PR-1 / Task A1). The awareness
+// primer is a server-sourced note injected on every harness turn; saving "" (an
+// empty textarea) disables it. Mirrors the curator config-action shape
+// (server action → tRPC → revalidatePath).
+
+export type SavePrimerResult = { ok: true } | { ok: false; error: string };
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function saveAwarenessPrimerAction(primer: string): Promise<SavePrimerResult> {
+  try {
+    await serverTRPC.awareness.setPrimer.mutate({ primer });
+    revalidatePath("/settings");
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: message(error) };
+  }
+}

--- a/apps/dashboard/app/settings/page.tsx
+++ b/apps/dashboard/app/settings/page.tsx
@@ -1,0 +1,45 @@
+// Settings home (spec 041 PR-1 / Task A1). Currently hosts the awareness primer —
+// a server-sourced note injected on every harness turn (spec 041 1B). Reads the
+// current primer server-side (the shipped default when never set) and renders the
+// admin field. Gated like the rest of the dashboard. Authentication has its own
+// sub-page (/settings/auth); this page links to it.
+
+import Link from "next/link";
+import { saveAwarenessPrimerAction } from "@/app/settings/actions";
+import { AwarenessPrimerForm } from "@/components/settings/awareness-primer-form";
+import { serverTRPC } from "@/lib/trpc-server";
+
+export const metadata = { title: "Settings · Librarian" };
+export const dynamic = "force-dynamic";
+
+async function loadPrimer(): Promise<string> {
+  try {
+    const { primer } = await serverTRPC.awareness.primer.query();
+    return primer;
+  } catch {
+    // Fail-soft: a transient read error shouldn't blank the page. The textarea
+    // renders empty; saving will surface any persistent error.
+    return "";
+  }
+}
+
+export default async function SettingsPage() {
+  const primer = await loadPrimer();
+
+  return (
+    <main className="mx-auto flex w-full max-w-2xl flex-col gap-6 p-6">
+      <header className="flex flex-col gap-1">
+        <h1 className="font-display text-2xl text-foreground">Settings</h1>
+        <p className="text-sm text-foreground/60">
+          Server-sourced settings that take effect without a redeploy.{" "}
+          <Link href="/settings/auth" className="underline">
+            Authentication
+          </Link>{" "}
+          has its own page.
+        </p>
+      </header>
+
+      <AwarenessPrimerForm initial={primer} onSave={saveAwarenessPrimerAction} />
+    </main>
+  );
+}

--- a/apps/dashboard/components/settings/awareness-primer-form.tsx
+++ b/apps/dashboard/components/settings/awareness-primer-form.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import type { SavePrimerResult } from "@/app/settings/actions";
+
+// The awareness-primer admin field (spec 041 PR-1 / Task A1). A labelled textarea
+// for the server-sourced primer that gets injected on EVERY harness turn (once A2
+// wires it into conv_state_get + the plugins render it). The textarea is
+// pre-filled with the current primer (the shipped default when never set); an
+// EMPTY textarea DISABLES the primer (no block injected anywhere).
+export function AwarenessPrimerForm({
+  initial,
+  onSave,
+}: {
+  initial: string;
+  onSave: (primer: string) => Promise<SavePrimerResult>;
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [status, setStatus] = useState<string | null>(null);
+  const [primer, setPrimer] = useState(initial);
+
+  const submit = (event: React.FormEvent) => {
+    event.preventDefault();
+    startTransition(async () => {
+      const result = await onSave(primer);
+      setStatus(result.ok ? "Saved." : `Error: ${result.error}`);
+      if (result.ok) router.refresh();
+    });
+  };
+
+  return (
+    <form
+      onSubmit={submit}
+      className="flex flex-col gap-3 rounded-md border bg-card p-4"
+      aria-label="Awareness primer form"
+    >
+      <h2 className="font-semibold">Awareness primer</h2>
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="text-xs text-muted-foreground" id="awareness-primer-hint">
+          This text is injected every turn on every harness, telling the agent it has durable memory
+          and which verbs to use. Leave it empty to disable the primer (no block injected anywhere).
+        </span>
+        <textarea
+          aria-label="Awareness primer text"
+          aria-describedby="awareness-primer-hint"
+          className="min-h-[120px] rounded-md border border-input bg-background p-2 font-mono text-sm"
+          value={primer}
+          onChange={(e) => setPrimer(e.target.value)}
+        />
+      </label>
+      <div className="flex items-center gap-3">
+        <button
+          type="submit"
+          disabled={pending}
+          className="rounded-md border bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground disabled:opacity-50"
+        >
+          {pending ? "Saving…" : "Save"}
+        </button>
+        {status ? <span className="text-sm text-muted-foreground">{status}</span> : null}
+      </div>
+    </form>
+  );
+}

--- a/apps/dashboard/components/site-nav.tsx
+++ b/apps/dashboard/components/site-nav.tsx
@@ -24,6 +24,7 @@ const TABS = [
   { href: "/curator", label: "Curator", match: (p: string) => p.startsWith("/curator") },
   { href: "/backups", label: "Backups", match: (p: string) => p.startsWith("/backups") },
   { href: "/tokens", label: "Tokens", match: (p: string) => p.startsWith("/tokens") },
+  { href: "/settings", label: "Settings", match: (p: string) => p === "/settings" },
   { href: "/settings/auth", label: "Auth", match: (p: string) => p.startsWith("/settings/auth") },
 ] as const;
 

--- a/apps/dashboard/tests/components/awareness-primer-form.test.tsx
+++ b/apps/dashboard/tests/components/awareness-primer-form.test.tsx
@@ -1,0 +1,59 @@
+// Awareness-primer admin field (spec 041 PR-1 / Task A1).
+//
+// The labelled textarea for the server-sourced primer. Asserts: it pre-fills with
+// the current primer; the hint says the text is injected EVERY TURN ON EVERY
+// HARNESS (so the operator understands its reach); editing + Save sends the new
+// text to the action; an emptied textarea sends "" (which disables the primer);
+// a failed save surfaces the error.
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
+
+const { AwarenessPrimerForm } = await import("@/components/settings/awareness-primer-form");
+
+describe("AwarenessPrimerForm", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("pre-fills the textarea with the current primer", () => {
+    render(<AwarenessPrimerForm initial="Current primer text." onSave={vi.fn()} />);
+    expect(screen.getByLabelText("Awareness primer text")).toHaveValue("Current primer text.");
+  });
+
+  it("hint says the primer is injected every turn on every harness", () => {
+    render(<AwarenessPrimerForm initial="x" onSave={vi.fn()} />);
+    expect(screen.getByText(/injected every turn on every harness/i)).toBeInTheDocument();
+  });
+
+  it("sends the edited primer to onSave and shows a saved status", async () => {
+    const onSave = vi.fn().mockResolvedValue({ ok: true });
+    render(<AwarenessPrimerForm initial="" onSave={onSave} />);
+
+    await userEvent.type(screen.getByLabelText("Awareness primer text"), "New primer");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave).toHaveBeenCalledWith("New primer");
+    await vi.waitFor(() => expect(screen.getByText("Saved.")).toBeInTheDocument());
+  });
+
+  it("sends '' when the textarea is cleared (disables the primer)", async () => {
+    const onSave = vi.fn().mockResolvedValue({ ok: true });
+    render(<AwarenessPrimerForm initial="Some default primer." onSave={onSave} />);
+
+    await userEvent.clear(screen.getByLabelText("Awareness primer text"));
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onSave).toHaveBeenCalledWith("");
+  });
+
+  it("surfaces the error from a failed save", async () => {
+    const onSave = vi.fn().mockResolvedValue({ ok: false, error: "boom" });
+    render(<AwarenessPrimerForm initial="x" onSave={onSave} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+    await vi.waitFor(() => expect(screen.getByText("Error: boom")).toBeInTheDocument());
+  });
+});

--- a/packages/core/src/awareness-primer.ts
+++ b/packages/core/src/awareness-primer.ts
@@ -1,0 +1,47 @@
+// Awareness primer (spec 041, feature 1B) — a short, server-sourced note injected
+// on every harness turn telling the model that The Librarian exists and which
+// verbs to reach for. It rides the existing per-turn conv-state injection channel
+// (A2 wires it into `conv_state_get`; the five plugins render it).
+//
+// Storage: a single flat settings key (`awareness.primer`). Semantics:
+//   - key NULL (never set) → reads back the SHIPPED DEFAULT (the primer works
+//     out-of-the-box, before any admin edit);
+//   - key "" (explicitly empty) → DISABLES the primer (reads back "", no block);
+//   - any other string → the operator's custom primer (round-trips verbatim).
+//
+// Reads are FAIL-SOFT: this fires every turn, so a locked/unreadable settings
+// store (e.g. a secret-stored value with no master key) must never throw — it
+// degrades to "" (no primer), same posture as `readWorkingStyle`.
+
+import type { SettingsStore } from "./store/settings-types.js";
+
+/** The flat settings key holding the operator-authored awareness primer. */
+export const AWARENESS_PRIMER_KEY = "awareness.primer";
+
+/**
+ * The shipped default primer (spec 041 Decision 3 — verbatim). Pre-filled in the
+ * dashboard and returned whenever the setting has never been written; phrased to
+ * read sensibly even mid-off-record ("worth keeping", not "always remember").
+ */
+export const DEFAULT_AWARENESS_PRIMER =
+  "You have The Librarian: durable, cross-session memory. " +
+  "Use `recall` to check what's already known before asking; " +
+  "use `remember` / `/learn` to save durable facts, preferences, and decisions worth keeping.";
+
+/**
+ * Read the awareness primer fail-soft.
+ *
+ *   - the key is null (never set)  → the shipped default (pre-filled out-of-box);
+ *   - the key is "" (disabled)     → "" (no primer block anywhere);
+ *   - the key is any other string  → that string verbatim;
+ *   - the store throws (locked/unreadable) → "" (NEVER throws — this read fires
+ *     every turn once A2 wires it into `conv_state_get`, and must not block it).
+ */
+export function readAwarenessPrimer(store: Pick<SettingsStore, "getSetting">): string {
+  try {
+    const value = store.getSetting(AWARENESS_PRIMER_KEY);
+    return value === null ? DEFAULT_AWARENESS_PRIMER : value;
+  } catch {
+    return "";
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -530,6 +530,11 @@ export type { ConversationStateStore } from "./store/conversation-state-store.js
 export type { ConversationState, ConversationStatePatch } from "./schemas/conversation-state.js";
 export { renderConvStateBlock } from "./conv-state-render.js";
 export {
+  AWARENESS_PRIMER_KEY,
+  DEFAULT_AWARENESS_PRIMER,
+  readAwarenessPrimer,
+} from "./awareness-primer.js";
+export {
   type ClaimHandoffInput,
   type ClaimHandoffOutput,
   type HandoffSummary,

--- a/packages/core/tests/awareness-primer.test.ts
+++ b/packages/core/tests/awareness-primer.test.ts
@@ -1,0 +1,86 @@
+// Awareness primer setting (spec 041 PR-1 / Task A1).
+//
+// The primer is a server-sourced note injected every harness turn (A2 wires the
+// read into `conv_state_get`). A1 lands the setting, its shipped default, and the
+// fail-soft read helper. Semantics under test:
+//   - key NULL (never set) → the SHIPPED DEFAULT (works out-of-the-box);
+//   - key "" (explicitly)  → DISABLED (reads back "");
+//   - custom string        → round-trips verbatim;
+//   - store throws         → "" (FAIL-SOFT; this read fires every turn, never blocks it).
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  AWARENESS_PRIMER_KEY,
+  DEFAULT_AWARENESS_PRIMER,
+  type LibrarianStore,
+  createLibrarianStore,
+  readAwarenessPrimer,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+interface Scope {
+  store: LibrarianStore;
+  dataDir: string;
+}
+
+function scope(): Scope {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-primer-"));
+  return { store: createLibrarianStore({ dataDir }), dataDir };
+}
+
+function teardown(s: Scope | null): void {
+  if (!s) return;
+  try {
+    s.store.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(s.dataDir, { recursive: true, force: true });
+}
+
+describe("awareness primer setting (spec 041 A1)", () => {
+  let s: Scope | null = null;
+  beforeEach(() => {
+    s = scope();
+  });
+  afterEach(() => {
+    teardown(s);
+    s = null;
+  });
+
+  it("reads back the shipped default when the setting was never written", () => {
+    expect(s!.store.getSetting(AWARENESS_PRIMER_KEY)).toBeNull();
+    expect(readAwarenessPrimer(s!.store)).toBe(DEFAULT_AWARENESS_PRIMER);
+  });
+
+  it("the shipped default matches spec 041 Decision 3 verbatim", () => {
+    expect(DEFAULT_AWARENESS_PRIMER).toBe(
+      "You have The Librarian: durable, cross-session memory. " +
+        "Use `recall` to check what's already known before asking; " +
+        "use `remember` / `/learn` to save durable facts, preferences, and decisions worth keeping.",
+    );
+  });
+
+  it("an explicit empty string DISABLES the primer (reads back '')", () => {
+    s!.store.setSetting(AWARENESS_PRIMER_KEY, "");
+    expect(readAwarenessPrimer(s!.store)).toBe("");
+  });
+
+  it("a custom primer round-trips verbatim", () => {
+    const custom = "You have memory. Use recall first.";
+    s!.store.setSetting(AWARENESS_PRIMER_KEY, custom);
+    expect(readAwarenessPrimer(s!.store)).toBe(custom);
+  });
+
+  it("is fail-soft: an unreadable settings store yields '' and never throws", () => {
+    const broken: Pick<typeof s.store, "getSetting"> = {
+      getSetting() {
+        throw new Error("settings store is locked");
+      },
+    };
+    expect(() => readAwarenessPrimer(broken)).not.toThrow();
+    expect(readAwarenessPrimer(broken)).toBe("");
+  });
+});

--- a/packages/mcp-server/src/trpc/awareness.ts
+++ b/packages/mcp-server/src/trpc/awareness.ts
@@ -1,0 +1,32 @@
+// Awareness-primer admin tRPC procedures (spec 041 PR-1 / Task A1).
+//
+// The awareness primer is a short, server-sourced note injected on every harness
+// turn telling the model that The Librarian exists and which verbs to reach for
+// (A2 wires the read into `conv_state_get`; the five plugins render it). This is a
+// small admin surface — read the current primer (with the shipped default applied
+// when unset), write a new one. It lives in its own router rather than under
+// `curator` because the primer is harness-awareness, not a curator concern.
+//
+// Semantics (mirrors `readAwarenessPrimer`): the key unset reads back the shipped
+// default; an explicit empty string DISABLES the primer; any other string is the
+// operator's custom primer. The read is fail-soft (an unreadable store → "").
+// Admin-gated, mirroring the curator-config pattern (`trpc/curator.ts`).
+
+import { AWARENESS_PRIMER_KEY, readAwarenessPrimer } from "@librarian/core";
+import { z } from "zod";
+import { adminProcedure, router } from "./trpc.js";
+
+export const awarenessRouter = router({
+  // The current primer with the shipped default applied (the dashboard pre-fills
+  // the textarea with this). An explicitly-cleared primer reads back as "".
+  primer: adminProcedure.query(({ ctx }) => ({ primer: readAwarenessPrimer(ctx.store) })),
+
+  // Set the primer text. "" DISABLES it (no block injected anywhere); any other
+  // string is the operator's custom primer. Returns the fresh readable value.
+  setPrimer: adminProcedure
+    .input(z.strictObject({ primer: z.string() }))
+    .mutation(({ ctx, input }) => {
+      ctx.store.setSetting(AWARENESS_PRIMER_KEY, input.primer);
+      return { primer: readAwarenessPrimer(ctx.store) };
+    }),
+});

--- a/packages/mcp-server/src/trpc/router.ts
+++ b/packages/mcp-server/src/trpc/router.ts
@@ -10,6 +10,7 @@
 
 import { addendumRouter } from "./addendum.js";
 import { authRouter } from "./auth.js";
+import { awarenessRouter } from "./awareness.js";
 import { backupRouter } from "./backup.js";
 import { curatorRouter } from "./curator.js";
 import { handoffsRouter } from "./handoffs.js";
@@ -23,6 +24,7 @@ import { router } from "./trpc.js";
 export const appRouter = router({
   addendum: addendumRouter,
   auth: authRouter,
+  awareness: awarenessRouter,
   backup: backupRouter,
   curator: curatorRouter,
   handoffs: handoffsRouter,

--- a/packages/mcp-server/tests/trpc/awareness.test.ts
+++ b/packages/mcp-server/tests/trpc/awareness.test.ts
@@ -1,0 +1,140 @@
+// Awareness-primer admin tRPC tests (spec 041 PR-1 / Task A1).
+//
+// The admin surface for the server-sourced awareness primer (spec 041 1B):
+//   - awareness.primer (query) → the current primer with the shipped default
+//     applied when unset; an explicitly-cleared primer reads back as "";
+//   - awareness.setPrimer (mutation) → sets the text ("" DISABLES it; any other
+//     string is the operator's custom primer) and returns the fresh value.
+// Both admin-gated (rejected without an admin bearer).
+
+import { DEFAULT_AWARENESS_PRIMER, createLibrarianStore } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanupTempDir, makeTempDir, startHttpServer } from "../../../../test/helpers.js";
+
+interface TrpcOk<T> {
+  result: { data: T };
+}
+interface TrpcErr {
+  error: unknown;
+}
+interface ServerHandle {
+  url: string;
+  token: string;
+  stop: () => Promise<void>;
+}
+
+async function trpcPost<T>(server: ServerHandle, path: string, input?: unknown): Promise<T> {
+  const response = await fetch(`${server.url}/trpc/${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${server.token}` },
+    body: input === undefined ? undefined : JSON.stringify(input),
+  });
+  const json = (await response.json()) as TrpcOk<T> | TrpcErr;
+  if (response.status >= 400 || "error" in json) {
+    throw new Error(`trpc POST ${path} failed: ${JSON.stringify(json)}`);
+  }
+  return (json as TrpcOk<T>).result.data;
+}
+
+async function trpcGet<T>(server: ServerHandle, path: string): Promise<T> {
+  const response = await fetch(`${server.url}/trpc/${path}`, {
+    method: "GET",
+    headers: { authorization: `Bearer ${server.token}` },
+  });
+  const json = (await response.json()) as TrpcOk<T> | TrpcErr;
+  if (response.status >= 400 || "error" in json) {
+    throw new Error(`trpc GET ${path} failed: ${JSON.stringify(json)}`);
+  }
+  return (json as TrpcOk<T>).result.data;
+}
+
+interface PrimerResult {
+  primer: string;
+}
+
+describe("tRPC awareness primer surface (spec 041 A1)", () => {
+  let dataDir = "";
+  beforeEach(() => {
+    dataDir = makeTempDir();
+  });
+  afterEach(() => {
+    cleanupTempDir(dataDir);
+  });
+
+  it("admin-gates primer read + write (rejected without an admin bearer)", async () => {
+    const server = await startHttpServer({ dataDir });
+    try {
+      const readUnauthed = await fetch(`${server.url}/trpc/awareness.primer`, { method: "GET" });
+      expect(readUnauthed.status).toBeGreaterThanOrEqual(400);
+
+      const writeUnauthed = await fetch(`${server.url}/trpc/awareness.setPrimer`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ primer: "x" }),
+      });
+      expect(writeUnauthed.status).toBeGreaterThanOrEqual(400);
+
+      const writeAgent = await fetch(`${server.url}/trpc/awareness.setPrimer`, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: "Bearer agent-token" },
+        body: JSON.stringify({ primer: "x" }),
+      });
+      expect(writeAgent.status).toBeGreaterThanOrEqual(400);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("reads the shipped default when the primer was never set", async () => {
+    const server = await startHttpServer({ dataDir });
+    try {
+      const result = await trpcGet<PrimerResult>(server, "awareness.primer");
+      expect(result.primer).toBe(DEFAULT_AWARENESS_PRIMER);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("round-trips a custom primer through write → read", async () => {
+    const server = await startHttpServer({ dataDir });
+    try {
+      const custom = "You have memory. Recall before asking.";
+      const wrote = await trpcPost<PrimerResult>(server, "awareness.setPrimer", { primer: custom });
+      expect(wrote.primer).toBe(custom);
+
+      const read = await trpcGet<PrimerResult>(server, "awareness.primer");
+      expect(read.primer).toBe(custom);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("an explicit empty string disables the primer (reads back '')", async () => {
+    const server = await startHttpServer({ dataDir });
+    try {
+      const wrote = await trpcPost<PrimerResult>(server, "awareness.setPrimer", { primer: "" });
+      expect(wrote.primer).toBe("");
+
+      const read = await trpcGet<PrimerResult>(server, "awareness.primer");
+      expect(read.primer).toBe("");
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("persists the custom primer across a server restart (settings store)", async () => {
+    const custom = "Persisted primer.";
+    // Seed via a store on the same dataDir, then boot a fresh server and read back.
+    const seed = createLibrarianStore({ dataDir });
+    seed.setSetting("awareness.primer", custom);
+    seed.close();
+
+    const server = await startHttpServer({ dataDir });
+    try {
+      const read = await trpcGet<PrimerResult>(server, "awareness.primer");
+      expect(read.primer).toBe(custom);
+    } finally {
+      await server.stop();
+    }
+  });
+});


### PR DESCRIPTION
## What & why

First PR of **spec 041** (the 1B *awareness primer*). The awareness primer is a short, operator-authored, server-sourced note that — once the full loop lands — is injected on **every harness turn**, telling the agent it has durable memory and which verbs to reach for (`recall` before asking, `remember` / `/learn` to save). Without it, an agent may never realise The Librarian is available.

**This PR (Task A1) lands the setting + its shipped default + the admin field only.** A2 wires the read into `conv_state_get` (additive top-level `primer` field); A3–A7 render it in the five plugins; A8 is the eyeball test. None of that is in this PR.

## The setting + default/empty semantics

New core module `packages/core/src/awareness-primer.ts` (next to `conv-state-render.ts`):

- `AWARENESS_PRIMER_KEY = "awareness.primer"` — a flat (non-secret) settings key.
- `DEFAULT_AWARENESS_PRIMER` — the shipped default, **verbatim from spec 041 Decision 3**.
- `readAwarenessPrimer(store)` — fail-soft read mirroring `readWorkingStyle`:
  - key **null** (never set) → the **shipped default** (pre-filled, works out-of-the-box);
  - key **`""`** (explicit) → **`""` — disables** the primer (no block injected anywhere);
  - any other string → that string **verbatim**;
  - store **throws** (locked/unreadable) → **`""`, never throws** (this read fires every turn once A2 wires it in, so it must never block a turn).

Exported from `@librarian/core` so A2 and the tests share them.

## Admin tRPC

A small new `awareness` router (`packages/mcp-server/src/trpc/awareness.ts`, registered in `router.ts`), both procedures `adminProcedure`:

- `awareness.primer` (query) → `{ primer }` with the default applied;
- `awareness.setPrimer({ primer })` (mutation) → writes the key, returns the fresh `{ primer }`.

Placed in its own router rather than under `curator` because the primer is harness-awareness, not a curator concern (and there is no general settings router; auth has its own).

## Dashboard field

- New `/settings` home (`app/settings/page.tsx`) — only `/settings/auth` existed before — hosting `AwarenessPrimerForm`: a labelled textarea pre-filled with the current primer, saved via a server action → `awareness.setPrimer` → `revalidatePath`. The hint says the text is **injected every turn on every harness**; an empty textarea **disables** the primer.
- A "Settings" nav tab (matches `/settings` exactly, distinct from the Auth tab).
- `[Unreleased] ### Added` CHANGELOG entry (operator-visible new admin setting; honest that the per-turn injection ships in a follow-up).

## Tests (TDD, all green)

- core `tests/awareness-primer.test.ts` (5): default-when-unset, exact-default-text (spec Decision 3), `""`-disables, custom round-trip, fail-soft throwing-stub.
- mcp-server `tests/trpc/awareness.test.ts` (5): admin-gating read+write, default-when-unset, custom round-trip, `""`-disables, persists across server restart.
- dashboard `tests/components/awareness-primer-form.test.tsx` (5): pre-fill, hint-says-every-turn-every-harness, edited→onSave+saved, cleared→`""`(disable), failed-save error.

Full `pnpm test` green (core 908, mcp-server 160, dashboard 205, root 22), `pnpm -r build` + typecheck + lint clean (no `error TS`). Review was self-conducted (no Task/Agent sub-agent in this sandbox) across fail-soft, default-vs-empty, admin-gating, default-text-verbatim (byte-checked), and hint-accuracy; no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)