### PR TITLE
feat(core): conv_state_get returns additive primer + canonical renderer (spec 041 PR-2, Task A2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,14 @@ changes from this point forward are catalogued here.
   will be injected **every turn on every harness** — reminding the model that The
   Librarian exists and which verbs to reach for (`recall` before asking,
   `remember` / `/learn` to save). Editing it changes what the next turn sees with
-  no plugin redeploy; **clearing it to empty disables the primer**. (This lands
-  the setting and admin field; the per-turn injection ships in a follow-up.)
+  no plugin redeploy; **clearing it to empty disables the primer**. The server now
+  returns the primer as an **additive `primer` field on every `conv_state_get`
+  response** — both when a conversation-state row exists (alongside the existing
+  row fields, so un-updated plugins are unaffected) and when none does — so it is
+  available on the very first turn and on harnesses without a stable conversation
+  id; reads are fail-soft (`""` on an unreadable settings store, never blocking a
+  turn). Per-turn injection of the `<librarian>` block reaches each harness as its
+  plugin adopts the new field (rolling out incrementally, backward-compatibly).
 
 - **The curator now self-improves under your supervision.** You can teach each
   curator job — **Intake** and **Grooming** — by editing its **prompt addendum**,

--- a/packages/core/src/conv-state-render.ts
+++ b/packages/core/src/conv-state-render.ts
@@ -33,3 +33,32 @@ export function renderConvStateBlock(state: ConversationState | null): string {
     "</conversation-state>",
   ].join("\n");
 }
+
+/**
+ * Render the awareness primer block (spec 041, feature 1B — Decision 2).
+ *
+ * The primer is a short, server-sourced note injected on every harness turn
+ * telling the model that The Librarian exists and which verbs to reach for. It
+ * rides the SAME per-turn injection channel as `renderConvStateBlock`, but is a
+ * SEPARATE `<librarian>` block — it is static awareness, not per-turn state, so
+ * it is deliberately not folded into `<conversation-state>`.
+ *
+ * Returns the empty string when `primer` is empty — that is the contract that
+ * lets the operator DISABLE the primer (an empty `awareness.primer` setting) and
+ * keeps the read fail-soft (an unreadable store degrades to `""` → no block).
+ *
+ * This is the CANONICAL reference: each of the five plugins (Tasks A3–A7)
+ * replicates a byte-identical `renderAwarenessPrimer` locally (AGENTS.md §2 "five
+ * peer implementations" rule). The exact bytes below are the source of truth —
+ * the model consumes a stable byte sequence every turn across all harnesses.
+ *
+ * Shape:
+ *
+ *   <librarian>
+ *   <primer text>
+ *   </librarian>
+ */
+export function renderAwarenessPrimer(primer: string): string {
+  if (!primer) return "";
+  return ["<librarian>", primer, "</librarian>"].join("\n");
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -528,7 +528,7 @@ export {
 export type { SettingMeta, SettingsStore } from "./store/settings-store.js";
 export type { ConversationStateStore } from "./store/conversation-state-store.js";
 export type { ConversationState, ConversationStatePatch } from "./schemas/conversation-state.js";
-export { renderConvStateBlock } from "./conv-state-render.js";
+export { renderAwarenessPrimer, renderConvStateBlock } from "./conv-state-render.js";
 export {
   AWARENESS_PRIMER_KEY,
   DEFAULT_AWARENESS_PRIMER,

--- a/packages/core/tests/conv-state-render.test.ts
+++ b/packages/core/tests/conv-state-render.test.ts
@@ -6,7 +6,7 @@
 // line; sessions-retirement dropped the always-`none` `session_id` line —
 // the block is now just `conv_id` + `off_record`.)
 
-import { renderConvStateBlock } from "@librarian/core";
+import { renderAwarenessPrimer, renderConvStateBlock } from "@librarian/core";
 import { describe, expect, it } from "vitest";
 
 describe("renderConvStateBlock (T2.3)", () => {
@@ -68,5 +68,42 @@ describe("renderConvStateBlock (T2.3)", () => {
       updated_at: "2026-05-27T00:00:00.000Z",
     };
     expect(renderConvStateBlock(state)).toBe(renderConvStateBlock({ ...state }));
+  });
+});
+
+// Spec 041 (1B awareness primer), Decision 2 — a SEPARATE `<librarian>` block,
+// not folded into `<conversation-state>`. This is the CANONICAL reference the
+// five plugin copies (Tasks A3–A7) must be byte-identical to, so the exact bytes
+// are pinned here.
+describe("renderAwarenessPrimer (spec 041 A2 — canonical reference)", () => {
+  it("returns empty string when the primer is empty (disabled / unreadable)", () => {
+    expect(renderAwarenessPrimer("")).toBe("");
+  });
+
+  it("emits the canonical <librarian> block when the primer is non-empty", () => {
+    const primer =
+      "You have The Librarian: durable, cross-session memory. " +
+      "Use `recall` to check what's already known before asking; " +
+      "use `remember` / `/learn` to save durable facts, preferences, and decisions worth keeping.";
+    expect(renderAwarenessPrimer(primer)).toBe(
+      [
+        "<librarian>",
+        "You have The Librarian: durable, cross-session memory. " +
+          "Use `recall` to check what's already known before asking; " +
+          "use `remember` / `/learn` to save durable facts, preferences, and decisions worth keeping.",
+        "</librarian>",
+      ].join("\n"),
+    );
+  });
+
+  it("wraps an arbitrary custom primer verbatim between the tags", () => {
+    expect(renderAwarenessPrimer("Use recall first.")).toBe(
+      ["<librarian>", "Use recall first.", "</librarian>"].join("\n"),
+    );
+  });
+
+  it("produces deterministic bytes across calls — every harness sees the same shape", () => {
+    const primer = "You have The Librarian.";
+    expect(renderAwarenessPrimer(primer)).toBe(renderAwarenessPrimer(primer));
   });
 });

--- a/packages/mcp-server/src/mcp/tools/conv-state-get.ts
+++ b/packages/mcp-server/src/mcp/tools/conv-state-get.ts
@@ -1,3 +1,4 @@
+import { readAwarenessPrimer } from "@librarian/core";
 import { textResult } from "../result.js";
 import type { ToolDefinition } from "../tool.js";
 import { requireString } from "./conv-state-shared.js";
@@ -5,8 +6,10 @@ import { requireString } from "./conv-state-shared.js";
 const convStateGet: ToolDefinition = {
   name: "conv_state_get",
   description:
-    "Return the conversation-state row for the supplied conv_id, or report 'no state' if absent. " +
-    "Hook code calls this on every turn to re-inject the canonical block from spec §4.9.",
+    "Return the conversation-state row for the supplied conv_id (or just the awareness " +
+    "primer when no row exists), always with an additive top-level `primer` field. " +
+    "Hook code calls this on every turn to re-inject the canonical block from spec §4.9 " +
+    "plus the server-sourced awareness primer (spec 041).",
   inputSchema: {
     type: "object",
     required: ["conv_id"],
@@ -22,8 +25,18 @@ const convStateGet: ToolDefinition = {
   handler(store, args) {
     const convId = requireString(args.conv_id, "conv_state.get: conv_id is required.");
     const state = store.convState.get(convId);
-    if (!state) return textResult(`No conversation state for conv_id ${convId}.`);
-    return textResult(JSON.stringify(state, null, 2));
+    // Spec 041 Decision 1 — the awareness primer is an ADDITIVE top-level field
+    // returned on EVERY call, whether or not a row exists. It is global (not
+    // conv_id-keyed), so it works on the first turn / on Codex (no stable id).
+    // `readAwarenessPrimer` is fail-soft (→ "" on an unreadable store), so this
+    // read never throws and never blocks the turn.
+    const primer = readAwarenessPrimer(store);
+    // With a row: row fields stay TOP-LEVEL (back-compat — un-updated plugins'
+    // conv_id-based parsing is untouched) plus the additive `primer`.
+    // With no row: just `{ primer }` (replacing the old "No conversation state…"
+    // text); old plugins find no `conv_id` → no block, exactly as before.
+    const response = state ? { ...state, primer } : { primer };
+    return textResult(JSON.stringify(response, null, 2));
   },
 };
 

--- a/packages/mcp-server/tests/mcp/conv-state.mcp.test.ts
+++ b/packages/mcp-server/tests/mcp/conv-state.mcp.test.ts
@@ -5,6 +5,7 @@
 // `conv_state_clear`. These tools are agent-callable (no admin gate —
 // the conversation owns its own state per spec §4.8).
 
+import { AWARENESS_PRIMER_KEY, DEFAULT_AWARENESS_PRIMER } from "@librarian/core";
 import type { LibrarianStore } from "@librarian/core";
 import { handleMcpPayload } from "@librarian/mcp-server";
 import { describe, expect, it } from "vitest";
@@ -45,10 +46,14 @@ describe("MCP conv_state tools (T2.2)", () => {
     });
   });
 
-  it("get reports 'no conversation state' for an unknown conv_id", async () => {
+  it("get returns a JSON object with the primer (no row) for an unknown conv_id", async () => {
     await withStore(async (store) => {
       const response = await call(store, "conv_state_get", { conv_id: "claude:nope" });
-      expect(extractText(response)).toMatch(/No conversation state/);
+      const json = JSON.parse(extractText(response));
+      // No row → just `{ primer }` (spec 041 Decision 1), replacing the old
+      // "No conversation state…" text. Old plugins find no `conv_id` → no block.
+      expect(json.conv_id).toBeUndefined();
+      expect(json.primer).toBe(DEFAULT_AWARENESS_PRIMER);
     });
   });
 
@@ -64,7 +69,10 @@ describe("MCP conv_state tools (T2.2)", () => {
 
       const get = await call(store, "conv_state_get", { conv_id: "claude:abc" });
       const getJson = JSON.parse(extractText(get));
-      expect(getJson).toEqual(upsertJson);
+      // The row fields stay top-level (back-compat); `primer` is additive.
+      const { primer, ...row } = getJson;
+      expect(row).toEqual(upsertJson);
+      expect(primer).toBe(DEFAULT_AWARENESS_PRIMER);
     });
   });
 
@@ -111,7 +119,9 @@ describe("MCP conv_state tools (T2.2)", () => {
       });
       await call(store, "conv_state_clear", { conv_id: "claude:abc" });
       const get = await call(store, "conv_state_get", { conv_id: "claude:abc" });
-      expect(extractText(get)).toMatch(/No conversation state/);
+      const json = JSON.parse(extractText(get));
+      expect(json.conv_id).toBeUndefined();
+      expect(json.primer).toBe(DEFAULT_AWARENESS_PRIMER);
     });
   });
 
@@ -119,6 +129,87 @@ describe("MCP conv_state tools (T2.2)", () => {
     await withStore(async (store) => {
       const response = await call(store, "conv_state_clear", { conv_id: "never-seen" });
       expect(extractText(response)).toMatch(/Cleared conversation state/);
+    });
+  });
+});
+
+// Spec 041 (1B awareness primer), Task A2 — `conv_state_get` returns an additive
+// top-level `primer` field on EVERY call (Decision 1, backward-compatible). The
+// row fields stay top-level so un-updated plugins keep working; the no-row case
+// returns `{ primer }` (replacing the old "No conversation state…" text).
+describe("conv_state_get returns the additive primer field (spec 041 A2)", () => {
+  it("WITH A ROW: row fields stay top-level + adds the primer (back-compat)", async () => {
+    await withStore(async (store) => {
+      await call(store, "conv_state_upsert", {
+        conv_id: "claude:withrow",
+        harness: "claude-code",
+        off_record: true,
+      });
+      const get = await call(store, "conv_state_get", { conv_id: "claude:withrow" });
+      const json = JSON.parse(extractText(get));
+      // Existing row fields are still where un-updated plugins expect them.
+      expect(json.conv_id).toBe("claude:withrow");
+      expect(json.off_record).toBe(true);
+      // …plus the additive primer.
+      expect(json.primer).toBe(DEFAULT_AWARENESS_PRIMER);
+    });
+  });
+
+  it("WITH NO ROW: returns just `{ primer }` (no conv_id) — the day-one floor", async () => {
+    await withStore(async (store) => {
+      const get = await call(store, "conv_state_get", { conv_id: "claude:norow" });
+      const json = JSON.parse(extractText(get));
+      expect(json.conv_id).toBeUndefined();
+      expect(json.off_record).toBeUndefined();
+      expect(json.primer).toBe(DEFAULT_AWARENESS_PRIMER);
+    });
+  });
+
+  it("SETTING EMPTY: a disabled primer yields `primer: ''` (with a row)", async () => {
+    await withStore(async (store) => {
+      store.setSetting(AWARENESS_PRIMER_KEY, "");
+      await call(store, "conv_state_upsert", {
+        conv_id: "claude:empty",
+        harness: "claude-code",
+      });
+      const get = await call(store, "conv_state_get", { conv_id: "claude:empty" });
+      const json = JSON.parse(extractText(get));
+      expect(json.conv_id).toBe("claude:empty");
+      expect(json.primer).toBe("");
+    });
+  });
+
+  it("SETTING EMPTY: a disabled primer yields `primer: ''` (no row)", async () => {
+    await withStore(async (store) => {
+      store.setSetting(AWARENESS_PRIMER_KEY, "");
+      const get = await call(store, "conv_state_get", { conv_id: "claude:empty-norow" });
+      const json = JSON.parse(extractText(get));
+      expect(json.conv_id).toBeUndefined();
+      expect(json.primer).toBe("");
+    });
+  });
+
+  it("CUSTOM primer round-trips verbatim into the response", async () => {
+    await withStore(async (store) => {
+      const custom = "You have memory. Use recall first.";
+      store.setSetting(AWARENESS_PRIMER_KEY, custom);
+      const get = await call(store, "conv_state_get", { conv_id: "claude:custom" });
+      const json = JSON.parse(extractText(get));
+      expect(json.primer).toBe(custom);
+    });
+  });
+
+  it("FAIL-SOFT: an unreadable settings store yields `primer: ''` and never throws", async () => {
+    await withStore(async (store) => {
+      // The primer read fires every turn — a locked/unreadable settings store
+      // must degrade to "" (no primer), never block the turn.
+      store.getSetting = () => {
+        throw new Error("settings store is locked");
+      };
+      const get = await call(store, "conv_state_get", { conv_id: "claude:locked" });
+      const json = JSON.parse(extractText(get));
+      expect(json.conv_id).toBeUndefined();
+      expect(json.primer).toBe("");
     });
   });
 });


### PR DESCRIPTION
## Spec 041 (1B awareness primer) — Task A2 (server, scope M)

Wires the awareness primer through the per-turn server round-trip, building on **A1** (#339, which landed the `awareness.primer` setting, shipped default, and the fail-soft `readAwarenessPrimer` read helper).

### What changed

**1. `conv_state_get` returns an additive top-level `primer` field on every call** (`packages/mcp-server/src/mcp/tools/conv-state-get.ts`), per spec 041 **Decision 1** (backward-compatible — NOT a `{ state, primer }` wrapper):

- **With a row:** `{ ...row, primer }` — the existing row fields stay **top-level** so un-updated plugins' `conv_id`-based parsing is untouched; `primer` is additive.
- **With no row:** `{ primer }` — a JSON object **replacing** the old `"No conversation state for conv_id …"` text. Old plugins find no `conv_id` → no block, exactly as before (no regression).
- `primer` = `readAwarenessPrimer(store)`: the shipped default / the operator's custom text / `""` when disabled (empty setting).
- **Fail-soft:** `primer: ""` on an unreadable settings store; the read never throws and never blocks the turn (it fires every turn).

The primer is **global** (not `conv_id`-keyed), so it works on the **first turn** (before any row exists) and on harnesses without a stable conversation id (Codex).

**2. Canonical `renderAwarenessPrimer(primer)`** beside `renderConvStateBlock` in `@librarian/core` (`packages/core/src/conv-state-render.ts`), per **Decision 2** — a **separate** `<librarian>` block, not folded into `<conversation-state>`:

```
<librarian>
<primer text>
</librarian>
```

Returns `""` when `primer` is empty. This is the **byte-pinned canonical reference** the five plugin copies (Tasks A3–A7) replicate.

### Back-compat for un-updated plugins
The response stays additive: row fields remain top-level (a with-row test asserts `conv_id` / `off_record` are unchanged), and `ConversationState` has no `primer` field so there is no spread collision. The server can ship before the plugins update without dropping the conv-state block anywhere — the sacred `conv_state_get` contract is respected (AGENTS.md §2).

### Tests
- `conv_state_get`: with a row / with no row / setting-empty (→ `primer: ""`) / custom round-trip / fail-soft store (→ `primer: ""`); plus the round-trip and no-row tests updated to the new JSON shape (`packages/mcp-server/tests/mcp/conv-state.mcp.test.ts`).
- `renderAwarenessPrimer`: non-empty (**exact bytes pinned**) / empty / custom / deterministic (`packages/core/tests/conv-state-render.test.ts`).

Full `pnpm test` + `pnpm -r build` (0 `error TS`) + `pnpm typecheck` + `pnpm lint` + `pnpm smoke` all green locally.

### Out of scope
No plugin changes (A3–A7, the 5 separate repos), no eyeball test (A8), no change to the A1 setting/admin field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)