### PR TITLE
chore(release): v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ changes from this point forward are catalogued here.
 
 ## [Unreleased]
 
+## [0.5.0] — 2026-06-07
+
 ### Added
 
 - **Awareness primer — a dashboard-editable note that tells every agent it has

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Monorepo release **v0.5.0** — the plan-045 deliverable's server/dashboard half.

- **042** LLM provider config (named providers, per-consumer model selection, dashboard CRUD).
- **043** curator unification (intake decision log, unified enablement, triggered grooming, intake split, two-job dashboard).
- **044** self-improving curator (git-versioned addenda, under-evaluation lifecycle, dry-run, admin merge/split/update/unmerge, grounded chat).
- **041 A1/A2** awareness-primer server side (`awareness.primer` setting + admin field, additive `conv_state_get` primer + canonical `<librarian>` renderer).

Moves the accumulated `[Unreleased]` entries under `[0.5.0] — 2026-06-07`; `[Unreleased]` is now empty. First of the coordinated cross-family release (plugins follow at 0.3.0). Docker image rebuilds on the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)