### PR TITLE
docs(runbook): correct the Codex plugin update command

### DIFF
--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -125,7 +125,12 @@ Same shape as Claude. The files to bump are:
 - `package.json` (the `version` field)
 - `CHANGELOG.md`
 
-Then tag + GitHub release. Users update via `codex plugin update the-librarian`.
+Then tag + GitHub release. Users update by **re-adding** the plugin:
+`codex plugin add the-librarian@the-librarian-codex` (there is **no**
+`codex plugin update` / `codex plugin path` command — re-add re-pulls the
+latest from the marketplace's default branch). Refresh the marketplace clone
+first with `codex plugin marketplace upgrade the-librarian-codex` (the
+marketplace **name**, not the `owner/repo` path).
 
 ### Hermes plugin
 


### PR DESCRIPTION
`codex plugin update` and `codex plugin path` don't exist (confirmed against a live Codex). The runbook now documents the real update path: `codex plugin marketplace upgrade the-librarian-codex` (marketplace **name**, not `owner/repo`) then re-add `codex plugin add the-librarian@the-librarian-codex`. Docs-only.

Note: the Pi (`pi update …`) and OpenCode (`opencode plugin update …`) update verbs in the same doc are **unverified** — flagging for a later check, not changing them on a guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)