### PR TITLE
fix(memory): route propose_memory through the curator (ADR 0004)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ changes from this point forward are catalogued here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`propose_memory` now goes through the curator instead of writing around it.**
+  Previously `propose_memory` wrote a standalone proposal directly — bypassing the
+  inbox, so it got **no dedup or merge** (an obvious restatement of an existing
+  memory became a duplicate proposal, and on approval a duplicate active memory),
+  and it slipped past the under-evaluation gate that holds an unproven curator
+  prompt's output for review. It now **submits to the consolidator inbox with a
+  force-proposal directive** (when intake is enabled): the curator dedups and
+  merges it like any submission, but it **always terminates as a proposal**, never
+  an auto-apply. The proposal therefore lands after the next consolidator tick
+  (the tool now replies "queued for review") rather than synchronously. When
+  intake is off, the legacy direct write remains — but now **surfaces detected
+  duplicates** in its response, matching `remember`. See
+  [ADR 0004](docs/adr/0004-propose-memory-routes-through-inbox.md).
+
 ## [0.5.0] — 2026-06-07
 
 ### Added

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -226,7 +226,13 @@ this repo.
   proposal id) so a write → verify chain is one round-trip instead of two. Today
   the agent has to call `recall include_ids:true` after a `remember` to discover
   the id, which is wasteful. Surface it in the result text (e.g. "Memory stored
-  ([mem_…])") so the existing `content[0].text` channel carries it.
+  ([mem_…])") so the existing `content[0].text` channel carries it. NOTE: with
+  intake enabled both verbs are now fire-and-forget into the inbox (ADR 0004 routed
+  `propose_memory` there too), so there is **no synchronous memory/proposal id** on
+  that path — the consolidator mints it on the next tick. This aspiration now holds
+  only for the legacy (intake-off) direct write; the intake-on path would need a
+  different handle (e.g. echo the inbox item id, or have the dashboard surface the
+  resulting proposal).
 - **Make references properly searchable (persist their embeddings).** References
   are now embedded lazily — only when `search_references` is actually called — so
   the consolidator/seed no longer pays to embed them. But `search_references` still

--- a/docs/adr/0004-propose-memory-routes-through-inbox.md
+++ b/docs/adr/0004-propose-memory-routes-through-inbox.md
@@ -1,0 +1,96 @@
+# ADR 0004 — `propose_memory` routes through the inbox (force-proposal)
+
+- **Status:** Accepted
+- **Date:** 2026-06-07
+- **Context:** Curator unification (spec 043) follow-up; closes a write-path gap.
+
+## Context
+
+Spec 043 introduced the inbox/intake model: `remember` became a
+fire-and-forget submission to the consolidator inbox (`remember.ts` →
+`store.submitToInbox`), where navigate→judge→edit dedups, merges, and
+files it — landing it active, or as a proposal when a category is
+protected or the intake addendum is `under_evaluation`.
+
+`propose_memory` was **never cut over**. It still does the pre-043
+direct write:
+
+```ts
+store.createMemory({ ...scoped, status: "proposed" }, { status: "proposed" });
+```
+
+`createMemory` runs `detectRelated` and returns a `duplicates` list, but
+`propose_memory` discards it. The consequence is three holes:
+
+1. **No merge/dedup.** Every `propose_memory` call creates a brand-new
+   standalone proposal, even when it restates an existing memory. On
+   approval that becomes a duplicate active memory. The detected
+   duplicates aren't even surfaced to the caller.
+2. **`/learn` over-proposes.** The `/learn` skill calls `propose_memory`
+   for every hand-picked lesson, so already-chosen lessons land as fresh
+   proposals needing a second approval, with zero dedup. (Addressed
+   separately — `/learn` switches to `remember`.)
+3. **Bypasses the under-evaluation gate.** The protection for an unproven
+   curator prompt is that the intake/grooming jobs force their own
+   would-be auto-applies into proposals for review
+   (`curator-force-propose.ts`). That gate sits in front of the inbox.
+   `propose_memory` writes around it — a proposal approved during a new
+   prompt's evaluation reaches active memory having passed through no
+   curator prompt at all. The mechanism works; the coverage had a hole.
+
+## Decision
+
+Route `propose_memory` through the inbox, like `remember`, with a
+**force-proposal** terminal so its "for review" intent survives curation.
+
+- A new `forceProposal` directive rides on the inbox submission
+  (`InboxSubmissionHints.forceProposal`). It is a routing directive, not
+  a filing hint, but travels the same submission→item→apply path.
+- The apply layer (`consolidator/apply.ts`) already force-proposes for
+  `underEvaluation`: a would-be auto-apply or active `create_new` is
+  re-routed to a proposal of the raw submission; a would-be auto-archive
+  is skipped (archive isn't proposable). `forceProposal` reuses that
+  exact routing — `forcePropose = underEvaluation || forceProposal` —
+  **minus** the addendum-version tagging, which stays specific to
+  `underEvaluation` evaluation batches.
+- `propose_memory` submits to the inbox with `forceProposal: true` when
+  intake is enabled, returning a "queued for review" message. When intake
+  is off it keeps the legacy direct write, but now **surfaces detected
+  duplicates** in its response (parity with `remember`).
+
+Net: a `propose_memory` submission is navigated and judged (so it
+dedups/merges against the corpus), but always terminates as a proposal,
+never an auto-apply.
+
+## Consequences
+
+**Positive**
+
+- `propose_memory` proposals are deduped/merged before a human ever sees
+  them — no more duplicate proposals, and the judge can route an obvious
+  restatement to an augment/supersede proposal instead of a fresh doc.
+- The under-evaluation gate now covers every memory write. No path
+  reaches active memory without passing the curator.
+- The legacy (intake-off) path stops silently swallowing duplicates.
+
+**Negative / trade-offs**
+
+- **Asynchronous.** The proposal no longer appears synchronously in the
+  tool response; it lands after the next consolidator tick. The response
+  message changes to "queued for review."
+- **Exact-duplicate submissions may produce no proposal.** If the judge
+  decides the submission is already covered (skip), nothing is filed —
+  arguably correct (the knowledge exists), but a behaviour change from
+  "always creates a proposal."
+- A `forceProposal` augment/supersede proposal records the intended
+  action (`proposed_action`) but not a target id, same limitation the
+  under-evaluation path already has. Acceptable: the common
+  `propose_memory` case is new knowledge (`create`).
+
+## Related
+
+- Spec 043 — curator unification / inbox cutover.
+- Spec 044 — self-improving curator (the `under_evaluation` force-propose
+  machinery this reuses).
+- `/learn` skill change (switch to `remember`) — sibling fix, separate
+  cross-repo PR across the five plugin repos.

--- a/packages/core/src/consolidator/apply.ts
+++ b/packages/core/src/consolidator/apply.ts
@@ -59,6 +59,14 @@ export interface ApplyConsolidationDeps {
    * Only meaningful with `underEvaluation`; ignored otherwise.
    */
   addendumVersion?: string | null;
+  /**
+   * Force-proposal routing (ADR 0004). When true, this submission must terminate
+   * as a PROPOSAL, never an auto-apply — the SAME routing as `underEvaluation` (a
+   * would-be auto-apply → proposal, a would-be auto-archive → skip), but WITHOUT
+   * the addendum-version tag (it is not an evaluation batch). `propose_memory`
+   * sets it so its submission is deduped/merged yet always lands for review.
+   */
+  forceProposal?: boolean;
   /** Optional sink for a swallowed store error, so a real bug stays observable. */
   onError?: (error: unknown) => void;
 }
@@ -137,22 +145,24 @@ export function applyConsolidationPlan(
     return { kind: proposed ? "proposed" : "created_new", id: memory.id };
   };
 
+  // Force-propose is on when the intake addendum is under_evaluation (spec 044 D-3)
+  // OR the submission itself demands review (propose_memory's forceProposal, ADR
+  // 0004). Both share the routing rule below; only under_evaluation also tags the
+  // produced proposal with the eval version (see `note()`).
+  const forcePropose = deps.underEvaluation === true || deps.forceProposal === true;
+
   try {
     if (plan.decision === "skip") return { kind: "skipped" };
 
-    // Under-evaluation force-propose (spec 044 D-3). The intake addendum is being
-    // evaluated, so NOTHING auto-applies regardless of the routed decision or
-    // confidence. Both the auto_apply lane AND create_new (which would land an
-    // ACTIVE doc) are re-routed to a PROPOSAL of the raw submission, EXCEPT a
-    // would-be auto-ARCHIVE which is SKIPPED — archive (and noop) are not proposable
-    // (the archive wrinkle). `split` is already always-proposed (below); the
-    // existing `propose` decision already files for review (left unchanged). Defence-
-    // in-depth like C4's split: even at confidence 1.0 an under-eval op never
-    // auto-applies.
-    if (
-      deps.underEvaluation &&
-      (plan.decision === "auto_apply" || plan.decision === "create_new")
-    ) {
+    // Force-propose (spec 044 D-3 / ADR 0004). When on, NOTHING auto-applies
+    // regardless of the routed decision or confidence. Both the auto_apply lane AND
+    // create_new (which would land an ACTIVE doc) are re-routed to a PROPOSAL of the
+    // raw submission, EXCEPT a would-be auto-ARCHIVE which is SKIPPED — archive (and
+    // noop) are not proposable (the archive wrinkle). `split` is already always-
+    // proposed (below); the existing `propose` decision already files for review
+    // (left unchanged). Defence-in-depth like C4's split: even at confidence 1.0 a
+    // force-proposed op never auto-applies.
+    if (forcePropose && (plan.decision === "auto_apply" || plan.decision === "create_new")) {
       if (plan.judgment.action === "archive" || plan.judgment.action === "noop") {
         return { kind: "skipped" };
       }

--- a/packages/core/src/consolidator/consolidate.ts
+++ b/packages/core/src/consolidator/consolidate.ts
@@ -122,6 +122,10 @@ export async function consolidateInboxItem(
     ...(deps.underEvaluation
       ? { underEvaluation: true, addendumVersion: deps.addendumVersion }
       : {}),
+    // A force-proposal directive rides on the submission itself (ADR 0004), distinct
+    // from the deps-level underEvaluation: propose_memory submissions always land as
+    // proposals, deduped/merged but never auto-applied.
+    ...(item.hints.forceProposal ? { forceProposal: true } : {}),
     ...(deps.onError ? { onError: deps.onError } : {}),
   };
   const outcome = applyConsolidationPlan(judged.plan, applyDeps);

--- a/packages/core/src/store/corpus/inbox.ts
+++ b/packages/core/src/store/corpus/inbox.ts
@@ -48,6 +48,14 @@ export interface InboxSubmissionHints {
    * carried through and applied to a NEW consolidated memory.
    */
   appliesTo?: string[];
+  /**
+   * A routing DIRECTIVE (not a filing hint): when true, the consolidator must
+   * terminate this submission as a PROPOSAL, never an auto-apply — even at high
+   * confidence. Carried so `propose_memory` can route through the inbox (gaining
+   * dedup/merge) while keeping its "for review" intent. See ADR 0004. Only `true`
+   * is persisted; absent/false means the normal accepted routing.
+   */
+  forceProposal?: boolean;
 }
 
 /** Write options: clock/id injection (for determinism) + the submission hints to persist. */
@@ -92,7 +100,7 @@ function quote(value: string): string {
 /** Serialize an inbox submission to its on-disk markdown (frontmatter + text). */
 export function serializeInboxItem(item: InboxItem): string {
   const lines = [`id: ${quote(item.id)}`, `created: ${quote(item.created)}`];
-  const { agentId, projectKey, tags, appliesTo } = item.hints;
+  const { agentId, projectKey, tags, appliesTo, forceProposal } = item.hints;
   // Hints are written only when present, so an inbox item with none stays minimal.
   if (agentId !== undefined) lines.push(`agent_id: ${quote(agentId)}`);
   if (projectKey !== undefined) {
@@ -110,6 +118,9 @@ export function serializeInboxItem(item: InboxItem): string {
         : "applies_to: []",
     );
   }
+  // A directive, not a filing hint: only the `true` case is meaningful, so absent
+  // and false both round-trip to "no directive" (omitted from the frontmatter).
+  if (forceProposal) lines.push("force_proposal: true");
   const head = `---\n${lines.join("\n")}\n---\n`;
   const body = item.text.trim();
   return body ? `${head}\n${body}\n` : head;
@@ -130,6 +141,7 @@ export function parseInboxItem(raw: string): InboxItem {
   if (Array.isArray(d.applies_to)) {
     hints.appliesTo = d.applies_to.filter((a): a is string => typeof a === "string");
   }
+  if (d.force_proposal === true) hints.forceProposal = true;
   return { id: String(d.id ?? ""), created, text: content.trim(), hints };
 }
 

--- a/packages/core/tests/consolidator-consolidate.test.ts
+++ b/packages/core/tests/consolidator-consolidate.test.ts
@@ -273,6 +273,44 @@ describe("consolidateInboxItem", () => {
     expect(createdOptions?.curator_note).toMatchObject({ addendum_version: "evalhash999" });
   });
 
+  it("threads a forceProposal submission hint into apply: force-proposes WITHOUT an eval tag (ADR 0004)", async () => {
+    // propose_memory's path: the submission carries a forceProposal hint (not a
+    // deps-level underEvaluation). A would-be auto-apply create lands as a PROPOSAL,
+    // proving hint → inbox item → applyConsolidationPlan. Unlike under-evaluation it
+    // is NOT an eval batch, so the proposal carries no addendum_version tag.
+    const ref = writeInbox(vault, "Anna moved to Berlin.", {
+      now: () => 1000,
+      generateId: () => "inbox_a",
+      hints: { forceProposal: true },
+    });
+    let createdOptions: Record<string, unknown> | undefined;
+    const store: ConsolidatorApplyStore = {
+      createMemory: (_input, options) => {
+        createdOptions = options;
+        return { memory: { id: "mem_p" } };
+      },
+      updateMemory: () => null,
+      archiveMemory: () => null,
+      getMemory: () => null,
+    };
+    const client = fakeClient(
+      JSON.stringify({
+        action: "create",
+        title: "Anna",
+        body: "Anna lives in Berlin.",
+        tags: [],
+        rationale: "novel",
+        confidence: 0.99,
+      }),
+    );
+
+    const result = await consolidateInboxItem(ref.relPath, baseDeps(store, client));
+
+    expect(result).toMatchObject({ status: "consolidated", outcome: { kind: "proposed" } });
+    expect(createdOptions?.requires_approval).toBe(true);
+    expect(createdOptions?.curator_note).not.toHaveProperty("addendum_version");
+  });
+
   it("completes (removes) the item even when apply rejects — a rejection is terminal", async () => {
     const ref = writeInbox(vault, "archive that", { now: () => 1000, generateId: () => "inbox_a" });
     const { store } = fakeStore(); // empty → the archive target is missing → rejected

--- a/packages/core/tests/corpus-inbox.test.ts
+++ b/packages/core/tests/corpus-inbox.test.ts
@@ -77,6 +77,18 @@ describe("writeInbox", () => {
     });
   });
 
+  it("round-trips a forceProposal routing directive (ADR 0004)", () => {
+    const ref = writeInbox(vault, "Anna moved to Berlin", {
+      now: () => 1000,
+      generateId: () => "inbox_a",
+      hints: { agentId: "agent-a", forceProposal: true },
+    });
+    expect(parseInboxItem(vault.readText(ref.relPath)).hints).toEqual({
+      agentId: "agent-a",
+      forceProposal: true,
+    });
+  });
+
   it("round-trips a null project_key (global) and an empty tag list", () => {
     const ref = writeInbox(vault, "global fact", {
       now: () => 1000,

--- a/packages/mcp-server/src/mcp/tools/propose-memory.ts
+++ b/packages/mcp-server/src/mcp/tools/propose-memory.ts
@@ -1,7 +1,29 @@
+import type { InboxSubmissionHints } from "@librarian/core";
+import { isConsolidatorEnabled } from "../../consolidator-config.js";
 import { textResult } from "../result.js";
 import type { ToolDefinition } from "../tool.js";
 import { scopeAgentArgs } from "../visibility.js";
 import { memoryInputSchema } from "./schemas.js";
+
+/**
+ * The submitter's filing/ownership hints plus the force-proposal directive (ADR
+ * 0004) — so a consolidated propose_memory submission keeps its scope AND always
+ * terminates as a proposal, never an auto-apply.
+ */
+function submissionHints(scoped: Record<string, unknown>): InboxSubmissionHints {
+  const hints: InboxSubmissionHints = { forceProposal: true };
+  if (typeof scoped.agent_id === "string") hints.agentId = scoped.agent_id;
+  if (scoped.project_key === null || typeof scoped.project_key === "string") {
+    hints.projectKey = scoped.project_key as string | null;
+  }
+  if (Array.isArray(scoped.tags)) {
+    hints.tags = scoped.tags.filter((t): t is string => typeof t === "string");
+  }
+  if (Array.isArray(scoped.applies_to)) {
+    hints.appliesTo = scoped.applies_to.filter((a): a is string => typeof a === "string");
+  }
+  return hints;
+}
 
 const proposeMemory: ToolDefinition = {
   name: "propose_memory",
@@ -9,8 +31,38 @@ const proposeMemory: ToolDefinition = {
   inputSchema: memoryInputSchema(),
   handler(store, args, context) {
     const scoped = scopeAgentArgs(args, context);
+    // conv_id is a domain-routing signal, not a memory field (mirrors `remember`).
+    delete scoped.conv_id;
+
+    // Inbox cutover (ADR 0004): when intake is enabled, propose_memory submits to
+    // the consolidator inbox with a force-proposal directive. The curator dedups
+    // and merges it (navigate→judge) like any submission, but always terminates it
+    // as a PROPOSAL — never an auto-apply. This closes the spec-043 gap where
+    // propose_memory bypassed the curator entirely (no merge, no under-eval gate).
+    // Otherwise the legacy direct write — which now surfaces detected duplicates.
+    if (isConsolidatorEnabled(store)) {
+      const title = typeof scoped.title === "string" ? scoped.title : "";
+      const body = typeof scoped.body === "string" ? scoped.body : "";
+      const text = title ? `${title}\n\n${body}` : body;
+      // An empty submission has nothing to consolidate — fall through to the legacy
+      // write rather than enqueueing an empty inbox item (parity with `remember`).
+      if (text.trim()) {
+        store.submitToInbox(text, submissionHints(scoped));
+        return textResult(
+          "Noted — queued for review. The curator will dedupe it and file a proposal shortly.",
+        );
+      }
+    }
+
     const result = store.createMemory({ ...scoped, status: "proposed" }, { status: "proposed" });
-    return textResult(`Memory proposal saved.\n\n${result.memory.title}: ${result.memory.body}`);
+    const duplicateText = result.duplicates?.length
+      ? `\n\nPossible duplicates:\n${result.duplicates
+          .map((memory) => `- ${memory.title}: ${memory.body}`)
+          .join("\n")}`
+      : "";
+    return textResult(
+      `Memory proposal saved.\n\n${result.memory.title}: ${result.memory.body}${duplicateText}`,
+    );
   },
 };
 

--- a/packages/mcp-server/tests/mcp/propose-memory-cutover.test.ts
+++ b/packages/mcp-server/tests/mcp/propose-memory-cutover.test.ts
@@ -1,0 +1,78 @@
+// propose_memory verb — inbox cutover routing (ADR 0004). When intake is enabled
+// (`curator.intake.enabled`) propose_memory submits to the consolidator inbox with
+// a force-proposal directive (so it is deduped/merged but always terminates as a
+// proposal), rather than writing a standalone proposal directly. When intake is off
+// it keeps the legacy direct write — but now surfaces detected duplicates, parity
+// with `remember`. Dispatched through handleMcpPayload over a real store.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { INTAKE_ENABLED_KEY, type LibrarianStore, createLibrarianStore } from "@librarian/core";
+import { handleMcpPayload } from "@librarian/mcp-server";
+import { afterEach, describe, expect, it } from "vitest";
+
+let store: LibrarianStore | null = null;
+let dataDir = "";
+
+function makeStore(): void {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-propose-"));
+  store = createLibrarianStore({ dataDir });
+}
+
+afterEach(() => {
+  try {
+    store?.close();
+  } catch {
+    /* ignore */
+  }
+  if (dataDir) fs.rmSync(dataDir, { recursive: true, force: true });
+  store = null;
+});
+
+type CallResult = { result: { content: { text: string }[] } };
+const propose = (args: Record<string, unknown>): Promise<unknown> =>
+  handleMcpPayload(store as never, {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: { name: "propose_memory", arguments: args },
+  });
+const text = (res: unknown): string => (res as CallResult).result.content[0]!.text;
+
+describe("propose_memory verb — inbox cutover routing (ADR 0004)", () => {
+  it("submits to the inbox with a force-proposal directive when intake is enabled", async () => {
+    makeStore();
+    store!.setSetting(INTAKE_ENABLED_KEY, "true");
+
+    const res = await propose({ title: "Anna", body: "moved to Berlin", agent_id: "agent-a" });
+
+    expect(text(res)).toMatch(/queued for review/i);
+    // Nothing filed yet — it's in the inbox awaiting consolidation, NOT a direct proposal.
+    expect(store!.listMemories({}).total).toBe(0);
+    const inboxDir = path.join(dataDir, "vault", "inbox");
+    const inboxFiles = fs.readdirSync(inboxDir).filter((f) => f.endsWith(".md"));
+    expect(inboxFiles).toHaveLength(1);
+    // The submission carries the force-proposal directive so consolidation lands a
+    // proposal, never an auto-apply.
+    const raw = fs.readFileSync(path.join(inboxDir, inboxFiles[0]!), "utf8");
+    expect(raw).toMatch(/force_proposal:\s*true/);
+  });
+
+  it("writes directly at proposed and surfaces duplicates when intake is off", async () => {
+    makeStore();
+    // Seed an active memory the proposal restates (same agent + identical content).
+    store!.createMemory({ agent_id: "agent-a", title: "Anna", body: "Anna lives in Berlin." });
+
+    const res = await propose({
+      title: "Anna",
+      body: "Anna lives in Berlin.",
+      agent_id: "agent-a",
+    });
+
+    // Legacy path: a proposal is created synchronously...
+    expect(store!.listMemories({ status: "proposed" }).total).toBe(1);
+    // ...and the detected duplicate is surfaced (no longer silently dropped).
+    expect(text(res)).toMatch(/duplicat/i);
+  });
+});


### PR DESCRIPTION
## The bug

`propose_memory` wrote a standalone proposal directly (`createMemory(..., {status:"proposed"})`), **bypassing the inbox entirely**. Three consequences:

1. **No dedup/merge.** A restatement of an existing memory became a duplicate proposal — and a duplicate *active* memory on approval. The `duplicates` list `createMemory` already computes was discarded.
2. **`/learn` over-proposed.** Every hand-picked lesson landed as a fresh proposal needing a second approval, with zero dedup. (`/learn` switching to `remember` is a separate cross-repo PR.)
3. **Bypassed the under-evaluation gate.** The protection that holds an unproven curator prompt's output for human review (`curator-force-propose.ts`) sits in front of the inbox. `propose_memory` wrote around it — a proposal approved during a new prompt's evaluation reached active memory having passed through no curator prompt at all.

Root cause: the spec-043 inbox cutover routed `remember` through the inbox but left `propose_memory` as the pre-043 direct write.

## The fix

Route `propose_memory` through the consolidator inbox with a **force-proposal directive** so its "for review" intent survives curation.

- New `InboxSubmissionHints.forceProposal` — a routing directive (not a filing hint), serialized/parsed on the inbox item.
- The apply layer reuses the existing under-evaluation routing — `forcePropose = underEvaluation || forceProposal` — so a would-be auto-apply or active `create_new` is re-routed to a proposal of the raw submission, and a would-be auto-archive is skipped. **Minus** the addendum-version tag, which stays specific to evaluation batches.
- `propose_memory` submits to the inbox with `forceProposal` when intake is enabled (replying "queued for review"); the legacy direct write remains when intake is off, but **now surfaces detected duplicates**, matching `remember`.

Net: a `propose_memory` submission is navigated + judged (so it dedups/merges), but **always terminates as a proposal**, never an auto-apply.

See [ADR 0004](docs/adr/0004-propose-memory-routes-through-inbox.md) for the decision, trade-offs, and the accepted behaviour changes (async proposal; an exact-duplicate submission may produce no proposal).

## Tests

TDD — RED first, then GREEN:
- `packages/core/tests/corpus-inbox.test.ts` — `forceProposal` round-trips on the inbox item.
- `packages/core/tests/consolidator-consolidate.test.ts` — a `forceProposal` submission force-proposes a would-be auto-apply create, **without** an eval tag.
- `packages/mcp-server/tests/mcp/propose-memory-cutover.test.ts` — tool routes to the inbox (force-proposal directive present) when intake is on; legacy path surfaces duplicates when off.

Full core (914) + mcp-server (168) suites pass; lint + typecheck clean. Independently reviewed for routing completeness (no path lets a force-proposal submission mutate an active memory), redaction parity, and `remember` parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)