### PR TITLE
feat(curator): bound grooming runs via configurable max_memories (ADR 0005)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ changes from this point forward are catalogued here.
 
 ## [Unreleased]
 
+### Added
+
+- **Configurable grooming run size — `curator.grooming.max_memories`.** The
+  grooming curator now reads a per-run cap on how many active+proposed memories
+  a single run feeds the model, wired through the tick into every run's evidence
+  gather and settable via the `curator.setConfig` admin API. This bounds a run
+  so one oversized slice can't exceed the LLM timeout — the cause of a
+  production incident where a ~60-memory global slice failed every scheduled run
+  with `llm_timeout` (a slow model couldn't process the whole slice in 60s, and
+  the failed slice re-ran forever). **Default 200** (the prior implicit cap), so
+  existing installs are unchanged; lower it for slow models / large slices.
+  Truncation is newest-first, so a cap below the slice size leaves the oldest
+  memories ungroomed until they next change — an informed trade-off documented
+  in [ADR 0005](docs/adr/0005-bounded-grooming-runs.md), with automatic
+  full-coverage bounding (chunking / rotation) proposed as the follow-up.
+
 ### Fixed
 
 - **`propose_memory` now goes through the curator instead of writing around it.**

--- a/apps/dashboard/tests/components/curator/cockpit-actions.test.tsx
+++ b/apps/dashboard/tests/components/curator/cockpit-actions.test.tsx
@@ -86,6 +86,7 @@ const config: CuratorConfig = {
   intervalMinutes: 60,
   triggerThreshold: 20,
   debounceMinutes: 60,
+  maxMemoriesPerRun: 200,
 };
 
 describe("CuratorConfigForm", () => {

--- a/apps/dashboard/tests/components/curator/cockpit.test.tsx
+++ b/apps/dashboard/tests/components/curator/cockpit.test.tsx
@@ -12,6 +12,7 @@ function config(over: Partial<CuratorConfig> = {}): CuratorConfig {
     intervalMinutes: 60,
     triggerThreshold: 20,
     debounceMinutes: 60,
+    maxMemoriesPerRun: 200,
     ...over,
   };
 }

--- a/docs/adr/0005-bounded-grooming-runs.md
+++ b/docs/adr/0005-bounded-grooming-runs.md
@@ -1,0 +1,95 @@
+# ADR 0005 — Bounded grooming runs (configurable per-run memory cap)
+
+- **Status:** Accepted
+- **Date:** 2026-06-07
+- **Context:** Live incident — every scheduled grooming run failing `llm_timeout`.
+
+## Context
+
+On a production instance, every recent scheduled grooming run failed with
+`llm_timeout`. The decision log made the cause unambiguous:
+
+| | input memories | duration | outcome |
+|---|---|---|---|
+| Completed runs | 1–13 | 3–60s | ✅ |
+| Failed runs | 52–61 | 60s flat | ❌ `llm_timeout` |
+
+The failures were all the same slice — the **`common` global slice** (no
+project), which had grown to ~55–61 memories. The configured model
+(`deepseek-v4-pro`, ~50–60 tok/s) needs ~150–200s to read that much
+context and emit all the curation operations, but the per-consumer timeout
+was 60s. The whole slice is sent in one prompt, so the request returned
+zero tokens and aborted at 60s. Because a failed run doesn't advance the
+slice's cursor, the identical oversized slice was reclaimed and re-run every
+tick — a permanent failure loop. (Confirmed by the fix: after raising the
+timeout to 240s the 61-memory slice completed in **171s / 10,464 output
+tokens**, and 15 consecutive runs passed with 0 failures.)
+
+The root cause is structural, not just a timeout that's too low: **nothing
+bounds a grooming run to fit its timeout.** The evidence cap
+(`curator-worker.ts` `DEFAULT_MAX_MEMORIES`) was a hardcoded 200 with no
+setting to lower it, so a single slice can grow without limit until it
+exceeds any fixed timeout. As the corpus grows, even a generous timeout is
+a treadmill — 171s is already 71% of a 240s ceiling.
+
+## Decision
+
+Make the grooming per-run memory cap **configurable**, wired through the
+tick so every run is bounded:
+
+- New setting `curator.grooming.max_memories` (read in `readCuratorConfig`
+  as `maxMemoriesPerRun`, settable via `writeCuratorConfig` / the
+  `curator.setConfig` tRPC), validated to an integer in `[1, 1000]`.
+- `runCuratorTick` passes it as `caps.maxMemories` into every run's evidence
+  gather (`gatherMemoryEvidence`), so a slice larger than the cap is
+  truncated rather than sent whole. An explicit `options.caps`
+  (manual/maintenance, tests) still overrides it.
+- **Default 200** — identical to the prior implicit cap, so existing installs
+  are byte-for-byte unchanged. An operator on a slow model / large slice
+  lowers it to keep runs inside the timeout.
+
+The immediate live remediation was a separate, operator-side change: raise
+`curator.grooming.timeout_ms` to 240000. That cleared the backlog. This ADR
+is the durable code-side lever that complements it.
+
+## Consequences
+
+**Positive**
+
+- An operator can now guarantee a grooming run fits its timeout regardless of
+  corpus size, by setting the cap below what the model can process in the
+  configured timeout.
+- No behaviour change for existing installs (default preserves 200).
+
+**Negative / trade-offs**
+
+- **Coverage gap when the cap truncates.** Slice memories are selected
+  `updated_at DESC` (`curator-source-vault.ts`), so a cap below the slice
+  size feeds only the most-recently-updated N — the oldest memories are never
+  groomed until their `updated_at` changes. This is an informed operator
+  trade-off (a bounded, *completing* run over the freshest memories beats a
+  run that always times out and grooms nothing), but it is a real gap.
+- Setting it requires the tRPC/API today; a dashboard control is a follow-up.
+
+## Follow-up (proposed, not in this ADR)
+
+The cap bounds a run but doesn't *automatically* keep coverage. The next
+increment is **automatic bounding with full coverage**, regardless of corpus
+size — two candidate designs:
+
+1. **Chunked runs** — when a slice exceeds the cap, process it as several
+   sequential bounded LLM calls within the tick. Each call fits the timeout;
+   the whole slice is covered every tick. Cost: cross-chunk dedup is missed
+   within a tick, and more calls per tick.
+2. **Rotating window** — select the N *least-recently-groomed* memories per
+   run (derivable from the runs log's `input_memory_ids`, or a stamped
+   `last_groomed_at`), so successive ticks cursor through the whole slice
+   without stranding the tail.
+
+Picking between these needs the maintainer's call on the dedup/coverage vs.
+cost trade; this ADR ships the safe, operator-controlled cap first.
+
+## Related
+
+- ADR 0004 — `propose_memory` routes through the inbox (sibling curator work).
+- Spec 044 — self-improving curator (the grooming tick this bounds).

--- a/packages/core/src/curator-config.ts
+++ b/packages/core/src/curator-config.ts
@@ -29,6 +29,11 @@ const KEYS = {
   // auto-trigger a groom within this many minutes of the last one. Seeded from the
   // legacy curator.interval_minutes at migration (see migrateCuratorEnablement).
   debounceMinutes: "curator.grooming.debounce_minutes",
+  // Bounded grooming runs (ADR 0005): the MAX active+proposed memories a single
+  // grooming run feeds the model. A slice larger than this is truncated (newest-
+  // first) so one oversized slice can't blow past the LLM timeout. Default 200
+  // (the prior implicit cap) — lower it for slow models / large slices.
+  maxMemoriesPerRun: "curator.grooming.max_memories",
 } as const;
 
 // Unified curator enablement keys (spec 043 D-E). BOTH jobs' on/off flags now
@@ -75,6 +80,13 @@ const DEFAULT_DEBOUNCE_MINUTES = DEFAULT_INTERVAL_MINUTES;
 const MIN_DEBOUNCE_MINUTES = MIN_INTERVAL_MINUTES;
 const MAX_DEBOUNCE_MINUTES = MAX_INTERVAL_MINUTES;
 
+// Bounded grooming runs (ADR 0005). The default matches the prior implicit cap
+// (curator-worker's DEFAULT_MAX_MEMORIES) so existing installs are unchanged; the
+// bounds keep a misconfiguration from feeding 0 or an absurd number of memories.
+const DEFAULT_MAX_MEMORIES_PER_RUN = 200;
+const MIN_MAX_MEMORIES_PER_RUN = 1;
+const MAX_MAX_MEMORIES_PER_RUN = 1000;
+
 export interface CuratorConfig {
   enabled: boolean;
   defaultAutoApply: AutoApplyLevel;
@@ -95,6 +107,13 @@ export interface CuratorConfig {
    * within this window of the last one. Seeded from the legacy intervalMinutes.
    */
   debounceMinutes: number;
+  /**
+   * Bounded grooming runs (ADR 0005): the maximum active+proposed memories a
+   * single grooming run feeds the model. A slice larger than this is truncated
+   * (newest-first) so one oversized slice can't exceed the LLM timeout. Default
+   * 200 (the prior implicit cap).
+   */
+  maxMemoriesPerRun: number;
 }
 
 export interface CuratorConfigPatch {
@@ -104,6 +123,7 @@ export interface CuratorConfigPatch {
   intervalMinutes?: number;
   triggerThreshold?: number;
   debounceMinutes?: number;
+  maxMemoriesPerRun?: number;
 }
 
 // Input validation for the admin API. Permissive shape (all optional); the deeper
@@ -116,6 +136,7 @@ export const CuratorConfigPatchSchema = z.strictObject({
   intervalMinutes: z.number().optional(),
   triggerThreshold: z.number().optional(),
   debounceMinutes: z.number().optional(),
+  maxMemoriesPerRun: z.number().optional(),
 });
 
 // The slices of the store this module needs. Curator-specific keys are all plain
@@ -148,6 +169,10 @@ export function readCuratorConfig(store: ConfigReader): CuratorConfig {
       DEFAULT_TRIGGER_THRESHOLD,
     ),
     debounceMinutes: parseNumber(store.getSetting(KEYS.debounceMinutes), DEFAULT_DEBOUNCE_MINUTES),
+    maxMemoriesPerRun: parseNumber(
+      store.getSetting(KEYS.maxMemoriesPerRun),
+      DEFAULT_MAX_MEMORIES_PER_RUN,
+    ),
   };
 }
 
@@ -271,6 +296,14 @@ export function writeCuratorConfig(store: ConfigWriter, patch: CuratorConfigPatc
       );
     }
   }
+  if (patch.maxMemoriesPerRun !== undefined) {
+    const n = patch.maxMemoriesPerRun;
+    if (!Number.isInteger(n) || n < MIN_MAX_MEMORIES_PER_RUN || n > MAX_MAX_MEMORIES_PER_RUN) {
+      throw new Error(
+        `max_memories must be an integer between ${MIN_MAX_MEMORIES_PER_RUN} and ${MAX_MAX_MEMORIES_PER_RUN}`,
+      );
+    }
+  }
 
   if (patch.enabled !== undefined) store.setSetting(KEYS.enabled, patch.enabled ? "true" : "false");
   if (patch.defaultAutoApply !== undefined)
@@ -283,4 +316,6 @@ export function writeCuratorConfig(store: ConfigWriter, patch: CuratorConfigPatc
     store.setSetting(KEYS.triggerThreshold, String(patch.triggerThreshold));
   if (patch.debounceMinutes !== undefined)
     store.setSetting(KEYS.debounceMinutes, String(patch.debounceMinutes));
+  if (patch.maxMemoriesPerRun !== undefined)
+    store.setSetting(KEYS.maxMemoriesPerRun, String(patch.maxMemoriesPerRun));
 }

--- a/packages/core/src/curator-tick.ts
+++ b/packages/core/src/curator-tick.ts
@@ -108,7 +108,11 @@ export async function runCuratorTick(options: CuratorTickOptions): Promise<Curat
     model: { provider: llm.providerId, name: llm.model },
     trigger: options.trigger ?? "schedule",
     ...(options.bypassSkip !== undefined ? { bypassSkip: options.bypassSkip } : {}),
-    ...(options.caps !== undefined ? { caps: options.caps } : {}),
+    // Bounded grooming runs (ADR 0005): the configured per-run memory cap
+    // (curator.grooming.max_memories) flows into every run's evidence gather so a
+    // single oversized slice can't exceed the LLM timeout. An explicit options.caps
+    // (manual/maintenance, tests) overrides it.
+    caps: { maxMemories: config.maxMemoriesPerRun, ...options.caps },
   });
   return { ran: true, summary };
 }

--- a/packages/core/tests/curator-config.test.ts
+++ b/packages/core/tests/curator-config.test.ts
@@ -64,6 +64,18 @@ describe("curator config", () => {
     // debounce floor (the repurposed interval default).
     expect(cfg.triggerThreshold).toBe(20);
     expect(cfg.debounceMinutes).toBe(60);
+    // Bounded grooming runs (ADR 0005): default cap preserves prior behaviour.
+    expect(cfg.maxMemoriesPerRun).toBe(200);
+  });
+
+  it("round-trips max_memories and rejects out-of-range values (ADR 0005)", () => {
+    const { store } = s!;
+    writeCuratorConfig(store, { maxMemoriesPerRun: 40 });
+    expect(readCuratorConfig(store).maxMemoriesPerRun).toBe(40);
+    expect(() => writeCuratorConfig(store, { maxMemoriesPerRun: 0 })).toThrow(/max_memories/i);
+    expect(() => writeCuratorConfig(store, { maxMemoriesPerRun: -1 })).toThrow(/max_memories/i);
+    expect(() => writeCuratorConfig(store, { maxMemoriesPerRun: 2.5 })).toThrow(/max_memories/i);
+    expect(() => writeCuratorConfig(store, { maxMemoriesPerRun: 100000 })).toThrow(/max_memories/i);
   });
 
   it("round-trips trigger_threshold and rejects invalid values (≥ 1 integer)", () => {

--- a/packages/core/tests/curator-tick.test.ts
+++ b/packages/core/tests/curator-tick.test.ts
@@ -124,6 +124,44 @@ describe("runCuratorTick — operational", () => {
     expect(capturedPrompt).toContain("MARKER-ADDENDUM prefer merging over archiving");
   });
 
+  it("bounds a grooming run's evidence to curator.grooming.max_memories (ADR 0005)", async () => {
+    // Three memories in ONE slice (same visibility + project). The configured cap
+    // limits how many reach the prompt, so a single slice can't outgrow the timeout.
+    const mk = (title: string) =>
+      store!.createMemory({
+        agent_id: "agent-a",
+        title,
+        body: "b",
+        category: "lessons",
+        visibility: "common",
+        scope: "project",
+        project_key: "proj-x",
+        priority: "normal",
+        confidence: "working",
+      });
+    mk("MEM-ALPHA");
+    mk("MEM-BETA");
+    mk("MEM-GAMMA");
+
+    let prompt = "";
+    const capturing: LlmClient = {
+      complete: async (request: LlmCompletionRequest) => {
+        prompt = request.messages.map((m) => m.content).join("\n");
+        return { content: JSON.stringify({ operations: [] }), model: "m", usage: null };
+      },
+    };
+    const markers = ["MEM-ALPHA", "MEM-BETA", "MEM-GAMMA"];
+
+    // Cap of 2 over a 3-memory slice → EXACTLY two survive into the evidence. This
+    // proves both that the three share one slice (else each would be its own run of
+    // one) AND that the configured cap value is honoured (not just "1 per slice").
+    writeCuratorConfig(store!, { enabled: true, maxMemoriesPerRun: 2 });
+    configureGrooming({ token: "dummy-decrypted-token" });
+    const capped = await runCuratorTick({ store: store!, buildClient: () => capturing });
+    expect(capped.ran).toBe(true);
+    expect(markers.filter((m) => prompt.includes(m))).toHaveLength(2);
+  });
+
   it("force-proposes (no auto-apply) while the grooming addendum is under_evaluation (spec 044 D-3)", async () => {
     seedMemory();
     // high_confidence so the create would otherwise auto-apply to active.


### PR DESCRIPTION
## The incident

A production instance had **every scheduled grooming run failing `llm_timeout`**. The decision log was unambiguous:

| | input memories | duration | outcome |
|---|---|---|---|
| Completed | 1–13 | 3–60s | ✅ |
| Failed | 52–61 | 60s flat | ❌ `llm_timeout` |

All failures were the same slice — the **`common` global slice** (~60 memories). The model (`deepseek-v4-pro`, ~50–60 tok/s) needs ~150–200s to process that much context, but the timeout was 60s, so the request returned 0 tokens and aborted. A failed run doesn't advance the slice, so the identical oversized slice re-ran every tick — a permanent loop.

**Root cause:** nothing bounds a grooming run to fit its timeout. The evidence cap was a hardcoded 200 (`curator-worker.ts`) with no setting to lower it, so a single slice can grow without limit.

(Operator-side, the immediate fix was raising `curator.grooming.timeout_ms` to 240000 — after which the 61-memory slice completed in **171s / 10,464 tokens** and 15 consecutive runs passed. But 171s is already 71% of a 240s ceiling, so it's a treadmill as the corpus grows. This PR is the durable lever.)

## The change

Make the grooming per-run memory cap configurable:
- New setting `curator.grooming.max_memories` → `readCuratorConfig().maxMemoriesPerRun`, validated to an integer in `[1, 1000]`, settable via the `curator.setConfig` admin tRPC.
- `runCuratorTick` passes it as `caps.maxMemories` into every run's evidence gather, so a slice larger than the cap is truncated rather than sent whole. An explicit `options.caps` (manual/tests) still overrides.
- **Default 200** — identical to the prior implicit cap, so existing installs are byte-for-byte unchanged.

## Trade-off (documented in ADR 0005)

Slice memories are selected `updated_at DESC`, so a cap below the slice size feeds only the freshest N — the oldest are ungroomed until they next change. An informed operator trade-off (a bounded *completing* run beats one that always times out). The ADR proposes **automatic full-coverage bounding** (chunking or least-recently-groomed rotation) as the follow-up, leaving the dedup/coverage/cost choice to the maintainer.

A dashboard control for the cap is a deferred follow-up; it's reachable via the admin API today.

## Tests
TDD — `curator-config.test.ts` (round-trip + validation + default 200) and `curator-tick.test.ts` (a cap of 2 over a 3-memory slice feeds exactly 2). Full core suite (916) + dashboard curator tests + mcp-server curator tRPC pass; lint + typecheck clean (dashboard `CuratorConfig` fixtures updated for the new field).

See [ADR 0005](docs/adr/0005-bounded-grooming-runs.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)