### PR TITLE
chore(release): v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ changes from this point forward are catalogued here.
 
 ## [Unreleased]
 
+## [0.6.0] — 2026-06-08
+
 ### Added
 
 - **Curator dashboard: editable cadences + clear run-now reasons.** The Curator
@@ -1147,7 +1149,10 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
-[Unreleased]: https://github.com/JimJafar/the-librarian/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/JimJafar/the-librarian/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/JimJafar/the-librarian/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/JimJafar/the-librarian/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/JimJafar/the-librarian/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/JimJafar/the-librarian/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/JimJafar/the-librarian/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/JimJafar/the-librarian/releases/tag/v0.1.0

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -65,9 +65,16 @@ structured operator feedback + an optional dashboard chat.
   grows with projects/agents. Fix: snapshot the **completed-runs** read once per
   `runDueCuration` pass for the idempotency check (safe — a serial pass only adds
   runs for *other* slices, different input hashes), leaving the cross-process lock
-  read (`findRunningRun`) live. Deferred from the plan-046 PR-1 review (the clean
-  fix touches lock/idempotency concurrency — do it deliberately, ideally after the
-  PR-2 rename settles these files). _(plan 046 PR-1 review, finding #1)_
+  read (`findRunningRun`) live. **Still deferred, kept low-priority.** The PR-2 rename has now
+  merged and settled these files, so the original timing caveat is spent. What
+  remains is the cost/benefit: the benefit is I/O-only (eliminating ~2N redundant
+  whole-file reads/parses per pass) and negligible at current scale — tens of
+  slices — though it grows with projects×agents; the cost is that the change
+  touches lock/idempotency concurrency, so it warrants its own focused PR with a
+  dedicated regression test (snapshot reused across slices within a pass; the
+  cross-process lock read kept live) rather than being bundled into unrelated work.
+  Pick it up when scale makes the I/O matter, or as a deliberate standalone change.
+  _(plan 046 PR-1 review, finding #1)_
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Release v0.6.0 (MINOR)

Rolls up the curator-naming + runtime job-control work (**plan 046**) and the preceding curator fixes into a MINOR release.

### What's in it
- **Dashboard-editable cadences, runtime-effective** — Intake (*every N minutes*) and Grooming (*every N days at HH:MM*) schedules are editable in the cockpit and take effect on the next poll, no restart. Enable/disable toggles likewise.
- **Re-introduced wall-clock grooming schedule** — 0.5.0 had retired the cron and made grooming intake-triggered only; it's back (alongside the trigger).
- **Configurable grooming run size** (`curator.grooming.max_memories`, ADR 0005) and **sweep interval** (`curator.intake.interval_minutes`).
- **`propose_memory` routed through the curator** (ADR 0004) — dedup/merge + the under-evaluation gate, always terminating as a proposal.
- **`consolidator` → `intake` / grooming-sense `curator` → `grooming` code-symbol rename** (no behaviour change; "Curator" retained as the umbrella).
- **Boot-scan timer-off fix** — `*_TICK_MS=0` now disables automatic curation entirely.

### Mechanics
- `[Unreleased]` block moved under `[0.6.0] — 2026-06-08`; root version `0.5.0 → 0.6.0`.
- Backfilled the stale CHANGELOG compare-links (the 0.4.0/0.5.0 releases never updated them) and repointed `[Unreleased]`.
- Also carries a one-line `docs/TODO.md` refresh of the deferred grooming-pass memoization rationale (separate commit).

Tag + GitHub release follow on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)