### PR TITLE
ci(release): automate release-on-merge; retire the [Unreleased] model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,34 @@ jobs:
           LIBRARIAN_AGENT_TOKEN: ci-agent-token
         run: docker compose -f docker/docker-compose.yml config
 
+  release-guard:
+    name: Release hygiene (version bump + no [Unreleased])
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.17.1"
+
+      # Every PR must bump the root version and file a dated CHANGELOG entry for
+      # it (no `[Unreleased]`). On a PR branch we hand the guard the base-main
+      # version so it can prove the bump actually happened; on main itself the
+      # static checks (version ↔ top entry, dated, linked) are enough.
+      - name: Check release hygiene
+        run: |
+          if [ "${{ github.ref }}" != "refs/heads/main" ]; then
+            git fetch --depth=1 origin main
+            RELEASE_BASE_VERSION="$(git show origin/main:package.json | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).version")"
+            export RELEASE_BASE_VERSION
+            echo "Base (origin/main) version: $RELEASE_BASE_VERSION"
+          fi
+          node scripts/check-release.mjs
+
   docker-image:
     name: Single-container image build + smoke
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: Release
+
+# The "every merge to main IS a release" model. When a PR that bumped the root
+# package.json version lands on main, this cuts the matching tag + GitHub
+# release automatically — no separate release PR, no hand-run `git tag` /
+# `gh release`. It is idempotent: a push to main whose version is already
+# tagged (e.g. a merge that didn't bump, or a re-run) is a clean no-op.
+#
+# CI green is enforced by branch protection on main, so a merge commit here is
+# already a passing build. The `release-guard` job in ci.yml independently keeps
+# the version ↔ CHANGELOG entry in sync on every PR.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Tag + GitHub release on version bump
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.17.1"
+
+      - name: Read version from package.json
+        id: ver
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Has this version already been released?
+        id: check
+        run: |
+          if git rev-parse "v${{ steps.ver.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "v${{ steps.ver.outputs.version }} is already tagged — nothing to release."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "v${{ steps.ver.outputs.version }} is new — will tag + release."
+          fi
+
+      - name: Validate release hygiene
+        if: steps.check.outputs.exists == 'false'
+        run: node scripts/check-release.mjs
+
+      - name: Extract release notes from CHANGELOG
+        if: steps.check.outputs.exists == 'false'
+        run: node scripts/check-release.mjs --notes > "${{ runner.temp }}/notes.md"
+
+      - name: Create annotated tag + GitHub release
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          V: v${{ steps.ver.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$V" -m "$V"
+          git push origin "$V"
+          gh release create "$V" --title "$V" --notes-file "${{ runner.temp }}/notes.md"
+          echo "Released $V."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,10 +67,17 @@ push, and never invent new ones unilaterally:
 
 Open source means people depend on what we ship. Treat that with care.
 
-- **Every user-visible change updates `CHANGELOG.md`.** Add an entry
-  under `## [Unreleased]` in the same PR that ships the change — not
-  a follow-up. Internal-only refactors can skip; when unsure, add the
-  entry (cheap, erasable).
+- **Every PR is a release. Bump the version and write the CHANGELOG
+  entry in the same PR.** There is no `## [Unreleased]` section — file
+  your notes under a new dated `## [X.Y.Z] — YYYY-MM-DD` heading at the
+  top of `CHANGELOG.md`, add its `[X.Y.Z]:` compare-link at the bottom,
+  and bump the root `package.json` to match (PATCH / MINOR / MAJOR per
+  [`docs/release.md`](./docs/release.md)). Every merge to `main` bumps
+  the version — even an internal refactor or doc fix takes a PATCH. The
+  merge itself cuts the tag + GitHub release automatically
+  (`.github/workflows/release.yml`); the `check:release` guard fails any
+  PR that leaves an `[Unreleased]` section, forgets the bump, or desyncs
+  the version from the top CHANGELOG entry.
 - **Error messages teach.** "Invalid input" is not an error message.
   "Expected ISO-8601 timestamp, got '2026-13-99'" is. Assume the
   reader is new and tired.
@@ -87,13 +94,17 @@ include a `Co-Authored-By:` trailer.
 
 ### Releases
 
-User-visible PRs need a release. Bump-size rule (PATCH / MINOR / MAJOR),
-trigger criteria, and the full per-repo procedure (CHANGELOG move, tag,
-GitHub release, dashboard badge refresh) live in
-[`docs/release.md`](./docs/release.md); the cross-family runbook
-covering all six repos is at
+There is no separate "cut a release" step — **merging to `main` IS the
+release.** Every PR bumps the root `package.json` and adds its dated
+CHANGELOG entry; on merge, CI tags `vX.Y.Z` and publishes the GitHub
+release automatically. You never create a release branch or hand-run
+`git tag` / `gh release` for the monorepo — the workflow does it, and
+trying to do it by hand just races the automation. The bump-size rule
+(PATCH / MINOR / MAJOR) and the full mechanics live in
+[`docs/release.md`](./docs/release.md); the cross-family runbook (which
+repos, version files, coordinated cross-repo bumps) is at
 [`docs/release-runbook.md`](./docs/release-runbook.md). Read those
-before cutting a release — don't reinvent the steps.
+before you pick a version.
 
 ### Tests are part of the change
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,20 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
-## [Unreleased]
+## [0.6.1] — 2026-06-08
+
+### Changed
+
+- **Release process: merging to `main` is now the release — no more
+  `[Unreleased]`.** Every PR bumps the root `package.json` and files its notes
+  under a dated `## [X.Y.Z]` heading in the same PR; the CHANGELOG no longer
+  carries an `[Unreleased]` section. A new **Release** workflow
+  (`.github/workflows/release.yml`) auto-creates the `vX.Y.Z` git tag + GitHub
+  release on the version-bumping merge to `main`, and a `check:release` CI guard
+  fails any PR that leaves an `[Unreleased]` section, forgets the version bump,
+  or desyncs `package.json` from the top CHANGELOG entry. `AGENTS.md`,
+  `docs/release.md`, and `docs/release-runbook.md` are updated to the new model;
+  the old separate-release-branch flow is retired. No runtime behaviour change.
 
 ## [0.6.0] — 2026-06-08
 
@@ -1149,7 +1162,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
-[Unreleased]: https://github.com/JimJafar/the-librarian/compare/v0.6.0...HEAD
+[0.6.1]: https://github.com/JimJafar/the-librarian/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/JimJafar/the-librarian/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/JimJafar/the-librarian/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/JimJafar/the-librarian/compare/v0.3.0...v0.4.0

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -2,16 +2,23 @@
 
 How we cut releases across the six repos. Pragmatic. Trunk-based. No release branches.
 
+**The model: merging to `main` IS the release.** Every PR bumps its repo's
+version file(s) and files a dated `## [X.Y.Z]` CHANGELOG entry in the **same
+PR** — there is no `[Unreleased]` section and no separate "cut a release" PR.
+The monorepo automates the tag + GitHub release on merge (see
+[`docs/release.md`](./release.md)); the plugin repos are migrating to the same
+automation and run the manual tag/release steps below until they have it.
+
 ## Repos at a glance
 
-| Repo | Artifact | Version source | Install path |
-|---|---|---|---|
-| `the-librarian` | Docker image, GitHub release | root `package.json` | `docker compose ... up -d` |
-| `the-librarian-claude-plugin` | GitHub tag/release | `.claude-plugin/plugin.json` **and** `.claude-plugin/marketplace.json` | `/plugin marketplace add` |
-| `the-librarian-codex-plugin` | GitHub tag/release | `.codex-plugin/plugin.json` **and** `package.json` | `codex plugin marketplace add` |
-| `the-librarian-hermes-plugin` | GitHub tag/release | **`plugin.yaml` `version`** | `hermes plugins install <git>` |
-| `the-librarian-opencode-plugin` | **npm** package + GitHub release | `package.json` | `opencode plugin install` (npm-backed) |
-| `the-librarian-pi-extension` | GitHub tag/release | `package.json` | `pi install git:...` |
+| Repo | Artifact | Version source | Install path | Auto-release on merge? |
+|---|---|---|---|---|
+| `the-librarian` | Docker image, GitHub release | root `package.json` | `docker compose ... up -d` | ✅ yes (`release.yml`) |
+| `the-librarian-claude-plugin` | GitHub tag/release | `.claude-plugin/plugin.json` **and** `.claude-plugin/marketplace.json` | `/plugin marketplace add` | ⏳ migrating — manual |
+| `the-librarian-codex-plugin` | GitHub tag/release | `.codex-plugin/plugin.json` **and** `package.json` | `codex plugin marketplace add` | ⏳ migrating — manual |
+| `the-librarian-hermes-plugin` | GitHub tag/release | **`plugin.yaml` `version`** | `hermes plugins install <git>` | ⏳ migrating — manual |
+| `the-librarian-opencode-plugin` | **npm** package + GitHub release | `package.json` | `opencode plugin install` (npm-backed) | ⏳ migrating — manual |
+| `the-librarian-pi-extension` | GitHub tag/release | `package.json` | `pi install git:...` | ⏳ migrating — manual |
 
 Only **opencode** needs `npm publish`. The other four plugins ship by git tag — the marketplace clients (Claude / Codex) and CLI installers (Hermes, Pi) pull straight from GitHub.
 
@@ -21,28 +28,25 @@ Trunk-based on `main`. Same model in every repo.
 
 - Feature branch off `main` → PR → merge. Never push to `main` directly.
 - One change per PR. Conventional commit subject (`feat(scope): …`, `fix(scope): …`, `refactor(scope): …`).
-- No long-lived release branches. A release is just `main` + a tag + a GitHub release.
+- **Bump the version and add the dated CHANGELOG entry in the feature PR itself.** No `[Unreleased]` section; no long-lived release branches. A release is just `main` + a tag + a GitHub release — cut automatically (monorepo) or by the manual steps below (plugins, for now).
 - Plugin repos are sibling repos to the monorepo, not submodules. Cross-cutting changes (like sessions-rethink) get coordinated by landing the monorepo PR first, then a matching PR in each affected plugin.
 
 ## Semver
 
 - **MAJOR** — breaking change to the MCP tool surface, the slash-command contract, the `source_ref` shape, the projection schema in a way that breaks an in-place upgrade, or any user-visible behaviour that needs a CHANGELOG migration note.
 - **MINOR** — new MCP tool, new slash command, new dashboard surface, additive schema bump (drop-and-rebuild memory side is additive — events.jsonl is canonical), new env var with a default.
-- **PATCH** — bug fix, doc tweak, internal refactor, test-only change.
+- **PATCH** — bug fix, doc tweak, internal refactor, test-only change, CI change.
 
 Pre-1.0 (we are at 0.x), MINOR bumps are allowed to carry small breaking changes — but only if the CHANGELOG entry calls them out under `### Removed` or `### Changed`. Once we hit 1.0, breaking changes need a MAJOR.
 
-## Trigger: when does a PR need a release?
+## Trigger: every merge bumps
 
-A merged PR needs a release when **any** of these is true:
+There is no "does this PR need a release?" judgement call anymore. **Every merge to `main` bumps the version** (PATCH at minimum) and ships a dated CHANGELOG entry — including internal refactors, test-only changes, CI changes, and doc nits. This removes the failure mode where a change landed on `main` with an `[Unreleased]` note and the version bump was forgotten as a "later" step.
 
-- The change is user-visible (new feature, bug fix that affects behaviour, doc change that affects install/config).
-- The change touches the MCP tool surface, the slash-command contract, or the projection schema.
-- The change ships across multiple repos in lockstep (then everything bumps together).
+- The bump *size* still follows Semver above (most internal changes are a PATCH).
+- A coordinated cross-repo change bumps every affected repo to **the same MINOR**.
 
-Internal refactors, test changes, CI changes, and doc nits that don't touch install/config can land on `main` without a release.
-
-When in doubt, cut the release. A `git tag` and a GitHub release are free; users who don't upgrade aren't affected.
+When unsure about size, round down to PATCH — a tag and a GitHub release are free, and users who don't upgrade aren't affected.
 
 ## Versioning across the family
 
@@ -50,42 +54,27 @@ Plugin versions track the monorepo loosely, not strictly. A monorepo MINOR bump 
 
 ---
 
-## Releasing the monorepo (`the-librarian`)
+## Releasing the monorepo (`the-librarian`) — automated
 
-The dashboard's version badge reads the running `package.json` and compares against the latest GitHub release of `JimJafar/the-librarian`. So the badge stays "up to date" only if `package.json` matches the latest GitHub release tag.
+**You don't cut the release; the merge does.** In your feature PR:
 
-```sh
-cd ~/code/the-librarian
-git checkout main && git pull
+1. Bump the root `package.json` (PATCH / MINOR / MAJOR — see Semver).
+2. Add a dated `## [X.Y.Z] — YYYY-MM-DD` section at the top of `CHANGELOG.md` and its `[X.Y.Z]:` compare-link at the bottom. (No `[Unreleased]` — the `check:release` guard enforces this.)
+3. Open the PR, get CI green, merge.
 
-# 1. Bump root package.json
-npm version <patch|minor|major> --no-git-tag-version
+On the merge, `.github/workflows/release.yml` reads the new version, creates the annotated `vX.Y.Z` tag, and publishes the GitHub release with your CHANGELOG section as the notes. The Docker image rebuilds via CI; the dashboard version badge (which compares the running `package.json` to the latest GitHub release of `JimJafar/the-librarian`) picks it up on its next 1-hour cache refresh — restart the server for an immediate update.
 
-# 2. Move CHANGELOG [Unreleased] entries under [vX.Y.Z] - YYYY-MM-DD, leave [Unreleased] empty
-$EDITOR CHANGELOG.md
-
-# 3. Commit on a release branch, PR it
-NEW=$(jq -r .version package.json)
-git checkout -b release/v$NEW
-git add package.json CHANGELOG.md
-git commit -m "chore(release): v$NEW"
-git push -u origin release/v$NEW
-gh pr create --title "chore(release): v$NEW" --body "Release notes in CHANGELOG.md"
-
-# 4. After CI passes and merge:
-git checkout main && git pull
-git tag -a v$NEW -m "v$NEW"
-git push origin v$NEW
-
-# 5. Create the GitHub release (copy the CHANGELOG section as notes)
-gh release create v$NEW --title "v$NEW" --notes-from-tag
-```
-
-The Docker image rebuild is automatic via CI on tag push (or rebuild via `docker compose up -d --build` on each deployment). The version badge picks up the new release on its next 1-hour cache refresh; restart the server for an immediate update.
+Full details and the enforcement guard: [`docs/release.md`](./release.md).
 
 ---
 
-## Releasing a plugin repo (Claude / Codex / Hermes / Pi)
+## Releasing a plugin repo (Claude / Codex / Hermes / Pi) — manual, for now
+
+> ⏳ **Migrating.** These repos will get the monorepo's auto-release workflow +
+> `check:release` guard. Until then, follow the manual steps — but the policy is
+> already the new one: **bump the version file(s) and add a dated CHANGELOG
+> section in the feature PR; no `[Unreleased]`.** The only manual part left is
+> the tag + GitHub release after merge.
 
 These four follow the same pattern: bump version files → tag → GitHub release. **No npm publish needed.** Marketplace clients and CLI installers pull straight from GitHub.
 
@@ -97,17 +86,16 @@ git checkout main && git pull
 
 NEW=0.3.0  # set me
 
-# Bump BOTH files
+# In the FEATURE PR: bump BOTH version files + add the dated CHANGELOG section.
 jq ".version = \"$NEW\"" .claude-plugin/plugin.json > tmp && mv tmp .claude-plugin/plugin.json
 jq "(.plugins[] | select(.name == \"the-librarian\")).version = \"$NEW\"" .claude-plugin/marketplace.json > tmp && mv tmp .claude-plugin/marketplace.json
 jq ".version = \"$NEW\"" package.json > tmp && mv tmp package.json
+$EDITOR CHANGELOG.md  # add `## [$NEW] — <date>` at the top + its compare-link (no [Unreleased])
 
-$EDITOR CHANGELOG.md  # move Unreleased → [vNEW]
-
-git checkout -b release/v$NEW
-git add -A && git commit -m "chore(release): v$NEW"
-git push -u origin release/v$NEW
-gh pr create --title "chore(release): v$NEW" --body-file <(awk "/## \[$NEW\]/,/## \[/" CHANGELOG.md | head -n -1)
+git checkout -b feat/<change>   # your normal feature branch
+git add -A && git commit -m "feat(scope): … (v$NEW)"
+git push -u origin HEAD
+gh pr create --title "feat(scope): …"
 
 # After CI green + merge:
 git checkout main && git pull
@@ -123,7 +111,7 @@ Same shape as Claude. The files to bump are:
 
 - `.codex-plugin/plugin.json` (the `version` field)
 - `package.json` (the `version` field)
-- `CHANGELOG.md`
+- `CHANGELOG.md` (dated `## [vNEW]` section, no `[Unreleased]`)
 
 Then tag + GitHub release. Users update by **re-adding** the plugin:
 `codex plugin add the-librarian@the-librarian-codex` (there is **no**
@@ -140,11 +128,11 @@ Hermes installs the plugin as a directory (no `package.json`/`setup.py`), but it
 cd ~/code/the-librarian-hermes-plugin
 git checkout main && git pull
 NEW=0.3.2
-$EDITOR plugin.yaml CHANGELOG.md   # bump plugin.yaml `version` to $NEW + move CHANGELOG
-git checkout -b release/v$NEW
-git add plugin.yaml CHANGELOG.md && git commit -m "chore(release): v$NEW"
-git push -u origin release/v$NEW
-gh pr create --title "chore(release): v$NEW"
+$EDITOR plugin.yaml CHANGELOG.md   # bump plugin.yaml `version` to $NEW + add dated [$NEW] section
+git checkout -b feat/<change>
+git add plugin.yaml CHANGELOG.md && git commit -m "feat(scope): … (v$NEW)"
+git push -u origin HEAD
+gh pr create --title "feat(scope): …"
 # merge, then:
 git checkout main && git pull
 git tag -a v$NEW -m "v$NEW" && git push origin v$NEW
@@ -162,11 +150,11 @@ cd ~/code/the-librarian-pi-extension
 git checkout main && git pull
 NEW=0.3.0
 jq ".version = \"$NEW\"" package.json > tmp && mv tmp package.json
-$EDITOR CHANGELOG.md
-git checkout -b release/v$NEW
-git add -A && git commit -m "chore(release): v$NEW"
-git push -u origin release/v$NEW
-gh pr create --title "chore(release): v$NEW"
+$EDITOR CHANGELOG.md   # add dated [$NEW] section (no [Unreleased])
+git checkout -b feat/<change>
+git add -A && git commit -m "feat(scope): … (v$NEW)"
+git push -u origin HEAD
+gh pr create --title "feat(scope): …"
 # merge → tag → release
 git checkout main && git pull
 git tag -a v$NEW -m "v$NEW" && git push origin v$NEW
@@ -177,7 +165,7 @@ Users update via `pi update the-librarian-pi-extension`.
 
 ---
 
-## Releasing the OpenCode plugin (npm)
+## Releasing the OpenCode plugin (npm) — manual, for now
 
 This is the only repo that needs `npm publish`. The version on npm is what `opencode plugin install` resolves against — a GitHub tag alone won't reach users.
 
@@ -185,15 +173,15 @@ This is the only repo that needs `npm publish`. The version on npm is what `open
 cd ~/code/the-librarian-opencode-plugin
 git checkout main && git pull
 
-# 1. Bump + CHANGELOG, like the others
+# 1. In the FEATURE PR: bump + dated CHANGELOG section, like the others
 NEW=0.3.0
 jq ".version = \"$NEW\"" package.json > tmp && mv tmp package.json
-$EDITOR CHANGELOG.md
+$EDITOR CHANGELOG.md   # add dated [$NEW] section (no [Unreleased])
 
-git checkout -b release/v$NEW
-git add -A && git commit -m "chore(release): v$NEW"
-git push -u origin release/v$NEW
-gh pr create --title "chore(release): v$NEW"
+git checkout -b feat/<change>
+git add -A && git commit -m "feat(scope): … (v$NEW)"
+git push -u origin HEAD
+gh pr create --title "feat(scope): …"
 
 # 2. After PR merge:
 git checkout main && git pull
@@ -219,7 +207,7 @@ Users update with `opencode plugin update the-librarian-opencode-plugin` (which 
 
 When a change spans the monorepo and one or more plugins (the sessions-rethink rollout is the canonical example), release them in this order:
 
-1. **Monorepo first.** The plugins talk to the server — never ship a plugin that depends on an MCP tool the deployed server doesn't have yet.
+1. **Monorepo first.** The plugins talk to the server — never ship a plugin that depends on an MCP tool the deployed server doesn't have yet. (The monorepo PR's merge auto-releases it.)
 2. **Then each affected plugin**, in any order. The four marketplace-style plugins (Claude / Codex / Hermes / Pi) are independent; the opencode npm publish can lag a few minutes behind them with no consequence.
 3. **Use the same MINOR version** across the family for the coordinated bump. PATCH numbers can drift freely between repos.
 
@@ -229,17 +217,21 @@ If the change is **breaking** for the MCP surface (a tool renamed or removed), a
 
 ## Release-day checklist (copy-paste)
 
-For a single repo release:
+**Monorepo (`the-librarian`) — automated:**
 
-- [ ] `git checkout main && git pull` (clean working tree)
-- [ ] Decide version bump (PATCH / MINOR / MAJOR — see Semver above)
-- [ ] Bump version file(s) — `package.json`, plus plugin manifest JSONs for Claude/Codex
-- [ ] Move `[Unreleased]` CHANGELOG entries under `[vX.Y.Z] - YYYY-MM-DD`
-- [ ] Branch + commit + PR with title `chore(release): vX.Y.Z`
-- [ ] Wait for CI green; merge
-- [ ] Tag `vX.Y.Z` on `main` and push the tag
+- [ ] In your feature PR: bump root `package.json` (PATCH / MINOR / MAJOR)
+- [ ] Add `## [X.Y.Z] — YYYY-MM-DD` at the top of `CHANGELOG.md` + its `[X.Y.Z]:` compare-link (no `[Unreleased]`)
+- [ ] `pnpm check:release` passes locally (also enforced by the **release-guard** CI job)
+- [ ] CI green → merge. The Release workflow tags + publishes automatically.
+- [ ] Verify the GitHub release appeared and the dashboard version badge shows "up to date" (restart the server, or wait for the 1-hour cache)
+
+**A plugin repo — manual until migrated:**
+
+- [ ] In your feature PR: bump the version file(s) — `package.json`, plus plugin manifest JSONs for Claude/Codex, or `plugin.yaml` for Hermes
+- [ ] Add `## [X.Y.Z] — YYYY-MM-DD` to `CHANGELOG.md` (no `[Unreleased]`)
+- [ ] CI green → merge
+- [ ] `git tag -a vX.Y.Z` on `main` and push the tag
 - [ ] `gh release create vX.Y.Z --notes-from-tag`
 - [ ] **OpenCode only:** `npm publish --access public`; confirm `npm view` reports the new version
-- [ ] **Monorepo only:** redeploy (or wait for the dashboard cache refresh) and verify the version badge shows "up to date"
 
 For a coordinated cross-repo release: do the monorepo first, then loop through the affected plugins in any order. Same MINOR version across all of them.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,66 +1,85 @@
 # Releasing `the-librarian`
 
-This is the per-repo release file. The full cross-family runbook (branching
-strategy, semver rules, version-coordination across the family, the OpenCode
-npm flow) lives in [`docs/release-runbook.md`](./release-runbook.md). Read
-that first if you're new to releases here.
+**Merging to `main` IS the release.** There is no separate release PR, no
+`release/vX` branch, and no hand-run `git tag` / `gh release` for this repo.
+Every PR bumps the version and writes its CHANGELOG entry; the merge cuts the
+tag + GitHub release automatically. This file is the per-repo bump-size rule;
+the cross-family runbook (which repos, version files, coordinated bumps) lives
+in [`docs/release-runbook.md`](./release-runbook.md).
 
-## When to cut a release
+## The model
 
-Any merged PR that is **user-visible** (new MCP tool, dashboard surface
-change, schema-affecting refactor, bug fix that changes observable
-behaviour, install / config / env-var change, doc update that affects
-operators) earns a release. Internal-only refactors, test-only changes,
-and CI-only changes don't. When in doubt, cut it — a tag and a GitHub
-release are free.
+1. **Every PR bumps the root `package.json`** — PATCH at minimum. There are no
+   "no-release" PRs on `main`: even an internal refactor or doc fix takes a PATCH.
+2. **The CHANGELOG has no `[Unreleased]` section.** File your notes directly
+   under a new dated heading at the top:
+
+   ```md
+   ## [X.Y.Z] — YYYY-MM-DD
+
+   ### Added
+   - ...
+   ```
+
+   and add the compare-link at the bottom:
+
+   ```md
+   [X.Y.Z]: https://github.com/JimJafar/the-librarian/compare/v<prev>...vX.Y.Z
+   ```
+
+3. **Merge to `main`.** `.github/workflows/release.yml` reads the version, and
+   if `vX.Y.Z` isn't tagged yet, creates the annotated tag + the GitHub release
+   (notes taken from your CHANGELOG section). It is idempotent: a merge that
+   didn't bump the version is a clean no-op.
+
+That's the whole contributor job — the `package.json` bump and the CHANGELOG
+entry. The workflow does the rest.
+
+## Enforcement
+
+`scripts/check-release.mjs` (run locally as `pnpm check:release`, and in CI as
+the **release-guard** job) fails your PR if:
+
+- the CHANGELOG still has an `## [Unreleased]` heading or `[Unreleased]:` link,
+- the top CHANGELOG heading isn't `## [<package.json version>] — <ISO date>`,
+- the date isn't a real `YYYY-MM-DD`, or the `[X.Y.Z]:` compare-link is missing,
+- the version wasn't raised above `main` (the PR forgot to bump).
+
+So you can't merge a change without a version + changelog entry — which is how
+`[Unreleased]` sections and forgotten bumps used to reach `main`.
 
 ## Semver, the short version
 
-- **MAJOR** — breaking change to the MCP surface, the slash-command
-  contract, the `source_ref` shape, or an in-place projection-schema
-  upgrade that breaks v(N) clients against v(N+1) data.
-- **MINOR** — new MCP tool, new slash command, new dashboard surface,
-  additive schema bump, new env var with a default.
-- **PATCH** — bug fix, doc tweak, internal refactor, test-only change.
+- **MAJOR** — breaking change to the MCP surface, the slash-command contract,
+  the `source_ref` shape, or an in-place projection-schema upgrade that breaks
+  v(N) clients against v(N+1) data.
+- **MINOR** — new MCP tool, new slash command, new dashboard surface, additive
+  schema bump, new env var with a default.
+- **PATCH** — bug fix, doc tweak, internal refactor, test-only or CI change.
 
-Pre-1.0, MINOR is allowed to carry small breakings if the CHANGELOG
-calls them out under `### Removed` or `### Changed`.
+Pre-1.0, MINOR is allowed to carry small breakings if the CHANGELOG calls them
+out under `### Removed` or `### Changed`.
 
-## Steps
+## Picking a version when others are in flight
 
-```sh
-cd ~/code/the-librarian
-git checkout main && git pull
+The version lives in two tracked places (`package.json` + the CHANGELOG
+heading), so two PRs that both bump to the same number **conflict on merge** —
+by design. The second one rebases onto `main` and re-picks the next number.
+Don't fight the conflict; let it make you choose a fresh version.
 
-# 1. Bump the root package.json
-NEW=<X.Y.Z>
-npm version $NEW --no-git-tag-version
+## After the release
 
-# 2. Move CHANGELOG [Unreleased] entries under [vX.Y.Z] - YYYY-MM-DD;
-#    leave [Unreleased] empty.
-$EDITOR CHANGELOG.md
-
-# 3. Branch, commit, PR
-git checkout -b release/v$NEW
-git add package.json CHANGELOG.md
-git commit -m "chore(release): v$NEW"
-git push -u origin release/v$NEW
-gh pr create --title "chore(release): v$NEW"
-
-# 4. After CI green + merge
-git checkout main && git pull
-git tag -a v$NEW -m "v$NEW"
-git push origin v$NEW
-gh release create v$NEW --title "v$NEW" --notes-from-tag
-```
-
-The dashboard version badge picks up the new release on its next
-1-hour cache refresh; restart the server for an immediate update.
+The Docker image rebuilds via CI, and deployment is automatic on merge. The
+dashboard version badge reads the running `package.json` and compares it to the
+latest GitHub release of `JimJafar/the-librarian`, refreshing on its 1-hour
+cache (restart the server for an immediate update).
 
 ## Coordinating with the plugin repos
 
-A change that ships across this repo and one or more plugin repos
-(the sessions-rethink rollout is the canonical example) releases
-**monorepo first**, then each affected plugin at the same MINOR
-version. The full cross-family rules are in
-[`docs/release-runbook.md`](./release-runbook.md#coordinated-cross-repo-release).
+A change that ships across this repo and one or more plugin repos releases
+**monorepo first**, then each affected plugin at the same MINOR version. The
+plugin repos are migrating to this same auto-release model; until a given repo
+has the Release workflow, follow its manual steps in
+[`docs/release-runbook.md`](./release-runbook.md#coordinated-cross-repo-release)
+— but the rule is identical there: bump + dated CHANGELOG entry in the same PR,
+no `[Unreleased]`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",
@@ -24,6 +24,7 @@
     "check:test-count": "node --no-warnings scripts/check-test-count.mjs",
     "check:no-secrets-in-vault": "node --no-warnings scripts/check-no-secrets-in-vault.mjs",
     "check:naming-canon": "node --no-warnings scripts/check-naming-canon.mjs",
+    "check:release": "node --no-warnings scripts/check-release.mjs",
     "audit:agent-ids": "node --no-warnings scripts/audit-agent-ids.mjs",
     "backfill:agent-ids": "node --no-warnings scripts/backfill-agent-ids.mjs"
   },

--- a/scripts/check-release.mjs
+++ b/scripts/check-release.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+// Release-hygiene guard — the "every merge to main IS a release" model.
+//
+// This repo has NO `## [Unreleased]` CHANGELOG section and NO separate
+// "cut a release" PR. Every PR that merges to `main` bumps the root
+// package.json version and files its notes under a dated
+// `## [X.Y.Z] — YYYY-MM-DD` heading; the push to `main` then auto-cuts the
+// git tag + GitHub release (.github/workflows/release.yml). This guard fails a
+// PR that breaks that contract, so a change can't land without a version bump
+// and a matching changelog entry — which is exactly how `[Unreleased]`
+// sections and forgotten version bumps used to slip onto `main`.
+//
+// ── Checks (working-tree only, no network) ───────────────────────────────────
+//   1. CHANGELOG.md has NO `## [Unreleased]` heading.
+//   2. The TOP-MOST `## [X.Y.Z] — YYYY-MM-DD` heading's version === the root
+//      package.json version (the release you're shipping is documented + on top).
+//   3. That date is a real ISO-8601 calendar date (catches 2026-13-99 etc.).
+//   4. A `[X.Y.Z]:` link-reference line exists at the bottom for that version.
+//
+// Plus, when the env var RELEASE_BASE_VERSION is set — CI sets it to the base
+// branch's version on PR branches — the current version must be strictly
+// greater (semver), i.e. the PR actually bumped it.
+//
+// ── What this does NOT check (be honest) ─────────────────────────────────────
+//   - The *size* of the bump (PATCH vs MINOR vs MAJOR) is a human/semver call;
+//     this guard only proves a bump happened, not that it's the right size.
+//   - Only the root package.json is versioned. The workspace packages are
+//     private and intentionally pinned at 0.0.0 — they are not inspected.
+//
+// Usage:
+//   node scripts/check-release.mjs            # guard (exit 1 on any violation)
+//   node scripts/check-release.mjs --notes    # print the top version's notes body
+//                                             # (used by the Release workflow)
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const changelogPath = path.join(repoRoot, "CHANGELOG.md");
+const pkgPath = path.join(repoRoot, "package.json");
+
+const pkgVersion = JSON.parse(fs.readFileSync(pkgPath, "utf8")).version;
+const changelog = fs.readFileSync(changelogPath, "utf8");
+const lines = changelog.split("\n");
+
+// The top-most release heading: `## [X.Y.Z] — YYYY-MM-DD` (em-dash or hyphen).
+const HEADING = /^## \[(\d+\.\d+\.\d+)\]\s*[—-]\s*(\d{4}-\d{2}-\d{2})\s*$/;
+// A bare `## [X.Y.Z]` heading with no/!ISO date — reported with a clearer error.
+const HEADING_LOOSE = /^## \[(\d+\.\d+\.\d+)\]/;
+
+function findTopHeading() {
+  for (let i = 0; i < lines.length; i++) {
+    if (HEADING_LOOSE.test(lines[i])) return { line: lines[i], index: i };
+  }
+  return null;
+}
+
+// `--notes`: print the body between the top release heading and the next
+// `## ` heading (the previous release), trimmed. No guard enforcement — the
+// Release workflow runs this only after the guard has already passed in CI.
+if (process.argv.includes("--notes")) {
+  const top = findTopHeading();
+  if (!top) {
+    console.error("[check-release] no release heading found in CHANGELOG.md");
+    process.exit(1);
+  }
+  const body = [];
+  for (let i = top.index + 1; i < lines.length; i++) {
+    if (/^## /.test(lines[i])) break;
+    body.push(lines[i]);
+  }
+  process.stdout.write(`${body.join("\n").trim()}\n`);
+  process.exit(0);
+}
+
+const failures = [];
+
+// (1) The `[Unreleased]` concept is gone — no section heading and no link
+//     reference. Both are anchored to line-start, so prose that *mentions*
+//     `[Unreleased]` (e.g. a changelog entry documenting its removal) is fine.
+if (/^## \[Unreleased\]/m.test(changelog) || /^\[Unreleased\]:/m.test(changelog)) {
+  failures.push(
+    "CHANGELOG.md still has an `## [Unreleased]` heading or an `[Unreleased]:` link " +
+      "reference. There is no Unreleased section in this model — file your notes " +
+      "directly under a dated `## [X.Y.Z] — YYYY-MM-DD` heading for the version this " +
+      "PR ships, and link it as `[X.Y.Z]:` at the bottom.",
+  );
+}
+
+const top = findTopHeading();
+if (!top) {
+  failures.push("CHANGELOG.md has no `## [X.Y.Z]` release heading at all.");
+} else {
+  const strict = top.line.match(HEADING);
+  if (!strict) {
+    failures.push(
+      `Top CHANGELOG heading is malformed: "${top.line.trim()}". ` +
+        "Expected `## [X.Y.Z] — YYYY-MM-DD` (e.g. `## [0.6.1] — 2026-06-08`).",
+    );
+  } else {
+    const [, headingVersion, date] = strict;
+
+    // (2) Top heading must match package.json.
+    if (headingVersion !== pkgVersion) {
+      failures.push(
+        `Version mismatch: package.json is ${pkgVersion} but the top CHANGELOG ` +
+          `entry is [${headingVersion}]. Bump both together — the version you ship ` +
+          "must be the newest CHANGELOG section.",
+      );
+    }
+
+    // (3) Date must be a real calendar date (reconstruct to catch overflow).
+    const d = new Date(`${date}T00:00:00Z`);
+    const roundTrips = !Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === date;
+    if (!roundTrips) {
+      failures.push(
+        `Top CHANGELOG entry has an invalid date "${date}" (expected a real YYYY-MM-DD).`,
+      );
+    }
+
+    // (4) The compare-link reference for this version must exist.
+    const linkRef = new RegExp(`^\\[${headingVersion.replace(/\./g, "\\.")}\\]:\\s+https?://`, "m");
+    if (!linkRef.test(changelog)) {
+      failures.push(
+        `Missing the \`[${headingVersion}]:\` compare-link at the bottom of CHANGELOG.md. ` +
+          "Add it next to the others and repoint the `[Unreleased]`-equivalent / newest link.",
+      );
+    }
+  }
+}
+
+// (5) When CI provides the base version, prove the PR actually bumped it.
+const baseVersion = (process.env.RELEASE_BASE_VERSION || "").trim();
+if (baseVersion && top) {
+  if (!semverGt(pkgVersion, baseVersion)) {
+    failures.push(
+      `Version was not bumped: this branch is ${pkgVersion} but base main is ` +
+        `${baseVersion}. Every PR must raise the version (PATCH at minimum) — see docs/release.md.`,
+    );
+  }
+}
+
+if (failures.length) {
+  console.error("[check-release] FAIL — release hygiene violated:");
+  for (const f of failures) console.error(`  - ${f}`);
+  console.error(
+    "\nThe model: every PR bumps the root package.json + files a dated " +
+      "`## [X.Y.Z]` CHANGELOG entry (no `[Unreleased]`); merging to main auto-cuts " +
+      "the tag + release. See docs/release.md and AGENTS.md → Releases.",
+  );
+  process.exit(1);
+}
+
+console.log(
+  `[check-release] OK: v${pkgVersion} is the top CHANGELOG entry, dated, linked, no [Unreleased]` +
+    (baseVersion ? ` (bumped from base ${baseVersion}).` : "."),
+);
+
+// Strict-greater semver compare on the X.Y.Z core (pre-release/build suffix ignored).
+function semverGt(a, b) {
+  const core = (v) => v.split(/[-+]/)[0].split(".").map(Number);
+  const [a1, a2, a3] = core(a);
+  const [b1, b2, b3] = core(b);
+  if (a1 !== b1) return a1 > b1;
+  if (a2 !== b2) return a2 > b2;
+  return a3 > b3;
+}


### PR DESCRIPTION
## Why

The old model — *add a `## [Unreleased]` entry now, cut the release in a separate PR later* — let `[Unreleased]` sections and forgotten version bumps reach `main` (six plugin repos sat with unreleased changelogs). This makes **merging to `main` the release**, and enforces it so it can't silently regress.

## What

- **`.github/workflows/release.yml`** — on push to `main`, reads the root `package.json` version; if `vX.Y.Z` isn't tagged yet, creates the annotated tag + GitHub release with notes from the matching CHANGELOG section. Idempotent (a no-bump merge is a no-op).
- **`scripts/check-release.mjs`** (`pnpm check:release`) + a fast **`release-guard`** CI job — fails any PR that:
  - keeps an `## [Unreleased]` heading or `[Unreleased]:` link,
  - has a top CHANGELOG heading that doesn't match `package.json` (with a real ISO date + compare-link), or
  - didn't raise the version above `main`.

  The guard's `--notes` mode feeds the release workflow.
- **`AGENTS.md` / `docs/release.md` / `docs/release-runbook.md`** — rewritten to the per-PR model. Monorepo is automated; plugin repos flagged as migrating to the same workflow (manual tag/release until then, but the no-`[Unreleased]` + bump-in-PR rule applies now).

## Dogfood

This PR bumps to **0.6.1** with its own dated entry — so on merge it should self-release `v0.6.1`, proving the workflow end-to-end. No runtime behaviour change.

## Follow-up (your call)

Add the **"Release hygiene (version bump + no [Unreleased])"** check to `main`'s required status checks so it actually blocks merges. Then roll the workflow + guard out to the six plugin repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)