### PR TITLE
feat(dashboard): memories select-all + archive permanent-delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [0.7.0] — 2026-06-08
+
+### Added
+
+- **Memories page: select-all / deselect-all.** A select-all control sits above
+  the row checkboxes and toggles every memory on the current page in one click
+  (showing an indeterminate state for a partial selection), so a whole page can
+  be fed to the bulk re-home flow without ticking each row.
+- **Archive page: checkboxes + permanently delete archived memories.** The
+  Archive page now has per-row checkboxes, a select-all control, and a
+  **Permanently delete (N)** action. Deletion is gated behind a confirmation
+  modal that lists the selected memories and warns it can't be undone from the
+  app. Backed by a new admin-only `memories.purge` tRPC mutation and a
+  `purgeMemory` store primitive that **hard-deletes the vault document** (the
+  narrow exception to "archive = move, never destroy"); the disposable index
+  drops the row on rebuild. Guarded to **archived-only** — an active or proposed
+  memory must be archived first, so a one-click delete can never hit a live
+  memory. Each purge is a git commit, so a deletion remains recoverable from
+  history by an admin even though it's gone from the app, recall, and the index.
+
 ## [0.6.2] — 2026-06-08
 
 ### Changed
@@ -1175,6 +1195,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[0.7.0]: https://github.com/JimJafar/the-librarian/compare/v0.6.2...v0.7.0
 [0.6.2]: https://github.com/JimJafar/the-librarian/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/JimJafar/the-librarian/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/JimJafar/the-librarian/compare/v0.5.0...v0.6.0

--- a/apps/dashboard/app/(memories)/actions.ts
+++ b/apps/dashboard/app/(memories)/actions.ts
@@ -123,6 +123,22 @@ export async function bulkUpdateMemoriesAction(
   }
 }
 
+export type PurgeResult = { ok: true; purged: number } | { ok: false; error: string };
+
+// Permanently delete archived memories (irreversible from the app). Hard-deletes
+// via tRPC `memories.purge`, which refuses any non-archived memory server-side.
+// Revalidates the archive view so the deleted rows drop out.
+export async function purgeMemoriesAction(ids: string[]): Promise<PurgeResult> {
+  if (ids.length === 0) return { ok: false, error: "No memories selected." };
+  try {
+    const result = await serverTRPC.memories.purge.mutate({ ids });
+    revalidatePath("/archive");
+    return { ok: true, purged: result.purged };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
 export type RecallResult = { ok: true; memories: MemoryRow[] } | { ok: false; error: string };
 
 export async function recallAction(query: string): Promise<RecallResult> {

--- a/apps/dashboard/app/(memories)/archive/page.tsx
+++ b/apps/dashboard/app/(memories)/archive/page.tsx
@@ -1,26 +1,12 @@
-import { SimpleMemoryList } from "@/components/memories/simple-list";
-import type { MemoryRow } from "@/components/memories/types";
-import { serverTRPC } from "@/lib/trpc-server";
+import { ArchiveView } from "@/components/memories/archive-view";
 
 export const dynamic = "force-dynamic";
 
-export default async function ArchivePage() {
-  let memories: MemoryRow[] = [];
-  let error: string | null = null;
-  try {
-    const result = await serverTRPC.memories.list.query({
-      status: "archived",
-      limit: 100,
-    } as Parameters<typeof serverTRPC.memories.list.query>[0]);
-    memories = result.memories as MemoryRow[];
-  } catch (err) {
-    error = err instanceof Error ? err.message : String(err);
-  }
+export default function ArchivePage() {
   return (
     <main className="flex flex-col gap-4 p-6">
       <h1 className="text-2xl font-semibold tracking-tight">Archive</h1>
-      {error ? <p className="text-sm text-destructive">{error}</p> : null}
-      <SimpleMemoryList memories={memories} emptyMessage="No archived memories." />
+      <ArchiveView />
     </main>
   );
 }

--- a/apps/dashboard/components/memories/archive-delete-modal.tsx
+++ b/apps/dashboard/components/memories/archive-delete-modal.tsx
@@ -1,0 +1,89 @@
+// Confirmation modal for permanently deleting archived memories.
+//
+// Permanent delete is irreversible from the app (it hard-deletes the vault
+// document; the deletion is a git commit, so only an admin could recover it from
+// history). This modal lists the selected memories and gates the destructive
+// action behind one deliberate confirmation click — the friction level Jim chose.
+
+"use client";
+
+import { useState, useTransition } from "react";
+import type { MemoryRow } from "./types";
+import { purgeMemoriesAction } from "@/app/(memories)/actions";
+import { Button } from "@/components/ui-v2/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui-v2/dialog";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  memories: MemoryRow[];
+  onDeleted: (count: number) => void;
+}
+
+export function ArchiveDeleteModal({ open, onOpenChange, memories, onDeleted }: Props) {
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+  const count = memories.length;
+
+  const submit = () => {
+    setError(null);
+    startTransition(async () => {
+      const result = await purgeMemoriesAction(memories.map((m) => m.id));
+      if (result.ok) {
+        onDeleted(result.purged);
+        onOpenChange(false);
+      } else {
+        setError(result.error);
+      }
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            Permanently delete {count} memor{count === 1 ? "y" : "ies"}?
+          </DialogTitle>
+          <DialogDescription>
+            This permanently deletes{" "}
+            {count === 1 ? "this archived memory" : `these ${count} archived memories`} and
+            can&apos;t be undone from the app.
+          </DialogDescription>
+        </DialogHeader>
+        <ul className="max-h-48 overflow-y-auto text-sm">
+          {memories.map((m) => (
+            <li
+              key={m.id}
+              className="truncate border-b border-ink-hairline/50 py-1 last:border-0"
+              title={m.title || "(untitled)"}
+            >
+              {m.title || "(untitled)"}
+            </li>
+          ))}
+        </ul>
+        {error ? <p className="text-xs text-ink-accent">{error}</p> : null}
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={pending}>
+            Cancel
+          </Button>
+          <Button
+            variant="outline"
+            className="border-destructive/50 text-destructive hover:bg-destructive/10"
+            onClick={submit}
+            disabled={pending || count === 0}
+          >
+            {pending ? "Deleting…" : `Delete ${count}`}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/dashboard/components/memories/archive-view.tsx
+++ b/apps/dashboard/components/memories/archive-view.tsx
@@ -1,0 +1,148 @@
+// Archive page view: list archived memories with per-row checkboxes, a
+// select-all control, and a bulk "Permanently delete" action (confirmed through
+// ArchiveDeleteModal). Permanent delete is admin-only + irreversible from the
+// app; the server `memories.purge` refuses any non-archived memory.
+
+"use client";
+
+import { useEffect, useState } from "react";
+import { ArchiveDeleteModal } from "./archive-delete-modal";
+import type { MemoryRow } from "./types";
+import { Button } from "@/components/ui-v2/button";
+import { Pill } from "@/components/ui-v2/pill";
+import { trpc } from "@/lib/trpc-client";
+
+export function ArchiveView() {
+  const listQuery = trpc.memories.list.useQuery({
+    status: "archived",
+    limit: 100,
+  } as Parameters<typeof trpc.memories.list.useQuery>[0]);
+  const memories = (listQuery.data?.memories ?? []) as MemoryRow[];
+
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [showDelete, setShowDelete] = useState(false);
+  const [toast, setToast] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!toast) return;
+    const timer = setTimeout(() => setToast(null), 4000);
+    return () => clearTimeout(timer);
+  }, [toast]);
+
+  // Drop any selected ids that are no longer present (e.g. after a delete /
+  // refetch) so the bulk count never references gone rows.
+  useEffect(() => {
+    setSelected((prev) => {
+      if (prev.size === 0) return prev;
+      const present = new Set(memories.map((m) => m.id));
+      const next = new Set([...prev].filter((id) => present.has(id)));
+      return next.size === prev.size ? prev : next;
+    });
+  }, [memories]);
+
+  const allSelected = memories.length > 0 && memories.every((m) => selected.has(m.id));
+  const someSelected = memories.some((m) => selected.has(m.id));
+
+  const toggle = (id: string) =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  const toggleAll = (on: boolean) =>
+    setSelected(on ? new Set(memories.map((m) => m.id)) : new Set());
+
+  if (listQuery.isLoading) {
+    return <p className="text-sm text-muted-foreground">Loading archived memories…</p>;
+  }
+  if (listQuery.isError) {
+    return (
+      <p className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+        Failed to load archive: {listQuery.error?.message ?? "unknown error"}
+      </p>
+    );
+  }
+  if (memories.length === 0) {
+    return <p className="text-sm text-muted-foreground">No archived memories.</p>;
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between gap-4">
+        <label className="flex w-fit cursor-pointer items-center gap-2 px-2 text-sm text-muted-foreground">
+          <input
+            type="checkbox"
+            aria-label="Select all archived memories"
+            checked={allSelected}
+            ref={(el) => {
+              if (el) el.indeterminate = someSelected && !allSelected;
+            }}
+            onChange={(e) => toggleAll(e.target.checked)}
+          />
+          {allSelected ? "Deselect all" : "Select all"}
+        </label>
+        {selected.size > 0 ? (
+          <Button
+            variant="outline"
+            className="border-destructive/50 text-destructive hover:bg-destructive/10"
+            onClick={() => setShowDelete(true)}
+            aria-label={`Permanently delete ${selected.size} archived memories`}
+          >
+            Permanently delete ({selected.size})
+          </Button>
+        ) : null}
+      </div>
+      {toast ? (
+        <div
+          role="status"
+          className="rounded-md border border-primary/40 bg-primary/5 px-3 py-2 text-sm"
+        >
+          {toast}
+        </div>
+      ) : null}
+      <ul className="flex flex-col gap-2">
+        {memories.map((memory) => (
+          <li key={memory.id} className="flex items-stretch gap-2">
+            <label className="flex items-center px-2">
+              <input
+                type="checkbox"
+                aria-label={`Select ${memory.title || memory.id}`}
+                checked={selected.has(memory.id)}
+                onChange={() => toggle(memory.id)}
+              />
+            </label>
+            <div className="min-w-0 flex-1 rounded-md border bg-card p-3">
+              <h3 className="truncate font-medium">{memory.title || "(untitled)"}</h3>
+              <p className="line-clamp-2 text-sm text-muted-foreground">{memory.body}</p>
+              <div className="mt-1 flex flex-wrap items-center gap-1 text-xs text-muted-foreground">
+                <Pill>{memory.category}</Pill>
+                <span>{memory.visibility}</span>
+                <span>·</span>
+                <span>{memory.scope}</span>
+                {memory.agent_id ? (
+                  <>
+                    <span>·</span>
+                    <span>{memory.agent_id}</span>
+                  </>
+                ) : null}
+                <span>·</span>
+                <span>{new Date(memory.updated_at).toLocaleDateString()}</span>
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+      <ArchiveDeleteModal
+        open={showDelete}
+        onOpenChange={setShowDelete}
+        memories={memories.filter((m) => selected.has(m.id))}
+        onDeleted={(count) => {
+          setSelected(new Set());
+          setToast(`Permanently deleted ${count} memor${count === 1 ? "y" : "ies"}.`);
+          listQuery.refetch();
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/dashboard/components/memories/list.tsx
+++ b/apps/dashboard/components/memories/list.tsx
@@ -26,6 +26,8 @@ interface Props {
   selectionEnabled?: boolean;
   selectedIds?: Set<string>;
   onToggleSelected?: (id: string) => void;
+  // Select-all / deselect-all for the rows currently shown (one page).
+  onToggleSelectAll?: (selectAll: boolean) => void;
 }
 
 export function MemoriesList({
@@ -43,6 +45,7 @@ export function MemoriesList({
   selectionEnabled = false,
   selectedIds,
   onToggleSelected,
+  onToggleSelectAll,
 }: Props) {
   if (isLoading) {
     return <p className="text-sm text-muted-foreground">Loading memories…</p>;
@@ -57,8 +60,26 @@ export function MemoriesList({
   if (memories.length === 0) {
     return <p className="text-sm text-muted-foreground">No memories match these filters.</p>;
   }
+  // Select-all reflects the rows currently shown (one page); the parent keeps the
+  // full cross-page selection. `indeterminate` shows a partial page selection.
+  const allSelected = !!selectedIds && memories.every((m) => selectedIds.has(m.id));
+  const someSelected = !!selectedIds && memories.some((m) => selectedIds.has(m.id));
   return (
     <div className="flex flex-col gap-3">
+      {selectionEnabled && selectedIds && onToggleSelectAll ? (
+        <label className="flex w-fit cursor-pointer items-center gap-2 px-2 text-sm text-muted-foreground">
+          <input
+            type="checkbox"
+            aria-label="Select all on this page"
+            checked={allSelected}
+            ref={(el) => {
+              if (el) el.indeterminate = someSelected && !allSelected;
+            }}
+            onChange={(e) => onToggleSelectAll(e.target.checked)}
+          />
+          {allSelected ? "Deselect all" : "Select all"}
+        </label>
+      ) : null}
       <ul className="flex flex-col gap-2">
         {memories.map((memory) => (
           <li key={memory.id} className="flex items-stretch gap-2">

--- a/apps/dashboard/components/memories/view.tsx
+++ b/apps/dashboard/components/memories/view.tsx
@@ -191,6 +191,16 @@ export function MemoriesView() {
                 return next;
               })
             }
+            onToggleSelectAll={(selectAll) =>
+              setBulkSelection((prev) => {
+                const next = new Set(prev);
+                for (const m of displayed) {
+                  if (selectAll) next.add(m.id);
+                  else next.delete(m.id);
+                }
+                return next;
+              })
+            }
           />
         </section>
         {selected ? (

--- a/apps/dashboard/tests/components/memories-list-selection.test.tsx
+++ b/apps/dashboard/tests/components/memories-list-selection.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { MemoriesList } from "@/components/memories/list";
+import type { MemoryRow } from "@/components/memories/types";
+
+function row(id: string): MemoryRow {
+  return {
+    id,
+    title: `Title ${id}`,
+    body: "body",
+    category: "lessons",
+    visibility: "private",
+    scope: "global",
+    project_key: null,
+    updated_at: "2026-06-01T00:00:00.000Z",
+    usefulness_score: 0,
+  } as MemoryRow;
+}
+
+function renderList(selectedIds: Set<string>) {
+  const onToggleSelectAll = vi.fn();
+  render(
+    <MemoriesList
+      memories={[row("a"), row("b")]}
+      isLoading={false}
+      isError={false}
+      selectedId={null}
+      onSelect={() => {}}
+      offset={0}
+      pageSize={25}
+      hasMore={false}
+      onOffsetChange={() => {}}
+      selectionEnabled
+      selectedIds={selectedIds}
+      onToggleSelected={() => {}}
+      onToggleSelectAll={onToggleSelectAll}
+    />,
+  );
+  return { onToggleSelectAll };
+}
+
+describe("MemoriesList select-all", () => {
+  it("offers 'Select all' and requests selecting the page when none are selected", async () => {
+    const { onToggleSelectAll } = renderList(new Set());
+    const selectAll = screen.getByLabelText("Select all on this page") as HTMLInputElement;
+    expect(selectAll.checked).toBe(false);
+    expect(screen.getByText("Select all")).toBeTruthy();
+    await userEvent.click(selectAll);
+    expect(onToggleSelectAll).toHaveBeenCalledWith(true);
+  });
+
+  it("offers 'Deselect all' and requests clearing when the whole page is selected", async () => {
+    const { onToggleSelectAll } = renderList(new Set(["a", "b"]));
+    const selectAll = screen.getByLabelText("Select all on this page") as HTMLInputElement;
+    expect(selectAll.checked).toBe(true);
+    expect(screen.getByText("Deselect all")).toBeTruthy();
+    await userEvent.click(selectAll);
+    expect(onToggleSelectAll).toHaveBeenCalledWith(false);
+  });
+
+  it("renders the select-all box indeterminate on a partial page selection", () => {
+    renderList(new Set(["a"]));
+    const selectAll = screen.getByLabelText("Select all on this page") as HTMLInputElement;
+    expect(selectAll.checked).toBe(false);
+    expect(selectAll.indeterminate).toBe(true);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/core/src/store/markdown/markdown-memory-store.ts
+++ b/packages/core/src/store/markdown/markdown-memory-store.ts
@@ -262,6 +262,29 @@ export function createMarkdownMemoryStore(deps: MarkdownMemoryStoreDeps): Memory
     );
   }
 
+  // Permanently delete an ARCHIVED memory: hard-delete its vault document (the
+  // narrow archive=move exception) and commit. The disposable index rebuilds
+  // from the vault on the next read, so the row drops automatically — no
+  // separate index delete. Guarded to archived-only so a one-click destroy can
+  // never hit a live (active/proposed) memory: archive it first. Idempotent —
+  // purging an already-absent memory is a no-op returning null. The deletion is
+  // a git commit, so an admin can still recover it from history.
+  function purgeMemory(id: string, agent_id: string = DEFAULT_AGENT_ID): Memory | null {
+    void agent_id;
+    const existing = getMemory(id);
+    if (!existing) return null; // already gone — idempotent no-op
+    if (existing.status !== MemoryStatus.Archived) {
+      throw new Error(
+        `Memory ${id} is ${existing.status}, not archived — only archived memories can be permanently deleted. Archive it first.`,
+      );
+    }
+    const rel = pathForId(id);
+    if (rel) vault.removeFile(rel);
+    idToPath?.delete(id); // keep the resolver cache current
+    commit(`memory: purge ${id}`);
+    return existing;
+  }
+
   function verifyMemory(
     id: string,
     result: string,
@@ -582,6 +605,7 @@ export function createMarkdownMemoryStore(deps: MarkdownMemoryStoreDeps): Memory
     updateMemory,
     archiveMemory,
     unarchiveMemory,
+    purgeMemory,
     verifyMemory,
     approveProposal,
     recordRecall,

--- a/packages/core/src/store/memory-types.ts
+++ b/packages/core/src/store/memory-types.ts
@@ -117,6 +117,11 @@ export interface MemoryStore {
   // The narrow inverse of archiveMemory (spec 044 D-5b): restore an archived
   // memory to Active (idempotent on an already-active row). Drives admin unmerge.
   unarchiveMemory: (id: string, agent_id?: string) => Memory | null;
+  // Permanently delete an ARCHIVED memory: hard-deletes the vault document (the
+  // narrow archive=move exception) + commits; the disposable index drops the row
+  // on rebuild. Archived-only — throws for an active/proposed memory (archive it
+  // first). Idempotent: an already-absent id is a no-op returning null.
+  purgeMemory: (id: string, agent_id?: string) => Memory | null;
   verifyMemory: (id: string, result: string, note?: string, agent_id?: string) => Memory | null;
   recordRecall: (memories: Memory[], agent_id?: string, query?: string) => void;
   approveProposal: (

--- a/packages/core/tests/store/markdown/markdown-memory-mutations.test.ts
+++ b/packages/core/tests/store/markdown/markdown-memory-mutations.test.ts
@@ -139,6 +139,34 @@ describe("markdown MemoryStore — unarchiveMemory", () => {
   });
 });
 
+describe("markdown MemoryStore — purgeMemory", () => {
+  it("hard-deletes an archived memory (file gone, getMemory null) and is idempotent", () => {
+    const { store, vault, seed } = setup();
+    seed({ id: "m", status: "archived" });
+    expect(vault.exists("memories/m.md")).toBe(true);
+
+    const purged = store.purgeMemory("m");
+    expect(purged!.id).toBe("m");
+    expect(vault.exists("memories/m.md")).toBe(false);
+    expect(store.getMemory("m")).toBeNull();
+
+    // idempotent — purging an already-absent memory is a no-op returning null
+    expect(store.purgeMemory("m")).toBeNull();
+  });
+
+  it("refuses to purge a non-archived memory (archive first) and leaves it untouched", () => {
+    const { store, seed } = setup();
+    seed({ id: "a", status: "active" });
+    expect(() => store.purgeMemory("a")).toThrow(/archived/i);
+    expect(store.getMemory("a")!.status).toBe("active");
+  });
+
+  it("is a no-op for an unknown id", () => {
+    const { store } = setup();
+    expect(store.purgeMemory("ghost")).toBeNull();
+  });
+});
+
 describe("markdown MemoryStore — verifyMemory", () => {
   it("nudges usefulness +1 / -1 and clamps to ±3", () => {
     const { store, seed } = setup();

--- a/packages/mcp-server/src/trpc/memories.ts
+++ b/packages/mcp-server/src/trpc/memories.ts
@@ -115,6 +115,12 @@ const BulkUpdateMemoryInputSchema = z.object({
   agent_id: z.string().optional(),
 });
 
+// Permanent delete (irreversible from the app): hard-delete ARCHIVED memories.
+const PurgeMemoriesInputSchema = z.object({
+  ids: z.array(z.string().min(1)).min(1).max(500),
+  agent_id: z.string().optional(),
+});
+
 const DistinctValuesFieldSchema = z.enum(["agent_id", "project_key", "category", "visibility"]);
 const DistinctValuesInputSchema = z.object({
   field: DistinctValuesFieldSchema,
@@ -339,6 +345,20 @@ export const memoriesRouter = router({
       patch,
       agent_id: input.agent_id ?? DASHBOARD_AGENT_ID,
     });
+  }),
+
+  // Permanent delete (irreversible from the app). Hard-deletes ARCHIVED memories
+  // via store.purgeMemory, which refuses any non-archived memory — so the archive
+  // page's bulk delete can never destroy a live memory. Each purge is a git
+  // commit (recoverable from history). Returns how many rows were removed; an
+  // absent id is a no-op, so a re-run is safe.
+  purge: adminProcedure.input(PurgeMemoriesInputSchema).mutation(({ ctx, input }) => {
+    const actor = input.agent_id ?? DASHBOARD_AGENT_ID;
+    let purged = 0;
+    for (const id of input.ids) {
+      if (ctx.store.purgeMemory(id, actor)) purged++;
+    }
+    return { purged };
   }),
 
   distinctValues: adminProcedure.input(DistinctValuesInputSchema).query(({ ctx, input }) => {

--- a/packages/mcp-server/tests/trpc/memories.test.ts
+++ b/packages/mcp-server/tests/trpc/memories.test.ts
@@ -481,6 +481,81 @@ describe("tRPC memories surface", () => {
   });
 });
 
+// Permanent delete (irreversible from the app): hard-delete ARCHIVED memories.
+// Archived-only (active/proposed must be archived first); each purge is a git
+// commit (recoverable from history); admin-gated.
+describe("tRPC memories.purge (permanent delete of archived memories)", () => {
+  it("hard-deletes archived memories, commits, and reports the count", async () => {
+    const dataDir = makeTempDir();
+    const a = seedMemory(dataDir, { title: "Trash A" });
+    const b = seedMemory(dataDir, { title: "Trash B" });
+    const server = await startHttpServer({ dataDir });
+    try {
+      // Purge is archived-only — archive both first.
+      await trpcPost(server, "memories.archive", { id: a.id });
+      await trpcPost(server, "memories.archive", { id: b.id });
+
+      const result = await trpcPost<{ purged: number }>(server, "memories.purge", {
+        ids: [a.id, b.id],
+      });
+      expect(result.purged).toBe(2);
+
+      // Gone from the corpus entirely.
+      expect(memoryStatus(dataDir, a.id)).toBeUndefined();
+      expect(memoryStatus(dataDir, b.id)).toBeUndefined();
+
+      // Committed (recoverable from git history).
+      const log = gitLog(dataDir);
+      expect(log.some((s) => s.includes(`purge ${a.id}`))).toBe(true);
+      expect(log.some((s) => s.includes(`purge ${b.id}`))).toBe(true);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("refuses to purge a non-archived (active) memory and leaves it untouched", async () => {
+    const dataDir = makeTempDir();
+    const m = seedMemory(dataDir, { title: "Still live" });
+    const server = await startHttpServer({ dataDir });
+    try {
+      const response = await fetch(`${server.url}/trpc/memories.purge`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${server.token}`,
+        },
+        body: JSON.stringify({ ids: [m.id] }),
+      });
+      expect(response.status).toBeGreaterThanOrEqual(400);
+      const json = (await response.json()) as TrpcErr;
+      expect(json.error?.message).toMatch(/archived/i);
+      expect(memoryStatus(dataDir, m.id)).toBe("active");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("rejects unauthenticated callers (admin-gated)", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const response = await fetch(`${server.url}/trpc/memories.purge`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ ids: ["mem_x"] }),
+      });
+      expect(response.status).toBe(401);
+      const json = (await response.json()) as TrpcErr;
+      expect(json.error?.data?.code).toBe("UNAUTHORIZED");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+});
+
 // Admin mutation primitives (spec 044 D-5a). merge/split/update run OUTSIDE a
 // curation run (an admin fixing the corpus directly), call the SAME shared store
 // primitives the curator run path uses, tag provenance `curator_note.source =


### PR DESCRIPTION
Two requested dashboard affordances, plus the backend the second needs.

## Memories page
- **Select-all / deselect-all** above the row checkboxes — toggles every memory on the current page in one click (indeterminate on a partial selection), feeding the existing bulk re-home flow.

## Archive page
- **Per-row checkboxes + select-all + "Permanently delete (N)"**, behind a confirmation modal that lists the selected memories and warns it can't be undone from the app (the friction level chosen: a single deliberate confirm).
- New admin-only **`memories.purge`** tRPC mutation + a **`purgeMemory`** store primitive that **hard-deletes the vault document** (the narrow exception to "archive = move, never destroy"); the disposable index drops the row on rebuild.
- **Archived-only** — an active/proposed memory must be archived first, so a one-click delete can never hit a live memory.
- Each purge is a **git commit**, so a deletion stays recoverable from history by an admin even though it's gone from the app, recall, and the index. (No history rewrite.)

## Tests
- core: `purgeMemory` — archived-only guard, idempotent, file removed, `getMemory` null.
- server: `memories.purge` — count + commit, refuses non-archived, admin-gated.
- dashboard: `MemoriesList` select-all (select/clear/indeterminate).
- Verified locally: core 964 pass, dashboard 219 pass, server memories suite 30 pass; typecheck + lint + guard clean.

MINOR → **0.7.0**; self-releases on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)