### PR TITLE
feat(dashboard): large faint brand watermark behind content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [0.7.3] — 2026-06-11
+
+### Added
+
+- **Brand watermark behind the dashboard.** A large, faint Librarian mark is
+  fixed and centred behind every page's content (decorative — `aria-hidden`,
+  `pointer-events-none`, `-z-10`, so it never intercepts clicks). The small nav
+  logo stays. It's the light (dark-ink) variant, subtle on the default light
+  theme and near-invisible on dark.
+
 ## [0.7.2] — 2026-06-11
 
 ### Added
@@ -1217,6 +1227,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[0.7.3]: https://github.com/JimJafar/the-librarian/compare/v0.7.2...v0.7.3
 [0.7.2]: https://github.com/JimJafar/the-librarian/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/JimJafar/the-librarian/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/JimJafar/the-librarian/compare/v0.6.2...v0.7.0

--- a/apps/dashboard/app/layout.tsx
+++ b/apps/dashboard/app/layout.tsx
@@ -72,6 +72,23 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
           disableTransitionOnChange
         >
           <Providers>
+            {/* Brand watermark — a large, faint mark fixed behind all content.
+                Decorative only: aria-hidden + pointer-events-none so it never
+                intercepts clicks; -z-10 keeps it behind the page content while
+                sitting above the body background. It's the light (dark-ink)
+                variant, so it's a subtle ghost on the light theme and near-
+                invisible on dark — fine for a watermark. */}
+            <div
+              aria-hidden
+              className="pointer-events-none fixed inset-0 -z-10 flex items-center justify-center overflow-hidden"
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element -- static SVG mark; next/image optimisation is N/A for vectors */}
+              <img
+                src="/the-librarian-mark-vector-light.svg"
+                alt=""
+                className="h-[85vh] w-auto opacity-[0.04]"
+              />
+            </div>
             <div className="flex min-h-screen flex-col">
               <SiteNav signedIn={signedIn} />
               {children}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Adds the Librarian mark as a **fixed, centred, very faint watermark** behind every page's content (root layout). Per your pick: centred & large, and the small nav logo stays.

- Decorative only — `aria-hidden` + `pointer-events-none` + `-z-10`, so it never intercepts clicks; sits above the body background, below content.
- `h-[85vh]`, `opacity-[0.04]`. Light (dark-ink) variant — a subtle ghost on the light theme, near-invisible on dark.

Easy knobs if you want to tune after seeing it: `opacity-[0.04]` (fainter/stronger) and `h-[85vh]` (size).

PATCH → **0.7.3**; self-releases on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)