### PR TITLE
feat(dashboard): flagged-memory review surface (plan 048 PR-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [0.9.0] — 2026-06-12
+
+### Added
+
+- **Dashboard: a "Flagged" review queue for `flag_memory`.** A new **Flagged**
+  nav tab + page lists every memory with an open flag, showing each flag's
+  reason, the flagging agent, and when — with per-row **Dismiss** (clear the
+  flags, keep the memory active) and **Archive** (archive + clear) actions.
+  Backed by two admin-only tRPC procedures, `memories.listFlagged` and
+  `memories.resolveFlag`. This is the human/curator adjudication surface for the
+  route-to-review flags introduced in 0.8.0 (plan 048 PR-2).
+
 ## [0.8.0] — 2026-06-12
 
 ### Added
@@ -1264,6 +1276,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[0.9.0]: https://github.com/JimJafar/the-librarian/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/JimJafar/the-librarian/compare/v0.7.4...v0.8.0
 [0.7.4]: https://github.com/JimJafar/the-librarian/compare/v0.7.3...v0.7.4
 [0.7.3]: https://github.com/JimJafar/the-librarian/compare/v0.7.2...v0.7.3

--- a/apps/dashboard/app/(memories)/actions.ts
+++ b/apps/dashboard/app/(memories)/actions.ts
@@ -97,6 +97,26 @@ export async function archiveMemoryAction(id: string): Promise<ActionResult> {
   }
 }
 
+// Adjudicate one flagged memory (spec 048 PR-2) via tRPC `memories.resolveFlag`.
+// `dismiss` clears the open flags and keeps the memory active; `archive`
+// archives it then clears its flags — either way the row drops out of the
+// flagged review queue. Revalidates the flagged + active + archive views so a
+// navigation back doesn't show a stale queue.
+export async function resolveFlagAction(
+  id: string,
+  action: "dismiss" | "archive",
+): Promise<ActionResult> {
+  try {
+    await serverTRPC.memories.resolveFlag.mutate({ id, action });
+    revalidatePath("/");
+    revalidatePath("/flagged");
+    revalidatePath("/archive");
+    return { ok: true };
+  } catch (err) {
+    return fail(err instanceof Error ? err.message : String(err));
+  }
+}
+
 export type BulkUpdateResult =
   | { ok: true; updated: number; transaction_id: string }
   | { ok: false; error: string };

--- a/apps/dashboard/app/(memories)/flagged/page.tsx
+++ b/apps/dashboard/app/(memories)/flagged/page.tsx
@@ -1,0 +1,12 @@
+import { FlaggedView } from "@/components/memories/flagged-view";
+
+export const dynamic = "force-dynamic";
+
+export default function FlaggedPage() {
+  return (
+    <main className="flex flex-col gap-4 p-6">
+      <h1 className="text-2xl font-semibold tracking-tight">Flagged</h1>
+      <FlaggedView />
+    </main>
+  );
+}

--- a/apps/dashboard/components/memories/flagged-view.tsx
+++ b/apps/dashboard/components/memories/flagged-view.tsx
@@ -1,0 +1,114 @@
+// Flagged review queue (spec 048 PR-2): list every memory an agent has flagged
+// for review, surfacing the title, body, and each open flag's reason + flagger,
+// with per-row Dismiss / Archive actions. A flag never changes a memory's
+// status — these stay active until an admin adjudicates here. Dismiss clears the
+// flags and keeps the memory; Archive archives it then clears the flags. Both
+// go through the `resolveFlagAction` server action, then refetch the queue.
+
+"use client";
+
+import { useTransition } from "react";
+import type { MemoryRow } from "./types";
+import { resolveFlagAction } from "@/app/(memories)/actions";
+import { Button } from "@/components/ui-v2/button";
+import { Pill } from "@/components/ui-v2/pill";
+import { trpc } from "@/lib/trpc-client";
+
+interface MemoryFlag {
+  agent_id: string;
+  reason: string;
+  created_at: string;
+}
+
+type FlaggedRow = MemoryRow & { flags?: MemoryFlag[] };
+
+export function FlaggedView() {
+  const listQuery = trpc.memories.listFlagged.useQuery(undefined, {
+    refetchOnWindowFocus: false,
+  });
+  const memories = (listQuery.data?.memories ?? []) as FlaggedRow[];
+  const [pending, startTransition] = useTransition();
+
+  const resolve = (id: string, action: "dismiss" | "archive") =>
+    startTransition(async () => {
+      await resolveFlagAction(id, action);
+      await listQuery.refetch();
+    });
+
+  if (listQuery.isLoading) {
+    return <p className="text-sm text-muted-foreground">Loading flagged memories…</p>;
+  }
+  if (listQuery.isError) {
+    return (
+      <p className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+        Failed to load flagged memories: {listQuery.error?.message ?? "unknown error"}
+      </p>
+    );
+  }
+  if (memories.length === 0) {
+    return <p className="text-sm text-muted-foreground">No flagged memories.</p>;
+  }
+
+  return (
+    <ul className="flex flex-col gap-2">
+      {memories.map((memory) => {
+        const flags = memory.flags ?? [];
+        return (
+          <li key={memory.id} className="rounded-md border bg-card p-3">
+            <div className="flex items-start justify-between gap-2">
+              <div className="min-w-0 flex-1">
+                <h3 className="truncate font-medium">{memory.title || "(untitled)"}</h3>
+                <p className="whitespace-pre-wrap break-words text-sm text-muted-foreground">
+                  {memory.body}
+                </p>
+                <ul className="mt-2 flex flex-col gap-1">
+                  {flags.map((flag, i) => (
+                    <li
+                      key={`${flag.agent_id}-${flag.created_at}-${i}`}
+                      className="rounded-md border border-destructive/30 bg-destructive/5 px-2 py-1 text-xs"
+                    >
+                      <span className="text-destructive">“{flag.reason}”</span>
+                      <span className="text-muted-foreground">
+                        {" "}
+                        — flagged by {flag.agent_id} ·{" "}
+                        {new Date(flag.created_at).toLocaleDateString()}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+                <div className="mt-1 flex flex-wrap items-center gap-1 text-xs text-muted-foreground">
+                  <Pill>{memory.category}</Pill>
+                  {memory.agent_id ? (
+                    <>
+                      <span>·</span>
+                      <span>{memory.agent_id}</span>
+                    </>
+                  ) : null}
+                  <span>·</span>
+                  <span>{new Date(memory.updated_at).toLocaleDateString()}</span>
+                </div>
+              </div>
+              <div className="flex shrink-0 gap-2">
+                <Button
+                  variant="outline"
+                  disabled={pending}
+                  onClick={() => resolve(memory.id, "dismiss")}
+                >
+                  Dismiss
+                </Button>
+                <Button
+                  variant="outline"
+                  className="border-destructive/50 text-destructive hover:bg-destructive/10"
+                  disabled={pending}
+                  onClick={() => resolve(memory.id, "archive")}
+                >
+                  Archive
+                </Button>
+              </div>
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/apps/dashboard/components/site-nav.tsx
+++ b/apps/dashboard/components/site-nav.tsx
@@ -20,6 +20,7 @@ const TABS = [
   { href: "/handoffs", label: "Handoffs", match: (p: string) => p.startsWith("/handoffs") },
   { href: "/analytics", label: "Analytics", match: (p: string) => p === "/analytics" },
   { href: "/proposals", label: "Proposals", match: (p: string) => p === "/proposals" },
+  { href: "/flagged", label: "Flagged", match: (p: string) => p === "/flagged" },
   { href: "/archive", label: "Archive", match: (p: string) => p === "/archive" },
   { href: "/curator", label: "Curator", match: (p: string) => p.startsWith("/curator") },
   { href: "/backups", label: "Backups", match: (p: string) => p.startsWith("/backups") },

--- a/apps/dashboard/tests/components/flagged-view.test.tsx
+++ b/apps/dashboard/tests/components/flagged-view.test.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The flagged review queue is a client view: it reads the queue from
+// trpc.memories.listFlagged and adjudicates each row through the
+// resolveFlagAction server action. Both are mocked so this stays a fast
+// component-only check — no QueryClient/TRPC provider, no real server.
+const refetch = vi.fn();
+let queryState: {
+  data?: { memories: unknown[] };
+  isLoading: boolean;
+  isError: boolean;
+  error?: { message: string };
+};
+
+vi.mock("@/lib/trpc-client", () => ({
+  trpc: {
+    memories: {
+      listFlagged: {
+        useQuery: () => ({ ...queryState, refetch }),
+      },
+    },
+  },
+}));
+
+const resolveFlagAction = vi.fn().mockResolvedValue({ ok: true });
+vi.mock("@/app/(memories)/actions", () => ({
+  resolveFlagAction: (id: string, action: "dismiss" | "archive") => resolveFlagAction(id, action),
+}));
+
+const { FlaggedView } = await import("@/components/memories/flagged-view");
+
+function flaggedRow() {
+  return {
+    id: "mem_1",
+    title: "Outdated deploy note",
+    body: "Deploy with the old script.",
+    category: "lessons",
+    visibility: "private",
+    scope: "global",
+    agent_id: "bede",
+    updated_at: "2026-06-01T00:00:00.000Z",
+    flags: [
+      {
+        agent_id: "scribe",
+        reason: "the deploy script was replaced",
+        created_at: "2026-06-02T00:00:00.000Z",
+      },
+    ],
+  };
+}
+
+beforeEach(() => {
+  refetch.mockReset();
+  resolveFlagAction.mockReset().mockResolvedValue({ ok: true });
+  queryState = { data: { memories: [flaggedRow()] }, isLoading: false, isError: false };
+});
+
+describe("FlaggedView", () => {
+  it("renders each flagged memory with its title, body, reason and flagger", () => {
+    render(<FlaggedView />);
+    expect(screen.getByText("Outdated deploy note")).toBeInTheDocument();
+    expect(screen.getByText("Deploy with the old script.")).toBeInTheDocument();
+    expect(screen.getByText(/the deploy script was replaced/)).toBeInTheDocument();
+    expect(screen.getByText(/scribe/)).toBeInTheDocument();
+  });
+
+  it("shows the empty state when nothing is flagged", () => {
+    queryState = { data: { memories: [] }, isLoading: false, isError: false };
+    render(<FlaggedView />);
+    expect(screen.getByText("No flagged memories.")).toBeInTheDocument();
+  });
+
+  it("dismisses a flag and refetches the queue", async () => {
+    render(<FlaggedView />);
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    await waitFor(() => expect(resolveFlagAction).toHaveBeenCalledWith("mem_1", "dismiss"));
+    await waitFor(() => expect(refetch).toHaveBeenCalled());
+  });
+
+  it("archives a flagged memory and refetches the queue", async () => {
+    render(<FlaggedView />);
+    fireEvent.click(screen.getByRole("button", { name: "Archive" }));
+    await waitFor(() => expect(resolveFlagAction).toHaveBeenCalledWith("mem_1", "archive"));
+    await waitFor(() => expect(refetch).toHaveBeenCalled());
+  });
+});

--- a/apps/dashboard/tests/components/site-nav.test.tsx
+++ b/apps/dashboard/tests/components/site-nav.test.tsx
@@ -33,6 +33,7 @@ const SECTIONS = [
   ["Handoffs", "/handoffs"],
   ["Analytics", "/analytics"],
   ["Proposals", "/proposals"],
+  ["Flagged", "/flagged"],
   ["Archive", "/archive"],
   ["Curator", "/curator"],
   ["Backups", "/backups"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/mcp-server/src/trpc/memories.ts
+++ b/packages/mcp-server/src/trpc/memories.ts
@@ -48,6 +48,10 @@ export interface MemoryShape {
   applies_to: string[];
   supersedes: string[];
   conflicts_with: string[];
+  // Open agent flags routing this memory to review (spec 047 / ADR 0006).
+  // Surfaced so the dashboard's flagged-review queue can show the reason +
+  // flagger for each open flag.
+  flags: { agent_id: string; reason: string; created_at: string }[];
   recall_count: number;
   usefulness_score: number;
   title: string;
@@ -96,6 +100,15 @@ const UpdateMemoryInputSchema = z.object({
 
 const ArchiveMemoryInputSchema = z.object({
   id: z.string().min(1),
+  agent_id: z.string().optional(),
+});
+
+// Adjudicate one flagged memory (spec 048 PR-2). `dismiss` clears the open
+// flags and leaves the memory active; `archive` archives it then clears the
+// flags (so it drops out of both the active list and the review queue).
+const ResolveFlagInputSchema = z.object({
+  id: z.string().min(1),
+  action: z.enum(["dismiss", "archive"]),
   agent_id: z.string().optional(),
 });
 
@@ -211,6 +224,18 @@ export const memoriesRouter = router({
       },
   ),
 
+  // Flagged-memory review queue (spec 048 PR-2): every memory with ≥1 open
+  // flag, each row carrying its `flags` so the dashboard can show the reason +
+  // flagger. A flag never changes status, so these stay `active` until an admin
+  // dismisses or archives them via `resolveFlag`.
+  listFlagged: adminProcedure.query(
+    ({ ctx }) =>
+      ctx.store.listMemories({ has_open_flags: true } as Record<string, unknown>) as {
+        memories: MemoryShape[];
+        total: number;
+      },
+  ),
+
   aggregates: adminProcedure.query(({ ctx }) => ctx.store.getAggregates()),
 
   related: adminProcedure.input(IdInputSchema).query(({ ctx, input }) => {
@@ -256,6 +281,23 @@ export const memoriesRouter = router({
           "Memory not found",
         ) as unknown as MemoryShape,
     ),
+
+  // Adjudicate one flagged memory (spec 048 PR-2). `dismiss` = clear the open
+  // flags, keep the memory active (the flag was wrong / already addressed);
+  // `archive` = archive the memory THEN clear its flags (the flag was right).
+  // Both record the reserved `dashboard-admin` actor like the sibling
+  // mutations. Returns the resulting memory row.
+  resolveFlag: adminProcedure.input(ResolveFlagInputSchema).mutation(({ ctx, input }) => {
+    const actor = input.agent_id ?? DASHBOARD_AGENT_ID;
+    // The store primitives are fail-soft (unknown id → null, never throw), so
+    // archive first to surface a missing row as NOT_FOUND, then clear the flags.
+    if (input.action === "archive") {
+      rethrowAsNotFound(() => ctx.store.archiveMemory(input.id, actor), "Memory not found");
+    }
+    const result = ctx.store.resolveFlags(input.id, actor);
+    if (!result) throw new TRPCError({ code: "NOT_FOUND", message: "Memory not found" });
+    return result as unknown as MemoryShape;
+  }),
 
   // Admin merge (spec 044 D-5a): collapse N sources into one target OUTSIDE a
   // curation run. Calls the SAME shared `mergeMemory` primitive the curator run

--- a/packages/mcp-server/tests/trpc/memories.test.ts
+++ b/packages/mcp-server/tests/trpc/memories.test.ts
@@ -38,6 +38,27 @@ function memoryStatus(dataDir: string, id: string): string | undefined {
   }
 }
 
+// Append an open flag to a memory by opening a fresh store — the HTTP server
+// runs in a separate process, so the review-queue tests seed flags directly.
+function flagMemory(dataDir: string, id: string, reason: string, agent_id = "scribe"): void {
+  const store = createLibrarianStore({ dataDir });
+  try {
+    store.flagMemory(id, reason, agent_id);
+  } finally {
+    store.close();
+  }
+}
+
+function openFlagCount(dataDir: string, id: string): number {
+  const store = createLibrarianStore({ dataDir });
+  try {
+    const flags = store.getMemory(id)?.flags;
+    return Array.isArray(flags) ? flags.length : 0;
+  } finally {
+    store.close();
+  }
+}
+
 interface TrpcOk<T> {
   result: { data: T };
 }
@@ -800,6 +821,137 @@ describe("tRPC unmerge / reverse-a-groom (spec 044 D-5b)", () => {
       expect(response.status).toBe(401);
       const json = (await response.json()) as TrpcErr;
       expect(json.error?.data?.code).toBe("UNAUTHORIZED");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+});
+
+// Flagged-memory review queue (spec 048 PR-2). `listFlagged` surfaces every
+// memory with ≥1 open flag (its `flags` carried along for the reviewer);
+// `resolveFlag` adjudicates one — `dismiss` clears the flags + keeps the memory
+// active, `archive` archives it THEN clears its flags. Admin-gated.
+describe("tRPC flagged-memory review queue (spec 048 PR-2)", () => {
+  interface FlaggedRow extends MemoryRow {
+    flags: { agent_id: string; reason: string; created_at: string }[];
+  }
+
+  it("memories.listFlagged returns only memories with open flags, carrying their flags", async () => {
+    const dataDir = makeTempDir();
+    const flagged = seedMemory(dataDir, { title: "Stale fact" });
+    seedMemory(dataDir, { title: "Clean fact" });
+    flagMemory(dataDir, flagged.id, "outdated since the rewrite", "scribe");
+    const server = await startHttpServer({ dataDir });
+    try {
+      const data = await trpcGet<{ memories: FlaggedRow[]; total: number }>(
+        server,
+        "memories.listFlagged",
+      );
+      expect(data.memories.map((m) => m.id)).toEqual([flagged.id]);
+      expect(data.memories[0].flags).toHaveLength(1);
+      expect(data.memories[0].flags[0]).toMatchObject({
+        agent_id: "scribe",
+        reason: "outdated since the rewrite",
+      });
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("memories.listFlagged returns an empty queue when nothing is flagged", async () => {
+    const dataDir = makeTempDir();
+    seedMemory(dataDir, { title: "Clean fact" });
+    const server = await startHttpServer({ dataDir });
+    try {
+      const data = await trpcGet<{ memories: FlaggedRow[]; total: number }>(
+        server,
+        "memories.listFlagged",
+      );
+      expect(data.memories).toEqual([]);
+      expect(data.total).toBe(0);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("memories.resolveFlag dismiss clears the flags and keeps the memory active", async () => {
+    const dataDir = makeTempDir();
+    const m = seedMemory(dataDir, { title: "Disputed" });
+    flagMemory(dataDir, m.id, "looks wrong", "scribe");
+    const server = await startHttpServer({ dataDir });
+    try {
+      const result = await trpcPost<MemoryRow>(server, "memories.resolveFlag", {
+        id: m.id,
+        action: "dismiss",
+      });
+      expect(result.status).toBe("active");
+      expect(openFlagCount(dataDir, m.id)).toBe(0);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("memories.resolveFlag archive archives the memory and clears its flags", async () => {
+    const dataDir = makeTempDir();
+    const m = seedMemory(dataDir, { title: "Genuinely wrong" });
+    flagMemory(dataDir, m.id, "incorrect", "scribe");
+    const server = await startHttpServer({ dataDir });
+    try {
+      const result = await trpcPost<MemoryRow>(server, "memories.resolveFlag", {
+        id: m.id,
+        action: "archive",
+      });
+      expect(result.status).toBe("archived");
+      expect(openFlagCount(dataDir, m.id)).toBe(0);
+      expect(memoryStatus(dataDir, m.id)).toBe("archived");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("memories.resolveFlag returns NOT_FOUND for an unknown id", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      const response = await fetch(`${server.url}/trpc/memories.resolveFlag`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${server.token}`,
+        },
+        body: JSON.stringify({ id: "mem_nope", action: "dismiss" }),
+      });
+      expect(response.status).toBe(404);
+      const json = (await response.json()) as TrpcErr;
+      expect(json.error?.data?.code).toBe("NOT_FOUND");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("listFlagged / resolveFlag reject unauthenticated callers (admin-gated)", async () => {
+    const dataDir = makeTempDir();
+    const m = seedMemory(dataDir, { title: "Protected by gate" });
+    flagMemory(dataDir, m.id, "wrong", "scribe");
+    const server = await startHttpServer({ dataDir });
+    try {
+      const listResponse = await fetch(`${server.url}/trpc/memories.listFlagged`);
+      expect(listResponse.status).toBe(401);
+      expect(((await listResponse.json()) as TrpcErr).error?.data?.code).toBe("UNAUTHORIZED");
+
+      const resolveResponse = await fetch(`${server.url}/trpc/memories.resolveFlag`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: m.id, action: "dismiss" }),
+      });
+      expect(resolveResponse.status).toBe(401);
+      expect(((await resolveResponse.json()) as TrpcErr).error?.data?.code).toBe("UNAUTHORIZED");
     } finally {
       await server.stop();
       cleanupTempDir(dataDir);


### PR DESCRIPTION
**PR-2 of plan 048.** MINOR → **0.9.0**. The human/curator adjudication surface for the route-to-review flags from 0.8.0.

- **`memories.listFlagged` + `memories.resolveFlag`** (admin tRPC) — list open-flag memories; resolve via `dismiss` (clear flags, keep active) or `archive` (archive + clear).
- **Dashboard "Flagged" tab + page** — lists each flagged memory with reason, flagger, and when; per-row Dismiss / Archive.

No MCP tool-surface change. mcp-server 196 + dashboard 130 tests green; typecheck clean; TDD throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)