### PR TITLE
fix(pi): rename npm package to publishable the-librarian-pi-extension

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "the-librarian",
       "source": "./integrations/claude",
       "description": "Librarian MCP server config + four optional slash commands (/handoff, /takeover, /learn, /toggle-private). The MCP config alone is fully functional; the commands are sugar.",
-      "version": "1.0.0-rc.1",
+      "version": "1.0.0-rc.2",
       "license": "Apache-2.0",
       "keywords": ["memory", "handoff", "mcp", "librarian", "recall", "cross-harness"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,13 @@ changes from this point forward are catalogued here.
 ### Changed
 
 - **Pi npm package renamed** from the unpublishable `@librarian/pi-extension`
-  (an npm scope nobody owns) back to the unscoped `the-librarian-pi-extension` —
-  the package already published from the pre-1.0 repo — so `npm publish` works
-  again and existing Pi users get a normal version bump rather than a package
-  migration. The Pi package and the Claude marketplace manifest are now
-  version-aligned to the root.
+  (an npm scope nobody owns) to `@the-librarian/pi-extension` — scoped under
+  the new `@the-librarian` npm org the owner controls, with
+  `publishConfig.access: public` so the scoped package publishes publicly.
+  The old unscoped `the-librarian-pi-extension` (v0.4.0), published from the
+  pre-1.0 repo, will be `npm deprecate`d post-publish to point at the new
+  `@the-librarian/pi-extension` name. The Pi package and the Claude
+  marketplace manifest are now version-aligned to the root.
 
 ## [1.0.0-rc.1] — 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.2] — 2026-06-13
+
+### Changed
+
+- **Pi npm package renamed** from the unpublishable `@librarian/pi-extension`
+  (an npm scope nobody owns) back to the unscoped `the-librarian-pi-extension` —
+  the package already published from the pre-1.0 repo — so `npm publish` works
+  again and existing Pi users get a normal version bump rather than a package
+  migration. The Pi package and the Claude marketplace manifest are now
+  version-aligned to the root.
+
 ## [1.0.0-rc.1] — 2026-06-12
 
 Phases 1–5 of the v1.0 rethink (`docs/specs/2026-06-12-rethink.md`): carve the
@@ -1584,6 +1595,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0-rc.2]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.1...v1.0.0-rc.2
 [1.0.0-rc.1]: https://github.com/JimJafar/the-librarian/compare/v0.11.0...v1.0.0-rc.1
 [0.11.0]: https://github.com/JimJafar/the-librarian/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/JimJafar/the-librarian/compare/v0.9.0...v0.10.0

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -31,7 +31,7 @@ One version — the root `package.json` — covers the whole tree:
 | Codex | `integrations/codex` | README config block — nothing to ship |
 | OpenCode | `integrations/opencode` | README config block — nothing to ship |
 | Hermes | `integrations/hermes` | Python adapter installed by copy/script into the Hermes `plugins/` dir; users re-copy on upgrade |
-| Pi | `integrations/pi` | npm package (`the-librarian-pi-extension`) published by hand from the workspace |
+| Pi | `integrations/pi` | npm package (`@the-librarian/pi-extension`) published by hand from the workspace |
 
 Keep `.claude-plugin/marketplace.json`'s `plugins[].version` and
 `integrations/pi/package.json` in step with the root version when the change
@@ -100,7 +100,7 @@ clean no-op.
 - **Claude marketplace** — installs pull this repo; the manifest's `source`
   points at `./integrations/claude`. A marketplace-visible change should bump
   `plugins[].version` in `.claude-plugin/marketplace.json` in the same PR.
-- **Pi (npm)** — `integrations/pi` (`the-librarian-pi-extension`) publishes
+- **Pi (npm)** — `integrations/pi` (`@the-librarian/pi-extension`) publishes
   from the workspace by hand today (`npm publish` in `integrations/pi`;
   there is no npm step in `release.yml`). Sanity-check the tarball with
   `npm pack --dry-run` before a risky change to what ships; the `files`

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -31,7 +31,7 @@ One version — the root `package.json` — covers the whole tree:
 | Codex | `integrations/codex` | README config block — nothing to ship |
 | OpenCode | `integrations/opencode` | README config block — nothing to ship |
 | Hermes | `integrations/hermes` | Python adapter installed by copy/script into the Hermes `plugins/` dir; users re-copy on upgrade |
-| Pi | `integrations/pi` | npm package (`@librarian/pi-extension`) published by hand from the workspace |
+| Pi | `integrations/pi` | npm package (`the-librarian-pi-extension`) published by hand from the workspace |
 
 Keep `.claude-plugin/marketplace.json`'s `plugins[].version` and
 `integrations/pi/package.json` in step with the root version when the change
@@ -100,7 +100,7 @@ clean no-op.
 - **Claude marketplace** — installs pull this repo; the manifest's `source`
   points at `./integrations/claude`. A marketplace-visible change should bump
   `plugins[].version` in `.claude-plugin/marketplace.json` in the same PR.
-- **Pi (npm)** — `integrations/pi` (`@librarian/pi-extension`) publishes
+- **Pi (npm)** — `integrations/pi` (`the-librarian-pi-extension`) publishes
   from the workspace by hand today (`npm publish` in `integrations/pi`;
   there is no npm step in `release.yml`). Sanity-check the tarball with
   `npm pack --dry-run` before a risky change to what ships; the `files`

--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -31,7 +31,7 @@ Librarian primer into the system prompt. One install, zero config files.
 From npm (once published — see "Publishing" below):
 
 ```sh
-pi install npm:@librarian/pi-extension
+pi install npm:the-librarian-pi-extension
 ```
 
 From source (works today):
@@ -69,8 +69,8 @@ This package is part of the `the-librarian` pnpm workspace:
 
 ```sh
 pnpm install
-pnpm --filter @librarian/pi-extension test        # vitest
-pnpm --filter @librarian/pi-extension typecheck   # tsc --noEmit
+pnpm --filter the-librarian-pi-extension test        # vitest
+pnpm --filter the-librarian-pi-extension typecheck   # tsc --noEmit
 ```
 
 The schema-parity suite imports the compiled `@librarian/mcp-server`, which is

--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -31,7 +31,7 @@ Librarian primer into the system prompt. One install, zero config files.
 From npm (once published — see "Publishing" below):
 
 ```sh
-pi install npm:the-librarian-pi-extension
+pi install npm:@the-librarian/pi-extension
 ```
 
 From source (works today):
@@ -69,8 +69,8 @@ This package is part of the `the-librarian` pnpm workspace:
 
 ```sh
 pnpm install
-pnpm --filter the-librarian-pi-extension test        # vitest
-pnpm --filter the-librarian-pi-extension typecheck   # tsc --noEmit
+pnpm --filter @the-librarian/pi-extension test        # vitest
+pnpm --filter @the-librarian/pi-extension typecheck   # tsc --noEmit
 ```
 
 The schema-parity suite imports the compiled `@librarian/mcp-server`, which is

--- a/integrations/pi/package.json
+++ b/integrations/pi/package.json
@@ -1,7 +1,10 @@
 {
-  "name": "the-librarian-pi-extension",
+  "name": "@the-librarian/pi-extension",
   "version": "1.0.0-rc.2",
   "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "Pi coding-agent package for The Librarian: the 7 memory/handoff tools + primer injection, backed by a remote Librarian MCP server.",
   "license": "Apache-2.0",
   "type": "module",

--- a/integrations/pi/package.json
+++ b/integrations/pi/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@librarian/pi-extension",
-  "version": "0.5.0",
+  "name": "the-librarian-pi-extension",
+  "version": "1.0.0-rc.2",
   "private": false,
   "description": "Pi coding-agent package for The Librarian: the 7 memory/handoff tools + primer injection, backed by a remote Librarian MCP server.",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.2",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Why

The rethink shipped the Pi extension as **`@librarian/pi-extension`**, but the `@librarian` npm scope isn't owned by anyone — every `@librarian/*` package in the monorepo is `private: true` (workspace-only), so the scope was never claimed. `npm publish` of a scoped package you don't own 403s. The old Pi package on npm was the **unscoped `the-librarian-pi-extension`** (v0.4.0, owned by `jimsangwine`).

## What

- Rename `integrations/pi` back to **`the-librarian-pi-extension`** (package name + the `pnpm --filter` references in its README + the runbook). Now `npm publish` works, and existing Pi users get a normal version bump instead of having to migrate to a new package name.
- Align the Pi package (`0.5.0` → `1.0.0-rc.2`) and the Claude marketplace manifest version to the root, per `docs/release-runbook.md`.
- Root → `1.0.0-rc.2` + CHANGELOG entry (the historical rc.1 changelog mention of the old name is left as-is — past entries aren't rewritten).

Lockfile is unaffected (the importer is path-keyed and nothing depends on the package by name). `check:release` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)