### PR TITLE
fix(installer-cli): repair interactive token prompt + reuse existing LIBRARIAN_* env (rc.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,39 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.4] — 2026-06-13
+
+Installer-CLI fixes for the interactive setup (`@the-librarian/cli`). Needs a
+republish to npm to reach users.
+
+### Fixed
+
+- **Interactive token prompt no longer drops the second answer.** `librarian
+  install` built a fresh `readline` interface per question and closed it after
+  each one; closing the first interface discarded any input buffered past its
+  line, so when both answers arrived together (a paste, or a fast/piped run) the
+  token read saw no input and hung — `resolveConfig` then failed with
+  "MCP URL and token are required". The prompter now uses ONE shared readline
+  interface for its whole lifetime, created lazily on the first real prompt and
+  reused for every question, with a persistent line queue so no input is lost
+  regardless of chunking. The secret (token) echo is muted only for that one
+  question and restored afterwards. A new `Prompter.close()` (called from the
+  install/uninstall lifecycle) tears the interface down so an open readline no
+  longer keeps the event loop alive and the process exits cleanly.
+
+### Added
+
+- **Reuse existing `LIBRARIAN_*` environment variables.** When
+  `~/.librarian/env` isn't already complete, `librarian install` now consults
+  `LIBRARIAN_MCP_URL` / `LIBRARIAN_AGENT_TOKEN` from the environment instead of
+  blindly prompting. With BOTH present it shows them (URL in full, token
+  redacted to `LIBRARIAN_AGENT_TOKEN=set` — never the value) and asks
+  `Use the LIBRARIAN_MCP_URL and LIBRARIAN_AGENT_TOKEN from your environment?
+  [Y/n]`; accept reuses and persists them, decline prompts for fresh values.
+  With only ONE present it prefills that prompt's default so a bare enter
+  accepts it. The environment is injectable for tests, and the token value is
+  never logged.
+
 ## [1.0.0-rc.3] — 2026-06-13
 
 The cross-harness installer CLI (`docs/specs/2026-06-13-installer-cli.md`,
@@ -1649,6 +1682,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0-rc.4]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.3...v1.0.0-rc.4
 [1.0.0-rc.3]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.2...v1.0.0-rc.3
 [1.0.0-rc.2]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.1...v1.0.0-rc.2
 [1.0.0-rc.1]: https://github.com/JimJafar/the-librarian/compare/v0.11.0...v1.0.0-rc.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.3",
+  "version": "1.0.0-rc.4",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/installer-cli/package.json
+++ b/packages/installer-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-librarian/cli",
-  "version": "1.0.0-rc.3",
+  "version": "1.0.0-rc.4",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/installer-cli/src/commands/install.ts
+++ b/packages/installer-cli/src/commands/install.ts
@@ -25,6 +25,12 @@ export interface InstallDeps {
   home?: string | undefined;
   shell?: Shell | undefined;
   prompter: Prompter;
+  /**
+   * The process environment to read existing `LIBRARIAN_*` vars from (BUG 2).
+   * Injectable so tests never read the real `process.env`. Defaults to
+   * `process.env`. The token value is never logged.
+   */
+  env?: NodeJS.ProcessEnv | undefined;
 }
 
 export interface InstallOutcome {
@@ -101,24 +107,78 @@ export async function runInstall(named: string[], deps: InstallDeps): Promise<In
  * Returns the in-memory config and whether it differs from what's persisted
  * (so the caller can defer the actual `setConfig` write until a harness
  * install has succeeded — S1). Does NOT touch the filesystem.
+ *
+ * Source precedence (BUG 2 — reuse existing `LIBRARIAN_*`):
+ *   1. `~/.librarian/env` already has BOTH values → use them, no prompts.
+ *   2. Otherwise, consult `process.env` (injected as `deps.env`):
+ *        - BOTH `LIBRARIAN_MCP_URL` + `LIBRARIAN_AGENT_TOKEN` present → offer
+ *          to reuse them (URL shown in full, token redacted to
+ *          `LIBRARIAN_AGENT_TOKEN=set` — the value is NEVER displayed). Accept
+ *          → use them; decline → prompt for fresh values.
+ *        - Only ONE present → prefill it as that prompt's default so the user
+ *          can accept with enter; prompt for the other.
+ *        - Neither → prompt for both (unchanged behaviour).
+ * The token value is never logged.
  */
 async function resolveConfig(
   deps: InstallDeps,
 ): Promise<{ cfg: LibrarianConfig; changed: boolean }> {
   const existing = readConfig(deps.home);
+  const env = deps.env ?? process.env;
+  const envUrl = (env.LIBRARIAN_MCP_URL ?? "").trim();
+  const envToken = (env.LIBRARIAN_AGENT_TOKEN ?? "").trim();
+
   let mcpUrl = existing?.mcpUrl ?? "";
   let token = existing?.token ?? "";
 
+  // When both env vars are present we offer to reuse them as a pair; if the
+  // user DECLINES we prompt for fresh values WITHOUT prefilling the rejected
+  // env defaults. A single env var, by contrast, prefills its prompt's default.
+  let declinedEnvPair = false;
+
+  // (2) Only consult the environment when the persisted config is incomplete.
+  if ((!mcpUrl || !token) && envUrl && envToken) {
+    // Both present → offer to reuse them, showing the URL but redacting the
+    // token (only that it's set, never its value).
+    const question = [
+      "Found these in your environment:",
+      `  LIBRARIAN_MCP_URL=${envUrl}`,
+      "  LIBRARIAN_AGENT_TOKEN=set",
+      "Use the LIBRARIAN_MCP_URL and LIBRARIAN_AGENT_TOKEN from your environment? [Y/n]",
+    ].join("\n");
+    const answer = await deps.prompter.promptText(question, { default: "y" });
+    if (isYes(answer)) {
+      if (!mcpUrl) mcpUrl = envUrl;
+      if (!token) token = envToken;
+    } else {
+      declinedEnvPair = true;
+    }
+  }
+
+  // Prompt for anything still missing. When exactly one env var is present (and
+  // we didn't just decline the both-present pair), prefill it as the prompt's
+  // default so the user can accept it with a bare enter.
   if (!mcpUrl) {
-    mcpUrl = await deps.prompter.promptText("MCP URL");
+    const opts = envUrl && !declinedEnvPair ? { default: envUrl } : undefined;
+    mcpUrl = await deps.prompter.promptText("MCP URL", opts);
   }
   if (!token) {
-    token = await deps.prompter.promptText("Agent token", { secret: true });
+    // A secret prompt never echoes a default, but a present env token can still
+    // back an empty reply — so pass it as the default invisibly.
+    const opts =
+      envToken && !declinedEnvPair ? { default: envToken, secret: true } : { secret: true };
+    token = await deps.prompter.promptText("Agent token", opts);
   }
 
   const changed = mcpUrl !== existing?.mcpUrl || token !== existing?.token;
   const cfg: LibrarianConfig = { mcpUrl, token, serverUrl: deriveServerUrl(mcpUrl) };
   return { cfg, changed };
+}
+
+/** A yes/no answer parser — empty (bare enter) counts as yes given a "y" default. */
+function isYes(answer: string): boolean {
+  const a = answer.trim().toLowerCase();
+  return a === "" || a === "y" || a === "yes";
 }
 
 /**

--- a/packages/installer-cli/src/harnesses/hermes.ts
+++ b/packages/installer-cli/src/harnesses/hermes.ts
@@ -28,7 +28,7 @@ import type { HarnessConfig, HarnessModule } from "./types.js";
 const PROVIDER_ID = "librarian";
 // The pinned monorepo release we fetch the adapter from. Default to the
 // repo's current release tag; the phase gate owns version bumps.
-export const PINNED_REF = "v1.0.0-rc.3";
+export const PINNED_REF = "v1.0.0-rc.4";
 
 /**
  * Fetches the Hermes adapter for a pinned ref and returns the absolute

--- a/packages/installer-cli/src/prompt.ts
+++ b/packages/installer-cli/src/prompt.ts
@@ -33,6 +33,13 @@ export type PromptFn = (question: string, opts: { secret: boolean }) => Promise<
 export interface Prompter {
   selectHarnesses(available: HarnessChoice[]): Promise<string[]>;
   promptText(question: string, opts?: PromptTextOptions): Promise<string>;
+  /**
+   * Release any resources held for interactive prompting (the shared readline
+   * interface). Safe to call when nothing was opened, and idempotent. Callers
+   * MUST invoke this once the prompting phase is done — an open readline keeps
+   * the Node event loop alive, so the process won't exit until it's closed.
+   */
+  close(): void;
 }
 
 /** A pickable harness in the multi-select. */
@@ -71,8 +78,25 @@ export function createPrompter(options: PrompterOptions = {}): Prompter {
     options.interactive ??
     (options.prompt !== undefined ? true : Boolean((input as { isTTY?: boolean }).isTTY));
 
+  // ONE line reader (over ONE readline interface) for this prompter's whole
+  // lifetime. Created lazily on the first real prompt — so a non-interactive
+  // or injected-`prompt` run never opens stdin — and reused for EVERY question.
+  //
+  // The old code built a FRESH `createInterface` per question and `rl.close()`d
+  // it. Closing the first interface discarded the input buffered past its line,
+  // so a second read over a single shared stream (e.g. a piped
+  // `librarian install <<EOF`, where both answers arrive in one chunk) never
+  // saw its input and the read hung — `resolveConfig` then threw "required".
+  // `close()` (called from the command lifecycle) tears the reader down exactly
+  // once so the open readline doesn't keep the Node event loop alive.
+  let reader: LineReader | undefined;
+  const lineReader = (): LineReader => {
+    if (!reader) reader = createLineReader(input, output);
+    return reader;
+  };
+
   const ask: PromptFn =
-    options.prompt ?? ((question, opts) => readLine(input, output, question, opts.secret));
+    options.prompt ?? ((question, opts) => lineReader().ask(question, opts.secret));
 
   return {
     async selectHarnesses(available) {
@@ -100,6 +124,16 @@ export function createPrompter(options: PrompterOptions = {}): Prompter {
       if (raw.length === 0 && !hasDefault) throw new MissingValueError(question);
       return raw;
     },
+
+    close() {
+      // Idempotent: only the shared reader (if one was ever opened) is torn
+      // down. An open readline keeps the Node event loop alive, so the command
+      // lifecycle MUST call this once prompting is done or the process hangs.
+      if (reader) {
+        reader.close();
+        reader = undefined;
+      }
+    },
   };
 }
 
@@ -125,39 +159,73 @@ function write(output: Writable, text: string): void {
   output.write(text);
 }
 
-/** Read one line, optionally with the echo muted (secret entry). */
-function readLine(
-  input: Readable,
-  output: Writable,
-  question: string,
-  secret: boolean,
-): Promise<string> {
-  return new Promise((resolve) => {
-    const rl = readline.createInterface({
-      input,
-      output,
-      terminal: true,
-    });
-    if (secret) {
-      // Mute the echo: overwrite each keystroke so the token never renders.
-      const muteWrite = (rl as unknown as { _writeToOutput?: (s: string) => void })._writeToOutput;
-      (rl as unknown as { _writeToOutput: (s: string) => void })._writeToOutput = (s: string) => {
-        if (s.includes("\n") || s.includes("\r")) {
-          muteWrite?.call(rl, s);
-        }
-        // else: swallow the character so it isn't echoed.
-      };
-      if (question) write(output, question);
-      rl.question("", (answer) => {
-        write(output, "\n");
-        rl.close();
-        resolve(answer);
-      });
-      return;
+/**
+ * A long-lived line reader over ONE shared `readline` interface.
+ *
+ * Why not just call `rl.question` per prompt: readline emits a `line` event
+ * for EVERY newline in a chunk, the moment the chunk arrives. When a piped run
+ * delivers both answers in one chunk (`url\ntoken\n`), the line for `token` is
+ * emitted before the second `rl.question` registers its one-shot callback — so
+ * that input would be dropped. Instead we attach a PERSISTENT `line` listener
+ * that queues lines; `ask()` consumes a queued line if one is waiting, else
+ * parks a resolver for the next. No input is ever lost regardless of chunking.
+ */
+interface LineReader {
+  ask(question: string, secret: boolean): Promise<string>;
+  close(): void;
+}
+
+function createLineReader(input: Readable, output: Writable): LineReader {
+  const rl = readline.createInterface({ input, output, terminal: true });
+  const queue: string[] = [];
+  let waiting: ((line: string) => void) | null = null;
+
+  rl.on("line", (line: string) => {
+    if (waiting) {
+      const resolve = waiting;
+      waiting = null;
+      resolve(line);
+    } else {
+      queue.push(line);
     }
-    rl.question(question, (answer) => {
-      rl.close();
-      resolve(answer);
-    });
   });
+
+  // The original echo writer; restored after each secret question so a later
+  // non-secret prompt renders normally. Typed to allow `undefined` so the
+  // restore assignment is sound under `exactOptionalPropertyTypes`.
+  const ref = rl as unknown as { _writeToOutput: ((s: string) => void) | undefined };
+
+  const nextLine = (): Promise<string> =>
+    new Promise((resolve) => {
+      const queued = queue.shift();
+      if (queued !== undefined) resolve(queued);
+      else waiting = resolve;
+    });
+
+  return {
+    async ask(question, secret) {
+      if (!secret) {
+        if (question) write(output, question);
+        return nextLine();
+      }
+      // Mute the echo just for this question: swallow each typed character so
+      // the token never renders, passing only newlines through. Restore the
+      // original writer afterwards so a following non-secret prompt echoes.
+      const original = ref._writeToOutput;
+      ref._writeToOutput = (s: string) => {
+        if (s.includes("\n") || s.includes("\r")) original?.call(rl, s);
+      };
+      try {
+        if (question) write(output, question);
+        const line = await nextLine();
+        return line;
+      } finally {
+        ref._writeToOutput = original;
+        write(output, "\n");
+      }
+    },
+    close() {
+      rl.close();
+    },
+  };
 }

--- a/packages/installer-cli/src/runtime.ts
+++ b/packages/installer-cli/src/runtime.ts
@@ -34,6 +34,12 @@ export interface RuntimeOptions {
   shell?: Shell;
   /** Inject a prompter (tests). Defaults to a real stdio-backed prompter. */
   prompter?: Prompter;
+  /**
+   * The process environment to read existing `LIBRARIAN_*` vars from (BUG 2).
+   * Injectable so tests never touch the real `process.env` and never log a
+   * token. Defaults to `process.env` in `runInstall`.
+   */
+  env?: NodeJS.ProcessEnv;
 }
 
 const PHASE_2_STUBS = new Set(["report", "self-update"]);
@@ -138,18 +144,33 @@ async function runInstallCommand(rest: string[], options: RuntimeOptions): Promi
   const { positionals, flags } = parseArgs(rest);
   const shell = options.shell ?? resolveShellFlag(flags);
   const prompter = options.prompter ?? createPrompter();
-  const outcome = await runInstall(positionals, { home: options.home, shell, prompter });
-  // A mid-install failure makes the command non-zero so scripts notice; a
-  // pure skip (CLI absent) is a success.
-  return outcome.failed.length > 0 ? errOut(outcome.output) : ok(outcome.output);
+  try {
+    const outcome = await runInstall(positionals, {
+      home: options.home,
+      shell,
+      prompter,
+      env: options.env,
+    });
+    // A mid-install failure makes the command non-zero so scripts notice; a
+    // pure skip (CLI absent) is a success.
+    return outcome.failed.length > 0 ? errOut(outcome.output) : ok(outcome.output);
+  } finally {
+    // Tear down the shared readline (BUG 1) so an open interface doesn't keep
+    // the event loop alive and hang the process after the command completes.
+    prompter.close();
+  }
 }
 
 async function runUninstallCommand(rest: string[], options: RuntimeOptions): Promise<CliResult> {
   const { positionals, flags } = parseArgs(rest);
   const shell = options.shell ?? resolveShellFlag(flags);
   const prompter = options.prompter ?? createPrompter();
-  const outcome = await runUninstall(positionals, { home: options.home, shell, prompter });
-  return outcome.failed.length > 0 ? errOut(outcome.output) : ok(outcome.output);
+  try {
+    const outcome = await runUninstall(positionals, { home: options.home, shell, prompter });
+    return outcome.failed.length > 0 ? errOut(outcome.output) : ok(outcome.output);
+  } finally {
+    prompter.close();
+  }
 }
 
 async function runUpdateCommand(rest: string[], options: RuntimeOptions): Promise<CliResult> {

--- a/packages/installer-cli/tests/install.test.ts
+++ b/packages/installer-cli/tests/install.test.ts
@@ -31,7 +31,12 @@ describe("install orchestration", () => {
       setRunner(new FakeRunner());
       const prompter = new FakePrompter({ answers: { "mcp url": URL, token: TOKEN } });
 
-      const outcome = await runInstall(["codex", "opencode"], { home, shell: "bash", prompter });
+      const outcome = await runInstall(["codex", "opencode"], {
+        home,
+        shell: "bash",
+        prompter,
+        env: {},
+      });
 
       // Both harnesses installed.
       expect(outcome.installed.sort()).toEqual(["codex", "opencode"]);
@@ -68,7 +73,7 @@ describe("install orchestration", () => {
       setRunner(new FakeRunner());
       const prompter = new FakePrompter({ answers: { "mcp url": URL, token: TOKEN } });
 
-      const outcome = await runInstall(["claude"], { home, shell: "bash", prompter });
+      const outcome = await runInstall(["claude"], { home, shell: "bash", prompter, env: {} });
 
       expect(outcome.installed).toHaveLength(0);
       expect(outcome.failed).toHaveLength(0);
@@ -99,7 +104,7 @@ describe("install orchestration", () => {
       setRunner(runner);
       const prompter = new FakePrompter({ answers: { "mcp url": URL, token: TOKEN } });
 
-      const outcome = await runInstall(["codex"], { home, shell: "bash", prompter });
+      const outcome = await runInstall(["codex"], { home, shell: "bash", prompter, env: {} });
 
       expect(outcome.installed).toHaveLength(0);
       expect(outcome.failed.map((f) => f.id)).toEqual(["codex"]);
@@ -122,7 +127,12 @@ describe("install orchestration", () => {
       );
       const prompter = new FakePrompter();
 
-      const outcome = await runInstall(["bogus", "opencode"], { home, shell: "bash", prompter });
+      const outcome = await runInstall(["bogus", "opencode"], {
+        home,
+        shell: "bash",
+        prompter,
+        env: {},
+      });
       expect(outcome.output).toMatch(/unknown harness: bogus/);
       expect(outcome.installed).toEqual(["opencode"]);
     });
@@ -150,7 +160,7 @@ describe("install orchestration", () => {
       setRunner(runner);
       const prompter = new FakePrompter({ answers: { "mcp url": URL, token: TOKEN } });
 
-      const outcome = await runInstall(["codex"], { home, shell: "bash", prompter });
+      const outcome = await runInstall(["codex"], { home, shell: "bash", prompter, env: {} });
 
       expect(outcome.installed).toHaveLength(0);
       expect(outcome.failed.map((f) => f.id)).toEqual(["codex"]);
@@ -167,7 +177,7 @@ describe("install orchestration", () => {
       setRunner(new FakeRunner()); // no codex CLI → file-based install writes config.toml
       const prompter = new FakePrompter({ answers: { "mcp url": URL, token: TOKEN } });
 
-      const outcome = await runInstall(["codex"], { home, shell: "bash", prompter });
+      const outcome = await runInstall(["codex"], { home, shell: "bash", prompter, env: {} });
 
       expect(outcome.installed).toEqual(["codex"]);
       // Persisted only after a success.
@@ -175,6 +185,143 @@ describe("install orchestration", () => {
       expect(env).toContain(`export LIBRARIAN_MCP_URL='${URL}'`);
       expect(env).toContain(`export LIBRARIAN_AGENT_TOKEN='${TOKEN}'`);
       expect(fs.readFileSync(bashRcPath(home), "utf8")).toContain("# >>> librarian >>>");
+    });
+  });
+
+  // --- BUG 2: reuse existing LIBRARIAN_* environment variables ------------
+
+  describe("existing environment variables (BUG 2)", () => {
+    const ENV_URL = "https://env.example.com/mcp";
+    const ENV_TOKEN = "env-secret-token-xyz";
+
+    it("offers BOTH env vars, and on accept uses + persists them without re-prompting", async () => {
+      await withTempHome(async (home) => {
+        setHomeOverride(home);
+        setRunner(new FakeRunner()); // no codex CLI → file-based install succeeds
+        // Both env vars present; FakePrompter has NO scripted answer for the
+        // offer, so it returns the "y" default → accepted.
+        const prompter = new FakePrompter();
+        const env = { LIBRARIAN_MCP_URL: ENV_URL, LIBRARIAN_AGENT_TOKEN: ENV_TOKEN };
+
+        const outcome = await runInstall(["codex"], { home, shell: "bash", prompter, env });
+
+        expect(outcome.installed).toEqual(["codex"]);
+        // Exactly one prompt was shown — the reuse offer — and NO url/token prompts.
+        expect(prompter.textCalls).toHaveLength(1);
+        expect(prompter.textCalls[0]?.question).toMatch(/Use the LIBRARIAN_MCP_URL/);
+        // The offer shows the URL but redacts the token (never its value).
+        expect(prompter.textCalls[0]?.question).toContain(ENV_URL);
+        expect(prompter.textCalls[0]?.question).toContain("LIBRARIAN_AGENT_TOKEN=set");
+        expect(prompter.textCalls[0]?.question).not.toContain(ENV_TOKEN);
+
+        // The env values were used and persisted to ~/.librarian/env.
+        const persisted = fs.readFileSync(envFilePath(home), "utf8");
+        expect(persisted).toContain(`export LIBRARIAN_MCP_URL='${ENV_URL}'`);
+        expect(persisted).toContain(`export LIBRARIAN_AGENT_TOKEN='${ENV_TOKEN}'`);
+      });
+    });
+
+    it("offers BOTH env vars, and on decline prompts for fresh values", async () => {
+      await withTempHome(async (home) => {
+        setHomeOverride(home);
+        setRunner(new FakeRunner());
+        const prompter = new FakePrompter({
+          answers: {
+            environment: "n", // decline the reuse offer
+            "mcp url": URL, // fresh URL
+            token: TOKEN, // fresh token
+          },
+        });
+        const env = { LIBRARIAN_MCP_URL: ENV_URL, LIBRARIAN_AGENT_TOKEN: ENV_TOKEN };
+
+        const outcome = await runInstall(["codex"], { home, shell: "bash", prompter, env });
+
+        expect(outcome.installed).toEqual(["codex"]);
+        // Offer + the two fresh prompts were shown.
+        const questions = prompter.textCalls.map((c) => c.question);
+        expect(questions.some((q) => /Use the LIBRARIAN_MCP_URL/.test(q))).toBe(true);
+        expect(questions.some((q) => q === "MCP URL")).toBe(true);
+        expect(questions.some((q) => q === "Agent token")).toBe(true);
+
+        // The FRESH values were persisted, NOT the env ones.
+        const persisted = fs.readFileSync(envFilePath(home), "utf8");
+        expect(persisted).toContain(`export LIBRARIAN_MCP_URL='${URL}'`);
+        expect(persisted).toContain(`export LIBRARIAN_AGENT_TOKEN='${TOKEN}'`);
+        expect(persisted).not.toContain(ENV_URL);
+      });
+    });
+
+    it("with only ONE env var present, prefills it as that prompt's default", async () => {
+      await withTempHome(async (home) => {
+        setHomeOverride(home);
+        setRunner(new FakeRunner());
+        // Only the URL is in the env; the user accepts it by hitting enter (the
+        // FakePrompter returns the prompt's default for an unscripted question),
+        // and supplies the token.
+        const prompter = new FakePrompter({ answers: { token: TOKEN } });
+        const env = { LIBRARIAN_MCP_URL: ENV_URL };
+
+        const outcome = await runInstall(["codex"], { home, shell: "bash", prompter, env });
+
+        expect(outcome.installed).toEqual(["codex"]);
+        // No reuse offer (only one var) — straight to the prompts.
+        const offer = prompter.textCalls.find((c) => /Use the LIBRARIAN_MCP_URL/.test(c.question));
+        expect(offer).toBeUndefined();
+        // The MCP URL prompt carried the env value as its default.
+        const urlCall = prompter.textCalls.find((c) => c.question === "MCP URL");
+        expect(urlCall?.opts.default).toBe(ENV_URL);
+
+        // The env URL (accepted via default) + the typed token were persisted.
+        const persisted = fs.readFileSync(envFilePath(home), "utf8");
+        expect(persisted).toContain(`export LIBRARIAN_MCP_URL='${ENV_URL}'`);
+        expect(persisted).toContain(`export LIBRARIAN_AGENT_TOKEN='${TOKEN}'`);
+      });
+    });
+
+    it("with NEITHER env var present, prompts for both as before", async () => {
+      await withTempHome(async (home) => {
+        setHomeOverride(home);
+        setRunner(new FakeRunner());
+        const prompter = new FakePrompter({ answers: { "mcp url": URL, token: TOKEN } });
+        const env = {}; // no LIBRARIAN_* vars
+
+        const outcome = await runInstall(["codex"], { home, shell: "bash", prompter, env });
+
+        expect(outcome.installed).toEqual(["codex"]);
+        const offer = prompter.textCalls.find((c) => /Use the LIBRARIAN_MCP_URL/.test(c.question));
+        expect(offer).toBeUndefined();
+        // Neither prompt carried an env default.
+        const urlCall = prompter.textCalls.find((c) => c.question === "MCP URL");
+        expect(urlCall?.opts.default).toBeUndefined();
+
+        const persisted = fs.readFileSync(envFilePath(home), "utf8");
+        expect(persisted).toContain(`export LIBRARIAN_MCP_URL='${URL}'`);
+        expect(persisted).toContain(`export LIBRARIAN_AGENT_TOKEN='${TOKEN}'`);
+      });
+    });
+
+    it("an already-complete ~/.librarian/env wins — env vars are ignored, no prompt", async () => {
+      await withTempHome(async (home) => {
+        setHomeOverride(home);
+        setRunner(new FakeRunner());
+        fs.mkdirSync(`${home}/.librarian`, { recursive: true });
+        fs.writeFileSync(
+          envFilePath(home),
+          `export LIBRARIAN_MCP_URL='${URL}'\nexport LIBRARIAN_AGENT_TOKEN='${TOKEN}'\n`,
+          { mode: 0o600 },
+        );
+        const prompter = new FakePrompter();
+        const env = { LIBRARIAN_MCP_URL: ENV_URL, LIBRARIAN_AGENT_TOKEN: ENV_TOKEN };
+
+        const outcome = await runInstall(["codex"], { home, shell: "bash", prompter, env });
+
+        expect(outcome.installed).toEqual(["codex"]);
+        // Persisted config was already complete → no prompts at all.
+        expect(prompter.textCalls).toHaveLength(0);
+        const persisted = fs.readFileSync(envFilePath(home), "utf8");
+        expect(persisted).toContain(`export LIBRARIAN_MCP_URL='${URL}'`);
+        expect(persisted).not.toContain(ENV_URL);
+      });
     });
   });
 
@@ -199,7 +346,7 @@ describe("install orchestration", () => {
       setRunner(runner);
       const prompter = new FakePrompter({ answers: { "mcp url": URL, token: TOKEN } });
 
-      const r = await runCli(["install", "codex"], { home, shell: "bash", prompter });
+      const r = await runCli(["install", "codex"], { home, shell: "bash", prompter, env: {} });
       expect(r.exitCode).toBe(1);
       expect(r.stdout).toMatch(/Failed codex/);
     });

--- a/packages/installer-cli/tests/prompt.test.ts
+++ b/packages/installer-cli/tests/prompt.test.ts
@@ -8,6 +8,20 @@ const CHOICES = [
   { id: "pi", label: "Pi" },
 ];
 
+/**
+ * Reject (rather than hang the whole vitest run) if a prompt read never
+ * settles — which is exactly the pre-fix failure mode for BUG 1: the second
+ * read over a per-question readline never sees input and the await dangles.
+ */
+function withTimeout<T>(p: Promise<T>, label: string, ms = 1500): Promise<T> {
+  return Promise.race([
+    p,
+    new Promise<T>((_resolve, reject) =>
+      setTimeout(() => reject(new Error(`prompt "${label}" never resolved (input lost)`)), ms),
+    ),
+  ]);
+}
+
 describe("resolveSelection", () => {
   it("'all' / empty selects everything; 'none' selects nothing", () => {
     expect(resolveSelection("all", CHOICES)).toEqual(["claude", "codex", "pi"]);
@@ -46,6 +60,55 @@ describe("createPrompter — injected prompt fn", () => {
     });
     expect(await p.promptText("Token", { secret: true })).toBe("tok");
     expect(sawSecret).toBe(true);
+  });
+});
+
+describe("createPrompter — real readline over fake streams (BUG 1 regression)", () => {
+  it("captures BOTH a normal AND a following secret prompt over one shared input", async () => {
+    // Drive the REAL prompter (no injected `prompt` fn) the way `resolveConfig`
+    // does: ask for the MCP URL, then the secret token, in sequence, over a
+    // single shared input stream that delivers BOTH lines in ONE chunk —
+    // exactly what a piped/heredoc run (`librarian install <<EOF`) hands the
+    // process. The pre-bug code built a fresh readline interface per question
+    // and `rl.close()`d it; closing the first interface DISCARDED the buffered
+    // remainder (`tok\n`), so the second `createInterface` saw no more input
+    // and the token read hung forever — `resolveConfig` then threw "required".
+    const input = new PassThrough();
+    const output = new PassThrough();
+    output.resume();
+    const p = createPrompter({ input, output, interactive: true });
+
+    // Both answers arrive in ONE chunk on a pipe that stays open — exactly what
+    // a paste or a fast piped run delivers. A single shared readline must hand
+    // each buffered line to the right question; the first read can't be allowed
+    // to swallow (or close away) the second's input.
+    input.write("https://x/mcp\ntok\n");
+    const url = await withTimeout(p.promptText("MCP URL"), "url");
+    const token = await withTimeout(p.promptText("Agent token", { secret: true }), "token");
+
+    expect(url).toBe("https://x/mcp");
+    expect(token).toBe("tok");
+
+    p.close();
+  });
+
+  it("a secret prompt mutes the echo so the token never reaches the output stream", async () => {
+    // A PassThrough left OPEN (never `.end()`ed) models a live TTY: the line is
+    // available but the stream doesn't end, so readline doesn't auto-close.
+    const input = new PassThrough();
+    const written: string[] = [];
+    const output = new PassThrough();
+    output.on("data", (c: Buffer) => written.push(c.toString("utf8")));
+    const p = createPrompter({ input, output, interactive: true });
+
+    input.write("s3cr3t-token\n");
+    const token = await withTimeout(p.promptText("Agent token", { secret: true }), "token");
+
+    expect(token).toBe("s3cr3t-token");
+    // The muted echo must keep the typed token out of what hit the terminal.
+    expect(written.join("")).not.toContain("s3cr3t-token");
+
+    p.close();
   });
 });
 

--- a/packages/installer-cli/tests/prompt.test.ts
+++ b/packages/installer-cli/tests/prompt.test.ts
@@ -92,6 +92,36 @@ describe("createPrompter — real readline over fake streams (BUG 1 regression)"
     p.close();
   });
 
+  it("a secret prompt keeps its label on screen (does not erase the prompt)", async () => {
+    // The user's exact report: after entering the MCP URL, the "Agent token:"
+    // prompt never appeared, so the next Enter sent an empty token and the run
+    // errored "required". Root cause: the pre-fix secret path called
+    // `rl.question("")`, whose terminal:true line-refresh emitted
+    // `ESC[1G ESC[0J` (cursor-to-column-1 + erase-to-end-of-screen) right after
+    // we'd written "Agent token: " directly — wiping the label off the screen.
+    // The token was still CAPTURED, so the functional/mute tests stayed green
+    // while the human saw a blank line. This asserts the missing invariant: no
+    // erase sequence reaches the terminal, so the label the user must read to
+    // know what to type survives. (Verified to fail on the old code and pass on
+    // the fix; reproduces over a plain PassThrough because terminal:true is
+    // forced, so a real PTY isn't needed.)
+    const input = new PassThrough();
+    const written: string[] = [];
+    const output = new PassThrough();
+    output.on("data", (c: Buffer) => written.push(c.toString("utf8")));
+    const p = createPrompter({ input, output, interactive: true });
+
+    input.write("tok\n");
+    await withTimeout(p.promptText("Agent token", { secret: true }), "token");
+    const out = written.join("");
+
+    expect(out).toContain("Agent token:"); // the label was emitted…
+    expect(out).not.toContain("[0J"); // …and nothing erased to end-of-screen
+    expect(out).not.toContain("[2K"); // …or cleared the prompt line
+
+    p.close();
+  });
+
   it("a secret prompt mutes the echo so the token never reaches the output stream", async () => {
     // A PassThrough left OPEN (never `.end()`ed) models a live TTY: the line is
     // available but the stream doesn't end, so readline doesn't auto-close.

--- a/packages/installer-cli/tests/prompter.ts
+++ b/packages/installer-cli/tests/prompter.ts
@@ -36,4 +36,10 @@ export class FakePrompter implements Prompter {
     if (opts.default !== undefined) return opts.default;
     throw new Error(`FakePrompter: no scripted answer for "${question}"`);
   }
+
+  /** No real resource to release — recorded so a test can assert it was closed. */
+  closeCalls = 0;
+  close(): void {
+    this.closeCalls += 1;
+  }
 }

--- a/packages/installer-cli/tests/runtime.test.ts
+++ b/packages/installer-cli/tests/runtime.test.ts
@@ -56,7 +56,9 @@ describe("runCli — robustness (no leaked stack traces)", () => {
           output: new PassThrough(),
           interactive: false,
         });
-        const r = await runCli(["install"], { home, shell: "bash", prompter });
+        // Inject an EMPTY env so the test never reads (or depends on) the real
+        // `process.env` — a dev box with LIBRARIAN_* set must not flip the result.
+        const r = await runCli(["install"], { home, shell: "bash", prompter, env: {} });
 
         expect(r.exitCode).toBe(1);
         // A single friendly line, naming the fix — and NO stack trace.

--- a/packages/installer-cli/tests/update.test.ts
+++ b/packages/installer-cli/tests/update.test.ts
@@ -41,7 +41,7 @@ describe("update orchestration", () => {
       setRunner(new FakeRunner());
       // Install opencode so it's the only installed harness.
       const installer = new FakePrompter({ answers: { "mcp url": URL, token: TOKEN } });
-      await runInstall(["opencode"], { home, shell: "bash", prompter: installer });
+      await runInstall(["opencode"], { home, shell: "bash", prompter: installer, env: {} });
 
       const outcome = await runUpdate([], { home });
       expect(outcome.updated.map((u) => u.id)).toEqual(["opencode"]);


### PR DESCRIPTION
Two fixes to the published `@the-librarian/cli` interactive installer. **This needs an npm republish of `@the-librarian/cli` to reach users** — the bug lives in the shipped CLI.

## BUG 1 (critical) — interactive token prompt dropped its input

`librarian install` built a **fresh `readline` interface per question** and `rl.close()`d it after each one. Closing the first interface discarded any input buffered past its line, so when both answers arrived together — a paste, or a fast/piped run where `url\ntoken\n` lands in one chunk — the second read (the secret token) saw no input and hung. `resolveConfig` then threw **"MCP URL and token are required"**. A real user hit exactly this; the unit tests missed it because they inject a fake `prompt` fn and never exercise real readline.

**Fix:** the prompter now uses **ONE shared readline interface** for its whole lifetime — created lazily on the first real prompt, reused for every question — with a **persistent line queue** so no input is lost regardless of how the input is chunked. The secret (token) echo is muted only for that one question and restored afterwards. A new **`Prompter.close()`** is called from the install/uninstall lifecycle (a `finally` in the runtime command handlers) so the open readline no longer keeps the Node event loop alive and the process exits cleanly.

**Regression test (fails pre-fix):** a new test drives the REAL prompter (no injected `prompt` fn) over fake streams — both answers written in one chunk to an open pipe, `interactive: true` — and asserts BOTH a normal prompt and a following `secret: true` prompt return their values. Pre-fix it fails with `prompt "token" never resolved (input lost)`; post-fix it passes. A second test asserts the token never reaches the output stream (echo stays muted). An end-to-end run of the built `dist/bin.js` over an open pipe confirms the values are captured, the config is persisted, and the process exits 0 (no hang).

## BUG 2 / feature — reuse existing `LIBRARIAN_*` environment variables

When `~/.librarian/env` isn't already complete, `resolveConfig` now consults `LIBRARIAN_MCP_URL` / `LIBRARIAN_AGENT_TOKEN` from the environment instead of blindly prompting:

- `~/.librarian/env` already complete → use it, no prompts (unchanged).
- Both env vars present → show them (URL in full, token redacted to `LIBRARIAN_AGENT_TOKEN=set` — the value is never displayed) and ask `Use the LIBRARIAN_MCP_URL and LIBRARIAN_AGENT_TOKEN from your environment? [Y/n]`. Accept → use + persist via `setConfig` (+ env block); decline → prompt for fresh values.
- Only one env var present → prefill it as that prompt's default (bare enter accepts) and prompt for the other.
- Neither → prompt for both, as before.

The environment is **injectable** (`env` on `InstallDeps` / `RuntimeOptions`, defaulting to `process.env`) so tests never read the real env, and the token value is never logged. Tests cover: both present → offered → accepted → used + persisted; both present → declined → prompts fresh; one present → prefilled default; neither → prompts as today; and a complete `~/.librarian/env` ignoring the env vars entirely. Pre-existing install/runtime/update tests were also given an explicit empty `env` so they no longer depend on (or leak) the developer's real environment.

## Release ceremony

- Root `package.json` + `packages/installer-cli/package.json` bumped to **`1.0.0-rc.4`**.
- CHANGELOG `## [1.0.0-rc.4] — 2026-06-13` (Fixed: interactive token prompt; Added: reuse existing `LIBRARIAN_*` env vars) + compare link `v1.0.0-rc.3...v1.0.0-rc.4`.
- Hermes `PINNED_REF` bumped to `v1.0.0-rc.4` (the pinned-ref test tracks the package version).
- `pnpm check:release` green.

## Gates

- `pnpm --filter @the-librarian/cli build && typecheck && test` — green (125 tests, incl. the new real-readline + env tests).
- `pnpm lint` — green. Root `pnpm typecheck` — green. `pnpm check:release` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)