### PR TITLE
ci(release): auto-publish @the-librarian/cli to npm on release (rc.5)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,3 +74,62 @@ jobs:
           git push origin "$V"
           gh release create "$V" --title "$V" --notes-file "${{ runner.temp }}/notes.md"
           echo "Released $V."
+
+  # Publish the PUBLIC packages to npm. Runs AFTER `release` so the `vX.Y.Z` tag
+  # exists before we publish — the published CLI pins that tag for its runtime
+  # adapter fetch (hermes), so the order matters. Idempotent in two independent
+  # ways, mirroring the release job's "every merge is a release, re-runs no-op"
+  # contract:
+  #   - per package, it skips if that exact version is already on npm — so a
+  #     no-bump merge is a no-op AND a re-run after a half-failed publish
+  #     recovers (it publishes only what's still missing);
+  #   - if NPM_TOKEN isn't set yet, it logs and exits 0 — so this workflow is
+  #     safe to land BEFORE the secret exists; auto-publish switches on the
+  #     moment the owner adds the secret, with no further code change.
+  # Private `@librarian/*` workspace packages are never published (private:true).
+  publish-npm:
+    name: Publish public packages to npm
+    needs: release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.17.1"
+
+      - name: Enable corepack (pnpm)
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.15.0 --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build the CLI
+        run: pnpm --filter @the-librarian/cli build
+
+      - name: Publish @the-librarian/cli (idempotent; skips if already on npm)
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NPM_TOKEN:-}" ]; then
+            echo "NPM_TOKEN not set — skipping npm publish."
+            echo "Add the NPM_TOKEN repo secret (an npm automation token) to enable auto-publish."
+            exit 0
+          fi
+          pnpm config set //registry.npmjs.org/:_authToken "${NPM_TOKEN}"
+          PKG=@the-librarian/cli
+          V="$(node -p "require('./packages/installer-cli/package.json').version")"
+          if npm view "${PKG}@${V}" version >/dev/null 2>&1; then
+            echo "${PKG}@${V} already on npm — nothing to publish."
+          else
+            echo "Publishing ${PKG}@${V}…"
+            pnpm --filter "${PKG}" publish --access public --no-git-checks
+            echo "Published ${PKG}@${V}."
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.5] — 2026-06-13
+
+Wire up automatic npm publishing so a merge to `main` ships the public CLI —
+no more hand-running `npm publish`. This republishes `@the-librarian/cli` with
+the rc.4 installer fixes (interactive token prompt + `LIBRARIAN_*` reuse).
+
+### Added
+
+- **Auto-publish `@the-librarian/cli` to npm on release.** `release.yml` gains a
+  `publish-npm` job that runs after the tag/GitHub release is cut and publishes
+  the public package with `pnpm publish --access public`. It is idempotent — it
+  skips any version already on npm, so a no-bump merge and a workflow re-run are
+  clean no-ops (a re-run also recovers a half-failed publish by shipping only
+  what's still missing). It is gated on an `NPM_TOKEN` repo secret: until that
+  secret exists the job logs and exits 0, so this change is safe to land first
+  and auto-publish switches on the moment the owner adds the secret — no further
+  code change. Private `@librarian/*` workspace packages are never published
+  (`private: true`).
+
+### Changed
+
+- **Pin the Hermes adapter ref to `v1.0.0-rc.5`.** The CLI fetches the Hermes
+  adapter from the matching release tag at install time; the version-tracking
+  test keeps `PINNED_REF` in lockstep with the package version, so the bump
+  moves it too.
+
 ## [1.0.0-rc.4] — 2026-06-13
 
 Installer-CLI fixes for the interactive setup (`@the-librarian/cli`). Needs a
@@ -1682,6 +1708,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0-rc.5]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.4...v1.0.0-rc.5
 [1.0.0-rc.4]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.3...v1.0.0-rc.4
 [1.0.0-rc.3]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.2...v1.0.0-rc.3
 [1.0.0-rc.2]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.1...v1.0.0-rc.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/installer-cli/package.json
+++ b/packages/installer-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-librarian/cli",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/installer-cli/src/harnesses/hermes.ts
+++ b/packages/installer-cli/src/harnesses/hermes.ts
@@ -28,7 +28,7 @@ import type { HarnessConfig, HarnessModule } from "./types.js";
 const PROVIDER_ID = "librarian";
 // The pinned monorepo release we fetch the adapter from. Default to the
 // repo's current release tag; the phase gate owns version bumps.
-export const PINNED_REF = "v1.0.0-rc.4";
+export const PINNED_REF = "v1.0.0-rc.5";
 
 /**
  * Fetches the Hermes adapter for a pinned ref and returns the absolute


### PR DESCRIPTION
## Why

Merging to \`main\` cuts the git tag + GitHub release, but **never publishes the CLI to npm** — that step was never added to the monorepo's release flow (it was Phase-2 in the installer spec §7/§12). So rc.4's installer fixes never reached users: npm is still on **rc.3**, which is why `librarian -v` shows rc.3 and there's no env-var detection.

This restores the auto-publish behaviour the old standalone plugin repos had, in the monorepo.

## What

A `publish-npm` job in `release.yml` that runs **after** the tag/release is cut and publishes the public package with `pnpm publish --access public` (validated locally with `--dry-run`: 107 files, `latest` tag, public access).

Idempotent two independent ways, matching the release job's "every merge is a release, re-runs no-op" contract:
- **Per-version skip** — `npm view @the-librarian/cli@<v>` first; a no-bump merge or a workflow re-run is a clean no-op, and a re-run after a half-failed publish recovers by shipping only what's missing.
- **Token-gated** — if `NPM_TOKEN` isn't set, it logs and `exit 0`. So this PR is safe to merge **before** the secret exists; auto-publish switches on the moment the secret is added, with no further code change.

Private `@librarian/*` workspace packages are never published (`private: true`).

Bumps to **rc.5** (the first auto-published version, carrying rc.4's prompt + env-detection fixes) and moves the pinned Hermes adapter ref in lockstep (the version-tracking test enforces `PINNED_REF === v${version}`).

## ⚠️ Required before this works: add the `NPM_TOKEN` secret

Per spec §9, only you can do this (I never touch npm credentials):

1. On npmjs.com → **Access Tokens** → create a **Granular/Automation** token with publish rights to the `@the-librarian` scope.
2. `gh secret set NPM_TOKEN` (or repo Settings → Secrets → Actions → New secret, name `NPM_TOKEN`).
3. Merge this PR. On merge: tag `v1.0.0-rc.5` → release → **auto-publish `@the-librarian/cli@1.0.0-rc.5`**.
4. Update your global install: `npm i -g @the-librarian/cli@latest` → `librarian -v` shows `1.0.0-rc.5`.

If you'd rather test the fixes **right now** without waiting on the secret, you can still hand-publish once from `packages/installer-cli`: `npm publish` (then `npm i -g @the-librarian/cli@latest`). The automation makes that the last time you do it by hand.

## Verification
- `node scripts/check-release.mjs` ✅ (rc.5 is top CHANGELOG entry, dated, linked)
- `pnpm --filter @the-librarian/cli test` ✅ 126 passing (incl. the PINNED_REF version-tracking test at rc.5)
- typecheck ✅, prettier ✅, `release.yml` YAML parses (jobs: release, publish-npm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)