### PR TITLE
feat(server): `librarian server` self-host CLI (impl of #367)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,57 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.7] — 2026-06-14
+
+Implement the `librarian server` self-host CLI from the rc.6 spec — the loop
+closer: **server on the host → token → clients.** `@the-librarian/cli` (the
+`librarian` bin) gains a host-only, Docker-driven `server` command group; no new
+tool, no rename.
+
+### Added
+
+- **`librarian server up`** — one command stands up the all-in-one container on a
+  fresh Docker host: clones the monorepo at the latest release tag (`--ref` pins a
+  tag or `main`), builds + runs the image (named `librarian_data` volume), waits
+  for both services healthy (rolling the container back on failure — never a
+  half-up deploy), surfaces the server-generated master key **once** with the
+  `SAVE THIS KEY` warning, and prints the MCP URL + a freshly minted agent token
+  ready to paste into `librarian install`. Offers to write this machine's own
+  `~/.librarian/env` when it's also a client.
+- **Bind-aware auth.** A `127.0.0.1` bind (default) runs with
+  `LIBRARIAN_ALLOW_NO_AUTH=true` (no admin token); `--host <tailnet-ip|0.0.0.0>`
+  omits it so the server generates + enforces the admin token (surfaced once).
+  `0.0.0.0` is ask-first; a detected Tailscale IP is offered, never auto-selected.
+- **`server update`** — re-pins forward to the latest release (idempotent no-op
+  when already current + healthy), rebuilds, recreates the container **preserving
+  the data volume**, reuses the existing agent token, and applies pending data-dir
+  migrations via `docker exec … migrate-data-dir`.
+- **`server down` / `status` / `logs`** — `down` stops the container and never
+  touches the data volume; `status` reports running/health/deployed-vs-latest with
+  an update badge; `logs [-f] [--service mcp|dashboard|all]` streams live.
+- **`server enable-boot` / `disable-boot`** (and `up --enable-boot`) — generate a
+  Linux systemd unit whose `ExecStart` is `docker start --attach the-librarian`
+  (references the existing named container, so **no secret lands in the unit
+  file**). macOS launchd is deferred (clean notice). 
+- **`server admin <backup|restore|auth|rebuild>`** — runs the admin CLI inside the
+  container (`docker exec`), so auth-lockout recovery works even when the dashboard
+  is locked. The all-in-one image now bundles `@librarian/cli` (`the-librarian`)
+  on `PATH`. `seed`/`migrate-data-dir`/`export`/`handoffs` are intentionally not
+  exposed here.
+- **`the-librarian restore`** (new admin command) — clones the configured backup
+  remote into the data dir and re-supplies the master key (`--secret-key`, which is
+  excluded from backups). Crash-safe (clones to a temp dir, swaps atomically, so a
+  failed clone never destroys an existing vault) and key-verified (rejects a
+  well-formed-but-wrong key that would otherwise leave an undecryptable server);
+  `--force` guards the populated-vault and differing-key cases.
+
+### Security
+
+- No agent token, admin token, or master key is ever written to a host file, a
+  log, or an error message: failed-step output from `up`/`update`/`server admin`
+  is run through a shared redactor before it is surfaced, and the boot unit carries
+  no secret.
+
 ## [1.0.0-rc.6] — 2026-06-13
 
 Spec only — no shipped code, so the published `@the-librarian/cli` is unchanged
@@ -1737,6 +1788,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0-rc.7]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.6...v1.0.0-rc.7
 [1.0.0-rc.6]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.5...v1.0.0-rc.6
 [1.0.0-rc.5]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.4...v1.0.0-rc.5
 [1.0.0-rc.4]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.3...v1.0.0-rc.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,14 @@ tool, no rename.
   `docker/all-in-one.Dockerfile` and `docker/mcp-server.Dockerfile` now install
   `ca-certificates` alongside `git`, with a static regression guard
   (`dockerfile-tls.test.ts`).
+- **Vault backup then failed to exec the `GIT_ASKPASS` helper**
+  (`fatal: cannot exec '…/askpass.sh': Permission denied`) on hardened
+  (`read_only`) deployments, where `/tmp` is a `noexec` tmpfs. The transient
+  askpass helper is now written to the data dir — a writable, exec-capable volume
+  outside the vault working tree — instead of `os.tmpdir()` (the token is still
+  supplied only via the helper's env, never embedded). `createSyncGitOps` /
+  `cloneVaultBackup` gain an optional `scratchDir`; the store + `restore` pass the
+  data dir.
 
 ## [1.0.0-rc.6] — 2026-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,17 @@ tool, no rename.
   is run through a shared redactor before it is surfaced, and the boot unit carries
   no secret.
 
+### Fixed
+
+- **Vault backup over HTTPS failed with `server certificate verification failed.
+  CAfile: none`.** The git-using images installed `git` with
+  `--no-install-recommends` on a slim base that ships no CA bundle, so the backup
+  `git push https://…github.com…` couldn't verify GitHub's certificate (reads were
+  unaffected — only git does outbound HTTPS; Node bundles its own CAs). Both
+  `docker/all-in-one.Dockerfile` and `docker/mcp-server.Dockerfile` now install
+  `ca-certificates` alongside `git`, with a static regression guard
+  (`dockerfile-tls.test.ts`).
+
 ## [1.0.0-rc.6] — 2026-06-13
 
 Spec only — no shipped code, so the published `@the-librarian/cli` is unchanged

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -2,10 +2,124 @@
 
 This deployment is designed for a low-traffic personal VPS or a remote host.
 
-## Single container (recommended)
+## One-command self-host (`librarian server`)
+
+The lowest-friction path. The `librarian` CLI drives the all-in-one container
+end to end: it builds and runs the image, manages the data volume, surfaces the
+secrets, and hands you the MCP URL + agent token to paste into clients. You never
+hand-write a `docker run` or an `.env` for the happy path.
+
+```sh
+npm i -g @the-librarian/cli
+librarian server up
+```
+
+`server up` (on a host with Docker + git):
+
+1. Clones the monorepo at the latest release tag into `~/.librarian/server`
+   (the deploy dir; `--dir` overrides) and builds `the-librarian:<tag>`.
+2. Runs the all-in-one container (named `the-librarian`) on the named data volume
+   `librarian_data` (`--data-volume` overrides), waits for **both** services to
+   report healthy, and rolls the container back if they don't (the data volume is
+   never touched).
+3. Surfaces, **once**, the server-generated **master key** with a
+   `SAVE THIS KEY — excluded from backups` warning. It is read back from
+   `/data/secret.key` and written to **no** host file or log — copy it now or you
+   cannot decrypt restored backups later.
+4. Prints the **MCP URL** (`http://<host>:3838/mcp`), the dashboard URL
+   (`http://<host>:3000`), and a freshly minted **agent token**. Paste the MCP URL
+   + agent token into `librarian install` (or `librarian config --mcp-url <url>
+   --token <token>`) on each client.
+5. Offers to write **this** machine's own `~/.librarian/env` (single-box dev gets
+   server + client in one shot) — offer, never force.
+
+### Bind host (`--host`)
+
+The default bind is `127.0.0.1` (host loopback only) — the server is reachable
+only from the machine it runs on, and runs with the localhost no-auth bypass (no
+admin token is generated). To reach it from elsewhere, choose a bind:
+
+- `--host <tailnet-ip>` — bind a specific reachable address (e.g. a Tailscale
+  IP). An interactive `up` with no `--host` **offers** a detected Tailscale
+  address; it never binds beyond localhost without your say-so.
+- `--host 0.0.0.0` — bind **all** interfaces. This is **ask-first**: a plain `up`
+  prompts before exposing every interface (`--yes` auto-accepts). `0.0.0.0` is a
+  bind directive, not a connectable address — point clients at the machine's real
+  LAN/tailnet IP.
+
+When bound **beyond** localhost the server generates and enforces an **admin
+token** (`/data/admin.token`), which `up` also surfaces once — paste it into the
+dashboard's auth wizard, or use it with `server admin auth`. Put port 3838 behind
+**TLS** (a reverse proxy) on any host reachable beyond loopback.
+
+### Pinning and updates
+
+- `--ref <tag|main>` pins `up`/`update` to an explicit release tag or `main`
+  (default: the latest release tag). Pinning is reproducibility, not freezing.
+- `librarian server update` re-pins **forward**: fetch tags → checkout the
+  resolved ref → rebuild → recreate the container (the `librarian_data` volume is
+  **preserved**) → apply pending data-dir migrations → wait for health. It is
+  **idempotent**: already at the resolved ref and healthy → a clean no-op. The
+  existing agent token is read back from the running container and reused, so
+  clients keep working with no action (only if it can't be read does `update`
+  mint and surface a fresh one).
+- `librarian server down` stops the container with `docker stop` only — it
+  **never** removes the container or the volume. The data is kept; a later `up`
+  or `update` recalls the same memories.
+- `librarian server status` reports running?, health, the deployed version, the
+  latest release, and an `up-to-date | update-available` badge (degrades to
+  `unknown`/`?` offline, never crashes).
+- `librarian server logs [-f] [--service mcp|dashboard|all]` tails the container
+  logs. `-f` follows live; `--service` filters the combined stream to the MCP
+  server (`mcp`), the dashboard (`dashboard`), or both (`all`, the default).
+
+### Boot persistence (Linux)
+
+- `librarian server enable-boot` (or `librarian server up --enable-boot`)
+  installs and enables a `the-librarian.service` systemd unit so the container
+  starts on boot. The unit references the **existing** named container
+  (`ExecStart=docker start --attach the-librarian`) and carries **no secret** —
+  the agent token is never written into the world-readable unit file. It survives
+  `server update` (the container name is stable).
+- `librarian server disable-boot` reverses it (disables + removes the unit,
+  reloads systemd; the container itself is untouched).
+- **macOS** boot persistence is deferred — these commands print a "Linux-only for
+  now" notice and skip cleanly; start the server manually with `server up`.
+
+### Admin from the host (`server admin`)
+
+`librarian server admin <backup|restore|auth|rebuild> [args…]` runs the bundled
+admin CLI **inside** the container (`docker exec the-librarian the-librarian
+<verb> …`). Because it runs in the container against the live data dir, it works
+**even when the dashboard is locked** — which is exactly what makes `auth`
+recovery and `backup`/`restore` reliable.
+
+- `backup` — push the vault to the configured GitHub backup remote.
+- `restore` — clone the backup remote back into the data dir. It needs the
+  master key via `--secret-key <hex>` (the key is **excluded from backups** by
+  design, so it must be re-supplied; an interactive run prompts for it, no-echo).
+  Use `--force` to replace a populated vault. This is the inverse of `backup`.
+- `auth status | reset-password | disable` — recover dashboard login from the
+  host shell (clear a lockout, set a new password) without the UI.
+- `rebuild` — regenerate the disposable in-memory recall index from the vault.
+
+`seed`, `migrate-data-dir`, `export`, and `handoffs` are deliberately **not**
+folded in (`migrate-data-dir` runs automatically on `update`; the rest are
+dev/dashboard surfaces). They remain reachable via a raw `docker exec` if ever
+needed.
+
+### What `server` does NOT drive
+
+`librarian server` manages the **all-in-one** container only. The two-container
+Compose stack (below) stays the **manual/advanced** path the CLI does not drive —
+use it when you want the split mcp-server + dashboard processes or
+Compose-native operations.
+
+## Single container — manual
 
 One image runs both services under `tini` (PID 1) → a small supervisor → the MCP
-server + the dashboard. The lowest-friction way to self-host:
+server + the dashboard. This is what `librarian server up` automates above; run
+it by hand when you want full control of the `docker run` invocation:
 
 ```sh
 docker build -f docker/all-in-one.Dockerfile -t the-librarian .

--- a/README.md
+++ b/README.md
@@ -20,6 +20,22 @@ single document and picked up cleanly in another.
 
 It runs as a small self-hosted server, reachable locally or over the network.
 
+## Self-host in one command
+
+The `librarian` CLI's `server` command group stands up the server for you — it
+builds and runs the all-in-one container, surfaces the master key once, and hands
+you the MCP URL + agent token to paste into clients:
+
+```sh
+npm i -g @the-librarian/cli
+librarian server up
+```
+
+`server up`/`update`/`down`/`status`/`logs`, Linux boot persistence
+(`enable-boot`), and host-side admin (`server admin backup|restore|auth|rebuild`)
+are all covered in the
+[one-command self-host guide](./DEPLOYMENT.md#one-command-self-host-librarian-server).
+
 ## Install on any harness
 
 Once your server is running, the `librarian` CLI wires The Librarian into your

--- a/docker/all-in-one.Dockerfile
+++ b/docker/all-in-one.Dockerfile
@@ -27,11 +27,14 @@ RUN pnpm install --frozen-lockfile --ignore-scripts
 COPY tsconfig.base.json ./
 COPY packages/core ./packages/core
 COPY packages/mcp-server ./packages/mcp-server
+COPY packages/cli ./packages/cli
 COPY apps/dashboard ./apps/dashboard
 
-# core + mcp-server first (the dashboard imports mcp-server types), then
-# dashboard.
+# core + mcp-server first (the dashboard imports mcp-server types, the admin CLI
+# imports both), then the admin CLI (`@librarian/cli` → the `the-librarian` bin,
+# folded into `server admin`), then the dashboard.
 RUN pnpm --filter @librarian/core --filter @librarian/mcp-server run build \
+  && pnpm --filter @librarian/cli run build \
   && pnpm --filter @librarian/dashboard run build
 
 # Prune the workspace to prod deps for the mcp-server runtime tree. The dashboard's
@@ -69,6 +72,27 @@ COPY --from=builder /app/packages/core/node_modules /app/mcp-server/packages/cor
 COPY --from=builder /app/packages/mcp-server/package.json /app/mcp-server/packages/mcp-server/package.json
 COPY --from=builder /app/packages/mcp-server/dist /app/mcp-server/packages/mcp-server/dist
 COPY --from=builder /app/packages/mcp-server/node_modules /app/mcp-server/packages/mcp-server/node_modules
+
+# --- admin CLI runtime tree under /app/cli (mirrors the mcp-server tree above) ---
+# `@librarian/cli` is the `the-librarian` binary folded into `librarian server
+# admin`. It lives in its own subtree so Node resolves its modules from here
+# regardless of cwd, exactly like the mcp-server tree. It imports @librarian/core
+# (and @librarian/mcp-server), so their built dist + node_modules come along.
+COPY --from=builder /app/package.json /app/pnpm-workspace.yaml /app/cli/
+COPY --from=builder /app/node_modules /app/cli/node_modules
+COPY --from=builder /app/packages/core/package.json /app/cli/packages/core/package.json
+COPY --from=builder /app/packages/core/dist /app/cli/packages/core/dist
+COPY --from=builder /app/packages/core/node_modules /app/cli/packages/core/node_modules
+COPY --from=builder /app/packages/mcp-server/package.json /app/cli/packages/mcp-server/package.json
+COPY --from=builder /app/packages/mcp-server/dist /app/cli/packages/mcp-server/dist
+COPY --from=builder /app/packages/mcp-server/node_modules /app/cli/packages/mcp-server/node_modules
+COPY --from=builder /app/packages/cli/package.json /app/cli/packages/cli/package.json
+COPY --from=builder /app/packages/cli/dist /app/cli/packages/cli/dist
+COPY --from=builder /app/packages/cli/node_modules /app/cli/packages/cli/node_modules
+# Put `the-librarian` on PATH: symlink the built bin into /usr/local/bin. The bin
+# is an ESM module with its own shebang; node resolves its deps from the subtree.
+RUN ln -s /app/cli/packages/cli/dist/bin.js /usr/local/bin/the-librarian \
+  && chmod +x /app/cli/packages/cli/dist/bin.js
 
 # --- dashboard standalone tree under /app/dashboard (mirrors dashboard.Dockerfile) ---
 COPY --from=builder /app/apps/dashboard/.next/standalone /app/dashboard/

--- a/docker/all-in-one.Dockerfile
+++ b/docker/all-in-one.Dockerfile
@@ -50,7 +50,7 @@ WORKDIR /app
 # its child. Equivalent to `docker run --init`.
 # tini (PID 1) + git (the markdown backend commits every write to the vault).
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends tini git \
+  && apt-get install -y --no-install-recommends tini git ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
 ENV NODE_ENV=production \

--- a/docker/mcp-server.Dockerfile
+++ b/docker/mcp-server.Dockerfile
@@ -36,7 +36,7 @@ WORKDIR /app
 
 # git — the markdown backend commits every write to the vault.
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends git \
+  && apt-get install -y --no-install-recommends git ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
 ENV NODE_ENV=production \

--- a/docs/specs/2026-06-13-server-cli.md
+++ b/docs/specs/2026-06-13-server-cli.md
@@ -58,9 +58,11 @@ asserted against the injected fake runner (no test starts a real container).
    memories.
 7. **Boot persistence (Linux).** `up --enable-boot` (or the interactive prompt)
    generates and enables a `the-librarian.service` systemd unit whose `ExecStart`
-   is the resolved `docker run`; the container restarts after a reboot;
-   `disable-boot` reverses it. macOS prints a "Linux-only for now" notice and
-   skips cleanly.
+   is `docker start --attach the-librarian` — it references the **existing** named
+   container and carries **no secret** (never the resolved `docker run`, which
+   would leak the agent token into the world-readable unit file); the container
+   restarts after a reboot; `disable-boot` reverses it. macOS prints a
+   "Linux-only for now" notice and skips cleanly.
 8. **Admin works even when the dashboard is locked.** The built all-in-one image
    has `the-librarian` on `PATH`; `server admin <backup|restore|auth|rebuild> …`
    runs `docker exec the-librarian the-librarian <cmd> …`, and `server admin auth
@@ -233,7 +235,15 @@ layer, but the CLI is never built and never copied into the runtime stage
 ## 9. Boot persistence
 
 - **Linux (systemd).** Generate a `the-librarian.service` unit whose `ExecStart`
-  is the resolved `docker run` and `ExecStop` is `docker stop`; `enable --now`.
+  is `docker start --attach the-librarian` (referencing the **existing** named
+  container created by `up`/`update`) and `ExecStop` is `docker stop`;
+  `enable --now`. We deliberately do **not** bake the resolved `docker run` into
+  `ExecStart`: that would write `-e LIBRARIAN_AGENT_TOKEN=…` into a
+  world-readable `/etc/systemd/system/*.service` file — a leak. The container
+  already carries its env (incl. the token) in Docker's own state, so referencing
+  it by name keeps **no secret in the unit file**, and it survives `update`
+  (which recreates the same container name). `--attach` keeps the container in the
+  foreground so systemd's `Type=simple` supervision + `Restart=always` work.
   Idempotent; `disable-boot` reverses it. (Today's host unit is ad-hoc — this
   makes it reproducible.) See Open Question 3 for user-unit vs system-unit default.
 - **macOS (launchd).** Deferred for v1: `up` notes that boot persistence is
@@ -361,7 +371,8 @@ testable) and carries its own acceptance check. Riskiest slices (S2, S7) are ear
       *Depends:* S2, S4.
 - [ ] **S6 — boot persistence (systemd; macOS deferred).**
       *Accept:* `enable-boot`/`up --enable-boot` writes the unit (`ExecStart` =
-      resolved `docker run`), `enable --now`, idempotent; `disable-boot`
+      `docker start --attach the-librarian` — the existing named container, no
+      secret in the file), `enable --now`, idempotent; `disable-boot`
       reverses; macOS prints the deferred notice + skips. (SC 7.)
       *Depends:* S2.
 - [ ] **S7 — bundle `@librarian/cli` + `admin` dispatch + build `restore`.**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.6",
+  "version": "1.0.0-rc.7",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/cli/src/commands/restore.ts
+++ b/packages/cli/src/commands/restore.ts
@@ -1,0 +1,209 @@
+// `the-librarian restore [--secret-key <hex>] [--force]` — the INVERSE of
+// `backup`. Backup pushes the vault (a git repo) to the configured GitHub backup
+// remote; restore CLONES that remote back into the data dir's vault so the server
+// can serve the recovered memories. Runs INSIDE the all-in-one container (via
+// `librarian server admin restore`), against the live data dir.
+//
+// The crux is the master key (spec §6/§7): the key is DELIBERATELY excluded from
+// backups, so a restore can clone every memory back but cannot decrypt the
+// admin secret-store without the operator re-supplying the key. We therefore take
+// `--secret-key` (or prompt for it, no-echo, when interactive), validate it, and
+// place it at `${dataDir}/secret.key` (0600) so the server boots able to decrypt.
+//
+// Guards (never silently clobber a populated data dir):
+//   - no backup remote configured → teaching error (nothing to restore from).
+//   - secret key absent + non-interactive → teaching error naming the exclusion.
+//   - malformed secret key → teaching error (validated BEFORE any write/clone).
+//   - non-empty vault without --force → refuse (don't clobber live memories).
+//   - a DIFFERING existing secret.key without --force → refuse (overwriting the
+//     master key on a populated data dir orphans every already-encrypted secret).
+//
+// The clone is injected (`deps.clone`) so tests pin the guards + argv without
+// reaching github.com; production defaults to core's token-safe `cloneVaultBackup`.
+
+import fs from "node:fs";
+import path from "node:path";
+import {
+  type LibrarianStore,
+  cloneVaultBackup,
+  resolveBackupRemote,
+  resolveSecretKey,
+  resolveVaultPath,
+  writeSecretKeyFile,
+} from "@librarian/core";
+import { type FlagMap, flagString } from "../parse-flags.js";
+import { readHiddenLine } from "../prompt.js";
+import type { CliResult } from "./_shared.js";
+
+const SECRET_KEY_FILE = "secret.key";
+
+export interface RestoreCommandDeps {
+  /** Clone the backup remote into `dest` (injected in tests; default: core). */
+  clone?: (opts: { remoteUrl: string; branch: string; token: string; dest: string }) => void;
+  /** No-echo secret-key prompt (injected in tests); returns null when cancelled. */
+  promptSecretKey?: () => string | null;
+  /** Whether a TTY is attached (so we may prompt). Default: `process.stdin.isTTY`. */
+  interactive?: boolean;
+}
+
+function ok(stdout: string): CliResult {
+  return { stdout, exitCode: 0 };
+}
+function fail(stdout: string): CliResult {
+  return { stdout, exitCode: 1 };
+}
+
+/**
+ * True when `dir` holds actual vault CONTENT — any entry other than `.git`. A
+ * freshly-constructed store git-initialises an otherwise-empty `vault/` (it
+ * contains only `.git`), which is logically empty and safe to restore over; only
+ * real memories (memories/inbox/references/… or any committed file) count as
+ * populated and trigger the clobber guard.
+ */
+function isPopulatedVault(dir: string): boolean {
+  try {
+    return fs.readdirSync(dir).some((entry) => entry !== ".git");
+  } catch {
+    return false; // absent → empty
+  }
+}
+
+/**
+ * Resolve + validate the operator-supplied master key: `--secret-key` wins;
+ * otherwise prompt (no-echo) when interactive; otherwise a teaching error naming
+ * that the key is excluded from backups and must be supplied. A present-but-
+ * malformed key is a teaching error too — and (crucially) we validate BEFORE any
+ * clone or write, so a bad key never clobbers the data dir.
+ *
+ * Returns the canonical 64-hex key on success, or a `CliResult` error to return.
+ */
+function resolveSuppliedKey(
+  flags: FlagMap,
+  deps: RestoreCommandDeps,
+): { keyHex: string } | { error: CliResult } {
+  let raw = flagString(flags["secret-key"]);
+  if (raw === undefined || raw.trim() === "") {
+    const interactive = deps.interactive ?? process.stdin.isTTY === true;
+    if (!interactive) {
+      return {
+        error: fail(
+          "restore needs the secret key (the master key), which is excluded from backups " +
+            "by design — supply it with --secret-key <hex>.\n" +
+            "Without it the vault restores but the server cannot decrypt restored secrets " +
+            "(e.g. the curator's LLM token). It is the 64-char hex key surfaced once at " +
+            "`server up` (SAVE THIS KEY).",
+        ),
+      };
+    }
+    const prompt =
+      deps.promptSecretKey ?? (() => readHiddenLine("Master key (hex, excluded from backups): "));
+    const entered = prompt();
+    if (!entered) {
+      return {
+        error: fail(
+          "No master key provided. Pass --secret-key <hex> or enter it at the prompt — " +
+            "it is excluded from backups and must be re-supplied to decrypt restored secrets.",
+        ),
+      };
+    }
+    raw = entered;
+  }
+
+  try {
+    // Validate (and canonicalise) without writing anything yet.
+    return { keyHex: resolveSecretKey(raw).toString("hex") };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      error: fail(
+        `Malformed --secret-key: ${message}.\n` +
+          "Expected the 64-char hex (or base64) master key surfaced at `server up`.",
+      ),
+    };
+  }
+}
+
+export function restoreCommand(
+  store: LibrarianStore,
+  _positionals: string[],
+  flags: FlagMap,
+  deps: RestoreCommandDeps = {},
+): CliResult {
+  const force = flags.force === true;
+
+  // 1. Resolve the backup remote the SAME way `backup` does.
+  const remote = resolveBackupRemote(store);
+  if (!remote) {
+    return fail(
+      "No backup remote configured — there is nothing to restore from. " +
+        "Set the GitHub repo + token in the backup settings first, then re-run restore.",
+    );
+  }
+
+  // 2. Resolve + validate the master key (BEFORE any clone/write).
+  const keyResult = resolveSuppliedKey(flags, deps);
+  if ("error" in keyResult) return keyResult.error;
+  const { keyHex } = keyResult;
+
+  // 3. Clobber guards — refuse to silently overwrite a populated data dir.
+  const vaultDir = resolveVaultPath({ dataDir: store.dataDir });
+  if (!force && isPopulatedVault(vaultDir)) {
+    return fail(
+      `The vault at ${vaultDir} already contains memories — refusing to overwrite them. ` +
+        "Re-run with --force to replace the existing vault with the backup.",
+    );
+  }
+
+  const keyFile = path.join(store.dataDir, SECRET_KEY_FILE);
+  if (!force && fs.existsSync(keyFile)) {
+    const existing = (() => {
+      try {
+        return resolveSecretKey(fs.readFileSync(keyFile, "utf8")).toString("hex");
+      } catch {
+        return null; // unreadable/malformed existing key → treat as differing
+      }
+    })();
+    if (existing !== keyHex) {
+      return fail(
+        `A different ${SECRET_KEY_FILE} already exists at ${keyFile} — refusing to overwrite ` +
+          "the master key on a populated data dir (it would orphan every already-encrypted " +
+          "secret). Re-run with --force if you mean to replace it.",
+      );
+    }
+  }
+
+  // 4. Clone the backup into the vault. git clone refuses an existing non-empty
+  //    dest, and the store git-initialises an empty `vault/` (it holds `.git`)
+  //    on construction — so always clear the dest first. The guard above already
+  //    secured the operator's consent before we reach a POPULATED vault.
+  const clone = deps.clone ?? cloneVaultBackup;
+  try {
+    fs.rmSync(vaultDir, { recursive: true, force: true });
+    clone({
+      remoteUrl: remote.auth.remoteUrl,
+      branch: remote.auth.branch,
+      token: remote.auth.token,
+      dest: vaultDir,
+    });
+  } catch (err) {
+    // Clone errors are already token-scrubbed at the clone site.
+    const message = err instanceof Error ? err.message : String(err);
+    return fail(`Restore failed while cloning ${remote.repo}: ${message}`);
+  }
+
+  // 5. Place the supplied master key (0600) so the server can decrypt secrets.
+  try {
+    writeSecretKeyFile(keyFile, keyHex, { force });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return fail(`Restore cloned the vault but could not write ${SECRET_KEY_FILE}: ${message}`);
+  }
+
+  // 6. Reindex the recall index from the restored vault (same path as `rebuild`).
+  store.reindex();
+
+  return ok(
+    `Restored the vault from ${remote.repo} into ${vaultDir}, placed ${SECRET_KEY_FILE} (0600), ` +
+      "and rebuilt the recall index.",
+  );
+}

--- a/packages/cli/src/commands/restore.ts
+++ b/packages/cli/src/commands/restore.ts
@@ -205,6 +205,9 @@ export function restoreCommand(
       branch: remote.auth.branch,
       token: remote.auth.token,
       dest: tempDir,
+      // The GIT_ASKPASS helper must run; a read_only container's /tmp is noexec.
+      // The data dir is writable + exec-capable (see runGitWithToken).
+      scratchDir: store.dataDir,
     });
   } catch (err) {
     // Clone errors are already token-scrubbed at the clone site. The original

--- a/packages/cli/src/commands/restore.ts
+++ b/packages/cli/src/commands/restore.ts
@@ -21,11 +21,13 @@
 // The clone is injected (`deps.clone`) so tests pin the guards + argv without
 // reaching github.com; production defaults to core's token-safe `cloneVaultBackup`.
 
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import {
   type LibrarianStore,
   cloneVaultBackup,
+  createJsonSettingsStore,
   resolveBackupRemote,
   resolveSecretKey,
   resolveVaultPath,
@@ -54,17 +56,35 @@ function fail(stdout: string): CliResult {
 }
 
 /**
- * True when `dir` holds actual vault CONTENT — any entry other than `.git`. A
- * freshly-constructed store git-initialises an otherwise-empty `vault/` (it
- * contains only `.git`), which is logically empty and safe to restore over; only
- * real memories (memories/inbox/references/… or any committed file) count as
- * populated and trigger the clobber guard.
+ * True when `dir` holds actual vault CONTENT. Two ways to be populated:
+ *   - a working-tree entry other than `.git` (real memories on disk), OR
+ *   - a committed HEAD (S-3): a `.git`-only dir whose history holds real
+ *     committed memories is NOT logically empty — clobbering it would lose that
+ *     history. A freshly-constructed store git-initialises an EMPTY `vault/`
+ *     (`.git` present but NO commits yet), which has no HEAD and is safe to
+ *     restore over.
+ * Either condition triggers the clobber guard.
  */
 function isPopulatedVault(dir: string): boolean {
+  let entries: string[];
   try {
-    return fs.readdirSync(dir).some((entry) => entry !== ".git");
+    entries = fs.readdirSync(dir);
   } catch {
     return false; // absent → empty
+  }
+  if (entries.some((entry) => entry !== ".git")) return true;
+  if (!entries.includes(".git")) return false; // empty dir, not even git-initialised
+  // `.git`-only: populated iff there is a committed HEAD (real history to lose).
+  return hasCommittedHead(dir);
+}
+
+/** True iff `git -C <dir> rev-parse HEAD` resolves a commit (the vault has history). */
+function hasCommittedHead(dir: string): boolean {
+  try {
+    execFileSync("git", ["-C", dir, "rev-parse", "--verify", "HEAD"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false; // no commits yet (or not a git repo) → empty
   }
 }
 
@@ -172,26 +192,57 @@ export function restoreCommand(
     }
   }
 
-  // 4. Clone the backup into the vault. git clone refuses an existing non-empty
-  //    dest, and the store git-initialises an empty `vault/` (it holds `.git`)
-  //    on construction — so always clear the dest first. The guard above already
-  //    secured the operator's consent before we reach a POPULATED vault.
+  // 4. Clone the backup into a TEMP sibling dir FIRST, then atomic-swap it into
+  //    place (I-1). git clone refuses an existing non-empty dest, so we clone a
+  //    pristine temp. CRUCIALLY the existing vault is NOT touched until the clone
+  //    succeeds: if `clone` throws, the operator's original vault stays intact.
   const clone = deps.clone ?? cloneVaultBackup;
+  const tempDir = `${vaultDir}.restore-${process.pid}-${Date.now()}`;
   try {
-    fs.rmSync(vaultDir, { recursive: true, force: true });
+    fs.rmSync(tempDir, { recursive: true, force: true }); // never clone onto a stale temp
     clone({
       remoteUrl: remote.auth.remoteUrl,
       branch: remote.auth.branch,
       token: remote.auth.token,
-      dest: vaultDir,
+      dest: tempDir,
     });
   } catch (err) {
-    // Clone errors are already token-scrubbed at the clone site.
+    // Clone errors are already token-scrubbed at the clone site. The original
+    // vault is UNTOUCHED — clean up the half-cloned temp and surface the error.
+    fs.rmSync(tempDir, { recursive: true, force: true });
     const message = err instanceof Error ? err.message : String(err);
-    return fail(`Restore failed while cloning ${remote.repo}: ${message}`);
+    return fail(
+      `Restore failed while cloning ${remote.repo}: ${message}\n` +
+        `Your existing vault at ${vaultDir} was left untouched.`,
+    );
   }
 
-  // 5. Place the supplied master key (0600) so the server can decrypt secrets.
+  // 5. VERIFY the supplied key actually decrypts this data dir's secrets (I-2)
+  //    BEFORE we swap the clone in or write the key. A shape-valid but WRONG key
+  //    would otherwise leave a server that can't decrypt any restored secret.
+  //    Verification reads the existing encrypted secret-store (settings.json,
+  //    which lives beside the vault and is unaffected by the clone) and attempts
+  //    a real decryption. No encrypted secret to check → skip (nothing to
+  //    orphan). On failure we abort with NOTHING swapped and the key NOT left
+  //    active — the original vault + key survive.
+  const verification = verifyKeyDecryptsExistingSecret(store.dataDir, keyHex);
+  if (verification.outcome === "mismatch") {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    return fail(
+      "The supplied --secret-key does not decrypt this backup's existing secrets — it is " +
+        "not the master key these secrets were encrypted with. Restore aborted: the wrong " +
+        "key was NOT made active, and your existing vault + secret.key were left untouched.\n" +
+        "Re-run with the 64-char hex master key surfaced at `server up` (SAVE THIS KEY).",
+    );
+  }
+
+  // 6. Atomic-ish swap: remove the old vault, then move the verified clone into
+  //    place. The clone already succeeded and the key already verified, so the
+  //    destructive step happens only once we know the restore can complete.
+  fs.rmSync(vaultDir, { recursive: true, force: true });
+  fs.renameSync(tempDir, vaultDir);
+
+  // 7. Place the supplied master key (0600) so the server can decrypt secrets.
   try {
     writeSecretKeyFile(keyFile, keyHex, { force });
   } catch (err) {
@@ -199,11 +250,45 @@ export function restoreCommand(
     return fail(`Restore cloned the vault but could not write ${SECRET_KEY_FILE}: ${message}`);
   }
 
-  // 6. Reindex the recall index from the restored vault (same path as `rebuild`).
+  // 8. Reindex the recall index from the restored vault (same path as `rebuild`).
   store.reindex();
 
+  const verifyNote =
+    verification.outcome === "verified"
+      ? "verified the supplied key decrypts the restored secrets, "
+      : "no encrypted secrets to verify the key against (skipped that check), ";
   return ok(
-    `Restored the vault from ${remote.repo} into ${vaultDir}, placed ${SECRET_KEY_FILE} (0600), ` +
-      "and rebuilt the recall index.",
+    `Restored the vault from ${remote.repo} into ${vaultDir}, ${verifyNote}` +
+      `placed ${SECRET_KEY_FILE} (0600), and rebuilt the recall index.`,
   );
+}
+
+/**
+ * Verify the operator-supplied master key actually decrypts this data dir's
+ * existing secret-store (I-2). The encrypted admin secrets live in
+ * `<dataDir>/settings.json` (beside, not inside, the git vault), so a populated
+ * data dir carries them even after the vault is re-cloned. We open that store
+ * with the SUPPLIED key and attempt to decrypt the first secret entry — a wrong
+ * key fails the AES-GCM authentication and throws (`decryptSecret` never returns
+ * unauthenticated plaintext). Outcomes:
+ *   - `verified`: a secret decrypted cleanly under the supplied key.
+ *   - `skip`: there are no encrypted secrets to check (nothing to orphan).
+ *   - `mismatch`: an encrypted secret exists but the key fails to decrypt it.
+ */
+function verifyKeyDecryptsExistingSecret(
+  dataDir: string,
+  keyHex: string,
+): { outcome: "verified" | "skip" | "mismatch" } {
+  const settings = createJsonSettingsStore({
+    filePath: path.join(dataDir, "settings.json"),
+    secretKey: resolveSecretKey(keyHex),
+  });
+  const firstSecret = settings.listSettings().find((entry) => entry.is_secret);
+  if (!firstSecret) return { outcome: "skip" };
+  try {
+    settings.getSetting(firstSecret.key); // decrypts under the supplied key
+    return { outcome: "verified" };
+  } catch {
+    return { outcome: "mismatch" };
+  }
 }

--- a/packages/cli/src/runtime.ts
+++ b/packages/cli/src/runtime.ts
@@ -16,6 +16,7 @@ import { backupCommand } from "./commands/backup.js";
 import { exportCommand } from "./commands/export.js";
 import { handoffVerbs } from "./commands/index.js";
 import { migrateDataDirCommand } from "./commands/migrate-data-dir.js";
+import { restoreCommand } from "./commands/restore.js";
 import { parseFlags } from "./parse-flags.js";
 
 export type { CliResult } from "./commands/_shared.js";
@@ -23,6 +24,7 @@ export type { CliResult } from "./commands/_shared.js";
 // Top-level commands that take flags (unlike the bare rebuild/seed).
 const topLevelCommands: Record<string, Command> = {
   backup: backupCommand,
+  restore: restoreCommand,
   export: exportCommand,
   "migrate-data-dir": migrateDataDirCommand,
 };
@@ -132,6 +134,8 @@ export function usage(): string {
     "  rebuild                       Rebuild the memory index from stored data",
     "  seed                          Seed sample memories (no-op if any exist)",
     "  backup                        Push the memory vault to the configured GitHub remote",
+    "  restore [--secret-key <hex>] [--force]",
+    "                                Clone the backup remote into the data dir (re-supply the master key)",
     "  export [--format ndjson|json] Dump memories to stdout",
     "  migrate-data-dir [--data-dir <path>]",
     "                                Migrate a pre-1.0 data dir (reports, never deletes)",

--- a/packages/cli/tests/restore-commands.test.ts
+++ b/packages/cli/tests/restore-commands.test.ts
@@ -1,0 +1,210 @@
+// `the-librarian restore` — clone the configured backup remote into the data
+// dir's vault and place the operator-supplied master key so the server can
+// decrypt restored secrets (the key is excluded from backups, spec §6/§7).
+//
+// The real clone reaches github.com, so the clone is an injected seam here; the
+// tests pin the guards (no remote, missing/malformed key, clobber refusal) and
+// that a happy-path restore clones, writes secret.key (0600), and reindexes.
+//
+// GitGuardian-safety: any 64-hex key is assembled from sub-threshold parts at
+// runtime — the committed source never contains a contiguous 64-hex run.
+
+import { randomBytes } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { type LibrarianStore, resolveSecretKey } from "@librarian/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { withStore } from "../../../test/helpers.js";
+import { restoreCommand } from "../src/commands/restore.js";
+import { runCli } from "../src/runtime.js";
+
+// A well-formed 64-hex key, assembled at runtime (never a contiguous literal).
+function freshKeyHex(): string {
+  return randomBytes(32).toString("hex");
+}
+
+const VAULT_DIRS = ["memories", "inbox", "references", "handoffs"];
+
+// A stub clone that materialises a minimal Librarian-vault-shaped dir at `dest`,
+// mirroring what `git clone` would leave behind — so the post-clone reindex has
+// something to walk and the test can assert the clone target.
+function fakeClone(opts: { remoteUrl: string; branch: string; token: string; dest: string }) {
+  fs.mkdirSync(opts.dest, { recursive: true });
+  fs.mkdirSync(path.join(opts.dest, ".git"), { recursive: true });
+  for (const d of VAULT_DIRS) fs.mkdirSync(path.join(opts.dest, d), { recursive: true });
+  fs.writeFileSync(path.join(opts.dest, "memories", "seed.md"), "# seed\n");
+}
+
+// Configure a backup remote via the env fallback (no master key needed), and
+// restore the prior env afterwards.
+const SAVED_ENV: Record<string, string | undefined> = {};
+function withBackupRemote() {
+  for (const k of ["LIBRARIAN_BACKUP_GITHUB_REPO", "LIBRARIAN_BACKUP_GITHUB_TOKEN"]) {
+    SAVED_ENV[k] = process.env[k];
+  }
+  process.env.LIBRARIAN_BACKUP_GITHUB_REPO = "octocat/backup";
+  // Assembled from parts so the committed source carries no real-looking PAT
+  // (the value only needs to be a non-empty placeholder for resolveBackupRemote).
+  process.env.LIBRARIAN_BACKUP_GITHUB_TOKEN = ["fake", "backup", "token"].join("-");
+}
+afterEach(() => {
+  for (const [k, v] of Object.entries(SAVED_ENV)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
+function vaultPath(dataDir: string): string {
+  return path.join(dataDir, "vault");
+}
+
+describe("the-librarian restore", () => {
+  it("clones, writes secret.key (0600) with the supplied key, and reindexes", async () => {
+    withBackupRemote();
+    await withStore(async (store: LibrarianStore, dataDir: string) => {
+      const supplied = freshKeyHex();
+      const clone = vi.fn(fakeClone);
+      const reindex = vi.spyOn(store, "reindex");
+
+      const r = restoreCommand(store, [], { "secret-key": supplied }, { clone });
+
+      expect(r.exitCode).toBe(0);
+      // Cloned into the data dir's vault from the configured remote.
+      expect(clone).toHaveBeenCalledTimes(1);
+      const opts = clone.mock.calls[0]![0];
+      expect(opts.dest).toBe(vaultPath(dataDir));
+      expect(opts.remoteUrl).toContain("octocat/backup");
+      // secret.key written with the supplied key, owner-only.
+      const keyFile = path.join(dataDir, "secret.key");
+      expect(fs.readFileSync(keyFile, "utf8").trim()).toBe(
+        resolveSecretKey(supplied).toString("hex"),
+      );
+      expect(fs.statSync(keyFile).mode & 0o077).toBe(0);
+      // Recall index rebuilt from the restored vault.
+      expect(reindex).toHaveBeenCalledTimes(1);
+      // The placed key decrypts secrets: a store opened against this data dir +
+      // key can read the canonical key back.
+      expect(
+        resolveSecretKey(fs.readFileSync(keyFile, "utf8")).equals(resolveSecretKey(supplied)),
+      ).toBe(true);
+    });
+  });
+
+  it("refuses with no backup remote configured — no clone, no key written", async () => {
+    // No withBackupRemote(): ensure the env fallback is absent for this test.
+    delete process.env.LIBRARIAN_BACKUP_GITHUB_REPO;
+    delete process.env.LIBRARIAN_BACKUP_GITHUB_TOKEN;
+    await withStore(async (store: LibrarianStore, dataDir: string) => {
+      const clone = vi.fn(fakeClone);
+      const r = restoreCommand(store, [], { "secret-key": freshKeyHex() }, { clone });
+      expect(r.exitCode).toBe(1);
+      expect(r.stdout).toMatch(/no backup remote/i);
+      expect(clone).not.toHaveBeenCalled();
+      expect(fs.existsSync(path.join(dataDir, "secret.key"))).toBe(false);
+    });
+  });
+
+  it("errors when --secret-key is absent and non-interactive — names the backup exclusion, no clone", async () => {
+    withBackupRemote();
+    await withStore(async (store: LibrarianStore, dataDir: string) => {
+      const clone = vi.fn(fakeClone);
+      const r = restoreCommand(store, [], {}, { clone, interactive: false });
+      expect(r.exitCode).toBe(1);
+      expect(r.stdout).toMatch(/secret key/i);
+      expect(r.stdout).toMatch(/excluded from backups/i);
+      // Nothing clobbered: no clone, no restored content, no key written.
+      expect(clone).not.toHaveBeenCalled();
+      expect(fs.existsSync(path.join(vaultPath(dataDir), "memories", "seed.md"))).toBe(false);
+      expect(fs.existsSync(path.join(dataDir, "secret.key"))).toBe(false);
+    });
+  });
+
+  it("prompts for the secret key when absent and interactive", async () => {
+    withBackupRemote();
+    await withStore(async (store: LibrarianStore, dataDir: string) => {
+      const supplied = freshKeyHex();
+      const clone = vi.fn(fakeClone);
+      const r = restoreCommand(
+        store,
+        [],
+        {},
+        { clone, interactive: true, promptSecretKey: () => supplied },
+      );
+      expect(r.exitCode).toBe(0);
+      expect(clone).toHaveBeenCalledTimes(1);
+      expect(fs.readFileSync(path.join(dataDir, "secret.key"), "utf8").trim()).toBe(
+        resolveSecretKey(supplied).toString("hex"),
+      );
+    });
+  });
+
+  it("rejects a malformed --secret-key — teaching error, nothing written", async () => {
+    withBackupRemote();
+    await withStore(async (store: LibrarianStore, dataDir: string) => {
+      const clone = vi.fn(fakeClone);
+      const r = restoreCommand(store, [], { "secret-key": "tooshort" }, { clone });
+      expect(r.exitCode).toBe(1);
+      expect(r.stdout).toMatch(/secret key|32 bytes/i);
+      expect(clone).not.toHaveBeenCalled();
+      expect(fs.existsSync(path.join(vaultPath(dataDir), "memories", "seed.md"))).toBe(false);
+      expect(fs.existsSync(path.join(dataDir, "secret.key"))).toBe(false);
+    });
+  });
+
+  it("refuses a non-empty vault without --force, then proceeds with --force", async () => {
+    withBackupRemote();
+    await withStore(async (store: LibrarianStore, dataDir: string) => {
+      // Pre-existing non-empty vault (existing memories).
+      const vault = vaultPath(dataDir);
+      fs.mkdirSync(path.join(vault, "memories"), { recursive: true });
+      fs.writeFileSync(path.join(vault, "memories", "existing.md"), "# keep me\n");
+
+      const supplied = freshKeyHex();
+      const clone = vi.fn(fakeClone);
+
+      const refused = restoreCommand(store, [], { "secret-key": supplied }, { clone });
+      expect(refused.exitCode).toBe(1);
+      expect(refused.stdout).toMatch(/--force/);
+      expect(clone).not.toHaveBeenCalled();
+      // The existing vault is untouched.
+      expect(fs.existsSync(path.join(vault, "memories", "existing.md"))).toBe(true);
+
+      const forced = restoreCommand(store, [], { "secret-key": supplied, force: true }, { clone });
+      expect(forced.exitCode).toBe(0);
+      expect(clone).toHaveBeenCalledTimes(1);
+      // The clobbered vault is the restored one (the stub's seed, not the old file).
+      expect(fs.existsSync(path.join(vault, "memories", "existing.md"))).toBe(false);
+      expect(fs.existsSync(path.join(vault, "memories", "seed.md"))).toBe(true);
+    });
+  });
+
+  it("refuses to overwrite a differing existing secret.key without --force", async () => {
+    withBackupRemote();
+    await withStore(async (store: LibrarianStore, dataDir: string) => {
+      const existing = freshKeyHex();
+      fs.writeFileSync(path.join(dataDir, "secret.key"), existing, { mode: 0o600 });
+
+      const supplied = freshKeyHex();
+      const clone = vi.fn(fakeClone);
+      const r = restoreCommand(store, [], { "secret-key": supplied }, { clone });
+      expect(r.exitCode).toBe(1);
+      expect(r.stdout).toMatch(/secret\.key|--force/i);
+      expect(clone).not.toHaveBeenCalled();
+      // The existing key is intact.
+      expect(fs.readFileSync(path.join(dataDir, "secret.key"), "utf8").trim()).toBe(existing);
+    });
+  });
+
+  it("is reachable through the CLI dispatcher (runtime wiring)", async () => {
+    // No remote configured → the dispatched command hits the no-remote guard,
+    // proving `restore` is wired into runCli (not an unknown command).
+    delete process.env.LIBRARIAN_BACKUP_GITHUB_REPO;
+    delete process.env.LIBRARIAN_BACKUP_GITHUB_TOKEN;
+    await withStore(async (store: LibrarianStore) => {
+      const r = runCli(["restore", "--secret-key", freshKeyHex()], store);
+      expect(r.exitCode).toBe(1);
+      expect(r.stdout).toMatch(/no backup remote/i);
+      expect(r.stdout).not.toMatch(/unknown command/i);
+    });
+  });
+});

--- a/packages/cli/tests/restore-commands.test.ts
+++ b/packages/cli/tests/restore-commands.test.ts
@@ -9,10 +9,11 @@
 // GitGuardian-safety: any 64-hex key is assembled from sub-threshold parts at
 // runtime — the committed source never contains a contiguous 64-hex run.
 
+import { execFileSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import { type LibrarianStore, resolveSecretKey } from "@librarian/core";
+import { type LibrarianStore, createJsonSettingsStore, resolveSecretKey } from "@librarian/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { withStore } from "../../../test/helpers.js";
 import { restoreCommand } from "../src/commands/restore.js";
@@ -58,6 +59,17 @@ function vaultPath(dataDir: string): string {
   return path.join(dataDir, "vault");
 }
 
+// Seed an AES-GCM-encrypted secret into the data dir's settings store (the file
+// `restore`'s key-verification reads back), encrypted under `keyHex`. This is the
+// existing-encrypted-secret an over-the-top `--force` restore must not orphan.
+function seedEncryptedSecret(dataDir: string, keyHex: string): void {
+  const settings = createJsonSettingsStore({
+    filePath: path.join(dataDir, "settings.json"),
+    secretKey: resolveSecretKey(keyHex),
+  });
+  settings.setSetting("curator.llm_token", "the-curator-llm-token", { secret: true });
+}
+
 describe("the-librarian restore", () => {
   it("clones, writes secret.key (0600) with the supplied key, and reindexes", async () => {
     withBackupRemote();
@@ -69,11 +81,18 @@ describe("the-librarian restore", () => {
       const r = restoreCommand(store, [], { "secret-key": supplied }, { clone });
 
       expect(r.exitCode).toBe(0);
-      // Cloned into the data dir's vault from the configured remote.
+      // Cloned from the configured remote into a TEMP sibling of the vault first
+      // (I-1 atomic swap), then swapped into the vault path — so the clone dest
+      // is a `vault.restore-…` temp, but the restored content ends up at vault/.
       expect(clone).toHaveBeenCalledTimes(1);
       const opts = clone.mock.calls[0]![0];
-      expect(opts.dest).toBe(vaultPath(dataDir));
+      expect(opts.dest).not.toBe(vaultPath(dataDir));
+      expect(opts.dest.startsWith(`${vaultPath(dataDir)}.restore-`)).toBe(true);
       expect(opts.remoteUrl).toContain("octocat/backup");
+      // After the swap the restored content lives at the canonical vault path,
+      // and the temp clone dir is gone.
+      expect(fs.existsSync(path.join(vaultPath(dataDir), "memories", "seed.md"))).toBe(true);
+      expect(fs.existsSync(opts.dest)).toBe(false);
       // secret.key written with the supplied key, owner-only.
       const keyFile = path.join(dataDir, "secret.key");
       expect(fs.readFileSync(keyFile, "utf8").trim()).toBe(
@@ -192,6 +211,124 @@ describe("the-librarian restore", () => {
       expect(clone).not.toHaveBeenCalled();
       // The existing key is intact.
       expect(fs.readFileSync(path.join(dataDir, "secret.key"), "utf8").trim()).toBe(existing);
+    });
+  });
+
+  it("survives a clone failure with --force — the pre-existing vault is left intact (I-1)", async () => {
+    withBackupRemote();
+    await withStore(async (store: LibrarianStore, dataDir: string) => {
+      // A populated live vault the operator is replacing.
+      const vault = vaultPath(dataDir);
+      fs.mkdirSync(path.join(vault, "memories"), { recursive: true });
+      fs.writeFileSync(path.join(vault, "memories", "precious.md"), "# do not lose me\n");
+
+      // A clone that fails AFTER the guards pass (e.g. github.com unreachable).
+      const clone = vi.fn(() => {
+        throw new Error("fatal: could not read from remote repository");
+      });
+
+      const r = restoreCommand(store, [], { "secret-key": freshKeyHex(), force: true }, { clone });
+
+      expect(r.exitCode).toBe(1);
+      expect(r.stdout).toMatch(/restore failed|cloning/i);
+      // THE INVARIANT: the original vault and its contents still exist.
+      expect(fs.existsSync(path.join(vault, "memories", "precious.md"))).toBe(true);
+      expect(fs.readFileSync(path.join(vault, "memories", "precious.md"), "utf8")).toBe(
+        "# do not lose me\n",
+      );
+      // No half-restored temp dir was left lying around in the data dir.
+      const stragglers = fs
+        .readdirSync(dataDir)
+        .filter((e) => e !== "vault" && e.startsWith("vault"));
+      expect(stragglers).toEqual([]);
+    });
+  });
+
+  it("verifies the supplied key decrypts a restored encrypted secret — wrong key rejected, not left active (I-2)", async () => {
+    withBackupRemote();
+    await withStore(async (store: LibrarianStore, dataDir: string) => {
+      // The data dir already holds a secret encrypted under the RIGHT key, plus
+      // that right key on disk. We restore over it with --force and a WRONG key.
+      const rightKey = freshKeyHex();
+      seedEncryptedSecret(dataDir, rightKey);
+      const keyFile = path.join(dataDir, "secret.key");
+      fs.writeFileSync(keyFile, rightKey, { mode: 0o600 });
+
+      const wrongKey = freshKeyHex();
+      const clone = vi.fn(fakeClone);
+
+      const r = restoreCommand(store, [], { "secret-key": wrongKey, force: true }, { clone });
+
+      expect(r.exitCode).toBe(1);
+      // A teaching error naming the key/backup mismatch.
+      expect(r.stdout).toMatch(/key.*(does not|doesn't|cannot|can't).*(match|decrypt)|wrong key/i);
+      // The WRONG key was NOT left active — the prior right key survives.
+      expect(fs.readFileSync(keyFile, "utf8").trim()).toBe(
+        resolveSecretKey(rightKey).toString("hex"),
+      );
+      // The right key still decrypts the still-present secret.
+      const settings = createJsonSettingsStore({
+        filePath: path.join(dataDir, "settings.json"),
+        secretKey: resolveSecretKey(rightKey),
+      });
+      expect(settings.getSetting("curator.llm_token")).toBe("the-curator-llm-token");
+    });
+  });
+
+  it("accepts the RIGHT key over a vault with an encrypted secret (I-2)", async () => {
+    withBackupRemote();
+    await withStore(async (store: LibrarianStore, dataDir: string) => {
+      const rightKey = freshKeyHex();
+      seedEncryptedSecret(dataDir, rightKey);
+      fs.writeFileSync(path.join(dataDir, "secret.key"), rightKey, { mode: 0o600 });
+
+      const clone = vi.fn(fakeClone);
+      const r = restoreCommand(store, [], { "secret-key": rightKey, force: true }, { clone });
+
+      expect(r.exitCode).toBe(0);
+      expect(clone).toHaveBeenCalledTimes(1);
+      expect(fs.readFileSync(path.join(dataDir, "secret.key"), "utf8").trim()).toBe(
+        resolveSecretKey(rightKey).toString("hex"),
+      );
+    });
+  });
+
+  it("skips key verification when there are NO encrypted secrets, and says so (I-2)", async () => {
+    withBackupRemote();
+    await withStore(async (store: LibrarianStore, dataDir: string) => {
+      // No settings.json / no encrypted secret to orphan: ANY well-formed key is fine.
+      const supplied = freshKeyHex();
+      const clone = vi.fn(fakeClone);
+      const r = restoreCommand(store, [], { "secret-key": supplied, force: true }, { clone });
+
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toMatch(/no encrypted secret|nothing to verify|skip/i);
+      expect(fs.readFileSync(path.join(dataDir, "secret.key"), "utf8").trim()).toBe(
+        resolveSecretKey(supplied).toString("hex"),
+      );
+    });
+  });
+
+  it("treats a .git-only vault with committed history as populated (S-3)", async () => {
+    withBackupRemote();
+    await withStore(async (store: LibrarianStore, dataDir: string) => {
+      // A real git repo with a committed HEAD but no working-tree entries other
+      // than .git (e.g. all files were removed but history remains). The dir-entry
+      // heuristic would call this "empty"; a committed HEAD means it is NOT.
+      const vault = vaultPath(dataDir);
+      fs.rmSync(vault, { recursive: true, force: true });
+      fs.mkdirSync(vault, { recursive: true });
+      const git = (args: string[]) => execFileSync("git", args, { cwd: vault, stdio: "ignore" });
+      git(["init", "-q"]);
+      git(["config", "user.email", "t@example.com"]);
+      git(["config", "user.name", "t"]);
+      git(["commit", "-q", "--allow-empty", "-m", "vault: seed"]);
+
+      const clone = vi.fn(fakeClone);
+      const refused = restoreCommand(store, [], { "secret-key": freshKeyHex() }, { clone });
+      expect(refused.exitCode).toBe(1);
+      expect(refused.stdout).toMatch(/--force/);
+      expect(clone).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/cli/tests/snapshots.test.ts
+++ b/packages/cli/tests/snapshots.test.ts
@@ -16,6 +16,8 @@ describe("CLI snapshots", () => {
         rebuild                       Rebuild the memory index from stored data
         seed                          Seed sample memories (no-op if any exist)
         backup                        Push the memory vault to the configured GitHub remote
+        restore [--secret-key <hex>] [--force]
+                                      Clone the backup remote into the data dir (re-supply the master key)
         export [--format ndjson|json] Dump memories to stdout
         migrate-data-dir [--data-dir <path>]
                                       Migrate a pre-1.0 data dir (reports, never deletes)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -176,6 +176,7 @@ export {
   loadOrCreateSecretKeyFile,
   resolveOptionalSecretKey,
   resolveSecretKey,
+  writeSecretKeyFile,
 } from "./secret-crypto.js";
 export {
   type GroomingConfig,

--- a/packages/core/src/secret-crypto.ts
+++ b/packages/core/src/secret-crypto.ts
@@ -117,6 +117,34 @@ export function loadOrCreateSecretKeyFile(filePath: string, io: FileIo = fs): Lo
 }
 
 /**
+ * Place an operator-SUPPLIED master key at `filePath` — the restore path
+ * (`the-librarian restore`), where the key is excluded from backups and must be
+ * re-supplied so the server can decrypt restored secrets. Distinct from
+ * {@link loadOrCreateSecretKeyFile}, which GENERATES a key when absent: here the
+ * key comes from the operator, so we validate it through {@link resolveSecretKey}
+ * (a malformed/low-entropy key throws BEFORE any write — nothing lands on disk)
+ * and persist the canonical 64-char hex form `resolveSecretKey` accepts (so a
+ * base64-supplied key is normalised, never a second on-disk format).
+ *
+ * - Default (`force` omitted/false): `open('wx', 0o600)` — refuses to clobber an
+ *   existing key (overwriting the master key on a populated data dir is
+ *   destructive: it orphans every already-encrypted secret). Owner-only from
+ *   creation.
+ * - `force: true`: `open('w', 0o600)` — overwrite (the restore `--force` path,
+ *   where the operator has accepted replacing the data dir).
+ */
+export function writeSecretKeyFile(
+  filePath: string,
+  rawKey: string | undefined,
+  options: { force?: boolean; io?: FileIo } = {},
+): void {
+  const io = options.io ?? fs;
+  // Validate first → a bad key throws here, before we touch the filesystem.
+  const keyHex = resolveSecretKey(rawKey).toString("hex");
+  io.writeFileSync(filePath, keyHex, { flag: options.force ? "w" : "wx", mode: 0o600 });
+}
+
+/**
  * Encrypt a UTF-8 string. Returns a self-describing payload
  * `gcm1.<iv>.<tag>.<ciphertext>` (each segment base64; base64 never contains
  * `.`, so the segments are unambiguous).

--- a/packages/core/src/store/git/sync-git-ops.ts
+++ b/packages/core/src/store/git/sync-git-ops.ts
@@ -70,7 +70,15 @@ export interface SyncGitOps {
   push(auth: GitPushAuth): void;
 }
 
-export function createSyncGitOps(opts: { cwd: string }): SyncGitOps {
+export function createSyncGitOps(opts: {
+  cwd: string;
+  /**
+   * Exec-capable dir for the transient GIT_ASKPASS helper used by `push` — pass
+   * the data dir. Defaults to os.tmpdir(). See `runGitWithToken` for why this
+   * matters under `read_only` containers (noexec /tmp).
+   */
+  scratchDir?: string;
+}): SyncGitOps {
   fs.mkdirSync(opts.cwd, { recursive: true });
 
   const git = (args: string[], env?: NodeJS.ProcessEnv): string =>
@@ -167,7 +175,7 @@ export function createSyncGitOps(opts: { cwd: string }): SyncGitOps {
     runGitWithToken(
       ["push", auth.remoteUrl, `${auth.ref ?? "HEAD"}:refs/heads/${auth.branch}`],
       auth.token,
-      opts.cwd,
+      { cwd: opts.cwd, scratchDir: opts.scratchDir },
     );
   }
 
@@ -181,13 +189,28 @@ export function createSyncGitOps(opts: { cwd: string }): SyncGitOps {
  * git's error output (scrubbed from message + stderr at the source). Shared by
  * push + clone.
  */
-function runGitWithToken(args: string[], token: string, cwd?: string): string {
-  const askDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-askpass-"));
+function runGitWithToken(
+  args: string[],
+  token: string,
+  runOpts: { cwd?: string | undefined; scratchDir?: string | undefined } = {},
+): string {
+  // The GIT_ASKPASS helper must be EXECUTABLE, which makes its location load-
+  // bearing in a hardened deployment: a `read_only` container mounts /tmp as a
+  // `noexec` tmpfs, so an askpass.sh under os.tmpdir() fails to exec ("cannot
+  // exec … Permission denied") and the backup push falls back to a (disabled)
+  // password prompt. Callers therefore pass `scratchDir` = the data dir — a
+  // writable, exec-capable volume that sits OUTSIDE the vault working tree (the
+  // vault repo is `<dataDir>/vault`), so the helper always runs and is never
+  // swept into a commit. Falls back to os.tmpdir() for tests / non-container
+  // callers that don't set it. The helper still reads the token from the child's
+  // env (never embedded in the file), so its location carries no secret.
+  const scratchBase = runOpts.scratchDir ?? os.tmpdir();
+  const askDir = fs.mkdtempSync(path.join(scratchBase, "librarian-askpass-"));
   const helper = path.join(askDir, "askpass.sh");
   fs.writeFileSync(helper, '#!/bin/sh\nprintf "%s" "$LIBRARIAN_GIT_TOKEN"\n', { mode: 0o700 });
   try {
     return execFileSync("git", args, {
-      ...(cwd ? { cwd } : {}),
+      ...(runOpts.cwd ? { cwd: runOpts.cwd } : {}),
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
       env: {
@@ -220,10 +243,16 @@ export function cloneVaultBackup(opts: {
   branch: string;
   token: string;
   dest: string;
+  /**
+   * Exec-capable dir for the transient GIT_ASKPASS helper (pass the data dir).
+   * Defaults to os.tmpdir(). See `runGitWithToken` (noexec /tmp under read_only).
+   */
+  scratchDir?: string;
 }): void {
   fs.mkdirSync(path.dirname(opts.dest), { recursive: true });
   runGitWithToken(
     ["clone", "--branch", opts.branch, "--single-branch", opts.remoteUrl, opts.dest],
     opts.token,
+    { scratchDir: opts.scratchDir },
   );
 }

--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -214,7 +214,11 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Libra
   // Memory + handoff live in the git vault; settings/secrets in sidecar JSON
   // files outside it.
   const vault = createVault({ dataDir });
-  const git = createSyncGitOps({ cwd: vault.root });
+  // scratchDir = the data dir: the GIT_ASKPASS helper push() writes must be on an
+  // exec-capable filesystem, and a read_only container's /tmp is noexec (would
+  // break backup). The data dir is a writable, exec-capable volume outside the
+  // vault working tree (`<dataDir>/vault`). See runGitWithToken.
+  const git = createSyncGitOps({ cwd: vault.root, scratchDir: dataDir });
   git.init();
   const commit = (message: string): void => {
     git.commitAll(message);

--- a/packages/core/tests/secret-crypto.test.ts
+++ b/packages/core/tests/secret-crypto.test.ts
@@ -15,6 +15,7 @@ import {
   loadOrCreateSecretKeyFile,
   resolveOptionalSecretKey,
   resolveSecretKey,
+  writeSecretKeyFile,
 } from "@librarian/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -156,6 +157,66 @@ describe("loadOrCreateSecretKeyFile", () => {
     expect(() => loadOrCreateSecretKeyFile(file)).toThrow(/32 bytes/i);
     // The bad file is left intact for the operator to inspect, not clobbered.
     expect(fs.readFileSync(file, "utf8")).toBe("not-a-valid-key");
+  });
+});
+
+describe("writeSecretKeyFile", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "lib-key-write-"));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes a supplied valid key as 64-char hex in a 0600 file", () => {
+    const file = path.join(dir, "secret.key");
+    const supplied = randomBytes(32).toString("hex");
+    writeSecretKeyFile(file, supplied);
+    expect(fs.readFileSync(file, "utf8").trim()).toMatch(/^[0-9a-f]{64}$/);
+    // Round-trips to the supplied key (canonicalised to lowercase hex).
+    expect(loadOrCreateSecretKeyFile(file).key.equals(resolveSecretKey(supplied))).toBe(true);
+    // Owner-only (umask-robust).
+    expect(fs.statSync(file).mode & 0o077).toBe(0);
+  });
+
+  it("normalises a base64-supplied key to the canonical 64-hex on-disk form", () => {
+    const file = path.join(dir, "secret.key");
+    const raw = randomBytes(32);
+    writeSecretKeyFile(file, raw.toString("base64"));
+    expect(fs.readFileSync(file, "utf8").trim()).toBe(raw.toString("hex"));
+  });
+
+  it("rejects a malformed key and writes nothing", () => {
+    const file = path.join(dir, "secret.key");
+    expect(() => writeSecretKeyFile(file, "tooshort")).toThrow(/32 bytes/i);
+    expect(fs.existsSync(file)).toBe(false);
+  });
+
+  it("rejects a low-entropy key and writes nothing", () => {
+    const file = path.join(dir, "secret.key");
+    expect(() => writeSecretKeyFile(file, "00".repeat(32))).toThrow(/entropy/i);
+    expect(fs.existsSync(file)).toBe(false);
+  });
+
+  it("refuses to overwrite an existing key file by default", () => {
+    const file = path.join(dir, "secret.key");
+    const first = randomBytes(32).toString("hex");
+    writeSecretKeyFile(file, first);
+    const second = randomBytes(32).toString("hex");
+    expect(() => writeSecretKeyFile(file, second)).toThrow(/exists/i);
+    // The original is left intact.
+    expect(fs.readFileSync(file, "utf8").trim()).toBe(first);
+  });
+
+  it("overwrites an existing key file when force is set, keeping 0600", () => {
+    const file = path.join(dir, "secret.key");
+    const first = randomBytes(32).toString("hex");
+    writeSecretKeyFile(file, first);
+    const second = randomBytes(32).toString("hex");
+    writeSecretKeyFile(file, second, { force: true });
+    expect(fs.readFileSync(file, "utf8").trim()).toBe(second);
+    expect(fs.statSync(file).mode & 0o077).toBe(0);
   });
 });
 

--- a/packages/core/tests/store/git/sync-git-ops.test.ts
+++ b/packages/core/tests/store/git/sync-git-ops.test.ts
@@ -10,7 +10,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { cloneVaultBackup, createSyncGitOps } from "@librarian/core";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 let cwd: string;
 
@@ -213,6 +213,67 @@ describe("sync git-ops", () => {
     } finally {
       fs.rmSync(remote, { recursive: true, force: true });
       fs.rmSync(dest, { recursive: true, force: true });
+    }
+  });
+
+  // Regression: the GIT_ASKPASS helper must be created under the caller-supplied
+  // scratchDir (the data dir), NOT os.tmpdir(). A read_only container mounts /tmp
+  // as a noexec tmpfs, so a helper under os.tmpdir() can't exec → backup push
+  // fails ("cannot exec … Permission denied"). scratchDir = the exec-capable data
+  // volume keeps it runnable.
+  it("push writes the GIT_ASKPASS helper under scratchDir, not os.tmpdir()", () => {
+    const scratchDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-scratch-"));
+    const git = createSyncGitOps({ cwd, scratchDir });
+    git.init();
+    write("memories/a.md", "hello\n");
+    git.commitAll("memory: a");
+
+    const remote = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-remote-"));
+    execFileSync("git", ["init", "--bare", remote], { stdio: "ignore" });
+    const spy = vi.spyOn(fs, "mkdtempSync");
+    try {
+      git.push({ remoteUrl: remote, branch: "main", token: "tok" });
+
+      const askpassDirs = spy.mock.calls
+        .map((c) => String(c[0]))
+        .filter((p) => p.includes("librarian-askpass-"));
+      expect(askpassDirs.length).toBeGreaterThan(0); // push did create the helper dir
+      for (const dir of askpassDirs) {
+        expect(dir.startsWith(scratchDir)).toBe(true); // under scratchDir, not /tmp
+      }
+    } finally {
+      spy.mockRestore();
+      fs.rmSync(remote, { recursive: true, force: true });
+      fs.rmSync(scratchDir, { recursive: true, force: true });
+    }
+  });
+
+  it("cloneVaultBackup writes the GIT_ASKPASS helper under scratchDir, not os.tmpdir()", () => {
+    const git = createSyncGitOps({ cwd });
+    git.init();
+    write("memories/a.md", "hello\n");
+    git.commitAll("memory: a");
+
+    const remote = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-remote-"));
+    const scratchDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-scratch-"));
+    const dest = path.join(scratchDir, "clone");
+    execFileSync("git", ["init", "--bare", remote], { stdio: "ignore" });
+    git.push({ remoteUrl: remote, branch: "main", token: "unused", scratchDir });
+    const spy = vi.spyOn(fs, "mkdtempSync");
+    try {
+      cloneVaultBackup({ remoteUrl: remote, branch: "main", token: "tok", dest, scratchDir });
+
+      const askpassDirs = spy.mock.calls
+        .map((c) => String(c[0]))
+        .filter((p) => p.includes("librarian-askpass-"));
+      expect(askpassDirs.length).toBeGreaterThan(0);
+      for (const dir of askpassDirs) {
+        expect(dir.startsWith(scratchDir)).toBe(true);
+      }
+    } finally {
+      spy.mockRestore();
+      fs.rmSync(remote, { recursive: true, force: true });
+      fs.rmSync(scratchDir, { recursive: true, force: true });
     }
   });
 });

--- a/packages/installer-cli/src/runtime.ts
+++ b/packages/installer-cli/src/runtime.ts
@@ -20,6 +20,7 @@ import { flagBool, flagString, parseArgs, type FlagMap } from "./parse-args.js";
 import { createPrompter, MissingValueError, type Prompter } from "./prompt.js";
 import { runDown } from "./server/down.js";
 import { isServerSubcommand, serverUsage, type ServerSubcommand } from "./server/index.js";
+import { runLogs } from "./server/logs.js";
 import { runUp } from "./server/up.js";
 import { status } from "./status.js";
 import { cliVersion } from "./version.js";
@@ -214,6 +215,9 @@ async function runServerCommand(rest: string[], options: RuntimeOptions): Promis
   if (subcommand === "down") {
     return runServerDownCommand();
   }
+  if (subcommand === "logs") {
+    return runServerLogsCommand(subRest);
+  }
   if (isServerSubcommand(subcommand)) {
     return serverSubcommandPending(subcommand);
   }
@@ -260,6 +264,20 @@ async function runServerUpCommand(rest: string[], options: RuntimeOptions): Prom
  */
 async function runServerDownCommand(): Promise<CliResult> {
   const result = await runDown({});
+  return ok(result.output);
+}
+
+/**
+ * `librarian server logs [-f] [--service mcp|dashboard|all]` (S4). `-f` is a
+ * short flag the tiny parser treats as a positional, so we accept it there (or
+ * `--follow`). `--service` selects which of the two co-located services to show
+ * (filtered from the combined stream). A bad `--service` value is a teaching
+ * error via the top-level catch.
+ */
+async function runServerLogsCommand(rest: string[]): Promise<CliResult> {
+  const { positionals, flags } = parseArgs(rest);
+  const follow = positionals.includes("-f") || flagBool(flags.follow) || flagBool(flags.f);
+  const result = await runLogs({ follow, service: flagString(flags.service) });
   return ok(result.output);
 }
 

--- a/packages/installer-cli/src/runtime.ts
+++ b/packages/installer-cli/src/runtime.ts
@@ -18,6 +18,7 @@ import { detectShell, type Shell } from "./env.js";
 import { allHarnesses } from "./harnesses/index.js";
 import { flagString, parseArgs, type FlagMap } from "./parse-args.js";
 import { createPrompter, MissingValueError, type Prompter } from "./prompt.js";
+import { isServerSubcommand, serverUsage, type ServerSubcommand } from "./server/index.js";
 import { status } from "./status.js";
 import { cliVersion } from "./version.js";
 
@@ -94,6 +95,10 @@ async function dispatch(argv: string[], options: RuntimeOptions): Promise<CliRes
   if (command === "doctor") {
     // Diagnostic: exits 0 even when it flags problems.
     return ok(await doctor(options.home));
+  }
+
+  if (command === "server") {
+    return runServerCommand(rest);
   }
 
   if (PHASE_2_STUBS.has(command)) {
@@ -179,6 +184,38 @@ async function runUpdateCommand(rest: string[], options: RuntimeOptions): Promis
   return outcome.failed.length > 0 ? errOut(outcome.output) : ok(outcome.output);
 }
 
+// --- server command group (self-host) ------------------------------------
+
+/**
+ * `librarian server [subcommand]`. With no subcommand (or `--help`/`-h`) it
+ * prints the command surface (§4). The individual subcommands land in their
+ * own slices (S2+); until then a known subcommand reports that it arrives in a
+ * later slice, and an unknown one errors with the surface. Preflight + the
+ * `docker.ts` seam exist now (S1) for those slices to call.
+ */
+function runServerCommand(rest: string[]): CliResult {
+  const [subcommand] = rest;
+
+  if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+    return ok(serverUsage());
+  }
+  if (isServerSubcommand(subcommand)) {
+    return serverSubcommandPending(subcommand);
+  }
+  return err(`Unknown server subcommand: ${subcommand}\n\n${serverUsage()}`);
+}
+
+function serverSubcommandPending(subcommand: ServerSubcommand): CliResult {
+  return ok(
+    [
+      `librarian server ${subcommand}: arrives in a later slice.`,
+      "",
+      "The `server` group is being built incrementally. Run `librarian server`",
+      "to see the full command surface.",
+    ].join("\n"),
+  );
+}
+
 // --- Phase 2 stubs (friendly "coming later") -----------------------------
 
 function runPhase2Stub(command: string): CliResult {
@@ -203,6 +240,7 @@ export function usage(): string {
     "  status                 Live table of harness / installed / version",
     "  doctor                 Diagnose token, server reachability, harness CLIs",
     "  config                 Show or set MCP URL, token, server URL",
+    "  server                 Self-host the Librarian server (run `server` for its commands)",
     "  self-update            Update the librarian CLI itself",
     "  report                 Push this machine's state to the server",
     "",

--- a/packages/installer-cli/src/runtime.ts
+++ b/packages/installer-cli/src/runtime.ts
@@ -21,6 +21,7 @@ import { createPrompter, MissingValueError, type Prompter } from "./prompt.js";
 import { runDown } from "./server/down.js";
 import { isServerSubcommand, serverUsage, type ServerSubcommand } from "./server/index.js";
 import { runLogs } from "./server/logs.js";
+import { serverStatus } from "./server/status.js";
 import { runUp } from "./server/up.js";
 import { status } from "./status.js";
 import { cliVersion } from "./version.js";
@@ -198,10 +199,11 @@ async function runUpdateCommand(rest: string[], options: RuntimeOptions): Promis
 
 /**
  * `librarian server [subcommand]`. With no subcommand (or `--help`/`-h`) it
- * prints the command surface (§4). `up` is implemented (S2, localhost path);
- * the remaining subcommands land in their own slices (S3+) and until then a
- * known one reports that it arrives in a later slice. An unknown subcommand
- * errors with the surface. Preflight + the `docker.ts` seam (S1) back `up`.
+ * prints the command surface (§4). Implemented: `up` (S2/S3), `down` / `logs` /
+ * `status` (S4). The remaining subcommands (`update`, `enable-boot`,
+ * `disable-boot`, `admin`) land in their own slices and until then a known one
+ * reports that it arrives in a later slice. An unknown subcommand errors with
+ * the surface. Preflight + the `docker.ts` seam (S1) back every container op.
  */
 async function runServerCommand(rest: string[], options: RuntimeOptions): Promise<CliResult> {
   const [subcommand, ...subRest] = rest;
@@ -217,6 +219,9 @@ async function runServerCommand(rest: string[], options: RuntimeOptions): Promis
   }
   if (subcommand === "logs") {
     return runServerLogsCommand(subRest);
+  }
+  if (subcommand === "status") {
+    return runServerStatusCommand(subRest, options);
   }
   if (isServerSubcommand(subcommand)) {
     return serverSubcommandPending(subcommand);
@@ -278,6 +283,18 @@ async function runServerLogsCommand(rest: string[]): Promise<CliResult> {
   const { positionals, flags } = parseArgs(rest);
   const follow = positionals.includes("-f") || flagBool(flags.follow) || flagBool(flags.f);
   const result = await runLogs({ follow, service: flagString(flags.service) });
+  return ok(result.output);
+}
+
+/**
+ * `librarian server status` (S4). Reports running/health (from `docker inspect`)
+ * and the deployed-vs-latest badge (deploy-state ref vs `fetchLatestVersion`).
+ * Offline/unknown degrades to `unknown`/`?` and still exits 0 — only a missing
+ * docker (preflight) makes it non-zero, via the top-level catch.
+ */
+async function runServerStatusCommand(rest: string[], options: RuntimeOptions): Promise<CliResult> {
+  const { flags } = parseArgs(rest);
+  const result = await serverStatus({ home: options.home, dir: flagString(flags.dir) });
   return ok(result.output);
 }
 

--- a/packages/installer-cli/src/runtime.ts
+++ b/packages/installer-cli/src/runtime.ts
@@ -16,9 +16,10 @@ import { formatConfig, readConfig, redact, setConfig, type LibrarianConfig } fro
 import { doctor } from "./doctor.js";
 import { detectShell, type Shell } from "./env.js";
 import { allHarnesses } from "./harnesses/index.js";
-import { flagString, parseArgs, type FlagMap } from "./parse-args.js";
+import { flagBool, flagString, parseArgs, type FlagMap } from "./parse-args.js";
 import { createPrompter, MissingValueError, type Prompter } from "./prompt.js";
 import { isServerSubcommand, serverUsage, type ServerSubcommand } from "./server/index.js";
+import { runUp } from "./server/up.js";
 import { status } from "./status.js";
 import { cliVersion } from "./version.js";
 
@@ -98,7 +99,7 @@ async function dispatch(argv: string[], options: RuntimeOptions): Promise<CliRes
   }
 
   if (command === "server") {
-    return runServerCommand(rest);
+    return runServerCommand(rest, options);
   }
 
   if (PHASE_2_STUBS.has(command)) {
@@ -188,21 +189,52 @@ async function runUpdateCommand(rest: string[], options: RuntimeOptions): Promis
 
 /**
  * `librarian server [subcommand]`. With no subcommand (or `--help`/`-h`) it
- * prints the command surface (§4). The individual subcommands land in their
- * own slices (S2+); until then a known subcommand reports that it arrives in a
- * later slice, and an unknown one errors with the surface. Preflight + the
- * `docker.ts` seam exist now (S1) for those slices to call.
+ * prints the command surface (§4). `up` is implemented (S2, localhost path);
+ * the remaining subcommands land in their own slices (S3+) and until then a
+ * known one reports that it arrives in a later slice. An unknown subcommand
+ * errors with the surface. Preflight + the `docker.ts` seam (S1) back `up`.
  */
-function runServerCommand(rest: string[]): CliResult {
-  const [subcommand] = rest;
+async function runServerCommand(rest: string[], options: RuntimeOptions): Promise<CliResult> {
+  const [subcommand, ...subRest] = rest;
 
   if (!subcommand || subcommand === "--help" || subcommand === "-h") {
     return ok(serverUsage());
+  }
+  if (subcommand === "up") {
+    return runServerUpCommand(subRest, options);
   }
   if (isServerSubcommand(subcommand)) {
     return serverSubcommandPending(subcommand);
   }
   return err(`Unknown server subcommand: ${subcommand}\n\n${serverUsage()}`);
+}
+
+/**
+ * `librarian server up [flags]` (S2, localhost path). Parses the flags, builds
+ * a prompter (for the loop-closer env offer), and runs the orchestrated flow.
+ * A failure surfaces as one clean stderr line via the top-level catch — no
+ * stack trace, and the master key (carried only on the success stdout) never
+ * reaches an error path.
+ */
+async function runServerUpCommand(rest: string[], options: RuntimeOptions): Promise<CliResult> {
+  const { flags } = parseArgs(rest);
+  const prompter = options.prompter ?? createPrompter();
+  try {
+    const result = await runUp(
+      {
+        ref: flagString(flags.ref),
+        dir: flagString(flags.dir),
+        host: flagString(flags.host),
+        dataVolume: flagString(flags["data-volume"]),
+        enableBoot: flagBool(flags["enable-boot"]),
+        yes: flagBool(flags.yes),
+      },
+      { home: options.home, prompter },
+    );
+    return ok(result.output);
+  } finally {
+    prompter.close();
+  }
 }
 
 function serverSubcommandPending(subcommand: ServerSubcommand): CliResult {

--- a/packages/installer-cli/src/runtime.ts
+++ b/packages/installer-cli/src/runtime.ts
@@ -278,11 +278,20 @@ async function runServerDownCommand(): Promise<CliResult> {
  * `--follow`). `--service` selects which of the two co-located services to show
  * (filtered from the combined stream). A bad `--service` value is a teaching
  * error via the top-level catch.
+ *
+ * A FOLLOW (`-f`) streams its lines straight to `process.stdout` LIVE inside
+ * `runLogs` (a tail never closes on its own — buffering it to return here is the
+ * old hang), so there's no captured `output` to print; we just propagate the
+ * followed process's exit code. The one-shot path returns its captured output.
  */
 async function runServerLogsCommand(rest: string[]): Promise<CliResult> {
   const { positionals, flags } = parseArgs(rest);
   const follow = positionals.includes("-f") || flagBool(flags.follow) || flagBool(flags.f);
   const result = await runLogs({ follow, service: flagString(flags.service) });
+  if (follow) {
+    // Lines already streamed live; pass through the follow's exit code.
+    return { stdout: "", stderr: "", exitCode: result.exitCode ?? 0 };
+  }
   return ok(result.output);
 }
 

--- a/packages/installer-cli/src/runtime.ts
+++ b/packages/installer-cli/src/runtime.ts
@@ -18,9 +18,10 @@ import { detectShell, type Shell } from "./env.js";
 import { allHarnesses } from "./harnesses/index.js";
 import { flagBool, flagString, parseArgs, type FlagMap } from "./parse-args.js";
 import { createPrompter, MissingValueError, type Prompter } from "./prompt.js";
+import { runAdmin } from "./server/admin.js";
 import { disableBoot, enableBoot } from "./server/boot.js";
 import { runDown } from "./server/down.js";
-import { isServerSubcommand, serverUsage, type ServerSubcommand } from "./server/index.js";
+import { serverUsage } from "./server/index.js";
 import { runLogs } from "./server/logs.js";
 import { serverStatus } from "./server/status.js";
 import { runUp } from "./server/up.js";
@@ -209,10 +210,9 @@ async function runUpdateCommand(rest: string[], options: RuntimeOptions): Promis
 /**
  * `librarian server [subcommand]`. With no subcommand (or `--help`/`-h`) it
  * prints the command surface (§4). Implemented: `up` (S2/S3), `down` / `logs` /
- * `status` (S4), `update` (S5), `enable-boot` / `disable-boot` (S6). The
- * remaining subcommand (`admin`) lands in its own slice and until then reports
- * that it arrives in a later slice. An unknown subcommand errors with the
- * surface. Preflight + the `docker.ts` seam (S1) back every container op.
+ * `status` (S4), `update` (S5), `enable-boot` / `disable-boot` (S6), `admin`
+ * (S7a). An unknown subcommand errors with the surface. Preflight + the
+ * `docker.ts` seam (S1) back every container op.
  */
 async function runServerCommand(rest: string[], options: RuntimeOptions): Promise<CliResult> {
   const [subcommand, ...subRest] = rest;
@@ -241,8 +241,8 @@ async function runServerCommand(rest: string[], options: RuntimeOptions): Promis
   if (subcommand === "disable-boot") {
     return runServerDisableBootCommand(options);
   }
-  if (isServerSubcommand(subcommand)) {
-    return serverSubcommandPending(subcommand);
+  if (subcommand === "admin") {
+    return runServerAdminCommand(subRest, options);
   }
   return err(`Unknown server subcommand: ${subcommand}\n\n${serverUsage()}`);
 }
@@ -302,6 +302,28 @@ async function runServerEnableBootCommand(options: RuntimeOptions): Promise<CliR
  */
 async function runServerDisableBootCommand(options: RuntimeOptions): Promise<CliResult> {
   const result = await disableBoot(options.platform ? { platform: options.platform } : {});
+  return ok(result.output);
+}
+
+/**
+ * `librarian server admin <backup|restore|auth|rebuild> [args…]` (S7a). Runs a
+ * curated admin verb inside the running container via
+ * `docker exec [-it] the-librarian the-librarian <verb> [args…]` (spec §7). The
+ * args are passed through VERBATIM — so we do NOT run them through `parseArgs`
+ * (that would reorder/strip flags); the in-container CLI parses them. An
+ * interactive run adds `-it` so the CLI can prompt (e.g. `restore`'s
+ * `--secret-key`). A rejected verb or a down container surfaces as one clean
+ * stderr line via the top-level catch, with no `docker exec`.
+ */
+async function runServerAdminCommand(
+  subRest: string[],
+  options: RuntimeOptions,
+): Promise<CliResult> {
+  const interactive = options.interactive ?? Boolean(process.stdin.isTTY);
+  const result = await runAdmin(subRest, {
+    interactive,
+    ...(options.platform ? { platform: options.platform } : {}),
+  });
   return ok(result.output);
 }
 
@@ -369,17 +391,6 @@ async function runServerStatusCommand(rest: string[], options: RuntimeOptions): 
   const { flags } = parseArgs(rest);
   const result = await serverStatus({ home: options.home, dir: flagString(flags.dir) });
   return ok(result.output);
-}
-
-function serverSubcommandPending(subcommand: ServerSubcommand): CliResult {
-  return ok(
-    [
-      `librarian server ${subcommand}: arrives in a later slice.`,
-      "",
-      "The `server` group is being built incrementally. Run `librarian server`",
-      "to see the full command surface.",
-    ].join("\n"),
-  );
 }
 
 // --- Phase 2 stubs (friendly "coming later") -----------------------------

--- a/packages/installer-cli/src/runtime.ts
+++ b/packages/installer-cli/src/runtime.ts
@@ -23,6 +23,7 @@ import { isServerSubcommand, serverUsage, type ServerSubcommand } from "./server
 import { runLogs } from "./server/logs.js";
 import { serverStatus } from "./server/status.js";
 import { runUp } from "./server/up.js";
+import { runUpdate as runServerUpdate } from "./server/update.js";
 import { status } from "./status.js";
 import { cliVersion } from "./version.js";
 
@@ -200,7 +201,7 @@ async function runUpdateCommand(rest: string[], options: RuntimeOptions): Promis
 /**
  * `librarian server [subcommand]`. With no subcommand (or `--help`/`-h`) it
  * prints the command surface (§4). Implemented: `up` (S2/S3), `down` / `logs` /
- * `status` (S4). The remaining subcommands (`update`, `enable-boot`,
+ * `status` (S4), `update` (S5). The remaining subcommands (`enable-boot`,
  * `disable-boot`, `admin`) land in their own slices and until then a known one
  * reports that it arrives in a later slice. An unknown subcommand errors with
  * the surface. Preflight + the `docker.ts` seam (S1) back every container op.
@@ -213,6 +214,9 @@ async function runServerCommand(rest: string[], options: RuntimeOptions): Promis
   }
   if (subcommand === "up") {
     return runServerUpCommand(subRest, options);
+  }
+  if (subcommand === "update") {
+    return runServerUpdateCommand(subRest, options);
   }
   if (subcommand === "down") {
     return runServerDownCommand();
@@ -259,6 +263,26 @@ async function runServerUpCommand(rest: string[], options: RuntimeOptions): Prom
   } finally {
     prompter.close();
   }
+}
+
+/**
+ * `librarian server update [--ref <tag|main>] [--yes]` (S5). Re-pins the deploy
+ * dir to the resolved ref, rebuilds the image, recreates the container
+ * (PRESERVING the data volume), waits for health (rolling back on failure), and
+ * applies pending data-dir migrations. Idempotent: already at the ref + healthy
+ * → a clean no-op. The agent token is reused from the running container (clients
+ * keep working) and never reaches an error path or a file. A failure surfaces as
+ * one clean stderr line via the top-level catch (already secret-redacted).
+ */
+async function runServerUpdateCommand(rest: string[], options: RuntimeOptions): Promise<CliResult> {
+  const { flags } = parseArgs(rest);
+  const result = await runServerUpdate({
+    ref: flagString(flags.ref),
+    dir: flagString(flags.dir),
+    yes: flagBool(flags.yes),
+    home: options.home,
+  });
+  return ok(result.output);
 }
 
 /**

--- a/packages/installer-cli/src/runtime.ts
+++ b/packages/installer-cli/src/runtime.ts
@@ -42,6 +42,13 @@ export interface RuntimeOptions {
    * token. Defaults to `process.env` in `runInstall`.
    */
   env?: NodeJS.ProcessEnv;
+  /**
+   * Whether the run is interactive (a TTY is attached). Gates `server up`'s
+   * best-effort offers (the Tailscale offer; the `0.0.0.0` confirm). Defaults
+   * to `process.stdin.isTTY` — a non-interactive run never silently exposes the
+   * server beyond localhost (it keeps `127.0.0.1`). Injectable for tests.
+   */
+  interactive?: boolean;
 }
 
 const PHASE_2_STUBS = new Set(["report", "self-update"]);
@@ -219,6 +226,10 @@ async function runServerCommand(rest: string[], options: RuntimeOptions): Promis
 async function runServerUpCommand(rest: string[], options: RuntimeOptions): Promise<CliResult> {
   const { flags } = parseArgs(rest);
   const prompter = options.prompter ?? createPrompter();
+  // Interactivity gates the best-effort offers (Tailscale; the `0.0.0.0`
+  // confirm). Explicit override wins; otherwise a TTY means interactive. A
+  // non-interactive run never silently exposes the server beyond localhost.
+  const interactive = options.interactive ?? Boolean(process.stdin.isTTY);
   try {
     const result = await runUp(
       {
@@ -229,7 +240,7 @@ async function runServerUpCommand(rest: string[], options: RuntimeOptions): Prom
         enableBoot: flagBool(flags["enable-boot"]),
         yes: flagBool(flags.yes),
       },
-      { home: options.home, prompter },
+      { home: options.home, prompter, interactive },
     );
     return ok(result.output);
   } finally {

--- a/packages/installer-cli/src/runtime.ts
+++ b/packages/installer-cli/src/runtime.ts
@@ -18,6 +18,7 @@ import { detectShell, type Shell } from "./env.js";
 import { allHarnesses } from "./harnesses/index.js";
 import { flagBool, flagString, parseArgs, type FlagMap } from "./parse-args.js";
 import { createPrompter, MissingValueError, type Prompter } from "./prompt.js";
+import { disableBoot, enableBoot } from "./server/boot.js";
 import { runDown } from "./server/down.js";
 import { isServerSubcommand, serverUsage, type ServerSubcommand } from "./server/index.js";
 import { runLogs } from "./server/logs.js";
@@ -53,6 +54,13 @@ export interface RuntimeOptions {
    * server beyond localhost (it keeps `127.0.0.1`). Injectable for tests.
    */
   interactive?: boolean;
+  /**
+   * The host platform, defaulting to `process.platform`. Threads into the
+   * `server` ops that branch on it: preflight's daemon hint and boot
+   * persistence (Linux systemd vs the macOS deferred notice). Injectable so the
+   * darwin path is testable from a Linux host.
+   */
+  platform?: NodeJS.Platform;
 }
 
 const PHASE_2_STUBS = new Set(["report", "self-update"]);
@@ -201,10 +209,10 @@ async function runUpdateCommand(rest: string[], options: RuntimeOptions): Promis
 /**
  * `librarian server [subcommand]`. With no subcommand (or `--help`/`-h`) it
  * prints the command surface (§4). Implemented: `up` (S2/S3), `down` / `logs` /
- * `status` (S4), `update` (S5). The remaining subcommands (`enable-boot`,
- * `disable-boot`, `admin`) land in their own slices and until then a known one
- * reports that it arrives in a later slice. An unknown subcommand errors with
- * the surface. Preflight + the `docker.ts` seam (S1) back every container op.
+ * `status` (S4), `update` (S5), `enable-boot` / `disable-boot` (S6). The
+ * remaining subcommand (`admin`) lands in its own slice and until then reports
+ * that it arrives in a later slice. An unknown subcommand errors with the
+ * surface. Preflight + the `docker.ts` seam (S1) back every container op.
  */
 async function runServerCommand(rest: string[], options: RuntimeOptions): Promise<CliResult> {
   const [subcommand, ...subRest] = rest;
@@ -226,6 +234,12 @@ async function runServerCommand(rest: string[], options: RuntimeOptions): Promis
   }
   if (subcommand === "status") {
     return runServerStatusCommand(subRest, options);
+  }
+  if (subcommand === "enable-boot") {
+    return runServerEnableBootCommand(options);
+  }
+  if (subcommand === "disable-boot") {
+    return runServerDisableBootCommand(options);
   }
   if (isServerSubcommand(subcommand)) {
     return serverSubcommandPending(subcommand);
@@ -257,12 +271,38 @@ async function runServerUpCommand(rest: string[], options: RuntimeOptions): Prom
         enableBoot: flagBool(flags["enable-boot"]),
         yes: flagBool(flags.yes),
       },
-      { home: options.home, prompter, interactive },
+      {
+        home: options.home,
+        prompter,
+        interactive,
+        ...(options.platform ? { platform: options.platform } : {}),
+      },
     );
     return ok(result.output);
   } finally {
     prompter.close();
   }
+}
+
+/**
+ * `librarian server enable-boot` (S6). On Linux, installs + enables the systemd
+ * unit that starts the existing named container on boot (the unit references the
+ * container by name and carries NO secret). On macOS, prints the deferred notice
+ * and exits 0 (NOT an error). A real failure surfaces as one clean stderr line.
+ */
+async function runServerEnableBootCommand(options: RuntimeOptions): Promise<CliResult> {
+  const result = await enableBoot(options.platform ? { platform: options.platform } : {});
+  return ok(result.output);
+}
+
+/**
+ * `librarian server disable-boot` (S6). On Linux, disables + removes the systemd
+ * unit and reloads systemd; safe if already disabled/absent (a teaching message,
+ * no crash). On macOS, prints the deferred notice and exits 0.
+ */
+async function runServerDisableBootCommand(options: RuntimeOptions): Promise<CliResult> {
+  const result = await disableBoot(options.platform ? { platform: options.platform } : {});
+  return ok(result.output);
 }
 
 /**

--- a/packages/installer-cli/src/runtime.ts
+++ b/packages/installer-cli/src/runtime.ts
@@ -18,6 +18,7 @@ import { detectShell, type Shell } from "./env.js";
 import { allHarnesses } from "./harnesses/index.js";
 import { flagBool, flagString, parseArgs, type FlagMap } from "./parse-args.js";
 import { createPrompter, MissingValueError, type Prompter } from "./prompt.js";
+import { runDown } from "./server/down.js";
 import { isServerSubcommand, serverUsage, type ServerSubcommand } from "./server/index.js";
 import { runUp } from "./server/up.js";
 import { status } from "./status.js";
@@ -210,6 +211,9 @@ async function runServerCommand(rest: string[], options: RuntimeOptions): Promis
   if (subcommand === "up") {
     return runServerUpCommand(subRest, options);
   }
+  if (subcommand === "down") {
+    return runServerDownCommand();
+  }
   if (isServerSubcommand(subcommand)) {
     return serverSubcommandPending(subcommand);
   }
@@ -246,6 +250,17 @@ async function runServerUpCommand(rest: string[], options: RuntimeOptions): Prom
   } finally {
     prompter.close();
   }
+}
+
+/**
+ * `librarian server down` (S4). Stops the container — DATA SACRED (it issues
+ * only `docker stop`, never any `rm`/volume op). A not-running container is a
+ * friendly success; a real failure surfaces via the top-level catch as one
+ * clean stderr line. No flags today.
+ */
+async function runServerDownCommand(): Promise<CliResult> {
+  const result = await runDown({});
+  return ok(result.output);
 }
 
 function serverSubcommandPending(subcommand: ServerSubcommand): CliResult {

--- a/packages/installer-cli/src/server/admin.ts
+++ b/packages/installer-cli/src/server/admin.ts
@@ -1,0 +1,144 @@
+// `librarian server admin <verb> [args…]` — run a curated subset of the
+// folded-in admin CLI (`@librarian/cli`, the `the-librarian` binary) INSIDE the
+// running all-in-one container. Spec §7 ("Folded-in admin").
+//
+// One uniform mechanism: `docker exec the-librarian the-librarian <verb> [args…]`.
+// Running it in the container (not on the host) gives the admin CLI direct
+// access to the data dir + the store/settings the server already uses — which is
+// exactly what lets `auth` recovery bypass a locked dashboard and lets
+// `backup`/`restore` reuse the store rather than re-implement it. (The CLI is
+// bundled into the runtime image in the same slice — see all-in-one.Dockerfile.)
+//
+// CURATED set (spec §7): only `backup | restore | auth | rebuild` are exposed.
+// `seed` / `migrate-data-dir` / `export` / `handoffs` exist in @librarian/cli but
+// are deliberately NOT folded in here (seed is dev-only; migrate-data-dir runs
+// automatically on `update`; export + handoffs are power-user/dashboard surfaces).
+// They stay reachable via a raw `docker exec` if ever truly needed.
+//
+// Args after the verb are passed through VERBATIM, in order — this module never
+// parses, reorders, or rewrites them (so e.g. `auth reset-password --user x` and
+// `restore --secret-key …` reach the CLI exactly as typed). A bearer/secret may
+// ride through as an arg the CLI itself reads; this module never logs or persists
+// it (AGENTS.md: privacy beats convenience).
+//
+// Everything goes through the injectable `docker.ts` seam, so tests assert the
+// exact argv without a real daemon or container.
+
+import { run } from "./docker.js";
+import { preflight } from "./preflight.js";
+import { CONTAINER_NAME } from "./up.js";
+
+/** The curated admin verbs exposed under `server admin` (spec §7). */
+export const ADMIN_VERBS = ["backup", "restore", "auth", "rebuild"] as const;
+
+export type AdminVerb = (typeof ADMIN_VERBS)[number];
+
+/** A teaching error from `admin`; the runtime renders `.message` as one stderr line. */
+export class AdminError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AdminError";
+  }
+}
+
+export interface AdminOptions {
+  /** Platform for preflight's daemon hint. Default `process.platform`. */
+  platform?: NodeJS.Platform | undefined;
+  /**
+   * Whether the run is interactive (a TTY is attached). When true we add
+   * `docker exec -it` so the in-container CLI can prompt (e.g. `restore`'s
+   * `--secret-key` prompt, `auth reset-password`). A non-interactive run omits
+   * `-it` so it works in scripts/CI without a TTY.
+   */
+  interactive?: boolean | undefined;
+}
+
+export interface AdminResult {
+  /** Human-readable report for stdout (the in-container CLI's own output). */
+  output: string;
+}
+
+/** True iff `verb` is one of the curated admin verbs. */
+function isAdminVerb(verb: string): verb is AdminVerb {
+  return (ADMIN_VERBS as readonly string[]).includes(verb);
+}
+
+/** The teaching message for an unknown/dropped verb — names what IS available. */
+function unknownVerbMessage(verb: string | undefined): string {
+  const allowed = ADMIN_VERBS.join(" | ");
+  const lead =
+    verb === undefined
+      ? "`librarian server admin` needs a subcommand."
+      : `\`${verb}\` is not an \`admin\` subcommand.`;
+  return [
+    lead,
+    "",
+    `Allowed: ${allowed}.`,
+    "",
+    "Not exposed here (by design): `seed` (dev-only), `migrate-data-dir` (runs",
+    "automatically on `librarian server update`), `export`, and `handoffs`",
+    "(power-user / dashboard surfaces).",
+  ].join("\n");
+}
+
+/**
+ * Confirm the container is up before exec'ing into it. `docker inspect` reports
+ * `running` when it is; any other status (or a failed inspect → absent) is a
+ * teaching error pointing at `server up`, with NO `docker exec`.
+ */
+async function assertContainerRunning(): Promise<void> {
+  const result = await run("docker", ["inspect", "--format", "{{.State.Status}}", CONTAINER_NAME]);
+  const status = result.code === 0 ? result.stdout.trim() : null;
+  if (status !== "running") {
+    throw new AdminError(
+      "The server isn't running — run `librarian server up` first, then re-run " +
+        "this admin command.",
+    );
+  }
+}
+
+/**
+ * Run `server admin <verb> [args…]`. Validates the verb is curated, preflights
+ * docker, confirms the container is running, then runs
+ * `docker exec [-it] the-librarian the-librarian <verb> [args…]` — passing the
+ * args through VERBATIM. A rejected verb / down container is a teaching
+ * `AdminError`; no `docker exec` runs in either case.
+ */
+export async function runAdmin(
+  argv: readonly string[],
+  options: AdminOptions = {},
+): Promise<AdminResult> {
+  const [verb, ...rest] = argv;
+
+  // Validate FIRST — a rejected verb must never reach a `docker exec` (and we
+  // don't even need a daemon to tell the user the verb is wrong).
+  if (verb === undefined || !isAdminVerb(verb)) {
+    throw new AdminError(unknownVerbMessage(verb));
+  }
+
+  await preflight(options.platform ? { platform: options.platform } : {});
+  await assertContainerRunning();
+
+  // `docker exec [-it] the-librarian the-librarian <verb> [args…]` — args verbatim.
+  const execArgs = [
+    "exec",
+    ...(options.interactive ? ["-it"] : []),
+    CONTAINER_NAME,
+    "the-librarian",
+    verb,
+    ...rest,
+  ];
+  const result = await run("docker", execArgs);
+
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || result.stdout.trim();
+    throw new AdminError(
+      `\`the-librarian ${verb}\` failed in the container (exit ${result.code ?? "signal"})` +
+        (detail ? `:\n${detail}` : ".") +
+        `\n\nResolve the error above, then re-run \`librarian server admin ${verb}\`.`,
+    );
+  }
+
+  // The in-container CLI's own output is the report (stdout, then any stderr).
+  return { output: result.stdout + result.stderr };
+}

--- a/packages/installer-cli/src/server/admin.ts
+++ b/packages/installer-cli/src/server/admin.ts
@@ -26,6 +26,7 @@
 
 import { run } from "./docker.js";
 import { preflight } from "./preflight.js";
+import { redactSecrets } from "./redact.js";
 import { CONTAINER_NAME } from "./up.js";
 
 /** The curated admin verbs exposed under `server admin` (spec §7). */
@@ -131,7 +132,10 @@ export async function runAdmin(
   const result = await run("docker", execArgs);
 
   if (result.code !== 0) {
-    const detail = result.stderr.trim() || result.stdout.trim();
+    // `admin` forwards secret-bearing args (`restore --secret-key …`, `auth …`),
+    // so a failed in-container step can echo them back. Redact before surfacing,
+    // identically to `update`/`up` (I-3) — the shared helper is the choke point.
+    const detail = redactSecrets(result.stderr.trim() || result.stdout.trim());
     throw new AdminError(
       `\`the-librarian ${verb}\` failed in the container (exit ${result.code ?? "signal"})` +
         (detail ? `:\n${detail}` : ".") +

--- a/packages/installer-cli/src/server/boot.ts
+++ b/packages/installer-cli/src/server/boot.ts
@@ -1,0 +1,272 @@
+// `librarian server enable-boot` / `disable-boot` — Linux systemd boot
+// persistence for the all-in-one container. (macOS launchd is deferred — §9.)
+//
+// SECURITY — the whole point of this slice. The systemd unit MUST NOT contain
+// any secret. We do NOT bake a `docker run -e LIBRARIAN_AGENT_TOKEN=…` into
+// `ExecStart`: that would write the agent token into a world-readable
+// `/etc/systemd/system/*.service` file — a leak. Instead the unit references the
+// EXISTING named container (created by `up`/`update`, whose env — including the
+// token — lives in Docker's own container state, not a file we manage):
+//
+//   ExecStart=/usr/bin/docker start --attach the-librarian
+//   ExecStop=/usr/bin/docker stop the-librarian
+//
+// `docker start --attach` re-uses the container exactly as `up` created it
+// (same name, same env, same volume) and stays in the foreground so systemd's
+// `Type=simple` supervision + `Restart=always` work. This survives a `server
+// update` (which recreates the SAME container name) and reboots, with NO secret
+// anywhere on disk that we write.
+//
+// We default to a SYSTEM unit (`/etc/systemd/system/…`, via `sudo`) because it
+// boots reliably without a login session. (A `--user` unit under
+// `~/.config/systemd/user/` would need `loginctl enable-linger` to survive
+// logout — out of scope for v1; deliberately not built.)
+//
+// Writing to `/etc/systemd/system` needs root, so the unit is written to a
+// temp file first (NON-SECRET content) and then `sudo cp`'d into place — every
+// privileged step (`sudo cp`/`chmod`/`rm`, `sudo systemctl …`) routes through
+// the injectable `docker.ts` runner so tests assert the exact argv and never
+// touch real systemd, sudo, or docker.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { run, which } from "./docker.js";
+import { CONTAINER_NAME } from "./up.js";
+
+/** The systemd unit file name (single instance per host). */
+export const UNIT_NAME = "the-librarian.service";
+
+/** The system-unit directory (a system unit boots without a login session). */
+const SYSTEMD_SYSTEM_DIR = "/etc/systemd/system";
+
+/** The absolute path the unit is installed at (the system unit, via sudo). */
+export function unitPath(): string {
+  return path.join(SYSTEMD_SYSTEM_DIR, UNIT_NAME);
+}
+
+/** Fallback docker path if `which docker` can't be resolved (well-known location). */
+const DEFAULT_DOCKER_PATH = "/usr/bin/docker";
+
+export interface BootOptions {
+  /** Platform — gates the macOS deferral. Default `process.platform`. */
+  platform?: NodeJS.Platform | undefined;
+}
+
+/** A teaching error from boot ops; the runtime renders `.message` as one stderr line. */
+export class BootError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BootError";
+  }
+}
+
+export interface BootResult {
+  /** Human-readable report for stdout. */
+  output: string;
+}
+
+/** Inputs to the pure unit generator (only a docker path — NEVER a secret). */
+export interface UnitInput {
+  /** The absolute path to the `docker` binary used in ExecStart/ExecStop. */
+  dockerPath: string;
+}
+
+/**
+ * Generate the systemd unit text. PURE + unit-tested. The headline invariant:
+ * it contains NO secret — no agent token, no `LIBRARIAN_AGENT_TOKEN`, no
+ * `docker run` / `-e` env injection — only a `docker start --attach` /
+ * `docker stop` of the EXISTING named container. The container already carries
+ * its env (incl. the token) in Docker's own state, so referencing it by name
+ * needs no secret in this file.
+ */
+export function generateUnit(input: UnitInput): string {
+  const { dockerPath } = input;
+  return [
+    "[Unit]",
+    "Description=The Librarian (all-in-one)",
+    "After=docker.service",
+    "Requires=docker.service",
+    "",
+    "[Service]",
+    "Type=simple",
+    // Reference the EXISTING named container — NO `docker run`, NO `-e <secret>`.
+    // `--attach` keeps it in the foreground so Type=simple supervision works.
+    `ExecStart=${dockerPath} start --attach ${CONTAINER_NAME}`,
+    `ExecStop=${dockerPath} stop ${CONTAINER_NAME}`,
+    "Restart=always",
+    "RestartSec=5",
+    "",
+    "[Install]",
+    "WantedBy=multi-user.target",
+    "",
+  ].join("\n");
+}
+
+/** The one-line macOS-deferred notice (shared by enable/disable + `up`). */
+export const MACOS_NOTICE =
+  "Boot persistence is Linux-only for now (launchd support is deferred). " +
+  "Skipping — on macOS, start the server manually with `librarian server up`, " +
+  "or use Docker Desktop's 'start on login' for the container.";
+
+/** True iff boot persistence is unsupported on this platform (macOS for now). */
+function isUnsupportedPlatform(platform: NodeJS.Platform): boolean {
+  return platform === "darwin";
+}
+
+/**
+ * Boot-specific preflight: `docker` must be on PATH (the unit runs `docker
+ * start` at boot). Unlike the container-op preflight this does NOT require git
+ * or a reachable daemon — enabling/disabling a unit file needs neither. A
+ * missing docker is a teaching `BootError`.
+ */
+async function requireDocker(): Promise<void> {
+  if ((await which("docker")) === null) {
+    throw new BootError(
+      "Docker is required but was not found on your PATH. " +
+        "The boot unit runs `docker start` — install Docker Engine (Linux) " +
+        "— see https://docs.docker.com/get-docker/ — then re-run this command.",
+    );
+  }
+}
+
+/**
+ * Resolve the absolute `docker` path for the unit's ExecStart. Goes through the
+ * injectable runner (`which docker`); falls back to the well-known
+ * `/usr/bin/docker` so a non-standard `which` output never breaks unit
+ * generation. The path is non-secret, so a fallback is safe.
+ */
+async function resolveDockerPath(): Promise<string> {
+  const resolved = await which("docker");
+  return resolved && resolved.trim().length > 0 ? resolved.trim() : DEFAULT_DOCKER_PATH;
+}
+
+/**
+ * Enable boot persistence. On Linux: write the unit to `/etc/systemd/system`
+ * (root, so temp-file + `sudo cp` + `sudo chmod 644`), `sudo systemctl
+ * daemon-reload`, then `sudo systemctl enable --now the-librarian.service`.
+ * Idempotent — re-running rewrites the SAME unit path and re-enables, never
+ * duplicating. On macOS: print the deferred notice and skip cleanly (NOT an
+ * error).
+ */
+export async function enableBoot(options: BootOptions = {}): Promise<BootResult> {
+  const platform = options.platform ?? process.platform;
+  if (isUnsupportedPlatform(platform)) {
+    return { output: MACOS_NOTICE };
+  }
+
+  // Boot persistence runs `docker start` at boot, so it needs `docker` on PATH
+  // — but NOT git (no clone here) and NOT a reachable daemon right now (the unit
+  // fires at boot, not at enable time). A lighter, boot-specific preflight.
+  await requireDocker();
+
+  const dockerPath = await resolveDockerPath();
+  const unit = generateUnit({ dockerPath });
+  await installUnit(unit);
+
+  // daemon-reload BEFORE enable --now so systemd sees the (possibly rewritten)
+  // unit. enable --now both enables-on-boot and starts the container now.
+  await sudoSystemctl(["daemon-reload"]);
+  await sudoSystemctl(["enable", "--now", UNIT_NAME]);
+
+  return {
+    output: [
+      `Boot persistence enabled — ${UNIT_NAME} will start the container on boot.`,
+      `  Unit: ${unitPath()} (references the existing '${CONTAINER_NAME}' container; no secret in the file)`,
+      "Disable it again with `librarian server disable-boot`.",
+    ].join("\n"),
+  };
+}
+
+/**
+ * Disable boot persistence. On Linux: `sudo systemctl disable --now
+ * the-librarian.service`, remove the unit file (`sudo rm -f`), then `sudo
+ * systemctl daemon-reload`. Safe if already disabled/absent — a non-zero
+ * `disable` (unit not loaded) becomes a friendly teaching message, never a
+ * crash; the `rm -f` + reload still run so a stale unit file is cleaned up. On
+ * macOS: print the deferred notice and skip cleanly.
+ */
+export async function disableBoot(options: BootOptions = {}): Promise<BootResult> {
+  const platform = options.platform ?? process.platform;
+  if (isUnsupportedPlatform(platform)) {
+    return { output: MACOS_NOTICE };
+  }
+
+  await requireDocker();
+
+  // disable --now: tolerate "unit does not exist / not loaded" — already off.
+  const disable = await run("sudo", ["systemctl", "disable", "--now", UNIT_NAME]);
+  const alreadyAbsent = disable.code !== 0 && isUnitAbsent(disable.stderr);
+  if (disable.code !== 0 && !alreadyAbsent) {
+    failIfNonZero("sudo", ["systemctl", "disable", "--now", UNIT_NAME], disable);
+  }
+
+  // Remove the unit file (idempotent with `-f`), then daemon-reload so systemd
+  // forgets it. `rm -f` never errors on an absent file.
+  await sudoRun(["rm", "-f", unitPath()]);
+  await sudoSystemctl(["daemon-reload"]);
+
+  return {
+    output: alreadyAbsent
+      ? [
+          `Boot persistence was not enabled (${UNIT_NAME} was not loaded) — nothing to disable.`,
+          `Removed any stale unit file at ${unitPath()} and reloaded systemd.`,
+        ].join("\n")
+      : [
+          `Boot persistence disabled — ${UNIT_NAME} removed and systemd reloaded.`,
+          "The container itself is untouched; stop it with `librarian server down`.",
+        ].join("\n"),
+  };
+}
+
+// --- privileged steps (every one through the injectable runner) ----------
+
+/**
+ * Write the unit to the system path. `/etc/systemd/system` needs root, so the
+ * NON-SECRET unit text is written to a temp file first, then `sudo cp`'d into
+ * place and `sudo chmod 644`'d (world-readable is fine — there is no secret in
+ * it, by construction). The temp file is removed afterward. The `cp`/`chmod`
+ * argv is asserted by tests; the temp source carries the unit content for the
+ * test's no-secret check (the fake runner doesn't really move it).
+ */
+async function installUnit(unit: string): Promise<void> {
+  const dir = mkdtempSync(path.join(tmpdir(), "librarian-unit-"));
+  const tmp = path.join(dir, UNIT_NAME);
+  writeFileSync(tmp, unit, "utf8");
+  try {
+    await sudoRun(["cp", tmp, unitPath()]);
+    await sudoRun(["chmod", "644", unitPath()]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/** Run `sudo systemctl <args…>`; a non-zero exit is a teaching error. */
+async function sudoSystemctl(args: string[]): Promise<void> {
+  await sudoRun(["systemctl", ...args]);
+}
+
+/** Run `sudo <args…>`; a non-zero exit is a teaching error. */
+async function sudoRun(args: string[]): Promise<void> {
+  const result = await run("sudo", args);
+  failIfNonZero("sudo", args, result);
+}
+
+/** True when a `systemctl disable` failure means the unit simply isn't loaded. */
+function isUnitAbsent(stderr: string): boolean {
+  return /does not exist|not loaded|no such file|not found/i.test(stderr);
+}
+
+function failIfNonZero(
+  cmd: string,
+  args: string[],
+  result: { code: number | null; stderr: string; stdout: string },
+): void {
+  if (result.code === 0) return;
+  const detail = result.stderr.trim() || result.stdout.trim();
+  throw new BootError(
+    `\`${cmd} ${args[0]}\` failed (exit ${result.code ?? "signal"})` +
+      (detail ? `:\n${detail}` : ".") +
+      "\n\nResolve the error above (you may need sudo privileges), then re-run the command.",
+  );
+}

--- a/packages/installer-cli/src/server/deploy-state.ts
+++ b/packages/installer-cli/src/server/deploy-state.ts
@@ -1,0 +1,96 @@
+// The NON-SECRET deploy-state file for the `server` command group.
+//
+// `up` runs the container with a chosen bind host, data volume, and ref, but
+// none of that was persisted anywhere — so `update` couldn't recreate the
+// container with the same config and `status` couldn't report the deployed ref
+// reliably (it would have to guess via `git describe`). This file records that
+// config in the deploy dir (default `~/.librarian/server/deploy-state.json`).
+//
+// SECURITY (AGENTS.md / spec §11): this file is NON-SECRET by construction. It
+// carries ONLY the five fields below — a bind host, a volume name, a ref, an
+// image tag, and the container name. It NEVER carries a bearer token, master
+// key, or admin token. `writeDeployState` whitelists exactly those fields, so a
+// caller that accidentally passes extra keys (a smuggled secret) cannot leak
+// them into the file. The master key / admin token are surfaced to stdout once
+// by `up` and persisted nowhere host-side — that contract is unchanged.
+
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * The deploy-state recorded after a successful `up` (and rewritten by `update`).
+ * Every field is NON-SECRET — see the module header. Do NOT add a token/key.
+ */
+export interface DeployState {
+  /** The container name every `server` command operates on. */
+  containerName: string;
+  /** The resolved bind host the container publishes on (`127.0.0.1`, a tailnet IP, `0.0.0.0`). */
+  host: string;
+  /** The named data volume mounted at `/data` (sacred across `down`/`update`). */
+  dataVolume: string;
+  /** The deployed ref — a `vX.Y.Z` tag or `main` (what was checked out + built). */
+  ref: string;
+  /** The built image tag (`the-librarian:<ref>`). */
+  imageTag: string;
+}
+
+/** The keys we ever persist — the whitelist that keeps secrets out of the file. */
+const STATE_KEYS = ["containerName", "host", "dataVolume", "ref", "imageTag"] as const;
+
+/** `<dir>/deploy-state.json` — the deploy-state file path within a deploy dir. */
+export function deployStatePath(dir: string): string {
+  return path.join(dir, "deploy-state.json");
+}
+
+/**
+ * Write the deploy-state to `<dir>/deploy-state.json`, creating `dir` if absent.
+ *
+ * Only the five declared fields are persisted — a `pick`, not a spread — so no
+ * extra key (e.g. a smuggled token) can ride along into the file. The file is
+ * non-secret, so it gets ordinary (not 0600) permissions.
+ */
+export function writeDeployState(dir: string, state: DeployState): void {
+  fs.mkdirSync(dir, { recursive: true });
+  // Pick ONLY the whitelisted keys — never spread `state`, which could carry
+  // extra (secret-shaped) properties a caller smuggled in.
+  const safe: DeployState = {
+    containerName: state.containerName,
+    host: state.host,
+    dataVolume: state.dataVolume,
+    ref: state.ref,
+    imageTag: state.imageTag,
+  };
+  fs.writeFileSync(deployStatePath(dir), `${JSON.stringify(safe, null, 2)}\n`, "utf8");
+}
+
+/**
+ * Read the deploy-state back, or `null` if the file is absent, unparseable, or
+ * missing any required field. Never throws — a missing/corrupt state file means
+ * the caller falls back (e.g. `status` uses `git describe`), never crashes.
+ */
+export function readDeployState(dir: string): DeployState | null {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(deployStatePath(dir), "utf8");
+  } catch {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const obj = parsed as Record<string, unknown>;
+  for (const key of STATE_KEYS) {
+    if (typeof obj[key] !== "string") return null;
+  }
+  return {
+    containerName: obj.containerName as string,
+    host: obj.host as string,
+    dataVolume: obj.dataVolume as string,
+    ref: obj.ref as string,
+    imageTag: obj.imageTag as string,
+  };
+}

--- a/packages/installer-cli/src/server/docker.ts
+++ b/packages/installer-cli/src/server/docker.ts
@@ -1,0 +1,91 @@
+// Injectable `docker` / `git` runner for the `server` command group.
+//
+// Every `server` subcommand (up / update / down / status / logs / boot /
+// admin) drives the host's `docker` and `git` binaries. They go through THIS
+// seam rather than `node:child_process` directly, so tests stub the runner and
+// assert the exact argv each command invokes — WITHOUT spawning a real process
+// or touching a real Docker daemon.
+//
+// This mirrors `src/exec.ts` (the harness CLI runner) deliberately: same
+// `Runner` shape, same `run`/`which`/`setRunner`/`resetRunner` surface. It is a
+// SEPARATE module-level runner, though — the harness commands and the server
+// commands inject independently, so a test that stubs one never disturbs the
+// other. Reusing `exec.ts`'s `Runner`/`RunResult`/`RunOptions` types keeps a
+// single fake (`FakeRunner`) usable for both.
+//
+// Security (AGENTS.md): a command may *carry* a bearer token via an env var its
+// native mechanism reads, but this module never logs, echoes, or persists the
+// streams it returns.
+
+import { spawn } from "node:child_process";
+import type { RunOptions, RunResult, Runner } from "../exec.js";
+
+export type { RunOptions, RunResult, Runner } from "../exec.js";
+
+// --- the real, process-spawning runner -----------------------------------
+
+const realRunner: Runner = {
+  run(cmd, args, opts = {}) {
+    return new Promise<RunResult>((resolve, reject) => {
+      const child = spawn(cmd, [...args], {
+        cwd: opts.cwd,
+        env: opts.env ? { ...process.env, ...opts.env } : process.env,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      let stdout = "";
+      let stderr = "";
+      child.stdout?.on("data", (chunk: Buffer) => {
+        stdout += chunk.toString("utf8");
+      });
+      child.stderr?.on("data", (chunk: Buffer) => {
+        stderr += chunk.toString("utf8");
+      });
+      // ENOENT (binary not on PATH) surfaces here, not as a non-zero exit.
+      child.on("error", reject);
+      child.on("close", (code) => {
+        resolve({ stdout, stderr, code });
+      });
+    });
+  },
+
+  async which(cmd) {
+    const probe = process.platform === "win32" ? "where" : "which";
+    try {
+      const { stdout, code } = await realRunner.run(probe, [cmd]);
+      if (code !== 0) return null;
+      const first = stdout
+        .split("\n")
+        .map((l) => l.trim())
+        .find((l) => l.length > 0);
+      return first ?? null;
+    } catch {
+      return null;
+    }
+  },
+};
+
+// --- the swappable module-level runner -----------------------------------
+
+let current: Runner = realRunner;
+
+/** Run a command (`docker`/`git`) through the current server runner. */
+export function run(cmd: string, args: readonly string[], opts?: RunOptions): Promise<RunResult> {
+  return current.run(cmd, args, opts);
+}
+
+/** Resolve a command to its PATH location through the current server runner. */
+export function which(cmd: string): Promise<string | null> {
+  return current.which(cmd);
+}
+
+/** Swap in a fake runner (tests). Returns the previous runner. */
+export function setRunner(runner: Runner): Runner {
+  const prev = current;
+  current = runner;
+  return prev;
+}
+
+/** Restore the real, process-spawning runner (tests). */
+export function resetRunner(): void {
+  current = realRunner;
+}

--- a/packages/installer-cli/src/server/docker.ts
+++ b/packages/installer-cli/src/server/docker.ts
@@ -16,11 +16,47 @@
 // Security (AGENTS.md): a command may *carry* a bearer token via an env var its
 // native mechanism reads, but this module never logs, echoes, or persists the
 // streams it returns.
+//
+// Two surfaces, two seams:
+//   - `run` CAPTURES a process's streams and resolves on close. Right for a
+//     command that EXITS on its own (`docker logs` without `-f`, `docker stop`,
+//     `docker info`): you want the whole output, after the fact.
+//   - `stream` does NOT capture — it hands each stdout/stderr chunk to a callback
+//     as it arrives and resolves only when the process exits. Right for a FOLLOW
+//     (`docker logs -f`), which never closes on its own: capturing it would buffer
+//     forever and emit nothing until the user Ctrl-Cs. Each seam injects
+//     independently (`setRunner`/`setStreamer`) so a test stubs exactly what it
+//     exercises, and neither ever spawns a real `docker`.
 
 import { spawn } from "node:child_process";
 import type { RunOptions, RunResult, Runner } from "../exec.js";
 
 export type { RunOptions, RunResult, Runner } from "../exec.js";
+
+// --- the streaming seam (for follows that never close on their own) -------
+
+/** Per-stream chunk handlers for a streaming spawn. Chunks arrive as they do. */
+export interface StreamHandlers {
+  /** Called with each stdout chunk (decoded utf8) as it arrives. */
+  onStdout?: (chunk: string) => void;
+  /** Called with each stderr chunk (decoded utf8) as it arrives. */
+  onStderr?: (chunk: string) => void;
+}
+
+/**
+ * The streaming counterpart to {@link Runner}. Spawns `cmd args…`, forwards
+ * each stdout/stderr chunk to the handlers LIVE (never buffered to the end),
+ * and resolves with the exit code when the process exits — `null` if it was
+ * signalled (e.g. the user Ctrl-Cs a `-f` follow, or the container stops).
+ */
+export interface Streamer {
+  stream(
+    cmd: string,
+    args: readonly string[],
+    handlers: StreamHandlers,
+    opts?: RunOptions,
+  ): Promise<number | null>;
+}
 
 // --- the real, process-spawning runner -----------------------------------
 
@@ -64,9 +100,39 @@ const realRunner: Runner = {
   },
 };
 
+// --- the real, process-spawning streamer ----------------------------------
+
+const realStreamer: Streamer = {
+  stream(cmd, args, handlers, opts = {}) {
+    return new Promise<number | null>((resolve, reject) => {
+      const child = spawn(cmd, [...args], {
+        cwd: opts.cwd,
+        env: opts.env ? { ...process.env, ...opts.env } : process.env,
+        // pipe (not inherit) so the caller can filter/transform per chunk; the
+        // caller is responsible for writing kept output to the terminal.
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      child.stdout?.on("data", (chunk: Buffer) => {
+        handlers.onStdout?.(chunk.toString("utf8"));
+      });
+      child.stderr?.on("data", (chunk: Buffer) => {
+        handlers.onStderr?.(chunk.toString("utf8"));
+      });
+      // ENOENT (binary not on PATH) surfaces here, not as a non-zero exit.
+      child.on("error", reject);
+      // Resolves only when the process EXITS — for `docker logs -f` that means
+      // the container stopped or the user Ctrl-C'd; until then chunks stream.
+      child.on("close", (code) => {
+        resolve(code);
+      });
+    });
+  },
+};
+
 // --- the swappable module-level runner -----------------------------------
 
 let current: Runner = realRunner;
+let currentStreamer: Streamer = realStreamer;
 
 /** Run a command (`docker`/`git`) through the current server runner. */
 export function run(cmd: string, args: readonly string[], opts?: RunOptions): Promise<RunResult> {
@@ -76,6 +142,20 @@ export function run(cmd: string, args: readonly string[], opts?: RunOptions): Pr
 /** Resolve a command to its PATH location through the current server runner. */
 export function which(cmd: string): Promise<string | null> {
   return current.which(cmd);
+}
+
+/**
+ * Stream a command (e.g. `docker logs -f`) through the current server streamer,
+ * forwarding each stdout/stderr chunk to `handlers` LIVE. Resolves with the exit
+ * code when the process exits.
+ */
+export function stream(
+  cmd: string,
+  args: readonly string[],
+  handlers: StreamHandlers,
+  opts?: RunOptions,
+): Promise<number | null> {
+  return currentStreamer.stream(cmd, args, handlers, opts);
 }
 
 /** Swap in a fake runner (tests). Returns the previous runner. */
@@ -88,4 +168,16 @@ export function setRunner(runner: Runner): Runner {
 /** Restore the real, process-spawning runner (tests). */
 export function resetRunner(): void {
   current = realRunner;
+}
+
+/** Swap in a fake streamer (tests). Returns the previous streamer. */
+export function setStreamer(streamer: Streamer): Streamer {
+  const prev = currentStreamer;
+  currentStreamer = streamer;
+  return prev;
+}
+
+/** Restore the real, process-spawning streamer (tests). */
+export function resetStreamer(): void {
+  currentStreamer = realStreamer;
 }

--- a/packages/installer-cli/src/server/down.ts
+++ b/packages/installer-cli/src/server/down.ts
@@ -1,0 +1,81 @@
+// `librarian server down` — stop the container. DATA IS SACRED.
+//
+// `down` maps to ONE command: `docker stop the-librarian`. It NEVER removes the
+// container (`docker rm`), never passes `-v`, never touches the data volume
+// (`docker volume rm`), and never force-removes (`rm -f`). A later `up`/`update`
+// brings the SAME memories back from the untouched named volume — that is the
+// whole point (spec §11, success criterion 6).
+//
+// Idempotent-ish: if the container isn't running (or doesn't exist), `docker
+// stop` exits non-zero with a "No such container" message — `down` turns that
+// into a friendly "nothing to stop" outcome rather than a crash or a stack
+// trace. A genuine daemon error (anything that isn't the not-found case) still
+// surfaces as a teaching error.
+//
+// Everything goes through the injectable `docker.ts` runner, so tests assert the
+// exact argv without a real daemon.
+
+import { run } from "./docker.js";
+import { preflight } from "./preflight.js";
+import { CONTAINER_NAME } from "./up.js";
+
+export interface DownOptions {
+  /** Platform for preflight's daemon hint. Default `process.platform`. */
+  platform?: NodeJS.Platform | undefined;
+}
+
+/** A teaching error from `down`; the runtime renders `.message` as one stderr line. */
+export class DownError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DownError";
+  }
+}
+
+export interface DownResult {
+  /** Human-readable report for stdout. */
+  output: string;
+}
+
+/** True when `docker stop`'s failure means the container simply isn't there. */
+function isNotRunning(stderr: string): boolean {
+  return /no such container|is not running/i.test(stderr);
+}
+
+/**
+ * Run `server down`. Preflights docker, then `docker stop the-librarian` — the
+ * ONLY command it ever issues. A not-found/not-running container is a friendly
+ * no-op; any other non-zero exit is a teaching `DownError`.
+ */
+export async function runDown(options: DownOptions = {}): Promise<DownResult> {
+  await preflight(options.platform ? { platform: options.platform } : {});
+
+  // The single, data-safe command. No `rm`, no `-v`, no `volume`, no `-f`.
+  const result = await run("docker", ["stop", CONTAINER_NAME]);
+
+  if (result.code === 0) {
+    return {
+      output: [
+        `Stopped ${CONTAINER_NAME}.`,
+        "The data volume is preserved — `librarian server up` brings the same memories back.",
+      ].join("\n"),
+    };
+  }
+
+  const detail = result.stderr.trim();
+  if (isNotRunning(detail)) {
+    return {
+      output: [
+        `${CONTAINER_NAME} is not running — nothing to stop.`,
+        "The data volume (if any) is untouched.",
+      ].join("\n"),
+    };
+  }
+
+  // A real failure (daemon error, permission, etc.) — teach, don't crash.
+  throw new DownError(
+    `\`docker stop ${CONTAINER_NAME}\` failed (exit ${result.code ?? "signal"})` +
+      (detail ? `:\n${detail}` : ".") +
+      "\n\nResolve the error above, then re-run `librarian server down`.",
+  );
+}

--- a/packages/installer-cli/src/server/index.ts
+++ b/packages/installer-cli/src/server/index.ts
@@ -1,0 +1,52 @@
+// The `librarian server` command group — self-host the Librarian from the CLI.
+//
+// S1 lays the foundation the later slices build on: the command SURFACE (the
+// help table from spec §4), the `docker.ts` seam, and `preflight()`. The
+// individual subcommands (up / update / down / status / logs / enable-boot /
+// disable-boot / admin) are implemented in their own slices; here they resolve
+// to a clear "arrives in a later slice" notice so the surface is honest about
+// what exists today.
+//
+// `server` with NO subcommand prints the surface; `librarian --help` reveals
+// this group alongside the harness commands (wired in `runtime.ts`).
+
+/** The `server` subcommands, in the order they appear in the surface (§4). */
+export const SERVER_SUBCOMMANDS = [
+  "up",
+  "update",
+  "down",
+  "status",
+  "logs",
+  "enable-boot",
+  "disable-boot",
+  "admin",
+] as const;
+
+export type ServerSubcommand = (typeof SERVER_SUBCOMMANDS)[number];
+
+/** The `librarian server` command surface (spec §4). */
+export function serverUsage(): string {
+  return [
+    "Usage: librarian server <subcommand> [flags]",
+    "",
+    "Self-host the Librarian server (build + run the all-in-one container),",
+    "then hand its MCP URL + agent token to `librarian install` on clients.",
+    "",
+    "Subcommands:",
+    "  up            Build + run the server; print the MCP URL + agent token",
+    "  update        Re-pin to a release, rebuild, recreate (data volume kept)",
+    "  down          Stop the container (the data volume is preserved)",
+    "  status        Running? healthy? deployed version vs latest release",
+    "  logs          Tail the container logs ([-f] [--service mcp|dashboard|all])",
+    "  enable-boot   Start the server on boot (Linux systemd; macOS deferred)",
+    "  disable-boot  Reverse enable-boot",
+    "  admin         Run an admin command in the container (backup|restore|auth|rebuild)",
+    "",
+    "Run `librarian server <subcommand> --help` for flags (per subcommand).",
+  ].join("\n");
+}
+
+/** True iff `name` is one of the known `server` subcommands. */
+export function isServerSubcommand(name: string): name is ServerSubcommand {
+  return (SERVER_SUBCOMMANDS as readonly string[]).includes(name);
+}

--- a/packages/installer-cli/src/server/logs.ts
+++ b/packages/installer-cli/src/server/logs.ts
@@ -15,14 +15,21 @@
 //   unfiltered. This is the most reliable signal available without changing the
 //   image to prefix each child's output.
 //
-// NOTE on `-f` (follow): the `docker.ts` runner CAPTURES a process's output and
-// resolves on close, so a true live `docker logs -f` tail does not stream
-// line-by-line through this seam — `-f` is still passed to docker (and asserted
-// in tests + honoured by a future streaming runner), and the captured output is
-// filtered the same way. Live streaming is a runner-level enhancement, out of
-// this slice's scope.
+// `-f` (follow) vs one-shot — two different `docker.ts` seams, because the two
+// commands have opposite lifetimes:
+//   - WITHOUT `-f`, `docker logs the-librarian` prints what's there and EXITS.
+//     The capturing `run()` seam is right: it resolves on close with the whole
+//     output, which we then service-filter and return for stdout.
+//   - WITH `-f`, `docker logs -f the-librarian` NEVER closes on its own — it
+//     tails until the container stops or the user Ctrl-Cs. Capturing it would
+//     buffer forever and emit nothing until then (the old bug). So `-f` uses the
+//     STREAMING seam (`stream()`): each line is service-filtered and written to
+//     the terminal AS IT ARRIVES, and the call resolves with the process's exit
+//     code when the follow ends. Both paths apply the identical JSON-shape
+//     `--service` filter; only the delivery (buffered-then-returned vs.
+//     live-per-line) differs.
 
-import { run } from "./docker.js";
+import { run, stream } from "./docker.js";
 import { preflight } from "./preflight.js";
 import { CONTAINER_NAME } from "./up.js";
 
@@ -38,6 +45,13 @@ export interface LogsOptions {
   service?: string | undefined;
   /** Platform for preflight's daemon hint. Default `process.platform`. */
   platform?: NodeJS.Platform | undefined;
+  /**
+   * Where a FOLLOW (`-f`) writes its (service-filtered) lines, AS THEY ARRIVE.
+   * Defaults to `process.stdout` so a live tail reaches the terminal directly —
+   * never buffered to the end. Injectable so tests observe ordering without a
+   * real terminal. Unused by the one-shot path (it returns its output instead).
+   */
+  write?: ((chunk: string) => void) | undefined;
 }
 
 /** A teaching error from `logs`; the runtime renders `.message` as one stderr line. */
@@ -49,8 +63,17 @@ export class LogsError extends Error {
 }
 
 export interface LogsResult {
-  /** The (possibly service-filtered) log output for stdout. */
+  /**
+   * The (service-filtered) log output for stdout. Populated by the one-shot
+   * (no-`-f`) path; EMPTY for a follow, which streams its lines live via
+   * `write` rather than returning them.
+   */
   output: string;
+  /**
+   * The followed process's exit code (`-f` path), or `0` for the one-shot path.
+   * `null` when the follow was signalled (e.g. Ctrl-C / container stop).
+   */
+  exitCode: number | null;
 }
 
 /** Validate + default the `--service` value, or throw a teaching error. */
@@ -80,34 +103,95 @@ function isMcpLine(line: string): boolean {
   }
 }
 
+/**
+ * True iff a single line belongs to `service`. `all` keeps everything; `mcp`
+ * keeps the NDJSON lines; `dashboard` keeps the non-NDJSON, non-blank lines.
+ * The SAME predicate drives both the buffered and the streaming paths.
+ */
+function keepLine(line: string, service: LogsService): boolean {
+  if (service === "all") return true;
+  if (service === "mcp") return isMcpLine(line);
+  // dashboard: everything that isn't an mcp NDJSON line, skipping blanks so the
+  // output isn't padded.
+  return line.trim().length > 0 && !isMcpLine(line);
+}
+
 /** Keep only the lines belonging to `service` (preserving order + blanks for `all`). */
 function filterByService(text: string, service: LogsService): string {
   if (service === "all") return text;
-  const lines = text.split("\n");
-  const keep =
-    service === "mcp"
-      ? lines.filter((l) => isMcpLine(l))
-      : // dashboard: everything that isn't an mcp NDJSON line, dropping the
-        // empty tail line so the output isn't padded with a blank.
-        lines.filter((l) => l.trim().length > 0 && !isMcpLine(l));
-  return keep.join("\n");
+  return text
+    .split("\n")
+    .filter((l) => keepLine(l, service))
+    .join("\n");
 }
 
 /**
- * Run `server logs`. Preflights docker, builds `docker logs [-f] the-librarian`,
- * then filters the captured output to the requested service. An unknown
- * `--service` is a teaching error; a non-zero `docker logs` exit surfaces its
- * stderr as a teaching error (e.g. "No such container").
+ * A streaming line filter: feed it raw stdout chunks (which may split mid-line),
+ * and it emits each COMPLETE line that belongs to `service` to `write` as soon
+ * as the line is whole — never buffering to the end. Returns a `flush()` for any
+ * trailing partial line left when the stream closes.
+ */
+function makeLineFilter(
+  service: LogsService,
+  write: (chunk: string) => void,
+): { push: (chunk: string) => void; flush: () => void } {
+  let buffer = "";
+  const emit = (line: string): void => {
+    if (keepLine(line, service)) write(line + "\n");
+  };
+  return {
+    push(chunk: string): void {
+      buffer += chunk;
+      let nl = buffer.indexOf("\n");
+      while (nl !== -1) {
+        emit(buffer.slice(0, nl));
+        buffer = buffer.slice(nl + 1);
+        nl = buffer.indexOf("\n");
+      }
+    },
+    flush(): void {
+      if (buffer.length > 0) {
+        emit(buffer);
+        buffer = "";
+      }
+    },
+  };
+}
+
+/**
+ * Run `server logs`. Preflights docker, then either:
+ *   - FOLLOW (`-f`): streams `docker logs -f the-librarian` through the streaming
+ *     seam, writing each service-matching line to `write` (default
+ *     `process.stdout`) AS IT ARRIVES, resolving with the process's exit code
+ *     when the follow ends (Ctrl-C / container stop). Output is empty (already
+ *     streamed live).
+ *   - ONE-SHOT (no `-f`): captures `docker logs the-librarian` via the capturing
+ *     runner (it exits on its own), service-filters the captured output, and
+ *     returns it for stdout.
+ *
+ * An unknown `--service` is a teaching error; a non-zero one-shot `docker logs`
+ * exit surfaces its stderr as a teaching error (e.g. "No such container").
  */
 export async function runLogs(options: LogsOptions = {}): Promise<LogsResult> {
   const service = resolveService(options.service);
   await preflight(options.platform ? { platform: options.platform } : {});
 
-  const args = ["logs"];
-  if (options.follow) args.push("-f");
-  args.push(CONTAINER_NAME);
+  if (options.follow) {
+    // Live tail: stream line-by-line, never buffer to close.
+    const write = options.write ?? ((chunk: string) => process.stdout.write(chunk));
+    const filter = makeLineFilter(service, write);
+    const exitCode = await stream("docker", ["logs", "-f", CONTAINER_NAME], {
+      onStdout: (chunk) => filter.push(chunk),
+      // `docker logs` writes the container's stderr stream here too; service
+      // filtering applies the same way so it isn't lost or unfiltered.
+      onStderr: (chunk) => filter.push(chunk),
+    });
+    filter.flush();
+    return { output: "", exitCode };
+  }
 
-  const result = await run("docker", args);
+  // One-shot: `docker logs` exits on its own, so capture + filter is correct.
+  const result = await run("docker", ["logs", CONTAINER_NAME]);
   if (result.code !== 0) {
     const detail = result.stderr.trim() || result.stdout.trim();
     throw new LogsError(
@@ -117,5 +201,5 @@ export async function runLogs(options: LogsOptions = {}): Promise<LogsResult> {
     );
   }
 
-  return { output: filterByService(result.stdout, service) };
+  return { output: filterByService(result.stdout, service), exitCode: result.code };
 }

--- a/packages/installer-cli/src/server/logs.ts
+++ b/packages/installer-cli/src/server/logs.ts
@@ -1,0 +1,121 @@
+// `librarian server logs [-f] [--service mcp|dashboard|all]`.
+//
+// Maps to `docker logs [-f] the-librarian`. The all-in-one image runs BOTH
+// services (mcp-server + dashboard) in ONE container under `docker/supervisor.mjs`,
+// which spawns its children with `stdio: "inherit"` — so it emits NO per-service
+// prefix. The two streams are interleaved with no supervisor-added label.
+//
+// How `--service` filtering works, given that constraint:
+//   - The mcp-server logs structured pino NDJSON — every line is a JSON object
+//     carrying `"service":"the-librarian"` (see packages/mcp-server/src/logging.ts).
+//   - The dashboard (Next.js standalone `server.js`) logs plain text.
+//   So we distinguish them by SHAPE: a line that parses as a JSON object is an
+//   mcp-server line; anything else is a dashboard line. `--service mcp` keeps the
+//   NDJSON lines; `--service dashboard` keeps the rest; `all` (default) is
+//   unfiltered. This is the most reliable signal available without changing the
+//   image to prefix each child's output.
+//
+// NOTE on `-f` (follow): the `docker.ts` runner CAPTURES a process's output and
+// resolves on close, so a true live `docker logs -f` tail does not stream
+// line-by-line through this seam — `-f` is still passed to docker (and asserted
+// in tests + honoured by a future streaming runner), and the captured output is
+// filtered the same way. Live streaming is a runner-level enhancement, out of
+// this slice's scope.
+
+import { run } from "./docker.js";
+import { preflight } from "./preflight.js";
+import { CONTAINER_NAME } from "./up.js";
+
+/** The services `--service` can target. `all` (default) is unfiltered. */
+export type LogsService = "mcp" | "dashboard" | "all";
+
+const SERVICES: readonly LogsService[] = ["mcp", "dashboard", "all"];
+
+export interface LogsOptions {
+  /** Follow the log output (`-f` / `--follow`). */
+  follow?: boolean | undefined;
+  /** Which service to show. Default `all` (unfiltered). */
+  service?: string | undefined;
+  /** Platform for preflight's daemon hint. Default `process.platform`. */
+  platform?: NodeJS.Platform | undefined;
+}
+
+/** A teaching error from `logs`; the runtime renders `.message` as one stderr line. */
+export class LogsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LogsError";
+  }
+}
+
+export interface LogsResult {
+  /** The (possibly service-filtered) log output for stdout. */
+  output: string;
+}
+
+/** Validate + default the `--service` value, or throw a teaching error. */
+function resolveService(raw: string | undefined): LogsService {
+  if (raw === undefined) return "all";
+  if ((SERVICES as readonly string[]).includes(raw)) return raw as LogsService;
+  throw new LogsError(
+    `Unknown --service '${raw}'. Valid values: mcp, dashboard, all (default). ` +
+      "`mcp` shows the MCP server's structured logs, `dashboard` shows the Next.js " +
+      "dashboard's, `all` shows both.",
+  );
+}
+
+/**
+ * True iff a log line is an mcp-server line — i.e. it parses as a JSON object
+ * (the pino NDJSON shape). The dashboard's plain-text lines do not parse as JSON
+ * objects, so they're treated as `dashboard`.
+ */
+function isMcpLine(line: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith("{")) return false;
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed);
+  } catch {
+    return false;
+  }
+}
+
+/** Keep only the lines belonging to `service` (preserving order + blanks for `all`). */
+function filterByService(text: string, service: LogsService): string {
+  if (service === "all") return text;
+  const lines = text.split("\n");
+  const keep =
+    service === "mcp"
+      ? lines.filter((l) => isMcpLine(l))
+      : // dashboard: everything that isn't an mcp NDJSON line, dropping the
+        // empty tail line so the output isn't padded with a blank.
+        lines.filter((l) => l.trim().length > 0 && !isMcpLine(l));
+  return keep.join("\n");
+}
+
+/**
+ * Run `server logs`. Preflights docker, builds `docker logs [-f] the-librarian`,
+ * then filters the captured output to the requested service. An unknown
+ * `--service` is a teaching error; a non-zero `docker logs` exit surfaces its
+ * stderr as a teaching error (e.g. "No such container").
+ */
+export async function runLogs(options: LogsOptions = {}): Promise<LogsResult> {
+  const service = resolveService(options.service);
+  await preflight(options.platform ? { platform: options.platform } : {});
+
+  const args = ["logs"];
+  if (options.follow) args.push("-f");
+  args.push(CONTAINER_NAME);
+
+  const result = await run("docker", args);
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || result.stdout.trim();
+    throw new LogsError(
+      `\`docker logs ${CONTAINER_NAME}\` failed (exit ${result.code ?? "signal"})` +
+        (detail ? `:\n${detail}` : ".") +
+        "\n\nIs the server up? Run `librarian server status`.",
+    );
+  }
+
+  return { output: filterByService(result.stdout, service) };
+}

--- a/packages/installer-cli/src/server/preflight.ts
+++ b/packages/installer-cli/src/server/preflight.ts
@@ -1,0 +1,77 @@
+// Preflight for the `server` command group.
+//
+// Every `server` subcommand that drives a container (up / update / down /
+// status / logs / boot / admin) first confirms the host actually has the tools
+// it needs: `docker` installed AND its daemon reachable, and `git` installed.
+// A missing or unreachable tool is a TEACHING error (what to install, or "is
+// the daemon running?") — never a stack trace, never a bare "error".
+//
+// The check goes through the `docker.ts` seam, so tests stub it and a real
+// daemon is never contacted. `platform` is injectable so the macOS-specific
+// "Docker Desktop" hint is testable on any host.
+
+import { run, which } from "./docker.js";
+
+/**
+ * A preflight failure carrying an actionable, teaching message. The CLI
+ * runtime renders `error.message` as one clean stderr line (no stack trace),
+ * so this message IS what the user reads.
+ */
+export class PreflightError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PreflightError";
+  }
+}
+
+export interface PreflightOptions {
+  /**
+   * The host platform, defaulting to `process.platform`. Injectable so the
+   * macOS "Docker Desktop" daemon hint is testable from any host.
+   */
+  platform?: NodeJS.Platform;
+}
+
+const DOCKER_INSTALL =
+  "Docker is required but was not found on your PATH. " +
+  "Install Docker Engine (Linux) or Docker Desktop (macOS) — " +
+  "see https://docs.docker.com/get-docker/ — then re-run this command.";
+
+const GIT_INSTALL =
+  "git is required but was not found on your PATH. " +
+  "Install git (e.g. `apt install git`, `brew install git`, or " +
+  "https://git-scm.com/downloads), then re-run this command.";
+
+function dockerDaemonHint(platform: NodeJS.Platform): string {
+  const start =
+    platform === "darwin"
+      ? "Is Docker Desktop running? Start Docker Desktop and wait for it to report ready, then re-run this command."
+      : "Is the Docker daemon running? Start it (e.g. `sudo systemctl start docker`) and confirm `docker info` succeeds, then re-run this command.";
+  return `Docker is installed but its daemon is unreachable. ${start}`;
+}
+
+/**
+ * Confirm `docker` (daemon reachable) and `git` are available, or throw a
+ * `PreflightError` with a teaching message. Resolves to nothing on success.
+ *
+ * Order matters: report a missing binary before probing the daemon, so a host
+ * without Docker is told to install it (not told the daemon is down).
+ */
+export async function preflight(options: PreflightOptions = {}): Promise<void> {
+  const platform = options.platform ?? process.platform;
+
+  if ((await which("docker")) === null) {
+    throw new PreflightError(DOCKER_INSTALL);
+  }
+
+  // Daemon probe: `docker info` exits non-zero (and prints to stderr) when the
+  // engine isn't reachable. We only care about the exit code here.
+  const info = await run("docker", ["info"]);
+  if (info.code !== 0) {
+    throw new PreflightError(dockerDaemonHint(platform));
+  }
+
+  if ((await which("git")) === null) {
+    throw new PreflightError(GIT_INSTALL);
+  }
+}

--- a/packages/installer-cli/src/server/redact.ts
+++ b/packages/installer-cli/src/server/redact.ts
@@ -1,0 +1,25 @@
+// Secret redaction for captured docker/git output before it reaches a
+// user-facing error or log (C1 / I-3 / S-2).
+//
+// `up`, `update`, and `admin` all surface a failed step's stderr/stdout so the
+// operator can triage — but those streams can carry secrets: the server's
+// one-time admin-token generation notice emits the token BY VALUE
+// (`packages/mcp-server/src/bin/http.ts`), a `docker run -e
+// LIBRARIAN_AGENT_TOKEN=…`/`restore --secret-key …` failure can echo the argv,
+// and a master key is a raw 64-hex run. This single helper is the shared choke
+// point so every surface redacts identically (no surface forgets).
+//
+// We defend three ways:
+//   - drop any whole line carrying the admin-token generation notice;
+//   - redact any `libadmin_<base64url>` token substring (the bearer shape);
+//   - redact any standalone 64-hex run (a raw key/token shape: the master key
+//     and the CSPRNG agent token are both 64-hex).
+// The redacted remainder is still surfaced so debugging works — just no secrets.
+export function redactSecrets(text: string): string {
+  return text
+    .split("\n")
+    .filter((line) => !/Generated a new admin token/i.test(line))
+    .join("\n")
+    .replace(/libadmin_[A-Za-z0-9_-]+/g, "[redacted-admin-token]")
+    .replace(/\b[0-9a-fA-F]{64}\b/g, "[redacted]");
+}

--- a/packages/installer-cli/src/server/status.ts
+++ b/packages/installer-cli/src/server/status.ts
@@ -1,0 +1,133 @@
+// `librarian server status` — running? healthy? deployed-vs-latest.
+//
+// Reports, all from the injectable `docker.ts` runner + the injectable
+// latest-release fetcher (so tests never touch a real daemon/network):
+//   - container running? (`docker inspect --format {{.State.Status}}`)
+//   - health (`docker inspect --format {{.State.Health.Status}}`)
+//   - the DEPLOYED version — the ref recorded in deploy-state.json, falling back
+//     to `git -C <dir> describe --tags` when no state file exists (e.g. a clone
+//     made before deploy-state existed)
+//   - the LATEST release (`fetchLatestVersion` — the same fetch `librarian
+//     status` uses for the harnesses)
+//   - an `up-to-date | update-available` badge via `isBehind(deployed, latest)`
+//
+// OFFLINE TOLERANCE (mirrors src/status.ts): an unreachable GitHub resolves
+// latest to `unknown` and the badge to `?`; an unknown deployed version does the
+// same. The command never crashes because the network was down or the deploy dir
+// wasn't a git repo — it renders `unknown`/`?` and exits 0.
+
+import path from "node:path";
+import { librarianDir } from "../paths.js";
+import { isBehind } from "../semver.js";
+import { fetchLatestVersion } from "../status.js";
+import { readDeployState } from "./deploy-state.js";
+import { run } from "./docker.js";
+import { preflight } from "./preflight.js";
+import { CONTAINER_NAME } from "./up.js";
+
+export interface ServerStatusOptions {
+  /** Override home (tests). */
+  home?: string | undefined;
+  /** Deploy dir override. Default: `~/.librarian/server`. */
+  dir?: string | undefined;
+  /** Platform for preflight's daemon hint. Default `process.platform`. */
+  platform?: NodeJS.Platform | undefined;
+}
+
+export interface ServerStatusResult {
+  /** The rendered status report for stdout. */
+  output: string;
+}
+
+/** The deploy dir `status` reads its recorded ref / git-describe fallback from. */
+function resolveDeployDir(options: ServerStatusOptions): string {
+  return options.dir ?? path.join(librarianDir(options.home), "server");
+}
+
+/**
+ * Read the container's `State.Status` (running / exited / …). Returns `null`
+ * when `docker inspect` fails — the container doesn't exist → "not running".
+ */
+async function inspectField(format: string): Promise<string | null> {
+  const result = await run("docker", ["inspect", "--format", format, CONTAINER_NAME]);
+  if (result.code !== 0) return null;
+  return result.stdout.trim();
+}
+
+/**
+ * Resolve the deployed version: the deploy-state ref first (authoritative — it's
+ * exactly what `up` checked out + built), else `git -C <dir> describe --tags`.
+ * Returns `null` (→ "unknown") when neither is available.
+ */
+async function resolveDeployed(deployDir: string): Promise<string | null> {
+  const state = readDeployState(deployDir);
+  if (state?.ref) return state.ref;
+
+  const described = await run("git", ["-C", deployDir, "describe", "--tags"]);
+  if (described.code === 0) {
+    const tag = described.stdout.trim();
+    if (tag) return tag;
+  }
+  return null;
+}
+
+/**
+ * Run `server status`. Preflights docker, probes the container's running/health
+ * state, resolves the deployed + latest versions, and renders the report. Never
+ * throws on an offline latest-fetch or an absent deploy dir — those degrade to
+ * `unknown`/`?`.
+ */
+export async function serverStatus(options: ServerStatusOptions = {}): Promise<ServerStatusResult> {
+  await preflight(options.platform ? { platform: options.platform } : {});
+  const deployDir = resolveDeployDir(options);
+
+  // Probe the container. A null status means `docker inspect` failed → absent.
+  const statusField = await inspectField("{{.State.Status}}");
+  const running = statusField === "running";
+  // Health is only meaningful when the container exists; an empty health string
+  // (no healthcheck, or container absent) renders "unknown".
+  const health = statusField === null ? null : await inspectField("{{.State.Health.Status}}");
+
+  const [deployed, latest] = await Promise.all([resolveDeployed(deployDir), fetchLatestVersion()]);
+
+  return { output: render({ statusField, running, health, deployed, latest }) };
+}
+
+interface RenderInput {
+  statusField: string | null;
+  running: boolean;
+  health: string | null;
+  deployed: string | null;
+  latest: string | null;
+}
+
+/**
+ * The `up-to-date | update-available | ?` badge. `?` whenever either version is
+ * unknown — an offline run never lies about an available update (mirrors the
+ * harness `status` table's `update?` column).
+ */
+function badge(deployed: string | null, latest: string | null): string {
+  if (!deployed || !latest) return "?";
+  return isBehind(deployed, latest) ? "update-available" : "up-to-date";
+}
+
+function render(input: RenderInput): string {
+  const { statusField, running, health, deployed, latest } = input;
+  const runningLabel = statusField === null ? "not running" : running ? "running" : statusField;
+  const healthLabel = health && health.length > 0 ? health : "unknown";
+
+  const lines = [
+    `The Librarian server (${CONTAINER_NAME}):`,
+    "",
+    `  Running:    ${runningLabel}`,
+    `  Health:     ${runningLabel === "not running" ? "—" : healthLabel}`,
+    `  Deployed:   ${deployed ?? "unknown"}`,
+    `  Latest:     ${latest ?? "unknown"}`,
+    `  Update:     ${badge(deployed, latest)}`,
+  ];
+
+  if (latest === null) {
+    lines.push("", "latest release unknown (could not reach GitHub) — Update shows ?");
+  }
+  return lines.join("\n");
+}

--- a/packages/installer-cli/src/server/up.ts
+++ b/packages/installer-cli/src/server/up.ts
@@ -1,27 +1,36 @@
-// `librarian server up` — build + run the all-in-one container (localhost path).
+// `librarian server up` — build + run the all-in-one container.
 //
 // This is the loop-closer: on a fresh Docker host it clones the monorepo at the
 // resolved release tag, builds `the-librarian:<tag>`, runs the all-in-one
-// container bound to host loopback, waits for it to report healthy, surfaces the
-// server-generated master key ONCE, and prints the MCP URL + dashboard URL + a
-// freshly minted agent token ready to paste into `librarian install`.
+// container bound to the resolved host, waits for it to report healthy, surfaces
+// the server-generated master key (and, beyond localhost, the admin token)
+// ONCE, and prints the MCP URL + dashboard URL + a freshly minted agent token
+// ready to paste into `librarian install`.
 //
-// S2 implements ONLY the localhost (`127.0.0.1`) happy path. The flow is
-// structured so S3 can cleanly add beyond-localhost binding (`--host`) and
-// admin-token surfacing:
-//   - `buildRunArgs({ host, … })` is the single place the `docker run` argv is
-//     constructed; S3 makes the `LIBRARIAN_ALLOW_NO_AUTH` flag + the publish
-//     address conditional on `host` there.
-//   - the post-health secret read (`readMasterKey`) is the seam S3 extends to
-//     also read `/data/admin.token` when bound beyond localhost.
+// Bind host (spec §5.3 / §6): the default is `127.0.0.1` (host loopback only).
+// `--host <addr>` sets it explicitly. Best-effort, an interactive run with no
+// `--host` is OFFERED a detected Tailscale tailnet IP. Binding to `0.0.0.0`
+// (all interfaces) is ask-first. We NEVER default to `0.0.0.0`, and a
+// non-interactive/`--yes` run never silently exposes the server beyond
+// localhost.
 //
-// EVERYTHING that touches the system is injected (`docker.ts` runner, the
-// latest-release fetcher, the prompter, `home`, and the health-poll sleep), so
-// the whole flow is exercised in tests WITHOUT a real daemon, network, or git.
+// The bind choice drives the auth model via `LIBRARIAN_ALLOW_NO_AUTH` (the
+// image always binds `0.0.0.0` internally, so the server can't see the host
+// publish address — spec §6):
+//   - `127.0.0.1`        → pass `-e LIBRARIAN_ALLOW_NO_AUTH=true`; the server
+//                          generates NO admin token (loopback no-auth bypass).
+//   - tailnet / `0.0.0.0`→ OMIT that flag; the server generates + enforces an
+//                          admin token at `/data/admin.token`, read back ONCE.
+//
+// EVERYTHING that touches the system is injected (`docker.ts` runner — which
+// also routes the Tailscale probe, the latest-release fetcher, the prompter,
+// `home`, the interactivity flag, and the health-poll sleep), so the whole flow
+// is exercised in tests WITHOUT a real daemon, network, git, or tailscale.
 //
 // Security (AGENTS.md): the agent token rides ONLY in the `docker run -e` arg
 // and (if the user accepts) into `~/.librarian/env` via env.ts. The master key
-// is surfaced to stdout exactly once and is NEVER written to a host file or log.
+// and admin token are surfaced to stdout exactly once each and are NEVER
+// written to a host file or log.
 
 import { randomBytes } from "node:crypto";
 import path from "node:path";
@@ -29,7 +38,7 @@ import { readEnvFile, writeEnvFile } from "../env.js";
 import { librarianDir } from "../paths.js";
 import type { Prompter } from "../prompt.js";
 import { fetchLatestVersion } from "../status.js";
-import { run, type RunResult } from "./docker.js";
+import { run, which, type RunResult } from "./docker.js";
 import { preflight } from "./preflight.js";
 
 /** The repository the deploy dir clones (same repo the latest-tag fetch targets). */
@@ -43,6 +52,9 @@ export const DEFAULT_DATA_VOLUME = "librarian_data";
 
 /** Host loopback — the default, only-reachable-locally bind (spec §5/§6). */
 export const LOCALHOST = "127.0.0.1";
+
+/** Bind-all-interfaces — never the default; ask-first (spec §5.3, §11). */
+export const ALL_INTERFACES = "0.0.0.0";
 
 /** The warning printed beside the one-time master-key surfacing (spec §5.4). */
 export const SAVE_KEY_WARNING = "SAVE THIS KEY — excluded from backups";
@@ -92,7 +104,11 @@ export interface UpOptions {
   ref?: string | undefined;
   /** Deploy dir override. Default: `~/.librarian/server`. */
   dir?: string | undefined;
-  /** Bind host. S2 only implements the localhost path (`127.0.0.1`). */
+  /**
+   * Bind host. Default `127.0.0.1` (loopback only). `--host <addr>` sets it
+   * explicitly; `0.0.0.0` (all interfaces) is ask-first. An interactive run
+   * with no `--host` may be offered a detected Tailscale IP instead (§5.3).
+   */
   host?: string | undefined;
   /** Named data volume. Default: `librarian_data`. */
   dataVolume?: string | undefined;
@@ -111,10 +127,16 @@ export interface UpOptions {
 export interface UpDeps {
   /** Override home (tests). */
   home?: string | undefined;
-  /** Prompter for the loop-closer env offer. */
+  /** Prompter for the loop-closer env offer and the bind-host offers. */
   prompter: Prompter;
   /** Platform for preflight's daemon hint. Default `process.platform`. */
   platform?: NodeJS.Platform | undefined;
+  /**
+   * Whether the run is interactive (a TTY is attached). Gates the best-effort
+   * Tailscale offer and the `0.0.0.0` confirm — a non-interactive run never
+   * silently exposes the server beyond localhost. Default `true`.
+   */
+  interactive?: boolean | undefined;
 }
 
 /** A teaching error from `up`; the runtime renders `.message` as one stderr line. */
@@ -125,7 +147,7 @@ export class UpError extends Error {
   }
 }
 
-// --- the docker run argv seam (S3 extends this) -------------------------
+// --- the docker run argv seam -------------------------------------------
 
 export interface RunArgsInput {
   host: string;
@@ -136,12 +158,13 @@ export interface RunArgsInput {
 
 /**
  * Construct the `docker run` argv (everything after `docker`). The SINGLE place
- * the run vector is assembled, so S3 can make `LIBRARIAN_ALLOW_NO_AUTH` and the
- * publish address conditional on `host` without touching the orchestration.
+ * the run vector is assembled: `LIBRARIAN_ALLOW_NO_AUTH` and the publish address
+ * are both derived from `host`.
  *
  * Localhost (`127.0.0.1`) → include `-e LIBRARIAN_ALLOW_NO_AUTH=true` (no admin
- * token; loopback-only no-auth bypass — spec §6). The image runs `tini` as PID
- * 1, so `--init` is deliberately omitted.
+ * token; loopback-only no-auth bypass — spec §6). Beyond localhost (a tailnet
+ * IP or `0.0.0.0`) → OMIT the flag so the server generates + enforces an admin
+ * token. The image runs `tini` as PID 1, so `--init` is deliberately omitted.
  */
 export function buildRunArgs(input: RunArgsInput): string[] {
   const { host, dataVolume, tag, agentToken } = input;
@@ -176,45 +199,42 @@ export interface UpResult {
 }
 
 /**
- * Run `server up` (localhost happy path). Throws `UpError` (teaching message)
- * on any failure; on a failed health-wait it rolls the container back first so
- * no half-up state is left behind.
+ * Run `server up`. Throws `UpError` (teaching message) on any failure; on a
+ * failed health-wait it rolls the container back first so no half-up state is
+ * left behind. Works for any resolved bind host (loopback / tailnet / all
+ * interfaces); the bind choice drives the auth model (§6).
  */
 export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult> {
-  const host = options.host ?? LOCALHOST;
-  if (host !== LOCALHOST) {
-    // S3 owns beyond-localhost binding (admin-token surfacing, `0.0.0.0`
-    // ask-first). Refuse rather than silently doing the wrong thing.
-    throw new UpError(
-      `Binding beyond ${LOCALHOST} (got --host ${host}) is not available yet — ` +
-        `this slice implements the localhost path only. Re-run without --host.`,
-    );
-  }
-
   // 1) Preflight: docker (daemon reachable) + git, or a teaching error.
   await preflight(deps.platform ? { platform: deps.platform } : {});
+
+  // 2) Resolve the bind host (default loopback; Tailscale offer; `0.0.0.0`
+  //    ask-first). May throw `UpError` if the user declines a `0.0.0.0` bind —
+  //    BEFORE any clone/build/run, so a declined exposure leaves nothing behind.
+  const host = await resolveBindHost(options, deps);
 
   const dataVolume = options.dataVolume ?? DEFAULT_DATA_VOLUME;
   const deployDir = options.dir ?? path.join(librarianDir(deps.home), "server");
 
-  // 2) Resolve the ref (default = latest release tag), then the deploy dir.
+  // 3) Resolve the ref (default = latest release tag), then the deploy dir.
   const tag = await resolveRef(options.ref);
   await prepareDeployDir(deployDir, tag);
 
-  // 3) Mint the agent token (the loop-closer). Never logged.
+  // 4) Mint the agent token (the loop-closer). Never logged.
   const agentToken = minter();
 
-  // 4) Build the image, then run the container.
+  // 5) Build the image, then run the container.
   await build(deployDir, tag);
   await dockerRun(buildRunArgs({ host, dataVolume, tag, agentToken }), deployDir);
 
-  // 5) Wait for health; roll back (and surface logs) on failure — no half-up.
+  // 6) Wait for health; roll back (and surface logs) on failure — no half-up.
   await waitForHealthy(options);
 
-  // 6) Read the server-generated master key back from the container.
-  const masterKey = await readMasterKey();
+  // 7) Read the server-generated secrets back from the container: the master
+  //    key always; the admin token too when bound beyond localhost (§6).
+  const secrets = await readSecrets(host);
 
-  // 7) `--enable-boot` is wired but deferred to S6.
+  // 8) `--enable-boot` is wired but deferred to S6.
   const lines: string[] = [];
   if (options.enableBoot) {
     lines.push(
@@ -223,10 +243,91 @@ export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult>
     );
   }
 
-  // 8) Close the loop: surface secrets/URLs + offer the local env write.
-  await closeTheLoop(lines, { host, agentToken, masterKey, options, deps });
+  // 9) Close the loop: surface secrets/URLs + offer the local env write.
+  await closeTheLoop(lines, { host, agentToken, secrets, options, deps });
 
   return { output: lines.join("\n") };
+}
+
+// --- bind-host resolution (spec §5.3, §6) -------------------------------
+
+/**
+ * Resolve the host the container publishes on:
+ *   - `--host <addr>` wins (explicit). `0.0.0.0` is still ask-first.
+ *   - no `--host`, interactive, not `--yes`, and `tailscale ip -4` yields a
+ *     tailnet IP → OFFER it (default: keep loopback).
+ *   - otherwise → `127.0.0.1` (we never silently expose beyond localhost).
+ *
+ * Binding to `0.0.0.0` requires explicit confirmation (`--yes` auto-accepts);
+ * declining aborts with a teaching error BEFORE any clone/build/run.
+ */
+async function resolveBindHost(options: UpOptions, deps: UpDeps): Promise<string> {
+  if (options.host !== undefined) {
+    const host = options.host.trim();
+    if (host === ALL_INTERFACES) {
+      await confirmAllInterfaces(options, deps);
+    }
+    return host;
+  }
+
+  // No explicit host: best-effort offer the Tailscale IP (interactive only).
+  const interactive = deps.interactive ?? true;
+  if (interactive && options.yes !== true) {
+    const tailnetIp = await detectTailscaleIp();
+    if (tailnetIp) {
+      const answer = await deps.prompter.promptText(
+        `Detected a Tailscale address (${tailnetIp}). Bind the server to it so your ` +
+          `tailnet can reach it (instead of localhost only)? [y/N]`,
+        { default: "n" },
+      );
+      if (isYes(answer)) return tailnetIp;
+    }
+  }
+
+  return LOCALHOST;
+}
+
+/**
+ * Confirm an all-interfaces (`0.0.0.0`) bind. `--yes` auto-accepts; otherwise
+ * prompt (default no). Declining throws `UpError` — exposing every interface is
+ * never something we do without an explicit yes.
+ */
+async function confirmAllInterfaces(options: UpOptions, deps: UpDeps): Promise<void> {
+  if (options.yes === true) return;
+
+  const answer = await deps.prompter.promptText(
+    `Binding to 0.0.0.0 exposes the server on ALL network interfaces — anyone who ` +
+      `can reach this machine can reach it. Continue? [y/N]`,
+    { default: "n" },
+  );
+  if (!isYes(answer)) {
+    throw new UpError(
+      "Aborted: binding to 0.0.0.0 (all interfaces) was declined. " +
+        "Re-run without --host for a localhost-only server, or with --host <tailnet-ip> " +
+        "for a specific reachable address.",
+    );
+  }
+}
+
+/**
+ * Best-effort probe for this machine's Tailscale IPv4 address, routed through
+ * the injectable `docker.ts` runner (so tests stub it; no real tailscale).
+ * Returns `null` when `tailscale` is absent or yields no usable IPv4 — the
+ * caller then stays on loopback. Never throws: a probe failure is silent.
+ */
+async function detectTailscaleIp(): Promise<string | null> {
+  if ((await which("tailscale")) === null) return null;
+  try {
+    const result = await run("tailscale", ["ip", "-4"]);
+    if (result.code !== 0) return null;
+    const ip = result.stdout
+      .split("\n")
+      .map((l) => l.trim())
+      .find((l) => /^\d{1,3}(\.\d{1,3}){3}$/.test(l));
+    return ip ?? null;
+  } catch {
+    return null;
+  }
 }
 
 // --- step helpers --------------------------------------------------------
@@ -346,10 +447,29 @@ async function waitForHealthy(options: UpOptions): Promise<void> {
   );
 }
 
+/** The server-generated secrets read back after the container is healthy. */
+interface ContainerSecrets {
+  /** The master key from `/data/secret.key` (always present). */
+  masterKey: string;
+  /**
+   * The admin token from `/data/admin.token` — present ONLY when bound beyond
+   * localhost (the server generates it then; on localhost it generates none).
+   */
+  adminToken?: string;
+}
+
 /**
- * Read the server-generated master key from `/data/secret.key`. The seam S3
- * extends to also read `/data/admin.token` when bound beyond localhost.
+ * Read the server-generated secrets from the container: the master key from
+ * `/data/secret.key` always, and — when bound beyond localhost — the admin
+ * token from `/data/admin.token`. Neither is ever written to a host file or log.
  */
+async function readSecrets(host: string): Promise<ContainerSecrets> {
+  const masterKey = await readMasterKey();
+  if (host === LOCALHOST) return { masterKey };
+  return { masterKey, adminToken: await readAdminToken() };
+}
+
+/** Read the server-generated master key from `/data/secret.key`. */
 async function readMasterKey(): Promise<string> {
   const result = await run("docker", ["exec", CONTAINER_NAME, "cat", "/data/secret.key"]);
   const key = result.stdout.trim();
@@ -363,21 +483,39 @@ async function readMasterKey(): Promise<string> {
 }
 
 /**
- * Close the loop: surface the master key ONCE (with the SAVE warning), print the
- * MCP + dashboard URLs and the minted agent token, and OFFER to write this
- * machine's `~/.librarian/env` when it's absent/incomplete (`--yes` auto-accepts).
+ * Read the server-generated admin token from `/data/admin.token` (present only
+ * when bound beyond localhost — the server mints it on first boot then). An
+ * empty read is unexpected for a beyond-localhost bind, so it teaches.
+ */
+async function readAdminToken(): Promise<string> {
+  const result = await run("docker", ["exec", CONTAINER_NAME, "cat", "/data/admin.token"]);
+  const token = result.stdout.trim();
+  if (!token) {
+    throw new UpError(
+      "The server became healthy but no admin token was found at /data/admin.token. " +
+        "An admin token is expected when binding beyond localhost — check `librarian server logs`.",
+    );
+  }
+  return token;
+}
+
+/**
+ * Close the loop: surface the master key ONCE (with the SAVE warning) — and,
+ * when bound beyond localhost, the admin token ONCE — print the MCP + dashboard
+ * URLs and the minted agent token, and OFFER to write this machine's
+ * `~/.librarian/env` when it's absent/incomplete (`--yes` auto-accepts).
  */
 async function closeTheLoop(
   lines: string[],
   ctx: {
     host: string;
     agentToken: string;
-    masterKey: string;
+    secrets: ContainerSecrets;
     options: UpOptions;
     deps: UpDeps;
   },
 ): Promise<void> {
-  const { host, agentToken, masterKey, options, deps } = ctx;
+  const { host, agentToken, secrets, options, deps } = ctx;
   const mcpUrl = `http://${host}:3838/mcp`;
   const dashboardUrl = `http://${host}:3000`;
 
@@ -388,13 +526,36 @@ async function closeTheLoop(
     `  Dashboard:   ${dashboardUrl}`,
     `  Agent token: ${agentToken}`,
     "",
+  );
+
+  // `0.0.0.0` is a bind directive, not a connectable address — point clients at
+  // the machine's real reachable IP rather than over-engineering auto-detection.
+  if (host === ALL_INTERFACES) {
+    lines.push(
+      "Note: 0.0.0.0 binds every interface but is NOT a connectable address — " +
+        "clients should use this machine's reachable LAN/tailnet IP in the URLs above.",
+      "",
+    );
+  }
+
+  lines.push(
     "Paste the MCP URL + agent token into `librarian install` on your clients.",
     "",
     // The ONE-TIME master-key surfacing. Never written to a host file or log.
     `Master key (${SAVE_KEY_WARNING}):`,
-    `  ${masterKey}`,
+    `  ${secrets.masterKey}`,
     "",
   );
+
+  // Beyond localhost the server enforces auth: surface the admin token ONCE.
+  if (secrets.adminToken) {
+    lines.push(
+      "Admin token (surfaced once — not stored anywhere on this host):",
+      `  ${secrets.adminToken}`,
+      "  Paste it into the dashboard to enable auth, or use it for `librarian server admin auth`.",
+      "",
+    );
+  }
 
   await offerLocalEnv(lines, { mcpUrl, agentToken, options, deps });
 }

--- a/packages/installer-cli/src/server/up.ts
+++ b/packages/installer-cli/src/server/up.ts
@@ -43,6 +43,11 @@ import { enableBoot } from "./boot.js";
 import { writeDeployState } from "./deploy-state.js";
 import { run, which, type RunResult } from "./docker.js";
 import { preflight } from "./preflight.js";
+import { redactSecrets } from "./redact.js";
+
+// Re-exported from its shared home so existing importers (`update.ts`) keep
+// working; new code should import from `./redact.js` directly.
+export { redactSecrets } from "./redact.js";
 
 /** The repository the deploy dir clones (same repo the latest-tag fetch targets). */
 export const REPO_URL = "https://github.com/JimJafar/the-librarian";
@@ -440,7 +445,8 @@ async function prepareDeployDir(dir: string, tag: string): Promise<void> {
       }
     }
     await git(["clone", REPO_URL, dir]);
-    await git(["-C", dir, "checkout", tag]);
+    // `--end-of-options` so a `--…`-shaped ref can't inject a git option (S-1).
+    await git(["-C", dir, "checkout", "--end-of-options", tag]);
     return;
   }
 
@@ -454,7 +460,8 @@ async function prepareDeployDir(dir: string, tag: string): Promise<void> {
     );
   }
   await git(["-C", dir, "fetch", "--tags", "origin"]);
-  await git(["-C", dir, "checkout", tag]);
+  // `--end-of-options` so a `--…`-shaped ref can't inject a git option (S-1).
+  await git(["-C", dir, "checkout", "--end-of-options", tag]);
 }
 
 /** True iff `origin` points at the same repo as `REPO_URL` (scheme/.git tolerant). */
@@ -539,25 +546,6 @@ export async function waitForHealthy(options: HealthWaitOptions): Promise<void> 
       (detail ? detail : "(no log output captured)") +
       `\n\nFix the cause above, then re-run \`librarian server up\`.`,
   );
-}
-
-/**
- * Strip secrets from captured `docker logs` before they reach a user-facing
- * error (C1). The server's one-time admin-token generation notice emits the
- * token BY VALUE (`packages/mcp-server/src/bin/http.ts`); the master-key notice
- * does not. We defend three ways:
- *   - drop any whole line carrying the admin-token generation notice;
- *   - redact any `libadmin_<base64url>` token substring (the bearer shape);
- *   - defensively redact any standalone 64-hex run (a raw key/token shape).
- * The redacted tail is still surfaced so debugging works — just without secrets.
- */
-export function redactSecrets(text: string): string {
-  return text
-    .split("\n")
-    .filter((line) => !/Generated a new admin token/i.test(line))
-    .join("\n")
-    .replace(/libadmin_[A-Za-z0-9_-]+/g, "[redacted-admin-token]")
-    .replace(/\b[0-9a-fA-F]{64}\b/g, "[redacted]");
 }
 
 /** The server-generated secrets read back after the container is healthy. */
@@ -743,7 +731,10 @@ async function dockerInDir(args: string[], cwd: string): Promise<void> {
 
 function failIfNonZero(cmd: string, args: string[], result: RunResult): void {
   if (result.code === 0) return;
-  const detail = result.stderr.trim() || result.stdout.trim();
+  // Redact in case a failed docker/git step echoed a secret-shaped arg — the
+  // agent token rides in the `docker run -e LIBRARIAN_AGENT_TOKEN=…` arg, so a
+  // `build`/`run` failure that echoes argv would otherwise leak it (S-2).
+  const detail = redactSecrets(result.stderr.trim() || result.stdout.trim());
   throw new UpError(
     `\`${cmd} ${args[0]}\` failed (exit ${result.code ?? "signal"})` +
       (detail ? `:\n${detail}` : ".") +

--- a/packages/installer-cli/src/server/up.ts
+++ b/packages/installer-cli/src/server/up.ts
@@ -39,6 +39,7 @@ import { readEnvFile, writeEnvFile } from "../env.js";
 import { librarianDir } from "../paths.js";
 import type { Prompter } from "../prompt.js";
 import { fetchLatestVersion } from "../status.js";
+import { writeDeployState } from "./deploy-state.js";
 import { run, which, type RunResult } from "./docker.js";
 import { preflight } from "./preflight.js";
 
@@ -243,6 +244,20 @@ export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult>
     await run("docker", ["rm", "-f", CONTAINER_NAME]).catch(() => undefined);
     throw error;
   }
+
+  // 7b) Persist the NON-SECRET deploy-state so `update` can recreate the
+  //     container with the same config and `status` can report the deployed
+  //     ref reliably. This carries the bind host / data volume / ref / image
+  //     tag / container name — NEVER a token or key (deploy-state.ts whitelists
+  //     the fields). Only after a confirmed-healthy run, so the recorded state
+  //     reflects a container that actually came up.
+  writeDeployState(deployDir, {
+    containerName: CONTAINER_NAME,
+    host,
+    dataVolume,
+    ref: tag,
+    imageTag: `${CONTAINER_NAME}:${tag}`,
+  });
 
   // 8) `--enable-boot` is wired but deferred to S6.
   const lines: string[] = [];

--- a/packages/installer-cli/src/server/up.ts
+++ b/packages/installer-cli/src/server/up.ts
@@ -33,6 +33,7 @@
 // written to a host file or log.
 
 import { randomBytes } from "node:crypto";
+import { isIP } from "node:net";
 import path from "node:path";
 import { readEnvFile, writeEnvFile } from "../env.js";
 import { librarianDir } from "../paths.js";
@@ -227,12 +228,21 @@ export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult>
   await build(deployDir, tag);
   await dockerRun(buildRunArgs({ host, dataVolume, tag, agentToken }), deployDir);
 
-  // 6) Wait for health; roll back (and surface logs) on failure — no half-up.
-  await waitForHealthy(options);
-
-  // 7) Read the server-generated secrets back from the container: the master
-  //    key always; the admin token too when bound beyond localhost (§6).
-  const secrets = await readSecrets(host);
+  // 6+7) Wait for health, then read back the server-generated secrets. ANY
+  //      failure in this post-`docker run` phase — a timeout/unhealthy report,
+  //      an exception from `docker inspect`/`sleep`, or a failed secret read —
+  //      MUST force-remove the container so no half-up state is left behind
+  //      (spec §11). `waitForHealthy` already rolls back on its own
+  //      timeout/unhealthy path; this guard catches the throwing cases it
+  //      can't (the second `rm -f` is best-effort + idempotent).
+  let secrets: ContainerSecrets;
+  try {
+    await waitForHealthy(options);
+    secrets = await readSecrets(host);
+  } catch (error) {
+    await run("docker", ["rm", "-f", CONTAINER_NAME]).catch(() => undefined);
+    throw error;
+  }
 
   // 8) `--enable-boot` is wired but deferred to S6.
   const lines: string[] = [];
@@ -262,10 +272,22 @@ export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult>
  * declining aborts with a teaching error BEFORE any clone/build/run.
  */
 async function resolveBindHost(options: UpOptions, deps: UpDeps): Promise<string> {
-  if (options.host !== undefined) {
-    const host = options.host.trim();
+  // An empty/whitespace `--host` (e.g. `--host ""`) is treated as "not provided"
+  // rather than slipping through as `""` — which would publish `-p :3000:3000`
+  // (ALL interfaces) with no ask-first (I1). Fall through to the default path.
+  if (options.host !== undefined && options.host.trim().length > 0) {
+    const host = normalizeHost(options.host.trim());
     if (host === ALL_INTERFACES) {
       await confirmAllInterfaces(options, deps);
+    } else if (isIpv6Literal(host)) {
+      // `::1` already normalized to loopback above; any OTHER IPv6 literal is
+      // beyond this slice's scope (the `-p` arg would need bracketing and the
+      // exposure path would need IPv6 reasoning). Teach rather than emit a
+      // malformed `-p ::ffff:…:3000:3000`.
+      throw new UpError(
+        `IPv6 bind addresses other than loopback (::1) are not supported yet (got '${host}'). ` +
+          "Use an IPv4 address (e.g. a tailnet IP) or '0.0.0.0' to bind all interfaces.",
+      );
     }
     return host;
   }
@@ -285,6 +307,24 @@ async function resolveBindHost(options: UpOptions, deps: UpDeps): Promise<string
   }
 
   return LOCALHOST;
+}
+
+/**
+ * Normalize loopback spellings to the canonical `127.0.0.1` (I3). The server
+ * treats `localhost` / `::1` / `127.0.0.1` identically (loopback no-auth bypass),
+ * so the CLI must too — otherwise `--host localhost` would omit `ALLOW_NO_AUTH`
+ * and try to read an admin token that the server never minted. Any other value
+ * is returned unchanged (the caller decides whether it's allowed).
+ */
+function normalizeHost(host: string): string {
+  const lower = host.toLowerCase();
+  if (lower === "localhost" || lower === "::1" || lower === LOCALHOST) return LOCALHOST;
+  return host;
+}
+
+/** True for a genuine IPv6 literal (after loopback normalization). */
+function isIpv6Literal(host: string): boolean {
+  return isIP(host) === 6;
 }
 
 /**
@@ -320,10 +360,12 @@ async function detectTailscaleIp(): Promise<string | null> {
   try {
     const result = await run("tailscale", ["ip", "-4"]);
     if (result.code !== 0) return null;
+    // Use `node:net` `isIP` so invalid octets (e.g. `999.1.2.3`) are rejected —
+    // a loose `\d{1,3}` regex would accept them (S1).
     const ip = result.stdout
       .split("\n")
       .map((l) => l.trim())
-      .find((l) => /^\d{1,3}(\.\d{1,3}){3}$/.test(l));
+      .find((l) => isIP(l) === 4);
     return ip ?? null;
   } catch {
     return null;
@@ -432,19 +474,41 @@ async function waitForHealthy(options: UpOptions): Promise<void> {
     if (i < attempts - 1) await sleepImpl(intervalMs);
   }
 
-  // Failed: surface logs (NOT the streams — they may carry secrets-shaped lines
-  // we don't echo; we hand the operator the command output for triage), then
-  // roll back so no half-up container survives.
+  // Failed: surface the recent logs for triage, but REDACT first. On a fresh
+  // beyond-localhost boot the server logs the generated admin token BY VALUE
+  // (the one sanctioned generation notice — http.ts); that line, and any bearer
+  // token in the captured output, must NEVER reach an error message (spec §5.6
+  // wants logs surfaced, just not secrets). Then roll back so no half-up
+  // container survives.
   const logs = await run("docker", ["logs", "--tail", String(tail), CONTAINER_NAME]);
   await run("docker", ["rm", "-f", CONTAINER_NAME]);
 
-  const detail = logs.stdout.trim() || logs.stderr.trim();
+  const detail = redactSecrets(logs.stdout.trim() || logs.stderr.trim());
   throw new UpError(
     `The server did not become healthy in time and was rolled back ` +
       `(container removed; the data volume is untouched). Recent logs:\n` +
       (detail ? detail : "(no log output captured)") +
       `\n\nFix the cause above, then re-run \`librarian server up\`.`,
   );
+}
+
+/**
+ * Strip secrets from captured `docker logs` before they reach a user-facing
+ * error (C1). The server's one-time admin-token generation notice emits the
+ * token BY VALUE (`packages/mcp-server/src/bin/http.ts`); the master-key notice
+ * does not. We defend three ways:
+ *   - drop any whole line carrying the admin-token generation notice;
+ *   - redact any `libadmin_<base64url>` token substring (the bearer shape);
+ *   - defensively redact any standalone 64-hex run (a raw key/token shape).
+ * The redacted tail is still surfaced so debugging works — just without secrets.
+ */
+export function redactSecrets(text: string): string {
+  return text
+    .split("\n")
+    .filter((line) => !/Generated a new admin token/i.test(line))
+    .join("\n")
+    .replace(/libadmin_[A-Za-z0-9_-]+/g, "[redacted-admin-token]")
+    .replace(/\b[0-9a-fA-F]{64}\b/g, "[redacted]");
 }
 
 /** The server-generated secrets read back after the container is healthy. */
@@ -531,6 +595,12 @@ async function closeTheLoop(
   // `0.0.0.0` is a bind directive, not a connectable address — point clients at
   // the machine's real reachable IP rather than over-engineering auto-detection.
   if (host === ALL_INTERFACES) {
+    // S2: a `--yes` run auto-accepts the all-interfaces bind with no prompt, so
+    // print a one-line trace of that exposure — otherwise it's invisible in CI
+    // logs (the only record of "we bound every interface, unattended").
+    if (options.yes === true) {
+      lines.push("Note: binding 0.0.0.0 (all interfaces) — auto-accepted via --yes.", "");
+    }
     lines.push(
       "Note: 0.0.0.0 binds every interface but is NOT a connectable address — " +
         "clients should use this machine's reachable LAN/tailnet IP in the URLs above.",

--- a/packages/installer-cli/src/server/up.ts
+++ b/packages/installer-cli/src/server/up.ts
@@ -99,6 +99,15 @@ export function resetTokenMinter(): void {
   minter = realMinter;
 }
 
+/**
+ * Mint one agent token through the CURRENT minter. Exported so `update` mints a
+ * fresh token (when the old container's token can't be read back) via the same
+ * injectable seam `up` uses — a single deterministic value in tests.
+ */
+export function mintAgentToken(): string {
+  return minter();
+}
+
 // --- options + result ----------------------------------------------------
 
 export interface UpOptions {
@@ -467,11 +476,29 @@ async function dockerRun(args: string[], deployDir: string): Promise<void> {
 }
 
 /**
- * Poll `docker inspect … Health.Status` until `healthy`, bounded. On timeout or
- * an unhealthy report: surface `docker logs --tail`, roll the container back
- * (`docker rm -f`), and throw — leaving NO half-up container.
+ * Health-wait tuning shared by `up` and `update` (the bounded poll + log-tail).
+ * A subset of `UpOptions` so `update` can reuse {@link waitForHealthy} without
+ * importing the whole `UpOptions` shape.
  */
-async function waitForHealthy(options: UpOptions): Promise<void> {
+export interface HealthWaitOptions {
+  /** Health-wait bound: how many polls before declaring failure (small in tests). */
+  healthAttempts?: number | undefined;
+  /** Milliseconds between health polls (0 in tests). */
+  healthIntervalMs?: number | undefined;
+  /** Lines of `docker logs` to surface on a failed health-wait. */
+  logTailLines?: number | undefined;
+}
+
+/**
+ * Poll `docker inspect … Health.Status` until `healthy`, bounded. On timeout or
+ * an unhealthy report: surface `docker logs --tail` (REDACTED), roll the
+ * container back (`docker rm -f`), and throw — leaving NO half-up container.
+ *
+ * Exported so `update` recreates with the IDENTICAL health-wait + rollback
+ * pattern (a failed recreate force-removes the new container and never advances
+ * deploy-state). The thrown `UpError`'s message is already secret-redacted.
+ */
+export async function waitForHealthy(options: HealthWaitOptions): Promise<void> {
   const attempts = options.healthAttempts ?? 60;
   const intervalMs = options.healthIntervalMs ?? 2000;
   const tail = options.logTailLines ?? 50;

--- a/packages/installer-cli/src/server/up.ts
+++ b/packages/installer-cli/src/server/up.ts
@@ -39,6 +39,7 @@ import { readEnvFile, writeEnvFile } from "../env.js";
 import { librarianDir } from "../paths.js";
 import type { Prompter } from "../prompt.js";
 import { fetchLatestVersion } from "../status.js";
+import { enableBoot } from "./boot.js";
 import { writeDeployState } from "./deploy-state.js";
 import { run, which, type RunResult } from "./docker.js";
 import { preflight } from "./preflight.js";
@@ -123,7 +124,11 @@ export interface UpOptions {
   host?: string | undefined;
   /** Named data volume. Default: `librarian_data`. */
   dataVolume?: string | undefined;
-  /** Enable boot persistence — wired as a known flag; deferred to S6 (no-op here). */
+  /**
+   * Enable boot persistence after a successful `up` (S6). On Linux, installs +
+   * enables the systemd unit; on macOS, prints the deferred notice and the `up`
+   * still succeeds. Opt-in: a plain `up` never enables boot silently.
+   */
   enableBoot?: boolean | undefined;
   /** Auto-accept prompts (loop-closer `~/.librarian/env` offer). */
   yes?: boolean | undefined;
@@ -268,13 +273,15 @@ export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult>
     imageTag: `${CONTAINER_NAME}:${tag}`,
   });
 
-  // 8) `--enable-boot` is wired but deferred to S6.
+  // 8) Boot persistence (opt-in, spec §5.8). With `--enable-boot`, install +
+  //    enable the systemd unit AFTER a healthy up (so the named container the
+  //    unit references actually exists). On macOS this prints the deferred
+  //    notice and continues — the `up` still succeeds. The unit references the
+  //    EXISTING container by name and carries NO secret (boot.ts).
   const lines: string[] = [];
   if (options.enableBoot) {
-    lines.push(
-      "Note: --enable-boot is recognised but boot persistence arrives in a later slice; skipping.",
-      "",
-    );
+    const bootResult = await enableBoot(deps.platform ? { platform: deps.platform } : {});
+    lines.push(bootResult.output, "");
   }
 
   // 9) Close the loop: surface secrets/URLs + offer the local env write.

--- a/packages/installer-cli/src/server/up.ts
+++ b/packages/installer-cli/src/server/up.ts
@@ -1,0 +1,494 @@
+// `librarian server up` — build + run the all-in-one container (localhost path).
+//
+// This is the loop-closer: on a fresh Docker host it clones the monorepo at the
+// resolved release tag, builds `the-librarian:<tag>`, runs the all-in-one
+// container bound to host loopback, waits for it to report healthy, surfaces the
+// server-generated master key ONCE, and prints the MCP URL + dashboard URL + a
+// freshly minted agent token ready to paste into `librarian install`.
+//
+// S2 implements ONLY the localhost (`127.0.0.1`) happy path. The flow is
+// structured so S3 can cleanly add beyond-localhost binding (`--host`) and
+// admin-token surfacing:
+//   - `buildRunArgs({ host, … })` is the single place the `docker run` argv is
+//     constructed; S3 makes the `LIBRARIAN_ALLOW_NO_AUTH` flag + the publish
+//     address conditional on `host` there.
+//   - the post-health secret read (`readMasterKey`) is the seam S3 extends to
+//     also read `/data/admin.token` when bound beyond localhost.
+//
+// EVERYTHING that touches the system is injected (`docker.ts` runner, the
+// latest-release fetcher, the prompter, `home`, and the health-poll sleep), so
+// the whole flow is exercised in tests WITHOUT a real daemon, network, or git.
+//
+// Security (AGENTS.md): the agent token rides ONLY in the `docker run -e` arg
+// and (if the user accepts) into `~/.librarian/env` via env.ts. The master key
+// is surfaced to stdout exactly once and is NEVER written to a host file or log.
+
+import { randomBytes } from "node:crypto";
+import path from "node:path";
+import { readEnvFile, writeEnvFile } from "../env.js";
+import { librarianDir } from "../paths.js";
+import type { Prompter } from "../prompt.js";
+import { fetchLatestVersion } from "../status.js";
+import { run, type RunResult } from "./docker.js";
+import { preflight } from "./preflight.js";
+
+/** The repository the deploy dir clones (same repo the latest-tag fetch targets). */
+export const REPO_URL = "https://github.com/JimJafar/the-librarian";
+
+/** The container name every `server` command operates on (single instance per host). */
+export const CONTAINER_NAME = "the-librarian";
+
+/** The named data volume default (`--data-volume` overrides). The volume is sacred. */
+export const DEFAULT_DATA_VOLUME = "librarian_data";
+
+/** Host loopback — the default, only-reachable-locally bind (spec §5/§6). */
+export const LOCALHOST = "127.0.0.1";
+
+/** The warning printed beside the one-time master-key surfacing (spec §5.4). */
+export const SAVE_KEY_WARNING = "SAVE THIS KEY — excluded from backups";
+
+// --- injectable health-poll sleep ---------------------------------------
+
+/** A sleep used between health polls. Injectable so tests don't actually wait. */
+export type Sleep = (ms: number) => Promise<void>;
+
+const realSleep: Sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+let sleepImpl: Sleep = realSleep;
+
+/** Override the health-poll sleep (tests inject a no-op so polling is instant). */
+export function setSleep(next: Sleep): void {
+  sleepImpl = next;
+}
+
+/** Restore the real sleep (tests). */
+export function resetSleep(): void {
+  sleepImpl = realSleep;
+}
+
+// --- injectable agent-token mint ----------------------------------------
+
+/** Mint one CSPRNG agent token. Injectable so tests assert a deterministic value. */
+export type TokenMinter = () => string;
+
+const realMinter: TokenMinter = () => randomBytes(32).toString("hex");
+
+let minter: TokenMinter = realMinter;
+
+/** Override the agent-token minter (tests). */
+export function setTokenMinter(next: TokenMinter): void {
+  minter = next;
+}
+
+/** Restore the real CSPRNG minter (tests). */
+export function resetTokenMinter(): void {
+  minter = realMinter;
+}
+
+// --- options + result ----------------------------------------------------
+
+export interface UpOptions {
+  /** Pinned ref (`vX.Y.Z` tag or `main`). Default: the latest release tag. */
+  ref?: string | undefined;
+  /** Deploy dir override. Default: `~/.librarian/server`. */
+  dir?: string | undefined;
+  /** Bind host. S2 only implements the localhost path (`127.0.0.1`). */
+  host?: string | undefined;
+  /** Named data volume. Default: `librarian_data`. */
+  dataVolume?: string | undefined;
+  /** Enable boot persistence — wired as a known flag; deferred to S6 (no-op here). */
+  enableBoot?: boolean | undefined;
+  /** Auto-accept prompts (loop-closer `~/.librarian/env` offer). */
+  yes?: boolean | undefined;
+  /** Health-wait bound: how many polls before declaring failure (small in tests). */
+  healthAttempts?: number | undefined;
+  /** Milliseconds between health polls (0 in tests). */
+  healthIntervalMs?: number | undefined;
+  /** Lines of `docker logs` to surface on a failed health-wait. */
+  logTailLines?: number | undefined;
+}
+
+export interface UpDeps {
+  /** Override home (tests). */
+  home?: string | undefined;
+  /** Prompter for the loop-closer env offer. */
+  prompter: Prompter;
+  /** Platform for preflight's daemon hint. Default `process.platform`. */
+  platform?: NodeJS.Platform | undefined;
+}
+
+/** A teaching error from `up`; the runtime renders `.message` as one stderr line. */
+export class UpError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UpError";
+  }
+}
+
+// --- the docker run argv seam (S3 extends this) -------------------------
+
+export interface RunArgsInput {
+  host: string;
+  dataVolume: string;
+  tag: string;
+  agentToken: string;
+}
+
+/**
+ * Construct the `docker run` argv (everything after `docker`). The SINGLE place
+ * the run vector is assembled, so S3 can make `LIBRARIAN_ALLOW_NO_AUTH` and the
+ * publish address conditional on `host` without touching the orchestration.
+ *
+ * Localhost (`127.0.0.1`) → include `-e LIBRARIAN_ALLOW_NO_AUTH=true` (no admin
+ * token; loopback-only no-auth bypass — spec §6). The image runs `tini` as PID
+ * 1, so `--init` is deliberately omitted.
+ */
+export function buildRunArgs(input: RunArgsInput): string[] {
+  const { host, dataVolume, tag, agentToken } = input;
+  const args = [
+    "run",
+    "-d",
+    "--name",
+    CONTAINER_NAME,
+    "--restart",
+    "unless-stopped",
+    "-p",
+    `${host}:3000:3000`,
+    "-p",
+    `${host}:3838:3838`,
+    "-v",
+    `${dataVolume}:/data`,
+    "-e",
+    `LIBRARIAN_AGENT_TOKEN=${agentToken}`,
+  ];
+  if (host === LOCALHOST) {
+    args.push("-e", "LIBRARIAN_ALLOW_NO_AUTH=true");
+  }
+  args.push(`${CONTAINER_NAME}:${tag}`);
+  return args;
+}
+
+// --- the up flow ---------------------------------------------------------
+
+export interface UpResult {
+  /** Human-readable report for stdout (carries the master key ONCE). */
+  output: string;
+}
+
+/**
+ * Run `server up` (localhost happy path). Throws `UpError` (teaching message)
+ * on any failure; on a failed health-wait it rolls the container back first so
+ * no half-up state is left behind.
+ */
+export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult> {
+  const host = options.host ?? LOCALHOST;
+  if (host !== LOCALHOST) {
+    // S3 owns beyond-localhost binding (admin-token surfacing, `0.0.0.0`
+    // ask-first). Refuse rather than silently doing the wrong thing.
+    throw new UpError(
+      `Binding beyond ${LOCALHOST} (got --host ${host}) is not available yet — ` +
+        `this slice implements the localhost path only. Re-run without --host.`,
+    );
+  }
+
+  // 1) Preflight: docker (daemon reachable) + git, or a teaching error.
+  await preflight(deps.platform ? { platform: deps.platform } : {});
+
+  const dataVolume = options.dataVolume ?? DEFAULT_DATA_VOLUME;
+  const deployDir = options.dir ?? path.join(librarianDir(deps.home), "server");
+
+  // 2) Resolve the ref (default = latest release tag), then the deploy dir.
+  const tag = await resolveRef(options.ref);
+  await prepareDeployDir(deployDir, tag);
+
+  // 3) Mint the agent token (the loop-closer). Never logged.
+  const agentToken = minter();
+
+  // 4) Build the image, then run the container.
+  await build(deployDir, tag);
+  await dockerRun(buildRunArgs({ host, dataVolume, tag, agentToken }), deployDir);
+
+  // 5) Wait for health; roll back (and surface logs) on failure — no half-up.
+  await waitForHealthy(options);
+
+  // 6) Read the server-generated master key back from the container.
+  const masterKey = await readMasterKey();
+
+  // 7) `--enable-boot` is wired but deferred to S6.
+  const lines: string[] = [];
+  if (options.enableBoot) {
+    lines.push(
+      "Note: --enable-boot is recognised but boot persistence arrives in a later slice; skipping.",
+      "",
+    );
+  }
+
+  // 8) Close the loop: surface secrets/URLs + offer the local env write.
+  await closeTheLoop(lines, { host, agentToken, masterKey, options, deps });
+
+  return { output: lines.join("\n") };
+}
+
+// --- step helpers --------------------------------------------------------
+
+/** Resolve the ref to deploy: an explicit `--ref` wins; else the latest tag. */
+async function resolveRef(ref: string | undefined): Promise<string> {
+  if (ref && ref.trim().length > 0) return ref.trim();
+  const latest = await fetchLatestVersion();
+  if (!latest) {
+    throw new UpError(
+      "Could not resolve the latest release tag from GitHub. " +
+        "Check your network, or pin a ref with `--ref <tag|main>`.",
+    );
+  }
+  // `fetchLatestVersion` strips the leading `v`; the tag we check out keeps it.
+  return `v${latest}`;
+}
+
+/**
+ * Ready the deploy dir at `tag`:
+ *   - absent → `git clone <repo> <dir>` then checkout the ref;
+ *   - already OUR managed clone → `git fetch` + checkout the ref;
+ *   - exists but isn't our clone (different remote / dirty) → STOP and ask.
+ * Never clobbers a dir we didn't create.
+ */
+async function prepareDeployDir(dir: string, tag: string): Promise<void> {
+  const gitDir = path.join(dir, ".git");
+  if (!(await pathExists(gitDir))) {
+    if (await pathExists(dir)) {
+      // A non-empty dir that isn't a git repo → not ours; don't clobber.
+      if (!(await isEmptyDir(dir))) {
+        throw new UpError(
+          `Deploy dir ${dir} exists but is not a Librarian clone (no .git). ` +
+            "Refusing to overwrite a directory I didn't create — " +
+            "remove it or choose another path with `--dir <path>`.",
+        );
+      }
+    }
+    await git(["clone", REPO_URL, dir]);
+    await git(["-C", dir, "checkout", tag]);
+    return;
+  }
+
+  // It's a git repo — confirm it's OUR clone before touching it.
+  const originResult = await run("git", ["-C", dir, "remote", "get-url", "origin"]);
+  const origin = originResult.stdout.trim();
+  if (!sameRepo(origin, REPO_URL)) {
+    throw new UpError(
+      `Deploy dir ${dir} is a git repo with a different remote (${origin || "none"}). ` +
+        "Refusing to touch a clone I didn't create — choose another path with `--dir <path>`.",
+    );
+  }
+  await git(["-C", dir, "fetch", "--tags", "origin"]);
+  await git(["-C", dir, "checkout", tag]);
+}
+
+/** True iff `origin` points at the same repo as `REPO_URL` (scheme/.git tolerant). */
+function sameRepo(origin: string, repo: string): boolean {
+  const norm = (u: string): string =>
+    u
+      .trim()
+      .replace(/\.git$/, "")
+      .replace(/\/$/, "")
+      .replace(/^git@github\.com:/, "https://github.com/")
+      .toLowerCase();
+  return norm(origin) === norm(repo);
+}
+
+/** Build the all-in-one image from the deploy dir (the VERIFIED build command). */
+async function build(deployDir: string, tag: string): Promise<void> {
+  await dockerInDir(
+    ["build", "-f", "docker/all-in-one.Dockerfile", "-t", `${CONTAINER_NAME}:${tag}`, "."],
+    deployDir,
+  );
+}
+
+/** Run the container (the assembled run argv) from the deploy dir. */
+async function dockerRun(args: string[], deployDir: string): Promise<void> {
+  await dockerInDir(args, deployDir);
+}
+
+/**
+ * Poll `docker inspect … Health.Status` until `healthy`, bounded. On timeout or
+ * an unhealthy report: surface `docker logs --tail`, roll the container back
+ * (`docker rm -f`), and throw — leaving NO half-up container.
+ */
+async function waitForHealthy(options: UpOptions): Promise<void> {
+  const attempts = options.healthAttempts ?? 60;
+  const intervalMs = options.healthIntervalMs ?? 2000;
+  const tail = options.logTailLines ?? 50;
+
+  for (let i = 0; i < attempts; i += 1) {
+    const result = await run("docker", [
+      "inspect",
+      "--format",
+      "{{.State.Health.Status}}",
+      CONTAINER_NAME,
+    ]);
+    const state = result.stdout.trim();
+    if (state === "healthy") return;
+    if (state === "unhealthy") break; // no point waiting out the bound
+    if (i < attempts - 1) await sleepImpl(intervalMs);
+  }
+
+  // Failed: surface logs (NOT the streams — they may carry secrets-shaped lines
+  // we don't echo; we hand the operator the command output for triage), then
+  // roll back so no half-up container survives.
+  const logs = await run("docker", ["logs", "--tail", String(tail), CONTAINER_NAME]);
+  await run("docker", ["rm", "-f", CONTAINER_NAME]);
+
+  const detail = logs.stdout.trim() || logs.stderr.trim();
+  throw new UpError(
+    `The server did not become healthy in time and was rolled back ` +
+      `(container removed; the data volume is untouched). Recent logs:\n` +
+      (detail ? detail : "(no log output captured)") +
+      `\n\nFix the cause above, then re-run \`librarian server up\`.`,
+  );
+}
+
+/**
+ * Read the server-generated master key from `/data/secret.key`. The seam S3
+ * extends to also read `/data/admin.token` when bound beyond localhost.
+ */
+async function readMasterKey(): Promise<string> {
+  const result = await run("docker", ["exec", CONTAINER_NAME, "cat", "/data/secret.key"]);
+  const key = result.stdout.trim();
+  if (!key) {
+    throw new UpError(
+      "The server became healthy but no master key was found at /data/secret.key. " +
+        "This is unexpected — check `librarian server logs`.",
+    );
+  }
+  return key;
+}
+
+/**
+ * Close the loop: surface the master key ONCE (with the SAVE warning), print the
+ * MCP + dashboard URLs and the minted agent token, and OFFER to write this
+ * machine's `~/.librarian/env` when it's absent/incomplete (`--yes` auto-accepts).
+ */
+async function closeTheLoop(
+  lines: string[],
+  ctx: {
+    host: string;
+    agentToken: string;
+    masterKey: string;
+    options: UpOptions;
+    deps: UpDeps;
+  },
+): Promise<void> {
+  const { host, agentToken, masterKey, options, deps } = ctx;
+  const mcpUrl = `http://${host}:3838/mcp`;
+  const dashboardUrl = `http://${host}:3000`;
+
+  lines.push(
+    "The Librarian server is up and healthy.",
+    "",
+    `  MCP URL:     ${mcpUrl}`,
+    `  Dashboard:   ${dashboardUrl}`,
+    `  Agent token: ${agentToken}`,
+    "",
+    "Paste the MCP URL + agent token into `librarian install` on your clients.",
+    "",
+    // The ONE-TIME master-key surfacing. Never written to a host file or log.
+    `Master key (${SAVE_KEY_WARNING}):`,
+    `  ${masterKey}`,
+    "",
+  );
+
+  await offerLocalEnv(lines, { mcpUrl, agentToken, options, deps });
+}
+
+/**
+ * Offer to write this machine's own `~/.librarian/env` (so single-box dev gets
+ * server + client in one shot). OFFER, never force: prompt (default no), or
+ * auto-accept with `--yes`. Reuses env.ts so the token lands chmod-600 and is
+ * never logged. Only offers when the env is absent/incomplete.
+ */
+async function offerLocalEnv(
+  lines: string[],
+  ctx: {
+    mcpUrl: string;
+    agentToken: string;
+    options: UpOptions;
+    deps: UpDeps;
+  },
+): Promise<void> {
+  const { mcpUrl, agentToken, options, deps } = ctx;
+  const existing = readEnvFile(deps.home);
+  const complete = Boolean(existing?.mcpUrl && existing?.token);
+  if (complete) {
+    lines.push("This machine's `~/.librarian/env` is already configured — left as is.");
+    return;
+  }
+
+  let accepted = options.yes === true;
+  if (!accepted) {
+    const answer = await deps.prompter.promptText(
+      "Write this machine's own ~/.librarian/env so local agents use this server? [y/N]",
+      { default: "n" },
+    );
+    accepted = isYes(answer);
+  }
+
+  if (accepted) {
+    writeEnvFile({ mcpUrl, token: agentToken }, deps.home);
+    lines.push("Wrote ~/.librarian/env (chmod 600) — local agents now point at this server.");
+  } else {
+    lines.push(
+      "Left ~/.librarian/env untouched. Configure a client later with:",
+      `  librarian config --mcp-url ${mcpUrl} --token <the agent token above>`,
+    );
+  }
+}
+
+function isYes(answer: string): boolean {
+  const a = answer.trim().toLowerCase();
+  return a === "y" || a === "yes";
+}
+
+// --- thin runner wrappers (teaching errors on a non-zero exit) ----------
+
+/** Run a `git …` command from anywhere; a non-zero exit is a teaching error. */
+async function git(args: string[]): Promise<void> {
+  const result = await run("git", args);
+  failIfNonZero("git", args, result);
+}
+
+/** Run a `docker …` command from the deploy dir; non-zero exit → teaching error. */
+async function dockerInDir(args: string[], cwd: string): Promise<void> {
+  const result = await run("docker", args, { cwd });
+  failIfNonZero("docker", args, result);
+}
+
+function failIfNonZero(cmd: string, args: string[], result: RunResult): void {
+  if (result.code === 0) return;
+  const detail = result.stderr.trim() || result.stdout.trim();
+  throw new UpError(
+    `\`${cmd} ${args[0]}\` failed (exit ${result.code ?? "signal"})` +
+      (detail ? `:\n${detail}` : ".") +
+      "\n\nResolve the error above, then re-run `librarian server up`.",
+  );
+}
+
+// --- tiny fs probes (kept here so the flow stays self-contained) ---------
+
+async function pathExists(p: string): Promise<boolean> {
+  const fs = await import("node:fs/promises");
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function isEmptyDir(p: string): Promise<boolean> {
+  const fs = await import("node:fs/promises");
+  try {
+    const entries = await fs.readdir(p);
+    return entries.length === 0;
+  } catch {
+    return false;
+  }
+}

--- a/packages/installer-cli/src/server/update.ts
+++ b/packages/installer-cli/src/server/update.ts
@@ -52,13 +52,8 @@ import { fetchLatestVersion } from "../status.js";
 import { readDeployState, writeDeployState } from "./deploy-state.js";
 import { run, type RunResult } from "./docker.js";
 import { preflight } from "./preflight.js";
-import {
-  buildRunArgs,
-  CONTAINER_NAME,
-  mintAgentToken,
-  redactSecrets,
-  waitForHealthy,
-} from "./up.js";
+import { redactSecrets } from "./redact.js";
+import { buildRunArgs, CONTAINER_NAME, mintAgentToken, waitForHealthy } from "./up.js";
 
 export interface UpdateOptions {
   /** Pinned ref (`vX.Y.Z` tag or `main`). Default: the latest release tag. */
@@ -130,8 +125,9 @@ export async function runUpdate(options: UpdateOptions = {}): Promise<UpdateResu
   }
 
   // 4) Update, in the deploy dir: fetch tags → checkout the resolved ref.
+  //    `--end-of-options` so a `--…`-shaped ref can't inject a git option (S-1).
   await git(["-C", deployDir, "fetch", "--tags", "origin"]);
-  await git(["-C", deployDir, "checkout", targetRef]);
+  await git(["-C", deployDir, "checkout", "--end-of-options", targetRef]);
 
   // 5) Build the new image from the deploy dir.
   await dockerInDir(

--- a/packages/installer-cli/src/server/update.ts
+++ b/packages/installer-cli/src/server/update.ts
@@ -1,0 +1,324 @@
+// `librarian server update` — re-pin forward, rebuild, recreate, migrate.
+//
+// The tag-pinned, deploy-dir-owning successor to `pull-and-restart.sh` (the
+// stash/branch dance is gone — the CLI owns its deploy dir, so it just fetches
+// tags and checks out the resolved ref). The flow (spec §8, success criterion 5):
+//
+//   1. Resolve the target ref: `--ref <tag|main>` pins it; default = the latest
+//      release tag (`fetchLatestVersion`).
+//   2. IDEMPOTENCY FIRST: read deploy-state (current ref) + the container's
+//      health. Already at the resolved ref AND healthy → a CLEAN no-op (no
+//      build, no run, no recreate). When `--ref` is given, compare against it.
+//   3. Otherwise update, IN THE DEPLOY DIR:
+//        git fetch --tags origin → git checkout <ref>
+//        → docker build -f docker/all-in-one.Dockerfile -t the-librarian:<ref> .
+//        → read back the EXISTING agent token from the running container's env
+//          (so clients keep working) BEFORE removing it
+//        → docker stop → docker rm <container>   (NEVER `-v`, NEVER `volume rm`)
+//        → docker run … (buildRunArgs with the SAME host + dataVolume from
+//          deploy-state, and the preserved/fresh agent token)
+//        → waitForHealthy (rolls back with `docker rm -f` on failure — reusing
+//          up's pattern, so a failed recreate leaves no half-up container and
+//          does NOT advance deploy-state)
+//        → docker exec the-librarian the-librarian migrate-data-dir
+//          (server boot only WARNS about pending data-dir migrations; the admin
+//           CLI APPLIES them — see packages/cli/src/commands/migrate-data-dir.ts.
+//           The `the-librarian` runtime binary is bundled into the image in S7;
+//           this slice asserts the argv, the runtime target arrives with S7.)
+//   4. writeDeployState with the new ref/imageTag (host/dataVolume unchanged).
+//
+// AGENT TOKEN ON UPDATE (decision): recreating the container needs
+// `LIBRARIAN_AGENT_TOKEN` again, but the token is a secret and is correctly NOT
+// persisted host-side. Re-minting it on every update would silently break every
+// client (their saved token would stop matching). So we PREFER reading the
+// existing token back from the running container's env via `docker inspect`
+// BEFORE we remove it, and reuse it on recreate — clients keep working with no
+// action. Only if the old container is gone/unreadable do we mint a FRESH token
+// and surface it ONCE with a "clients must update their token" note. Either way
+// the token rides ONLY in the `docker run -e` arg — it is NEVER written to a
+// file or log (the spec's no-leak boundary; tests scan for it).
+//
+// The DATA VOLUME is sacred: recreate removes the CONTAINER only (`docker rm`),
+// never the named volume (the `-v` flag / `docker volume rm` never appear), so
+// `up`/`update`/`down` all recall the same memories from the untouched volume.
+//
+// Everything goes through the injectable `docker.ts` runner + the injectable
+// latest-release fetcher, so tests assert the exact argv (and its order) WITHOUT
+// a real daemon, network, or git.
+
+import path from "node:path";
+import { librarianDir } from "../paths.js";
+import { fetchLatestVersion } from "../status.js";
+import { readDeployState, writeDeployState } from "./deploy-state.js";
+import { run, type RunResult } from "./docker.js";
+import { preflight } from "./preflight.js";
+import {
+  buildRunArgs,
+  CONTAINER_NAME,
+  mintAgentToken,
+  redactSecrets,
+  waitForHealthy,
+} from "./up.js";
+
+export interface UpdateOptions {
+  /** Pinned ref (`vX.Y.Z` tag or `main`). Default: the latest release tag. */
+  ref?: string | undefined;
+  /** Auto-accept prompts (none today; wired for surface parity with `up`). */
+  yes?: boolean | undefined;
+  /** Deploy dir override. Default: `~/.librarian/server`. */
+  dir?: string | undefined;
+  /** Override home (tests). */
+  home?: string | undefined;
+  /** Platform for preflight's daemon hint. Default `process.platform`. */
+  platform?: NodeJS.Platform | undefined;
+  /** Health-wait bound: how many polls before declaring failure (small in tests). */
+  healthAttempts?: number | undefined;
+  /** Milliseconds between health polls (0 in tests). */
+  healthIntervalMs?: number | undefined;
+  /** Lines of `docker logs` to surface on a failed health-wait. */
+  logTailLines?: number | undefined;
+}
+
+/** A teaching error from `update`; the runtime renders `.message` as one stderr line. */
+export class UpdateError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UpdateError";
+  }
+}
+
+export interface UpdateResult {
+  /** Human-readable report for stdout (carries a FRESH agent token at most once). */
+  output: string;
+}
+
+/**
+ * Run `server update`. Throws `UpdateError` (teaching message) on a failure
+ * before/around the recreate; a failed health-wait throws the (already
+ * secret-redacted) `UpError` from `waitForHealthy` after rolling the new
+ * container back. deploy-state is advanced ONLY after a confirmed-healthy
+ * recreate, so a failed update never records the new ref.
+ */
+export async function runUpdate(options: UpdateOptions = {}): Promise<UpdateResult> {
+  // 1) Preflight: docker (daemon reachable) + git, or a teaching error.
+  await preflight(options.platform ? { platform: options.platform } : {});
+
+  const deployDir = options.dir ?? path.join(librarianDir(options.home), "server");
+
+  // The deploy-state is authoritative for the bind host + data volume to reuse.
+  // Without it we cannot recreate the container with the same config — teach.
+  const state = readDeployState(deployDir);
+  if (!state) {
+    throw new UpdateError(
+      `No deploy-state found at ${deployDir} — this host has not run \`librarian server up\` ` +
+        "(or the deploy dir is wrong). Run `librarian server up` first, " +
+        "or pass `--dir <path>` to point at an existing deploy dir.",
+    );
+  }
+
+  // 2) Resolve the target ref (explicit `--ref` wins; else the latest tag).
+  const targetRef = await resolveRef(options.ref);
+
+  // 3) IDEMPOTENCY FIRST: already at the resolved ref AND healthy → clean no-op.
+  if (state.ref === targetRef && (await isHealthy())) {
+    return {
+      output: [
+        `Already up to date (${targetRef}) — the container is healthy.`,
+        "Nothing to do. Pin a different ref with `--ref <tag|main>` to change it.",
+      ].join("\n"),
+    };
+  }
+
+  // 4) Update, in the deploy dir: fetch tags → checkout the resolved ref.
+  await git(["-C", deployDir, "fetch", "--tags", "origin"]);
+  await git(["-C", deployDir, "checkout", targetRef]);
+
+  // 5) Build the new image from the deploy dir.
+  await dockerInDir(
+    ["build", "-f", "docker/all-in-one.Dockerfile", "-t", `${CONTAINER_NAME}:${targetRef}`, "."],
+    deployDir,
+  );
+
+  // 6) Agent token: PREFER the existing token (so clients keep working). Read it
+  //    from the running container's env BEFORE removal; fall back to a fresh
+  //    mint only if the old container is gone/unreadable.
+  const existing = await readExistingAgentToken();
+  const agentToken = existing ?? mintAgentToken();
+  const tokenIsFresh = existing === null;
+
+  // 7) Recreate — CONTAINER ONLY. `docker stop` then `docker rm <name>`:
+  //    NEVER `-v`, NEVER `docker volume rm`. The named data volume persists.
+  await dockerStop();
+  await dockerRm();
+
+  // 8) Run the new container with the SAME host + data volume from deploy-state.
+  await dockerInDir(
+    buildRunArgs({
+      host: state.host,
+      dataVolume: state.dataVolume,
+      tag: targetRef,
+      agentToken,
+    }),
+    deployDir,
+  );
+
+  // 9) Wait for health (rolls back with `docker rm -f` on failure — up's
+  //    pattern). If this throws, deploy-state is NOT advanced below.
+  await waitForHealthy(options);
+
+  // 10) Apply pending data-dir migrations via the bundled admin CLI (S7 bundles
+  //     the `the-librarian` binary into the image; this slice asserts the argv).
+  await dockerExecMigrate();
+
+  // 11) Persist the new ref/imageTag — host/dataVolume/containerName unchanged.
+  writeDeployState(deployDir, {
+    containerName: state.containerName,
+    host: state.host,
+    dataVolume: state.dataVolume,
+    ref: targetRef,
+    imageTag: `${CONTAINER_NAME}:${targetRef}`,
+  });
+
+  return { output: renderSuccess(targetRef, tokenIsFresh ? agentToken : null) };
+}
+
+// --- ref + health probes -------------------------------------------------
+
+/** Resolve the target ref: an explicit `--ref` wins; else the latest tag. */
+async function resolveRef(ref: string | undefined): Promise<string> {
+  if (ref && ref.trim().length > 0) return ref.trim();
+  const latest = await fetchLatestVersion();
+  if (!latest) {
+    throw new UpdateError(
+      "Could not resolve the latest release tag from GitHub. " +
+        "Check your network, or pin a ref with `--ref <tag|main>`.",
+    );
+  }
+  // `fetchLatestVersion` strips the leading `v`; the tag we check out keeps it.
+  return `v${latest}`;
+}
+
+/**
+ * True iff the container exists AND reports `healthy`. Used by the idempotency
+ * check — already at the ref but unhealthy means we still recreate. A failing
+ * `docker inspect` (no such container) → not healthy.
+ */
+async function isHealthy(): Promise<boolean> {
+  const status = await run("docker", ["inspect", "--format", "{{.State.Status}}", CONTAINER_NAME]);
+  if (status.code !== 0 || status.stdout.trim() !== "running") return false;
+  const health = await run("docker", [
+    "inspect",
+    "--format",
+    "{{.State.Health.Status}}",
+    CONTAINER_NAME,
+  ]);
+  return health.code === 0 && health.stdout.trim() === "healthy";
+}
+
+// --- agent-token read-back (clients keep working) ------------------------
+
+/**
+ * Read the EXISTING agent token from the running container's env, or `null` when
+ * the container is gone/unreadable or carries no such var. We inspect the env
+ * BEFORE the container is removed so an `update` doesn't silently break clients.
+ * The value is returned to the caller for reuse on recreate — never logged.
+ */
+async function readExistingAgentToken(): Promise<string | null> {
+  const result = await run("docker", [
+    "inspect",
+    "--format",
+    "{{range .Config.Env}}{{println .}}{{end}}",
+    CONTAINER_NAME,
+  ]);
+  if (result.code !== 0) return null;
+  for (const line of result.stdout.split("\n")) {
+    const trimmed = line.trim();
+    const prefix = "LIBRARIAN_AGENT_TOKEN=";
+    if (trimmed.startsWith(prefix)) {
+      const value = trimmed.slice(prefix.length);
+      return value.length > 0 ? value : null;
+    }
+  }
+  return null;
+}
+
+// --- thin runner wrappers (teaching errors on a non-zero exit) ----------
+
+/** Run a `git …` command; a non-zero exit is a teaching error. */
+async function git(args: string[]): Promise<void> {
+  const result = await run("git", args);
+  failIfNonZero("git", args, result);
+}
+
+/** Run a `docker …` command from the deploy dir; non-zero exit → teaching error. */
+async function dockerInDir(args: string[], cwd: string): Promise<void> {
+  const result = await run("docker", args, { cwd });
+  failIfNonZero("docker", args, result);
+}
+
+/** Stop the old container. A not-running/not-found container is fine (we recreate). */
+async function dockerStop(): Promise<void> {
+  const result = await run("docker", ["stop", CONTAINER_NAME]);
+  if (result.code === 0) return;
+  if (isNotFound(result.stderr)) return; // nothing to stop — proceed to rm/run
+  failIfNonZero("docker", ["stop", CONTAINER_NAME], result);
+}
+
+/**
+ * Remove the old CONTAINER (NOT the volume). `docker rm <name>` — never `-v`,
+ * never `docker volume rm`. A not-found container is fine (we recreate).
+ */
+async function dockerRm(): Promise<void> {
+  const result = await run("docker", ["rm", CONTAINER_NAME]);
+  if (result.code === 0) return;
+  if (isNotFound(result.stderr)) return; // already gone — proceed to run
+  failIfNonZero("docker", ["rm", CONTAINER_NAME], result);
+}
+
+/** Apply pending data-dir migrations inside the (now-healthy) container. */
+async function dockerExecMigrate(): Promise<void> {
+  const args = ["exec", CONTAINER_NAME, CONTAINER_NAME, "migrate-data-dir"];
+  const result = await run("docker", args);
+  failIfNonZero("docker", args, result);
+}
+
+/** True when a docker error means the container simply isn't there. */
+function isNotFound(stderr: string): boolean {
+  return /no such container|no such object|is not running/i.test(stderr);
+}
+
+function failIfNonZero(cmd: string, args: string[], result: RunResult): void {
+  if (result.code === 0) return;
+  // Redact in case a non-zero docker step echoed a secret-shaped line.
+  const detail = redactSecrets(result.stderr.trim() || result.stdout.trim());
+  throw new UpdateError(
+    `\`${cmd} ${args[0]}\` failed (exit ${result.code ?? "signal"})` +
+      (detail ? `:\n${detail}` : ".") +
+      "\n\nResolve the error above, then re-run `librarian server update`.",
+  );
+}
+
+// --- success report ------------------------------------------------------
+
+/**
+ * The success report. `freshToken` is non-null ONLY when we had to mint a new
+ * agent token (the old container's token was unreadable) — then we surface it
+ * ONCE with a clients-must-update note. When the existing token was reused,
+ * nothing about the token is printed (clients keep working untouched).
+ */
+function renderSuccess(ref: string, freshToken: string | null): string {
+  const lines = [
+    `Updated The Librarian server to ${ref} — the container is healthy.`,
+    "The data volume was preserved; pending data-dir migrations were applied.",
+  ];
+  if (freshToken) {
+    lines.push(
+      "",
+      "NOTE: the previous container's agent token could not be read back, so a " +
+        "FRESH agent token was minted. Existing clients must update their token:",
+      `  Agent token: ${freshToken}`,
+      "Paste it into `librarian install` / `librarian config --token <token>` on your clients.",
+    );
+  }
+  return lines.join("\n");
+}

--- a/packages/installer-cli/tests/all-in-one-dockerfile.test.ts
+++ b/packages/installer-cli/tests/all-in-one-dockerfile.test.ts
@@ -1,0 +1,62 @@
+// S7a — the all-in-one image must bundle the admin CLI (`@librarian/cli`, the
+// `the-librarian` binary) so `server admin` can `docker exec the-librarian
+// the-librarian <verb>` (spec §7).
+//
+// A real `docker build` is slow (minutes; pulls + compiles), so the build is
+// verified separately/by hand. THIS test is a fast, static guard on the
+// Dockerfile contract — the things that, if dropped, silently break
+// `server admin` at runtime:
+//   1. the BUILDER copies the `packages/cli` SOURCE (it can't build what isn't
+//      there), then BUILDS `@librarian/cli`;
+//   2. the RUNTIME stage copies the built CLI tree (its dist + package.json +
+//      node_modules, plus the `@librarian/core` dist it imports);
+//   3. `the-librarian` is reachable on PATH at runtime.
+// It mirrors the existing, working mcp-server runtime-tree copy.
+
+import fs from "node:fs";
+import { describe, expect, it } from "vitest";
+
+/** The all-in-one Dockerfile, read once (repo root is three dirs up from tests/). */
+const dockerfile = fs.readFileSync(
+  new URL("../../../docker/all-in-one.Dockerfile", import.meta.url),
+  "utf8",
+);
+
+/** Collapse whitespace so a multi-line `RUN … \` reads as one string to match. */
+const flat = dockerfile.replace(/\\\n/g, " ").replace(/[ \t]+/g, " ");
+
+describe("all-in-one.Dockerfile — builder builds the admin CLI", () => {
+  it("copies the packages/cli SOURCE into the builder (can't build what's absent)", () => {
+    // The source COPY (not just the package.json manifest copy on line ~22).
+    expect(flat).toMatch(/COPY packages\/cli \.\/packages\/cli/);
+  });
+
+  it("builds @librarian/cli alongside core/mcp-server", () => {
+    // A `pnpm … --filter @librarian/cli … run build` somewhere in the builder.
+    expect(flat).toMatch(/pnpm[^\n]*--filter @librarian\/cli[^\n]*run build/);
+  });
+});
+
+describe("all-in-one.Dockerfile — runtime stage bundles the admin CLI tree", () => {
+  it("copies the built CLI dist into the runtime image", () => {
+    expect(flat).toMatch(/COPY --from=builder \/app\/packages\/cli\/dist \S+/);
+  });
+
+  it("copies the CLI package.json so Node resolves its bin/main", () => {
+    expect(flat).toMatch(/COPY --from=builder \/app\/packages\/cli\/package\.json \S+/);
+  });
+
+  it("copies the @librarian/core dist the CLI imports into the CLI subtree", () => {
+    // The CLI depends on @librarian/core; its dist must live under the CLI tree
+    // (mirrors how the mcp-server tree carries packages/core/dist).
+    expect(flat).toMatch(/COPY --from=builder \/app\/packages\/core\/dist \/app\/cli\/\S+/);
+  });
+
+  it("puts `the-librarian` on PATH at runtime (symlink or PATH entry)", () => {
+    const onPath =
+      /ln -s\S* [^\n]*the-librarian/.test(flat) || // symlink into a PATH dir
+      /ENV PATH=[^\n]*\/app\/cli/.test(flat) || // CLI bin dir prepended to PATH
+      /\/usr\/local\/bin\/the-librarian/.test(flat);
+    expect(onPath).toBe(true);
+  });
+});

--- a/packages/installer-cli/tests/dockerfile-tls.test.ts
+++ b/packages/installer-cli/tests/dockerfile-tls.test.ts
@@ -1,0 +1,37 @@
+// Regression guard for the backup-breaking TLS bug: `git` was installed with
+// `--no-install-recommends` on a slim base that ships no CA bundle, so
+// `git push https://…github.com…` (the vault backup) failed with
+// "server certificate verification failed. CAfile: none CRLfile: none".
+//
+// `ca-certificates` is a *recommended* (not hard) dependency of git, so
+// `--no-install-recommends` drops it. Both git-using images must install it in
+// the SAME apt-get line as git, or backup silently breaks at runtime. A real
+// `docker build` + push is slow and needs network/auth, so this is a fast static
+// guard on the Dockerfile contract (the build+smoke CI job exercises it for real).
+
+import fs from "node:fs";
+import { describe, expect, it } from "vitest";
+
+/** The apt-get install invocation (up to the next `&&`), whitespace-flattened. */
+function aptInstall(relPathFromTests: string): string {
+  const text = fs.readFileSync(new URL(relPathFromTests, import.meta.url), "utf8");
+  const flat = text.replace(/\\\n/g, " ").replace(/[ \t]+/g, " ");
+  return flat.match(/apt-get install[^&]*/)?.[0] ?? "";
+}
+
+describe.each([
+  ["all-in-one.Dockerfile", "../../../docker/all-in-one.Dockerfile"],
+  ["mcp-server.Dockerfile", "../../../docker/mcp-server.Dockerfile"],
+])("%s installs a CA bundle so git can verify TLS (backup push)", (_name, rel) => {
+  const install = aptInstall(rel);
+
+  it("installs git", () => {
+    expect(install).toMatch(/\bgit\b/);
+  });
+
+  it("installs ca-certificates in the same apt-get line as git", () => {
+    // Same line => the CA bundle is present whenever git is, so a slim base's
+    // missing /etc/ssl/certs/ca-certificates.crt can't break `git push https`.
+    expect(install).toMatch(/\bca-certificates\b/);
+  });
+});

--- a/packages/installer-cli/tests/helpers.ts
+++ b/packages/installer-cli/tests/helpers.ts
@@ -5,6 +5,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { RunOptions, RunResult, Runner } from "../src/exec.js";
+import type { StreamHandlers, Streamer } from "../src/server/docker.js";
 
 /** Run `fn` with a fresh temp home dir, cleaned up afterwards. */
 export async function withTempHome<T>(fn: (home: string) => T | Promise<T>): Promise<T> {
@@ -73,4 +74,59 @@ export class FakeRunner implements Runner {
 
 function key(cmd: string, args: readonly string[]): string {
   return `${cmd} ${[...args].join(" ")}`;
+}
+
+/** A single recorded invocation of the stub streamer. */
+export interface StreamCall {
+  cmd: string;
+  args: string[];
+  opts: RunOptions | undefined;
+}
+
+/**
+ * A scriptable, recording stub for the streaming seam (`docker logs -f`). It
+ * models a follow process: when `stream` is called it emits each scripted
+ * stdout/stderr chunk to the handlers IN ORDER (live, not batched at the end),
+ * then resolves with the scripted exit code — mimicking the process exiting
+ * (container stop / Ctrl-C). Nothing spawns a real process.
+ */
+export class FakeStreamer implements Streamer {
+  /** Every `stream` invocation, in order. */
+  readonly calls: StreamCall[] = [];
+  /** stdout chunks emitted, in order, on every `stream` call. */
+  private stdoutChunks: string[] = [];
+  /** stderr chunks emitted, in order, on every `stream` call. */
+  private stderrChunks: string[] = [];
+  /** The exit code the followed process resolves with. */
+  private exitCode: number | null = 0;
+
+  /** Script the stdout chunks emitted (each forwarded to `onStdout` in turn). */
+  withStdout(...chunks: string[]): this {
+    this.stdoutChunks = chunks;
+    return this;
+  }
+
+  /** Script the stderr chunks emitted (each forwarded to `onStderr` in turn). */
+  withStderr(...chunks: string[]): this {
+    this.stderrChunks = chunks;
+    return this;
+  }
+
+  /** Set the exit code the followed process resolves with (default 0). */
+  withExit(code: number | null): this {
+    this.exitCode = code;
+    return this;
+  }
+
+  async stream(
+    cmd: string,
+    args: readonly string[],
+    handlers: StreamHandlers,
+    opts?: RunOptions,
+  ): Promise<number | null> {
+    this.calls.push({ cmd, args: [...args], opts });
+    for (const chunk of this.stdoutChunks) handlers.onStdout?.(chunk);
+    for (const chunk of this.stderrChunks) handlers.onStderr?.(chunk);
+    return this.exitCode;
+  }
 }

--- a/packages/installer-cli/tests/server-admin.test.ts
+++ b/packages/installer-cli/tests/server-admin.test.ts
@@ -162,6 +162,43 @@ describe("server admin — only the curated verbs are exposed (spec §7)", () =>
   });
 });
 
+describe("server admin — a failing exec REDACTS secret-bearing output (I-3)", () => {
+  it("redacts a libadmin token + 64-hex run from a failed exec's surfaced detail", async () => {
+    await withTempHome(async (home) => {
+      // Assembled from sub-threshold parts so no realistic secret literal is committed.
+      const fakeAdminToken = "libadmin_" + "FAKETOKENVALUE";
+      const fakeAdminLine =
+        "Generated a new admin token (LIBRARIAN_ADMIN_TOKEN): " + fakeAdminToken;
+      const fakeHexKey = "0123456789abcdef".repeat(4); // a 64-hex master-key shape
+
+      const runner = adminReady().onRun(
+        "docker",
+        ["exec", "the-librarian", "the-librarian", "restore", "--secret-key", fakeHexKey],
+        {
+          // The in-container CLI echoes the secret-bearing argv + a token line on failure.
+          stderr: `restore failed for --secret-key ${fakeHexKey}\n${fakeAdminLine}\nsee logs\n`,
+          code: 1,
+        },
+      );
+      setDockerRunner(runner);
+
+      const r = await runCli(["server", "admin", "restore", "--secret-key", fakeHexKey], {
+        home,
+        interactive: false,
+      });
+      expect(r.exitCode).toBe(1);
+
+      // The surfaced error must carry NEITHER the admin token, the gen line, nor
+      // the raw 64-hex key.
+      expect(r.stderr).not.toContain(fakeAdminToken);
+      expect(r.stderr).not.toMatch(/Generated a new admin token/i);
+      expect(r.stderr).not.toContain(fakeHexKey);
+      // ...but the non-secret remainder is still surfaced for triage.
+      expect(r.stderr).toMatch(/restore failed|see logs/i);
+    });
+  });
+});
+
 describe("server admin — preflight + container-running guards", () => {
   it("docker missing → teaching error, NO exec", async () => {
     await withTempHome(async (home) => {

--- a/packages/installer-cli/tests/server-admin.test.ts
+++ b/packages/installer-cli/tests/server-admin.test.ts
@@ -1,0 +1,201 @@
+// S7a — `librarian server admin <verb> [args…]`: dispatch a curated subset of
+// the folded-in `@librarian/cli` (`the-librarian`) into the running container.
+//
+// The load-bearing assertions (spec §7):
+//   - The argv is EXACTLY `docker exec the-librarian the-librarian <verb> [args…]`
+//     with the remaining args passed through VERBATIM, in order.
+//   - Only `backup | restore | auth | rebuild` are exposed; anything else
+//     (`seed`, `migrate-data-dir`, `export`, `handoffs`, or a typo) is a teaching
+//     error that names the allowed verbs and runs NO `docker exec`.
+//   - Preflight runs first; a container that isn't running is a teaching error
+//     ("the server isn't running — `librarian server up` first") with NO exec.
+
+import { afterEach, describe, expect, it } from "vitest";
+import { resetRunner } from "../src/exec.js";
+import { runCli } from "../src/runtime.js";
+import {
+  resetRunner as resetDockerRunner,
+  setRunner as setDockerRunner,
+} from "../src/server/docker.js";
+import { FakeRunner, withTempHome } from "./helpers.js";
+
+afterEach(() => {
+  resetRunner();
+  resetDockerRunner();
+});
+
+/** A runner with docker present, daemon reachable, and the container running. */
+function adminReady(): FakeRunner {
+  return new FakeRunner()
+    .withWhich("docker")
+    .withWhich("git")
+    .onRun("docker", ["info"], { code: 0 })
+    .onRun("docker", ["inspect", "--format", "{{.State.Status}}", "the-librarian"], {
+      stdout: "running\n",
+      code: 0,
+    });
+}
+
+/** The `docker exec` calls the runner recorded, in order (verb + passthrough). */
+function execCalls(runner: FakeRunner): string[][] {
+  return runner.calls.filter((c) => c.cmd === "docker" && c.args[0] === "exec").map((c) => c.args);
+}
+
+describe("server admin — dispatches the curated verbs into the container", () => {
+  it("`backup` → docker exec the-librarian the-librarian backup", async () => {
+    await withTempHome(async (home) => {
+      const runner = adminReady();
+      setDockerRunner(runner);
+
+      const r = await runCli(["server", "admin", "backup"], { home, interactive: false });
+      expect(r.exitCode).toBe(0);
+
+      expect(execCalls(runner)).toEqual([["exec", "the-librarian", "the-librarian", "backup"]]);
+    });
+  });
+
+  it("`auth reset-password --user x` passes the sub-verb + args through VERBATIM, in order", async () => {
+    await withTempHome(async (home) => {
+      const runner = adminReady();
+      setDockerRunner(runner);
+
+      const r = await runCli(["server", "admin", "auth", "reset-password", "--user", "x"], {
+        home,
+        interactive: false,
+      });
+      expect(r.exitCode).toBe(0);
+
+      expect(execCalls(runner)).toEqual([
+        ["exec", "the-librarian", "the-librarian", "auth", "reset-password", "--user", "x"],
+      ]);
+    });
+  });
+
+  it("`rebuild` → docker exec the-librarian the-librarian rebuild", async () => {
+    await withTempHome(async (home) => {
+      const runner = adminReady();
+      setDockerRunner(runner);
+
+      const r = await runCli(["server", "admin", "rebuild"], { home, interactive: false });
+      expect(r.exitCode).toBe(0);
+
+      expect(execCalls(runner)).toEqual([["exec", "the-librarian", "the-librarian", "rebuild"]]);
+    });
+  });
+
+  it("`restore --secret-key …` passes the flag + value through VERBATIM", async () => {
+    await withTempHome(async (home) => {
+      const runner = adminReady();
+      setDockerRunner(runner);
+
+      const r = await runCli(["server", "admin", "restore", "--secret-key", "abc123"], {
+        home,
+        interactive: false,
+      });
+      expect(r.exitCode).toBe(0);
+
+      expect(execCalls(runner)).toEqual([
+        ["exec", "the-librarian", "the-librarian", "restore", "--secret-key", "abc123"],
+      ]);
+    });
+  });
+
+  it("an interactive run adds `-it` so prompts (e.g. restore's secret-key) work", async () => {
+    await withTempHome(async (home) => {
+      const runner = adminReady();
+      setDockerRunner(runner);
+
+      const r = await runCli(["server", "admin", "restore"], { home, interactive: true });
+      expect(r.exitCode).toBe(0);
+
+      expect(execCalls(runner)).toEqual([
+        ["exec", "-it", "the-librarian", "the-librarian", "restore"],
+      ]);
+    });
+  });
+});
+
+describe("server admin — only the curated verbs are exposed (spec §7)", () => {
+  it("`seed` is NOT folded in → teaching error, NO docker exec", async () => {
+    await withTempHome(async (home) => {
+      const runner = adminReady();
+      setDockerRunner(runner);
+
+      const r = await runCli(["server", "admin", "seed"], { home, interactive: false });
+      expect(r.exitCode).toBe(1);
+      // Names the allowed verbs so the reader knows what IS available.
+      expect(r.stderr).toMatch(/backup/);
+      expect(r.stderr).toMatch(/restore/);
+      expect(r.stderr).toMatch(/auth/);
+      expect(r.stderr).toMatch(/rebuild/);
+      // Mentions the rejected verb so the error is specific.
+      expect(r.stderr).toMatch(/seed/);
+      // NOTHING was exec'd into the container.
+      expect(execCalls(runner)).toEqual([]);
+      // No stack trace leaked.
+      expect(r.stderr).not.toMatch(/at \w+.*\(/);
+    });
+  });
+
+  it("an unknown verb (`frobnicate`) → teaching error naming the allowed verbs, NO exec", async () => {
+    await withTempHome(async (home) => {
+      const runner = adminReady();
+      setDockerRunner(runner);
+
+      const r = await runCli(["server", "admin", "frobnicate"], { home, interactive: false });
+      expect(r.exitCode).toBe(1);
+      expect(r.stderr).toMatch(/backup.*restore.*auth.*rebuild|backup|restore|auth|rebuild/);
+      expect(execCalls(runner)).toEqual([]);
+    });
+  });
+
+  it("no verb at all → teaching error naming the allowed verbs, NO exec", async () => {
+    await withTempHome(async (home) => {
+      const runner = adminReady();
+      setDockerRunner(runner);
+
+      const r = await runCli(["server", "admin"], { home, interactive: false });
+      expect(r.exitCode).toBe(1);
+      expect(r.stderr).toMatch(/backup/);
+      expect(execCalls(runner)).toEqual([]);
+    });
+  });
+});
+
+describe("server admin — preflight + container-running guards", () => {
+  it("docker missing → teaching error, NO exec", async () => {
+    await withTempHome(async (home) => {
+      const runner = new FakeRunner(); // nothing on PATH
+      setDockerRunner(runner);
+
+      const r = await runCli(["server", "admin", "backup"], { home, interactive: false });
+      expect(r.exitCode).toBe(1);
+      expect(r.stderr).toMatch(/docker/i);
+      expect(r.stderr).toMatch(/install/i);
+      expect(execCalls(runner)).toEqual([]);
+    });
+  });
+
+  it("container not running → teaching error pointing at `server up`, NO exec", async () => {
+    await withTempHome(async (home) => {
+      // docker + daemon fine, but `inspect` reports the container is absent.
+      const runner = new FakeRunner()
+        .withWhich("docker")
+        .withWhich("git")
+        .onRun("docker", ["info"], { code: 0 })
+        .onRun("docker", ["inspect", "--format", "{{.State.Status}}", "the-librarian"], {
+          stderr: "Error: No such object: the-librarian\n",
+          code: 1,
+        });
+      setDockerRunner(runner);
+
+      const r = await runCli(["server", "admin", "backup"], { home, interactive: false });
+      expect(r.exitCode).toBe(1);
+      expect(r.stderr).toMatch(/not running|isn't running|is not running/i);
+      expect(r.stderr).toMatch(/server up/);
+      expect(execCalls(runner)).toEqual([]);
+      // No stack trace leaked.
+      expect(r.stderr).not.toMatch(/at \w+.*\(/);
+    });
+  });
+});

--- a/packages/installer-cli/tests/server-boot-runtime.test.ts
+++ b/packages/installer-cli/tests/server-boot-runtime.test.ts
@@ -1,0 +1,209 @@
+// S6 — boot persistence wired into the CLI runtime.
+//
+// Drives the public `runCli(["server", "enable-boot"|"disable-boot", …])` and
+// `runCli(["server", "up", "--enable-boot"])` entries against the injected
+// `docker.ts` FakeRunner, so the EXACT systemctl/sudo argv is asserted and no
+// real systemd/sudo/docker is touched. Platform is injectable so the macOS
+// deferral is testable from a Linux host.
+
+import { afterEach, describe, expect, it } from "vitest";
+import { resetRunner } from "../src/exec.js";
+import { runCli } from "../src/runtime.js";
+import {
+  resetRunner as resetDockerRunner,
+  setRunner as setDockerRunner,
+} from "../src/server/docker.js";
+import { resetSleep, resetTokenMinter, setSleep, setTokenMinter } from "../src/server/up.js";
+import { resetLatestFetcher, setLatestFetcher } from "../src/status.js";
+import { FakeRunner, withTempHome } from "./helpers.js";
+import { FakePrompter } from "./prompter.js";
+
+const UNIT_PATH = "/etc/systemd/system/the-librarian.service";
+const UNIT_NAME = "the-librarian.service";
+const AGENT_TOKEN = "agent-token-deterministic-for-tests";
+const MASTER_KEY = "master-key-read-back-from-the-container-once";
+const LATEST = "1.4.2";
+
+afterEach(() => {
+  resetRunner();
+  resetDockerRunner();
+  resetLatestFetcher();
+  resetSleep();
+  resetTokenMinter();
+});
+
+/** A runner with docker/systemctl/sudo present, every call succeeding. */
+function bootReady(): FakeRunner {
+  return new FakeRunner()
+    .withWhich("docker")
+    .withWhich("git")
+    .withWhich("systemctl")
+    .withWhich("sudo")
+    .onRun("docker", ["info"], { code: 0 })
+    .withFallback({ code: 0 });
+}
+
+/** A fully-successful localhost `up` runner, plus systemctl/sudo for boot. */
+function upPlusBootReady(): FakeRunner {
+  return bootReady()
+    .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", "the-librarian"], {
+      stdout: "healthy\n",
+      code: 0,
+    })
+    .onRun("docker", ["exec", "the-librarian", "cat", "/data/secret.key"], {
+      stdout: `${MASTER_KEY}\n`,
+      code: 0,
+    });
+}
+
+function stubUpSeams(): void {
+  setLatestFetcher(async () => LATEST);
+  setTokenMinter(() => AGENT_TOKEN);
+  setSleep(async () => undefined);
+}
+
+describe("server enable-boot (linux) — standalone", () => {
+  it("installs the unit and enables --now, exit 0", async () => {
+    await withTempHome(async (home) => {
+      const runner = bootReady();
+      setDockerRunner(runner);
+
+      const r = await runCli(["server", "enable-boot"], { home, platform: "linux" });
+      expect(r.exitCode).toBe(0);
+
+      expect(
+        runner.calls.some(
+          (c) => c.cmd === "sudo" && c.args[0] === "cp" && c.args.includes(UNIT_PATH),
+        ),
+      ).toBe(true);
+      expect(
+        runner.calls.some(
+          (c) =>
+            c.cmd === "sudo" &&
+            c.args[0] === "systemctl" &&
+            c.args.includes("enable") &&
+            c.args.includes("--now") &&
+            c.args.includes(UNIT_NAME),
+        ),
+      ).toBe(true);
+      expect(r.stdout).toMatch(/boot/i);
+    });
+  });
+});
+
+describe("server disable-boot (linux) — standalone", () => {
+  it("disables --now, removes the unit, daemon-reload, exit 0", async () => {
+    await withTempHome(async (home) => {
+      const runner = bootReady();
+      setDockerRunner(runner);
+
+      const r = await runCli(["server", "disable-boot"], { home, platform: "linux" });
+      expect(r.exitCode).toBe(0);
+
+      expect(
+        runner.calls.some(
+          (c) => c.cmd === "sudo" && c.args[0] === "systemctl" && c.args.includes("disable"),
+        ),
+      ).toBe(true);
+      expect(
+        runner.calls.some(
+          (c) => c.cmd === "sudo" && c.args[0] === "rm" && c.args.includes(UNIT_PATH),
+        ),
+      ).toBe(true);
+    });
+  });
+});
+
+describe("server enable-boot / disable-boot (macOS) — deferred notice, no systemctl", () => {
+  it("enable-boot on darwin prints the Linux-only notice and exits 0", async () => {
+    await withTempHome(async (home) => {
+      const runner = bootReady();
+      setDockerRunner(runner);
+
+      const r = await runCli(["server", "enable-boot"], { home, platform: "darwin" });
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toMatch(/linux-only|linux only|launchd|deferred/i);
+      expect(runner.calls.some((c) => c.cmd === "sudo")).toBe(false);
+    });
+  });
+
+  it("disable-boot on darwin prints the notice and exits 0", async () => {
+    await withTempHome(async (home) => {
+      const runner = bootReady();
+      setDockerRunner(runner);
+
+      const r = await runCli(["server", "disable-boot"], { home, platform: "darwin" });
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toMatch(/linux-only|linux only|launchd|deferred/i);
+      expect(runner.calls.some((c) => c.cmd === "sudo")).toBe(false);
+    });
+  });
+});
+
+describe("server up --enable-boot (linux) — boot enable runs AFTER a healthy up", () => {
+  it("the systemctl enable argv appears after the docker run argv", async () => {
+    await withTempHome(async (home) => {
+      const runner = upPlusBootReady();
+      setDockerRunner(runner);
+      stubUpSeams();
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
+
+      const r = await runCli(["server", "up", "--enable-boot"], {
+        home,
+        prompter,
+        platform: "linux",
+      });
+      expect(r.exitCode).toBe(0);
+
+      const idxRun = runner.calls.findIndex((c) => c.cmd === "docker" && c.args[0] === "run");
+      const idxEnable = runner.calls.findIndex(
+        (c) => c.cmd === "sudo" && c.args[0] === "systemctl" && c.args.includes("enable"),
+      );
+      expect(idxRun).toBeGreaterThanOrEqual(0);
+      expect(idxEnable).toBeGreaterThan(idxRun);
+
+      // The healthy `up` still closed the loop (URL + token surfaced).
+      expect(r.stdout).toContain("http://127.0.0.1:3838/mcp");
+      expect(r.stdout).toContain(AGENT_TOKEN);
+      // The deferred-note from the old wiring is GONE.
+      expect(r.stdout).not.toMatch(/recognised but boot persistence arrives in a later slice/i);
+    });
+  });
+
+  it("does NOT enable boot on a plain `up` (opt-in only)", async () => {
+    await withTempHome(async (home) => {
+      const runner = upPlusBootReady();
+      setDockerRunner(runner);
+      stubUpSeams();
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
+
+      const r = await runCli(["server", "up"], { home, prompter, platform: "linux" });
+      expect(r.exitCode).toBe(0);
+      expect(runner.calls.some((c) => c.cmd === "sudo")).toBe(false);
+    });
+  });
+});
+
+describe("server up --enable-boot (macOS) — notice, up still succeeds", () => {
+  it("prints the Linux-only boot notice and the up succeeds (no systemctl)", async () => {
+    await withTempHome(async (home) => {
+      const runner = upPlusBootReady();
+      setDockerRunner(runner);
+      stubUpSeams();
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
+
+      const r = await runCli(["server", "up", "--enable-boot"], {
+        home,
+        prompter,
+        platform: "darwin",
+      });
+      expect(r.exitCode).toBe(0);
+
+      // The up succeeded (loop closed) AND the boot notice is shown.
+      expect(r.stdout).toContain("http://127.0.0.1:3838/mcp");
+      expect(r.stdout).toMatch(/linux-only|linux only|launchd|deferred/i);
+      // Nothing touched systemd.
+      expect(runner.calls.some((c) => c.cmd === "sudo")).toBe(false);
+    });
+  });
+});

--- a/packages/installer-cli/tests/server-boot.test.ts
+++ b/packages/installer-cli/tests/server-boot.test.ts
@@ -1,0 +1,227 @@
+// S6 — boot persistence (Linux systemd; macOS deferred).
+//
+// The whole point of this slice is a systemd unit that survives reboots AND
+// `server update` WITHOUT leaking a secret. The container created by `up`/
+// `update` already holds the agent token in Docker's own state, so the unit
+// references the EXISTING named container (`docker start --attach the-librarian`)
+// rather than re-running `docker run -e LIBRARIAN_AGENT_TOKEN=…`, which would
+// write the token into a world-readable `/etc/systemd/system/*.service` file.
+//
+// Every test drives the seam: the unit generator is a PURE function (the
+// headline no-secret test asserts its text directly), and `enableBoot`/
+// `disableBoot` route `systemctl`/`sudo` through the injected `docker.ts`
+// FakeRunner so the EXACT argv is asserted — no real systemd, sudo, or docker.
+
+import fs from "node:fs";
+import { afterEach, describe, expect, it } from "vitest";
+import { resetRunner } from "../src/exec.js";
+import { disableBoot, enableBoot, generateUnit, UNIT_NAME, unitPath } from "../src/server/boot.js";
+import {
+  resetRunner as resetDockerRunner,
+  setRunner as setDockerRunner,
+} from "../src/server/docker.js";
+import { CONTAINER_NAME } from "../src/server/up.js";
+import { FakeRunner } from "./helpers.js";
+
+afterEach(() => {
+  resetRunner();
+  resetDockerRunner();
+});
+
+const UNIT_PATH = "/etc/systemd/system/the-librarian.service";
+
+/** A FakeRunner with systemctl/sudo present and all calls succeeding. */
+function systemdReady(): FakeRunner {
+  return new FakeRunner()
+    .withWhich("docker")
+    .withWhich("systemctl")
+    .withWhich("sudo")
+    .withFallback({ code: 0 });
+}
+
+/** The argv of a recorded `sudo systemctl …` call (after `sudo`), or undefined. */
+function systemctlArgs(runner: FakeRunner, ...match: string[]): boolean {
+  return runner.calls.some(
+    (c) => c.cmd === "sudo" && c.args[0] === "systemctl" && match.every((m) => c.args.includes(m)),
+  );
+}
+
+describe("generateUnit — the headline: NO SECRET in the unit (SC 7 + privacy)", () => {
+  it("references the named container via `docker start` — no token, no `docker run`", () => {
+    const unit = generateUnit({ dockerPath: "/usr/bin/docker" });
+
+    // The invariant. None of these may EVER appear in the unit text.
+    expect(unit).not.toContain("LIBRARIAN_AGENT_TOKEN");
+    expect(unit).not.toContain("docker run");
+    expect(unit).not.toMatch(/-e\s/); // no `-e <env>` env injection at all
+    expect(unit).not.toMatch(/token/i);
+    expect(unit).not.toMatch(/secret/i);
+    expect(unit).not.toMatch(/key/i);
+
+    // What it MUST contain: a `docker start` referencing the named container.
+    expect(unit).toContain(`/usr/bin/docker start --attach ${CONTAINER_NAME}`);
+    expect(unit).toContain(`/usr/bin/docker stop ${CONTAINER_NAME}`);
+  });
+
+  it("is a well-formed systemd unit (sections + boot wiring)", () => {
+    const unit = generateUnit({ dockerPath: "/usr/bin/docker" });
+    expect(unit).toContain("[Unit]");
+    expect(unit).toContain("[Service]");
+    expect(unit).toContain("[Install]");
+    expect(unit).toContain("After=docker.service");
+    expect(unit).toContain("Requires=docker.service");
+    expect(unit).toContain("WantedBy=multi-user.target");
+    expect(unit).toMatch(/Restart=always/);
+  });
+
+  it("honours a resolved docker path other than /usr/bin/docker", () => {
+    const unit = generateUnit({ dockerPath: "/opt/homebrew/bin/docker" });
+    expect(unit).toContain(`/opt/homebrew/bin/docker start --attach ${CONTAINER_NAME}`);
+    expect(unit).not.toContain("/usr/bin/docker start");
+  });
+});
+
+describe("enableBoot (linux) — writes the unit, daemon-reload, enable --now", () => {
+  it("writes the unit to /etc/systemd/system, reloads, then enables --now (with sudo)", async () => {
+    const runner = systemdReady();
+    // Capture the temp unit content AT THE MOMENT of the `sudo cp` (before the
+    // flow's `finally` removes the temp dir) — the FakeRunner doesn't really
+    // copy, so we read the source file the implementation handed `cp`.
+    let copiedContent: string | undefined;
+    let copiedDest: string | undefined;
+    const realRun = runner.run.bind(runner);
+    runner.run = async (cmd, args, opts) => {
+      if (cmd === "sudo" && args[0] === "cp") {
+        copiedContent = fs.readFileSync(args[1] as string, "utf8");
+        copiedDest = args[2];
+      }
+      return realRun(cmd, args, opts);
+    };
+    setDockerRunner(runner);
+
+    const result = await enableBoot({ platform: "linux" });
+
+    // The unit landed at the system path with the right content (no secret).
+    expect(copiedDest).toBe(UNIT_PATH);
+    expect(copiedContent).toContain(`docker start --attach ${CONTAINER_NAME}`);
+    expect(copiedContent).not.toContain("LIBRARIAN_AGENT_TOKEN");
+    expect(copiedContent).not.toMatch(/token|secret|key/i);
+
+    // daemon-reload BEFORE enable --now.
+    expect(systemctlArgs(runner, "daemon-reload")).toBe(true);
+    expect(systemctlArgs(runner, "enable", "--now", UNIT_NAME)).toBe(true);
+
+    // Ordering: the unit write precedes daemon-reload precedes enable.
+    const idxWrite = runner.calls.findIndex(
+      (c) => c.cmd === "sudo" && c.args.includes(UNIT_PATH) && c.args[0] !== "systemctl",
+    );
+    const idxReload = runner.calls.findIndex(
+      (c) => c.cmd === "sudo" && c.args[0] === "systemctl" && c.args.includes("daemon-reload"),
+    );
+    const idxEnable = runner.calls.findIndex(
+      (c) => c.cmd === "sudo" && c.args[0] === "systemctl" && c.args.includes("enable"),
+    );
+    expect(idxWrite).toBeGreaterThanOrEqual(0);
+    expect(idxWrite).toBeLessThan(idxReload);
+    expect(idxReload).toBeLessThan(idxEnable);
+
+    expect(result.output).toMatch(/boot/i);
+  });
+
+  it("is idempotent: running twice rewrites the unit + re-enables, no duplicate units", async () => {
+    const runner = systemdReady();
+    setDockerRunner(runner);
+
+    await enableBoot({ platform: "linux" });
+    await enableBoot({ platform: "linux" });
+
+    // Both runs targeted the SAME unit path (no `the-librarian-2.service` etc).
+    const enables = runner.calls.filter(
+      (c) => c.cmd === "sudo" && c.args[0] === "systemctl" && c.args.includes("enable"),
+    );
+    expect(enables.length).toBe(2);
+    for (const e of enables) expect(e.args).toContain(UNIT_NAME);
+    // No alternate unit name was ever created.
+    expect(
+      runner.calls.some((c) =>
+        c.args.some((a) => /the-librarian-\d|the-librarian\.service\.\d/.test(a)),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("disableBoot (linux) — disable --now, remove the unit, daemon-reload", () => {
+  it("disables --now, then removes the unit file, then daemon-reloads", async () => {
+    const runner = systemdReady();
+    setDockerRunner(runner);
+
+    const result = await disableBoot({ platform: "linux" });
+
+    expect(systemctlArgs(runner, "disable", "--now", UNIT_NAME)).toBe(true);
+    // The unit file was removed (sudo rm of the unit path).
+    expect(
+      runner.calls.some(
+        (c) => c.cmd === "sudo" && c.args[0] === "rm" && c.args.includes(UNIT_PATH),
+      ),
+    ).toBe(true);
+    expect(systemctlArgs(runner, "daemon-reload")).toBe(true);
+
+    // Ordering: disable precedes rm precedes daemon-reload.
+    const idxDisable = runner.calls.findIndex(
+      (c) => c.cmd === "sudo" && c.args[0] === "systemctl" && c.args.includes("disable"),
+    );
+    const idxRm = runner.calls.findIndex((c) => c.cmd === "sudo" && c.args[0] === "rm");
+    const idxReload = runner.calls.findIndex(
+      (c) => c.cmd === "sudo" && c.args[0] === "systemctl" && c.args.includes("daemon-reload"),
+    );
+    expect(idxDisable).toBeLessThan(idxRm);
+    expect(idxRm).toBeLessThan(idxReload);
+
+    expect(result.output).toMatch(/disabled|removed|boot/i);
+  });
+
+  it("already-disabled/absent unit is a friendly message, not a crash", async () => {
+    // systemctl disable on an unknown unit exits non-zero with a "not loaded" note.
+    const runner = systemdReady()
+      .onRun("sudo", ["systemctl", "disable", "--now", UNIT_NAME], {
+        stderr: "Failed to disable unit: Unit the-librarian.service does not exist.\n",
+        code: 1,
+      })
+      .onRun("sudo", ["rm", "-f", UNIT_PATH], { code: 0 });
+    setDockerRunner(runner);
+
+    const result = await disableBoot({ platform: "linux" });
+    expect(result.output).toMatch(/already|not.*enabled|nothing|removed|boot/i);
+    // No stack trace leaked into the message.
+    expect(result.output).not.toMatch(/at \w+.*\(/);
+  });
+});
+
+describe("boot persistence — macOS is a clear deferred notice, never an error", () => {
+  it("enableBoot on darwin prints the Linux-only notice and runs NO systemctl", async () => {
+    const runner = systemdReady();
+    setDockerRunner(runner);
+
+    const result = await enableBoot({ platform: "darwin" });
+    expect(result.output).toMatch(/linux-only|linux only|launchd|deferred/i);
+    // Nothing touched systemd.
+    expect(runner.calls.some((c) => c.cmd === "sudo")).toBe(false);
+    expect(runner.calls.some((c) => c.args.includes("systemctl"))).toBe(false);
+  });
+
+  it("disableBoot on darwin prints the notice and runs NO systemctl", async () => {
+    const runner = systemdReady();
+    setDockerRunner(runner);
+
+    const result = await disableBoot({ platform: "darwin" });
+    expect(result.output).toMatch(/linux-only|linux only|launchd|deferred/i);
+    expect(runner.calls.some((c) => c.cmd === "sudo")).toBe(false);
+  });
+});
+
+describe("boot — paths/constants are stable", () => {
+  it("unitPath() is the system path, UNIT_NAME is the service file name", () => {
+    expect(UNIT_NAME).toBe("the-librarian.service");
+    expect(unitPath()).toBe(UNIT_PATH);
+  });
+});

--- a/packages/installer-cli/tests/server-deploy-state.test.ts
+++ b/packages/installer-cli/tests/server-deploy-state.test.ts
@@ -1,0 +1,108 @@
+// `server/deploy-state.ts` — the NON-SECRET deploy-state file that lets
+// `update` recreate the container with the same config and `status` report the
+// deployed ref reliably. It lives in the deploy dir (default
+// `~/.librarian/server/deploy-state.json`) and carries NO token/key — ever.
+//
+// These tests assert the round-trip, the path-injection (works under a fake
+// home), and — load-bearing for "data is sacred" / "no leaks" — that no secret
+// shape can be written to it.
+
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  deployStatePath,
+  readDeployState,
+  writeDeployState,
+  type DeployState,
+} from "../src/server/deploy-state.js";
+import { withTempHome } from "./helpers.js";
+
+const SAMPLE: DeployState = {
+  containerName: "the-librarian",
+  host: "127.0.0.1",
+  dataVolume: "librarian_data",
+  ref: "v1.4.2",
+  imageTag: "the-librarian:v1.4.2",
+};
+
+describe("deploy-state — round-trip under a fake home", () => {
+  it("writeDeployState then readDeployState returns the same state", async () => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".librarian", "server");
+      writeDeployState(dir, SAMPLE);
+      expect(readDeployState(dir)).toEqual(SAMPLE);
+    });
+  });
+
+  it("writes to <dir>/deploy-state.json and creates the dir if absent", async () => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".librarian", "server");
+      expect(fs.existsSync(dir)).toBe(false);
+      writeDeployState(dir, SAMPLE);
+      expect(fs.existsSync(deployStatePath(dir))).toBe(true);
+      expect(deployStatePath(dir)).toBe(path.join(dir, "deploy-state.json"));
+    });
+  });
+
+  it("readDeployState returns null when the file is absent", async () => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".librarian", "server");
+      expect(readDeployState(dir)).toBeNull();
+    });
+  });
+
+  it("readDeployState returns null on malformed JSON (never throws)", async () => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".librarian", "server");
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(deployStatePath(dir), "{ not json", "utf8");
+      expect(readDeployState(dir)).toBeNull();
+    });
+  });
+
+  it("readDeployState returns null when required fields are missing", async () => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".librarian", "server");
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(deployStatePath(dir), JSON.stringify({ host: "127.0.0.1" }), "utf8");
+      expect(readDeployState(dir)).toBeNull();
+    });
+  });
+});
+
+describe("deploy-state — carries NO secret (the file is non-secret)", () => {
+  it("the serialized state contains exactly the five non-secret fields", async () => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".librarian", "server");
+      writeDeployState(dir, SAMPLE);
+      const parsed = JSON.parse(fs.readFileSync(deployStatePath(dir), "utf8")) as Record<
+        string,
+        unknown
+      >;
+      expect(Object.keys(parsed).sort()).toEqual(
+        ["containerName", "dataVolume", "host", "imageTag", "ref"].sort(),
+      );
+    });
+  });
+
+  it("a secret-shaped value smuggled onto the input is NOT persisted", async () => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".librarian", "server");
+      // Assemble a secret-shaped literal at runtime (GitGuardian scans commits).
+      const fakeToken = "tok_" + "0123456789abcdef".repeat(4);
+      // Even if a caller passes extra keys, writeDeployState only ever persists
+      // the five declared non-secret fields.
+      writeDeployState(dir, {
+        ...SAMPLE,
+        // @ts-expect-error — extra keys are not part of DeployState and must be dropped.
+        token: fakeToken,
+        // @ts-expect-error — same for an admin token / master key.
+        adminToken: fakeToken,
+      });
+      const raw = fs.readFileSync(deployStatePath(dir), "utf8");
+      expect(raw).not.toContain(fakeToken);
+      expect(raw).not.toContain("token");
+    });
+  });
+});

--- a/packages/installer-cli/tests/server-down.test.ts
+++ b/packages/installer-cli/tests/server-down.test.ts
@@ -1,0 +1,117 @@
+// S4 — `librarian server down`: stop the container, DATA SACRED.
+//
+// `down` maps to `docker stop the-librarian` and NOTHING else. The
+// load-bearing assertions (success criterion 6 — data is sacred): the argv is
+// EXACTLY `docker stop the-librarian`, and NO `rm` / `-v` / `volume` / `rm -f`
+// ever appears. A later `up`/`update` brings the same data back. When the
+// container isn't running, `down` prints a friendly message and does not crash.
+
+import { afterEach, describe, expect, it } from "vitest";
+import { resetRunner } from "../src/exec.js";
+import { runCli } from "../src/runtime.js";
+import {
+  resetRunner as resetDockerRunner,
+  setRunner as setDockerRunner,
+} from "../src/server/docker.js";
+import { FakeRunner, withTempHome } from "./helpers.js";
+
+afterEach(() => {
+  resetRunner();
+  resetDockerRunner();
+});
+
+/** A runner with docker present + daemon reachable (preflight passes). */
+function dockerReady(): FakeRunner {
+  return new FakeRunner()
+    .withWhich("docker")
+    .withWhich("git")
+    .onRun("docker", ["info"], { code: 0 });
+}
+
+/** True iff the runner ever issued a destructive docker op (rm / volume / -v). */
+function ranDestructive(runner: FakeRunner): boolean {
+  return runner.calls.some(
+    (c) =>
+      c.cmd === "docker" &&
+      (c.args.includes("rm") ||
+        c.args.includes("-v") ||
+        c.args.includes("volume") ||
+        c.args.includes("-f")),
+  );
+}
+
+describe("server down — stops the container, never removes data (SC 6)", () => {
+  it("argv is EXACTLY `docker stop the-librarian` — no rm/-v/volume/rm -f", async () => {
+    await withTempHome(async (home) => {
+      const runner = dockerReady().onRun("docker", ["stop", "the-librarian"], {
+        stdout: "the-librarian\n",
+        code: 0,
+      });
+      setDockerRunner(runner);
+
+      const r = await runCli(["server", "down"], { home });
+      expect(r.exitCode).toBe(0);
+
+      // The stop call happened, with EXACTLY this argv.
+      expect(runner.ran("docker", ["stop", "the-librarian"])).toBe(true);
+      // The ONLY docker command (besides the preflight `info`) is `stop`.
+      const dockerVerbs = runner.calls.filter((c) => c.cmd === "docker").map((c) => c.args[0]);
+      expect(dockerVerbs).toEqual(["info", "stop"]);
+      // NOTHING destructive ran.
+      expect(ranDestructive(runner)).toBe(false);
+    });
+  });
+
+  it("reports the container was stopped", async () => {
+    await withTempHome(async (home) => {
+      const runner = dockerReady().onRun("docker", ["stop", "the-librarian"], {
+        stdout: "the-librarian\n",
+        code: 0,
+      });
+      setDockerRunner(runner);
+
+      const r = await runCli(["server", "down"], { home });
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toMatch(/stopped/i);
+      // Data-sacred reassurance: the data volume is preserved.
+      expect(r.stdout).toMatch(/data|volume|preserved|kept/i);
+    });
+  });
+});
+
+describe("server down — not running is friendly, not a crash", () => {
+  it("a missing container prints a clear message and exits 0 (idempotent-ish)", async () => {
+    await withTempHome(async (home) => {
+      // `docker stop` on an absent container exits non-zero with "No such container".
+      const runner = dockerReady().onRun("docker", ["stop", "the-librarian"], {
+        stderr: "Error response from daemon: No such container: the-librarian\n",
+        code: 1,
+      });
+      setDockerRunner(runner);
+
+      const r = await runCli(["server", "down"], { home });
+      // Not a crash — a friendly outcome.
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toMatch(/not running|no.*container|already|nothing to stop/i);
+      // Still no destructive op, even on the not-running path.
+      expect(ranDestructive(runner)).toBe(false);
+      // No stack trace leaked.
+      expect(r.stderr).not.toMatch(/at \w+.*\(/);
+    });
+  });
+});
+
+describe("server down — preflight teaches when docker is missing", () => {
+  it("docker absent → teaching error, never a destructive op", async () => {
+    await withTempHome(async (home) => {
+      const runner = new FakeRunner(); // nothing on PATH
+      setDockerRunner(runner);
+
+      const r = await runCli(["server", "down"], { home });
+      expect(r.exitCode).toBe(1);
+      expect(r.stderr).toMatch(/docker/i);
+      expect(r.stderr).toMatch(/install/i);
+      expect(ranDestructive(runner)).toBe(false);
+    });
+  });
+});

--- a/packages/installer-cli/tests/server-logs.test.ts
+++ b/packages/installer-cli/tests/server-logs.test.ts
@@ -1,0 +1,157 @@
+// S4 — `librarian server logs [-f] [--service mcp|dashboard|all]`.
+//
+// `logs` maps to `docker logs [-f] the-librarian`. The all-in-one image runs
+// BOTH services (mcp-server + dashboard) in ONE container under a supervisor
+// that uses `stdio: "inherit"` — so it emits NO per-service prefix. The
+// mcp-server logs structured pino NDJSON (each line a JSON object carrying
+// `"service":"the-librarian"`); the dashboard (Next.js standalone) logs plain
+// text. `--service mcp` keeps the NDJSON lines; `--service dashboard` keeps the
+// rest; `all` (default) is unfiltered. `-f` follows.
+
+import { afterEach, describe, expect, it } from "vitest";
+import { resetRunner } from "../src/exec.js";
+import { runCli } from "../src/runtime.js";
+import {
+  resetRunner as resetDockerRunner,
+  setRunner as setDockerRunner,
+} from "../src/server/docker.js";
+import { FakeRunner, withTempHome } from "./helpers.js";
+
+afterEach(() => {
+  resetRunner();
+  resetDockerRunner();
+});
+
+// A combined log stream: two mcp-server NDJSON lines + two dashboard text lines.
+const MCP_LINE_A = '{"level":30,"time":1,"service":"the-librarian","msg":"http listening on 3838"}';
+const MCP_LINE_B = '{"level":40,"time":2,"service":"the-librarian","msg":"recall hit"}';
+const DASH_LINE_A = "  ▲ Next.js 14.2.0";
+const DASH_LINE_B = "  - Local:   http://0.0.0.0:3000";
+const COMBINED = [MCP_LINE_A, DASH_LINE_A, MCP_LINE_B, DASH_LINE_B].join("\n") + "\n";
+
+/** docker present + daemon reachable, with a scripted `docker logs` output. */
+function dockerReady(logsArgs: string[]): FakeRunner {
+  return new FakeRunner()
+    .withWhich("docker")
+    .withWhich("git")
+    .onRun("docker", ["info"], { code: 0 })
+    .onRun("docker", logsArgs, { stdout: COMBINED, code: 0 });
+}
+
+/** The argv (after `docker`) of the recorded `logs` call. */
+function logsArgs(runner: FakeRunner): string[] | undefined {
+  return runner.calls.find((c) => c.cmd === "docker" && c.args[0] === "logs")?.args;
+}
+
+describe("server logs — default/all is unfiltered", () => {
+  it("`logs` maps to `docker logs the-librarian` and prints every line", async () => {
+    await withTempHome(async (home) => {
+      const runner = dockerReady(["logs", "the-librarian"]);
+      setDockerRunner(runner);
+
+      const r = await runCli(["server", "logs"], { home });
+      expect(r.exitCode).toBe(0);
+      expect(logsArgs(runner)).toEqual(["logs", "the-librarian"]);
+      // Unfiltered — both services' lines present.
+      expect(r.stdout).toContain("http listening on 3838");
+      expect(r.stdout).toContain("Next.js");
+    });
+  });
+
+  it("`--service all` is explicit-but-unfiltered (no -f)", async () => {
+    await withTempHome(async (home) => {
+      const runner = dockerReady(["logs", "the-librarian"]);
+      setDockerRunner(runner);
+
+      const r = await runCli(["server", "logs", "--service", "all"], { home });
+      expect(r.exitCode).toBe(0);
+      expect(logsArgs(runner)).toEqual(["logs", "the-librarian"]);
+      expect(r.stdout).toContain("http listening on 3838");
+      expect(r.stdout).toContain("Next.js");
+    });
+  });
+});
+
+describe("server logs — -f follows", () => {
+  it("`-f` adds the follow flag to the docker argv", async () => {
+    await withTempHome(async (home) => {
+      const runner = dockerReady(["logs", "-f", "the-librarian"]);
+      setDockerRunner(runner);
+
+      const r = await runCli(["server", "logs", "-f"], { home });
+      expect(r.exitCode).toBe(0);
+      expect(logsArgs(runner)).toEqual(["logs", "-f", "the-librarian"]);
+    });
+  });
+
+  it("`--follow` is the long form of `-f`", async () => {
+    await withTempHome(async (home) => {
+      const runner = dockerReady(["logs", "-f", "the-librarian"]);
+      setDockerRunner(runner);
+
+      const r = await runCli(["server", "logs", "--follow"], { home });
+      expect(r.exitCode).toBe(0);
+      expect(logsArgs(runner)).toEqual(["logs", "-f", "the-librarian"]);
+    });
+  });
+});
+
+describe("server logs — --service filters the combined stream", () => {
+  it("`-f --service mcp` follows AND keeps only the mcp-server (NDJSON) lines", async () => {
+    await withTempHome(async (home) => {
+      const runner = dockerReady(["logs", "-f", "the-librarian"]);
+      setDockerRunner(runner);
+
+      const r = await runCli(["server", "logs", "-f", "--service", "mcp"], { home });
+      expect(r.exitCode).toBe(0);
+      // docker logs invoked WITH -f.
+      expect(logsArgs(runner)).toEqual(["logs", "-f", "the-librarian"]);
+      // The mcp (NDJSON) lines are kept...
+      expect(r.stdout).toContain("http listening on 3838");
+      expect(r.stdout).toContain("recall hit");
+      // ...and the dashboard (plain-text) lines are filtered out.
+      expect(r.stdout).not.toContain("Next.js");
+      expect(r.stdout).not.toContain("Local:");
+    });
+  });
+
+  it("`--service dashboard` keeps only the dashboard (non-NDJSON) lines", async () => {
+    await withTempHome(async (home) => {
+      const runner = dockerReady(["logs", "the-librarian"]);
+      setDockerRunner(runner);
+
+      const r = await runCli(["server", "logs", "--service", "dashboard"], { home });
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toContain("Next.js");
+      expect(r.stdout).toContain("Local:");
+      // The mcp NDJSON lines are filtered out.
+      expect(r.stdout).not.toContain("http listening on 3838");
+      expect(r.stdout).not.toContain("recall hit");
+    });
+  });
+
+  it("an unknown --service value teaches the valid choices (no crash)", async () => {
+    await withTempHome(async (home) => {
+      const runner = dockerReady(["logs", "the-librarian"]);
+      setDockerRunner(runner);
+
+      const r = await runCli(["server", "logs", "--service", "frobnicate"], { home });
+      expect(r.exitCode).toBe(1);
+      expect(r.stderr).toMatch(/mcp/);
+      expect(r.stderr).toMatch(/dashboard/);
+      expect(r.stderr).toMatch(/all/);
+    });
+  });
+});
+
+describe("server logs — preflight teaches when docker is missing", () => {
+  it("docker absent → teaching error", async () => {
+    await withTempHome(async (home) => {
+      setDockerRunner(new FakeRunner()); // nothing on PATH
+      const r = await runCli(["server", "logs"], { home });
+      expect(r.exitCode).toBe(1);
+      expect(r.stderr).toMatch(/docker/i);
+      expect(r.stderr).toMatch(/install/i);
+    });
+  });
+});

--- a/packages/installer-cli/tests/server-logs.test.ts
+++ b/packages/installer-cli/tests/server-logs.test.ts
@@ -13,13 +13,17 @@ import { resetRunner } from "../src/exec.js";
 import { runCli } from "../src/runtime.js";
 import {
   resetRunner as resetDockerRunner,
+  resetStreamer as resetDockerStreamer,
   setRunner as setDockerRunner,
+  setStreamer as setDockerStreamer,
 } from "../src/server/docker.js";
-import { FakeRunner, withTempHome } from "./helpers.js";
+import { runLogs } from "../src/server/logs.js";
+import { FakeRunner, FakeStreamer, withTempHome } from "./helpers.js";
 
 afterEach(() => {
   resetRunner();
   resetDockerRunner();
+  resetDockerStreamer();
 });
 
 // A combined log stream: two mcp-server NDJSON lines + two dashboard text lines.
@@ -38,9 +42,22 @@ function dockerReady(logsArgs: string[]): FakeRunner {
     .onRun("docker", logsArgs, { stdout: COMBINED, code: 0 });
 }
 
+/** docker present + daemon reachable, WITHOUT scripting `docker logs` (follow streams). */
+function dockerReadyForFollow(): FakeRunner {
+  return new FakeRunner()
+    .withWhich("docker")
+    .withWhich("git")
+    .onRun("docker", ["info"], { code: 0 });
+}
+
 /** The argv (after `docker`) of the recorded `logs` call. */
 function logsArgs(runner: FakeRunner): string[] | undefined {
   return runner.calls.find((c) => c.cmd === "docker" && c.args[0] === "logs")?.args;
+}
+
+/** The argv (after `docker`) of the recorded streaming `logs` call. */
+function streamLogsArgs(streamer: FakeStreamer): string[] | undefined {
+  return streamer.calls.find((c) => c.cmd === "docker" && c.args[0] === "logs")?.args;
 }
 
 describe("server logs — default/all is unfiltered", () => {
@@ -72,47 +89,100 @@ describe("server logs — default/all is unfiltered", () => {
   });
 });
 
-describe("server logs — -f follows", () => {
-  it("`-f` adds the follow flag to the docker argv", async () => {
+describe("server logs — -f STREAMS live (never buffers to close)", () => {
+  it("`-f` uses the streaming seam — `docker logs -f the-librarian`, NOT the buffering run()", async () => {
+    const runner = dockerReadyForFollow();
+    setDockerRunner(runner);
+    const streamer = new FakeStreamer().withStdout(COMBINED).withExit(0);
+    setDockerStreamer(streamer);
+
+    const lines: string[] = [];
+    const code = await runLogs({ follow: true, write: (s) => lines.push(s) });
+
+    // The streaming seam carried the follow — NOT the capturing run().
+    expect(streamLogsArgs(streamer)).toEqual(["logs", "-f", "the-librarian"]);
+    expect(runner.ran("docker", ["logs", "-f", "the-librarian"])).toBe(false);
+    // Resolves with the followed process's exit code.
+    expect(code.exitCode).toBe(0);
+    // Every line reached the sink (live).
+    expect(lines.join("")).toContain("http listening on 3838");
+    expect(lines.join("")).toContain("Next.js");
+  });
+
+  it("lines reach the terminal AS THEY ARRIVE, in order (not end-buffered)", async () => {
+    const runner = dockerReadyForFollow();
+    setDockerRunner(runner);
+    // Three separate chunks, emitted one at a time by the streamer.
+    const streamer = new FakeStreamer()
+      .withStdout("line one\n", "line two\n", "line three\n")
+      .withExit(0);
+    setDockerStreamer(streamer);
+
+    const writes: string[] = [];
+    await runLogs({ follow: true, service: "dashboard", write: (s) => writes.push(s) });
+
+    // Each line was written separately, in arrival order — not concatenated once.
+    const joined = writes.join("");
+    expect(joined.indexOf("line one")).toBeLessThan(joined.indexOf("line two"));
+    expect(joined.indexOf("line two")).toBeLessThan(joined.indexOf("line three"));
+  });
+
+  it("`-f` via the CLI streams to the terminal and exits cleanly", async () => {
     await withTempHome(async (home) => {
-      const runner = dockerReady(["logs", "-f", "the-librarian"]);
+      const runner = dockerReadyForFollow();
       setDockerRunner(runner);
+      const streamer = new FakeStreamer().withStdout(COMBINED).withExit(0);
+      setDockerStreamer(streamer);
 
       const r = await runCli(["server", "logs", "-f"], { home });
       expect(r.exitCode).toBe(0);
-      expect(logsArgs(runner)).toEqual(["logs", "-f", "the-librarian"]);
+      expect(streamLogsArgs(streamer)).toEqual(["logs", "-f", "the-librarian"]);
+      // The CLI did NOT route the follow through the capturing run().
+      expect(runner.ran("docker", ["logs", "-f", "the-librarian"])).toBe(false);
     });
   });
 
-  it("`--follow` is the long form of `-f`", async () => {
+  it("`--follow` is the long form of `-f` (also streams)", async () => {
     await withTempHome(async (home) => {
-      const runner = dockerReady(["logs", "-f", "the-librarian"]);
+      const runner = dockerReadyForFollow();
       setDockerRunner(runner);
+      const streamer = new FakeStreamer().withStdout(COMBINED).withExit(0);
+      setDockerStreamer(streamer);
 
       const r = await runCli(["server", "logs", "--follow"], { home });
       expect(r.exitCode).toBe(0);
-      expect(logsArgs(runner)).toEqual(["logs", "-f", "the-librarian"]);
+      expect(streamLogsArgs(streamer)).toEqual(["logs", "-f", "the-librarian"]);
     });
   });
 });
 
 describe("server logs — --service filters the combined stream", () => {
-  it("`-f --service mcp` follows AND keeps only the mcp-server (NDJSON) lines", async () => {
-    await withTempHome(async (home) => {
-      const runner = dockerReady(["logs", "-f", "the-librarian"]);
-      setDockerRunner(runner);
+  it("`-f --service mcp` STREAMS and keeps only the mcp-server (NDJSON) lines, live", async () => {
+    const runner = dockerReadyForFollow();
+    setDockerRunner(runner);
+    // Emit the four lines one at a time, interleaved, as a follow would.
+    const streamer = new FakeStreamer()
+      .withStdout(MCP_LINE_A + "\n", DASH_LINE_A + "\n", MCP_LINE_B + "\n", DASH_LINE_B + "\n")
+      .withExit(0);
+    setDockerStreamer(streamer);
 
-      const r = await runCli(["server", "logs", "-f", "--service", "mcp"], { home });
-      expect(r.exitCode).toBe(0);
-      // docker logs invoked WITH -f.
-      expect(logsArgs(runner)).toEqual(["logs", "-f", "the-librarian"]);
-      // The mcp (NDJSON) lines are kept...
-      expect(r.stdout).toContain("http listening on 3838");
-      expect(r.stdout).toContain("recall hit");
-      // ...and the dashboard (plain-text) lines are filtered out.
-      expect(r.stdout).not.toContain("Next.js");
-      expect(r.stdout).not.toContain("Local:");
-    });
+    const writes: string[] = [];
+    const code = await runLogs({ follow: true, service: "mcp", write: (s) => writes.push(s) });
+
+    // Streaming seam carried the follow.
+    expect(streamLogsArgs(streamer)).toEqual(["logs", "-f", "the-librarian"]);
+    expect(code.exitCode).toBe(0);
+    const joined = writes.join("");
+    // The mcp (NDJSON) lines are kept, in order...
+    expect(joined).toContain("http listening on 3838");
+    expect(joined).toContain("recall hit");
+    expect(joined.indexOf("http listening on 3838")).toBeLessThan(joined.indexOf("recall hit"));
+    // ...and the dashboard (plain-text) lines are filtered OUT.
+    expect(joined).not.toContain("Next.js");
+    expect(joined).not.toContain("Local:");
+    // Filtered line-by-line: each kept mcp line was a SEPARATE write (not one blob).
+    const mcpWrites = writes.filter((w) => w.includes("the-librarian"));
+    expect(mcpWrites.length).toBe(2);
   });
 
   it("`--service dashboard` keeps only the dashboard (non-NDJSON) lines", async () => {

--- a/packages/installer-cli/tests/server-status.test.ts
+++ b/packages/installer-cli/tests/server-status.test.ts
@@ -1,0 +1,196 @@
+// S4 — `librarian server status`: running? healthy? deployed-vs-latest badge.
+//
+// `status` reports, from stubbed `docker inspect` + a stubbed
+// `fetchLatestVersion` (no real daemon/network):
+//   - container running? (docker inspect state)
+//   - health (`{{.State.Health.Status}}`)
+//   - the DEPLOYED version (the ref from deploy-state, else `git describe`)
+//   - the LATEST release (`fetchLatestVersion`)
+//   - an `up-to-date | update-available` badge via `isBehind(deployed, latest)`
+// Offline / unknown latest renders `unknown`/`?` and NEVER crashes (mirrors
+// status.ts's offline tolerance). A container that doesn't exist → "not running".
+
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resetRunner } from "../src/exec.js";
+import { runCli } from "../src/runtime.js";
+import { writeDeployState } from "../src/server/deploy-state.js";
+import {
+  resetRunner as resetDockerRunner,
+  setRunner as setDockerRunner,
+} from "../src/server/docker.js";
+import { resetLatestFetcher, setLatestFetcher } from "../src/status.js";
+import { FakeRunner, withTempHome } from "./helpers.js";
+
+afterEach(() => {
+  resetRunner();
+  resetDockerRunner();
+  resetLatestFetcher();
+});
+
+const DEPLOYED = "v1.4.2";
+
+/** Seed a deploy-state recording the deployed ref `v1.4.2`. */
+function seedDeployState(home: string): void {
+  writeDeployState(path.join(home, ".librarian", "server"), {
+    containerName: "the-librarian",
+    host: "127.0.0.1",
+    dataVolume: "librarian_data",
+    ref: DEPLOYED,
+    imageTag: `the-librarian:${DEPLOYED}`,
+  });
+}
+
+/** docker present, daemon up, container running + healthy. */
+function runningHealthy(): FakeRunner {
+  return new FakeRunner()
+    .withWhich("docker")
+    .withWhich("git")
+    .onRun("docker", ["info"], { code: 0 })
+    .onRun("docker", ["inspect", "--format", "{{.State.Status}}", "the-librarian"], {
+      stdout: "running\n",
+      code: 0,
+    })
+    .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", "the-librarian"], {
+      stdout: "healthy\n",
+      code: 0,
+    });
+}
+
+describe("server status — running + healthy, deployed vs latest badge", () => {
+  it("a NEWER latest → update-available", async () => {
+    await withTempHome(async (home) => {
+      seedDeployState(home);
+      setDockerRunner(runningHealthy());
+      setLatestFetcher(async () => "1.5.0"); // newer than deployed 1.4.2
+
+      const r = await runCli(["server", "status"], { home });
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toMatch(/running/i);
+      expect(r.stdout).toMatch(/healthy/i);
+      expect(r.stdout).toContain(DEPLOYED); // deployed version
+      expect(r.stdout).toContain("1.5.0"); // latest
+      expect(r.stdout).toMatch(/update-available/i);
+      expect(r.stdout).not.toMatch(/up-to-date/i);
+    });
+  });
+
+  it("an EQUAL latest → up-to-date", async () => {
+    await withTempHome(async (home) => {
+      seedDeployState(home);
+      setDockerRunner(runningHealthy());
+      setLatestFetcher(async () => "1.4.2"); // equal to deployed
+
+      const r = await runCli(["server", "status"], { home });
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toMatch(/up-to-date/i);
+      expect(r.stdout).not.toMatch(/update-available/i);
+    });
+  });
+});
+
+describe("server status — offline tolerance (never crashes)", () => {
+  it("fetchLatestVersion returns null → latest unknown, badge ?, no crash", async () => {
+    await withTempHome(async (home) => {
+      seedDeployState(home);
+      setDockerRunner(runningHealthy());
+      setLatestFetcher(async () => null); // offline
+
+      const r = await runCli(["server", "status"], { home });
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toMatch(/unknown/i);
+      // The badge degrades to `?` rather than lying about an update.
+      expect(r.stdout).toContain("?");
+      expect(r.stdout).not.toMatch(/update-available/i);
+      expect(r.stdout).not.toMatch(/up-to-date/i);
+    });
+  });
+});
+
+describe("server status — container absent → not running", () => {
+  it("`docker inspect` non-zero (no such container) → not running, no crash", async () => {
+    await withTempHome(async (home) => {
+      seedDeployState(home);
+      const runner = new FakeRunner()
+        .withWhich("docker")
+        .withWhich("git")
+        .onRun("docker", ["info"], { code: 0 })
+        .onRun("docker", ["inspect", "--format", "{{.State.Status}}", "the-librarian"], {
+          stderr: "Error: No such object: the-librarian\n",
+          code: 1,
+        });
+      setDockerRunner(runner);
+      setLatestFetcher(async () => "1.5.0");
+
+      const r = await runCli(["server", "status"], { home });
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toMatch(/not running/i);
+      // Still reports the deployed version it knows from deploy-state.
+      expect(r.stdout).toContain(DEPLOYED);
+    });
+  });
+});
+
+describe("server status — deployed version from deploy-state, else git describe", () => {
+  it("reads the deployed ref from deploy-state.json", async () => {
+    await withTempHome(async (home) => {
+      seedDeployState(home);
+      setDockerRunner(runningHealthy());
+      setLatestFetcher(async () => "1.4.2");
+
+      const r = await runCli(["server", "status"], { home });
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toContain(DEPLOYED);
+    });
+  });
+
+  it("falls back to `git -C <dir> describe --tags` when no deploy-state exists", async () => {
+    await withTempHome(async (home) => {
+      // No deploy-state seeded — status must fall back to git describe.
+      const deployDir = path.join(home, ".librarian", "server");
+      const runner = runningHealthy().onRun("git", ["-C", deployDir, "describe", "--tags"], {
+        stdout: "v1.3.9\n",
+        code: 0,
+      });
+      setDockerRunner(runner);
+      setLatestFetcher(async () => "1.5.0");
+
+      const r = await runCli(["server", "status"], { home });
+      expect(r.exitCode).toBe(0);
+      // The git-describe value is surfaced as the deployed version.
+      expect(r.stdout).toContain("v1.3.9");
+      expect(runner.ran("git", ["-C", deployDir, "describe", "--tags"])).toBe(true);
+    });
+  });
+
+  it("deployed unknown (no deploy-state AND git describe fails) → unknown, badge ?", async () => {
+    await withTempHome(async (home) => {
+      const deployDir = path.join(home, ".librarian", "server");
+      const runner = runningHealthy().onRun("git", ["-C", deployDir, "describe", "--tags"], {
+        stderr: "fatal: not a git repository\n",
+        code: 128,
+      });
+      setDockerRunner(runner);
+      setLatestFetcher(async () => "1.5.0");
+
+      const r = await runCli(["server", "status"], { home });
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toMatch(/unknown/i);
+      expect(r.stdout).toContain("?");
+      expect(r.stdout).not.toMatch(/update-available/i);
+    });
+  });
+});
+
+describe("server status — preflight teaches when docker is missing", () => {
+  it("docker absent → teaching error", async () => {
+    await withTempHome(async (home) => {
+      setDockerRunner(new FakeRunner());
+      setLatestFetcher(async () => "1.5.0");
+      const r = await runCli(["server", "status"], { home });
+      expect(r.exitCode).toBe(1);
+      expect(r.stderr).toMatch(/docker/i);
+      expect(r.stderr).toMatch(/install/i);
+    });
+  });
+});

--- a/packages/installer-cli/tests/server-up.test.ts
+++ b/packages/installer-cli/tests/server-up.test.ts
@@ -12,6 +12,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { readEnvFile } from "../src/env.js";
 import { resetRunner } from "../src/exec.js";
 import { runCli } from "../src/runtime.js";
+import { deployStatePath, readDeployState } from "../src/server/deploy-state.js";
 import {
   resetRunner as resetDockerRunner,
   setRunner as setDockerRunner,
@@ -343,6 +344,60 @@ describe("server up — loop-closer (MCP URL + token + env offer)", () => {
       expect(r.exitCode).toBe(0);
       expect(readEnvFile(home)?.token).toBe(AGENT_TOKEN);
       expect(prompter.textCalls.length).toBe(0);
+    });
+  });
+});
+
+describe("server up — writes the NON-SECRET deploy-state (S4/S5 prerequisite)", () => {
+  it("writes deploy-state.json with host/dataVolume/ref/imageTag/containerName and NO secret", async () => {
+    await withTempHome(async (home) => {
+      const runner = healthyRunner();
+      setDockerRunner(runner);
+      stubSeams();
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
+
+      const r = await runCli(["server", "up"], { home, prompter });
+      expect(r.exitCode).toBe(0);
+
+      const deployDir = path.join(home, ".librarian", "server");
+      const state = readDeployState(deployDir);
+      expect(state).toEqual({
+        containerName: "the-librarian",
+        host: "127.0.0.1",
+        dataVolume: "librarian_data",
+        ref: LATEST_TAG,
+        imageTag: `the-librarian:${LATEST_TAG}`,
+      });
+
+      // The state file carries NO secret: not the agent token, not the master key.
+      const raw = fs.readFileSync(deployStatePath(deployDir), "utf8");
+      expect(raw).not.toContain(AGENT_TOKEN);
+      expect(raw).not.toContain(MASTER_KEY);
+      expect(raw).not.toMatch(/token|secret|key/i);
+    });
+  });
+
+  it("records the override host/volume/ref the operator chose", async () => {
+    await withTempHome(async (home) => {
+      const runner = healthyRunner();
+      setDockerRunner(runner);
+      stubSeams();
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
+
+      const customDir = path.join(home, "custom-deploy");
+      const r = await runCli(
+        ["server", "up", "--data-volume", "my_vol", "--dir", customDir, "--ref", "main"],
+        { home, prompter },
+      );
+      expect(r.exitCode).toBe(0);
+
+      expect(readDeployState(customDir)).toEqual({
+        containerName: "the-librarian",
+        host: "127.0.0.1",
+        dataVolume: "my_vol",
+        ref: "main",
+        imageTag: "the-librarian:main",
+      });
     });
   });
 });

--- a/packages/installer-cli/tests/server-up.test.ts
+++ b/packages/installer-cli/tests/server-up.test.ts
@@ -82,11 +82,14 @@ describe("server up — fresh localhost happy path (exact argv)", () => {
 
       const deployDir = path.join(home, ".librarian", "server");
 
-      // git clone <repo> <dir>, then checkout the resolved tag.
+      // git clone <repo> <dir>, then checkout the resolved tag. The ref is passed
+      // after `--end-of-options` so a `--…`-shaped ref can't inject a git option (S-1).
       expect(
         runner.ran("git", ["clone", "https://github.com/JimJafar/the-librarian", deployDir]),
       ).toBe(true);
-      expect(runner.ran("git", ["-C", deployDir, "checkout", LATEST_TAG])).toBe(true);
+      expect(runner.ran("git", ["-C", deployDir, "checkout", "--end-of-options", LATEST_TAG])).toBe(
+        true,
+      );
 
       // docker build with the VERIFIED command.
       expect(
@@ -160,7 +163,9 @@ describe("server up — flags reflected in argv", () => {
       expect(
         runner.ran("git", ["clone", "https://github.com/JimJafar/the-librarian", customDir]),
       ).toBe(true);
-      expect(runner.ran("git", ["-C", customDir, "checkout", "main"])).toBe(true);
+      expect(runner.ran("git", ["-C", customDir, "checkout", "--end-of-options", "main"])).toBe(
+        true,
+      );
 
       // The image tag follows the ref; the volume is the override.
       expect(
@@ -214,6 +219,54 @@ describe("server up — health-wait failure rolls back (no half-up)", () => {
       expect(runner.ran("docker", ["exec", "the-librarian", "cat", "/data/secret.key"])).toBe(
         false,
       );
+    });
+  });
+});
+
+describe("server up — a failed docker step REDACTS secret-bearing argv (S-2)", () => {
+  it("a docker run failure that echoes the -e agent-token arg is surfaced redacted", async () => {
+    await withTempHome(async (home) => {
+      // The real minter yields a 64-hex token; mirror that shape here (assembled
+      // from sub-threshold parts) so redactSecrets's 64-hex rule can catch it.
+      const hexAgentToken = "fedcba9876543210".repeat(4);
+      setLatestFetcher(async () => LATEST);
+      setTokenMinter(() => hexAgentToken);
+      setSleep(async () => undefined);
+
+      // Everything up to `docker run` succeeds (clone/checkout/build); only the
+      // `docker run -d …` step fails — and echoes the full argv it was given, so
+      // the token in the `-e LIBRARIAN_AGENT_TOKEN=…` arg appears in its stderr.
+      const runner = new FakeRunner()
+        .withWhich("docker")
+        .withWhich("git")
+        .withFallback({ code: 0 })
+        .onRun("docker", ["info"], { code: 0 });
+      // Script the failing `docker run` by matching its full argv.
+      const runArgs = buildRunArgs({
+        host: "127.0.0.1",
+        dataVolume: "librarian_data",
+        tag: LATEST_TAG,
+        agentToken: hexAgentToken,
+      });
+      runner.onRun("docker", runArgs, {
+        stderr:
+          "docker: Error response from daemon: invalid reference, while running with " +
+          `${runArgs.join(" ")}\n`,
+        code: 1,
+      });
+      setDockerRunner(runner);
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
+
+      const r = await runCli(["server", "up"], { home, prompter });
+      expect(r.exitCode).toBe(1);
+      // It failed at the `docker run` step (not earlier).
+      expect(r.stderr).toMatch(/docker run/);
+      // The token must NOT appear in the surfaced error...
+      expect(r.stderr).not.toContain(hexAgentToken);
+      // ...but the non-secret remainder of the error IS surfaced.
+      expect(r.stderr).toMatch(/Error response from daemon/);
+      // ...and it must not have leaked into any file either.
+      expect(filesContaining(home, hexAgentToken)).toEqual([]);
     });
   });
 });
@@ -288,10 +341,13 @@ describe("server up — foreign deploy dir stops and asks (never clobbers)", () 
       const r = await runCli(["server", "up"], { home, prompter });
       expect(r.exitCode).toBe(0);
 
-      // No clone (already ours); fetch tags + checkout the resolved tag.
+      // No clone (already ours); fetch tags + checkout the resolved tag (ref
+      // after `--end-of-options` so a `--…`-shaped ref can't inject an option, S-1).
       expect(runner.calls.some((c) => c.cmd === "git" && c.args[0] === "clone")).toBe(false);
       expect(runner.ran("git", ["-C", deployDir, "fetch", "--tags", "origin"])).toBe(true);
-      expect(runner.ran("git", ["-C", deployDir, "checkout", LATEST_TAG])).toBe(true);
+      expect(runner.ran("git", ["-C", deployDir, "checkout", "--end-of-options", LATEST_TAG])).toBe(
+        true,
+      );
     });
   });
 });

--- a/packages/installer-cli/tests/server-up.test.ts
+++ b/packages/installer-cli/tests/server-up.test.ts
@@ -1,0 +1,410 @@
+// S2 — `librarian server up` (localhost happy path).
+//
+// Every test drives the public `runCli(["server", "up", …])` entry against a
+// fresh temp home, the injected `docker.ts` FakeRunner (so the EXACT git/docker
+// argv is asserted), a stubbed latest-release fetcher, a deterministic agent
+// token, a no-op health-poll sleep, and a scripted prompter. No real daemon,
+// network, or git is ever touched.
+
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { readEnvFile } from "../src/env.js";
+import { resetRunner } from "../src/exec.js";
+import { runCli } from "../src/runtime.js";
+import {
+  resetRunner as resetDockerRunner,
+  setRunner as setDockerRunner,
+} from "../src/server/docker.js";
+import {
+  buildRunArgs,
+  resetSleep,
+  resetTokenMinter,
+  setSleep,
+  setTokenMinter,
+} from "../src/server/up.js";
+import { resetLatestFetcher, setLatestFetcher } from "../src/status.js";
+import { FakeRunner, withTempHome } from "./helpers.js";
+import { FakePrompter } from "./prompter.js";
+
+const AGENT_TOKEN = "agent-token-deterministic-for-tests";
+const MASTER_KEY = "master-key-read-back-from-the-container-once";
+const LATEST = "1.4.2"; // fetchLatestVersion returns the v-stripped version
+const LATEST_TAG = "v1.4.2";
+
+afterEach(() => {
+  resetRunner();
+  resetDockerRunner();
+  resetLatestFetcher();
+  resetSleep();
+  resetTokenMinter();
+});
+
+/** A FakeRunner wired for a fully-successful localhost `up`. */
+function healthyRunner(): FakeRunner {
+  return new FakeRunner()
+    .withWhich("docker")
+    .withWhich("git")
+    .onRun("docker", ["info"], { code: 0 })
+    .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", "the-librarian"], {
+      stdout: "healthy\n",
+      code: 0,
+    })
+    .onRun("docker", ["exec", "the-librarian", "cat", "/data/secret.key"], {
+      stdout: `${MASTER_KEY}\n`,
+      code: 0,
+    });
+}
+
+/** Install the deterministic seams shared by the happy-path tests. */
+function stubSeams(): void {
+  setLatestFetcher(async () => LATEST);
+  setTokenMinter(() => AGENT_TOKEN);
+  setSleep(async () => undefined);
+}
+
+/** The argv (after `docker`) any `run -d …` call recorded by the runner. */
+function dockerRunArgs(runner: FakeRunner): string[] | undefined {
+  return runner.calls.find((c) => c.cmd === "docker" && c.args[0] === "run")?.args;
+}
+
+describe("server up — fresh localhost happy path (exact argv)", () => {
+  it("clones at the latest tag, builds, then runs the localhost container", async () => {
+    await withTempHome(async (home) => {
+      const runner = healthyRunner();
+      setDockerRunner(runner);
+      stubSeams();
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
+
+      const r = await runCli(["server", "up"], { home, prompter });
+      expect(r.exitCode).toBe(0);
+
+      const deployDir = path.join(home, ".librarian", "server");
+
+      // git clone <repo> <dir>, then checkout the resolved tag.
+      expect(
+        runner.ran("git", ["clone", "https://github.com/JimJafar/the-librarian", deployDir]),
+      ).toBe(true);
+      expect(runner.ran("git", ["-C", deployDir, "checkout", LATEST_TAG])).toBe(true);
+
+      // docker build with the VERIFIED command.
+      expect(
+        runner.ran("docker", [
+          "build",
+          "-f",
+          "docker/all-in-one.Dockerfile",
+          "-t",
+          `the-librarian:${LATEST_TAG}`,
+          ".",
+        ]),
+      ).toBe(true);
+
+      // docker run — the EXACT localhost argv (ALLOW_NO_AUTH present, no --init).
+      expect(dockerRunArgs(runner)).toEqual([
+        "run",
+        "-d",
+        "--name",
+        "the-librarian",
+        "--restart",
+        "unless-stopped",
+        "-p",
+        "127.0.0.1:3000:3000",
+        "-p",
+        "127.0.0.1:3838:3838",
+        "-v",
+        "librarian_data:/data",
+        "-e",
+        `LIBRARIAN_AGENT_TOKEN=${AGENT_TOKEN}`,
+        "-e",
+        "LIBRARIAN_ALLOW_NO_AUTH=true",
+        `the-librarian:${LATEST_TAG}`,
+      ]);
+    });
+  });
+
+  it("runs build + run from the deploy dir (cwd carries the Dockerfile context)", async () => {
+    await withTempHome(async (home) => {
+      const runner = healthyRunner();
+      setDockerRunner(runner);
+      stubSeams();
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
+
+      await runCli(["server", "up"], { home, prompter });
+
+      const deployDir = path.join(home, ".librarian", "server");
+      const build = runner.calls.find((c) => c.cmd === "docker" && c.args[0] === "build");
+      const dRun = runner.calls.find((c) => c.cmd === "docker" && c.args[0] === "run");
+      expect(build?.opts?.cwd).toBe(deployDir);
+      expect(dRun?.opts?.cwd).toBe(deployDir);
+    });
+  });
+});
+
+describe("server up — flags reflected in argv", () => {
+  it("--data-volume, --dir and --ref are honoured", async () => {
+    await withTempHome(async (home) => {
+      const runner = healthyRunner();
+      setDockerRunner(runner);
+      stubSeams();
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
+
+      const customDir = path.join(home, "custom-deploy");
+      const r = await runCli(
+        ["server", "up", "--data-volume", "my_vol", "--dir", customDir, "--ref", "main"],
+        { home, prompter },
+      );
+      expect(r.exitCode).toBe(0);
+
+      // Clone + checkout at the pinned ref, into the custom dir.
+      expect(
+        runner.ran("git", ["clone", "https://github.com/JimJafar/the-librarian", customDir]),
+      ).toBe(true);
+      expect(runner.ran("git", ["-C", customDir, "checkout", "main"])).toBe(true);
+
+      // The image tag follows the ref; the volume is the override.
+      expect(
+        runner.ran("docker", [
+          "build",
+          "-f",
+          "docker/all-in-one.Dockerfile",
+          "-t",
+          "the-librarian:main",
+          ".",
+        ]),
+      ).toBe(true);
+      const runArgs = dockerRunArgs(runner);
+      expect(runArgs).toContain("my_vol:/data");
+      expect(runArgs?.[runArgs.length - 1]).toBe("the-librarian:main");
+    });
+  });
+});
+
+describe("server up — health-wait failure rolls back (no half-up)", () => {
+  it("an unhealthy container is removed, logs surfaced, and the command errors", async () => {
+    await withTempHome(async (home) => {
+      const runner = new FakeRunner()
+        .withWhich("docker")
+        .withWhich("git")
+        .onRun("docker", ["info"], { code: 0 })
+        .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", "the-librarian"], {
+          stdout: "unhealthy\n",
+          code: 0,
+        })
+        .onRun("docker", ["logs", "--tail", "50", "the-librarian"], {
+          stdout: "boom: the server crashed on boot\n",
+          code: 0,
+        });
+      setDockerRunner(runner);
+      stubSeams();
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
+
+      // The container reports `unhealthy`, so the poll terminates fast (no need
+      // to wait out the bound) and the flow rolls back.
+      const r = await runCli(["server", "up"], { home, prompter });
+
+      expect(r.exitCode).toBe(1);
+      // Rolled back — the container was force-removed.
+      expect(runner.ran("docker", ["rm", "-f", "the-librarian"])).toBe(true);
+      // Logs were surfaced to the operator.
+      expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "logs")).toBe(true);
+      expect(r.stderr).toMatch(/did not become healthy/i);
+      expect(r.stderr).toMatch(/rolled back/i);
+      // No master-key read happened (we failed before the exec).
+      expect(runner.ran("docker", ["exec", "the-librarian", "cat", "/data/secret.key"])).toBe(
+        false,
+      );
+    });
+  });
+});
+
+describe("server up — master key surfaced once, persisted nowhere", () => {
+  it("prints the key exactly once with the SAVE warning and writes it to no file", async () => {
+    await withTempHome(async (home) => {
+      const runner = healthyRunner();
+      setDockerRunner(runner);
+      stubSeams();
+      // Accept the env-write offer — even then, the MASTER KEY must not land in
+      // any file (only the agent token may).
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "y" } });
+
+      const r = await runCli(["server", "up"], { home, prompter });
+      expect(r.exitCode).toBe(0);
+
+      // Surfaced exactly once, beside the SAVE warning.
+      expect(r.stdout).toContain(MASTER_KEY);
+      expect(r.stdout.split(MASTER_KEY).length - 1).toBe(1);
+      expect(r.stdout).toMatch(/SAVE THIS KEY — excluded from backups/);
+
+      // The master key appears in NO file under the home / deploy tree.
+      const filesWithKey = filesContaining(home, MASTER_KEY);
+      expect(filesWithKey).toEqual([]);
+    });
+  });
+});
+
+describe("server up — foreign deploy dir stops and asks (never clobbers)", () => {
+  it("a git repo with a different remote halts before any clobbering git op", async () => {
+    await withTempHome(async (home) => {
+      const deployDir = path.join(home, ".librarian", "server");
+      fs.mkdirSync(path.join(deployDir, ".git"), { recursive: true });
+
+      const runner = healthyRunner().onRun(
+        "git",
+        ["-C", deployDir, "remote", "get-url", "origin"],
+        { stdout: "https://github.com/someone-else/other-repo.git\n", code: 0 },
+      );
+      setDockerRunner(runner);
+      stubSeams();
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
+
+      const r = await runCli(["server", "up"], { home, prompter });
+      expect(r.exitCode).toBe(1);
+      expect(r.stderr).toMatch(/different remote/i);
+
+      // It must NOT have clobbered: no clone, no fetch, no checkout.
+      expect(runner.calls.some((c) => c.cmd === "git" && c.args[0] === "clone")).toBe(false);
+      expect(runner.calls.some((c) => c.cmd === "git" && c.args.includes("checkout"))).toBe(false);
+      expect(runner.calls.some((c) => c.cmd === "git" && c.args.includes("fetch"))).toBe(false);
+      // And it never reached docker build/run.
+      expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "build")).toBe(false);
+    });
+  });
+
+  it("our managed clone fetches + checks out the ref (does not re-clone)", async () => {
+    await withTempHome(async (home) => {
+      const deployDir = path.join(home, ".librarian", "server");
+      fs.mkdirSync(path.join(deployDir, ".git"), { recursive: true });
+
+      const runner = healthyRunner().onRun(
+        "git",
+        ["-C", deployDir, "remote", "get-url", "origin"],
+        { stdout: "git@github.com:JimJafar/the-librarian.git\n", code: 0 },
+      );
+      setDockerRunner(runner);
+      stubSeams();
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
+
+      const r = await runCli(["server", "up"], { home, prompter });
+      expect(r.exitCode).toBe(0);
+
+      // No clone (already ours); fetch tags + checkout the resolved tag.
+      expect(runner.calls.some((c) => c.cmd === "git" && c.args[0] === "clone")).toBe(false);
+      expect(runner.ran("git", ["-C", deployDir, "fetch", "--tags", "origin"])).toBe(true);
+      expect(runner.ran("git", ["-C", deployDir, "checkout", LATEST_TAG])).toBe(true);
+    });
+  });
+});
+
+describe("server up — loop-closer (MCP URL + token + env offer)", () => {
+  it("prints the MCP/dashboard URLs + agent token; writes env only when accepted", async () => {
+    await withTempHome(async (home) => {
+      const runner = healthyRunner();
+      setDockerRunner(runner);
+      stubSeams();
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "y" } });
+
+      const r = await runCli(["server", "up"], { home, prompter });
+      expect(r.exitCode).toBe(0);
+
+      expect(r.stdout).toContain("http://127.0.0.1:3838/mcp");
+      expect(r.stdout).toContain("http://127.0.0.1:3000");
+      expect(r.stdout).toContain(AGENT_TOKEN);
+
+      // Accepted → env written with the URL + agent token (the agent token MAY
+      // be persisted; the master key may not).
+      const env = readEnvFile(home);
+      expect(env?.mcpUrl).toBe("http://127.0.0.1:3838/mcp");
+      expect(env?.token).toBe(AGENT_TOKEN);
+    });
+  });
+
+  it("declined offer leaves ~/.librarian/env unwritten", async () => {
+    await withTempHome(async (home) => {
+      const runner = healthyRunner();
+      setDockerRunner(runner);
+      stubSeams();
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
+
+      const r = await runCli(["server", "up"], { home, prompter });
+      expect(r.exitCode).toBe(0);
+      expect(readEnvFile(home)).toBeNull();
+    });
+  });
+
+  it("--yes auto-accepts the env write without prompting", async () => {
+    await withTempHome(async (home) => {
+      const runner = healthyRunner();
+      setDockerRunner(runner);
+      stubSeams();
+      // A prompter that THROWS if asked — proves --yes never prompts.
+      const prompter = new FakePrompter({});
+
+      const r = await runCli(["server", "up", "--yes"], { home, prompter });
+      expect(r.exitCode).toBe(0);
+      expect(readEnvFile(home)?.token).toBe(AGENT_TOKEN);
+      expect(prompter.textCalls.length).toBe(0);
+    });
+  });
+});
+
+describe("server up — beyond-localhost binding is deferred (S3)", () => {
+  it("--host beyond 127.0.0.1 stops with a clear not-yet message", async () => {
+    await withTempHome(async (home) => {
+      const runner = healthyRunner();
+      setDockerRunner(runner);
+      stubSeams();
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
+
+      const r = await runCli(["server", "up", "--host", "0.0.0.0"], { home, prompter });
+      expect(r.exitCode).toBe(1);
+      expect(r.stderr).toMatch(/localhost path only/i);
+      // Stopped before any git/docker work.
+      expect(runner.calls.some((c) => c.cmd === "git")).toBe(false);
+    });
+  });
+});
+
+describe("buildRunArgs — the S3 seam", () => {
+  it("localhost includes ALLOW_NO_AUTH and omits --init", () => {
+    const args = buildRunArgs({
+      host: "127.0.0.1",
+      dataVolume: "librarian_data",
+      tag: "v1.0.0",
+      agentToken: "tok",
+    });
+    expect(args).toContain("LIBRARIAN_ALLOW_NO_AUTH=true");
+    expect(args).not.toContain("--init");
+    expect(args[args.length - 1]).toBe("the-librarian:v1.0.0");
+  });
+});
+
+// --- helpers -------------------------------------------------------------
+
+/** Recursively collect files under `dir` whose contents contain `needle`. */
+function filesContaining(dir: string, needle: string): string[] {
+  const hits: string[] = [];
+  const walk = (d: string): void => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(d, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = path.join(d, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.isFile()) {
+        let content = "";
+        try {
+          content = fs.readFileSync(full, "utf8");
+        } catch {
+          continue;
+        }
+        if (content.includes(needle)) hits.push(full);
+      }
+    }
+  };
+  walk(dir);
+  return hits;
+}

--- a/packages/installer-cli/tests/server-up.test.ts
+++ b/packages/installer-cli/tests/server-up.test.ts
@@ -347,19 +347,263 @@ describe("server up — loop-closer (MCP URL + token + env offer)", () => {
   });
 });
 
-describe("server up — beyond-localhost binding is deferred (S3)", () => {
-  it("--host beyond 127.0.0.1 stops with a clear not-yet message", async () => {
+describe("server up — beyond-localhost binding (S3)", () => {
+  const TAILNET = "100.101.102.103";
+  const ADMIN_TOKEN = "admin-token-read-back-from-the-container-once";
+
+  /** A FakeRunner wired for a fully-successful beyond-localhost `up`. */
+  function beyondRunner(): FakeRunner {
+    return healthyRunner().onRun("docker", ["exec", "the-librarian", "cat", "/data/admin.token"], {
+      stdout: `${ADMIN_TOKEN}\n`,
+      code: 0,
+    });
+  }
+
+  it("--host <tailnet-ip>: omits ALLOW_NO_AUTH, binds the tailnet IP, reads + surfaces the admin token once, MCP URL uses the host", async () => {
     await withTempHome(async (home) => {
+      const runner = beyondRunner();
+      setDockerRunner(runner);
+      stubSeams();
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
+
+      const r = await runCli(["server", "up", "--host", TAILNET], { home, prompter });
+      expect(r.exitCode).toBe(0);
+
+      // docker run argv: OMITS ALLOW_NO_AUTH, publishes on the tailnet IP.
+      const runArgs = dockerRunArgs(runner);
+      expect(runArgs).not.toContain("LIBRARIAN_ALLOW_NO_AUTH=true");
+      expect(runArgs).toContain(`${TAILNET}:3000:3000`);
+      expect(runArgs).toContain(`${TAILNET}:3838:3838`);
+
+      // After health, the admin token is read from the container...
+      expect(runner.ran("docker", ["exec", "the-librarian", "cat", "/data/admin.token"])).toBe(
+        true,
+      );
+      // ...and surfaced exactly once.
+      expect(r.stdout).toContain(ADMIN_TOKEN);
+      expect(r.stdout.split(ADMIN_TOKEN).length - 1).toBe(1);
+
+      // The MCP URL uses the chosen host.
+      expect(r.stdout).toContain(`http://${TAILNET}:3838/mcp`);
+      expect(r.stdout).toContain(`http://${TAILNET}:3000`);
+    });
+  });
+
+  it("argv DIFF (SC 3): localhost reads only secret.key; beyond-localhost omits ALLOW_NO_AUTH and reads BOTH secret.key + admin.token", async () => {
+    await withTempHome(async (home) => {
+      // --- localhost run ---
+      const local = healthyRunner();
+      setDockerRunner(local);
+      stubSeams();
+      const lr = await runCli(["server", "up"], {
+        home,
+        prompter: new FakePrompter({ answers: { "~/.librarian/env": "n" } }),
+      });
+      expect(lr.exitCode).toBe(0);
+
+      const localRun = dockerRunArgs(local);
+      expect(localRun).toContain("LIBRARIAN_ALLOW_NO_AUTH=true");
+      // Reads ONLY the master key — no admin.token read on localhost.
+      expect(local.ran("docker", ["exec", "the-librarian", "cat", "/data/secret.key"])).toBe(true);
+      expect(local.ran("docker", ["exec", "the-librarian", "cat", "/data/admin.token"])).toBe(
+        false,
+      );
+      resetDockerRunner();
+    });
+
+    await withTempHome(async (home) => {
+      // --- beyond-localhost run ---
+      const beyond = beyondRunner();
+      setDockerRunner(beyond);
+      stubSeams();
+      const br = await runCli(["server", "up", "--host", TAILNET], {
+        home,
+        prompter: new FakePrompter({ answers: { "~/.librarian/env": "n" } }),
+      });
+      expect(br.exitCode).toBe(0);
+
+      const beyondRun = dockerRunArgs(beyond);
+      expect(beyondRun).not.toContain("LIBRARIAN_ALLOW_NO_AUTH=true");
+      // Reads BOTH the master key AND the admin token.
+      expect(beyond.ran("docker", ["exec", "the-librarian", "cat", "/data/secret.key"])).toBe(true);
+      expect(beyond.ran("docker", ["exec", "the-librarian", "cat", "/data/admin.token"])).toBe(
+        true,
+      );
+    });
+  });
+
+  it("the admin token (and master key) appear in stdout once and in NO file under the home/deploy tree", async () => {
+    await withTempHome(async (home) => {
+      const runner = beyondRunner();
+      setDockerRunner(runner);
+      stubSeams();
+      // Accept the env-write offer — even then, neither secret may land in a file.
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "y" } });
+
+      const r = await runCli(["server", "up", "--host", TAILNET, "--yes"], { home, prompter });
+      expect(r.exitCode).toBe(0);
+
+      expect(r.stdout.split(ADMIN_TOKEN).length - 1).toBe(1);
+      expect(r.stdout.split(MASTER_KEY).length - 1).toBe(1);
+
+      expect(filesContaining(home, ADMIN_TOKEN)).toEqual([]);
+      expect(filesContaining(home, MASTER_KEY)).toEqual([]);
+    });
+  });
+
+  it("--host 0.0.0.0 WITHOUT --yes prompts; declining aborts before docker run", async () => {
+    await withTempHome(async (home) => {
+      const runner = beyondRunner();
+      setDockerRunner(runner);
+      stubSeams();
+      // The confirm prompt is keyed on "0.0.0.0"; answer "n" to decline.
+      const prompter = new FakePrompter({ answers: { "0.0.0.0": "n" } });
+
+      const r = await runCli(["server", "up", "--host", "0.0.0.0"], { home, prompter });
+      expect(r.exitCode).toBe(1);
+      expect(r.stderr).toMatch(/all interfaces|0\.0\.0\.0|aborted|declin/i);
+
+      // Aborted before any docker run (and before git work).
+      expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "run")).toBe(false);
+      // The confirm was actually asked.
+      expect(prompter.textCalls.some((c) => c.question.includes("0.0.0.0"))).toBe(true);
+    });
+  });
+
+  it("--host 0.0.0.0 with --yes proceeds (no confirm prompt) and prints the unreachable-address note", async () => {
+    await withTempHome(async (home) => {
+      const runner = beyondRunner();
+      setDockerRunner(runner);
+      stubSeams();
+      // A prompter that THROWS if the 0.0.0.0 confirm is asked — proves --yes skips it.
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
+
+      const r = await runCli(["server", "up", "--host", "0.0.0.0", "--yes"], { home, prompter });
+      expect(r.exitCode).toBe(0);
+
+      const runArgs = dockerRunArgs(runner);
+      expect(runArgs).toContain("0.0.0.0:3838:3838");
+      expect(runArgs).not.toContain("LIBRARIAN_ALLOW_NO_AUTH=true");
+      // 0.0.0.0 is a bind, not a connectable address — a one-line note tells the user.
+      expect(r.stdout).toMatch(/reachable|LAN|tailnet|not a connectable/i);
+      // No 0.0.0.0 confirm prompt happened under --yes.
+      expect(prompter.textCalls.some((c) => c.question.includes("0.0.0.0"))).toBe(false);
+    });
+  });
+});
+
+describe("server up — Tailscale best-effort offer (S3)", () => {
+  const TAILNET = "100.64.0.7";
+
+  /** A healthy runner that ALSO reads back the admin token (beyond-localhost). */
+  function tsRunner(): FakeRunner {
+    return healthyRunner()
+      .withWhich("tailscale")
+      .onRun("tailscale", ["ip", "-4"], { stdout: `${TAILNET}\n`, code: 0 })
+      .onRun("docker", ["exec", "the-librarian", "cat", "/data/admin.token"], {
+        stdout: "admin-token-from-tailscale-offer\n",
+        code: 0,
+      });
+  }
+
+  it("interactive + no --host + tailscale IP present → offers it; accepting binds the tailnet IP", async () => {
+    await withTempHome(async (home) => {
+      const runner = tsRunner();
+      setDockerRunner(runner);
+      stubSeams();
+      // Accept the tailscale offer (keyed on "tailscale"); decline the env write.
+      const prompter = new FakePrompter({
+        answers: { tailscale: "y", "~/.librarian/env": "n" },
+      });
+
+      const r = await runCli(["server", "up"], { home, prompter, interactive: true });
+      expect(r.exitCode).toBe(0);
+
+      // Offered (a prompt mentioning tailscale was shown)...
+      expect(prompter.textCalls.some((c) => c.question.toLowerCase().includes("tailscale"))).toBe(
+        true,
+      );
+      // ...and accepted → bound to the tailnet IP (ALLOW_NO_AUTH omitted).
+      const runArgs = dockerRunArgs(runner);
+      expect(runArgs).toContain(`${TAILNET}:3838:3838`);
+      expect(runArgs).not.toContain("LIBRARIAN_ALLOW_NO_AUTH=true");
+    });
+  });
+
+  it("interactive + tailscale IP present but DECLINED → stays on 127.0.0.1", async () => {
+    await withTempHome(async (home) => {
+      const runner = tsRunner();
+      setDockerRunner(runner);
+      stubSeams();
+      const prompter = new FakePrompter({
+        answers: { tailscale: "n", "~/.librarian/env": "n" },
+      });
+
+      const r = await runCli(["server", "up"], { home, prompter, interactive: true });
+      expect(r.exitCode).toBe(0);
+
+      const runArgs = dockerRunArgs(runner);
+      expect(runArgs).toContain("127.0.0.1:3838:3838");
+      expect(runArgs).toContain("LIBRARIAN_ALLOW_NO_AUTH=true");
+    });
+  });
+
+  it("--yes never offers tailscale (stays 127.0.0.1, no silent exposure)", async () => {
+    await withTempHome(async (home) => {
+      const runner = tsRunner();
+      setDockerRunner(runner);
+      stubSeams();
+      const prompter = new FakePrompter({});
+
+      const r = await runCli(["server", "up", "--yes"], { home, prompter, interactive: true });
+      expect(r.exitCode).toBe(0);
+
+      const runArgs = dockerRunArgs(runner);
+      expect(runArgs).toContain("127.0.0.1:3838:3838");
+      expect(runArgs).toContain("LIBRARIAN_ALLOW_NO_AUTH=true");
+      expect(prompter.textCalls.some((c) => c.question.toLowerCase().includes("tailscale"))).toBe(
+        false,
+      );
+    });
+  });
+
+  it("non-interactive never offers tailscale (stays 127.0.0.1)", async () => {
+    await withTempHome(async (home) => {
+      const runner = tsRunner();
+      setDockerRunner(runner);
+      stubSeams();
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
+
+      const r = await runCli(["server", "up"], { home, prompter, interactive: false });
+      expect(r.exitCode).toBe(0);
+
+      const runArgs = dockerRunArgs(runner);
+      expect(runArgs).toContain("127.0.0.1:3838:3838");
+      expect(runArgs).toContain("LIBRARIAN_ALLOW_NO_AUTH=true");
+      expect(prompter.textCalls.some((c) => c.question.toLowerCase().includes("tailscale"))).toBe(
+        false,
+      );
+    });
+  });
+
+  it("tailscale absent (which → null) → no offer, no error (silent skip)", async () => {
+    await withTempHome(async (home) => {
+      // healthyRunner does NOT mark tailscale present → which() returns null.
       const runner = healthyRunner();
       setDockerRunner(runner);
       stubSeams();
       const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
 
-      const r = await runCli(["server", "up", "--host", "0.0.0.0"], { home, prompter });
-      expect(r.exitCode).toBe(1);
-      expect(r.stderr).toMatch(/localhost path only/i);
-      // Stopped before any git/docker work.
-      expect(runner.calls.some((c) => c.cmd === "git")).toBe(false);
+      const r = await runCli(["server", "up"], { home, prompter, interactive: true });
+      expect(r.exitCode).toBe(0);
+
+      // No tailscale probe call recorded beyond which(); no tailscale prompt.
+      expect(runner.calls.some((c) => c.cmd === "tailscale" && c.args[0] === "ip")).toBe(false);
+      expect(prompter.textCalls.some((c) => c.question.toLowerCase().includes("tailscale"))).toBe(
+        false,
+      );
+      // Stayed on localhost.
+      expect(dockerRunArgs(runner)).toContain("127.0.0.1:3838:3838");
     });
   });
 });
@@ -374,6 +618,19 @@ describe("buildRunArgs — the S3 seam", () => {
     });
     expect(args).toContain("LIBRARIAN_ALLOW_NO_AUTH=true");
     expect(args).not.toContain("--init");
+    expect(args[args.length - 1]).toBe("the-librarian:v1.0.0");
+  });
+
+  it("beyond-localhost omits ALLOW_NO_AUTH and publishes on the chosen host", () => {
+    const args = buildRunArgs({
+      host: "100.1.2.3",
+      dataVolume: "librarian_data",
+      tag: "v1.0.0",
+      agentToken: "tok",
+    });
+    expect(args).not.toContain("LIBRARIAN_ALLOW_NO_AUTH=true");
+    expect(args).toContain("100.1.2.3:3000:3000");
+    expect(args).toContain("100.1.2.3:3838:3838");
     expect(args[args.length - 1]).toBe("the-librarian:v1.0.0");
   });
 });

--- a/packages/installer-cli/tests/server-up.test.ts
+++ b/packages/installer-cli/tests/server-up.test.ts
@@ -486,10 +486,157 @@ describe("server up — beyond-localhost binding (S3)", () => {
       expect(runArgs).not.toContain("LIBRARIAN_ALLOW_NO_AUTH=true");
       // 0.0.0.0 is a bind, not a connectable address — a one-line note tells the user.
       expect(r.stdout).toMatch(/reachable|LAN|tailnet|not a connectable/i);
+      // S2: the auto-accepted exposure must be VISIBLE in the output (e.g. CI logs),
+      // not silent — a one-line note naming 0.0.0.0 and the --yes auto-accept.
+      expect(r.stdout).toMatch(/binding 0\.0\.0\.0.*auto-accepted.*--yes/i);
       // No 0.0.0.0 confirm prompt happened under --yes.
       expect(prompter.textCalls.some((c) => c.question.includes("0.0.0.0"))).toBe(false);
     });
   });
+});
+
+describe("server up — failed health-wait redacts secrets from surfaced logs (C1)", () => {
+  const TAILNET = "100.101.102.103";
+  // Assembled from sub-threshold parts so no realistic secret literal is committed
+  // (GitGuardian scans every commit). The value is deliberately fake + low-entropy:
+  // redaction works on the `libadmin_` prefix / the boot-log line, not the body.
+  const FAKE_ADMIN_LOG_LINE =
+    "Generated a new admin token (LIBRARIAN_ADMIN_TOKEN): " + "libadmin_" + "FAKETOKENVALUE";
+  const FAKE_ADMIN_TOKEN = "libadmin_" + "FAKETOKENVALUE";
+
+  it("a beyond-localhost up that goes unhealthy never surfaces the boot-logged admin token, and rolls back", async () => {
+    await withTempHome(async (home) => {
+      const runner = new FakeRunner()
+        .withWhich("docker")
+        .withWhich("git")
+        .onRun("docker", ["info"], { code: 0 })
+        .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", "the-librarian"], {
+          stdout: "unhealthy\n",
+          code: 0,
+        })
+        // The boot logs CONTAIN the one-time admin-token generation line.
+        .onRun("docker", ["logs", "--tail", "50", "the-librarian"], {
+          stdout: `boot: starting up\n${FAKE_ADMIN_LOG_LINE}\nboot: health probe failed\n`,
+          code: 0,
+        });
+      setDockerRunner(runner);
+      stubSeams();
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
+
+      const r = await runCli(["server", "up", "--host", TAILNET], { home, prompter });
+      expect(r.exitCode).toBe(1);
+
+      // The surfaced error must NOT carry the bearer token nor the generation line.
+      expect(r.stderr).not.toContain(FAKE_ADMIN_TOKEN);
+      expect(r.stderr).not.toMatch(/Generated a new admin token/i);
+      // ...but the (redacted) tail is still surfaced for debugging.
+      expect(r.stderr).toMatch(/boot: starting up/);
+      expect(r.stderr).toMatch(/boot: health probe failed/);
+      expect(r.stderr).toMatch(/did not become healthy/i);
+
+      // Rolled back — no half-up container.
+      expect(runner.ran("docker", ["rm", "-f", "the-librarian"])).toBe(true);
+    });
+  });
+});
+
+describe("server up — any post-run failure rolls back (I2, no half-up)", () => {
+  it("an exception thrown mid-health-loop (docker inspect rejects) still force-removes the container", async () => {
+    await withTempHome(async (home) => {
+      const runner = healthyRunner();
+      // Make `docker inspect` (the health probe) REJECT instead of returning.
+      const realRun = runner.run.bind(runner);
+      runner.run = async (cmd, args, opts) => {
+        if (cmd === "docker" && args[0] === "inspect") {
+          // still record the call so we can reason about ordering
+          runner.calls.push({ cmd, args: [...args], opts });
+          throw new Error("docker inspect exploded mid-health-loop");
+        }
+        return realRun(cmd, args, opts);
+      };
+      setDockerRunner(runner);
+      stubSeams();
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
+
+      const r = await runCli(["server", "up"], { home, prompter });
+      expect(r.exitCode).toBe(1);
+
+      // Even though the failure was an exception (not the timeout/unhealthy return
+      // path), the container must be force-removed — no half-up state survives.
+      expect(runner.ran("docker", ["rm", "-f", "the-librarian"])).toBe(true);
+    });
+  });
+});
+
+describe("server up — empty/whitespace --host does not silently bind all interfaces (I1)", () => {
+  it("--host '' defaults to loopback (no all-interfaces bind, no confirm prompt)", async () => {
+    await withTempHome(async (home) => {
+      const runner = healthyRunner();
+      setDockerRunner(runner);
+      stubSeams();
+      // A prompter that THROWS if any 0.0.0.0 confirm is asked — there must be none.
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
+
+      const r = await runCli(["server", "up", "--host", ""], { home, prompter });
+      expect(r.exitCode).toBe(0);
+
+      const runArgs = dockerRunArgs(runner);
+      // Defaulted to loopback — NOT `:3000:3000` (all interfaces).
+      expect(runArgs).toContain("127.0.0.1:3000:3000");
+      expect(runArgs).toContain("127.0.0.1:3838:3838");
+      expect(runArgs?.some((a) => a === ":3000:3000")).toBe(false);
+      expect(runArgs).toContain("LIBRARIAN_ALLOW_NO_AUTH=true");
+      // No all-interfaces confirm was ever shown.
+      expect(prompter.textCalls.some((c) => c.question.includes("0.0.0.0"))).toBe(false);
+    });
+  });
+
+  it("--host '   ' (whitespace) also defaults to loopback", async () => {
+    await withTempHome(async (home) => {
+      const runner = healthyRunner();
+      setDockerRunner(runner);
+      stubSeams();
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
+
+      const r = await runCli(["server", "up", "--host", "   "], { home, prompter });
+      expect(r.exitCode).toBe(0);
+
+      const runArgs = dockerRunArgs(runner);
+      expect(runArgs).toContain("127.0.0.1:3000:3000");
+      expect(runArgs).toContain("LIBRARIAN_ALLOW_NO_AUTH=true");
+    });
+  });
+});
+
+describe("server up — loopback spellings normalize to 127.0.0.1 (I3)", () => {
+  for (const spelling of ["localhost", "::1"]) {
+    it(`--host ${spelling} behaves identically to 127.0.0.1 (ALLOW_NO_AUTH, only secret.key, no admin.token)`, async () => {
+      await withTempHome(async (home) => {
+        const runner = healthyRunner();
+        setDockerRunner(runner);
+        stubSeams();
+        const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
+
+        const r = await runCli(["server", "up", "--host", spelling], { home, prompter });
+        expect(r.exitCode).toBe(0);
+
+        const runArgs = dockerRunArgs(runner);
+        // Normalized to loopback: includes ALLOW_NO_AUTH, publishes on 127.0.0.1
+        // (a well-formed `-p` arg — no malformed `::1:3000:3000`).
+        expect(runArgs).toContain("LIBRARIAN_ALLOW_NO_AUTH=true");
+        expect(runArgs).toContain("127.0.0.1:3000:3000");
+        expect(runArgs).toContain("127.0.0.1:3838:3838");
+
+        // Reads ONLY the master key — no admin-token read on loopback.
+        expect(runner.ran("docker", ["exec", "the-librarian", "cat", "/data/secret.key"])).toBe(
+          true,
+        );
+        expect(runner.ran("docker", ["exec", "the-librarian", "cat", "/data/admin.token"])).toBe(
+          false,
+        );
+      });
+    });
+  }
 });
 
 describe("server up — Tailscale best-effort offer (S3)", () => {

--- a/packages/installer-cli/tests/server-update.test.ts
+++ b/packages/installer-cli/tests/server-update.test.ts
@@ -146,7 +146,9 @@ describe("server update — upgrade path argv sequence (SC 5)", () => {
 
       // Each step, with its exact argv.
       expect(runner.ran("git", ["-C", dir, "fetch", "--tags", "origin"])).toBe(true);
-      expect(runner.ran("git", ["-C", dir, "checkout", LATEST_TAG])).toBe(true);
+      // The ref is passed after `--end-of-options` so a `--…`-shaped ref can't
+      // inject a git option (S-1).
+      expect(runner.ran("git", ["-C", dir, "checkout", "--end-of-options", LATEST_TAG])).toBe(true);
       expect(
         runner.ran("docker", [
           "build",
@@ -238,7 +240,7 @@ describe("server update — --ref reflected in checkout + build tag", () => {
       const r = await runCli(["server", "update", "--ref", "main"], { home });
       expect(r.exitCode).toBe(0);
 
-      expect(runner.ran("git", ["-C", dir, "checkout", "main"])).toBe(true);
+      expect(runner.ran("git", ["-C", dir, "checkout", "--end-of-options", "main"])).toBe(true);
       expect(
         runner.ran("docker", [
           "build",

--- a/packages/installer-cli/tests/server-update.test.ts
+++ b/packages/installer-cli/tests/server-update.test.ts
@@ -1,0 +1,491 @@
+// S5 — `librarian server update`: re-pin forward, rebuild, recreate, migrate.
+//
+// Every test drives the public `runCli(["server", "update", …])` entry against
+// a fresh temp home, the injected `docker.ts` FakeRunner (so the EXACT git/docker
+// argv + ITS ORDER is asserted), a stubbed latest-release fetcher, a no-op
+// health-poll sleep, and a deterministic agent-token minter. No real daemon,
+// network, or git is ever touched.
+//
+// The load-bearing properties (success criterion 5 + spec §8/§11):
+//   - upgrade sequence: git fetch tags → checkout newest → docker build →
+//     stop → rm (container, NOT volume) → docker run (same host/volume) →
+//     health poll → `docker exec … migrate-data-dir`;
+//   - idempotent no-op: already at the resolved ref + healthy → no build/run/rm;
+//   - VOLUME SACRED: no `docker volume rm`, no `docker rm -v`, ever;
+//   - rollback: a failed health-wait force-removes the new container, errors,
+//     and does NOT advance deploy-state; surfaced logs are redacted;
+//   - agent-token: read back from the OLD container's env before removal and
+//     reused on recreate (clients keep working); never written to a file/log.
+
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resetRunner } from "../src/exec.js";
+import { runCli } from "../src/runtime.js";
+import { readDeployState, writeDeployState } from "../src/server/deploy-state.js";
+import {
+  resetRunner as resetDockerRunner,
+  setRunner as setDockerRunner,
+} from "../src/server/docker.js";
+import { resetSleep, resetTokenMinter, setSleep, setTokenMinter } from "../src/server/up.js";
+import { resetLatestFetcher, setLatestFetcher } from "../src/status.js";
+import { FakeRunner, withTempHome } from "./helpers.js";
+
+const OLD_REF = "v1.4.2";
+const LATEST = "1.5.0"; // fetchLatestVersion returns the v-stripped version
+const LATEST_TAG = "v1.5.0";
+const EXISTING_AGENT_TOKEN = "agent-token-already-running-in-the-old-container";
+const FRESH_AGENT_TOKEN = "fresh-agent-token-minted-on-update";
+
+afterEach(() => {
+  resetRunner();
+  resetDockerRunner();
+  resetLatestFetcher();
+  resetSleep();
+  resetTokenMinter();
+});
+
+/** The deploy dir under a temp home. */
+function deployDirOf(home: string): string {
+  return path.join(home, ".librarian", "server");
+}
+
+/** Seed a deploy-state recording the (old) deployed ref + a managed clone. */
+function seedDeployState(home: string, ref = OLD_REF): string {
+  const dir = deployDirOf(home);
+  fs.mkdirSync(path.join(dir, ".git"), { recursive: true });
+  writeDeployState(dir, {
+    containerName: "the-librarian",
+    host: "127.0.0.1",
+    dataVolume: "librarian_data",
+    ref,
+    imageTag: `the-librarian:${ref}`,
+  });
+  return dir;
+}
+
+/** The argv (after `docker`) of the `run -d …` call recorded by the runner. */
+function dockerRunArgs(runner: FakeRunner): string[] | undefined {
+  return runner.calls.find((c) => c.cmd === "docker" && c.args[0] === "run")?.args;
+}
+
+/**
+ * The ordered list of `<cmd> <verb>` for git/docker calls. For docker the verb
+ * is `args[0]`; for git the verb is the first arg that isn't the `-C <dir>`
+ * prefix (so `git -C <dir> fetch …` reads as `git fetch`).
+ */
+function verbSequence(runner: FakeRunner): string[] {
+  return runner.calls
+    .filter((c) => c.cmd === "docker" || c.cmd === "git")
+    .map((c) => {
+      if (c.cmd === "git" && c.args[0] === "-C") return `git ${c.args[2]}`;
+      return `${c.cmd} ${c.args[0]}`;
+    });
+}
+
+/** True iff the runner ever issued a volume-destroying op (rm -v / volume rm). */
+function ranVolumeDestructive(runner: FakeRunner): boolean {
+  return runner.calls.some(
+    (c) =>
+      c.cmd === "docker" &&
+      ((c.args[0] === "rm" && c.args.includes("-v")) ||
+        (c.args[0] === "volume" && c.args.includes("rm"))),
+  );
+}
+
+/**
+ * A FakeRunner wired for a successful UPGRADE: docker + git on PATH, daemon up,
+ * the OLD container reports its agent token via `docker inspect` env, and the
+ * NEW container becomes healthy.
+ */
+function upgradeRunner(): FakeRunner {
+  return (
+    new FakeRunner()
+      .withWhich("docker")
+      .withWhich("git")
+      .onRun("docker", ["info"], { code: 0 })
+      // Read the existing agent token from the running container's env.
+      .onRun(
+        "docker",
+        ["inspect", "--format", "{{range .Config.Env}}{{println .}}{{end}}", "the-librarian"],
+        {
+          stdout: `PATH=/usr/bin\nLIBRARIAN_AGENT_TOKEN=${EXISTING_AGENT_TOKEN}\nNODE_ENV=production\n`,
+          code: 0,
+        },
+      )
+      // The container is running (idempotency probe) ...
+      .onRun("docker", ["inspect", "--format", "{{.State.Status}}", "the-librarian"], {
+        stdout: "running\n",
+        code: 0,
+      })
+      // ... and (re)created healthy.
+      .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", "the-librarian"], {
+        stdout: "healthy\n",
+        code: 0,
+      })
+  );
+}
+
+/** Install the deterministic seams the update tests share. */
+function stubSeams(): void {
+  setLatestFetcher(async () => LATEST);
+  setTokenMinter(() => FRESH_AGENT_TOKEN);
+  setSleep(async () => undefined);
+}
+
+describe("server update — upgrade path argv sequence (SC 5)", () => {
+  it("fetch tags → checkout newest → build → stop → rm → run → health → migrate, in order", async () => {
+    await withTempHome(async (home) => {
+      const dir = seedDeployState(home);
+      const runner = upgradeRunner();
+      setDockerRunner(runner);
+      stubSeams();
+
+      const r = await runCli(["server", "update"], { home });
+      expect(r.exitCode).toBe(0);
+
+      // Each step, with its exact argv.
+      expect(runner.ran("git", ["-C", dir, "fetch", "--tags", "origin"])).toBe(true);
+      expect(runner.ran("git", ["-C", dir, "checkout", LATEST_TAG])).toBe(true);
+      expect(
+        runner.ran("docker", [
+          "build",
+          "-f",
+          "docker/all-in-one.Dockerfile",
+          "-t",
+          `the-librarian:${LATEST_TAG}`,
+          ".",
+        ]),
+      ).toBe(true);
+      expect(runner.ran("docker", ["stop", "the-librarian"])).toBe(true);
+      // Container removed — NOT the volume (no `-v`).
+      expect(runner.ran("docker", ["rm", "the-librarian"])).toBe(true);
+      // Recreated with the SAME host + volume from deploy-state.
+      const runArgs = dockerRunArgs(runner);
+      expect(runArgs).toContain("127.0.0.1:3838:3838");
+      expect(runArgs).toContain("librarian_data:/data");
+      expect(runArgs?.[runArgs.length - 1]).toBe(`the-librarian:${LATEST_TAG}`);
+      // Migrations applied AFTER the new container is healthy.
+      expect(
+        runner.ran("docker", ["exec", "the-librarian", "the-librarian", "migrate-data-dir"]),
+      ).toBe(true);
+
+      // The relative ORDER of the load-bearing steps.
+      const seq = verbSequence(runner);
+      const idx = (needle: string): number => seq.indexOf(needle);
+      expect(idx("git fetch")).toBeGreaterThanOrEqual(0);
+      expect(idx("git fetch")).toBeLessThan(idx("git checkout"));
+      expect(idx("git checkout")).toBeLessThan(idx("docker build"));
+      expect(idx("docker build")).toBeLessThan(idx("docker stop"));
+      expect(idx("docker stop")).toBeLessThan(idx("docker rm"));
+      expect(idx("docker rm")).toBeLessThan(idx("docker run"));
+      // The migrate exec is the last docker verb of the flow.
+      expect(idx("docker run")).toBeLessThan(idx("docker exec"));
+
+      // deploy-state advanced to the new ref (host/volume unchanged).
+      expect(readDeployState(dir)).toEqual({
+        containerName: "the-librarian",
+        host: "127.0.0.1",
+        dataVolume: "librarian_data",
+        ref: LATEST_TAG,
+        imageTag: `the-librarian:${LATEST_TAG}`,
+      });
+    });
+  });
+
+  it("reuses the existing agent token read from the old container (clients keep working)", async () => {
+    await withTempHome(async (home) => {
+      seedDeployState(home);
+      const runner = upgradeRunner();
+      setDockerRunner(runner);
+      stubSeams();
+
+      const r = await runCli(["server", "update"], { home });
+      expect(r.exitCode).toBe(0);
+
+      // The recreated container carries the EXISTING token, not a freshly minted one.
+      const runArgs = dockerRunArgs(runner);
+      expect(runArgs).toContain(`LIBRARIAN_AGENT_TOKEN=${EXISTING_AGENT_TOKEN}`);
+      expect(runArgs).not.toContain(`LIBRARIAN_AGENT_TOKEN=${FRESH_AGENT_TOKEN}`);
+
+      // The token was inspected from the old container BEFORE it was removed.
+      const inspectIdx = runner.calls.findIndex(
+        (c) =>
+          c.cmd === "docker" &&
+          c.args[0] === "inspect" &&
+          c.args.includes("{{range .Config.Env}}{{println .}}{{end}}"),
+      );
+      const rmIdx = runner.calls.findIndex((c) => c.cmd === "docker" && c.args[0] === "rm");
+      expect(inspectIdx).toBeGreaterThanOrEqual(0);
+      expect(rmIdx).toBeGreaterThan(inspectIdx);
+
+      // The token NEVER lands in any file under the home/deploy tree, and NEVER
+      // appears in the surfaced output.
+      expect(filesContaining(home, EXISTING_AGENT_TOKEN)).toEqual([]);
+      expect(r.stdout).not.toContain(EXISTING_AGENT_TOKEN);
+    });
+  });
+});
+
+describe("server update — --ref reflected in checkout + build tag", () => {
+  it("--ref main checks out + builds main", async () => {
+    await withTempHome(async (home) => {
+      const dir = seedDeployState(home);
+      const runner = upgradeRunner();
+      setDockerRunner(runner);
+      stubSeams();
+
+      const r = await runCli(["server", "update", "--ref", "main"], { home });
+      expect(r.exitCode).toBe(0);
+
+      expect(runner.ran("git", ["-C", dir, "checkout", "main"])).toBe(true);
+      expect(
+        runner.ran("docker", [
+          "build",
+          "-f",
+          "docker/all-in-one.Dockerfile",
+          "-t",
+          "the-librarian:main",
+          ".",
+        ]),
+      ).toBe(true);
+      const runArgs = dockerRunArgs(runner);
+      expect(runArgs?.[runArgs.length - 1]).toBe("the-librarian:main");
+      expect(readDeployState(dir)?.ref).toBe("main");
+    });
+  });
+});
+
+describe("server update — idempotent no-op (SC 5)", () => {
+  it("already at latest + healthy → prints up-to-date, NO build/run/rm", async () => {
+    await withTempHome(async (home) => {
+      // deploy-state ref EQUALS the resolved latest.
+      seedDeployState(home, LATEST_TAG);
+      const runner = upgradeRunner();
+      setDockerRunner(runner);
+      stubSeams();
+
+      const r = await runCli(["server", "update"], { home });
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toMatch(/already up to date/i);
+      expect(r.stdout).toContain(LATEST_TAG);
+
+      // The hallmark of a clean no-op: NO build, NO run, NO rm, NO stop, NO checkout.
+      expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "build")).toBe(false);
+      expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "run")).toBe(false);
+      expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "rm")).toBe(false);
+      expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "stop")).toBe(false);
+      expect(runner.calls.some((c) => c.cmd === "git" && c.args.includes("checkout"))).toBe(false);
+    });
+  });
+
+  it("--ref pinned to the current ref + healthy → no-op", async () => {
+    await withTempHome(async (home) => {
+      seedDeployState(home, OLD_REF);
+      const runner = upgradeRunner();
+      setDockerRunner(runner);
+      stubSeams();
+
+      // Pin --ref to exactly what's deployed; even though latest is newer, the
+      // pinned compare wins → no-op.
+      const r = await runCli(["server", "update", "--ref", OLD_REF], { home });
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toMatch(/already up to date/i);
+      expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "build")).toBe(false);
+      expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "run")).toBe(false);
+    });
+  });
+
+  it("at the ref but NOT healthy → recreates (not a no-op)", async () => {
+    await withTempHome(async (home) => {
+      seedDeployState(home, LATEST_TAG);
+      // The container is at the ref but reports `exited` (not healthy) → recreate.
+      const runner = upgradeRunner().onRun(
+        "docker",
+        ["inspect", "--format", "{{.State.Status}}", "the-librarian"],
+        { stdout: "exited\n", code: 0 },
+      );
+      setDockerRunner(runner);
+      stubSeams();
+
+      const r = await runCli(["server", "update"], { home });
+      expect(r.exitCode).toBe(0);
+      // It DID rebuild + recreate because the container wasn't healthy.
+      expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "build")).toBe(true);
+      expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "run")).toBe(true);
+    });
+  });
+});
+
+describe("server update — VOLUME SACRED across the whole flow (SC 5/6)", () => {
+  it("an upgrade never issues `docker volume rm` nor `docker rm -v`", async () => {
+    await withTempHome(async (home) => {
+      seedDeployState(home);
+      const runner = upgradeRunner();
+      setDockerRunner(runner);
+      stubSeams();
+
+      const r = await runCli(["server", "update"], { home });
+      expect(r.exitCode).toBe(0);
+      expect(ranVolumeDestructive(runner)).toBe(false);
+      // The `rm` that DID run is the container only — no `-v`.
+      const rmCall = runner.calls.find((c) => c.cmd === "docker" && c.args[0] === "rm");
+      expect(rmCall?.args).toEqual(["rm", "the-librarian"]);
+    });
+  });
+});
+
+describe("server update — rollback on a failed health-wait (SC 5)", () => {
+  it("new container goes unhealthy → force-removed, errors, deploy-state NOT advanced, logs redacted", async () => {
+    await withTempHome(async (home) => {
+      const dir = seedDeployState(home);
+      // Assembled from sub-threshold parts so no realistic secret literal is committed.
+      const fakeAdminLine =
+        "Generated a new admin token (LIBRARIAN_ADMIN_TOKEN): " + "libadmin_" + "FAKETOKENVALUE";
+      const fakeAdminToken = "libadmin_" + "FAKETOKENVALUE";
+
+      const runner = new FakeRunner()
+        .withWhich("docker")
+        .withWhich("git")
+        .onRun("docker", ["info"], { code: 0 })
+        .onRun(
+          "docker",
+          ["inspect", "--format", "{{range .Config.Env}}{{println .}}{{end}}", "the-librarian"],
+          { stdout: `LIBRARIAN_AGENT_TOKEN=${EXISTING_AGENT_TOKEN}\n`, code: 0 },
+        )
+        // The recreated container never becomes healthy.
+        .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", "the-librarian"], {
+          stdout: "unhealthy\n",
+          code: 0,
+        })
+        // Boot logs carry the one-time admin-token generation line.
+        .onRun("docker", ["logs", "--tail", "50", "the-librarian"], {
+          stdout: `boot: starting up\n${fakeAdminLine}\nboot: health probe failed\n`,
+          code: 0,
+        });
+      setDockerRunner(runner);
+      stubSeams();
+
+      const r = await runCli(["server", "update"], { home });
+      expect(r.exitCode).toBe(1);
+      expect(r.stderr).toMatch(/did not become healthy|rolled back/i);
+
+      // Rolled back — the new container was force-removed.
+      expect(runner.ran("docker", ["rm", "-f", "the-librarian"])).toBe(true);
+
+      // The surfaced error must NOT carry the boot-logged token nor the gen line.
+      expect(r.stderr).not.toContain(fakeAdminToken);
+      expect(r.stderr).not.toMatch(/Generated a new admin token/i);
+      // ...but the (redacted) tail is still surfaced for debugging.
+      expect(r.stderr).toMatch(/boot: starting up/);
+
+      // deploy-state was NOT advanced — still the old ref.
+      expect(readDeployState(dir)?.ref).toBe(OLD_REF);
+
+      // The agent token never leaked into the error or any file.
+      expect(r.stderr).not.toContain(EXISTING_AGENT_TOKEN);
+      expect(filesContaining(home, EXISTING_AGENT_TOKEN)).toEqual([]);
+    });
+  });
+});
+
+describe("server update — fresh token when the old container is unreadable", () => {
+  it("old container gone (inspect env fails) → mints a fresh token, surfaces it once with a re-paste note", async () => {
+    await withTempHome(async (home) => {
+      seedDeployState(home);
+      const runner = new FakeRunner()
+        .withWhich("docker")
+        .withWhich("git")
+        .onRun("docker", ["info"], { code: 0 })
+        // Env inspect fails — the old container is gone/unreadable.
+        .onRun(
+          "docker",
+          ["inspect", "--format", "{{range .Config.Env}}{{println .}}{{end}}", "the-librarian"],
+          { stderr: "Error: No such object: the-librarian\n", code: 1 },
+        )
+        .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", "the-librarian"], {
+          stdout: "healthy\n",
+          code: 0,
+        });
+      setDockerRunner(runner);
+      stubSeams();
+
+      const r = await runCli(["server", "update"], { home });
+      expect(r.exitCode).toBe(0);
+
+      // A fresh token was minted and used on recreate.
+      const runArgs = dockerRunArgs(runner);
+      expect(runArgs).toContain(`LIBRARIAN_AGENT_TOKEN=${FRESH_AGENT_TOKEN}`);
+
+      // Surfaced exactly once, with a clients-must-update note.
+      expect(r.stdout).toContain(FRESH_AGENT_TOKEN);
+      expect(r.stdout.split(FRESH_AGENT_TOKEN).length - 1).toBe(1);
+      expect(r.stdout).toMatch(/clients|update.*token|re-?paste/i);
+
+      // Even a freshly minted token is written to NO file under the tree.
+      expect(filesContaining(home, FRESH_AGENT_TOKEN)).toEqual([]);
+    });
+  });
+});
+
+describe("server update — preflight + no-deploy-state teach", () => {
+  it("docker absent → teaching error, no git/docker ops", async () => {
+    await withTempHome(async (home) => {
+      seedDeployState(home);
+      const runner = new FakeRunner(); // nothing on PATH
+      setDockerRunner(runner);
+      stubSeams();
+
+      const r = await runCli(["server", "update"], { home });
+      expect(r.exitCode).toBe(1);
+      expect(r.stderr).toMatch(/docker/i);
+      expect(r.stderr).toMatch(/install/i);
+    });
+  });
+
+  it("no deploy-state → teaching error pointing at `server up`", async () => {
+    await withTempHome(async (home) => {
+      // No deploy-state seeded.
+      const runner = upgradeRunner();
+      setDockerRunner(runner);
+      stubSeams();
+
+      const r = await runCli(["server", "update"], { home });
+      expect(r.exitCode).toBe(1);
+      expect(r.stderr).toMatch(/server up|no.*deploy|not.*deployed|deploy-state/i);
+      // It never tried to build/run without knowing the config.
+      expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "build")).toBe(false);
+    });
+  });
+});
+
+// --- helpers -------------------------------------------------------------
+
+/** Recursively collect files under `dir` whose contents contain `needle`. */
+function filesContaining(dir: string, needle: string): string[] {
+  const hits: string[] = [];
+  const walk = (d: string): void => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(d, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = path.join(d, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.isFile()) {
+        let content = "";
+        try {
+          content = fs.readFileSync(full, "utf8");
+        } catch {
+          continue;
+        }
+        if (content.includes(needle)) hits.push(full);
+      }
+    }
+  };
+  walk(dir);
+  return hits;
+}

--- a/packages/installer-cli/tests/server.test.ts
+++ b/packages/installer-cli/tests/server.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { resetRunner } from "../src/exec.js";
+import { runCli } from "../src/runtime.js";
+import {
+  resetRunner as resetDockerRunner,
+  setRunner as setDockerRunner,
+} from "../src/server/docker.js";
+import { PreflightError, preflight } from "../src/server/preflight.js";
+import { FakeRunner } from "./helpers.js";
+
+afterEach(() => {
+  resetRunner();
+  resetDockerRunner();
+});
+
+describe("librarian --help — both command groups", () => {
+  it("reveals BOTH a harness command (install) and the server group", async () => {
+    const r = await runCli(["--help"]);
+    expect(r.exitCode).toBe(0);
+    // A harness command from the original surface…
+    expect(r.stdout).toMatch(/\binstall\b/);
+    // …and the new server group.
+    expect(r.stdout).toMatch(/\bserver\b/);
+  });
+});
+
+describe("librarian server (no subcommand) — the command surface", () => {
+  it("prints the server command surface (spec §4)", async () => {
+    const r = await runCli(["server"]);
+    expect(r.exitCode).toBe(0);
+    // Every subcommand from the surface table appears.
+    for (const sub of [
+      "up",
+      "update",
+      "down",
+      "status",
+      "logs",
+      "enable-boot",
+      "disable-boot",
+      "admin",
+    ]) {
+      expect(r.stdout).toContain(sub);
+    }
+  });
+
+  it("--help on the group also prints the surface", async () => {
+    const r = await runCli(["server", "--help"]);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("up");
+    expect(r.stdout).toContain("admin");
+  });
+
+  it("an unknown subcommand errors and shows the surface", async () => {
+    const r = await runCli(["server", "frobnicate"]);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toMatch(/Unknown server subcommand/);
+    expect(r.stderr).toContain("up");
+  });
+});
+
+describe("server preflight — teaching errors via the injected runner", () => {
+  it("docker missing: names docker and how to install it (never a stack trace)", async () => {
+    setDockerRunner(new FakeRunner()); // nothing on PATH
+    await expect(preflight()).rejects.toBeInstanceOf(PreflightError);
+    const message = await preflight().catch((e: Error) => e.message);
+    expect(message).toMatch(/docker/i);
+    expect(message).toMatch(/install/i);
+    // Actionable, not a bare "invalid"/"error".
+    expect(message).not.toMatch(/^(invalid|error)$/i);
+    expect(message).not.toMatch(/PreflightError/);
+  });
+
+  it("docker present but daemon unreachable: teaches that the daemon is down", async () => {
+    setDockerRunner(
+      new FakeRunner()
+        .withWhich("docker")
+        .withWhich("git")
+        .onRun("docker", ["info"], { code: 1, stderr: "Cannot connect to the Docker daemon" }),
+    );
+    const message = await preflight({ platform: "linux" }).catch((e: Error) => e.message);
+    expect(message).toMatch(/daemon/i);
+    expect(message).toMatch(/running/i);
+    // Linux hint does NOT mention Docker Desktop.
+    expect(message).not.toMatch(/Docker Desktop/);
+  });
+
+  it("on macOS the daemon-unreachable message mentions Docker Desktop", async () => {
+    setDockerRunner(
+      new FakeRunner().withWhich("docker").withWhich("git").onRun("docker", ["info"], { code: 1 }),
+    );
+    const message = await preflight({ platform: "darwin" }).catch((e: Error) => e.message);
+    expect(message).toMatch(/Docker Desktop/);
+  });
+
+  it("git missing (docker fine): names git and how to install it", async () => {
+    setDockerRunner(
+      new FakeRunner()
+        .withWhich("docker") // docker present, daemon ok (info exits 0 by default)
+        .onRun("docker", ["info"], { code: 0 }),
+      // git deliberately NOT marked present
+    );
+    const message = await preflight({ platform: "linux" }).catch((e: Error) => e.message);
+    expect(message).toMatch(/git/i);
+    expect(message).toMatch(/install/i);
+  });
+
+  it("all tools present + daemon reachable: resolves (no throw)", async () => {
+    setDockerRunner(
+      new FakeRunner().withWhich("docker").withWhich("git").onRun("docker", ["info"], { code: 0 }),
+    );
+    await expect(preflight({ platform: "linux" })).resolves.toBeUndefined();
+  });
+
+  it("never invokes a real binary — every probe goes through the injected runner", async () => {
+    const runner = new FakeRunner().withWhich("docker").withWhich("git");
+    setDockerRunner(runner);
+    await preflight({ platform: "linux" });
+    // The only `run` recorded is the daemon probe; `which` is recorded too.
+    expect(runner.calls).toContainEqual(expect.objectContaining({ cmd: "docker", args: ["info"] }));
+  });
+});


### PR DESCRIPTION
## What this is

Implements the `librarian server` self-host CLI from the spec (`docs/specs/2026-06-13-server-cli.md`) — the loop closer: **server on the host → token → clients.** `@the-librarian/cli` (the `librarian` bin) gains a host-only, Docker-driven `server` command group; no new tool, no rename.

Built autonomously via `sdlc-orchestrate` (Build → Review → Fix → Ship per slice), test-first, one commit per vertical slice.

> **Stacked PR — merge order matters.** Base is `spec-server-cli` (PR #367), not `main`, because the installer CLI this attaches to lives only on that stack (`main` is at `0.11.0` and predates it). **Merge #367 (the spec) first, then this PR.** GitHub will retarget this PR to `main` once #367 lands.

## What shipped (spec §14 tasks S1–S9)

- **`server up`** — clones at the latest release tag (`--ref` pins a tag/`main`), builds + runs the all-in-one image (named `librarian_data` volume), health-waits with rollback (never half-up), surfaces the server-generated master key **once** (`SAVE THIS KEY`), prints the MCP URL + a minted agent token, offers to write this box's own `~/.librarian/env`.
- **Bind-aware auth** — `127.0.0.1` (default) → `LIBRARIAN_ALLOW_NO_AUTH=true`, no admin token; `--host <tailnet|0.0.0.0>` → server generates + enforces the admin token (surfaced once). `0.0.0.0` ask-first; Tailscale IP offered, never auto-selected.
- **`server update`** — re-pins forward (idempotent no-op when current+healthy), recreates the container **preserving the data volume**, reuses the existing agent token, applies pending data-dir migrations via `docker exec`.
- **`server down` / `status` / `logs`** — `down` is `docker stop` only (data sacred); `status` shows running/health/deployed-vs-latest badge; `logs [-f] [--service mcp|dashboard|all]` streams live.
- **`server enable-boot` / `disable-boot`** — Linux systemd unit whose `ExecStart` is `docker start --attach the-librarian`, so **no secret lands in the unit file**. macOS launchd deferred.
- **`server admin <backup|restore|auth|rebuild>`** — runs the admin CLI inside the container (works when the dashboard is locked). The all-in-one image now bundles `@librarian/cli` (`the-librarian`) on `PATH`.
- **`the-librarian restore`** (new) — clones the backup remote + re-supplies the master key (`--secret-key`, excluded from backups). Crash-safe (temp-clone + atomic swap) and key-verified (rejects a valid-shape-but-wrong key that would orphan secrets); `--force` guards the populated-vault / differing-key cases.

## Grounded corrections vs. the original spec wording

- The "admin token only beyond localhost" rule is realized via `LIBRARIAN_ALLOW_NO_AUTH` (the container always binds `0.0.0.0`, so it can't see the host publish address).
- `update` applies migrations via `docker exec … migrate-data-dir` (server boot only *warns*).
- The all-in-one image genuinely lacked `@librarian/cli` at runtime — now bundled (image built + verified that `docker exec the-librarian the-librarian --help` works).
- Boot unit uses `docker start` (not the resolved `docker run`) — baking the run into the unit would leak the agent token into a world-readable file. Spec §9/SC7 corrected to match.

## Reviews & verification

Two fresh-context adversarial review passes (`sdlc-review`) found and fixed real issues before merge:
- **Phase 1:** admin token leaked into the error surfaced on a failed `up` (server logs it by value at boot; the failure path echoed `docker logs` verbatim) — fixed with a shared redactor; plus host edge-cases + exception-path rollback.
- **Phase 2:** `restore` deleted the vault before cloning (data loss on a mid-restore failure) and accepted a valid-shape-but-wrong key (silent undecryptable server) — both fixed and tested.

Gate, re-run bare against the final HEAD (exit codes checked directly, no `tail` masking):
- `pnpm run typecheck` ✅ · `pnpm run lint` ✅ · `pnpm test` ✅ (all workspaces) · `pnpm run check:release` ✅
- Secrets: no agent token / admin token / master key in any committed file, log, or error (shared redactor on failure paths; secret-free boot unit; tests assert it).

## Release

Bumps root `package.json` → `1.0.0-rc.7` with a dated `CHANGELOG.md` entry + compare-link (`check:release` green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
