### PR TITLE
docs(adr): auth & secrets model — ADR 0008 + hardening spec (rc.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,30 +39,6 @@ Docs only — no shipped code, so the published `@the-librarian/cli` is unchange
 
 ### Added
 
-- **ADR 0008 — auth & secrets model** (`docs/adr/0008-auth-secrets-model.md`) and a
-  buildable spec (`docs/specs/2026-06-14-auth-secrets-hardening.md`). Records the
-  decision to shrink the network surface and make the secrets model match its real
-  value: move the admin tRPC API to an **internal-only listener** and **drop the
-  admin token** as a network gate (amends ADR 0002 — the tRPC shape stands, its
-  exposure changes); **externalize the master key** (CLI-minted into a `0600` deploy
-  env-file, off the data volume) with a documented ladder
-  (env-file → `systemd-creds` → external secrets manager); and make **per-client
-  agent tokens + rotation** the real hardening. The spec phases it: Phase 1
-  (listener split + admin-token removal + key externalization), Phase 2 (per-client
-  tokens). Captures the reasoning — the vault is plaintext by design, the master key
-  protected only the server's own creds (and weakly, co-located), and the admin
-  tRPC was network-exposed only incidentally.
-
-### Changed
-
-- **ADR 0002 re-pointed** to note its network-exposure aspect is amended by ADR 0008.
-
-## [1.0.0-rc.8] — 2026-06-14
-
-Docs only — no shipped code, so the published `@the-librarian/cli` is unchanged.
-
-### Added
-
 - **Spec: README review & improvement sweep**
   (`docs/specs/2026-06-14-readme-review.md`). A lightweight, buildable plan to make
   every README clear, correct, and useful to consumers — its core discipline is
@@ -1870,7 +1846,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
-[1.0.0-rc.8]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.7...v1.0.0-rc.8
+[1.0.0-rc.9]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.8...v1.0.0-rc.9
 [1.0.0-rc.7]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.6...v1.0.0-rc.7
 [1.0.0-rc.6]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.5...v1.0.0-rc.6
 [1.0.0-rc.5]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.4...v1.0.0-rc.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,54 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.9] — 2026-06-14
+
+Docs only — no shipped code, so the published `@the-librarian/cli` is unchanged.
+
+### Added
+
+- **ADR 0008 — auth & secrets model** (`docs/adr/0008-auth-secrets-model.md`) and a
+  buildable spec (`docs/specs/2026-06-14-auth-secrets-hardening.md`). Records the
+  decision to shrink the network surface and make the secrets model match its real
+  value: move the admin tRPC API to an **internal-only listener** and **drop the
+  admin token** as a network gate (amends ADR 0002 — the tRPC shape stands, its
+  exposure changes); **externalize the master key** (CLI-minted into a `0600` deploy
+  env-file, off the data volume) with a documented ladder
+  (env-file → `systemd-creds` → external secrets manager); and make **per-client
+  agent tokens + rotation** the real hardening. The spec phases it: Phase 1
+  (listener split + admin-token removal + key externalization), Phase 2 (per-client
+  tokens). Captures the reasoning — the vault is plaintext by design, the master key
+  protected only the server's own creds (and weakly, co-located), and the admin
+  tRPC was network-exposed only incidentally.
+
+### Changed
+
+- **ADR 0002 re-pointed** to note its network-exposure aspect is amended by ADR 0008.
+
+## [1.0.0-rc.8] — 2026-06-14
+
+Docs only — no shipped code, so the published `@the-librarian/cli` is unchanged.
+
+### Added
+
+- **ADR 0008 — auth & secrets model** (`docs/adr/0008-auth-secrets-model.md`) and a
+  buildable spec (`docs/specs/2026-06-14-auth-secrets-hardening.md`). Records the
+  decision to shrink the network surface and make the secrets model match its real
+  value: move the admin tRPC API to an **internal-only listener** and **drop the
+  admin token** as a network gate (amends ADR 0002 — the tRPC shape stands, its
+  exposure changes); **externalize the master key** (CLI-minted into a `0600` deploy
+  env-file, off the data volume) with a documented ladder
+  (env-file → `systemd-creds` → external secrets manager); and make **per-client
+  agent tokens + rotation** the real hardening. The spec phases it: Phase 1
+  (listener split + admin-token removal + key externalization), Phase 2 (per-client
+  tokens). Captures the reasoning — the vault is plaintext by design, the master key
+  protected only the server's own creds (and weakly, co-located), and the admin
+  tRPC was network-exposed only incidentally.
+
+### Changed
+
+- **ADR 0002 re-pointed** to note its network-exposure aspect is amended by ADR 0008.
+
 ## [1.0.0-rc.8] — 2026-06-14
 
 Docs only — no shipped code, so the published `@the-librarian/cli` is unchanged.

--- a/docs/adr/0002-trpc-admin-api.md
+++ b/docs/adr/0002-trpc-admin-api.md
@@ -1,6 +1,6 @@
 # ADR 0002 — tRPC for the dashboard admin API
 
-- **Status:** Accepted
+- **Status:** Accepted — tRPC remains the admin API shape; its *network exposure* is amended by [ADR 0008](./0008-auth-secrets-model.md) (2026-06-14): `/trpc` moves to an internal-only listener and the admin token is dropped as a network gate.
 - **Date:** 2026-05-20
 - **Phase context:** Maintainability overhaul, Phase 4 (T4.3–T4.5) and Phase 6 (T6.2).
 

--- a/docs/adr/0008-auth-secrets-model.md
+++ b/docs/adr/0008-auth-secrets-model.md
@@ -1,0 +1,122 @@
+# ADR 0008 — Auth & secrets model: shrink the network surface, externalize the key
+
+- **Status:** Accepted
+- **Date:** 2026-06-14
+- **Amends:** ADR 0002 (tRPC admin API) — the tRPC choice stands; its *network exposure* changes.
+- **Related:** ADR 0001 (separate services), ADR 0006 (agent-facing MCP surface).
+
+## Context
+
+Shipping the one-command `librarian server` CLI (v1.0.0-rc.7) made it trivial to
+stand up a **network-exposed** server (e.g. bound to a tailnet IP), which prompted
+a review of what each credential actually protects. Reading the code (not the
+marketing) turned up a model that looks layered but mostly isn't:
+
+- **The data is not encrypted at rest.** The vault — your memories — is plaintext
+  markdown in a git repo, deliberately (so it's editable in Obsidian/any editor).
+  The master key never touched it.
+- **The master key (`LIBRARIAN_SECRET_KEY`) protects only the server's *own*
+  third-party creds** in `settings.json` (the curator LLM API key, the backup
+  GitHub PAT, OAuth client secrets) and derives the dashboard session-signing key.
+  But in the default mode the server **auto-generates it into the data volume**
+  (`/data/secret.key`, 0600) — *beside* the ciphertext it protects. Against the
+  realistic at-rest threat (a data-volume snapshot/backup/shared-storage leak) the
+  key and ciphertext leak together, so the encryption provides ~no protection. It
+  is real only if the key lives **off** the data volume.
+- **The admin tRPC API is network-exposed only incidentally.** `/trpc/*` and
+  `/mcp` are dispatched off the *same* HTTP listener (`routes.ts`), which binds
+  `0.0.0.0` and is published because **`/mcp` must be reachable by remote agents**.
+  The only legitimate tRPC caller — the dashboard — always reaches it *internally*
+  (loopback in the all-in-one; the docker network in compose). No supported
+  topology needs remote admin tRPC. Yet a network peer with the admin token can
+  `POST /trpc/auth.config` and get back **decrypted** secrets, full memory CRUD,
+  backup/auth config — bypassing the dashboard entirely.
+- **The admin token therefore guards a surface that shouldn't exist** on the
+  network. Its in-practice job is "the credential the co-located dashboard uses."
+- **The agent token is the one genuinely load-bearing credential** — it's the only
+  thing authenticating memory read/write across the network, and it's *used on
+  every client call*. Its real exposure is **client-side**: it sits plaintext in
+  `~/.librarian/env` on every client machine (N copies vs one server).
+
+Net: a real core (the agent token) wrapped in two weak/incidental layers (the
+co-located master key; the admin token's network gate) that give the *appearance*
+of depth without the substance.
+
+## Decision
+
+Three changes, smallest-surface-first:
+
+1. **Internalize the admin tRPC surface; drop the admin token as a network gate.**
+   Serve `/trpc/*` on an internal-only listener (loopback in the all-in-one; the
+   docker network in compose), separate from the **public** listener that carries
+   `/mcp` + `/healthz` + `/primer.md`. The published port (`-p <host>:3838`) then
+   exposes only the agent surface. With tRPC unreachable from the network, the
+   admin token is no longer a network gate and is dropped for the default
+   (co-located-dashboard) deploys. A **remote** dashboard becomes an explicit,
+   separately-secured opt-in (its own TLS-terminated exposure), never the default.
+
+2. **Externalize the master key.** The CLI **mints** it at install (exactly as it
+   already mints the agent token) and passes it via env, so it lives in the
+   **deploy config, not the data volume**. The server already resolves
+   `env → file → generate`, so an env-supplied key is never written to `/data`.
+   Document a ladder (low→high assurance): (a) **default** — CLI-minted key in a
+   `0600` deploy env-file the unit references (off the data volume); (b)
+   **`systemd-creds`** (TPM-bound) for the Linux/systemd boot path; (c) an
+   **external secrets manager** for those who run one. Stop describing this as
+   "encrypted at rest" beyond what externalization actually delivers.
+
+3. **Treat the agent token as the real security boundary.** Invest hardening
+   *here*, since client-side leak is the dominant threat: **per-client tokens**
+   (the `LIBRARIAN_AGENT_TOKENS` map already supports distinct tokens per agent, so
+   one leak is revocable without re-keying everyone) plus a documented
+   **rotation/revocation** story.
+
+## Consequences
+
+**Positive**
+- The dangerous admin API (notably `auth.config`, which *returns decrypted
+  secrets*) is **off the network** — defense by not-exposing, strictly better than
+  defense by token. Removes the largest attack surface.
+- Externalizing the key makes at-rest encryption **actually meaningful** for the
+  realistic data-volume-leak threat, at near-zero user friction (the CLI handles
+  it; the user never types it).
+- Per-client agent tokens make the high-exposure credential **revocable** without a
+  fleet-wide re-key.
+- Fewer credentials to reason about: the admin token disappears for the common
+  case; the model collapses to "agent token = network auth, master key = at-rest
+  for the server's own creds (externalized)."
+
+**Negative / costs**
+- A code change to **split the mcp-server's HTTP listener** (public vs internal)
+  plus dashboard config to reach the internal tRPC endpoint. Amends the transport
+  assumption in ADR 0002 (the tRPC *shape* is unchanged).
+- A **remote dashboard** now needs deliberate setup rather than working by
+  accident. Acceptable: it was never a supported topology.
+- Key-in-deploy-env (default tier) does **not** protect against a full host/root
+  compromise — only against data-volume leakage. We state this honestly rather
+  than imply more. `systemd-creds`/external managers raise the bar for those who
+  want it.
+- Per-client tokens + rotation add operational surface (managing/rotating a set
+  rather than one shared token).
+
+**Threat model (explicit):** these changes target (a) network attack surface and
+(b) data-volume-leak at rest. They do **not** claim protection against a root/host
+compromise, which can read process memory regardless.
+
+## Alternatives considered
+
+- **Keep admin tRPC public, rely on the admin token (status quo).** Rejected:
+  defense-by-token over a surface that needn't exist; the network exposure is
+  incidental, not required.
+- **Encrypt the vault/memories at rest.** Rejected: breaks the plaintext-markdown,
+  edit-in-Obsidian design; and the realistic threat is the whole volume, which
+  per-file encryption-with-a-co-located-key wouldn't address anyway.
+- **Store the master key in GitHub at install.** Rejected: GitHub Actions secrets
+  are write-only / CI-scoped (a running server can't read them back); a private
+  repo/gist is just "key in a repo" plus a PAT chicken-and-egg. No GitHub product
+  fits runtime secret retrieval.
+- **Back up secrets/settings for "complete DR".** Rejected: on a fresh-server
+  restore the agent token, admin token, and master key all regenerate and the
+  vault is plaintext, so nothing needs preserving — you reconfigure a couple of
+  third-party creds. Backing up secrets only saves re-entry, at the cost of a new
+  secret-leak surface on the backup remote.

--- a/docs/specs/2026-06-14-auth-secrets-hardening.md
+++ b/docs/specs/2026-06-14-auth-secrets-hardening.md
@@ -1,0 +1,153 @@
+# Spec: auth & secrets hardening (ADR 0008)
+
+**Status:** Ready to build, 2026-06-14. Implements [ADR 0008](../adr/0008-auth-secrets-model.md)
+(amends [ADR 0002](../adr/0002-trpc-admin-api.md)). Written with the `sdlc-spec`
+method, grounded against the code on `main` @ v1.0.0-rc.7.
+
+## 1. Objective
+
+Make the auth/secrets model match its actual security value instead of *looking*
+layered. Three changes from ADR 0008: (1) take the admin tRPC API off the network
+and drop the admin token as a network gate; (2) externalize the master key so it
+lives off the data volume; (3) make per-client agent tokens + rotation the real
+hardening. Audience: self-hosters running a network-exposed (e.g. tailnet) server.
+
+Grounded facts this builds on: the mcp-server runs **one** HTTP listener routing
+`/mcp` + `/healthz` + `/primer.md` + `/trpc/*` by path (`routes.ts`); the dashboard
+reaches tRPC at `LIBRARIAN_SERVER_URL + /trpc` (`trpc-server.ts`, the proxy route);
+`server up` passes secrets **inline** via `-e LIBRARIAN_AGENT_TOKEN=…` (`up.ts:205`);
+the per-client token map `LIBRARIAN_AGENT_TOKENS` is already supported
+(`auth.ts:13`, `agent-tokens.ts`).
+
+## 2. Success criteria
+
+The acceptance bar; each becomes a test. "Published port" = the host-exposed
+`-p <host>:3838`.
+
+1. **Admin API off the network.** `/trpc/*` is **not** served on the published
+   listener (a request to `http://<host>:3838/trpc/...` is refused/404), and **is**
+   served on a separate internal listener (loopback in the all-in-one; the docker
+   network in compose). `/mcp`, `/healthz`, `/primer.md` remain on the published
+   listener.
+2. **No admin operation is reachable from the published port.** A peer with *any*
+   token hitting `http://<host>:3838` cannot invoke an `adminProcedure` or an
+   admin-role action — there is no admin surface there to reach.
+3. **Admin token dropped for the default deploy.** `server up` no longer mints or
+   surfaces an admin token; compose starts **without** `LIBRARIAN_ADMIN_TOKEN`
+   (the `:?` requirement is gone); the dashboard still performs all admin
+   operations via the internal tRPC endpoint.
+4. **Master key off the data volume.** `server up` delivers secrets via a **`0600`
+   env-file** (`--env-file`), not inline `-e`; the master key is CLI-minted into
+   it; `docker inspect` env does **not** contain the key value; `/data/secret.key`
+   is **not** created when the key is env-supplied; the key is surfaced once with
+   the SAVE warning.
+5. **Externalization documented + boot wired.** README documents the ladder
+   (deploy env-file default → `systemd-creds` → external secrets manager); the
+   generated `the-librarian.service` references the env-file; reboot still brings
+   the server up.
+6. **(Phase 2) Per-client tokens + rotation.** Each client is issued a **distinct**
+   agent token (populating `LIBRARIAN_AGENT_TOKENS`); a rotate command invalidates
+   one client's token (its next call → 401) **without** affecting other clients;
+   revoke removes a client.
+7. **Releasable.** No secret in any committed file/log/error; `pnpm test` /
+   `typecheck` / `lint` green; PR bumps root version + dated CHANGELOG (`check:release`).
+
+## 3. Scope
+
+**Phase 1 (in):** the listener split, dashboard repoint, admin-token removal, master-key
+externalization (env-file), and the README/boot wiring. The high-leverage, smaller change.
+
+**Phase 2 (in):** per-client agent tokens + a rotate/revoke command.
+
+**Out of scope:** a **remote dashboard** topology (dashboard on a different host than
+the mcp-server) — becomes an explicit, separately-TLS'd opt-in, not built here;
+encrypting the vault/memories at rest; a dashboard UI for token management (CLI only
+for now); migrating existing single-token deployments' clients automatically.
+
+## 4. Key decisions (from ADR 0008 + grounded)
+
+- **Two listeners, not path-filtering one.** Public listener (`LIBRARIAN_HOST:PORT`,
+  published) serves the agent surface; a second listener bound to an internal host
+  (`LIBRARIAN_TRPC_HOST`, default `127.0.0.1`) serves `/trpc`. Cleaner + harder to
+  misconfigure than source-filtering a shared socket.
+- **Internal tRPC is trusted (no admin token).** The internal listener grants admin
+  role without a bearer (it's loopback/docker-network only). Public `/mcp` never
+  grants admin (agent-role only; there are no `adminOnly` MCP tools today).
+- **Secrets via a `0600` env-file + `--env-file`** (move the agent token there too,
+  for consistency + to keep it off argv/`docker inspect`). The master key is
+  CLI-minted into that file (symmetric with the agent token); the server already
+  resolves `env → file → generate`, so it never writes `/data/secret.key`.
+- **Per-client tokens reuse the existing `LIBRARIAN_AGENT_TOKENS` map** — no new
+  auth primitive, just population + lifecycle.
+
+## 5. Open questions
+
+1. **Compose docker-network trust.** In the all-in-one, "internal" = loopback
+   (clearly safe to drop the admin token). In **compose**, "internal" = the docker
+   network, shared by any container on it. Drop the token entirely (trust the
+   network), or keep an internal-only admin token for the compose path? (Leaning:
+   drop for the default single-stack network; revisit if multi-tenant networks are
+   a concern.)
+2. **Dashboard tRPC URL var.** Reuse `LIBRARIAN_SERVER_URL` (point it at the
+   internal `host:trpc-port`) or add a distinct `LIBRARIAN_TRPC_URL`? (Leaning: a
+   distinct var, since the agent `/mcp` URL and the admin `/trpc` URL now differ.)
+3. **Phase 2 client identity.** Key per-client tokens off the installer's
+   `machine-id`? And is rotation a `server admin` verb, a client `librarian`
+   command, or both?
+
+## 6. Task plan
+
+Vertically sliced, ordered by dependency, riskiest first. Each leaves the system working.
+
+### Phase 1 — shrink the surface + externalize the key
+
+- [ ] **P1 — split the mcp-server HTTP into two listeners.** Public
+      (`/mcp`,`/healthz`,`/primer.md`) on `LIBRARIAN_HOST:PORT`; internal (`/trpc/*`)
+      on `LIBRARIAN_TRPC_HOST` (default `127.0.0.1`) : `LIBRARIAN_TRPC_PORT`.
+      *Accept:* `/trpc` on the public listener → 404/refused; `/trpc` on the internal
+      listener → works; `/mcp` only on public. (SC 1.) *Depends:* none. *(riskiest — first)*
+- [ ] **P2 — repoint the dashboard at the internal tRPC endpoint** (server-side
+      client + browser proxy), and wire it in the all-in-one (supervisor env →
+      `127.0.0.1:<trpc-port>`) and compose (`mcp-server:<trpc-port>`, not published).
+      *Accept:* dashboard tRPC calls succeed via the internal endpoint; the published
+      port serves no `/trpc`. *Depends:* P1.
+- [ ] **P3 — drop the admin token as a network gate.** Internal listener grants
+      admin role without a bearer; remove admin-token auto-generation, the compose
+      `:?` requirement, and `server up`'s surfacing of it.
+      *Accept:* `server up` prints no admin token; compose starts without
+      `LIBRARIAN_ADMIN_TOKEN`; no `adminProcedure` reachable from the published port.
+      (SC 2, 3.) *Depends:* P1, P2. *(see Open Q1)*
+- [ ] **P4 — deliver secrets via a `0600` env-file; mint the master key into it.**
+      Switch `server up` from inline `-e` to `--env-file`; CLI mints
+      `LIBRARIAN_SECRET_KEY` (like the agent token); server uses env, never writes
+      `/data/secret.key`.
+      *Accept:* `docker run` uses `--env-file`; file mode `0600`; key absent from
+      `docker inspect` env + from `/data`; surfaced once. (SC 4.) *Depends:* P3
+      (same `up.ts` region — serialize).
+- [ ] **P5 — externalization docs + boot wiring.** README ladder (env-file →
+      `systemd-creds` → external manager); `the-librarian.service` references the
+      env-file.
+      *Accept:* README documents the ladder; generated unit references the env-file;
+      reboot brings the server up. (SC 5.) *Depends:* P4.
+- [ ] **P6 — Phase 1 release gate.** tests/typecheck/lint green; version bump +
+      CHANGELOG; PR. (SC 7.) *Depends:* P1–P5.
+
+### Phase 2 — per-client agent tokens + rotation
+
+- [ ] **P7 — issue per-client agent tokens.** `librarian install` / `server up`
+      mint a distinct token per client (keyed off machine-id), populating
+      `LIBRARIAN_AGENT_TOKENS`.
+      *Accept:* each client gets a distinct token; the map is populated; a token
+      authenticates only as its own agent. (SC 6, part.) *Depends:* P4 (env-file
+      delivery for the map). *(see Open Q3)*
+- [ ] **P8 — rotate / revoke a client's token.** A command regenerates or removes
+      one client's token and reloads the server.
+      *Accept:* rotating invalidates that client's old token (401) without affecting
+      others; revoke removes a client. (SC 6, part.) *Depends:* P7.
+- [ ] **P9 — Phase 2 release gate.** Gate + PR. *Depends:* P7, P8.
+
+## 7. Checkpoint
+
+Phase 1 is the security win and is independently shippable; Phase 2 (per-client
+tokens) is the larger investment and can follow. Resolve the §5 open questions
+before P3/P7. Hand the tasks to `sdlc-implement` once reviewed.

--- a/docs/specs/2026-06-14-auth-secrets-hardening.md
+++ b/docs/specs/2026-06-14-auth-secrets-hardening.md
@@ -87,18 +87,17 @@ for now); migrating existing single-token deployments' clients automatically.
    put `mcp-server` + `dashboard` on a dedicated **internal** docker network
    (`internal: true`, not shared with other stacks) with the tRPC port unpublished —
    no token; the boundary is network isolation, not a bearer. Consistent with ADR
-   0008's "defense by not-exposing." *(Owner: confirm this posture; only revisit if
-   you intentionally run other containers on that network.)*
+   0008's "defense by not-exposing." *(Confirmed 2026-06-14; revisit only if you
+   intentionally run other containers on that network.)*
 2. **Dashboard tRPC URL → add a distinct `LIBRARIAN_TRPC_URL`** (the agent `/mcp`
    URL and the admin `/trpc` URL are now different ports, so conflating them in
    `LIBRARIAN_SERVER_URL` would be wrong). Defaults to the internal listener:
    `127.0.0.1:<trpc-port>` (all-in-one) / `mcp-server:<trpc-port>` (compose).
-3. **Phase 2 client identity → agent-id = the installer's `machine-id`** (hostname
-   for display), and **lifecycle is a `server admin` verb** —
-   `server admin token issue|rotate|revoke <agent-id>`. The server owns the token
-   map; clients receive/update their token via `librarian install` / `config` (paste
-   the issued token, as today). The full Phase-2 design lands in its own spec.
-   *(Owner: confirm direction before Phase 2.)*
+3. **Phase 2 client identity → deferred to the Phase-2 spec** (owner decision,
+   2026-06-14). The identity scheme (agent-id source) and the management surface
+   (where issue/rotate/revoke lives — server vs client) are decided when Phase 2 is
+   specced. Phase 2 reuses the existing `LIBRARIAN_AGENT_TOKENS` map (§4); the
+   lifecycle UX is intentionally left open here. Phase-1 does not depend on it.
 
 ## 6. Task plan
 
@@ -139,12 +138,12 @@ Vertically sliced, ordered by dependency, riskiest first. Each leaves the system
 
 ### Phase 2 — per-client agent tokens + rotation
 
-- [ ] **P7 — issue per-client agent tokens.** `librarian install` / `server up`
-      mint a distinct token per client (keyed off machine-id), populating
-      `LIBRARIAN_AGENT_TOKENS`.
+- [ ] **P7 — issue per-client agent tokens.** Mint a distinct token per client,
+      populating `LIBRARIAN_AGENT_TOKENS`. *Identity scheme + management surface are
+      deferred to the Phase-2 spec (§5.3)* — design them there before building.
       *Accept:* each client gets a distinct token; the map is populated; a token
       authenticates only as its own agent. (SC 6, part.) *Depends:* P4 (env-file
-      delivery for the map). *(see Open Q3)*
+      delivery for the map). *(Phase-2 spec decides the details first.)*
 - [ ] **P8 — rotate / revoke a client's token.** A command regenerates or removes
       one client's token and reloads the server.
       *Accept:* rotating invalidates that client's old token (401) without affecting
@@ -154,5 +153,7 @@ Vertically sliced, ordered by dependency, riskiest first. Each leaves the system
 ## 7. Checkpoint
 
 Phase 1 is the security win and is independently shippable; Phase 2 (per-client
-tokens) is the larger investment and can follow. Resolve the §5 open questions
-before P3/P7. Hand the tasks to `sdlc-implement` once reviewed.
+tokens) is the larger investment and can follow. The §5 questions are resolved
+(Q1/Q2 confirmed; Q3 deferred to the Phase-2 spec), so Phase 1 (P1–P6) is ready to
+hand to `sdlc-implement`. Phase 2 (P7–P9) needs its own spec first (the deferred
+identity/lifecycle design).

--- a/docs/specs/2026-06-14-auth-secrets-hardening.md
+++ b/docs/specs/2026-06-14-auth-secrets-hardening.md
@@ -80,20 +80,25 @@ for now); migrating existing single-token deployments' clients automatically.
 - **Per-client tokens reuse the existing `LIBRARIAN_AGENT_TOKENS` map** — no new
   auth primitive, just population + lifecycle.
 
-## 5. Open questions
+## 5. Resolved (were open questions, 2026-06-14)
 
-1. **Compose docker-network trust.** In the all-in-one, "internal" = loopback
-   (clearly safe to drop the admin token). In **compose**, "internal" = the docker
-   network, shared by any container on it. Drop the token entirely (trust the
-   network), or keep an internal-only admin token for the compose path? (Leaning:
-   drop for the default single-stack network; revisit if multi-tenant networks are
-   a concern.)
-2. **Dashboard tRPC URL var.** Reuse `LIBRARIAN_SERVER_URL` (point it at the
-   internal `host:trpc-port`) or add a distinct `LIBRARIAN_TRPC_URL`? (Leaning: a
-   distinct var, since the agent `/mcp` URL and the admin `/trpc` URL now differ.)
-3. **Phase 2 client identity.** Key per-client tokens off the installer's
-   `machine-id`? And is rotation a `server admin` verb, a client `librarian`
-   command, or both?
+1. **Compose docker-network trust → drop the admin token; isolate the network.**
+   All-in-one: tRPC on loopback (`127.0.0.1`), no token (loopback trust). Compose:
+   put `mcp-server` + `dashboard` on a dedicated **internal** docker network
+   (`internal: true`, not shared with other stacks) with the tRPC port unpublished —
+   no token; the boundary is network isolation, not a bearer. Consistent with ADR
+   0008's "defense by not-exposing." *(Owner: confirm this posture; only revisit if
+   you intentionally run other containers on that network.)*
+2. **Dashboard tRPC URL → add a distinct `LIBRARIAN_TRPC_URL`** (the agent `/mcp`
+   URL and the admin `/trpc` URL are now different ports, so conflating them in
+   `LIBRARIAN_SERVER_URL` would be wrong). Defaults to the internal listener:
+   `127.0.0.1:<trpc-port>` (all-in-one) / `mcp-server:<trpc-port>` (compose).
+3. **Phase 2 client identity → agent-id = the installer's `machine-id`** (hostname
+   for display), and **lifecycle is a `server admin` verb** —
+   `server admin token issue|rotate|revoke <agent-id>`. The server owns the token
+   map; clients receive/update their token via `librarian install` / `config` (paste
+   the issued token, as today). The full Phase-2 design lands in its own spec.
+   *(Owner: confirm direction before Phase 2.)*
 
 ## 6. Task plan
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## What

Records and plans the auth/secrets rethink that came out of reviewing the rc.7 server CLI.

- **ADR 0008** (`docs/adr/0008-auth-secrets-model.md`) — amends ADR 0002 (re-pointed). Three decisions: (1) move the admin tRPC API to an **internal-only listener** and **drop the admin token** as a network gate; (2) **externalize the master key** off the data volume (CLI-minted into a `0600` env-file; README ladder: env-file → `systemd-creds` → secrets manager); (3) make **per-client agent tokens + rotation** the real hardening. Captures the reasoning honestly: the vault is plaintext by design, the master key protected only the server's own creds (and weakly, co-located), and admin tRPC was network-exposed only incidentally.
- **Spec** (`docs/specs/2026-06-14-auth-secrets-hardening.md`) — testable success criteria + a phased plan (Phase 1: listener split + admin-token removal + key externalization; Phase 2: per-client tokens).
- **Open questions resolved** (owner-confirmed): Q1 internal docker network, no token; Q2 add a distinct `LIBRARIAN_TRPC_URL`; Q3 per-client identity/lifecycle **deferred to the Phase-2 spec**.
- **Docs only** — no shipped code.

## Merge order
This is **rc.9** — merge **after** the README PR (rc.8). After that merges I'll rebase this onto the updated `main` so the CHANGELOG slots `rc.9` cleanly above `rc.8` (the branch currently skips rc.8, which lives on the README PR).

Phase 1 is ready to hand to `sdlc-implement` once this lands; Phase 2 needs its own spec first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
