### PR TITLE
fix(dashboard): make trpc-server edge-safe so middleware doesn't 500 when the tRPC URL env is unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.12] — 2026-06-14
+
+### Fixed
+
+- **Dashboard no longer 500s in the edge runtime when the tRPC URL env is unset.**
+  `apps/dashboard/lib/trpc-server.ts` is `import "server-only"`, but Next's
+  middleware bundler still pulls it into the **edge runtime** (middleware →
+  `auth-config-client` → `trpc-server`), where `process.stderr` is undefined. Its
+  cold-start misconfiguration warning used `process.stderr.write`, which threw at
+  module init and 500'd **every request** whenever neither `LIBRARIAN_TRPC_URL`
+  nor `LIBRARIAN_SERVER_URL` was set. Switched the warning to `console.warn`
+  (edge-safe). Regression test added.
+
 ## [1.0.0-rc.11] — 2026-06-14
 
 Internal/tooling only — no shipped code; the published `@the-librarian/cli` and
@@ -1924,6 +1937,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0-rc.12]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.11...v1.0.0-rc.12
 [1.0.0-rc.11]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.10...v1.0.0-rc.11
 [1.0.0-rc.10]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.9...v1.0.0-rc.10
 [1.0.0-rc.9]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.8...v1.0.0-rc.9

--- a/apps/dashboard/lib/trpc-server.ts
+++ b/apps/dashboard/lib/trpc-server.ts
@@ -17,10 +17,16 @@ export function resolveTrpcBaseUrl(): string {
 
 // Surface misconfiguration once at cold start so admin tRPC calls
 // don't silently fall back to the dev default without a clue why.
+//
+// EDGE-SAFE: despite `import "server-only"`, Next's middleware bundler pulls
+// this module into the EDGE runtime (middleware.ts → auth-config-client.ts →
+// here), where `process.stderr` is undefined — a `process.stderr.write` at
+// module init would throw and 500 every request. `console.warn` is supported in
+// the edge runtime, so use it (never `process.stderr`/`process.stdout` here).
 if (!process.env.LIBRARIAN_TRPC_URL && !process.env.LIBRARIAN_SERVER_URL) {
-  process.stderr.write(
+  console.warn(
     `[trpc-server] LIBRARIAN_TRPC_URL (and LIBRARIAN_SERVER_URL fallback) unset; ` +
-      `falling back to ${DEFAULT_SERVER_URL} (dev only).\n`,
+      `falling back to ${DEFAULT_SERVER_URL} (dev only).`,
   );
 }
 

--- a/apps/dashboard/tests/trpc-server-edge-safe.test.ts
+++ b/apps/dashboard/tests/trpc-server-edge-safe.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Regression: `trpc-server.ts` must not touch `process.stderr` at module init.
+// It is `import "server-only"`, but Next's middleware bundler still pulls it into
+// the EDGE runtime via auth-config-client.ts → middleware.ts, where
+// `process.stderr` is undefined — so a module-init `process.stderr.write` throws
+// and every request 500s (only when the misconfig warning fires, i.e. neither
+// LIBRARIAN_TRPC_URL nor LIBRARIAN_SERVER_URL is set). The cold-start warning
+// must use `console.warn` (edge-safe), never `process.stderr.write`.
+
+const PRIOR = {
+  trpc: process.env.LIBRARIAN_TRPC_URL,
+  server: process.env.LIBRARIAN_SERVER_URL,
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (PRIOR.trpc === undefined) delete process.env.LIBRARIAN_TRPC_URL;
+  else process.env.LIBRARIAN_TRPC_URL = PRIOR.trpc;
+  if (PRIOR.server === undefined) delete process.env.LIBRARIAN_SERVER_URL;
+  else process.env.LIBRARIAN_SERVER_URL = PRIOR.server;
+});
+
+describe("trpc-server module init is edge-safe", () => {
+  it("warns via console.warn (never process.stderr) when neither URL is set", async () => {
+    delete process.env.LIBRARIAN_TRPC_URL;
+    delete process.env.LIBRARIAN_SERVER_URL;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    vi.resetModules();
+    await import("@/lib/trpc-server");
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.join(" ")).toContain("LIBRARIAN_TRPC_URL");
+    // The edge runtime has no process.stderr — the warning must not reach it.
+    expect(stderrWrite.mock.calls.flat().join(" ")).not.toContain("LIBRARIAN_TRPC_URL");
+  });
+
+  it("stays silent when LIBRARIAN_TRPC_URL is set (configured deploy)", async () => {
+    process.env.LIBRARIAN_TRPC_URL = "http://mcp-server:3840";
+    delete process.env.LIBRARIAN_SERVER_URL;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    vi.resetModules();
+    await import("@/lib/trpc-server");
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.11",
+  "version": "1.0.0-rc.12",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Fix: dashboard 500s in the edge runtime when the tRPC URL env is unset

`apps/dashboard/lib/trpc-server.ts` carries `import "server-only"`, but Next's
**middleware bundler** still pulls it into the **edge runtime**:

```
middleware.ts → @/lib/auth-config-client → ./trpc-server
```

`server-only` guards against *client* bundles, not the edge runtime — so the
module loads in middleware, where `process.stderr` is `undefined`. Its cold-start
misconfiguration warning used `process.stderr.write(...)` **at module init**,
which threw on load and **500'd every request** whenever neither
`LIBRARIAN_TRPC_URL` nor `LIBRARIAN_SERVER_URL` was set. It was only masked by
setting those envs.

### Fix
Swap the warning to `console.warn` (supported in the edge runtime). The rest of
the module is already edge-safe — the tRPC client (`@trpc/client` + `fetch`) sets
up without Node-only APIs at init, and the actual `auth.config` query only runs
when middleware calls it. So this one swap makes the whole import chain edge-safe;
no need to restructure the middleware → auth-config-client → trpc-server chain.

### Why not "stop middleware importing trpc-server"
Middleware *needs* the auth config to decide enforcement, and gets it via
`auth-config-client → trpc-server` — an intentional chain. The only edge-unsafe
thing was the `process.stderr` write at module init, so fixing that is the
minimal, correct fix.

### Test
Regression test (`tests/trpc-server-edge-safe.test.ts`) pins that the cold-start
warning fires via `console.warn` and **never** `process.stderr` when the URL env
is unset — it fails against the old `process.stderr.write` and passes after.

### Verification
`pnpm typecheck` ✅, `pnpm lint` ✅, dashboard vitest **249 passed** ✅,
`check:release` ✅ (rc.11). Discovered + sidestepped (by setting the envs) in
another session; this is the real fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
