### PR TITLE
feat(dashboard): vault redesign Phase 1 — typeset, polish, harden, adapt, filter (rc.13)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ __pycache__/
 # Autonomous-build scratch notes — local-only, never committed (per build workflow)
 AUTONOMOUS-BUILD-NOTES-*.md
 
+# Impeccable live-mode session journals (local recovery state, not project source).
+# The config (.impeccable/live/config.json) IS committed; only sessions are local.
+.impeccable/live/sessions/
+

--- a/.impeccable/critique/2026-06-14T17-54-41Z__apps-dashboard-app-vault-page-tsx.md
+++ b/.impeccable/critique/2026-06-14T17-54-41Z__apps-dashboard-app-vault-page-tsx.md
@@ -1,0 +1,118 @@
+---
+target: /vault
+total_score: 26
+p0_count: 1
+p1_count: 2
+timestamp: 2026-06-14T17-54-41Z
+slug: apps-dashboard-app-vault-page-tsx
+---
+# Critique — `/vault` (Vault explorer)
+
+## Design Health Score
+
+| # | Heuristic | Score | Key Issue |
+|---|-----------|-------|-----------|
+| 1 | Visibility of System Status | 2 | File selection is a full navigation with no loading state; current mode (view/edit/history) barely indicated. |
+| 2 | Match System / Real World | 3 | Strong domain language — vault, wikilinks, backlinks, frontmatter→"Properties", primer. |
+| 3 | User Control and Freedom | 3 | Cancel everywhere; compare-and-swap blocks silent overwrite; delete/restore are git-recoverable and say so. |
+| 4 | Consistency and Standards | 2 | Patchwork: editorial `ui-v2` chrome over legacy shadcn content cards; hand-rolled badge instead of `Pill`; buttons instead of `Tabs`. |
+| 5 | Error Prevention | 3 | Confirm dialogs, schema validation on save, live byte cap, conflict detection. |
+| 6 | Recognition Rather Than Recall | 3 | Tree, path, backlinks all visible; but mode state and shortcuts are not surfaced. |
+| 7 | Flexibility and Efficiency | 2 | No keyboard shortcuts, no tree filter/search, full-page nav per file; `KeyHint` unused. |
+| 8 | Aesthetic and Minimalist Design | 2 | Clean but unfinished — shadcn cards + dead `prose` classes make the reading surface generic and typographically thin. |
+| 9 | Error Recovery | 3 | Inline `role="alert"` errors, teaching copy, conflict-as-error. |
+| 10 | Help and Documentation | 3 | Dialog descriptions genuinely teach; empty state explains what lives in the vault. |
+| **Total** | | **26/40** | **Acceptable — solid, safe, well-taught; visually mid-migration and not yet keyboard-efficient.** |
+
+## Anti-Patterns Verdict
+
+**Does this look AI-generated?** Not in the slop-trope sense — but yes in the "generic admin template" sense, which is exactly what the redesign exists to escape.
+
+- **LLM assessment:** No gradient text, no glassmorphism, no eyebrow kickers, no hero-metric cards, no side-stripes. The tells here are subtler: every *content* container is a `rounded-md border bg-card` shadcn panel with `text-muted-foreground` labels. The action chrome (Button/Dialog/Input) is on the editorial `ui-v2` system, but the panels the operator actually reads — markdown article, Properties, Backlinks, history list, diff — are stock shadcn. It reads as "a competent shadcn admin," not "The Reading Room."
+- **Deterministic scan:** `detect.mjs` → `[]` (exit 0, clean). Zero trope hits. This corroborates the LLM read: the problem isn't a bannable pattern, it's design-system drift the trope detector can't see. Confirmed separately: `@tailwindcss/typography` is not a dependency and no `prose` CSS exists, so the `prose prose-sm` classes in `markdown-content.tsx` are dead — the markdown reader is running on a handful of arbitrary `[&_h1]:text-lg` overrides.
+- **Visual overlays:** No browser automation available this session and the dev server was not confirmed running, so no live overlay was injected. Findings are from source review + the CLI detector. Re-run with the dashboard served (`pnpm --filter @librarian/dashboard dev`) and a browser tool for in-page overlays.
+
+## Overall Impression
+
+This is a genuinely well-engineered admin surface — safe (compare-and-swap, confirm dialogs, git-recoverable deletes), honest (teaching copy on every dialog), and information-complete (tree, rendered markdown, wikilinks, backlinks, frontmatter, per-file history with diff + restore). The *engineering* is the strong part.
+
+The *design* is mid-migration and it shows on the one surface where it matters most: the place the operator reads their curated knowledge. The reading pane is a bordered shadcn card with thin, under-built markdown typography; the chrome around it is half on the editorial system, half on legacy tokens. The single biggest opportunity: bring the content surfaces onto the "Reading Room" system and make the markdown pane the typographic hero it should be.
+
+## What's Working
+
+- **Teaching copy is exemplary.** "Wikilinks pointing at the old filename are rewritten across the vault, so nothing dangles." "Removed as a git commit — it stays recoverable." This is the rare admin tool that explains its own safety model inline. Keep every word.
+- **Safety model is visible and correct.** Compare-and-swap conflict detection on save, schema validation that renders inline (never writes invalid), live 2KB byte counter for primer/curator files, confirm-behind-dialog for rename/delete/restore. Error prevention is a real strength.
+- **Domain IA is right.** Tree → file → (rendered body + Properties + Backlinks) → History/diff/restore mirrors how an Obsidian user already thinks. Frontmatter relabeled "Properties" is a thoughtful real-world match.
+
+## Priority Issues
+
+### [P1] Content surfaces are generic shadcn cards, not the editorial system
+- **Why it matters:** This is the precise "escape generic-admin feel" goal from PRODUCT.md, failing on the highest-traffic surface. The markdown article (`rounded-md border bg-card p-6`), `FrontmatterTable`, `BacklinksPane`, the history commit list, and the diff `<pre>` are all stock shadcn cards with `text-muted-foreground`. DESIGN.md's Flat-By-Default and Sharp-Corner rules are violated throughout.
+- **Fix:** Migrate to flat hairline surfaces — drop `rounded-md`/`bg-card`/`border`, separate with `Hairline` + `paper-surface` only where a true panel is needed; swap `text-muted-foreground` → `text-foreground/60`; replace the hand-rolled kind badge with the `Pill` component (`accent`/`default`).
+- **Suggested command:** `/impeccable polish`
+
+### [P1] The markdown reading pane is typographically dead
+- **Why it matters:** Reading memories/handoffs/references is the vault's entire purpose. `prose prose-sm` is a no-op (no `@tailwindcss/typography`, no `prose` CSS), so the body falls back to `[&_h1]:text-lg` (18px) / `[&_h2]:text-base` / `[&_h3]:text-sm` — headings barely larger than body, no Fraunces display, no spacing rhythm, no measure cap, and blockquotes/tables/`hr`/code blocks/ordered+nested lists are unstyled.
+- **Fix:** Build a real editorial prose style — Fraunces headings on a proper scale, Newsreader body capped at 65–75ch, styled lists/blockquotes/tables/code, IBM Plex Mono for code. Either install + theme `@tailwindcss/typography` or author a scoped `.vault-prose`.
+- **Suggested command:** `/impeccable typeset`
+
+### [P2] Mode switching uses plain buttons; current mode is nearly invisible
+- **Why it matters:** view / edit / history is a textbook tab set, but it's three `outline` buttons. Only History exposes `aria-pressed`; there's no active indicator for view vs edit. Visibility-of-status + consistency both suffer, and the `ui-v2` `Tabs` (with the vermilion underline) already exists.
+- **Fix:** Replace the button row with `ui-v2` `Tabs` so the active mode reads at a glance and the surface matches the rest of the redesign.
+- **Suggested command:** `/impeccable polish`
+
+### [P2] No power-user efficiency on a power-user surface
+- **Why it matters:** The operator is `Alex`. There are no keyboard shortcuts (edit/save/history/cancel), no filter/search over the tree (a 500-file vault is an unscannable 260px column), and every file open is a full server navigation. The redesign's keyboard-first promise — `KeyHint`, `j/k` — is entirely absent here.
+- **Fix:** Add a tree filter input; `KeyHint`s on Edit/Save/History; `j/k` tree navigation; consider client-side detail swap so selection feels instant. (Tree filter is a net-new feature — better scoped via `shape`.)
+- **Suggested command:** `/impeccable harden` (+ `/impeccable shape` for the tree filter)
+
+### [P2] Destructive actions look benign; no feedback on selection
+- **Why it matters:** Delete and Restore confirm with `variant="primary"` — the same vermilion as benign Create/Save (`ui-v2` Button has no destructive variant, though `--destructive` exists). And selecting a tree file triggers a full navigation with no pending/skeleton state, so a slow vault read looks frozen.
+- **Fix:** Add a destructive button treatment for the confirm step of delete/restore; add a loading indicator on file selection (`loading.tsx` / optimistic selected state).
+- **Suggested command:** `/impeccable harden`
+
+## Persona Red Flags
+
+**Alex (Power User):** No keyboard shortcuts for any action. No tree filter/search — a large vault is an unfiltered scroll. Every file open is a full page navigation (no client-side swap). `KeyHint` exists in the system but isn't wired here. Will feel slow and hand-holdy.
+
+**Sam (Accessibility):** `ui-v2` `Button` defines no `focus-visible` ring (relies on the UA outline; inconsistent with `Tabs`/`Dialog`, which do ring). The editorial `Input` focus cue is a border-color change only — a color-only signal that's borderline for low vision. `text-muted-foreground` on `bg-card` (kind badge, labels) needs a 4.5:1 check. Mode state leans on `aria-pressed` alone.
+
+**The Operator / Curator (project persona, from Design Context):** Expects a "considered editorial tool" that practices what it preaches; instead reads their curated knowledge inside a stock shadcn card with thin heading hierarchy. The brand promise ("practice what you preach") is undercut exactly where the operator spends their reading time, and long documents are tiring to scan.
+
+## Minor Observations
+
+- `Last modified {file.mtime}` prints a raw mtime in muted text — humanize it and set it in mono (Mono-for-Machines).
+- Diff coloring: green/red add-remove is a fair real-world convention (and the `+`/`-` glyphs remain for color-blind users), but `text-sky-600` on `@@` hunk headers is gratuitously off-palette — use ink/muted.
+- The "Activity" audit-trail entry is a tiny `text-sm underline` link — weak affordance for an important surface; promote it.
+- New-file and editor `textarea`s use legacy boxed `rounded-md border-input bg-background`; the raw editor is `text-xs` (12px) for writing markdown — cramped, and off the editorial Input vocabulary.
+- Tree rows are `px-2 py-1` (~28px) — below the 44px mobile touch target (`Casey`).
+
+## Questions to Consider
+
+- What would the vault feel like if the **reading pane were the hero** — full editorial typography, generous measure — instead of a bordered card sharing weight with the sidebar?
+- Could file selection be **instant** (client detail swap / optimistic state) rather than a full server navigation?
+- If view / edit / history is a tab set, why is it three buttons?
+- For a 500-file vault, how does the operator **find** a file with no filter?
+
+## Addendum — user-reported layout break (post-critique, P0)
+
+Source-only review (no running browser) under-weighted a hard layout failure the
+operator confirmed: **the surface is broken on mobile and mostly unusable at 13".**
+
+- **[P0] History/diff column overflow blows the page out.** `DiffView` is a `<pre>`
+  with `whitespace-pre` (no wrap) inside a CSS grid track (`lg:grid-cols-[1fr_2fr]`
+  in `file-history.tsx`; the content grid `lg:grid-cols-[2fr_1fr]` in `file-view.tsx`
+  is the same hazard). Grid/flex children default to `min-width: auto`, so a long
+  unwrapped diff line expands the track past the viewport and pushes the Restore
+  button (and the rest of the layout) off-screen. Root-cause fix: `min-w-0` on the
+  grid children so `overflow-x-auto` scrolls *within* the column. → `/impeccable layout`
+- **[P1] History list shouldn't own a whole column.** The commit blocks are long and
+  waste a full `1fr`/`2fr` column. Restructure: stack the list above the diff, or make
+  each commit an accordion row that loads its diff inline when expanded — removing the
+  wide second column entirely and fixing narrow screens at the same time. → `/impeccable layout`
+- **[P1] Unusable on mobile / 13".** Beyond the overflow: tree rows below 44px, the
+  fixed 260px sidebar, and the nested two-column grids need a real responsive pass
+  (stacking, thumb-zone, contained scroll). → `/impeccable adapt`
+
+Decision: fix `/vault` now; the shadcn-card → editorial migration is **flagged as a
+cross-surface follow-up** (Memories, Curator, Proposals, etc. likely share it).

--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,264 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-06-14T00:00:00Z",
+  "title": "Design System: The Librarian Dashboard",
+  "extensions": {
+    "colorMeta": {
+      "vermilion": {
+        "role": "primary",
+        "displayName": "Vermilion (Saffron in dark)",
+        "canonical": "#d14b2a",
+        "darkVariant": "#e6a33d",
+        "tonalRamp": [
+          "#3a1208",
+          "#5c1d0e",
+          "#7d2815",
+          "#9e341c",
+          "#bf4023",
+          "#d14b2a",
+          "#e07a5f",
+          "#f0b5a3"
+        ]
+      },
+      "sage": {
+        "role": "secondary",
+        "displayName": "Sage",
+        "canonical": "#7b8b6f",
+        "darkVariant": "#7a8b5c",
+        "tonalRamp": [
+          "#1f261b",
+          "#33402c",
+          "#48563d",
+          "#5d6e4f",
+          "#7b8b6f",
+          "#9aa890",
+          "#bcc6b3",
+          "#dde2d8"
+        ]
+      },
+      "ink": {
+        "role": "neutral",
+        "displayName": "Ink (Parchment Ink in dark)",
+        "canonical": "#1a1612",
+        "darkVariant": "#e8e0d0",
+        "tonalRamp": [
+          "#0d0b09",
+          "#1a1612",
+          "#2e2820",
+          "#4a4034",
+          "#6b5e4d",
+          "#928269",
+          "#c2b49a",
+          "#ede7d8"
+        ]
+      },
+      "paper-body": {
+        "role": "neutral",
+        "displayName": "Paper — Body",
+        "canonical": "#f5f1e8",
+        "darkVariant": "#1c1814",
+        "tonalRamp": [
+          "#2e2a22",
+          "#4a4436",
+          "#6e664f",
+          "#948a6d",
+          "#bcae8c",
+          "#dcd2b8",
+          "#ece3cf",
+          "#f5f1e8"
+        ]
+      },
+      "paper-surface": {
+        "role": "neutral",
+        "displayName": "Paper — Surface",
+        "canonical": "#faf7f0",
+        "darkVariant": "#231e18",
+        "tonalRamp": [
+          "#332f26",
+          "#50493a",
+          "#746c54",
+          "#9a9072",
+          "#c1b694",
+          "#ddd4b9",
+          "#ede7d6",
+          "#faf7f0"
+        ]
+      },
+      "mono-fill": {
+        "role": "neutral",
+        "displayName": "Mono Fill",
+        "canonical": "#ede7d8",
+        "darkVariant": "#2a241d",
+        "tonalRamp": [
+          "#3a3526",
+          "#564f3a",
+          "#746c50",
+          "#948b6a",
+          "#b7ae8a",
+          "#d2cab0",
+          "#e2dcc8",
+          "#ede7d8"
+        ]
+      }
+    },
+    "typographyMeta": {
+      "display": {
+        "displayName": "Display — Fraunces",
+        "purpose": "Page and surface titles; fixed rem, never clamp(). Licensed target: PP Editorial New."
+      },
+      "body": {
+        "displayName": "Body — Newsreader",
+        "purpose": "Prose, descriptions, and — distinctively — control labels and button text. Licensed target: PP Neue Montreal."
+      },
+      "data": {
+        "displayName": "Data / Mono — IBM Plex Mono",
+        "purpose": "Every machine-generated string: ids, timestamps, tokens, counts, table cells."
+      },
+      "label": {
+        "displayName": "Label — IBM Plex Mono",
+        "purpose": "Uppercase column heads and metadata at 11px / 0.08em; KeyHint at 10px."
+      }
+    },
+    "shadows": [],
+    "motion": [
+      {
+        "name": "state-transition",
+        "value": "150ms ease",
+        "purpose": "Color/border state changes on buttons, rows, tabs, inputs. Users are in flow."
+      },
+      {
+        "name": "dialog-fade",
+        "value": "fade only, ~150–200ms",
+        "purpose": "Radix dialog overlay + content. No scale, no blur, no slide."
+      }
+    ],
+    "breakpoints": [{ "name": "md", "value": "768px" }]
+  },
+  "components": [
+    {
+      "name": "Outline Button",
+      "kind": "button",
+      "refersTo": "button-outline",
+      "description": "The everyday action. Square, hairline border, ink on paper, no shadow.",
+      "html": "<button class=\"ds-btn-outline\">Recall</button>",
+      "css": ".ds-btn-outline{font-family:Newsreader,Georgia,serif;font-size:.875rem;color:#1a1612;background:transparent;border:1px solid rgba(26,22,18,.2);border-radius:0;padding:6px 12px;cursor:pointer;transition:background .15s ease}.ds-btn-outline:hover{background:rgba(26,22,18,.04)}.ds-btn-outline:focus-visible{outline:2px solid #d14b2a;outline-offset:2px}"
+    },
+    {
+      "name": "Primary Button",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "Exactly one per surface. Vermilion border and text, transparent fill — the One Pen Rule applied to action.",
+      "html": "<button class=\"ds-btn-primary\">Remember</button>",
+      "css": ".ds-btn-primary{font-family:Newsreader,Georgia,serif;font-size:.875rem;color:#d14b2a;background:transparent;border:1px solid #d14b2a;border-radius:0;padding:6px 12px;cursor:pointer;transition:background .15s ease}.ds-btn-primary:hover{background:rgba(209,75,42,.06)}.ds-btn-primary:focus-visible{outline:2px solid #d14b2a;outline-offset:2px}"
+    },
+    {
+      "name": "Underline Input",
+      "kind": "input",
+      "refersTo": "input-underline",
+      "description": "No box. A single hairline bottom border that turns vermilion on focus — no ring, no glow.",
+      "html": "<input class=\"ds-input\" placeholder=\"Search memories…\">",
+      "css": ".ds-input{display:block;width:240px;font-family:Newsreader,Georgia,serif;font-size:.875rem;color:#1a1612;background:transparent;border:0;border-bottom:1px solid rgba(26,22,18,.12);border-radius:0;padding:6px 4px}.ds-input::placeholder{color:rgba(26,22,18,.4)}.ds-input:focus{outline:none;border-bottom-color:#d14b2a}"
+    },
+    {
+      "name": "Mono Pill",
+      "kind": "chip",
+      "refersTo": "pill-default",
+      "description": "A machine string sitting in a faint wash — ids, timestamps, event types. Square, mono, no border.",
+      "html": "<span class=\"ds-pill\">mem_8f2a10</span>",
+      "css": ".ds-pill{display:inline-flex;align-items:center;font-family:'IBM Plex Mono',ui-monospace,monospace;font-size:.75rem;line-height:1;color:#1a1612;background:rgba(26,22,18,.06);border-radius:0;padding:2px 6px}"
+    },
+    {
+      "name": "Accent Pill",
+      "kind": "chip",
+      "refersTo": "pill-accent",
+      "description": "The one state per view that matters: vermilion text + vermilion hairline border.",
+      "html": "<span class=\"ds-pill-accent\">proposed</span>",
+      "css": ".ds-pill-accent{display:inline-flex;align-items:center;font-family:Newsreader,Georgia,serif;font-size:.75rem;line-height:1;color:#d14b2a;background:transparent;border:1px solid #d14b2a;border-radius:0;padding:2px 6px}"
+    },
+    {
+      "name": "Editorial Table",
+      "kind": "custom",
+      "refersTo": "table-cell",
+      "description": "The signature surface. No card chrome, 32px rows, mono data, hairline separators, vermilion selection.",
+      "html": "<table class=\"ds-table\"><thead><tr><th>Id</th><th>Memory</th><th>State</th></tr></thead><tbody><tr><td>mem_8f2a10</td><td>Prefers pnpm over npm</td><td>active</td></tr><tr class=\"ds-row-selected\"><td>mem_3c9b21</td><td>Deploys via Fly.io</td><td>proposed</td></tr></tbody></table>",
+      "css": ".ds-table{border-collapse:collapse;width:420px;color:#1a1612;font-family:'IBM Plex Mono',ui-monospace,monospace;font-size:.8125rem}.ds-table thead tr{border-bottom:1px solid rgba(26,22,18,.12)}.ds-table th{height:32px;padding:0 8px;text-align:left;font-family:'IBM Plex Mono',ui-monospace,monospace;font-size:.6875rem;font-weight:500;letter-spacing:.08em;text-transform:uppercase;color:rgba(26,22,18,.6)}.ds-table td{height:32px;padding:0 8px;border-bottom:1px solid rgba(26,22,18,.12)}.ds-table tbody tr{transition:background .15s ease}.ds-table tbody tr:hover{background:rgba(26,22,18,.03)}.ds-table .ds-row-selected{background:rgba(209,75,42,.08)}"
+    },
+    {
+      "name": "Tab Strip",
+      "kind": "nav",
+      "refersTo": "tabs",
+      "description": "Hairline strip; the active trigger carries a 2px vermilion underline and ink text.",
+      "html": "<div class=\"ds-tabs\"><button class=\"ds-tab ds-tab-active\">Active</button><button class=\"ds-tab\">Proposed</button><button class=\"ds-tab\">Archive</button></div>",
+      "css": ".ds-tabs{display:inline-flex;align-items:flex-end;gap:16px;border-bottom:1px solid rgba(26,22,18,.12)}.ds-tab{height:36px;padding:0 4px;background:transparent;border:0;border-bottom:2px solid transparent;margin-bottom:-1px;font-family:Newsreader,Georgia,serif;font-size:.875rem;font-weight:500;color:rgba(26,22,18,.6);cursor:pointer;transition:color .15s ease}.ds-tab:hover{color:#1a1612}.ds-tab-active{color:#1a1612;border-bottom-color:#d14b2a}.ds-tab:focus-visible{outline:2px solid #d14b2a;outline-offset:2px}"
+    },
+    {
+      "name": "Key Hint",
+      "kind": "custom",
+      "refersTo": "key-hint",
+      "description": "Inline kbd in mono with a vermilion border — teaches the shortcut beside its action. Keyboard-first stewardship made literal.",
+      "html": "<kbd class=\"ds-key\">R</kbd>",
+      "css": ".ds-key{display:inline-flex;align-items:center;justify-content:center;min-width:1.25rem;padding:0 4px;font-family:'IBM Plex Mono',ui-monospace,monospace;font-size:10px;line-height:1;text-transform:uppercase;color:#d14b2a;border:1px solid rgba(209,75,42,.4);border-radius:0}"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Reading Room",
+    "overview": "A quiet research library rendered with the exactness of a technical instrument. The body is warm paper, the text is ink, and rules are hairlines drawn at 1px — the chrome recedes so the corpus is what you see. The mood is editorial, scholarly, and calm, but 'calm' is not 'soft': the surface is crisp and precise, mono-forward for every machine string, closer to a well-set reference work than to anything decorative. There is exactly one mark of colour, the rubricator's pen — vermilion in light, saffron in dark — spent only on the single primary action and the current selection. Depth is never a drop shadow; it is a tonal shift or a hairline.",
+    "keyCharacteristics": [
+      "Warm paper + ink, two themes (light Manuscript default, dark Scriptorium).",
+      "A single rubric accent — vermilion / saffron — reserved for the one real action and current state.",
+      "Flat by default: no shadows, ever. Separation is a hairline or a tonal wash.",
+      "Sharp corners (0px radius) on editorial components.",
+      "A three-face editorial type system: Fraunces (display), Newsreader (body), IBM Plex Mono (machine strings).",
+      "Dense, keyboard-first: ⌘K palette, j/k navigation, inline KeyHint shortcuts."
+    ],
+    "rules": [
+      {
+        "name": "The One Pen Rule",
+        "body": "The rubric accent carries the single primary action of a view and the current selection — nothing else. If two things on a screen are accented, one is wrong. Its rarity is the signal.",
+        "section": "colors"
+      },
+      {
+        "name": "The Warm Paper Rule",
+        "body": "The body is warm paper (#f5f1e8), chosen for slow careful work — not cream-by-reflex. Warmth is carried by paper + ink + accent; surfaces step in tone, not hue.",
+        "section": "colors"
+      },
+      {
+        "name": "The Mono-for-Machines Rule",
+        "body": "Every machine-generated string is IBM Plex Mono; prose and headings are the serifs. The mono/serif split tells human from machine at a glance.",
+        "section": "typography"
+      },
+      {
+        "name": "The Serif Spine Rule",
+        "body": "No neutral sans for chrome. Buttons, labels, and inputs are Newsreader on purpose; a sans default would erase the editorial voice.",
+        "section": "typography"
+      },
+      {
+        "name": "The Flat-By-Default Rule",
+        "body": "Surfaces are flat at rest and in motion. Separation is a hairline or a tonal step — never a shadow, glow, or blur.",
+        "section": "elevation"
+      },
+      {
+        "name": "The Sharp Corner Rule",
+        "body": "Editorial components have a 0px radius. A rounded card is the fastest way to read as default shadcn.",
+        "section": "components"
+      }
+    ],
+    "dos": [
+      "Do reserve the rubric accent (vermilion #d14b2a / saffron #e6a33d) for the one primary action and the current selection.",
+      "Do set every machine string in IBM Plex Mono and all prose / labels in the serifs.",
+      "Do separate with a hairline (1px @ 12%) or a tonal wash (foreground/2–6%). Depth is tone, never shadow.",
+      "Do keep corners square (rounded-none) on editorial components.",
+      "Do step surfaces in tone (paper-body → paper-surface → mono-fill), not in hue.",
+      "Do verify contrast: body ≥4.5:1, large ≥3:1, and check muted/placeholder ink on warm paper.",
+      "Do give every control a visible focus state (vermilion border / ring-2 ring-ink-accent) and a keyboard path; pair primary actions with a KeyHint."
+    ],
+    "donts": [
+      "Don't ship the default shadcn / Vercel SaaS admin look — no rounded cards, no drop shadows, no slate-gray dark mode.",
+      "Don't use AI-slop landing dressing: no cream-bg-by-reflex, no gradient text, no glassmorphism, no tiny uppercase tracked eyebrows, no hero-metric cards.",
+      "Don't drift toward a cold enterprise console or toward consumer-playful (bubbly corners, mascots, emoji, gamification).",
+      "Don't write box-shadow. If a surface needs to lift, it doesn't — give it a hairline.",
+      "Don't introduce a second accent hue or a neutral sans for chrome.",
+      "Don't accent two things on one screen. If everything is illuminated, nothing is."
+    ]
+  }
+}

--- a/.impeccable/live/config.json
+++ b/.impeccable/live/config.json
@@ -1,0 +1,6 @@
+{
+  "files": ["apps/dashboard/app/layout.tsx"],
+  "insertBefore": "</body>",
+  "commentSyntax": "jsx",
+  "cspChecked": true
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,95 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.13] — 2026-06-14
+
+Dashboard vault redesign, Phase 1 (the `/vault` surface of the `impeccable-redesign`
+work). The reading room finally reads like a reading room — editorial typography for
+the markdown reader, shadcn cards swapped for flat hairline editorial, keyboard-first
+stewardship wired (focus rings, destructive variant, `N`/`E`/`D`/`J`/`K`/`/` shortcuts),
+touch adaptation via `(pointer: coarse)`, and a substring filter for vaults too large
+to scroll. No behaviour or contract changes outside the `/vault` route; the rest of the
+dashboard is untouched and still wears its legacy chrome (queued for Phase 2).
+
+### Fixed
+
+- **Long lines in the vault diff view now wrap inside the column.** `DiffView` used
+  `whitespace-pre` per-line, so a prose-heavy diff (the vault is overwhelmingly notes,
+  not code) forced per-line horizontal scrolling on a 13" screen. Swapped to
+  `whitespace-pre-wrap` — indentation preserved, lines wrap on word boundaries,
+  `overflow-x-auto` stays as defensive backstop. Closes [#372](https://github.com/JimJafar/the-librarian/issues/372).
+
+### Added
+
+- **Editorial typography for the markdown reader.** New `.vault-prose` block in
+  `globals.css`: Newsreader 16px @ 1.75 leading capped at 68ch, Fraunces headings
+  (~1.25 ratio, balanced wrap, sharp), IBM Plex Mono inline code on the warm mono-fill
+  tint, pre blocks with hairline border + `pre-wrap`, real bullets with muted markers,
+  vermilion links with underline-offset, 1-px hairline blockquote rule, tabular-num
+  tables. The dashboard's dense 14px UI body stays untouched — only the reader opts
+  into the editorial measure. Replaces the dead `prose prose-sm` Tailwind classes
+  (typography plugin wasn't installed; the scoped CSS avoids the dep).
+- **`destructive` Button variant + focus-visible ring on every variant.** The ring is
+  the rubric accent (vermilion/saffron) with offset, applied to outline/primary/
+  destructive/ghost equally — keyboard users see the same one-mark-of-colour the rest
+  of the system reserves for current state. The destructive variant lands on the Delete
+  trigger and its confirm so an irreversible write looks like one; Restore stays primary
+  (a write, but a new commit, reversible).
+- **Per-action keyboard shortcuts on the vault surface.** `N` opens the new-file
+  dialog; `E` switches the file Tabs to Edit; `D` opens the Delete confirm; `J` / `K`
+  cycle the selected file through the (filtered) tree, wrap at both ends; `/` focuses
+  the tree filter (Esc clears + blurs). The handlers skip when focus is in an
+  input/textarea/contenteditable so typing into a search box never gets hijacked.
+  `KeyHint` badges render the mnemonic next to each action and hide on coarse
+  pointers (no keyboard, no need for the hint). The `<kbd>` is `aria-hidden` so the
+  accessible button name stays clean ("Delete", not "Delete D"). Shortcuts also
+  joined the global `?` cheatsheet so it's the single source of truth.
+- **Per-row pending state on tree links** via Next 15's `useLinkStatus` — only the
+  clicked row pulses a vermilion dot, not the whole tree. Honours `prefers-reduced-motion`.
+- **`(pointer: coarse)` adaptation.** Buttons, Tabs triggers, file-tree rows, dir
+  summaries, and backlinks all bump to ≥44 × 44 px on touch devices without changing
+  desktop density (verified at 28–36px desktop / 44–48px touch via Playwright
+  device-emulation). The KeyHint hides on coarse, the filter input bumps to 44px,
+  and the vault tree caps at `max-h-60 overflow-y-auto` on mobile once a file is
+  selected so a 30-file tree doesn't push content off the fold.
+- **Vault tree filter.** Substring match on the full path, case-insensitive, instant
+  (no debounce — 500 files is trivial). Pruned tree keeps directories whose subtree
+  has at least one match (path context preserved, not a flat result list); empty
+  filter passes the tree through unchanged. While a filter is active every `<details>`
+  re-mounts in the open state so matches inside collapsed dirs become visible — filter
+  clears, user's collapse state returns. `j`/`k` cycles the *filtered* list so the
+  user never lands on a hidden file. Empty match renders an inline "No files match …"
+  with one-tap clear. `filterTree` is exported and unit-tested directly (6 cases).
+
+### Changed
+
+- **Vault layout fix → accordion file history.** Contained the explorer overflow
+  (the unwrapped `<pre>` in a CSS grid track with `min-width: auto` was pushing the
+  Restore button off-screen): added `min-w-0` on the explorer content section, the
+  file-view article + aside, and the file-history list; restructured the file history
+  from a `lg:grid-cols-[1fr_2fr]` two-column layout into a single-column accordion
+  where each commit row expands in place to load its diff inline, one open at a time.
+- **Vault chrome migrated from shadcn cards to flat hairline editorial.** Header pill
+  is the `ui-v2` `Pill` component; Edit/History are now the `ui-v2` `Tabs` (with View
+  renamed to **Read**) so mode switching gets its canonical affordance, with Rename
+  and Delete sitting as file-level actions in the header; the article surface lost its
+  rounded card for hairline + paper-surface + sharp + generous padding; FrontmatterTable
+  and BacklinksPane lost their cards entirely, flowing as hairline-divided rows under
+  the DESIGN.md mono-label treatment (font-mono · 11px · uppercase · tracking 0.08em
+  · `foreground/60`). New-file + raw-markdown textareas: hairline + mono-fill + sharp +
+  ink-accent focus ring. Tree rows: sharp corners, `foreground/60` for inactive items.
+- **Design system context captured in-repo.** `PRODUCT.md` and `DESIGN.md` document
+  the "Reading Room" editorial system (warm-paper/ink palette, single
+  vermilion/saffron rubric, flat-by-default, Fraunces/Newsreader/IBM Plex Mono), with
+  `.impeccable/` carrying the live config + critique snapshots and `CLAUDE.md`
+  pointing future agents at both.
+
+### Tests
+
+- 13 new tests (256 dashboard tests total): 6 `filterTree` cases (passthrough,
+  case-insensitive, dir-prune, segment match, no-match, mixed root + dirs), 1
+  accordion-expand test for the new file-history shape, plus minor coverage updates.
+
 ## [1.0.0-rc.12] — 2026-06-14
 
 ### Fixed
@@ -1937,6 +2026,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0-rc.13]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.12...v1.0.0-rc.13
 [1.0.0-rc.12]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.11...v1.0.0-rc.12
 [1.0.0-rc.11]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.10...v1.0.0-rc.11
 [1.0.0-rc.10]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.9...v1.0.0-rc.10

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,3 +6,19 @@ Hermes, Pi). Read and follow them on every change. They're imported below so
 this file stays the Claude Code entrypoint without duplicating the rules.
 
 @AGENTS.md
+
+## Design Context
+
+The dashboard redesign (`apps/dashboard`) has a documented design system, set up
+with the Impeccable skill. Read these before touching any user-facing component:
+
+- **[PRODUCT.md](./PRODUCT.md)** — strategic: register (`product`), users,
+  purpose, brand personality (*editorial · scholarly · calm*), anti-references,
+  design principles, accessibility (WCAG 2.1 AA + full keyboard).
+- **[DESIGN.md](./DESIGN.md)** — visual: the *"Reading Room"* editorial system —
+  warm-paper/ink palette, single vermilion/saffron rubric accent, flat-by-default
+  (no shadows), sharp corners, Fraunces / Newsreader / IBM Plex Mono. Tokens in
+  the frontmatter are normative.
+
+Run `/impeccable critique`, `/impeccable polish`, or `/impeccable live` against a
+surface to iterate on it on-brand.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,365 @@
+---
+name: The Librarian Dashboard
+description: Editorial admin cockpit for a markdown-native agent-memory vault — a quiet reading room with the precision of an instrument.
+colors:
+  paper-body: "#f5f1e8"
+  paper-surface: "#faf7f0"
+  ink: "#1a1612"
+  mono-fill: "#ede7d8"
+  vermilion: "#d14b2a"
+  sage: "#7b8b6f"
+  hairline: "#1a16121f"
+  browser-chrome: "#061b22"
+typography:
+  display:
+    fontFamily: "Fraunces, Georgia, serif"
+    fontSize: "1.25rem"
+    fontWeight: 400
+    lineHeight: 1.15
+    letterSpacing: "-0.01em"
+  title:
+    fontFamily: "Fraunces, Georgia, serif"
+    fontSize: "1.125rem"
+    fontWeight: 500
+    lineHeight: 1.2
+    letterSpacing: "-0.01em"
+  body:
+    fontFamily: "Newsreader, Georgia, serif"
+    fontSize: "0.875rem"
+    fontWeight: 400
+    lineHeight: 1.5
+  data:
+    fontFamily: "IBM Plex Mono, ui-monospace, monospace"
+    fontSize: "0.8125rem"
+    fontWeight: 400
+    lineHeight: 1.4
+  label:
+    fontFamily: "IBM Plex Mono, ui-monospace, monospace"
+    fontSize: "0.6875rem"
+    fontWeight: 500
+    letterSpacing: "0.08em"
+rounded:
+  sharp: "0px"
+  legacy: "0.5rem"
+spacing:
+  xs: "4px"
+  sm: "8px"
+  md: "12px"
+  lg: "16px"
+  xl: "24px"
+components:
+  button-outline:
+    backgroundColor: "transparent"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.sharp}"
+    padding: "6px 12px"
+    typography: "{typography.body}"
+  button-primary:
+    backgroundColor: "transparent"
+    textColor: "{colors.vermilion}"
+    rounded: "{rounded.sharp}"
+    padding: "6px 12px"
+    typography: "{typography.body}"
+  input-underline:
+    backgroundColor: "transparent"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.sharp}"
+    padding: "6px 4px"
+    typography: "{typography.body}"
+  pill-default:
+    backgroundColor: "{colors.mono-fill}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.sharp}"
+    padding: "2px 6px"
+    typography: "{typography.label}"
+  pill-accent:
+    backgroundColor: "transparent"
+    textColor: "{colors.vermilion}"
+    rounded: "{rounded.sharp}"
+    padding: "2px 6px"
+  table-cell:
+    textColor: "{colors.ink}"
+    typography: "{typography.data}"
+    height: "32px"
+    padding: "0 8px"
+  dialog-content:
+    backgroundColor: "{colors.paper-surface}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.sharp}"
+    padding: "24px"
+---
+
+# Design System: The Librarian Dashboard
+
+## 1. Overview
+
+**Creative North Star: "The Reading Room"**
+
+A quiet research library, rendered with the exactness of a technical instrument.
+The body is warm paper, the text is ink, and rules are hairlines drawn at 1px —
+the chrome recedes so the corpus is what you see. The mood is the one PRODUCT.md
+names: *editorial · scholarly · calm*. But "calm" here is not "soft": the surface
+is crisp and precise, mono-forward for every machine-generated string, closer to
+a well-set reference work or an instrument panel than to anything hand-made or
+decorative. The operator is a steward curating a living knowledge graph; the
+interface behaves like good library furniture — it disappears into the task.
+
+There is exactly one mark of colour, and it is the rubricator's pen: **vermilion**
+in the light *Manuscript* theme, **saffron** in the dark *Scriptorium* theme.
+It is spent only on the single primary action of a view and on the current
+selection. Everywhere else the system works in paper, ink, and hairline. Depth is
+never a drop shadow — it is a tonal shift or a 1px rule.
+
+This system explicitly **rejects** the things PRODUCT.md rules out. It is **not**
+a default shadcn / Vercel SaaS admin — no rounded cards, no drop shadows, no
+slate-gray dark mode. It is **not** AI-slop landing dressing — no cream-bg-by-
+reflex, no gradient text, no glassmorphism, no tiny uppercase tracked eyebrows
+over every block, no hero-metric cards. It is **not** a cold enterprise console
+(density for its own sake, gray and joyless), and it is **not** consumer-playful
+(bubbly corners, mascots, emoji, gamification).
+
+**Key Characteristics:**
+
+- Warm paper + ink, two themes (light *Manuscript* default, dark *Scriptorium*).
+- A single rubric accent — vermilion / saffron — reserved for the one real action and current state.
+- Flat by default: no shadows, ever. Separation is a hairline or a tonal wash.
+- Sharp corners (0px radius) on editorial components.
+- A three-face editorial type system: Fraunces (display), Newsreader (body), IBM Plex Mono (machine strings).
+- Dense, keyboard-first: ⌘K palette, `j/k` navigation, inline `KeyHint` shortcuts.
+
+## 2. Colors: The Manuscript & Scriptorium Palette
+
+A warm-paper neutral field with a single illuminated accent. Two themes share
+every component shape; only the palette swaps.
+
+### Primary
+
+- **Vermilion** (`#d14b2a`, light) / **Saffron** (`#e6a33d`, dark): the rubricator's
+  pen. The primary-action button outline and text, the active tab underline, the
+  selected-row wash (at ~8% opacity), the focus ring, the inline `KeyHint` border,
+  the accent `Pill`. Token: `--ink-accent`. This is the only hue in the system.
+
+### Secondary
+
+- **Sage** (`#7b8b6f`, light) / **Sage** (`#7a8b5c`, dark): a desaturated green-gray
+  for *secondary / paused / muted* state only — e.g. a paused curator, a
+  superseded memory. Token: `--ink-accent-subdued`. It is a state colour, never
+  decoration, and never competes with the rubric accent.
+
+### Neutral
+
+- **Ink** (`#1a1612`, light) / **Parchment Ink** (`#e8e0d0`, dark): the single
+  foreground. All text, all icons. Lower opacities (`/70`, `/60`, `/40`) step it
+  back for secondary text, labels, and placeholders. Token: `--foreground`.
+- **Paper — Body** (`#f5f1e8`, light) / **#1c1814** (dark): the page field, behind
+  everything. Token: `--background`.
+- **Paper — Surface** (`#faf7f0`, light) / **#231e18** (dark): raised reading
+  surfaces — dialogs, popovers, the editorial card fill. One step warmer/lighter
+  than the body. Token: `--ink-surface`.
+- **Mono Fill** (`#ede7d8`, light) / **#2a241d** (dark): the fill behind mono
+  chips and id tokens. Token: `--ink-mono-fill`.
+- **Hairline** (`#1a1612` at 12%, light) / **#e8e0d0** at 14% (dark): the only
+  divider. Token: `--ink-hairline`.
+- **Browser Chrome** (`#061b22`): a deep petrol used *only* for the mobile
+  browser theme-color bar and the PWA tile — never a UI surface. Listed so it
+  isn't mistaken for an in-app colour.
+
+### Named Rules
+
+**The One Pen Rule.** The rubric accent (vermilion / saffron) carries the single
+primary action of a view and the current selection — nothing else. If two things
+on a screen are accented, one of them is wrong. Its rarity is the signal.
+
+**The Warm Paper Rule.** The body is warm paper (`#f5f1e8`), chosen deliberately
+for a tool meant for slow, careful work — it is **not** the cream-by-reflex of a
+generated landing page. Warmth is carried by paper + ink + the rubric accent, so
+do **not** tint every surface "because the brand feels warm." Surfaces step in
+tone, not in hue.
+
+## 3. Typography
+
+**Display Font:** Fraunces (with Georgia, serif)
+**Body Font:** Newsreader (with Georgia, serif)
+**Label / Mono Font:** IBM Plex Mono (with ui-monospace)
+
+> The licensed target faces are **PP Editorial New** (display) and **PP Neue
+> Montreal** (text); Fraunces + Newsreader are the free fallback shipping today
+> and the swap-in is a one-liner in `app/layout.tsx` once the licence lands.
+
+**Character:** Two serifs and a mono, not a serif-plus-sans. Fraunces is a
+high-contrast display serif with optical sizing and a little wonk; Newsreader is
+a calm, screen-tuned reading serif. They share a spine but differ in voice
+(display vs. text), and IBM Plex Mono supplies the hard contrast axis. The result
+reads as a set page, not an app shell — yet every machine string stays
+unmistakably mechanical.
+
+### Hierarchy
+
+- **Display** (Fraunces, 400, ~1.25–1.5rem, `-0.01em`, line-height 1.15): page and
+  surface titles, the `Inspector` heading (`text-xl`). Fixed rem, never `clamp()`
+  — this is product UI, not a hero.
+- **Title** (Fraunces, 500, 1.125rem, `tracking-tight`): dialog titles, section
+  heads.
+- **Body** (Newsreader, 400, 0.875rem, line-height 1.5): prose, descriptions, and
+  — distinctively — control labels and button text (`font-sans` resolves to
+  Newsreader). Cap reading prose at 65–75ch.
+- **Data** (IBM Plex Mono, 400, 0.8125rem): table cells, the dense list surfaces.
+- **Label** (IBM Plex Mono, 500, 0.6875rem, `0.08em`, uppercase): table column
+  heads (`text-foreground/60`), eyebrow-scale metadata. KeyHint drops to 10px.
+
+### Named Rules
+
+**The Mono-for-Machines Rule.** Every machine-generated string — ids (`mem_…`,
+`ses_…`), timestamps, tokens, counts, query chips, raw values in a filter — is
+set in IBM Plex Mono. Prose and headings are the serifs. The mono / serif split
+is how the eye tells *human* from *machine* at a glance; never set an id in serif
+or a sentence in mono.
+
+**The Serif Spine Rule.** This UI does not reach for a neutral sans for "chrome."
+Buttons, labels, and inputs are set in Newsreader on purpose; a sans default here
+would erase the editorial voice and pull the surface back toward generic admin.
+
+## 4. Elevation
+
+**Flat by default — there are no shadows in this system.** Not on cards, not on
+dialogs, not on the nav. Depth is conveyed two ways only: a **hairline** (1px at
+12% ink) or a **tonal wash** (foreground at a low alpha). The `Dialog` floats over
+a `bg-black/50` overlay and a fill of `paper-surface` with a hairline border — and
+no shadow at all. If you find yourself writing `box-shadow`, you have left the
+system.
+
+### Tonal Layering Vocabulary
+
+- **Inspector / rail fill** (`foreground / 2%`): the right-rail detail panel reads
+  as a quieter plane than the content.
+- **Row hover** (`foreground / 3%`): the only feedback a table row needs.
+- **Chip / pill fill** (`foreground / 6%`, or the `mono-fill` token): a machine
+  string sits in a faint wash, not a bordered box.
+- **Selected row** (`vermilion / 8%`): selection is the accent, barely tinted.
+
+### Named Rules
+
+**The Flat-By-Default Rule.** Surfaces are flat at rest and flat in motion.
+Separation is a hairline or a tonal step — never a shadow, never a glow, never a
+blur. A "card" in this system is paper bounded by a hairline, not a lifted slab.
+
+## 5. Components
+
+Every editorial component shares a vocabulary: sharp corners, hairline edges, ink
+on paper, and the rubric accent held in reserve. They live under
+`components/ui-v2/` and are drop-in replacements for the legacy shadcn set during
+the rolling D1.x migration.
+
+### Buttons
+
+- **Shape:** square (`0px` radius). No drop shadow.
+- **Outline (default):** transparent fill, 1px `foreground/20` border, ink text;
+  hover lifts a `foreground/4%` wash. The everyday action.
+- **Primary:** transparent fill, 1px **vermilion** border and vermilion text;
+  hover `vermilion/6%`. Exactly one per surface — the One Pen Rule applied to
+  action.
+- **Ghost:** transparent border, ink text, `foreground/4%` hover. For toolbar /
+  inline actions.
+- **Padding:** `6px 12px`; `text-sm`; `disabled:opacity-50`.
+
+### Chips & Pills
+
+- **Pill — default:** mono text in a faint fill (`mono-fill`), square corners,
+  `2px 6px`. For ids, timestamps, event types. *(The current stub uses a
+  `foreground/6%` wash pending wiring to the `mono-fill` token.)*
+- **Pill — accent:** vermilion text + vermilion hairline border, sans. The one
+  state per view that matters.
+- **Pill — muted:** sage text + sage border. Secondary / paused state.
+- **FilterChip:** a `label` (sans, `foreground/70`) + `value` (mono, ink) in a
+  `foreground/3%` box with a `foreground/15` border and a `×` remove handle that
+  reddens to vermilion on hover.
+
+### Inputs / Fields
+
+- **Style:** no box. A single hairline **bottom** border (`--ink-hairline`),
+  transparent fill, ink text, `text-sm`. A `mono` variant sets technical input in
+  IBM Plex Mono.
+- **Focus:** the bottom border becomes **vermilion** (`focus:border-ink-accent`);
+  no ring, no glow. Crisp, instrument-like.
+- **Placeholder:** `foreground/40` — verify this clears 4.5:1 on paper; bump toward
+  ink if it doesn't.
+
+### Tables
+
+- **The signature surface.** No card chrome. 32px rows, `13px` mono/sans body,
+  `11px` uppercase mono column heads at `foreground/60`.
+- **Separators:** a hairline under the header and under every row — no vertical
+  rules, no zebra.
+- **States:** row hover `foreground/3%`; selected row `vermilion/8%` via
+  `data-state="selected"`.
+
+### Navigation
+
+- **Top bar only.** A persistent strip with a hairline bottom edge over a
+  `bg-muted/20` field; the monochrome line-art mark at left, tab links, then
+  version badge / theme toggle / sign-out at right. Active tab: `bg-background` +
+  `text-foreground`; inactive: `foreground/60` → `foreground` on hover. Collapses
+  behind a hamburger below `md`.
+- **Tabs (in-page):** Radix tabs with a hairline strip; the active trigger carries
+  a 2px **vermilion** underline (`border-b-2`) and ink text; focus shows a 2px
+  vermilion ring.
+
+### Dialog
+
+Radix dialog, editorial chrome: `paper-surface` fill, 1px hairline border, **no
+shadow**, `24px` padding, a Fraunces (`font-display`) title, and a hairline-ruled
+header and footer. Overlay is `black/50` with a plain fade — no scale, no blur.
+
+### Inspector (signature)
+
+The right-rail detail panel every list surface drops selected-row content into: a
+hairline left border, a `foreground/2%` fill, a Fraunces `text-xl` title, and a
+scrollable ink body. Collapse + the `[` shortcut are part of its contract.
+
+### KeyHint (signature)
+
+A small `kbd` set in IBM Plex Mono `10px` uppercase with a `vermilion/40` border
+and vermilion text, rendered inline beside an action so the operator learns the
+shortcut without opening the cheatsheet. The literal expression of keyboard-first
+stewardship.
+
+### Named Rules
+
+**The Sharp Corner Rule.** Editorial components have a `0px` radius. A rounded
+card is the single fastest way to make this surface read as default shadcn — so
+corners are square unless a Radix primitive ships otherwise.
+
+## 6. Do's and Don'ts
+
+### Do:
+
+- **Do** reserve the rubric accent (vermilion `#d14b2a` / saffron `#e6a33d`) for
+  the one primary action and the current selection — the One Pen Rule.
+- **Do** set every machine string (ids, timestamps, tokens, counts) in IBM Plex
+  Mono, and all prose / labels in the serifs.
+- **Do** separate with a hairline (`--ink-hairline`, 1px @ 12%) or a tonal wash
+  (`foreground/2–6%`). Depth is tone, never shadow.
+- **Do** keep corners square (`rounded-none`) on editorial components.
+- **Do** step surfaces in **tone** (paper-body → paper-surface → mono-fill), not
+  in hue.
+- **Do** verify contrast: body ≥4.5:1, large ≥3:1, and check muted/placeholder
+  ink on warm paper — it's the easy WCAG 2.1 AA miss here.
+- **Do** give every control a visible focus state (the vermilion border / `ring-2
+  ring-ink-accent`) and a keyboard path; pair primary actions with a `KeyHint`.
+
+### Don't:
+
+- **Don't** ship the default shadcn / Vercel SaaS admin look — no rounded cards,
+  no drop shadows, no slate-gray dark mode.
+- **Don't** use AI-slop landing dressing: no cream-bg-by-reflex, no gradient text
+  (`background-clip: text`), no glassmorphism, no tiny uppercase tracked eyebrows
+  over every section, no hero-metric cards.
+- **Don't** drift toward a cold enterprise console (gray, joyless, dense for its
+  own sake) or toward consumer-playful (bubbly corners, mascots, emoji,
+  gamification).
+- **Don't** write `box-shadow`. If a surface needs to lift, it doesn't — give it a
+  hairline.
+- **Don't** introduce a second accent hue or a neutral sans for chrome. Two serifs
+  + one mono + one rubric accent is the whole system.
+- **Don't** accent two things on one screen. If everything is illuminated, nothing
+  is.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,103 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+The **operator** who self-hosts The Librarian — typically a single, technical
+owner running the server for themselves and their AI agents. In the dashboard
+they are a **curator/steward**, not a passive viewer: they review what the
+resident curator proposed, accept or reject proposals, flag wrong or stale
+memories, edit vault files and the primer, manage handoffs, tokens, backups,
+and auth, and tune the curator's prompt addendums.
+
+Their context is **deliberate curation, not high-frequency monitoring.** They
+drop in to make considered decisions about a living knowledge graph that agents
+read from and write to — then leave. The dashboard is the *complete* admin
+surface (rethink: "operators never need git or Obsidian"), so trust and
+legibility matter more than dashboards-of-dashboards realtime telemetry.
+
+**Job to be done:** keep the agent-memory corpus accurate, well-organised, and
+trustworthy — approve/reject the curator's work, correct mistakes, and
+configure the system — without ever dropping to git, a database, or Obsidian.
+
+## Product Purpose
+
+The Librarian is a markdown-native, git-backed knowledge graph — a durable,
+portable **memory + handoff layer** for AI agents — served to any harness over
+MCP and tended by a resident "curator." The dashboard (Next.js, port 3000) is
+its admin cockpit: Memories, Proposals, Flagged, Archive, Handoffs, Analytics,
+the Curator cockpit, the Vault explorer/editor, Backups, Tokens, and Settings.
+
+It exists because agents need memory that is durable and human-auditable, and
+humans need a surface they can *trust* to oversee and steward that memory.
+**Success looks like:** the operator trusts the corpus, can curate it
+confidently in a few minutes, never needs to touch git or Obsidian, and feels
+like they are working inside a considered editorial tool — not a generic admin
+panel bolted onto a database.
+
+## Brand Personality
+
+**Editorial · scholarly · calm.**
+
+Voice: precise, literate, unhurried, craft-respecting. The product's governing
+metaphor is a **manuscript vault tended by a resident librarian** — paper, ink,
+hairlines, marginalia, a quiet reading room rather than a control panel. The
+two shipped themes name this directly: light **Manuscript** (warm paper, the
+default — it reads as a tool for slow, deliberate work) and dark
+**Scriptorium**.
+
+Emotional goal: **trust and quiet confidence.** The operator should feel like a
+careful steward of something valuable, never a button-masher in a noisy
+console. Restraint signals competence.
+
+## Anti-references
+
+This should explicitly NOT look like:
+
+- **Default shadcn / Vercel SaaS admin** — rounded cards, drop shadows,
+  slate-gray dark mode, the AI/template "starter dashboard" look. This is the
+  generic-admin feel the redesign exists to escape.
+- **AI-slop landing tropes** — cream-bg-by-default, gradient text,
+  glassmorphism, tiny uppercase tracked eyebrows above every section,
+  hero-metric cards.
+- **Cold enterprise console** — Datadog/Grafana density-for-its-own-sake; gray,
+  joyless, a dashboard of dashboards.
+- **Consumer-playful** — bubbly rounded corners, mascots, emoji, gamification.
+  Too cute for a serious curation tool.
+
+## Design Principles
+
+1. **Earned familiarity, distinctive voice.** Standard affordances behave
+   exactly as a fluent user expects — tables, command palette, forms, modals.
+   The editorial identity lives in the *material* (paper, ink, hairlines, sharp
+   corners, serif headings, mono for technical strings), never in reinventing
+   controls. Escape "generic admin" through character, not novelty.
+2. **The tool disappears into the task.** Curation is the point; the chrome
+   should recede. Density and clarity over decoration — every element earns its
+   place by serving a curatorial decision.
+3. **Practice what you preach.** This is the admin surface for a meticulously
+   curated knowledge system. The UI itself must feel curated, consistent, and
+   trustworthy; sloppiness here quietly undermines the product's entire claim.
+4. **Keyboard-first stewardship.** The operator does repeated review work — the
+   ⌘K palette, `j/k` navigation, per-surface shortcut map, and `?` overlay are
+   first-class, not afterthoughts.
+5. **Calm, not loud.** No urgency theatre, no gratuitous motion. The accent
+   (terracotta in light, ochre in dark) is reserved for the one real action and
+   current selection/state — never decoration.
+
+## Accessibility & Inclusion
+
+- **WCAG 2.1 AA.** Body text ≥4.5:1, large text ≥3:1, visible focus rings,
+  every control labelled. The warm-paper-with-muted-ink palette is exactly the
+  combination that fails contrast by accident — verify it, don't assume it.
+- **Full keyboard operation.** Everything reachable without a mouse: the ⌘K
+  command palette, `j/k` row navigation, the per-surface shortcut map, and the
+  `?` shortcuts overlay. Visible focus state on every interactive element.
+- **Reduced motion is baseline.** Motion conveys state, not decoration; every
+  animation ships a `prefers-reduced-motion` alternative (crossfade or instant).
+- **Two themes, parity in both.** Light **Manuscript** (default) and dark
+  **Scriptorium** via `next-themes`; contrast and state vocabulary must hold in
+  each.

--- a/apps/dashboard/app/globals.css
+++ b/apps/dashboard/app/globals.css
@@ -107,3 +107,207 @@
       "calt" 1;
   }
 }
+
+@layer components {
+  /* Editorial prose for the vault reader. Scoped so the dashboard's
+     dense 14px UI body stays where it is and only the markdown reader
+     gets the 16px / 65–75ch reading-room ramp. Replaces the dead
+     `prose prose-sm` no-ops (tailwindcss/typography isn't installed
+     and the system prefers a hand-tuned scale anyway). */
+  .vault-prose {
+    font-family: var(--font-body), Georgia, serif;
+    font-size: 1rem; /* 16px — primary reading content, not chrome */
+    line-height: 1.75; /* generous for paragraph reading */
+    color: var(--foreground);
+    max-width: 68ch;
+    text-wrap: pretty;
+    font-feature-settings:
+      "kern" 1,
+      "liga" 1,
+      "calt" 1;
+  }
+
+  /* Paragraph and block rhythm. Each block sets its own margin via a
+     type selector (specificity 0,1,1) so we beat Tailwind preflight's
+     `p { margin: 0 }` reset (0,0,1) without needing `!important`.
+     Headings set their own margins below. */
+  .vault-prose p,
+  .vault-prose ul,
+  .vault-prose ol,
+  .vault-prose pre,
+  .vault-prose blockquote,
+  .vault-prose table {
+    margin: 1.25em 0 0;
+  }
+
+  .vault-prose h1,
+  .vault-prose h2,
+  .vault-prose h3,
+  .vault-prose h4 {
+    font-family: var(--font-display), Georgia, serif;
+    font-weight: 500;
+    line-height: 1.2;
+    letter-spacing: -0.01em;
+    color: var(--foreground);
+    text-wrap: balance;
+  }
+
+  .vault-prose h1 {
+    font-size: 1.75rem; /* 28px */
+    margin-top: 0;
+    margin-bottom: 0.5em;
+  }
+
+  .vault-prose h2 {
+    font-size: 1.375rem; /* 22px */
+    margin-top: 1.75em;
+    margin-bottom: 0.5em;
+  }
+
+  .vault-prose h3 {
+    font-size: 1.125rem; /* 18px */
+    margin-top: 1.5em;
+    margin-bottom: 0.4em;
+  }
+
+  .vault-prose h4 {
+    font-size: 1rem;
+    font-weight: 600;
+    margin-top: 1.25em;
+    margin-bottom: 0.25em;
+  }
+
+  /* Tight first-heading: a doc that opens with a heading shouldn't push
+     the heading down by the > * + * gap. */
+  .vault-prose > :first-child {
+    margin-top: 0;
+  }
+
+  /* Reset only the paragraph margins that adjacent-sibling rules can't
+     reach (paragraphs inside list items, blockquotes). Top-level
+     paragraph spacing lives on `> * + *` above so it survives type
+     selectors that would otherwise out-specify the universal sibling. */
+  .vault-prose li > p,
+  .vault-prose blockquote > p {
+    margin: 0;
+  }
+
+  /* Links: the rubric accent earns its place on the one actionable token
+     in editorial prose. Underline with offset so descenders don't collide. */
+  .vault-prose a {
+    color: var(--ink-accent);
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 0.18em;
+    word-break: break-word;
+  }
+
+  .vault-prose a:hover {
+    text-decoration-thickness: 2px;
+  }
+
+  /* Inline code: mono on a paper-darker tint, sharp corners, no border.
+     Slightly under 1em so it sits visually flush with surrounding body. */
+  .vault-prose code {
+    font-family: var(--font-mono), ui-monospace, monospace;
+    font-size: 0.875em;
+    background-color: var(--ink-mono-fill);
+    padding: 0.1em 0.35em;
+    font-feature-settings: "liga" 0;
+  }
+
+  .vault-prose a code {
+    color: inherit;
+  }
+
+  /* Code blocks: hairline-bounded, mono, wrapping (per #372 — prose-heavy
+     vaults read better wrapped than horizontal-scrolled). overflow-x-auto
+     remains as a defensive measure for any single un-wrappable token. */
+  .vault-prose pre {
+    font-family: var(--font-mono), ui-monospace, monospace;
+    font-size: 0.8125rem;
+    line-height: 1.55;
+    background-color: var(--ink-mono-fill);
+    border: 1px solid var(--ink-hairline);
+    padding: 0.75rem 1rem;
+    overflow-x: auto;
+    white-space: pre-wrap;
+    max-width: 100%;
+  }
+
+  .vault-prose pre code {
+    background: none;
+    padding: 0;
+    font-size: inherit;
+  }
+
+  /* Lists: real bullets, not Tailwind reset's nothing. Indent enough that
+     the second line of a list item aligns with the first. */
+  .vault-prose ul,
+  .vault-prose ol {
+    padding-left: 1.5em;
+  }
+
+  .vault-prose ul {
+    list-style: disc;
+  }
+
+  .vault-prose ol {
+    list-style: decimal;
+  }
+
+  .vault-prose li {
+    margin-top: 0.4em;
+  }
+
+  .vault-prose li::marker {
+    color: color-mix(in oklab, var(--foreground) 55%, transparent);
+  }
+
+  .vault-prose li > p {
+    margin: 0;
+  }
+
+  /* Blockquote: the editorial pull-quote — a single hairline rule + italic.
+     Not a colored side-stripe; it's the system's separator at 1px. */
+  .vault-prose blockquote {
+    border-left: 1px solid var(--ink-hairline);
+    padding-left: 1em;
+    font-style: italic;
+    color: color-mix(in oklab, var(--foreground) 80%, transparent);
+  }
+
+  /* Horizontal rule: a true hairline, not the browser's beveled default. */
+  .vault-prose hr {
+    border: none;
+    border-top: 1px solid var(--ink-hairline);
+    margin: 2em 0;
+  }
+
+  /* Tables: hairline rows, numerals align. No box around the whole table —
+     editorial reading prefers open margins. */
+  .vault-prose table {
+    width: 100%;
+    border-collapse: collapse;
+    font-variant-numeric: tabular-nums;
+    font-size: 0.9375rem;
+  }
+
+  .vault-prose th,
+  .vault-prose td {
+    text-align: left;
+    padding: 0.5em 0.75em;
+    border-bottom: 1px solid var(--ink-hairline);
+  }
+
+  .vault-prose th {
+    font-weight: 500;
+    color: color-mix(in oklab, var(--foreground) 75%, transparent);
+  }
+
+  .vault-prose img {
+    max-width: 100%;
+    height: auto;
+    border: 1px solid var(--ink-hairline);
+  }
+}

--- a/apps/dashboard/components/keyboard-host.tsx
+++ b/apps/dashboard/components/keyboard-host.tsx
@@ -35,6 +35,7 @@ const SHORTCUTS: Array<{ keys: string; description: string }> = [
   { keys: "E", description: "Vault: edit current file" },
   { keys: "D", description: "Vault: delete current file" },
   { keys: "J / K", description: "Vault: next / previous file" },
+  { keys: "/", description: "Vault: filter the tree" },
 ];
 
 export function KeyboardHost() {

--- a/apps/dashboard/components/keyboard-host.tsx
+++ b/apps/dashboard/components/keyboard-host.tsx
@@ -28,6 +28,13 @@ const SHORTCUTS: Array<{ keys: string; description: string }> = [
   { keys: "G M", description: "Go to Memories" },
   { keys: "G H", description: "Go to Handoffs" },
   { keys: "Esc", description: "Close palette / overlay" },
+  // Per-surface (vault) — D1.x: harden. Listed here so the cheatsheet
+  // is the one place to look; the bindings themselves live with the
+  // surface they act on (vault-explorer + file-view).
+  { keys: "N", description: "Vault: new file" },
+  { keys: "E", description: "Vault: edit current file" },
+  { keys: "D", description: "Vault: delete current file" },
+  { keys: "J / K", description: "Vault: next / previous file" },
 ];
 
 export function KeyboardHost() {

--- a/apps/dashboard/components/ui-v2/button.tsx
+++ b/apps/dashboard/components/ui-v2/button.tsx
@@ -27,8 +27,11 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
   { variant = "outline", className = "", children, ...rest },
   ref,
 ) {
+  // Density is dense by default (operator at a keyboard) — coarse-pointer
+  // devices (touch screens) get a 44×44px tap area without changing the
+  // desktop's tight rhythm.
   const base =
-    "inline-flex items-center gap-2 rounded-none px-3 py-1.5 text-sm font-sans transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ink-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50";
+    "inline-flex items-center gap-2 rounded-none px-3 py-1.5 text-sm font-sans transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ink-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 pointer-coarse:min-h-11 pointer-coarse:px-4 pointer-coarse:py-2.5";
   return (
     <button ref={ref} className={`${base} ${variants[variant]} ${className}`.trim()} {...rest}>
       {children}

--- a/apps/dashboard/components/ui-v2/button.tsx
+++ b/apps/dashboard/components/ui-v2/button.tsx
@@ -1,12 +1,15 @@
-// Editorial-style button stub for the D1.x dashboard redesign.
+// Editorial-style button.
 //
 // Per spec: outline default, optional primary variant for the one
-// real action per surface. No drop shadows; hairline border + ink
-// foreground. Real interaction logic lives downstream in D1.1–D1.4.
+// real action per surface, destructive for irreversible writes,
+// ghost for tertiary affordances. No drop shadows; hairline border
+// + ink foreground. The focus-visible ring is the rubric accent so
+// keyboard users see the same one-mark-of-colour the rest of the
+// system reserves for current state.
 
 import { forwardRef, type ButtonHTMLAttributes } from "react";
 
-type Variant = "outline" | "primary" | "ghost";
+type Variant = "outline" | "primary" | "destructive" | "ghost";
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: Variant;
@@ -15,6 +18,8 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 const variants: Record<Variant, string> = {
   outline: "border border-foreground/20 bg-transparent text-foreground hover:bg-foreground/[0.04]",
   primary: "border border-ink-accent bg-transparent text-ink-accent hover:bg-ink-accent/[0.06]",
+  destructive:
+    "border border-destructive bg-transparent text-destructive hover:bg-destructive/[0.08]",
   ghost: "border border-transparent text-foreground hover:bg-foreground/[0.04]",
 };
 
@@ -23,7 +28,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
   ref,
 ) {
   const base =
-    "inline-flex items-center gap-2 rounded-none px-3 py-1.5 text-sm font-sans transition-colors disabled:cursor-not-allowed disabled:opacity-50";
+    "inline-flex items-center gap-2 rounded-none px-3 py-1.5 text-sm font-sans transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ink-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50";
   return (
     <button ref={ref} className={`${base} ${variants[variant]} ${className}`.trim()} {...rest}>
       {children}

--- a/apps/dashboard/components/ui-v2/key-hint.tsx
+++ b/apps/dashboard/components/ui-v2/key-hint.tsx
@@ -13,10 +13,13 @@ interface KeyHintProps {
 }
 
 export function KeyHint({ shortcut }: KeyHintProps) {
+  // Coarse pointers (touch) don't have a keyboard to invoke the shortcut,
+  // so the visual mnemonic is noise. Hide it there; the action stays
+  // tappable, just without the kbd hint cluttering the label.
   return (
     <kbd
       aria-hidden
-      className="ml-1 inline-flex min-w-[1.25rem] items-center justify-center border border-ink-accent/40 px-1 py-0 font-mono text-[10px] uppercase leading-none text-ink-accent"
+      className="ml-1 inline-flex min-w-[1.25rem] items-center justify-center border border-ink-accent/40 px-1 py-0 font-mono text-[10px] uppercase leading-none text-ink-accent pointer-coarse:hidden"
     >
       {shortcut}
     </kbd>

--- a/apps/dashboard/components/ui-v2/key-hint.tsx
+++ b/apps/dashboard/components/ui-v2/key-hint.tsx
@@ -3,8 +3,10 @@
 // Editorial direction: every action has a shortcut, and the shortcut
 // reads in vermilion (light) / saffron (dark) right next to its
 // trigger so the user doesn't have to invoke the cheatsheet to learn
-// the map. D1.4 wires the matching keypress; this stub just renders
-// the kbd element with the accent.
+// the map. The kbd is `aria-hidden` because it's a sighted mnemonic —
+// the canonical machine-readable form is `aria-keyshortcuts` on the
+// trigger itself, and including this in a button's accessible name
+// would read "Delete D" rather than "Delete" to screen readers.
 
 interface KeyHintProps {
   shortcut: string;
@@ -12,7 +14,10 @@ interface KeyHintProps {
 
 export function KeyHint({ shortcut }: KeyHintProps) {
   return (
-    <kbd className="ml-1 inline-flex min-w-[1.25rem] items-center justify-center border border-ink-accent/40 px-1 py-0 font-mono text-[10px] uppercase leading-none text-ink-accent">
+    <kbd
+      aria-hidden
+      className="ml-1 inline-flex min-w-[1.25rem] items-center justify-center border border-ink-accent/40 px-1 py-0 font-mono text-[10px] uppercase leading-none text-ink-accent"
+    >
       {shortcut}
     </kbd>
   );

--- a/apps/dashboard/components/ui-v2/tabs.tsx
+++ b/apps/dashboard/components/ui-v2/tabs.tsx
@@ -31,7 +31,7 @@ const TabsTrigger = forwardRef<
   return (
     <TabsPrimitive.Trigger
       ref={ref}
-      className={`-mb-px inline-flex h-9 items-center border-b-2 border-transparent px-1 text-sm font-medium text-foreground/60 transition-colors hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ink-accent disabled:cursor-not-allowed disabled:opacity-50 data-[state=active]:border-ink-accent data-[state=active]:text-foreground ${className}`.trim()}
+      className={`-mb-px inline-flex h-9 items-center border-b-2 border-transparent px-1 text-sm font-medium text-foreground/60 transition-colors hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ink-accent disabled:cursor-not-allowed disabled:opacity-50 data-[state=active]:border-ink-accent data-[state=active]:text-foreground pointer-coarse:h-11 pointer-coarse:px-3 pointer-coarse:text-base ${className}`.trim()}
       {...props}
     />
   );

--- a/apps/dashboard/components/vault/editor.tsx
+++ b/apps/dashboard/components/vault/editor.tsx
@@ -58,13 +58,13 @@ export function VaultEditor({
     <form onSubmit={submit} className="flex flex-col gap-3" aria-label={`Edit ${file.path}`}>
       <textarea
         aria-label="Raw markdown"
-        className="min-h-[320px] rounded-md border border-input bg-background p-3 font-mono text-xs"
+        className="min-h-[320px] border border-ink-hairline bg-ink-mono-fill p-3 font-mono text-xs leading-relaxed text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ink-accent"
         value={raw}
         onChange={(e) => setRaw(e.target.value)}
         spellCheck={false}
       />
       {budgeted ? (
-        <p className={`text-xs ${bytes > BYTE_CAP ? "text-destructive" : "text-muted-foreground"}`}>
+        <p className={`text-xs ${bytes > BYTE_CAP ? "text-destructive" : "text-foreground/60"}`}>
           {bytes} / {BYTE_CAP} bytes
         </p>
       ) : null}

--- a/apps/dashboard/components/vault/file-history.tsx
+++ b/apps/dashboard/components/vault/file-history.tsx
@@ -11,6 +11,7 @@
 // dependency-free, consistent with the dashboard's existing markdown-and-
 // tailwind posture.
 
+import { ChevronRight } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useState, useTransition } from "react";
 import type {
@@ -38,7 +39,7 @@ export interface HistoryActions {
 export function FileHistory({ path, actions }: { path: string; actions: HistoryActions }) {
   const [commits, setCommits] = useState<VaultFileCommit[] | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [selected, setSelected] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<string | null>(null);
   const [diff, setDiff] = useState<string | null>(null);
   const [, startTransition] = useTransition();
 
@@ -56,8 +57,18 @@ export function FileHistory({ path, actions }: { path: string; actions: HistoryA
     // deliberately out of the deps so an inline-object caller can't loop this.
   }, [path]);
 
-  const select = (commit: VaultFileCommit) => {
-    setSelected(commit.hash);
+  // Accordion: a commit row expands in place and loads its diff inline. The old
+  // two-column layout gave the unwrapped diff <pre> its own always-on column,
+  // and a long line blew that column (and the Restore button) past the
+  // viewport. Inline-on-demand keeps history single-column at every width; one
+  // row open at a time, re-clicking the open row collapses it.
+  const toggle = (commit: VaultFileCommit) => {
+    if (expanded === commit.hash) {
+      setExpanded(null);
+      setDiff(null);
+      return;
+    }
+    setExpanded(commit.hash);
     setDiff(null);
     startTransition(async () => {
       // "What this version changed": diff from the previous version in the
@@ -87,54 +98,60 @@ export function FileHistory({ path, actions }: { path: string; actions: HistoryA
   }
 
   return (
-    <div className="grid gap-6 lg:grid-cols-[1fr_2fr]">
-      <ol aria-label="File history" className="flex flex-col gap-1 text-sm">
-        {commits.map((commit) => (
-          <li key={commit.hash}>
+    <ol aria-label="File history" className="flex min-w-0 flex-col border-t border-ink-hairline">
+      {commits.map((commit) => {
+        const isOpen = expanded === commit.hash;
+        const regionId = `commit-${commit.hash.slice(0, 12)}`;
+        return (
+          <li key={commit.hash} className="border-b border-ink-hairline">
             <button
               type="button"
-              onClick={() => select(commit)}
-              aria-current={selected === commit.hash ? "true" : undefined}
-              className={`w-full rounded-md border px-3 py-2 text-left transition-colors ${
-                selected === commit.hash ? "border-foreground bg-muted" : "bg-card hover:bg-muted"
-              }`}
+              onClick={() => toggle(commit)}
+              aria-expanded={isOpen}
+              aria-controls={regionId}
+              className="flex w-full items-start gap-2.5 py-2.5 text-left transition-colors hover:bg-foreground/[0.03] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ink-accent"
             >
-              <span className="block truncate font-medium text-foreground">{commit.subject}</span>
-              <span className="block font-mono text-xs text-muted-foreground">
-                {commit.hash.slice(0, 12)} · {formatDate(commit.date)}
+              <ChevronRight
+                aria-hidden
+                className={`mt-0.5 h-4 w-4 shrink-0 text-foreground/40 transition-transform motion-reduce:transition-none ${
+                  isOpen ? "rotate-90" : ""
+                }`}
+              />
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-sm text-foreground">{commit.subject}</span>
+                <span className="block font-mono text-xs text-foreground/50">
+                  {commit.hash.slice(0, 12)} · {formatDate(commit.date)}
+                </span>
               </span>
             </button>
+            {isOpen ? (
+              <div
+                id={regionId}
+                role="region"
+                aria-label={`Changes in ${commit.hash.slice(0, 12)}`}
+                className="min-w-0 pb-3 pl-[26px]"
+              >
+                <div className="mb-2 flex items-center justify-between gap-2">
+                  <span className="font-mono text-xs text-foreground/50">
+                    What this version changed
+                  </span>
+                  <RestoreVersionDialog
+                    path={path}
+                    hash={commit.hash}
+                    onRestore={actions.restoreVersion}
+                  />
+                </div>
+                {diff === null ? (
+                  <p className="text-sm text-muted-foreground">Loading diff…</p>
+                ) : (
+                  <DiffView diff={diff} />
+                )}
+              </div>
+            ) : null}
           </li>
-        ))}
-      </ol>
-      <section aria-label="Version detail" className="flex flex-col gap-3">
-        {selected === null ? (
-          <p className="text-sm text-muted-foreground">
-            Select a commit to see what that version changed.
-          </p>
-        ) : (
-          <>
-            <div className="flex items-center gap-2">
-              <span className="font-mono text-xs text-muted-foreground">
-                {selected.slice(0, 12)}
-              </span>
-              <span className="ml-auto">
-                <RestoreVersionDialog
-                  path={path}
-                  hash={selected}
-                  onRestore={actions.restoreVersion}
-                />
-              </span>
-            </div>
-            {diff === null ? (
-              <p className="text-sm text-muted-foreground">Loading diff…</p>
-            ) : (
-              <DiffView diff={diff} />
-            )}
-          </>
-        )}
-      </section>
-    </div>
+        );
+      })}
+    </ol>
   );
 }
 
@@ -150,7 +167,7 @@ export function DiffView({ diff }: { diff: string }) {
   return (
     <pre
       aria-label="Unified diff"
-      className="overflow-x-auto rounded-md border bg-card p-3 font-mono text-xs leading-5"
+      className="max-w-full overflow-x-auto border border-ink-hairline bg-foreground/[0.03] p-3 font-mono text-xs leading-5"
     >
       {diff.split("\n").map((line, index) => (
         <span key={index} className={`block whitespace-pre ${diffLineClass(line)}`}>

--- a/apps/dashboard/components/vault/file-history.tsx
+++ b/apps/dashboard/components/vault/file-history.tsx
@@ -170,7 +170,7 @@ export function DiffView({ diff }: { diff: string }) {
       className="max-w-full overflow-x-auto border border-ink-hairline bg-foreground/[0.03] p-3 font-mono text-xs leading-5"
     >
       {diff.split("\n").map((line, index) => (
-        <span key={index} className={`block whitespace-pre ${diffLineClass(line)}`}>
+        <span key={index} className={`block whitespace-pre-wrap ${diffLineClass(line)}`}>
           {line || " "}
         </span>
       ))}

--- a/apps/dashboard/components/vault/file-tree.tsx
+++ b/apps/dashboard/components/vault/file-tree.tsx
@@ -25,9 +25,14 @@ function RowPending() {
 export function FileTree({
   nodes,
   selectedPath,
+  forceOpen = false,
 }: {
   nodes: VaultTreeNode[];
   selectedPath: string | null;
+  /** When true, every `<details>` directory is rendered open regardless
+   *  of any prior user-collapse — used while a filter is active so a
+   *  match inside a collapsed dir is still visible. */
+  forceOpen?: boolean;
 }) {
   if (nodes.length === 0) {
     return <p className="px-2 py-1 text-foreground/60">The vault is empty.</p>;
@@ -35,22 +40,39 @@ export function FileTree({
   return (
     <ul className="flex flex-col">
       {nodes.map((node) => (
-        <TreeNode key={node.path} node={node} selectedPath={selectedPath} />
+        <TreeNode key={node.path} node={node} selectedPath={selectedPath} forceOpen={forceOpen} />
       ))}
     </ul>
   );
 }
 
-function TreeNode({ node, selectedPath }: { node: VaultTreeNode; selectedPath: string | null }) {
+function TreeNode({
+  node,
+  selectedPath,
+  forceOpen,
+}: {
+  node: VaultTreeNode;
+  selectedPath: string | null;
+  forceOpen: boolean;
+}) {
   if (node.type === "dir") {
+    // Default: render `<details open>` (open by default, user can collapse).
+    // When `forceOpen` is true we re-mount via the `key` so any user-applied
+    // collapse is discarded and the dir's matches become visible — toggling
+    // the `open` attribute imperatively after user interaction desyncs with
+    // browser state, so re-mount is the predictable fix.
     return (
       <li>
-        <details open>
+        <details key={forceOpen ? "forced-open" : "user"} open>
           <summary className="cursor-pointer select-none px-2 py-1 font-medium text-foreground/80 pointer-coarse:min-h-11 pointer-coarse:py-3 pointer-coarse:text-base">
             {node.name}/
           </summary>
           <div className="ml-3 border-l border-ink-hairline pl-1">
-            <FileTree nodes={node.children ?? []} selectedPath={selectedPath} />
+            <FileTree
+              nodes={node.children ?? []}
+              selectedPath={selectedPath}
+              forceOpen={forceOpen}
+            />
           </div>
         </details>
       </li>

--- a/apps/dashboard/components/vault/file-tree.tsx
+++ b/apps/dashboard/components/vault/file-tree.tsx
@@ -15,7 +15,7 @@ export function FileTree({
   selectedPath: string | null;
 }) {
   if (nodes.length === 0) {
-    return <p className="px-2 py-1 text-muted-foreground">The vault is empty.</p>;
+    return <p className="px-2 py-1 text-foreground/60">The vault is empty.</p>;
   }
   return (
     <ul className="flex flex-col">
@@ -47,10 +47,10 @@ function TreeNode({ node, selectedPath }: { node: VaultTreeNode; selectedPath: s
       <Link
         href={`/vault?path=${encodeURIComponent(node.path)}`}
         aria-current={active ? "page" : undefined}
-        className={`block truncate rounded-sm px-2 py-1 ${
+        className={`block truncate px-2 py-1 transition-colors ${
           active
             ? "bg-foreground/[0.06] text-foreground"
-            : "text-muted-foreground hover:text-foreground"
+            : "text-foreground/60 hover:text-foreground"
         }`}
       >
         {node.name}

--- a/apps/dashboard/components/vault/file-tree.tsx
+++ b/apps/dashboard/components/vault/file-tree.tsx
@@ -4,8 +4,23 @@
 // files as links that select via the `?path=` search param. Server-sorted
 // (dirs first, then name); the component renders, never re-orders.
 
-import Link from "next/link";
+import Link, { useLinkStatus } from "next/link";
 import type { VaultTreeNode } from "@/components/vault/types";
+
+/** Subtle row-level loading dot — shows only while THIS row's Link is
+ *  resolving its destination. Renders a thin animated vermilion dot to
+ *  the right of the name. `useLinkStatus` is only valid as a descendant
+ *  of a Link, hence the inner component. */
+function RowPending() {
+  const { pending } = useLinkStatus();
+  if (!pending) return null;
+  return (
+    <span
+      aria-hidden
+      className="ml-auto inline-block h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-ink-accent motion-reduce:animate-none"
+    />
+  );
+}
 
 export function FileTree({
   nodes,
@@ -47,13 +62,14 @@ function TreeNode({ node, selectedPath }: { node: VaultTreeNode; selectedPath: s
       <Link
         href={`/vault?path=${encodeURIComponent(node.path)}`}
         aria-current={active ? "page" : undefined}
-        className={`block truncate px-2 py-1 transition-colors ${
+        className={`flex min-w-0 items-center gap-2 px-2 py-1 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ink-accent ${
           active
             ? "bg-foreground/[0.06] text-foreground"
             : "text-foreground/60 hover:text-foreground"
         }`}
       >
-        {node.name}
+        <span className="truncate">{node.name}</span>
+        <RowPending />
       </Link>
     </li>
   );

--- a/apps/dashboard/components/vault/file-tree.tsx
+++ b/apps/dashboard/components/vault/file-tree.tsx
@@ -46,7 +46,7 @@ function TreeNode({ node, selectedPath }: { node: VaultTreeNode; selectedPath: s
     return (
       <li>
         <details open>
-          <summary className="cursor-pointer select-none px-2 py-1 font-medium text-foreground/80">
+          <summary className="cursor-pointer select-none px-2 py-1 font-medium text-foreground/80 pointer-coarse:min-h-11 pointer-coarse:py-3 pointer-coarse:text-base">
             {node.name}/
           </summary>
           <div className="ml-3 border-l border-ink-hairline pl-1">
@@ -62,7 +62,7 @@ function TreeNode({ node, selectedPath }: { node: VaultTreeNode; selectedPath: s
       <Link
         href={`/vault?path=${encodeURIComponent(node.path)}`}
         aria-current={active ? "page" : undefined}
-        className={`flex min-w-0 items-center gap-2 px-2 py-1 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ink-accent ${
+        className={`flex min-w-0 items-center gap-2 px-2 py-1 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ink-accent pointer-coarse:min-h-11 pointer-coarse:py-3 pointer-coarse:text-base ${
           active
             ? "bg-foreground/[0.06] text-foreground"
             : "text-foreground/60 hover:text-foreground"

--- a/apps/dashboard/components/vault/file-view.tsx
+++ b/apps/dashboard/components/vault/file-view.tsx
@@ -172,7 +172,7 @@ function BacklinksPane({ backlinks }: { backlinks: string[] }) {
             <li key={path}>
               <Link
                 href={`/vault?path=${encodeURIComponent(path)}`}
-                className="break-all font-mono text-xs text-ink-accent underline underline-offset-2 hover:decoration-2"
+                className="block break-all font-mono text-xs text-ink-accent underline underline-offset-2 hover:decoration-2 pointer-coarse:min-h-11 pointer-coarse:py-2 pointer-coarse:text-sm"
               >
                 {path}
               </Link>

--- a/apps/dashboard/components/vault/file-view.tsx
+++ b/apps/dashboard/components/vault/file-view.tsx
@@ -48,7 +48,7 @@ export function FileView({ file, actions }: { file: VaultFile; actions: VaultAct
   return (
     <div className="flex flex-col gap-4">
       <header className="flex flex-wrap items-center gap-2">
-        <h2 className="font-mono text-sm text-foreground">{file.path}</h2>
+        <h2 className="min-w-0 break-all font-mono text-sm text-foreground">{file.path}</h2>
         <span className="rounded-sm border border-ink-hairline px-1.5 py-0.5 text-xs uppercase text-muted-foreground">
           {file.kind}
         </span>
@@ -76,10 +76,10 @@ export function FileView({ file, actions }: { file: VaultFile; actions: VaultAct
         <FileHistory path={file.path} actions={actions} />
       ) : (
         <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
-          <article className="rounded-md border bg-card p-6">
+          <article className="min-w-0 rounded-md border bg-card p-6">
             <MarkdownContent body={file.body} links={file.links} />
           </article>
-          <aside className="flex flex-col gap-4">
+          <aside className="flex min-w-0 flex-col gap-4">
             {file.frontmatter ? <FrontmatterTable frontmatter={file.frontmatter} /> : null}
             <BacklinksPane backlinks={file.backlinks} />
             <p className="text-xs text-muted-foreground">Last modified {file.mtime}</p>
@@ -134,7 +134,7 @@ function BacklinksPane({ backlinks }: { backlinks: string[] }) {
             <li key={path}>
               <Link
                 href={`/vault?path=${encodeURIComponent(path)}`}
-                className="font-mono text-xs underline"
+                className="break-all font-mono text-xs underline"
               >
                 {path}
               </Link>

--- a/apps/dashboard/components/vault/file-view.tsx
+++ b/apps/dashboard/components/vault/file-view.tsx
@@ -24,6 +24,8 @@ import {
   DialogTitle,
 } from "@/components/ui-v2/dialog";
 import { Input } from "@/components/ui-v2/input";
+import { Pill } from "@/components/ui-v2/pill";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui-v2/tabs";
 import { VaultEditor } from "@/components/vault/editor";
 import { FileHistory, type HistoryActions } from "@/components/vault/file-history";
 import { MarkdownContent } from "@/components/vault/markdown-content";
@@ -47,45 +49,45 @@ export function FileView({ file, actions }: { file: VaultFile; actions: VaultAct
 
   return (
     <div className="flex flex-col gap-4">
-      <header className="flex flex-wrap items-center gap-2">
+      <header className="flex flex-wrap items-center gap-3">
         <h2 className="min-w-0 break-all font-mono text-sm text-foreground">{file.path}</h2>
-        <span className="rounded-sm border border-ink-hairline px-1.5 py-0.5 text-xs uppercase text-muted-foreground">
+        <Pill variant="default" className="uppercase">
           {file.kind}
-        </span>
+        </Pill>
         <span className="ml-auto flex items-center gap-2">
-          {mode === "edit" ? null : (
-            <Button variant="outline" onClick={() => setMode("edit")}>
-              Edit
-            </Button>
-          )}
-          <Button
-            variant="outline"
-            aria-pressed={mode === "history"}
-            onClick={() => setMode(mode === "history" ? "view" : "history")}
-          >
-            History
-          </Button>
           <RenameDialog path={file.path} onRename={actions.rename} />
           <DeleteDialog path={file.path} onDelete={actions.remove} />
         </span>
       </header>
 
-      {mode === "edit" ? (
-        <VaultEditor file={file} onSave={actions.save} onDone={() => setMode("view")} />
-      ) : mode === "history" ? (
-        <FileHistory path={file.path} actions={actions} />
-      ) : (
-        <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
-          <article className="min-w-0 rounded-md border bg-card p-6">
-            <MarkdownContent body={file.body} links={file.links} />
-          </article>
-          <aside className="flex min-w-0 flex-col gap-4">
-            {file.frontmatter ? <FrontmatterTable frontmatter={file.frontmatter} /> : null}
-            <BacklinksPane backlinks={file.backlinks} />
-            <p className="text-xs text-muted-foreground">Last modified {file.mtime}</p>
-          </aside>
-        </div>
-      )}
+      <Tabs value={mode} onValueChange={(next) => setMode(next as FileViewMode)}>
+        <TabsList aria-label="File mode">
+          <TabsTrigger value="view">Read</TabsTrigger>
+          <TabsTrigger value="edit">Edit</TabsTrigger>
+          <TabsTrigger value="history">History</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="view">
+          <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+            <article className="min-w-0 border border-ink-hairline bg-ink-surface px-7 py-8">
+              <MarkdownContent body={file.body} links={file.links} />
+            </article>
+            <aside className="flex min-w-0 flex-col gap-6">
+              {file.frontmatter ? <FrontmatterTable frontmatter={file.frontmatter} /> : null}
+              <BacklinksPane backlinks={file.backlinks} />
+              <p className="text-xs text-foreground/60">Last modified {file.mtime}</p>
+            </aside>
+          </div>
+        </TabsContent>
+
+        <TabsContent value="edit">
+          <VaultEditor file={file} onSave={actions.save} onDone={() => setMode("view")} />
+        </TabsContent>
+
+        <TabsContent value="history">
+          <FileHistory path={file.path} actions={actions} />
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }
@@ -95,12 +97,14 @@ function FrontmatterTable({ frontmatter }: { frontmatter: Record<string, unknown
   const entries = Object.entries(frontmatter);
   if (entries.length === 0) return null;
   return (
-    <section aria-label="Frontmatter" className="rounded-md border bg-card p-4 text-sm">
-      <h3 className="mb-2 text-xs font-medium uppercase text-muted-foreground">Properties</h3>
-      <dl className="flex flex-col gap-2">
+    <section aria-label="Frontmatter" className="flex flex-col gap-3 text-sm">
+      <h3 className="font-mono text-[0.6875rem] font-medium uppercase tracking-[0.08em] text-foreground/60">
+        Properties
+      </h3>
+      <dl className="flex flex-col divide-y divide-ink-hairline">
         {entries.map(([key, value]) => (
-          <div key={key} className="flex flex-col">
-            <dt className="text-xs text-muted-foreground">{key}</dt>
+          <div key={key} className="flex flex-col gap-0.5 py-2 first:pt-0">
+            <dt className="text-xs text-foreground/60">{key}</dt>
             <dd className="break-all font-mono text-xs text-foreground">
               {formatFrontmatterValue(value)}
             </dd>
@@ -124,17 +128,19 @@ function formatFrontmatterValue(value: unknown): string {
 /** The "what links here" pane, from the server-built link index. */
 function BacklinksPane({ backlinks }: { backlinks: string[] }) {
   return (
-    <section aria-label="Backlinks" className="rounded-md border bg-card p-4 text-sm">
-      <h3 className="mb-2 text-xs font-medium uppercase text-muted-foreground">Backlinks</h3>
+    <section aria-label="Backlinks" className="flex flex-col gap-3 text-sm">
+      <h3 className="font-mono text-[0.6875rem] font-medium uppercase tracking-[0.08em] text-foreground/60">
+        Backlinks
+      </h3>
       {backlinks.length === 0 ? (
-        <p className="text-xs text-muted-foreground">Nothing links here.</p>
+        <p className="text-xs text-foreground/60">Nothing links here.</p>
       ) : (
-        <ul className="flex flex-col gap-1">
+        <ul className="flex flex-col gap-1.5">
           {backlinks.map((path) => (
             <li key={path}>
               <Link
                 href={`/vault?path=${encodeURIComponent(path)}`}
-                className="break-all font-mono text-xs underline"
+                className="break-all font-mono text-xs text-ink-accent underline underline-offset-2 hover:decoration-2"
               >
                 {path}
               </Link>

--- a/apps/dashboard/components/vault/file-view.tsx
+++ b/apps/dashboard/components/vault/file-view.tsx
@@ -8,7 +8,7 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 import type {
   RenameVaultFileResult,
   SaveVaultFileResult,
@@ -24,6 +24,7 @@ import {
   DialogTitle,
 } from "@/components/ui-v2/dialog";
 import { Input } from "@/components/ui-v2/input";
+import { KeyHint } from "@/components/ui-v2/key-hint";
 import { Pill } from "@/components/ui-v2/pill";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui-v2/tabs";
 import { VaultEditor } from "@/components/vault/editor";
@@ -46,6 +47,34 @@ type FileViewMode = "view" | "edit" | "history";
 
 export function FileView({ file, actions }: { file: VaultFile; actions: VaultActions }) {
   const [mode, setMode] = useState<FileViewMode>("view");
+  const deleteTriggerRef = useRef<HTMLButtonElement | null>(null);
+
+  // Per-surface shortcuts: E switches to Edit, D opens the delete confirm.
+  // Skip when focus is in an input/textarea/contenteditable so typing "e"
+  // into a search box doesn't yank the user out of their flow. The Tabs
+  // own their own arrow-key cycling natively (Radix), so we don't compete.
+  useEffect(() => {
+    function handler(event: KeyboardEvent) {
+      const target = event.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)
+      ) {
+        return;
+      }
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+      const key = event.key.toLowerCase();
+      if (key === "e") {
+        event.preventDefault();
+        setMode("edit");
+      } else if (key === "d") {
+        event.preventDefault();
+        deleteTriggerRef.current?.click();
+      }
+    }
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
 
   return (
     <div className="flex flex-col gap-4">
@@ -56,14 +85,17 @@ export function FileView({ file, actions }: { file: VaultFile; actions: VaultAct
         </Pill>
         <span className="ml-auto flex items-center gap-2">
           <RenameDialog path={file.path} onRename={actions.rename} />
-          <DeleteDialog path={file.path} onDelete={actions.remove} />
+          <DeleteDialog path={file.path} onDelete={actions.remove} triggerRef={deleteTriggerRef} />
         </span>
       </header>
 
       <Tabs value={mode} onValueChange={(next) => setMode(next as FileViewMode)}>
         <TabsList aria-label="File mode">
           <TabsTrigger value="view">Read</TabsTrigger>
-          <TabsTrigger value="edit">Edit</TabsTrigger>
+          <TabsTrigger value="edit">
+            Edit
+            <KeyHint shortcut="E" />
+          </TabsTrigger>
           <TabsTrigger value="history">History</TabsTrigger>
         </TabsList>
 
@@ -221,7 +253,15 @@ function RenameDialog({ path, onRename }: { path: string; onRename: VaultActions
   );
 }
 
-function DeleteDialog({ path, onDelete }: { path: string; onDelete: VaultActions["remove"] }) {
+function DeleteDialog({
+  path,
+  onDelete,
+  triggerRef,
+}: {
+  path: string;
+  onDelete: VaultActions["remove"];
+  triggerRef?: React.Ref<HTMLButtonElement>;
+}) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -242,8 +282,9 @@ function DeleteDialog({ path, onDelete }: { path: string; onDelete: VaultActions
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <Button variant="outline" onClick={() => setOpen(true)}>
+      <Button ref={triggerRef} variant="destructive" onClick={() => setOpen(true)}>
         Delete
+        <KeyHint shortcut="D" />
       </Button>
       <DialogContent>
         <DialogHeader>
@@ -258,7 +299,7 @@ function DeleteDialog({ path, onDelete }: { path: string; onDelete: VaultActions
           <Button type="button" variant="ghost" onClick={() => setOpen(false)}>
             Cancel
           </Button>
-          <Button type="button" variant="primary" onClick={confirm} disabled={pending}>
+          <Button type="button" variant="destructive" onClick={confirm} disabled={pending}>
             {pending ? "Deleting…" : "Delete file"}
           </Button>
         </DialogFooter>

--- a/apps/dashboard/components/vault/markdown-content.tsx
+++ b/apps/dashboard/components/vault/markdown-content.tsx
@@ -44,7 +44,7 @@ export function MarkdownContent({
   links: { target: string; path: string | null }[];
 }) {
   return (
-    <div className="prose prose-sm max-w-none text-sm leading-relaxed [&_a]:underline [&_code]:font-mono [&_h1]:text-lg [&_h2]:text-base [&_h3]:text-sm [&_li]:ml-4 [&_li]:list-disc [&_p]:my-2">
+    <div className="prose prose-sm min-w-0 max-w-none text-sm leading-relaxed [&_a]:break-words [&_a]:underline [&_code]:font-mono [&_h1]:text-lg [&_h2]:text-base [&_h3]:text-sm [&_li]:ml-4 [&_li]:list-disc [&_p]:my-2 [&_pre]:max-w-full [&_pre]:overflow-x-auto">
       <ReactMarkdown
         components={{
           a: ({ href, children }) =>

--- a/apps/dashboard/components/vault/markdown-content.tsx
+++ b/apps/dashboard/components/vault/markdown-content.tsx
@@ -43,8 +43,13 @@ export function MarkdownContent({
   body: string;
   links: { target: string; path: string | null }[];
 }) {
+  // The Reading Room: Newsreader body at 16px, Fraunces headings, IBM Plex
+  // Mono for code, capped at 68ch — the editorial reading ramp lives in
+  // `.vault-prose` (globals.css) so the dashboard's dense 14px UI body
+  // stays untouched. Replaces the old `prose prose-sm` no-ops (the
+  // typography plugin isn't installed).
   return (
-    <div className="prose prose-sm min-w-0 max-w-none text-sm leading-relaxed [&_a]:break-words [&_a]:underline [&_code]:font-mono [&_h1]:text-lg [&_h2]:text-base [&_h3]:text-sm [&_li]:ml-4 [&_li]:list-disc [&_p]:my-2 [&_pre]:max-w-full [&_pre]:overflow-x-auto">
+    <div className="vault-prose min-w-0">
       <ReactMarkdown
         components={{
           a: ({ href, children }) =>

--- a/apps/dashboard/components/vault/vault-explorer.tsx
+++ b/apps/dashboard/components/vault/vault-explorer.tsx
@@ -56,7 +56,7 @@ export function VaultExplorer({
           </nav>
         )}
       </aside>
-      <section>
+      <section className="min-w-0">
         {fileError ? (
           <p className="text-sm text-destructive">{fileError}</p>
         ) : file ? (

--- a/apps/dashboard/components/vault/vault-explorer.tsx
+++ b/apps/dashboard/components/vault/vault-explorer.tsx
@@ -2,11 +2,12 @@
 
 // The vault explorer layout (rethink T18/T19): tree sidebar + file panel.
 // Pure composition — the page fetched everything server-side; this component
-// owns only the "new file" dialog and hands the selected file to FileView.
+// owns the "new file" dialog and the j/k tree-navigation hook, and hands the
+// selected file to FileView.
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useState, useTransition } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react";
 import { Button } from "@/components/ui-v2/button";
 import {
   Dialog,
@@ -17,10 +18,29 @@ import {
   DialogFooter,
 } from "@/components/ui-v2/dialog";
 import { Input } from "@/components/ui-v2/input";
+import { KeyHint } from "@/components/ui-v2/key-hint";
 import { FileTree } from "@/components/vault/file-tree";
 import { FileView } from "@/components/vault/file-view";
 import type { VaultActions } from "@/components/vault/file-view";
 import type { VaultFile, VaultTreeNode } from "@/components/vault/types";
+
+/** Pre-order flatten of the tree to a stable list of file paths — the
+ *  shape j/k navigation needs. Directory nodes themselves aren't
+ *  selectable (they're container affordances), so we skip them. */
+function flattenFiles(nodes: VaultTreeNode[]): string[] {
+  const out: string[] = [];
+  const walk = (list: VaultTreeNode[]) => {
+    for (const node of list) {
+      if (node.type === "dir") {
+        if (node.children) walk(node.children);
+      } else {
+        out.push(node.path);
+      }
+    }
+  };
+  walk(nodes);
+  return out;
+}
 
 export function VaultExplorer({
   tree,
@@ -37,12 +57,64 @@ export function VaultExplorer({
   fileError: string | null;
   actions: VaultActions;
 }) {
+  const router = useRouter();
+  const flatPaths = useMemo(() => flattenFiles(tree), [tree]);
+  const newFileTriggerRef = useRef<HTMLButtonElement | null>(null);
+
+  // j/k cycles the selected file through the flattened tree. No selection
+  // yet (?path= unset) lands on the first file. Wraps at both ends — vim
+  // convention and easier to learn than "stop at the end."
+  const move = useCallback(
+    (delta: 1 | -1) => {
+      if (flatPaths.length === 0) return;
+      const currentIndex = selectedPath ? flatPaths.indexOf(selectedPath) : -1;
+      const nextIndex =
+        currentIndex === -1
+          ? delta === 1
+            ? 0
+            : flatPaths.length - 1
+          : (currentIndex + delta + flatPaths.length) % flatPaths.length;
+      const nextPath = flatPaths[nextIndex];
+      if (!nextPath) return; // unreachable given the empty-list guard above, but keeps the type narrow.
+      router.push(`/vault?path=${encodeURIComponent(nextPath)}`);
+    },
+    [flatPaths, selectedPath, router],
+  );
+
+  // Vault-page shortcuts: N opens New file; J / K move down / up through
+  // the file list. Skip when focus is in an input or contenteditable.
+  useEffect(() => {
+    function handler(event: KeyboardEvent) {
+      const target = event.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)
+      ) {
+        return;
+      }
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+      const key = event.key.toLowerCase();
+      if (key === "n") {
+        event.preventDefault();
+        newFileTriggerRef.current?.click();
+      } else if (key === "j") {
+        event.preventDefault();
+        move(1);
+      } else if (key === "k") {
+        event.preventDefault();
+        move(-1);
+      }
+    }
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [move]);
+
   return (
     <div className="grid gap-6 md:grid-cols-[260px_1fr]">
       <aside className="flex flex-col gap-3">
         <div className="flex items-center justify-between">
           <h1 className="font-display text-xl text-foreground">Vault</h1>
-          <NewFileDialog onCreate={actions.create} />
+          <NewFileDialog onCreate={actions.create} triggerRef={newFileTriggerRef} />
         </div>
         {/* The audit trail (rethink T21): the vault's git history + restore. */}
         <Link href="/vault/activity" className="text-sm underline">
@@ -75,7 +147,13 @@ export function VaultExplorer({
   );
 }
 
-function NewFileDialog({ onCreate }: { onCreate: VaultActions["create"] }) {
+function NewFileDialog({
+  onCreate,
+  triggerRef,
+}: {
+  onCreate: VaultActions["create"];
+  triggerRef?: React.Ref<HTMLButtonElement>;
+}) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
   const [path, setPath] = useState("");
@@ -99,8 +177,9 @@ function NewFileDialog({ onCreate }: { onCreate: VaultActions["create"] }) {
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <Button variant="outline" onClick={() => setOpen(true)}>
+      <Button ref={triggerRef} variant="outline" onClick={() => setOpen(true)}>
         New file
+        <KeyHint shortcut="N" />
       </Button>
       <DialogContent>
         <DialogHeader>

--- a/apps/dashboard/components/vault/vault-explorer.tsx
+++ b/apps/dashboard/components/vault/vault-explorer.tsx
@@ -125,7 +125,13 @@ export function VaultExplorer({
         ) : (
           <nav
             aria-label="Vault tree"
-            className="border border-ink-hairline bg-ink-surface p-2 text-sm"
+            // On mobile the tree sits above the file content; capping its
+            // height once a file is open keeps the content above the
+            // fold instead of forcing the user to scroll past 30 rows.
+            // Desktop (md+) returns to the natural full-height tree.
+            className={`border border-ink-hairline bg-ink-surface p-2 text-sm md:max-h-none md:overflow-visible ${
+              selectedPath ? "max-h-60 overflow-y-auto" : ""
+            }`}
           >
             <FileTree nodes={tree} selectedPath={selectedPath} />
           </nav>

--- a/apps/dashboard/components/vault/vault-explorer.tsx
+++ b/apps/dashboard/components/vault/vault-explorer.tsx
@@ -42,6 +42,30 @@ function flattenFiles(nodes: VaultTreeNode[]): string[] {
   return out;
 }
 
+/** Prune the tree to the nodes whose full path matches `query` (case-
+ *  insensitive substring on the file path). Directories with at least
+ *  one matching descendant are kept (with the matching subset only) so
+ *  the user sees the path context, not a flat result list. Exported
+ *  for direct unit testing — the visual filter is just a thin shell
+ *  around this function. */
+export function filterTree(nodes: VaultTreeNode[], query: string): VaultTreeNode[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return nodes;
+  const walk = (list: VaultTreeNode[]): VaultTreeNode[] => {
+    const out: VaultTreeNode[] = [];
+    for (const node of list) {
+      if (node.type === "dir") {
+        const kids = walk(node.children ?? []);
+        if (kids.length > 0) out.push({ ...node, children: kids });
+      } else if (node.path.toLowerCase().includes(q)) {
+        out.push(node);
+      }
+    }
+    return out;
+  };
+  return walk(nodes);
+}
+
 export function VaultExplorer({
   tree,
   treeError,
@@ -58,8 +82,15 @@ export function VaultExplorer({
   actions: VaultActions;
 }) {
   const router = useRouter();
-  const flatPaths = useMemo(() => flattenFiles(tree), [tree]);
+  const [filter, setFilter] = useState("");
+  const filterInputRef = useRef<HTMLInputElement | null>(null);
   const newFileTriggerRef = useRef<HTMLButtonElement | null>(null);
+
+  // Filter prunes the tree; j/k navigation follows the visible (filtered)
+  // list so cycling never lands on a hidden file. With an empty filter
+  // both memos pass through unchanged.
+  const filteredTree = useMemo(() => filterTree(tree, filter), [tree, filter]);
+  const flatPaths = useMemo(() => flattenFiles(filteredTree), [filteredTree]);
 
   // j/k cycles the selected file through the flattened tree. No selection
   // yet (?path= unset) lands on the first file. Wraps at both ends — vim
@@ -81,8 +112,10 @@ export function VaultExplorer({
     [flatPaths, selectedPath, router],
   );
 
-  // Vault-page shortcuts: N opens New file; J / K move down / up through
-  // the file list. Skip when focus is in an input or contenteditable.
+  // Vault-page shortcuts: N opens New file; J / K cycle the filtered list;
+  // `/` jumps focus to the filter (vim/GitHub convention). Skip when
+  // focus is already in an input/textarea/contenteditable so typing
+  // normally doesn't get hijacked.
   useEffect(() => {
     function handler(event: KeyboardEvent) {
       const target = event.target as HTMLElement | null;
@@ -93,6 +126,12 @@ export function VaultExplorer({
         return;
       }
       if (event.metaKey || event.ctrlKey || event.altKey) return;
+      if (event.key === "/") {
+        event.preventDefault();
+        filterInputRef.current?.focus();
+        filterInputRef.current?.select();
+        return;
+      }
       const key = event.key.toLowerCase();
       if (key === "n") {
         event.preventDefault();
@@ -123,18 +162,71 @@ export function VaultExplorer({
         {treeError ? (
           <p className="text-sm text-destructive">{treeError}</p>
         ) : (
-          <nav
-            aria-label="Vault tree"
-            // On mobile the tree sits above the file content; capping its
-            // height once a file is open keeps the content above the
-            // fold instead of forcing the user to scroll past 30 rows.
-            // Desktop (md+) returns to the natural full-height tree.
-            className={`border border-ink-hairline bg-ink-surface p-2 text-sm md:max-h-none md:overflow-visible ${
-              selectedPath ? "max-h-60 overflow-y-auto" : ""
-            }`}
-          >
-            <FileTree nodes={tree} selectedPath={selectedPath} />
-          </nav>
+          <>
+            <div className="relative">
+              <input
+                ref={filterInputRef}
+                type="search"
+                aria-label="Filter vault by path"
+                placeholder="Filter…"
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Escape") {
+                    setFilter("");
+                    e.currentTarget.blur();
+                  }
+                }}
+                className="w-full border border-ink-hairline bg-ink-surface px-2 py-1.5 font-mono text-xs text-foreground placeholder:text-foreground/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ink-accent pointer-coarse:min-h-11 pointer-coarse:py-2.5 pointer-coarse:text-sm"
+              />
+              {filter ? (
+                <button
+                  type="button"
+                  aria-label="Clear filter"
+                  onClick={() => {
+                    setFilter("");
+                    filterInputRef.current?.focus();
+                  }}
+                  className="absolute right-1.5 top-1/2 -translate-y-1/2 px-1.5 py-0.5 font-mono text-xs text-foreground/60 hover:text-foreground"
+                >
+                  ✕
+                </button>
+              ) : (
+                <span
+                  aria-hidden
+                  className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 pointer-coarse:hidden"
+                >
+                  <KeyHint shortcut="/" />
+                </span>
+              )}
+            </div>
+            <nav
+              aria-label="Vault tree"
+              // On mobile the tree sits above the file content; capping its
+              // height once a file is open keeps the content above the
+              // fold instead of forcing the user to scroll past 30 rows.
+              // Desktop (md+) returns to the natural full-height tree.
+              className={`border border-ink-hairline bg-ink-surface p-2 text-sm md:max-h-none md:overflow-visible ${
+                selectedPath ? "max-h-60 overflow-y-auto" : ""
+              }`}
+            >
+              {filteredTree.length === 0 ? (
+                <p className="px-2 py-1 text-foreground/60">
+                  No files match{" "}
+                  <span className="font-mono text-foreground">&ldquo;{filter}&rdquo;</span>.
+                </p>
+              ) : (
+                <FileTree
+                  nodes={filteredTree}
+                  selectedPath={selectedPath}
+                  // Filter active → force every dir open so matches inside
+                  // collapsed dirs become visible without the user clicking
+                  // through. Idle → respect user's collapse state.
+                  forceOpen={filter.trim().length > 0}
+                />
+              )}
+            </nav>
+          </>
         )}
       </aside>
       <section className="min-w-0">

--- a/apps/dashboard/components/vault/vault-explorer.tsx
+++ b/apps/dashboard/components/vault/vault-explorer.tsx
@@ -51,7 +51,10 @@ export function VaultExplorer({
         {treeError ? (
           <p className="text-sm text-destructive">{treeError}</p>
         ) : (
-          <nav aria-label="Vault tree" className="rounded-md border bg-card p-2 text-sm">
+          <nav
+            aria-label="Vault tree"
+            className="border border-ink-hairline bg-ink-surface p-2 text-sm"
+          >
             <FileTree nodes={tree} selectedPath={selectedPath} />
           </nav>
         )}
@@ -62,7 +65,7 @@ export function VaultExplorer({
         ) : file ? (
           <FileView file={file} actions={actions} />
         ) : (
-          <p className="text-sm text-muted-foreground">
+          <p className="text-sm text-foreground/60">
             Select a file to view it — memories, handoffs, references, curator addendums, and the
             primer all live here.
           </p>
@@ -122,7 +125,7 @@ function NewFileDialog({ onCreate }: { onCreate: VaultActions["create"] }) {
             Content
             <textarea
               aria-label="New file content"
-              className="min-h-[120px] rounded-md border border-input bg-background p-2 font-mono text-xs"
+              className="min-h-[120px] border border-ink-hairline bg-ink-mono-fill p-2 font-mono text-xs text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ink-accent"
               value={raw}
               onChange={(e) => setRaw(e.target.value)}
             />

--- a/apps/dashboard/tests/components/vault/file-history.test.tsx
+++ b/apps/dashboard/tests/components/vault/file-history.test.tsx
@@ -64,6 +64,20 @@ describe("FileHistory", () => {
     expect(await screen.findByLabelText("Unified diff")).toHaveTextContent("+# Doc v2");
   });
 
+  it("expands a commit inline and collapses it on a second click (accordion)", async () => {
+    render(<FileHistory path="references/doc.md" actions={actions()} />);
+    const row = await screen.findByRole("button", { name: /vault: edit references\/doc\.md/ });
+    expect(row).toHaveAttribute("aria-expanded", "false");
+
+    await userEvent.click(row);
+    expect(row).toHaveAttribute("aria-expanded", "true");
+    expect(await screen.findByLabelText("Unified diff")).toBeInTheDocument();
+
+    await userEvent.click(row);
+    expect(row).toHaveAttribute("aria-expanded", "false");
+    await vi.waitFor(() => expect(screen.queryByLabelText("Unified diff")).not.toBeInTheDocument());
+  });
+
   it("the oldest commit diffs from the file's birth (no `from`)", async () => {
     const acts = actions();
     render(<FileHistory path="references/doc.md" actions={acts} />);

--- a/apps/dashboard/tests/components/vault/file-view.test.tsx
+++ b/apps/dashboard/tests/components/vault/file-view.test.tsx
@@ -79,7 +79,9 @@ describe("FileView", () => {
 
   it("Edit toggles the raw editor pre-filled with the file text", async () => {
     render(<FileView file={memoryFile} actions={actions()} />);
-    await userEvent.click(screen.getByRole("button", { name: "Edit" }));
+    // Edit / Read / History are now tabs (D1.x polish) — Radix renders them
+    // as role=tab; Rename + Delete stay role=button since they open dialogs.
+    await userEvent.click(screen.getByRole("tab", { name: "Edit" }));
     expect(screen.getByLabelText("Raw markdown")).toHaveValue(memoryFile.raw);
   });
 

--- a/apps/dashboard/tests/components/vault/vault-explorer.test.tsx
+++ b/apps/dashboard/tests/components/vault/vault-explorer.test.tsx
@@ -1,0 +1,83 @@
+// Vault tree filter (rethink T18 + D1.x harden): substring-match prune
+// keeps directories whose subtree has at least one matching descendant
+// so the user gets path context, not a flat result list.
+
+import { describe, expect, it } from "vitest";
+import type { VaultTreeNode } from "@/components/vault/types";
+
+const { filterTree } = await import("@/components/vault/vault-explorer");
+
+const tree: VaultTreeNode[] = [
+  {
+    name: "memories",
+    path: "memories",
+    type: "dir",
+    children: [
+      {
+        name: "anna-1.md",
+        path: "memories/anna-1.md",
+        type: "file",
+        mtime: "2026-06-12T00:00:00.000Z",
+      },
+      {
+        name: "ben-2.md",
+        path: "memories/ben-2.md",
+        type: "file",
+        mtime: "2026-06-12T00:00:00.000Z",
+      },
+    ],
+  },
+  {
+    name: "references",
+    path: "references",
+    type: "dir",
+    children: [
+      {
+        name: "style.md",
+        path: "references/style.md",
+        type: "file",
+        mtime: "2026-06-12T00:00:00.000Z",
+      },
+    ],
+  },
+  { name: "primer.md", path: "primer.md", type: "file", mtime: "2026-06-12T00:00:00.000Z" },
+];
+
+describe("filterTree", () => {
+  it("returns the original tree unchanged when query is empty or whitespace", () => {
+    expect(filterTree(tree, "")).toBe(tree);
+    expect(filterTree(tree, "   ")).toBe(tree);
+  });
+
+  it("keeps files whose path includes the query (case-insensitive)", () => {
+    const out = filterTree(tree, "ANNA");
+    expect(out).toHaveLength(1);
+    expect(out[0]?.name).toBe("memories");
+    expect(out[0]?.children).toHaveLength(1);
+    expect(out[0]?.children?.[0]?.name).toBe("anna-1.md");
+  });
+
+  it("drops directories whose entire subtree filters out", () => {
+    const out = filterTree(tree, "style");
+    expect(out.map((n) => n.name)).toEqual(["references"]);
+    expect(out[0]?.children).toHaveLength(1);
+    expect(out[0]?.children?.[0]?.path).toBe("references/style.md");
+  });
+
+  it("matches by directory segment so 'memories/' surfaces every file in that dir", () => {
+    const out = filterTree(tree, "memories/");
+    expect(out).toHaveLength(1);
+    expect(out[0]?.name).toBe("memories");
+    expect(out[0]?.children?.map((c) => c.name)).toEqual(["anna-1.md", "ben-2.md"]);
+  });
+
+  it("returns an empty list when nothing matches — caller renders the empty state", () => {
+    expect(filterTree(tree, "nonexistent-xyz")).toEqual([]);
+  });
+
+  it("matches top-level files alongside dir descendants", () => {
+    const out = filterTree(tree, ".md");
+    // every file matches; every dir survives; primer stays at root.
+    expect(out.map((n) => n.name).sort()).toEqual(["memories", "primer.md", "references"]);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.12",
+  "version": "1.0.0-rc.13",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Summary

Vault `/vault` redesign Phase 1 — the reading room finally reads like a reading room.

- **Editorial typography** for the markdown reader (`vault-prose` block: Newsreader 16 / 1.75 @ 68ch, Fraunces headings, IBM Plex Mono code on the warm mono-fill tint). Replaces the dead `prose prose-sm` no-ops; the dashboard's dense 14px UI body stays untouched — only the reader opts into the editorial measure.
- **Shadcn cards → flat hairline editorial.** Header `Pill`, ui-v2 `Tabs` for Read/Edit/History (with vermilion underline + hairline strip), hairline-bordered article, FrontmatterTable + BacklinksPane as hairline-divided sections under the DESIGN.md mono-label treatment.
- **Keyboard-first stewardship.** Focus-visible ring + `destructive` Button variant; per-surface shortcuts: `N` (new file), `E` (edit), `D` (delete), `J`/`K` (cycle), `/` (focus filter), `Esc` (clear + blur). Handlers skip when focus is in an input. Shortcuts joined the global `?` cheatsheet. `KeyHint` badges render the mnemonic, `aria-hidden` so accessible names stay clean.
- **`(pointer: coarse)` adaptation.** Tap targets bump from 28–36px on desktop to 44–48px on touch without changing desktop density (Playwright-verified). Tree caps at `max-h-60` on mobile once a file is selected so 30 rows don't push the content off the fold.
- **Tree filter.** Substring match on full path, case-insensitive, instant. Pruned tree keeps dir context (not a flat list); active filter auto-opens collapsed dirs (re-mount via `key` flip — preserves user collapse state when cleared). `j`/`k` cycles the filtered list. Empty-match state with one-tap clear. `filterTree` exported and unit-tested.
- **Per-row pending state** on tree links via Next 15 `useLinkStatus` — vermilion pulse on the clicked row only, honours `prefers-reduced-motion`.
- **Fix:** wrap long lines in vault diff view (closes #372).

Design-context docs (PRODUCT.md, DESIGN.md, `.impeccable/` config) capturing the *Reading Room* editorial system land here too — first surface to use them.

## Verification

- `pnpm typecheck` + `pnpm run lint` clean
- **256 dashboard tests pass** (+13 since rc.12 main: 6 `filterTree` cases, 1 accordion-expand test, plus coverage).
- Playwright + screenshot pass at 1280 / 768 / 375 / iPhone 14 (coarse pointer): zero page errors, zero horizontal overflow, touch targets verified ≥44px.
- `pnpm run check:release` confirms rc.13 is the dated top entry + linked.

## Scope

Phase 1 is **only** the `/vault` route. The rest of the dashboard (Memories, Handoffs, Proposals, Curator, Settings, Backups, Tokens, Analytics, Archive, Flagged) still wears the legacy shadcn vocabulary and is queued for Phase 2 — same `vault-prose` / hairline / Pill / Tabs / KeyHint vocabulary, applied surface by surface.

## Test plan

- [ ] Open `/vault`, pick a file in **Read** mode — confirm Newsreader 16px reads as deliberate, paragraph rhythm is clear, inline code on warm tint.
- [ ] Switch to **History** — accordion expands a commit row inline, diff wraps within the column, Restore button stays on-screen.
- [ ] Switch to **Edit** — textarea wears hairline + mono-fill + sharp + focus ring.
- [ ] Hit `?` — confirm the vault shortcuts (N/E/D/J/K/`/`) appear.
- [ ] With several files: press `/`, type a substring → tree prunes; press `Esc` → cleared. Type a no-match string → "No files match …".
- [ ] Press `j`/`k` → cycles files (filtered or full); press `n` → new-file dialog; press `d` → delete confirm (destructive red).
- [ ] At 375px (or DevTools touch emulation) — every action button, tab, and tree row tappable; KeyHints hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)