### PR TITLE
fix(docker): publish the agent port on compose deploys; drop internal-only network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.14] — 2026-06-14
+
+### Fixed
+
+- **Compose deploys couldn't reach the server.** Since rc.10 (ADR 0008), the
+  two-service `docker/docker-compose.yml` attached both services **only** to a
+  `internal: true` network. Docker does not publish host ports for a container
+  whose only network is internal, so the agent surface (`/mcp`, `/healthz`,
+  `/primer.md` on `:3838`) — and the dashboard on `:3839` — silently stopped
+  being reachable from the host on every compose deploy from rc.10 onward (it
+  also cut the mcp-server's outbound curator/backup calls). The server itself
+  ran fine; it just wasn't published. The network is now a normal bridge; the
+  admin tRPC port (3840) stays off the host because it is simply never published
+  (ADR 0008 intact). Adds `test/docker-compose.test.ts` pinning the invariants —
+  `docker compose config` validates syntax only and the smoke test runs
+  in-network, so neither caught this.
+
 ## [1.0.0-rc.13] — 2026-06-14
 
 Dashboard vault redesign, Phase 1 (the `/vault` surface of the `impeccable-redesign`
@@ -2026,6 +2043,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0-rc.14]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.13...v1.0.0-rc.14
 [1.0.0-rc.13]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.12...v1.0.0-rc.13
 [1.0.0-rc.12]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.11...v1.0.0-rc.12
 [1.0.0-rc.11]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.10...v1.0.0-rc.11

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -95,10 +95,14 @@ services:
       retries: 3
       start_period: 15s
 
-# Dedicated network for the dashboard ↔ mcp-server admin tRPC link (ADR 0008 P2,
-# spec §5 Q1). `internal: true` keeps it off the default bridge and gives it no
-# gateway to the outside, so the unpublished tRPC port (3840) is reachable ONLY
-# by the two services attached here — not from the host and not from other stacks.
+# Dedicated bridge network for the two services (ADR 0008 P2, spec §5 Q1).
+# NOT `internal: true`: an internal network has no gateway, so Docker (a) will
+# not publish the agent port (3838) to the host, and (b) cuts the mcp-server's
+# required egress (curator LLM calls, GitHub backups) — that combination is what
+# took the agent surface offline on compose deploys in rc.10–rc.13. The admin
+# tRPC port (3840) is kept off the host by simply never publishing it (it is
+# absent from every `ports:` above); a dedicated user-defined network still
+# isolates it from other docker stacks.
 networks:
   librarian-internal:
-    internal: true
+    internal: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.13",
+  "version": "1.0.0-rc.14",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/test/docker-compose.test.ts
+++ b/test/docker-compose.test.ts
@@ -1,0 +1,48 @@
+// Docker-compose host-publishing guard.
+//
+// rc.10 (ADR 0008) shipped a compose where both services were attached only to
+// a `internal: true` network. Docker does NOT publish host ports for a container
+// whose only network is internal (and an internal network also cuts the
+// mcp-server's required egress — curator LLM, GitHub backups), so the agent
+// surface (port 3838) silently became unreachable from the host on every compose
+// deploy from rc.10 through rc.13. `docker compose config` (syntax only) and the
+// in-network smoke test both stayed green, so nothing caught it. This pins the
+// invariants that would have.
+
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "..");
+const compose = fs.readFileSync(path.join(REPO_ROOT, "docker", "docker-compose.yml"), "utf8");
+
+describe("docker-compose host publishing", () => {
+  it("declares no `internal: true` network — it would block host publishing + egress", () => {
+    const internalLines = compose
+      .split("\n")
+      .filter((line) => /^\s*internal:\s*true\s*$/.test(line));
+    expect(
+      internalLines,
+      "an `internal: true` docker network has no gateway: Docker won't publish the agent " +
+        "port (3838) to the host and the mcp-server loses egress (curator, backups). Keep the " +
+        "services on a normal bridge; the tRPC port stays off-host by simply not being published.",
+    ).toEqual([]);
+  });
+
+  it("publishes the mcp-server agent port (3838) to the host", () => {
+    expect(
+      /:3838:3838"/.test(compose),
+      "the agent surface (/mcp + /healthz + /primer.md) must be published to the host on 3838",
+    ).toBe(true);
+  });
+
+  it("never publishes the admin tRPC port (3840) to the host", () => {
+    // 3840 appears only as the internal LIBRARIAN_TRPC_PORT env value, never in a
+    // host `ports:` mapping (which would read `:3840:3840`). ADR 0008: the admin
+    // API — which can return decrypted secrets — stays off the host entirely.
+    expect(
+      /:3840:3840/.test(compose),
+      "the admin tRPC port (3840) must never be published to the host (ADR 0008)",
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## The bug

Since **rc.10 (ADR 0008)**, `docker/docker-compose.yml` attached both services to a single `internal: true` network. **Docker does not publish host ports for a container whose only network is internal** — so the agent surface (`/mcp`, `/healthz`, `/primer.md` on `:3838`) and the dashboard (`:3839`) silently stopped being reachable from the host on every compose deploy from rc.10 onward. (It also cut the mcp-server's outbound egress — curator LLM, GitHub backups.)

The server process was healthy the whole time (bound `0.0.0.0:3838` inside the container, healthcheck green); it just wasn't published. Observed live: `docker ps` shows no published ports, host `:3838` refuses, container logs show it listening.

This took down a running self-hosted instance on the rc.10+ auto-deploy.

## The fix

Make `librarian-internal` a normal bridge (`internal: false`). The admin tRPC port (3840) **stays off the host** because it is simply never published (absent from every `ports:`), so ADR 0008's "admin API off the network, no bearer needed" guarantee is **intact** — the `internal: true` flag was providing no real protection for an already-unpublished port while breaking host publishing and egress.

## Regression test

`test/docker-compose.test.ts` pins three invariants:
- no `internal: true` network (the regression),
- the agent port `:3838` **is** published,
- the admin tRPC port `:3840` is **never** published.

`docker compose config` only validates syntax and the smoke test runs *inside* the compose network, so neither caught this — the new test closes that gap.

## Versioning

`1.0.0-rc.13` → **`1.0.0-rc.14`** (PATCH/fix). CHANGELOG + compare-link added; `check:release` green (bumped from base rc.13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)