### PR TITLE
fix(core): harden intake-grooming-trigger teardown against ENOTEMPTY (rc.19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.19] — 2026-06-15
+
+### Fixed
+
+- **Flaky teardown** in `packages/core` `intake-grooming-trigger`
+  tests. The markdown backend's git operations occasionally left a
+  transient handle inside `.git/`, which caused
+  `fs.rmSync(dataDir, { recursive: true, force: true })` in the
+  `afterEach` to fail with `ENOTEMPTY: rmdir … vault/.git`.
+  `force` only swallows `ENOENT`, not `ENOTEMPTY`, so add the
+  node-builtin retry loop (`maxRetries: 5, retryDelay: 50`) to
+  ride out the race.
+
 ## [1.0.0-rc.18] — 2026-06-15
 
 Dashboard redesign Phase 4 — every remaining shadcn-era surface
@@ -2481,6 +2494,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0-rc.19]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.18...v1.0.0-rc.19
 [1.0.0-rc.18]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.17...v1.0.0-rc.18
 [1.0.0-rc.17]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.16...v1.0.0-rc.17
 [1.0.0-rc.16]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.15...v1.0.0-rc.16

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.18",
+  "version": "1.0.0-rc.19",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/core/tests/intake-grooming-trigger.test.ts
+++ b/packages/core/tests/intake-grooming-trigger.test.ts
@@ -40,7 +40,12 @@ afterEach(() => {
   } catch {
     /* ignore */
   }
-  fs.rmSync(dataDir, { recursive: true, force: true });
+  // The markdown backend runs git operations synchronously, but the OS
+  // occasionally still has a transient handle on a file under .git/ when
+  // we tear down (observed as `ENOTEMPTY: rmdir … vault/.git`). `force`
+  // only swallows ENOENT, not ENOTEMPTY, so use the node-builtin retry
+  // loop to ride out the race instead of letting it fail the suite.
+  fs.rmSync(dataDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
   store = null;
 });
 


### PR DESCRIPTION
## Summary

The `packages/core` `intake-grooming-trigger` tests occasionally fail in teardown with:

```
Error: ENOTEMPTY: directory not empty, rmdir '/tmp/librarian-groom-trigger-XXXX/vault/.git'
```

Root cause: the markdown backend runs git operations synchronously, but the OS sometimes still has a transient handle on a file inside `.git/` when the `afterEach`'s `fs.rmSync` runs. `fs.rmSync`'s `force` option only swallows `ENOENT`, not `ENOTEMPTY`, so the race fails the test instead of being absorbed.

Standard fix: add the node-builtin `maxRetries` / `retryDelay` to `fs.rmSync` so it rides out the race.

## Verification

- Local: ` pnpm --filter @librarian/core exec vitest run tests/intake-grooming-trigger.test.ts` → **6 passed**.
- `pnpm run check:release` confirms rc.19 is the dated top entry, linked.

## Scope

One file. Other tests in the package use the same teardown pattern and could observe the same flake — they can pick the retry loop up the same way if it surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)