### PR TITLE
feat(dashboard): /activity rows expand to show per-commit diffs (rc.20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,49 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.20] — 2026-06-15
+
+The vault activity feed becomes an accordion: each commit row
+expands in place to show the per-file diffs that commit introduced,
+instead of just naming the files it touched. Same shape as the
+per-file history accordion on the vault file view, but commit-scoped
+— one fetch returns the whole commit's diff, lazy-loaded on expand.
+
+### Added
+
+- **`GitHistory.commitDiff(hash)`** in `packages/core` returns the
+  per-file diffs for a single vault commit as a structured
+  `CommitDiff` (`{ hash, files: [{ path, status, fromPath?, diff }] }`).
+  One `git show -M --pretty=format:` under the hood; sections split
+  on the `diff --git` header; status (added / modified / deleted /
+  renamed) is derived from the section's metadata.
+- **`store.vaultCommitDiff(hash)`** on `LibrarianStore` thin-wraps
+  it for the dashboard.
+- **`vault.commitDiff` tRPC procedure** (admin) on the activity
+  router — `{ hash } → CommitDiff`.
+- **`commitDiffAction({ hash })`** server action in the dashboard
+  for the accordion's lazy-load on expand.
+- **`<DiffView>` extracted** to `components/vault/diff-view.tsx` so
+  the activity feed and the per-file history accordion render diffs
+  through the same primitive. Editorial palette: verdigris wash for
+  additions, red-ochre wash for deletions, foreground/55 for hunk
+  markers and headers (swapped from the emerald/red/sky Tailwind
+  defaults). `file-history.tsx` re-exports `DiffView` under the
+  original name for backwards-compat with existing tests.
+
+### Changed
+
+- **`/activity` ActivityFeed** rebuilt as an accordion. Each commit
+  row gains a chevron toggle; expand lazy-loads the commit's diff
+  via `commitDiffAction` and renders each file as a SectionLabel +
+  path header followed by the editorial `<DiffView>`. The inline
+  file-list stays under the subject line so the at-a-glance "which
+  files" answer is preserved.
+- **`/settings/primer`** drops the page-level "Settings" heading +
+  byline. The Settings dropdown in the top nav carries the
+  cross-page context; the form's own Primer heading + subtitle says
+  the rest. Removes the duplicate-context noise.
+
 ## [1.0.0-rc.19] — 2026-06-15
 
 ### Fixed
@@ -2494,6 +2537,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0-rc.20]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.19...v1.0.0-rc.20
 [1.0.0-rc.19]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.18...v1.0.0-rc.19
 [1.0.0-rc.18]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.17...v1.0.0-rc.18
 [1.0.0-rc.17]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.16...v1.0.0-rc.17

--- a/apps/dashboard/app/activity/page.tsx
+++ b/apps/dashboard/app/activity/page.tsx
@@ -5,7 +5,7 @@
 // history IS the audit trail.
 
 import Link from "next/link";
-import { restoreVaultAction } from "@/app/vault/activity/actions";
+import { commitDiffAction, restoreVaultAction } from "@/app/vault/activity/actions";
 import { ActivityFeed } from "@/components/vault/activity-feed";
 import type { VaultActivityEntry } from "@/components/vault/types";
 import { serverTRPC } from "@/lib/trpc-server";
@@ -50,7 +50,11 @@ export default async function VaultActivityPage() {
         </p>
       ) : null}
 
-      <ActivityFeed entries={entries} onRestore={restoreVaultAction} />
+      <ActivityFeed
+        entries={entries}
+        onRestore={restoreVaultAction}
+        onCommitDiff={commitDiffAction}
+      />
     </main>
   );
 }

--- a/apps/dashboard/app/settings/primer/page.tsx
+++ b/apps/dashboard/app/settings/primer/page.tsx
@@ -1,16 +1,16 @@
-// Settings home (spec 041 A1, repointed by rethink T11). Currently hosts the
+// Primer settings (spec 041 A1, repointed by rethink T11). Hosts the
 // primer — the one ≤2KB vault/primer.md document delivered when an agent
 // connects (MCP initialize `instructions` + GET /primer.md). Reads the current
 // primer server-side (the boot-seeded default on a fresh install) and renders
-// the admin field. Gated like the rest of the dashboard. Authentication has
-// its own sub-page (/settings/auth); this page links to it.
+// the admin field. Gated like the rest of the dashboard. The Settings menu
+// in the top nav covers the cross-page context — no page-level header here
+// (the form's own Primer heading + subtitle carries all the meaning).
 
-import Link from "next/link";
 import { saveAwarenessPrimerAction } from "@/app/settings/primer/actions";
 import { AwarenessPrimerForm } from "@/components/settings/awareness-primer-form";
 import { serverTRPC } from "@/lib/trpc-server";
 
-export const metadata = { title: "Settings · Librarian" };
+export const metadata = { title: "Primer · Librarian" };
 export const dynamic = "force-dynamic";
 
 async function loadPrimer(): Promise<string> {
@@ -24,25 +24,11 @@ async function loadPrimer(): Promise<string> {
   }
 }
 
-export default async function SettingsPage() {
+export default async function PrimerSettingsPage() {
   const primer = await loadPrimer();
 
   return (
     <main className="flex flex-col gap-8 p-6">
-      <header className="flex flex-col gap-1.5">
-        <h1 className="font-display text-xl text-foreground">Settings</h1>
-        <p className="text-sm text-foreground/60">
-          Server-sourced settings that take effect without a redeploy.{" "}
-          <Link
-            href="/settings/auth"
-            className="text-ink-accent underline-offset-2 hover:underline"
-          >
-            Authentication
-          </Link>{" "}
-          has its own page.
-        </p>
-      </header>
-
       <AwarenessPrimerForm initial={primer} onSave={saveAwarenessPrimerAction} />
     </main>
   );

--- a/apps/dashboard/app/vault/activity/actions.ts
+++ b/apps/dashboard/app/vault/activity/actions.ts
@@ -1,11 +1,13 @@
 "use server";
 
-// Whole-vault restore server action (rethink T21, spec §8 / D16). A thin
-// wrapper over the admin activity router: the typed confirmation phrase is
-// forwarded VERBATIM — the server validates it (the modal's ceremony can't be
-// bypassed by skipping the UI), runs the guarded sequence (curator pause →
-// pre-restore tag → one revert commit → index invalidation → resume) and the
-// teaching errors come back as-is.
+// Server actions for /activity (rethink T21, spec §8 / D16):
+//  - restoreVaultAction: thin wrapper over the admin activity router for the
+//    guarded whole-vault restore. The typed confirmation phrase is forwarded
+//    VERBATIM — the server validates it, runs the guarded sequence (curator
+//    pause → pre-restore tag → one revert commit → index invalidation →
+//    resume), and the teaching errors come back as-is.
+//  - commitDiffAction: lazy-loads the per-file diffs for a single commit
+//    when the operator expands an accordion row.
 
 import { revalidatePath } from "next/cache";
 import { serverTRPC } from "@/lib/trpc-server";
@@ -23,6 +25,26 @@ export async function restoreVaultAction(input: {
     revalidatePath("/");
     revalidatePath("/activity");
     return { ok: true, ...result };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+export interface CommitDiffFileShape {
+  path: string;
+  status: "added" | "modified" | "deleted" | "renamed";
+  fromPath?: string;
+  diff: string;
+}
+
+export type CommitDiffResult =
+  | { ok: true; hash: string; files: CommitDiffFileShape[] }
+  | { ok: false; error: string };
+
+export async function commitDiffAction(input: { hash: string }): Promise<CommitDiffResult> {
+  try {
+    const result = await serverTRPC.activity.commitDiff.query(input);
+    return { ok: true, hash: result.hash, files: result.files };
   } catch (error) {
     return { ok: false, error: error instanceof Error ? error.message : String(error) };
   }

--- a/apps/dashboard/components/memories/list.tsx
+++ b/apps/dashboard/components/memories/list.tsx
@@ -122,7 +122,11 @@ export function MemoriesList({
               selected={selectedId === memory.id}
               ariaPressed={selectedId === memory.id}
               onClick={() => onSelect(memory.id)}
-              className="flex-1"
+              // min-w-0 lets the flex-1 button shrink below its content's
+              // min-content (the title's truncate alone clips the text but
+              // doesn't free the button to shrink — without this, a long
+              // unbroken title forces the row past the viewport).
+              className="min-w-0 flex-1"
               meta={[
                 memory.project_key ? <span>{memory.project_key}</span> : null,
                 <span>updated {new Date(memory.updated_at).toLocaleDateString()}</span>,

--- a/apps/dashboard/components/vault/activity-feed.tsx
+++ b/apps/dashboard/components/vault/activity-feed.tsx
@@ -1,15 +1,22 @@
 "use client";
 
-// The vault activity feed (rethink T21, spec §8 / D16) — editorial rebuild.
-// Recent vault commits with the files each touched and a provenance Pill
-// derived server-side from the commit-subject conventions (agent / curator /
-// admin / system). One bordered container with hairline-separated commits;
-// each row has a destructive "Restore vault to here" that opens the typed-
-// phrase ceremony before arming.
+// The vault activity feed (rethink T21, spec §8 / D16). Editorial rebuild
+// (rc.19): each commit row is now an accordion — click to expand and
+// lazy-load the per-file diffs the commit introduced. Replaces the inline
+// file-list line, which only told the operator *which* files changed; the
+// accordion shows *what* changed.
+//
+// Each row carries a destructive "Restore vault to here" that opens the
+// typed-phrase ceremony before arming.
 
+import { ChevronRight } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
-import type { RestoreVaultResult } from "@/app/vault/activity/actions";
+import type {
+  CommitDiffFileShape,
+  CommitDiffResult,
+  RestoreVaultResult,
+} from "@/app/vault/activity/actions";
 import { Button } from "@/components/ui-v2/button";
 import {
   Dialog,
@@ -22,6 +29,7 @@ import {
 import { Input } from "@/components/ui-v2/input";
 import { Pill } from "@/components/ui-v2/pill";
 import { SectionLabel } from "@/components/ui-v2/section-label";
+import { DiffView } from "@/components/vault/diff-view";
 import type { VaultActivityEntry } from "@/components/vault/types";
 
 /** What the admin must type — mirrors the server's RESTORE_CONFIRMATION_PHRASE. */
@@ -31,6 +39,8 @@ export type RestoreVaultActionFn = (input: {
   hash: string;
   confirm: string;
 }) => Promise<RestoreVaultResult>;
+
+export type CommitDiffActionFn = (input: { hash: string }) => Promise<CommitDiffResult>;
 
 // Map the schema-defined sources onto the brand palette. Curator (verdigris
 // accent) is the only source that ever auto-applies vault changes; admin
@@ -45,12 +55,21 @@ const SOURCE_VARIANT: Record<Source, "default" | "accent" | "muted"> = {
   other: "default",
 };
 
+const STATUS_LABEL: Record<CommitDiffFileShape["status"], string> = {
+  added: "added",
+  modified: "modified",
+  deleted: "deleted",
+  renamed: "renamed",
+};
+
 export function ActivityFeed({
   entries,
   onRestore,
+  onCommitDiff,
 }: {
   entries: VaultActivityEntry[];
   onRestore: RestoreVaultActionFn;
+  onCommitDiff: CommitDiffActionFn;
 }) {
   if (entries.length === 0) {
     return <p className="text-sm text-foreground/60">No vault commits yet.</p>;
@@ -61,42 +80,133 @@ export function ActivityFeed({
       className="flex flex-col border border-ink-hairline bg-ink-surface"
     >
       {entries.map((entry, i) => (
-        <li
-          key={entry.hash}
-          className={`flex flex-col gap-1.5 px-4 py-3 text-sm ${
-            i > 0 ? "border-t border-ink-hairline" : ""
-          }`}
-        >
-          <div className="flex flex-wrap items-center gap-2">
-            <Pill variant={SOURCE_VARIANT[entry.source] ?? "default"}>{entry.source}</Pill>
-            <span className="min-w-0 flex-1 truncate text-foreground" title={entry.subject}>
-              {entry.subject}
-            </span>
-            <span className="flex items-center gap-2 whitespace-nowrap">
-              <span
-                className="font-mono text-xs text-foreground/60"
-                title={`${entry.hash} · ${entry.date}`}
-              >
-                {entry.hash.slice(0, 12)} · {formatDate(entry.date)}
-              </span>
-              <RestoreVaultDialog entry={entry} onRestore={onRestore} />
-            </span>
-          </div>
-          {entry.files.length > 0 ? (
-            <p className="break-all font-mono text-xs text-foreground/60">
-              {entry.files.join("  ·  ")}
-            </p>
-          ) : null}
+        <li key={entry.hash} className={i > 0 ? "border-t border-ink-hairline" : ""}>
+          <CommitRow entry={entry} onRestore={onRestore} onCommitDiff={onCommitDiff} />
         </li>
       ))}
     </ol>
   );
 }
 
+function CommitRow({
+  entry,
+  onRestore,
+  onCommitDiff,
+}: {
+  entry: VaultActivityEntry;
+  onRestore: RestoreVaultActionFn;
+  onCommitDiff: CommitDiffActionFn;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [files, setFiles] = useState<CommitDiffFileShape[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const regionId = `commit-${entry.hash.slice(0, 12)}`;
+
+  const toggle = () => {
+    const next = !expanded;
+    setExpanded(next);
+    // Lazy-load the diff the first time the row opens. Cached for subsequent
+    // toggles — re-collapsing keeps the data so re-opening is instant.
+    if (next && files === null && !pending) {
+      startTransition(async () => {
+        const result = await onCommitDiff({ hash: entry.hash });
+        if (result.ok) setFiles(result.files);
+        else setError(result.error);
+      });
+    }
+  };
+
+  return (
+    <div className="flex flex-col">
+      <div className="flex flex-col gap-1.5 px-4 py-3 text-sm">
+        <div className="flex items-start gap-2">
+          <button
+            type="button"
+            onClick={toggle}
+            aria-expanded={expanded}
+            aria-controls={regionId}
+            aria-label={`${expanded ? "Hide" : "Show"} diff for commit ${entry.hash.slice(0, 12)}`}
+            className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center text-foreground/40 transition-colors hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ink-accent"
+          >
+            <ChevronRight
+              aria-hidden
+              className={`h-4 w-4 transition-transform motion-reduce:transition-none ${
+                expanded ? "rotate-90" : ""
+              }`}
+            />
+          </button>
+          <Pill variant={SOURCE_VARIANT[entry.source] ?? "default"}>{entry.source}</Pill>
+          <span className="min-w-0 flex-1 truncate text-foreground" title={entry.subject}>
+            {entry.subject}
+          </span>
+          <span className="flex items-center gap-2 whitespace-nowrap">
+            <span
+              className="font-mono text-xs text-foreground/60"
+              title={`${entry.hash} · ${entry.date}`}
+            >
+              {entry.hash.slice(0, 12)} · {formatDate(entry.date)}
+            </span>
+            <RestoreVaultDialog entry={entry} onRestore={onRestore} />
+          </span>
+        </div>
+        {entry.files.length > 0 ? (
+          <p className="break-all pl-7 font-mono text-xs text-foreground/60">
+            {entry.files.join("  ·  ")}
+          </p>
+        ) : null}
+      </div>
+
+      {expanded ? (
+        <div
+          id={regionId}
+          role="region"
+          aria-label={`Changes in ${entry.hash.slice(0, 12)}`}
+          className="flex flex-col gap-4 border-t border-ink-hairline bg-foreground/[0.02] px-4 py-4"
+        >
+          {pending ? (
+            <p className="text-sm text-foreground/60">Loading diff…</p>
+          ) : error ? (
+            <p
+              role="alert"
+              className="border border-destructive/40 bg-destructive/[0.06] p-3 text-sm text-destructive"
+            >
+              {error}
+            </p>
+          ) : files === null ? null : files.length === 0 ? (
+            <p className="text-sm text-foreground/60">
+              No file diffs recorded for this commit. (Empty commit, or binary-only changes.)
+            </p>
+          ) : (
+            files.map((file) => <FileDiffSection key={file.path} file={file} />)
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function FileDiffSection({ file }: { file: CommitDiffFileShape }) {
+  return (
+    <section className="flex min-w-0 flex-col gap-2" aria-label={`${file.path} (${file.status})`}>
+      <header className="flex flex-wrap items-baseline gap-2 text-sm">
+        <SectionLabel as="span">{STATUS_LABEL[file.status]}</SectionLabel>
+        <span className="font-mono text-xs text-foreground" title={file.path}>
+          {file.path}
+        </span>
+        {file.fromPath ? (
+          <span className="font-mono text-xs text-foreground/55" title={file.fromPath}>
+            (was {file.fromPath})
+          </span>
+        ) : null}
+      </header>
+      <DiffView diff={file.diff} />
+    </section>
+  );
+}
+
 function formatDate(iso: string): string {
-  // ISO → '2026-06-12 10:00' — date + minutes, locale-agnostic so the
-  // audit trail reads the same across viewers (timestamps drive ordering,
-  // not casual reading).
   return iso.replace("T", " ").slice(0, 16);
 }
 

--- a/apps/dashboard/components/vault/diff-view.tsx
+++ b/apps/dashboard/components/vault/diff-view.tsx
@@ -1,0 +1,43 @@
+// Unified diff as a <pre> with per-line +/- colouring. No diff library —
+// react-markdown / dashboard's existing posture is "render what we get from
+// the server, no client transform beyond presentation". Shared between the
+// file-history accordion (per-file diffs) and the activity-feed accordion
+// (per-commit, per-file diffs).
+//
+// Editorial palette: verdigris wash for additions (positive rubric), red
+// ochre wash for deletions (destructive rubric), foreground/55 for hunk
+// markers and diff/index/+++/--- headers, foreground/85 for context lines.
+// Data-content driving colour, not chrome — the "two colours per surface"
+// guidance applies to design ink, not to a syntactically-mandated diff.
+
+export function DiffView({ diff }: { diff: string }) {
+  if (!diff.trim()) {
+    return <p className="text-sm text-foreground/60">No changes — versions are identical.</p>;
+  }
+  return (
+    <pre
+      aria-label="Unified diff"
+      className="max-w-full overflow-x-auto border border-ink-hairline bg-foreground/[0.03] p-3 font-mono text-xs leading-5"
+    >
+      {diff.split("\n").map((line, index) => (
+        <span key={index} className={`block whitespace-pre-wrap ${diffLineClass(line)}`}>
+          {line || " "}
+        </span>
+      ))}
+    </pre>
+  );
+}
+
+function diffLineClass(line: string): string {
+  // Headers first so '+++' / '---' don't fall through into the addition /
+  // deletion branches below.
+  if (line.startsWith("+++") || line.startsWith("---")) return "text-foreground/55";
+  if (line.startsWith("@@")) return "text-foreground/55";
+  if (line.startsWith("diff ") || line.startsWith("index ")) return "text-foreground/55";
+  if (line.startsWith("new file mode") || line.startsWith("deleted file mode"))
+    return "text-foreground/55";
+  if (line.startsWith("rename ") || line.startsWith("similarity ")) return "text-foreground/55";
+  if (line.startsWith("+")) return "bg-ink-accent/[0.10] text-foreground";
+  if (line.startsWith("-")) return "bg-destructive/[0.10] text-destructive";
+  return "text-foreground/85";
+}

--- a/apps/dashboard/components/vault/file-history.tsx
+++ b/apps/dashboard/components/vault/file-history.tsx
@@ -29,6 +29,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui-v2/dialog";
+import { DiffView } from "@/components/vault/diff-view";
+
+// Re-export under the original name for the existing tests that imported
+// DiffView from this module (it now lives next to it under diff-view.tsx).
+export { DiffView };
 
 export interface HistoryActions {
   history: (input: { path: string }) => Promise<FileHistoryResult>;
@@ -157,34 +162,6 @@ export function FileHistory({ path, actions }: { path: string; actions: HistoryA
 
 function formatDate(iso: string): string {
   return iso.replace("T", " ").slice(0, 16);
-}
-
-/** Unified diff as a <pre> with per-line +/- colouring (no diff dependency). */
-export function DiffView({ diff }: { diff: string }) {
-  if (!diff.trim()) {
-    return <p className="text-sm text-muted-foreground">No changes — versions are identical.</p>;
-  }
-  return (
-    <pre
-      aria-label="Unified diff"
-      className="max-w-full overflow-x-auto border border-ink-hairline bg-foreground/[0.03] p-3 font-mono text-xs leading-5"
-    >
-      {diff.split("\n").map((line, index) => (
-        <span key={index} className={`block whitespace-pre-wrap ${diffLineClass(line)}`}>
-          {line || " "}
-        </span>
-      ))}
-    </pre>
-  );
-}
-
-function diffLineClass(line: string): string {
-  if (line.startsWith("+++") || line.startsWith("---")) return "text-muted-foreground";
-  if (line.startsWith("@@")) return "text-sky-600 dark:text-sky-400";
-  if (line.startsWith("+")) return "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400";
-  if (line.startsWith("-")) return "bg-red-500/10 text-red-700 dark:text-red-400";
-  if (line.startsWith("diff ") || line.startsWith("index ")) return "text-muted-foreground";
-  return "text-foreground";
 }
 
 function RestoreVersionDialog({

--- a/apps/dashboard/tests/components/vault/activity-feed.test.tsx
+++ b/apps/dashboard/tests/components/vault/activity-feed.test.tsx
@@ -38,7 +38,7 @@ afterEach(() => vi.clearAllMocks());
 
 describe("ActivityFeed", () => {
   it("lists commits with subject, provenance badge, files, and short hash", () => {
-    render(<ActivityFeed entries={entries} onRestore={vi.fn()} />);
+    render(<ActivityFeed entries={entries} onRestore={vi.fn()} onCommitDiff={vi.fn()} />);
     const feed = screen.getByRole("list", { name: "Vault activity" });
     expect(feed).toHaveTextContent("memory: update mem_1");
     expect(feed).toHaveTextContent("curator");
@@ -54,7 +54,7 @@ describe("ActivityFeed", () => {
       preRestoreTag: "pre-restore-20260612-100000",
       commit: "c".repeat(40),
     });
-    render(<ActivityFeed entries={entries} onRestore={onRestore} />);
+    render(<ActivityFeed entries={entries} onRestore={onRestore} onCommitDiff={vi.fn()} />);
     await userEvent.click(screen.getAllByRole("button", { name: "Restore vault to here" })[1]!);
 
     const submit = await screen.findByRole("button", { name: "Restore vault" });
@@ -80,10 +80,50 @@ describe("ActivityFeed", () => {
       ok: false,
       error: "a curator run is in flight — wait for it to finish, then retry the restore",
     });
-    render(<ActivityFeed entries={entries} onRestore={onRestore} />);
+    render(<ActivityFeed entries={entries} onRestore={onRestore} onCommitDiff={vi.fn()} />);
     await userEvent.click(screen.getAllByRole("button", { name: "Restore vault to here" })[0]!);
     await userEvent.type(screen.getByLabelText("Restore confirmation"), "RESTORE");
     await userEvent.click(screen.getByRole("button", { name: "Restore vault" }));
     expect(await screen.findByRole("alert")).toHaveTextContent(/curator run is in flight/);
+  });
+
+  it("expands a commit row to lazy-load and render the per-file diff", async () => {
+    const onCommitDiff = vi.fn().mockResolvedValue({
+      ok: true,
+      hash: "b".repeat(40),
+      files: [
+        {
+          path: "memories/anna-1.md",
+          status: "modified",
+          diff: "diff --git a/memories/anna-1.md b/memories/anna-1.md\n@@ -1,1 +1,1 @@\n-old line\n+new line",
+        },
+      ],
+    });
+    render(<ActivityFeed entries={entries} onRestore={vi.fn()} onCommitDiff={onCommitDiff} />);
+
+    // Lazy: nothing fetched yet.
+    expect(onCommitDiff).not.toHaveBeenCalled();
+
+    // First entry's commit is bbbb… — expand it.
+    const toggles = screen.getAllByRole("button", { name: /Show diff for commit/i });
+    await userEvent.click(toggles[0]!);
+
+    await vi.waitFor(() => expect(onCommitDiff).toHaveBeenCalledWith({ hash: "b".repeat(40) }));
+    // The DiffView surfaces the unified diff text inline.
+    expect(await screen.findByText(/-old line/)).toBeInTheDocument();
+    expect(screen.getByText(/\+new line/)).toBeInTheDocument();
+    // File header carries status + path.
+    expect(screen.getByText("modified")).toBeInTheDocument();
+  });
+
+  it("surfaces a commit-diff load error inside the expanded region", async () => {
+    const onCommitDiff = vi.fn().mockResolvedValue({
+      ok: false,
+      error: "git: unknown revision",
+    });
+    render(<ActivityFeed entries={entries} onRestore={vi.fn()} onCommitDiff={onCommitDiff} />);
+    const toggles = screen.getAllByRole("button", { name: /Show diff for commit/i });
+    await userEvent.click(toggles[0]!);
+    expect(await screen.findByRole("alert")).toHaveTextContent(/unknown revision/);
   });
 });

--- a/apps/dashboard/tests/components/vault/file-history.test.tsx
+++ b/apps/dashboard/tests/components/vault/file-history.test.tsx
@@ -126,8 +126,10 @@ describe("DiffView", () => {
     expect(pre).toHaveTextContent("-old line");
     expect(pre).toHaveTextContent("+new line");
     const lines = Array.from(pre.querySelectorAll("span"));
-    expect(lines.find((l) => l.textContent === "+new line")?.className).toMatch(/emerald/);
-    expect(lines.find((l) => l.textContent === "-old line")?.className).toMatch(/red/);
+    // Editorial palette: verdigris wash for additions, destructive (red-ochre)
+    // for deletions (rc.19 — swapped from emerald/red Tailwind defaults).
+    expect(lines.find((l) => l.textContent === "+new line")?.className).toMatch(/ink-accent/);
+    expect(lines.find((l) => l.textContent === "-old line")?.className).toMatch(/destructive/);
   });
 
   it("says so when the versions are identical", () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.19",
+  "version": "1.0.0-rc.20",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -325,6 +325,8 @@ export {
   vaultFileKind,
 } from "./store/vault-files.js";
 export {
+  type CommitDiff,
+  type CommitDiffFile,
   type FileCommit,
   type GitHistory,
   type GitHistoryFileDiffOptions,

--- a/packages/core/src/store/git/git-history.ts
+++ b/packages/core/src/store/git/git-history.ts
@@ -73,6 +73,28 @@ export interface VaultCommit {
   files: string[];
 }
 
+/** One file's change in a commit's diff. */
+export interface CommitDiffFile {
+  /** The file's path AT this commit (post-rename for R rows). */
+  path: string;
+  /** Whether the commit added / modified / deleted / renamed the file. */
+  status: "added" | "modified" | "deleted" | "renamed";
+  /** The file's pre-rename path when `status === "renamed"`; otherwise omitted. */
+  fromPath?: string;
+  /** Unified diff text for this file in this commit. Empty when binary or
+   *  rename-only with no content change. */
+  diff: string;
+}
+
+/** Per-file diffs for the change introduced by a single commit (rethink T21
+ *  audit-trail accordion). */
+export interface CommitDiff {
+  /** Full commit hash. */
+  hash: string;
+  /** Per-file changes; order matches git's diff-tree output (rename-sensitive). */
+  files: CommitDiffFile[];
+}
+
 export interface GitHistory {
   /**
    * Every commit that touched `relPath`, newest first, following renames.
@@ -96,6 +118,12 @@ export interface GitHistory {
    * that commit are returned. Empty on a commitless repo.
    */
   recentCommits(options?: { limit?: number; before?: string }): VaultCommit[];
+  /**
+   * Per-file diffs for the change introduced by `hash` (rethink T21
+   * activity-feed accordion). One `git show` invocation under the hood;
+   * sections split on the `diff --git` header. Throws for an unknown hash.
+   */
+  commitDiff(hash: string): CommitDiff;
   /** Does this hash name a commit in the repo? */
   commitExists(hash: string): boolean;
   /**
@@ -202,6 +230,22 @@ export function createGitHistory(opts: { cwd: string }): GitHistory {
     return commits.slice(0, limit);
   }
 
+  function commitDiff(hash: string): CommitDiff {
+    const h = assertCommitHash(hash);
+    // `git show -M --pretty=format:` writes the unified diff for the commit
+    // with NO commit header, so the output is exactly the concatenation of
+    // per-file diff sections. `--first-parent` keeps the output sane on a
+    // merge commit (the audit trail records linear curator/admin commits,
+    // but be defensive). Section boundaries: each starts with `diff --git`.
+    const text =
+      tryGit(["show", "-M", "--first-parent", "--pretty=format:", "--no-color", h]) ?? "";
+    // Split on lines that start with `diff --git ` — keep the marker by
+    // using a look-ahead so each section retains its header.
+    const sections = text.split(/(?=^diff --git )/m).filter((s) => s.trim().length > 0);
+    const files: CommitDiffFile[] = sections.map(parseDiffSection);
+    return { hash: h, files };
+  }
+
   function commitExists(hash: string): boolean {
     return tryGit(["cat-file", "-e", `${assertCommitHash(hash)}^{commit}`]) !== null;
   }
@@ -229,6 +273,7 @@ export function createGitHistory(opts: { cwd: string }): GitHistory {
     fileAtCommit,
     fileDiff,
     recentCommits,
+    commitDiff,
     commitExists,
     tag,
     restoreTreeTo,
@@ -245,4 +290,33 @@ function pathAtCommit(statusLines: string[]): string | null {
     if (parts[1]) return parts[1];
   }
   return null;
+}
+
+/** Parse one `diff --git a/from b/to` section into a structured CommitDiffFile.
+ *  Status is derived from the section's metadata lines (`new file mode`,
+ *  `deleted file mode`, `rename from/to`) rather than from `--name-status`,
+ *  so it reflects the same data git's own diff already emitted. */
+function parseDiffSection(section: string): CommitDiffFile {
+  const headerMatch = section.split("\n", 1)[0]?.match(/^diff --git a\/(.+?) b\/(.+?)$/);
+  const fromPath = headerMatch?.[1] ?? "";
+  const toPath = headerMatch?.[2] ?? "";
+
+  let status: CommitDiffFile["status"];
+  if (/^new file mode /m.test(section)) {
+    status = "added";
+  } else if (/^deleted file mode /m.test(section)) {
+    status = "deleted";
+  } else if (fromPath !== toPath || /^rename (from|to) /m.test(section)) {
+    status = "renamed";
+  } else {
+    status = "modified";
+  }
+
+  const path = status === "deleted" ? fromPath : toPath;
+  return {
+    path,
+    status,
+    ...(status === "renamed" && fromPath ? { fromPath } : {}),
+    diff: section,
+  };
 }

--- a/packages/core/src/store/git/index.ts
+++ b/packages/core/src/store/git/index.ts
@@ -3,6 +3,8 @@
 
 export { type GitOps, createGitOps } from "./git-ops.js";
 export {
+  type CommitDiff,
+  type CommitDiffFile,
   type FileCommit,
   type GitHistory,
   type GitHistoryFileDiffOptions,

--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -21,6 +21,7 @@ import {
 } from "./corpus-index.js";
 import type { CurationStore } from "./curation-store.js";
 import {
+  type CommitDiff,
   type GitPushAuth,
   type VaultCommit,
   createGitHistory,
@@ -118,6 +119,13 @@ export interface LibrarianStore
    * IS the audit trail — it replaces the retired event ledger.
    */
   vaultActivity(input?: { limit?: number; before?: string }): VaultActivityEntry[];
+  /**
+   * The per-file diffs introduced by a single vault commit (rethink T21
+   * activity-feed accordion). Throws `GitHashError` on a malformed hash;
+   * returns an empty `files` array for a commit unknown to the repo (the
+   * caller surfaces this as a not-found teaching error at the tRPC boundary).
+   */
+  vaultCommitDiff(hash: string): CommitDiff;
   /**
    * The guarded whole-vault restore (rethink T21, spec §8 / D16): refuse
    * while a curation run is in flight or another restore holds the lock →
@@ -380,6 +388,7 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Libra
         ...entry,
         source: classifyVaultCommit(entry.subject),
       })),
+    vaultCommitDiff: (hash) => gitHistory.commitDiff(hash),
     restoreVaultTo: (hash, options) =>
       restoreVaultToCommit(
         {

--- a/packages/core/tests/store/git/git-history.test.ts
+++ b/packages/core/tests/store/git/git-history.test.ts
@@ -256,3 +256,47 @@ describe("tag / restoreTreeTo (the whole-vault restore plumbing)", () => {
     expect(commit).not.toBeNull();
   });
 });
+
+describe("commitDiff", () => {
+  it("returns per-file diffs for a multi-file commit, with status + path", () => {
+    write("a.md", "v1\n");
+    write("b.md", "kept\n");
+    git.commitAll("seed");
+    write("a.md", "v2\n");
+    write("c.md", "fresh\n");
+    fs.rmSync(path.join(cwd, "b.md"));
+    const c = git.commitAll("multi: edit a, add c, drop b");
+
+    const { hash, files } = createGitHistory({ cwd }).commitDiff(c!);
+    expect(hash).toBe(c);
+    // Order matches git's diff-tree output; convert to a path-keyed map.
+    const byPath = Object.fromEntries(files.map((f) => [f.path, f]));
+    expect(byPath["a.md"]?.status).toBe("modified");
+    expect(byPath["a.md"]?.diff).toMatch(/-v1/);
+    expect(byPath["a.md"]?.diff).toMatch(/\+v2/);
+    expect(byPath["b.md"]?.status).toBe("deleted");
+    expect(byPath["c.md"]?.status).toBe("added");
+    expect(byPath["c.md"]?.diff).toMatch(/\+fresh/);
+  });
+
+  it("flags renames with fromPath", () => {
+    write("old.md", "content\n");
+    git.commitAll("seed");
+    fs.renameSync(path.join(cwd, "old.md"), path.join(cwd, "new.md"));
+    const c = git.commitAll("rename");
+    const { files } = createGitHistory({ cwd }).commitDiff(c!);
+    const renamed = files.find((f) => f.path === "new.md");
+    expect(renamed?.status).toBe("renamed");
+    expect(renamed?.fromPath).toBe("old.md");
+  });
+
+  it("rejects flag-shaped hashes before they reach git", () => {
+    expect(() => createGitHistory({ cwd }).commitDiff("--unsafe")).toThrow(GitHashError);
+  });
+
+  it("returns an empty files array for an unknown commit (commitless repo)", () => {
+    // A 40-hex string that isn't a real commit — git show fails soft via tryGit.
+    const { files } = createGitHistory({ cwd }).commitDiff("f".repeat(40));
+    expect(files).toEqual([]);
+  });
+});

--- a/packages/mcp-server/src/trpc/activity.ts
+++ b/packages/mcp-server/src/trpc/activity.ts
@@ -46,6 +46,8 @@ const RestoreInputSchema = z.object({
   confirm: z.string(),
 });
 
+const CommitDiffInputSchema = z.object({ hash: HashSchema });
+
 function rethrow(error: unknown): never {
   if (error instanceof GitHashError) {
     throw new TRPCError({ code: "BAD_REQUEST", message: error.message });
@@ -67,6 +69,20 @@ export const activityRouter = router({
         ...(input?.limit !== undefined ? { limit: input.limit } : {}),
         ...(input?.before !== undefined ? { before: input.before } : {}),
       });
+    } catch (error) {
+      rethrow(error);
+    }
+  }),
+
+  /**
+   * Per-file diffs introduced by a single vault commit (rethink T21
+   * activity-feed accordion). Returns the empty-files shape for an unknown
+   * commit so the dashboard can render "no diff available" rather than
+   * surface a not-found error mid-accordion expand.
+   */
+  commitDiff: adminProcedure.input(CommitDiffInputSchema).query(({ ctx, input }) => {
+    try {
+      return ctx.store.vaultCommitDiff(input.hash);
     } catch (error) {
       rethrow(error);
     }


### PR DESCRIPTION
## Summary

Each row on `/activity` now expands inline to show the diff that commit introduced. Same shape as the per-file history accordion on the vault file view, but commit-scoped — one fetch returns the whole commit, lazy-loaded on expand. Plus a small cleanup on `/settings/primer` (drops the duplicate-context page header).

## What changed

**Backend (`packages/core` + `packages/mcp-server`)**
- New `GitHistory.commitDiff(hash)` returns a structured `CommitDiff` (`{ hash, files: [{ path, status, fromPath?, diff }] }`). Single `git show -M --pretty=format:` under the hood; sections split on the `diff --git` header; status (added / modified / deleted / renamed) derived from the section's own metadata. Argv-discipline via `assertCommitHash`; unknown commits soft-fail to an empty `files` array.
- `store.vaultCommitDiff(hash)` thin-wraps it on `LibrarianStore`.
- `vault.commitDiff` tRPC procedure (admin) wired to the activity router.

**Dashboard**
- `commitDiffAction({ hash })` server action wraps the tRPC call.
- `<DiffView>` extracted to its own module so the activity feed and the per-file history accordion render through one primitive. Editorial palette: verdigris wash for additions, red-ochre wash for deletions, foreground/55 for hunk markers and headers (swapped from the emerald/red/sky Tailwind defaults). `file-history.tsx` re-exports `DiffView` under the original name for backwards-compat with the existing tests.
- `ActivityFeed` rows gain a chevron toggle; expand lazy-loads the commit diff and renders each file as a `SectionLabel` + path header + `<DiffView>`. The inline file-list under the subject stays put so the at-a-glance "which files" answer is preserved.

**`/settings/primer`** drops the page-level "Settings" heading + byline. The Settings dropdown in the top nav carries the cross-page context; the form's own Primer heading + subtitle says the rest.

## Verification

- `pnpm typecheck` + `pnpm run lint` clean.
- **258 dashboard tests pass** (+2 new ActivityFeed accordion tests; DiffView color test updated for the editorial palette).
- **22 git-history tests pass** (+4 new `commitDiff` tests: multi-file commits with mixed statuses, rename + `fromPath`, flag-shaped hash rejection, unknown-commit soft-fail).
- `pnpm run check:release` confirms rc.20 is the dated top entry, linked.

## Test plan

- [ ] `/activity` loads; each row shows the inline file-list under the subject (unchanged behaviour).
- [ ] Click the chevron on a commit row → diff loads → renders one `<DiffView>` per file with a SectionLabel header (status + path).
- [ ] Renames show `(was old-path)` next to the new path.
- [ ] Added lines have the verdigris wash; deleted lines have the red-ochre wash.
- [ ] Toggling a row collapses without re-fetching; reopening is instant (cached).
- [ ] An empty commit (or one only touching binary files) shows "No file diffs recorded for this commit."
- [ ] `/settings/primer` no longer carries the "Settings" page header — just the AwarenessPrimerForm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)