### PR TITLE
fix(cli): unbreak server up/update checkout and unfreeze npm auto-publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,15 @@ jobs:
           fi
           pnpm config set //registry.npmjs.org/:_authToken "${NPM_TOKEN}"
           PKG=@the-librarian/cli
-          V="$(node -p "require('./packages/installer-cli/package.json').version")"
+          # Single source of truth: the ROOT package.json version (the one every
+          # PR bumps + the `release` job tags above). The published package's own
+          # version had drifted (frozen at rc.5 while root advanced), so the read
+          # below kept seeing a version already on npm and the publish silently
+          # no-op'd. Stamp the root version into every public workspace package so
+          # the npm artifact always matches the tag. `--no-git-checks` (below)
+          # tolerates the resulting dirty tree.
+          node scripts/stamp-version.mjs
+          V="$(node -p "require('./package.json').version")"
           if npm view "${PKG}@${V}" version >/dev/null 2>&1; then
             echo "${PKG}@${V} already on npm — nothing to publish."
           else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,40 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.21] — 2026-06-15
+
+Two release-plumbing fixes for `librarian server`.
+
+### Fixed
+
+- **`librarian server up` / `update` no longer fail at the git checkout step.**
+  The deploy-dir checkout passed the ref after `--end-of-options`, but
+  `git checkout` does **not** honor that marker — it reads it as a pathspec
+  (`error: pathspec '--end-of-options' did not match`, reproduced on git 2.43) —
+  so `up`/`update` aborted before building the image. The ref is now resolved to
+  a commit SHA via `git rev-parse --end-of-options` (which *does* honor it, so
+  the S-1 anti-injection guard is preserved) and that SHA is checked out. Covered
+  by a real-git regression test — the existing suites mock the git runner, so by
+  construction they could not catch this.
+- **npm auto-publish unstuck.** `@the-librarian/cli` is published from
+  `packages/installer-cli`, whose version had drifted (frozen at `1.0.0-rc.5`)
+  while the root advanced — so the publish step kept seeing a version already on
+  npm and silently no-op'd, freezing npm at rc.5 while GitHub releases reached
+  rc.20. The Release workflow now stamps the root version into every public
+  workspace package before publishing.
+- **Hermes adapter pin no longer drifts.** `PINNED_REF` (the tag the Hermes
+  adapter is fetched from) was a hardcoded `v1.0.0-rc.5`; it now derives from the
+  CLI's own version so it tracks the published tag automatically. It had only
+  stayed green because `installer-cli` was frozen at that same rc.5.
+
+### Added
+
+- **`scripts/stamp-version.mjs`** (also `pnpm sync:versions`) — stamps the root
+  version into every public workspace package, keeping the published
+  `@the-librarian/cli` version in lockstep with the root (and an honest
+  `librarian --version` for source builds). Private packages stay pinned at
+  `0.0.0`.
+
 ## [1.0.0-rc.20] — 2026-06-15
 
 The vault activity feed becomes an accordion: each commit row
@@ -2537,6 +2571,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0-rc.21]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.20...v1.0.0-rc.21
 [1.0.0-rc.20]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.19...v1.0.0-rc.20
 [1.0.0-rc.19]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.18...v1.0.0-rc.19
 [1.0.0-rc.18]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.17...v1.0.0-rc.18

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.20",
+  "version": "1.0.0-rc.21",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",
@@ -21,6 +21,7 @@
     "format:check": "prettier --check .",
     "typecheck": "pnpm -r run typecheck",
     "build": "pnpm -r run build",
+    "sync:versions": "node scripts/stamp-version.mjs",
     "check:test-count": "node --no-warnings scripts/check-test-count.mjs",
     "check:no-secrets-in-vault": "node --no-warnings scripts/check-no-secrets-in-vault.mjs",
     "check:naming-canon": "node --no-warnings scripts/check-naming-canon.mjs",

--- a/packages/installer-cli/package.json
+++ b/packages/installer-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-librarian/cli",
-  "version": "1.0.0-rc.5",
+  "version": "1.0.0-rc.21",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/installer-cli/src/harnesses/hermes.ts
+++ b/packages/installer-cli/src/harnesses/hermes.ts
@@ -23,12 +23,16 @@ import os from "node:os";
 import path from "node:path";
 import { run } from "../exec.js";
 import { hermesConfigPath, hermesHomeDir, hermesPluginDir } from "../paths.js";
+import { cliVersion } from "../version.js";
 import type { HarnessConfig, HarnessModule } from "./types.js";
 
 const PROVIDER_ID = "librarian";
-// The pinned monorepo release we fetch the adapter from. Default to the
-// repo's current release tag; the phase gate owns version bumps.
-export const PINNED_REF = "v1.0.0-rc.5";
+// The pinned monorepo release we fetch the adapter from: the tag matching this
+// CLI's own version. DERIVED (not hardcoded) so it can't drift — the published
+// package's version is stamped from the root at publish (scripts/stamp-version.mjs),
+// and the matching `vX.Y.Z` tag exists before the package is published. A
+// hardcoded literal here silently froze at rc.5 once before.
+export const PINNED_REF = `v${cliVersion()}`;
 
 /**
  * Fetches the Hermes adapter for a pinned ref and returns the absolute

--- a/packages/installer-cli/src/server/up.ts
+++ b/packages/installer-cli/src/server/up.ts
@@ -580,8 +580,7 @@ async function prepareDeployDir(dir: string, tag: string): Promise<void> {
       }
     }
     await git(["clone", REPO_URL, dir]);
-    // `--end-of-options` so a `--…`-shaped ref can't inject a git option (S-1).
-    await git(["-C", dir, "checkout", "--end-of-options", tag]);
+    await checkoutRef(dir, tag);
     return;
   }
 
@@ -595,8 +594,7 @@ async function prepareDeployDir(dir: string, tag: string): Promise<void> {
     );
   }
   await git(["-C", dir, "fetch", "--tags", "origin"]);
-  // `--end-of-options` so a `--…`-shaped ref can't inject a git option (S-1).
-  await git(["-C", dir, "checkout", "--end-of-options", tag]);
+  await checkoutRef(dir, tag);
 }
 
 /** True iff `origin` points at the same repo as `REPO_URL` (scheme/.git tolerant). */
@@ -802,6 +800,28 @@ function isYes(answer: string): boolean {
 async function git(args: string[]): Promise<void> {
   const result = await run("git", args);
   failIfNonZero("git", args, result);
+}
+
+/**
+ * Check out `ref` in `dir` without letting a `--…`-shaped ref inject a git
+ * option (S-1). `git checkout` does NOT honor `--end-of-options` — it reads the
+ * marker itself as a pathspec (`pathspec '--end-of-options' did not match`,
+ * verified on git 2.43), so guarding the ref on the checkout fails outright.
+ * `git rev-parse` DOES honor `--end-of-options`, so we resolve the ref to a
+ * commit SHA there (the injection guard that actually works), then check out
+ * that SHA — a hex object id can never be parsed as an option.
+ */
+export async function checkoutRef(dir: string, ref: string): Promise<void> {
+  const resolved = await run("git", [
+    "-C",
+    dir,
+    "rev-parse",
+    "--verify",
+    "--end-of-options",
+    `${ref}^{commit}`,
+  ]);
+  failIfNonZero("git", ["-C", dir, "rev-parse", ref], resolved);
+  await git(["-C", dir, "checkout", resolved.stdout.trim()]);
 }
 
 /** Run a `docker …` command from the deploy dir; non-zero exit → teaching error. */

--- a/packages/installer-cli/src/server/update.ts
+++ b/packages/installer-cli/src/server/update.ts
@@ -145,9 +145,8 @@ export async function runUpdate(options: UpdateOptions = {}): Promise<UpdateResu
   }
 
   // 4) Update, in the deploy dir: fetch tags → checkout the resolved ref.
-  //    `--end-of-options` so a `--…`-shaped ref can't inject a git option (S-1).
   await git(["-C", deployDir, "fetch", "--tags", "origin"]);
-  await git(["-C", deployDir, "checkout", "--end-of-options", targetRef]);
+  await checkoutRef(deployDir, targetRef);
 
   // 5) Build the new image from the deploy dir.
   await dockerInDir(
@@ -281,6 +280,26 @@ async function readExistingContainerEnv(): Promise<Map<string, string>> {
 async function git(args: string[]): Promise<void> {
   const result = await run("git", args);
   failIfNonZero("git", args, result);
+}
+
+/**
+ * Check out `ref` in `dir` without letting a `--…`-shaped ref inject a git
+ * option (S-1). `git checkout` does NOT honor `--end-of-options` — it reads the
+ * marker itself as a pathspec (verified on git 2.43) — so we resolve the ref to
+ * a commit SHA with `git rev-parse` (which DOES honor it, the injection guard
+ * that works), then check out that SHA — a hex object id can't be an option.
+ */
+async function checkoutRef(dir: string, ref: string): Promise<void> {
+  const resolved = await run("git", [
+    "-C",
+    dir,
+    "rev-parse",
+    "--verify",
+    "--end-of-options",
+    `${ref}^{commit}`,
+  ]);
+  failIfNonZero("git", ["-C", dir, "rev-parse", ref], resolved);
+  await git(["-C", dir, "checkout", resolved.stdout.trim()]);
 }
 
 /** Run a `docker …` command from the deploy dir; non-zero exit → teaching error. */

--- a/packages/installer-cli/tests/server-checkout-ref.test.ts
+++ b/packages/installer-cli/tests/server-checkout-ref.test.ts
@@ -1,0 +1,73 @@
+// Regression (real git, no mock): `git checkout --end-of-options <ref>` is
+// REJECTED by real git — `checkout` reads the `--end-of-options` marker as a
+// pathspec (`error: pathspec '--end-of-options' did not match`, verified on git
+// 2.43), which broke `server up`/`update` at the checkout step. The other tests
+// in this package inject a FakeRunner and only assert argv, so they CANNOT catch
+// this — by construction they never run real git. This test drives `checkoutRef`
+// against a throwaway LOCAL git repo (no network, no daemon) so the real binary
+// validates the fix: resolve the ref to a SHA via `rev-parse` (which DOES honor
+// `--end-of-options`, keeping the S-1 injection guard), then check out the SHA.
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resetRunner } from "../src/server/docker.js";
+import { checkoutRef } from "../src/server/up.js";
+
+/** Run a git command in `dir`, returning trimmed stdout. */
+function git(dir: string, ...args: string[]): string {
+  return execFileSync("git", ["-C", dir, ...args], { stdio: ["ignore", "pipe", "pipe"] })
+    .toString()
+    .trim();
+}
+
+/** A throwaway repo with one commit and a tag; returns its dir + tag commit SHA. */
+function makeRepo(): { dir: string; tagSha: string } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-checkout-"));
+  execFileSync("git", ["init", "-q", "-b", "main", dir]);
+  git(dir, "config", "user.email", "test@example.com");
+  git(dir, "config", "user.name", "Test");
+  git(dir, "config", "commit.gpgsign", "false");
+  fs.writeFileSync(path.join(dir, "file.txt"), "hello\n");
+  git(dir, "add", "-A");
+  git(dir, "commit", "-q", "-m", "init");
+  git(dir, "tag", "v0.0.0-test");
+  return { dir, tagSha: git(dir, "rev-parse", "v0.0.0-test^{commit}") };
+}
+
+describe("checkoutRef (real git, local repo)", () => {
+  // The other suites inject a fake runner; ensure checkoutRef uses REAL git here.
+  afterEach(() => resetRunner());
+
+  it("checks out a tag by resolving it to a commit SHA", async () => {
+    resetRunner();
+    const { dir, tagSha } = makeRepo();
+    try {
+      // Make HEAD differ from the tag first, so a no-op can't masquerade as success.
+      fs.writeFileSync(path.join(dir, "file.txt"), "changed\n");
+      git(dir, "commit", "-aqm", "second");
+      expect(git(dir, "rev-parse", "HEAD")).not.toBe(tagSha);
+
+      await checkoutRef(dir, "v0.0.0-test");
+
+      expect(git(dir, "rev-parse", "HEAD")).toBe(tagSha);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects an option-shaped ref instead of executing it (S-1 guard)", async () => {
+    resetRunner();
+    const { dir } = makeRepo();
+    try {
+      // `--end-of-options` makes rev-parse treat this as a (bogus) revision, not
+      // an option — so it fails to resolve and checkoutRef throws, never running
+      // it as a git flag.
+      await expect(checkoutRef(dir, "--upload-pack=touch /tmp/pwned")).rejects.toThrow();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/installer-cli/tests/server-up.test.ts
+++ b/packages/installer-cli/tests/server-up.test.ts
@@ -94,14 +94,23 @@ describe("server up — fresh localhost happy path (exact argv)", () => {
 
       const deployDir = path.join(home, ".librarian", "server");
 
-      // git clone <repo> <dir>, then checkout the resolved tag. The ref is passed
-      // after `--end-of-options` so a `--…`-shaped ref can't inject a git option (S-1).
+      // git clone <repo> <dir>, then resolve the ref to a SHA — guarded on
+      // `rev-parse` (which DOES honor `--end-of-options`; `git checkout` does
+      // NOT) — and check out that SHA (S-1). The checkout itself running is
+      // proven by the docker build/run below (it follows the checkout in code).
       expect(
         runner.ran("git", ["clone", "https://github.com/JimJafar/the-librarian", deployDir]),
       ).toBe(true);
-      expect(runner.ran("git", ["-C", deployDir, "checkout", "--end-of-options", LATEST_TAG])).toBe(
-        true,
-      );
+      expect(
+        runner.ran("git", [
+          "-C",
+          deployDir,
+          "rev-parse",
+          "--verify",
+          "--end-of-options",
+          `${LATEST_TAG}^{commit}`,
+        ]),
+      ).toBe(true);
 
       // docker build with the VERIFIED command.
       expect(
@@ -180,9 +189,16 @@ describe("server up — flags reflected in argv", () => {
       expect(
         runner.ran("git", ["clone", "https://github.com/JimJafar/the-librarian", customDir]),
       ).toBe(true);
-      expect(runner.ran("git", ["-C", customDir, "checkout", "--end-of-options", "main"])).toBe(
-        true,
-      );
+      expect(
+        runner.ran("git", [
+          "-C",
+          customDir,
+          "rev-parse",
+          "--verify",
+          "--end-of-options",
+          "main^{commit}",
+        ]),
+      ).toBe(true);
 
       // The image tag follows the ref; the volume is the override.
       expect(
@@ -432,13 +448,20 @@ describe("server up — foreign deploy dir stops and asks (never clobbers)", () 
       const r = await runCli(["server", "up"], { home, prompter });
       expect(r.exitCode).toBe(0);
 
-      // No clone (already ours); fetch tags + checkout the resolved tag (ref
-      // after `--end-of-options` so a `--…`-shaped ref can't inject an option, S-1).
+      // No clone (already ours); fetch tags + resolve the ref on `rev-parse`
+      // (the guard `git checkout` can't honor, S-1) before checking out the SHA.
       expect(runner.calls.some((c) => c.cmd === "git" && c.args[0] === "clone")).toBe(false);
       expect(runner.ran("git", ["-C", deployDir, "fetch", "--tags", "origin"])).toBe(true);
-      expect(runner.ran("git", ["-C", deployDir, "checkout", "--end-of-options", LATEST_TAG])).toBe(
-        true,
-      );
+      expect(
+        runner.ran("git", [
+          "-C",
+          deployDir,
+          "rev-parse",
+          "--verify",
+          "--end-of-options",
+          `${LATEST_TAG}^{commit}`,
+        ]),
+      ).toBe(true);
     });
   });
 });

--- a/packages/installer-cli/tests/server-update.test.ts
+++ b/packages/installer-cli/tests/server-update.test.ts
@@ -176,9 +176,18 @@ describe("server update — upgrade path argv sequence (SC 5)", () => {
 
       // Each step, with its exact argv.
       expect(runner.ran("git", ["-C", dir, "fetch", "--tags", "origin"])).toBe(true);
-      // The ref is passed after `--end-of-options` so a `--…`-shaped ref can't
-      // inject a git option (S-1).
-      expect(runner.ran("git", ["-C", dir, "checkout", "--end-of-options", LATEST_TAG])).toBe(true);
+      // The ref is resolved on `rev-parse --end-of-options` (the injection guard
+      // `git checkout` does NOT honor, S-1); the resolved SHA is then checked out.
+      expect(
+        runner.ran("git", [
+          "-C",
+          dir,
+          "rev-parse",
+          "--verify",
+          "--end-of-options",
+          `${LATEST_TAG}^{commit}`,
+        ]),
+      ).toBe(true);
       expect(
         runner.ran("docker", [
           "build",
@@ -331,7 +340,16 @@ describe("server update — --ref reflected in checkout + build tag", () => {
       const r = await runCli(["server", "update", "--ref", "main"], { home });
       expect(r.exitCode).toBe(0);
 
-      expect(runner.ran("git", ["-C", dir, "checkout", "--end-of-options", "main"])).toBe(true);
+      expect(
+        runner.ran("git", [
+          "-C",
+          dir,
+          "rev-parse",
+          "--verify",
+          "--end-of-options",
+          "main^{commit}",
+        ]),
+      ).toBe(true);
       expect(
         runner.ran("docker", [
           "build",

--- a/scripts/stamp-version.mjs
+++ b/scripts/stamp-version.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+// Keep the PUBLIC workspace packages' versions in lockstep with the root
+// package.json — the single source of truth that every PR bumps and the Release
+// workflow tags.
+//
+// Why this exists: `@the-librarian/cli` (packages/installer-cli) is published to
+// npm, but the "bump the root package.json" release model only versioned the
+// root. The published package's own version drifted (frozen at rc.5 while the
+// root advanced to rc.20+), so the publish step kept reading the stale version,
+// saw it already on npm, and silently no-op'd — npm froze at rc.5 while GitHub
+// releases marched on. The Release workflow runs this before `npm publish` so the
+// published artifact always matches the tag; `pnpm sync:versions` runs it locally
+// so a source build's `librarian --version` is honest too.
+//
+// Private packages (private:true, pinned at 0.0.0) are deliberately left alone.
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+
+/**
+ * Given a package.json's raw text and the canonical root version, return the
+ * rewritten text with `version` set to `rootVersion`, or `null` when nothing
+ * should change — the package is private (stays pinned at 0.0.0) or is already at
+ * the version. Preserves the repo's package.json style (2-space indent + trailing
+ * newline). Exported (pure) so it is unit-tested without touching the filesystem.
+ */
+export function stampPackageJson(raw, rootVersion) {
+  const pkg = JSON.parse(raw);
+  if (pkg.private === true) return null;
+  if (pkg.version === rootVersion) return null;
+  pkg.version = rootVersion;
+  return `${JSON.stringify(pkg, null, 2)}\n`;
+}
+
+/**
+ * Stamp every public package under `packages/` to the root version. Returns the
+ * root version and the list of package dirs that changed.
+ */
+export function stampAll(root = repoRoot) {
+  const rootVersion = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8")).version;
+  const packagesDir = path.join(root, "packages");
+  const changed = [];
+  for (const entry of fs.readdirSync(packagesDir)) {
+    const file = path.join(packagesDir, entry, "package.json");
+    if (!fs.existsSync(file)) continue;
+    const next = stampPackageJson(fs.readFileSync(file, "utf8"), rootVersion);
+    if (next === null) continue;
+    fs.writeFileSync(file, next);
+    changed.push(entry);
+  }
+  return { rootVersion, changed };
+}
+
+// CLI entrypoint (run directly, not when imported by the test).
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  const { rootVersion, changed } = stampAll();
+  console.log(
+    changed.length
+      ? `[stamp-version] set ${changed.join(", ")} to ${rootVersion}.`
+      : `[stamp-version] all public packages already at ${rootVersion}.`,
+  );
+}

--- a/test/stamp-version.test.ts
+++ b/test/stamp-version.test.ts
@@ -1,0 +1,34 @@
+// Guards the version-sync mechanism the npm publish relies on. `@the-librarian/cli`
+// is published from the root version (stamped at publish time); the bug this
+// prevents is the published package's version drifting from the root and the
+// publish silently no-op'ing on the stale version (npm froze at rc.5 while the
+// root reached rc.20+). See scripts/stamp-version.mjs.
+
+import { describe, expect, it } from "vitest";
+import { stampPackageJson } from "../scripts/stamp-version.mjs";
+
+describe("stampPackageJson", () => {
+  it("stamps a public package to the root version", () => {
+    const raw = `${JSON.stringify(
+      { name: "@the-librarian/cli", version: "1.0.0-rc.5", private: false },
+      null,
+      2,
+    )}\n`;
+    const out = stampPackageJson(raw, "1.0.0-rc.21");
+    expect(out).not.toBeNull();
+    expect(JSON.parse(out).version).toBe("1.0.0-rc.21");
+    // Preserves the repo's package.json style (2-space indent + trailing newline).
+    expect(out.endsWith("\n")).toBe(true);
+    expect(out).toContain('\n  "name"');
+  });
+
+  it("leaves private packages untouched (returns null)", () => {
+    const raw = JSON.stringify({ name: "@librarian/core", version: "0.0.0", private: true });
+    expect(stampPackageJson(raw, "1.0.0-rc.21")).toBeNull();
+  });
+
+  it("is a no-op when already at the root version (returns null)", () => {
+    const raw = JSON.stringify({ name: "@the-librarian/cli", version: "1.0.0-rc.21" });
+    expect(stampPackageJson(raw, "1.0.0-rc.21")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Why

Two release-plumbing bugs surfaced while migrating a live deployment to the all-in-one container. Both are the same root-cause class: a version/ref that should track the release had silently frozen.

## 1. `librarian server up` / `update` fail at the git checkout

`prepareDeployDir` (and `update`) ran `git checkout --end-of-options <ref>`. **`git checkout` does not honor `--end-of-options`** — it reads the marker itself as a pathspec:

```
error: pathspec '--end-of-options' did not match any file(s) known to git
error: pathspec 'v1.0.0-rc.20' did not match any file(s) known to git
```

Reproduced on git **2.43.0** (not a version-too-old issue). So every `up`/`update` aborted before building the image. The unit suites never caught it because they inject a `FakeRunner` and only assert argv — by construction they never run real git, so they pinned the broken command.

**Fix:** resolve the ref to a commit SHA with `git rev-parse --verify --end-of-options <ref>^{commit}` (rev-parse *does* honor the flag, so the S-1 anti-injection guard is preserved), then check out the SHA — a hex object id can't be parsed as an option. New `checkoutRef` helper in `up.ts` + `update.ts`.

## 2. npm auto-publish frozen at rc.5

`@the-librarian/cli` publishes from `packages/installer-cli`, but the "every PR bumps the **root** `package.json`" model never versioned the installer-cli package — it stayed at `1.0.0-rc.5`. The publish step read *that* version, saw it already on npm, and silently no-op'd (exit 0), so **npm froze at rc.5 while GitHub releases reached rc.20**. NPM_TOKEN was fine; tagging was fine; only the publish was stuck.

**Fix:** `scripts/stamp-version.mjs` (also `pnpm sync:versions`) stamps the root version into every public workspace package; the Release workflow runs it before publishing, so the npm artifact always matches the tag. The same drift had frozen the Hermes adapter's `PINNED_REF` at rc.5 — it now derives from the CLI version so it can't drift again.

## Tests

- **Real-git regression test** (`tests/server-checkout-ref.test.ts`) — drives `checkoutRef` against a throwaway local repo (no network); checks out a tag and rejects an option-shaped ref. This is the test the mock suites couldn't be.
- Updated `server-up` / `server-update` mock assertions to the new `rev-parse` → `checkout <sha>` flow.
- `test/stamp-version.test.ts` — unit-tests the stamp logic (public stamped, private left at 0.0.0, no-op when current).

## Verification (all green, exit codes checked directly)

`pnpm build` · `pnpm lint` · `pnpm format:check` · `pnpm typecheck` · `pnpm test` · `check:test-count` (2038 tests) · `check:release` (rc.21).

## Release

Bumps root → **rc.21** + dated CHANGELOG entry + compare-link. This PR also stamps `installer-cli` to rc.21, so on merge the Release workflow publishes rc.21 to npm (the first publish since rc.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
