### PR TITLE
fix(server): server/CLI hardening cluster (post-migration bugs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ snap-docker → native-docker host migration. See
   emit stdout to a non-TTY pipe, so health/log capture came back empty → a false
   health timeout that rolled back a running container. `up` now raises a teaching
   error naming the cause instead of the cryptic "(no log output captured)".
+- **`server up` now shows progress.** A multi-minute `up` was a blank line with no
+  sense of what was happening. It now prints numbered phase messages
+  (`[1/5]…[5/5]`) and **streams the slow image build live** (base-image pull, deps
+  install, embeddings-model download), so you can see where it is and what remains.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,44 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.22] — 2026-06-16
+
+A cluster of `librarian server` / admin-CLI fixes surfaced by a real LXC +
+snap-docker → native-docker host migration. See
+`docs/specs/2026-06-15-server-cli-hardening.md`.
+
+### Fixed
+
+- **The admin CLI can now read encrypted settings.** `the-librarian` built its
+  store with no master key, so it could not decrypt secret settings — `restore`
+  reported a false `No backup remote configured` on a dashboard-configured deploy
+  (the encrypted `backup.github.token` read was swallowed). It now resolves the key
+  (env → `<dataDir>/secret.key`, never generating one); a malformed key degrades to
+  keyless instead of crashing every command.
+- **`server up` no longer re-mints the master key.** It minted a fresh key on every
+  run, orphaning every secret encrypted under the previous one (curator token,
+  backup PAT). `up` now reuses an existing `deploy.env` key and only mints on a
+  first deploy.
+- **`server admin` no longer fails with "the input device is not a TTY".** Its
+  runner ignores stdin, so the old `-it` could never deliver a working prompt.
+  Interactive verbs now use an inherited-stdio exec (a real TTY); non-interactive —
+  including when `--secret-key` is supplied — runs without `-t`.
+- **The dashboard can restore into a fresh deployment.** The Restore button was
+  gated on local successful-run history, so a new deployment restoring from an
+  existing remote (a host migration) could never enable it. It now gates on a
+  resolvable remote (`backup.config.canRestore`).
+- **`server up` detects the snap-docker health-read failure.** Snap docker does not
+  emit stdout to a non-TTY pipe, so health/log capture came back empty → a false
+  health timeout that rolled back a running container. `up` now raises a teaching
+  error naming the cause instead of the cryptic "(no log output captured)".
+
+### Changed
+
+- README + DEPLOYMENT document that `librarian server` requires **native Docker**
+  (snap docker is unsupported — hidden-dir build context + non-TTY-pipe stdout), and
+  reconcile the master-key externalization recipe with the actual reuse/rotation
+  behavior.
+
 ## [1.0.0-rc.21] — 2026-06-15
 
 Two release-plumbing fixes for `librarian server`.
@@ -2571,6 +2609,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0-rc.22]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.21...v1.0.0-rc.22
 [1.0.0-rc.21]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.20...v1.0.0-rc.21
 [1.0.0-rc.20]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.19...v1.0.0-rc.20
 [1.0.0-rc.19]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.18...v1.0.0-rc.19

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -202,20 +202,21 @@ copy** of the key on disk; it does not change the live-host exposure above.
 
 ### (c) External secrets manager — documented recipe
 
-If you run a secrets manager (Vault, AWS/GCP Secrets Manager, 1Password, …),
-fetch the key from it and provide it as `LIBRARIAN_SECRET_KEY` in the environment
-**before** `librarian server up` / `update` (or before `docker run` / `docker
-compose`). The CLI sees a key already in env and **uses it as-is** — it does not
-mint a new one, and (env wins) the server never writes `/data/secret.key`:
+`librarian server up` mints the master key on a **first** deploy and writes it to
+the `0600` deploy env-file (rung (a)); both `up` and `update` then **reuse** that
+key on every subsequent run rather than minting a new one. (Re-minting a fresh key
+would orphan every secret encrypted under the old one — the curator's LLM token,
+the backup PAT — so reuse is the default and the key is never silently rotated.)
 
-```sh
-export LIBRARIAN_SECRET_KEY="$(your-secrets-cli read librarian/secret-key)"
-librarian server up        # uses the provided key; mints nothing
-```
-
-This keeps the canonical key in your manager (rotation, audit, access control
-there) and off both the data volume and any long-lived deploy file. Same live-host
-caveat: once the process is running, the key is in its memory regardless.
+So the integration with a secrets manager (Vault, AWS/GCP Secrets Manager,
+1Password, …) is: on the first deploy, capture the **surfaced** key and store it in
+your manager as the canonical copy (rotation, audit, access control live there).
+The key stays off the data volume — while it's in the deploy env-file the server
+never writes `/data/secret.key`. To rotate to a manager-issued key, replace
+`LIBRARIAN_SECRET_KEY` in `<deployDir>/deploy.env` (default `~/.librarian/server`)
+and run `librarian server update`; remember a rotation orphans secrets encrypted
+under the previous key, so re-enter them in the dashboard afterwards. Same
+live-host caveat: once the process is running, the key is in its memory regardless.
 
 ### Admin from the host (`server admin`)
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -37,6 +37,31 @@ librarian server up
 5. Offers to write **this** machine's own `~/.librarian/env` (single-box dev gets
    server + client in one shot) — offer, never force.
 
+### Docker engine: use native Docker, not snap
+
+`librarian server` requires **native Docker** (Docker CE / `docker.io`). It is
+**not supported on snap-packaged Docker** (`/snap/bin/docker` — common on Ubuntu,
+especially inside an LXC container). Snap's confinement breaks `server up` in two
+ways that surface as unrelated-looking failures:
+
+- **It can't read a hidden build-context dir.** The default deploy dir
+  `~/.librarian/server` is hidden (the leading `.`), so `docker build` fails
+  instantly with no output. _Workaround if you're stuck on snap:_ put the deploy
+  dir somewhere non-hidden with `--dir` (e.g.
+  `librarian server up --dir ~/librarian-deploy`), and pass the **same** `--dir` to
+  every later `update` / `status`.
+- **It doesn't emit stdout to a non-TTY pipe.** `server up` reads container health
+  and logs by capturing `docker` output through a pipe; under snap that comes back
+  empty, so `up` can't tell the container became healthy — it times out and rolls
+  back a container that was actually running. There is **no workaround** for this
+  one; it's the reason snap is unsupported. (`up` detects the empty-read signature
+  and says so, rather than reporting a misleading health timeout.)
+
+On Ubuntu / LXC, install the official **Docker CE** packages instead of the snap
+(enable LXC nesting first if you're in an unprivileged container). With native
+Docker none of the above applies — `server up` works with the default deploy dir
+and no extra flags.
+
 ### Bind host (`--host`)
 
 The default bind is `127.0.0.1` (host loopback only) — the server is reachable

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -237,11 +237,16 @@ So the integration with a secrets manager (Vault, AWS/GCP Secrets Manager,
 1Password, …) is: on the first deploy, capture the **surfaced** key and store it in
 your manager as the canonical copy (rotation, audit, access control live there).
 The key stays off the data volume — while it's in the deploy env-file the server
-never writes `/data/secret.key`. To rotate to a manager-issued key, replace
-`LIBRARIAN_SECRET_KEY` in `<deployDir>/deploy.env` (default `~/.librarian/server`)
-and run `librarian server update`; remember a rotation orphans secrets encrypted
-under the previous key, so re-enter them in the dashboard afterwards. Same
-live-host caveat: once the process is running, the key is in its memory regardless.
+never writes `/data/secret.key`.
+
+There is **no turn-key rotation**: once set, `up` and `update` preserve the key
+(`update` reads it back from the **running container**, so editing `deploy.env`
+alone does **not** rotate it), and rotating the master key would orphan every
+secret encrypted under the old one. Treat the first-deploy key as durable and keep
+its canonical copy in your manager. If you must re-key deliberately, stand up a
+fresh deployment with the new key supplied at create time and re-enter the
+encrypted settings (curator token, backup PAT) in the dashboard. Same live-host
+caveat: once the process is running, the key is in its memory regardless.
 
 ### Admin from the host (`server admin`)
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ librarian server up
 are all covered in the
 [one-command self-host guide](./DEPLOYMENT.md#one-command-self-host-librarian-server).
 
+> **Use native Docker, not the snap.** `librarian server` is unsupported on
+> snap-packaged Docker (common on Ubuntu / LXC) — its confinement breaks the build
+> and hides container health. Install Docker CE. See
+> [Docker engine: use native Docker, not snap](./DEPLOYMENT.md#docker-engine-use-native-docker-not-snap).
+
 ## Install on any harness
 
 Once your server is running, the `librarian` CLI wires The Librarian into your

--- a/apps/dashboard/app/settings/backups/page.tsx
+++ b/apps/dashboard/app/settings/backups/page.tsx
@@ -86,8 +86,6 @@ export default async function BackupsPage() {
     error = err instanceof Error ? err.message : String(err);
   }
 
-  const hasBackups = runs.some((run) => run.status === "ok");
-
   return (
     <main className="flex flex-col gap-8 p-6">
       <header className="flex flex-col gap-1.5">
@@ -131,7 +129,7 @@ export default async function BackupsPage() {
         <RestoreButton
           onStage={stageRestoreAction}
           onRestart={restartAction}
-          hasBackups={hasBackups}
+          canRestore={config?.canRestore ?? false}
         />
       </section>
 

--- a/apps/dashboard/components/backups/restore-button.tsx
+++ b/apps/dashboard/components/backups/restore-button.tsx
@@ -12,13 +12,16 @@ import { Button } from "@/components/ui-v2/button";
 export function RestoreButton({
   onStage,
   onRestart,
-  hasBackups,
+  canRestore,
 }: {
   onStage: () => Promise<StageRestoreResult>;
   onRestart: () => Promise<RestartResult>;
-  /** True when at least one successful backup exists — the precondition for
-   *  staging a restore. False on fresh installs (or all-failed history). */
-  hasBackups: boolean;
+  /** True when a backup REMOTE is configured (repo + token resolvable) — the real
+   *  precondition for staging a restore. It does NOT require a prior successful run
+   *  here: a fresh deployment restoring from an existing remote has none, and
+   *  gating on local run history made the button impossible to use after a host
+   *  migration. */
+  canRestore: boolean;
 }) {
   const [pending, startTransition] = useTransition();
   const [confirming, setConfirming] = useState(false);
@@ -72,8 +75,10 @@ export function RestoreButton({
           variant="outline"
           className="self-start"
           onClick={() => setConfirming(true)}
-          disabled={!hasBackups}
-          title={hasBackups ? undefined : "No backups to restore from yet — run one first."}
+          disabled={!canRestore}
+          title={
+            canRestore ? undefined : "Configure a backup repository + token first (Target, above)."
+          }
         >
           Restore from backup…
         </Button>

--- a/apps/dashboard/tests/components/backups/cockpit.test.tsx
+++ b/apps/dashboard/tests/components/backups/cockpit.test.tsx
@@ -88,7 +88,7 @@ describe("RestoreButton → RestartPrompt", () => {
   it("confirms, stages, then reveals the warned restart prompt", async () => {
     const onStage = vi.fn().mockResolvedValue({ ok: true, staged: "me/bk" });
     const onRestart = vi.fn().mockResolvedValue({ ok: true });
-    render(<RestoreButton onStage={onStage} onRestart={onRestart} hasBackups />);
+    render(<RestoreButton onStage={onStage} onRestart={onRestart} canRestore />);
 
     fireEvent.click(screen.getByRole("button", { name: /Restore from backup/ }));
     fireEvent.click(screen.getByRole("button", { name: "Confirm restore" }));
@@ -102,11 +102,11 @@ describe("RestoreButton → RestartPrompt", () => {
     await waitFor(() => expect(onRestart).toHaveBeenCalledTimes(1));
   });
 
-  it("disables Restore when there are no successful backups to restore from", () => {
-    render(<RestoreButton onStage={vi.fn()} onRestart={vi.fn()} hasBackups={false} />);
+  it("disables Restore when no backup remote is configured", () => {
+    render(<RestoreButton onStage={vi.fn()} onRestart={vi.fn()} canRestore={false} />);
     const button = screen.getByRole("button", { name: /Restore from backup/ });
     expect(button).toBeDisabled();
-    expect(button).toHaveAttribute("title", expect.stringMatching(/No backups to restore/));
+    expect(button).toHaveAttribute("title", expect.stringMatching(/Configure a backup repository/));
   });
 });
 

--- a/docs/specs/2026-06-15-server-cli-hardening.md
+++ b/docs/specs/2026-06-15-server-cli-hardening.md
@@ -1,0 +1,135 @@
+# Spec: `librarian server` + admin-CLI hardening (post-migration bug cluster)
+
+**Status:** Ready to build, 2026-06-15. Grounded against `main` @ v1.0.0-rc.21.
+
+## 1. Objective
+
+A real migration (unprivileged-LXC + snap docker → native docker on a new host)
+surfaced a cluster of `librarian server` / folded-in admin-CLI bugs that made
+restore-from-backup into a fresh deployment impossible without manual `docker exec`
+workarounds. Fix the ones that are code bugs; document the one that isn't (snap
+docker). Audience: self-hosters, especially anyone restoring a backup onto a new
+host. The `git checkout --end-of-options` bug from the same session already shipped
+in #384 (rc.21) and is out of scope here.
+
+## 2. Success criteria
+
+Each becomes a regression test that fails before the fix and passes after.
+
+1. **The admin CLI can read encrypted settings (root cause).** The `the-librarian`
+   binary builds its store with the resolved master key (`LIBRARIAN_SECRET_KEY` env
+   → `<dataDir>/secret.key` file), so `getSetting` on a secret (e.g.
+   `backup.github.token`) returns the decrypted value instead of throwing. Result:
+   `restore` resolves a **dashboard-saved** (encrypted) backup remote via
+   `resolveBackupRemote` — no false `No backup remote configured` when a repo+token
+   are set in the dashboard.
+   *Test:* a settings store with an encrypted `backup.github.token` + the key in env
+   → the CLI-constructed store reads it back; `resolveBackupRemote` is non-null.
+
+2. **`server up` preserves an existing master key.** When `<deployDir>/deploy.env`
+   already carries `LIBRARIAN_SECRET_KEY`, a re-run of `up` **reuses** it (mints
+   nothing), so secrets encrypted under it (curator token, backup PAT) stay
+   decryptable. A first deploy (no existing key) still mints + surfaces one.
+   *Test:* `runUp` with a pre-existing `deploy.env` key → new `deploy.env` carries
+   the SAME key, and the key is NOT re-surfaced as freshly minted; no existing key →
+   mints + surfaces. DEPLOYMENT.md rung-(c) wording reconciled to match.
+
+3. **`server admin` no longer dies with "the input device is not a TTY".** It
+   requests a docker pseudo-TTY (`-t`) only when it will actually prompt AND the
+   exec inherits a real stdin; otherwise it runs the verb non-interactively. With
+   `--secret-key` supplied (no prompt), `restore` runs to completion regardless of
+   the caller's stdin.
+   *Test:* the exec argv for `restore --secret-key X` omits `-t`; an interactive
+   prompt path (no key) uses an stdin-inheriting exec, not the capture runner that
+   ignores stdin.
+
+4. **The dashboard can restore into a fresh deployment.** The Restore control is
+   enabled when a backup **remote is configured** (repo + token present), not gated
+   on local successful-run history — so a brand-new deployment with zero runs but a
+   valid remote can stage a restore.
+   *Test:* config has repo+token and zero `ok` runs → the restore affordance is
+   enabled (server-side `canRestore`/equivalent is true).
+
+5. **The snap-docker incompatibility is documented and detected.**
+   - **README/DEPLOYMENT** gain a clear note: `librarian server` is unsupported on
+     **snap docker** — snap confinement can't read hidden build-context dirs and
+     doesn't emit stdout to non-TTY pipes (which silently breaks `up`'s health/log
+     capture). Recommend native `docker-ce`; give the non-hidden `--dir` note for
+     anyone who must use snap.
+   - **Detection (the fixable part):** when `up`'s health-poll reads **empty** output
+     from `docker inspect` where a status is required (the snap symptom), it raises a
+     teaching error naming the likely snap-docker cause and pointing at the docs —
+     instead of the cryptic `did not become healthy … (no log output captured)`.
+   *Test:* an injected runner returning empty stdout for the health inspect →
+   `up`/`waitForHealthy` throws an error whose message names snap docker + the docs.
+
+6. **Releasable.** One root `package.json` bump + dated `CHANGELOG.md` entry +
+   compare-link (`check:release`); `build`/`lint`/`typecheck`/`test`/`check:test-count`
+   green; **one PR, not merged.**
+
+## 3. Scope
+
+**In:** the five fixes above + the docs + the single release. Each ships with a
+regression test (Criterion 6 of AGENTS.md).
+
+**Out:**
+- Full snap-docker support (PTY-wrapping every docker spawn) — documented as
+  unsupported instead (§5).
+- Changing the default deploy dir away from the hidden `~/.librarian/server`
+  (behavior change; README + `--dir` suffices).
+- The `git checkout --end-of-options` fix — already shipped (#384 / rc.21).
+- Remote-dashboard topology, at-rest vault encryption, auth model changes.
+
+## 4. Key decisions
+
+- **P1 fix location:** `packages/cli/src/bin.ts` resolves the key (env →
+  `<dataDir>/secret.key`) and passes it to `createLibrarianStore({ secretKey })`.
+  Reuse the existing core key-resolution helper (`resolveSecretKey` + the same
+  env→file order boot uses) rather than re-implementing. This is the single highest-
+  impact fix — every admin verb that reads a secret depends on it.
+- **P2 fix:** in `runUp`, read `<deployDir>/deploy.env` first; if it has
+  `LIBRARIAN_SECRET_KEY`, reuse it; else mint. Surface "minted" vs "reused" honestly
+  in the output (only a freshly-minted key gets the SAVE-THIS-KEY banner). Mirrors
+  how `update` already preserves the key.
+- **P3 fix:** give the admin runner an stdin-inheriting exec mode for the genuinely
+  interactive prompt path; for non-interactive (a `--secret-key`/value already
+  supplied, or no TTY) drop `-it` entirely. The capture runner that uses
+  `stdio:["ignore",…]` must never be paired with `-t`.
+- **P4 fix:** compute the restore-enabled flag from `resolveBackupRemote`/config
+  (`repo` + `hasToken`) — server-side — and pass it to the button instead of
+  `runs.some(status==="ok")`. Keep the typed-confirmation guard.
+- **P5 detection:** treat a persistently-empty `docker inspect` health read as a
+  distinct failure with a teaching message; keep it conservative (only when output
+  is empty, exit code aside) to avoid false positives on native docker.
+
+## 5. Open questions
+
+None blocking — owner pre-authorised an autonomous build to a non-merged PR
+(2026-06-15). Decisions in §4 are the chosen defaults; revisit at review.
+
+## 6. Task plan (ordered; each leaves the system green)
+
+- [ ] **P1 — admin CLI reads encrypted settings.** `bin.ts` resolves + passes the
+      master key to `createLibrarianStore`. *Accept:* SC-1 test (CLI store reads an
+      encrypted setting; `resolveBackupRemote` non-null with a dashboard-style token).
+      *Depends:* none. *(root cause — first)*
+- [ ] **P2 — `up` reuses an existing master key.** *Accept:* SC-2 test (reuse when
+      `deploy.env` has a key; mint when not; banner only on mint). Reconcile
+      DEPLOYMENT.md rung-(c). *Depends:* none.
+- [ ] **P3 — `server admin` TTY handling.** *Accept:* SC-3 test (no `-t` for
+      `restore --secret-key`; interactive path inherits stdin). *Depends:* none.
+- [ ] **P4 — dashboard restore enabled by remote config.** *Accept:* SC-4 test
+      (enabled with repo+token + zero runs). *Depends:* none.
+- [ ] **P5 — snap-docker docs + detection.** README/DEPLOYMENT note; `up` teaching
+      error on empty health-inspect output. *Accept:* SC-5 test + docs present.
+      *Depends:* P2 (same `up.ts` region — serialize after P2).
+- [ ] **P6 — release gate.** Single root version bump (rc.22) + dated CHANGELOG +
+      compare-link; full gate green; open PR (do NOT merge). *Accept:* SC-6.
+      *Depends:* P1–P5.
+
+## 7. Checkpoint
+
+Owner is asleep and pre-authorised straight-through `sdlc-spec → sdlc-orchestrate`
+to a single non-merged PR. Build P1→P6, adversarially review the whole diff with a
+fresh-context pass, re-run the full gate against merged HEAD (exit codes, no
+`tail`/`head` on a gate), then open the PR and stop.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.21",
+  "version": "1.0.0-rc.22",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -5,10 +5,12 @@
 // runtime, prints the captured stdout, and translates the structured
 // result into a process exit code.
 
-import { createLibrarianStore } from "@librarian/core";
 import { runCli } from "./runtime.js";
+import { createCliStore } from "./store.js";
 
-const store = createLibrarianStore();
+// Keyed store (env → <dataDir>/secret.key) so admin verbs can decrypt secret
+// settings — e.g. the dashboard-saved backup token `restore` needs. See store.ts.
+const store = createCliStore();
 try {
   const result = runCli(process.argv.slice(2), store);
   if (result.stdout) console.log(result.stdout);

--- a/packages/cli/src/store.ts
+++ b/packages/cli/src/store.ts
@@ -1,0 +1,58 @@
+// The CLI bin's store factory.
+//
+// Unlike the long-running server (which resolves the master key at boot), the
+// `the-librarian` CLI previously built its store with NO key
+// (`createLibrarianStore()`), so it could not DECRYPT secret settings. That made
+// `restore` (and any admin verb that reads an encrypted setting) fail to see
+// dashboard-saved config — e.g. `resolveBackupRemote` returned null because the
+// encrypted `backup.github.token` read threw and was swallowed → the misleading
+// "No backup remote configured" on a deployment that HAD a remote configured.
+//
+// Resolution mirrors boot's "env wins, then the data volume" order —
+//   LIBRARIAN_SECRET_KEY → <dataDir>/secret.key → null
+// — but NEVER generates a key: the CLI is a transient client of an already-keyed
+// data dir, and minting one here would write a stray key that can't decrypt the
+// server's existing secrets. With no key resolvable the store stays keyless
+// (secret reads still fail), exactly as before; on a normal deploy the key is in
+// env or on the data volume, so admin verbs can now read encrypted config.
+
+import fs from "node:fs";
+import path from "node:path";
+import {
+  type LibrarianStore,
+  createLibrarianStore,
+  resolveDataDir,
+  resolveOptionalSecretKey,
+} from "@librarian/core";
+
+const SECRET_KEY_FILE = "secret.key";
+
+function readFileOrUndefined(filePath: string): string | undefined {
+  try {
+    return fs.readFileSync(filePath, "utf8");
+  } catch {
+    return undefined; // absent/unreadable → no file-resident key
+  }
+}
+
+/**
+ * Resolve the master key for a CLI invocation: `LIBRARIAN_SECRET_KEY` env →
+ * `<dataDir>/secret.key` → null. NEVER generates one (see the file header).
+ * Exported for the regression test.
+ */
+export function resolveCliSecretKey(
+  dataDir: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Buffer | null {
+  const raw = env.LIBRARIAN_SECRET_KEY ?? readFileOrUndefined(path.join(dataDir, SECRET_KEY_FILE));
+  return resolveOptionalSecretKey(raw);
+}
+
+/**
+ * Build the store the CLI bin uses — keyed (when a key is resolvable) so it can
+ * read encrypted settings.
+ */
+export function createCliStore(env: NodeJS.ProcessEnv = process.env): LibrarianStore {
+  const dataDir = resolveDataDir(undefined);
+  return createLibrarianStore({ dataDir, secretKey: resolveCliSecretKey(dataDir, env) });
+}

--- a/packages/cli/src/store.ts
+++ b/packages/cli/src/store.ts
@@ -44,8 +44,21 @@ export function resolveCliSecretKey(
   dataDir: string,
   env: NodeJS.ProcessEnv = process.env,
 ): Buffer | null {
-  const raw = env.LIBRARIAN_SECRET_KEY ?? readFileOrUndefined(path.join(dataDir, SECRET_KEY_FILE));
-  return resolveOptionalSecretKey(raw);
+  // Mirror boot's order: a present env value wins, but an EMPTY/whitespace env
+  // value falls through to the file (a bare `??` would select "" and silently go
+  // keyless — re-introducing the very bug this fixes).
+  const raw =
+    (env.LIBRARIAN_SECRET_KEY ?? "").trim() ||
+    readFileOrUndefined(path.join(dataDir, SECRET_KEY_FILE));
+  try {
+    return resolveOptionalSecretKey(raw);
+  } catch {
+    // A malformed key (hand-edited/truncated `secret.key`, or a bad env value) must
+    // NOT crash every CLI invocation — including verbs that need no secret at all,
+    // and `--help`. Degrade to a keyless store; secret-reading verbs then surface
+    // their own teaching error rather than a stack trace (AGENTS.md: never leak one).
+    return null;
+  }
 }
 
 /**

--- a/packages/cli/tests/cli-store.test.ts
+++ b/packages/cli/tests/cli-store.test.ts
@@ -1,0 +1,111 @@
+// SC-1 (server/CLI hardening): the `the-librarian` CLI must resolve the master key
+// so its store can DECRYPT secret settings — specifically the dashboard-saved
+// backup token that `restore`'s `resolveBackupRemote` reads.
+//
+// Why the existing restore tests missed this: they configure the remote via the
+// ENV fallback (`LIBRARIAN_BACKUP_GITHUB_*`, plaintext, no decryption). Production
+// `restore` against a dashboard-configured deploy hits the ENCRYPTED settings
+// path, which a keyless store can't read. This test exercises that path.
+//
+// GitGuardian-safety: the key is assembled at runtime (no contiguous 64-hex
+// literal); the token is a plain placeholder, never a PAT-shaped value.
+
+import { randomBytes } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createJsonSettingsStore, resolveBackupRemote, resolveSecretKey } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveCliSecretKey } from "../src/store.js";
+
+function tempDataDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "lib-cli-store-"));
+}
+
+// Seed an ENCRYPTED, dashboard-style backup remote into <dataDir>/settings.json:
+// repo is plaintext, token is an encrypted secret (the shape the dashboard writes).
+function seedEncryptedRemote(dataDir: string, keyHex: string): void {
+  const settings = createJsonSettingsStore({
+    filePath: path.join(dataDir, "settings.json"),
+    secretKey: resolveSecretKey(keyHex),
+  });
+  settings.setSetting("backup.github.repo", "octocat/backup");
+  settings.setSetting("backup.github.token", ["placeholder", "pat", "value"].join("-"), {
+    secret: true,
+  });
+}
+
+const SAVED: Record<string, string | undefined> = {};
+beforeEach(() => {
+  // resolveBackupRemote falls back to these env vars — clear them so ONLY the
+  // encrypted store setting can satisfy it (the entire point of the test).
+  for (const k of [
+    "LIBRARIAN_SECRET_KEY",
+    "LIBRARIAN_BACKUP_GITHUB_REPO",
+    "LIBRARIAN_BACKUP_GITHUB_TOKEN",
+  ]) {
+    SAVED[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+afterEach(() => {
+  for (const [k, v] of Object.entries(SAVED)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
+describe("CLI store key resolution (SC-1)", () => {
+  it("resolveCliSecretKey reads the key from <dataDir>/secret.key (env unset)", () => {
+    const dataDir = tempDataDir();
+    try {
+      const keyHex = randomBytes(32).toString("hex");
+      fs.writeFileSync(path.join(dataDir, "secret.key"), keyHex, { mode: 0o600 });
+      const key = resolveCliSecretKey(dataDir, {});
+      expect(key).not.toBeNull();
+      expect(key?.toString("hex")).toBe(keyHex);
+    } finally {
+      fs.rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("resolveCliSecretKey prefers env, and returns null (never generates) when absent", () => {
+    const dataDir = tempDataDir();
+    try {
+      const envKey = randomBytes(32).toString("hex");
+      expect(resolveCliSecretKey(dataDir, { LIBRARIAN_SECRET_KEY: envKey })?.toString("hex")).toBe(
+        envKey,
+      );
+      // No env, no file → null, and crucially NO secret.key is written.
+      expect(resolveCliSecretKey(dataDir, {})).toBeNull();
+      expect(fs.existsSync(path.join(dataDir, "secret.key"))).toBe(false);
+    } finally {
+      fs.rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("a KEYED store reads the encrypted backup remote; a KEYLESS one cannot (the bug)", () => {
+    const dataDir = tempDataDir();
+    try {
+      const keyHex = randomBytes(32).toString("hex");
+      seedEncryptedRemote(dataDir, keyHex);
+      fs.writeFileSync(path.join(dataDir, "secret.key"), keyHex, { mode: 0o600 });
+      const filePath = path.join(dataDir, "settings.json");
+
+      // Keyed via resolveCliSecretKey (the fix): the token decrypts → remote resolves.
+      const keyed = createJsonSettingsStore({
+        filePath,
+        secretKey: resolveCliSecretKey(dataDir, {}),
+      });
+      const remote = resolveBackupRemote(keyed, {});
+      expect(remote).not.toBeNull();
+      expect(remote?.repo).toBe("octocat/backup");
+
+      // Keyless (the old bin behavior): the token read throws → swallowed → null.
+      const keyless = createJsonSettingsStore({ filePath, secretKey: null });
+      expect(resolveBackupRemote(keyless, {})).toBeNull();
+    } finally {
+      fs.rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/tests/cli-store.test.ts
+++ b/packages/cli/tests/cli-store.test.ts
@@ -84,6 +84,37 @@ describe("CLI store key resolution (SC-1)", () => {
     }
   });
 
+  it("an empty/whitespace env value falls through to the file (not keyless)", () => {
+    const dataDir = tempDataDir();
+    try {
+      const keyHex = randomBytes(32).toString("hex");
+      fs.writeFileSync(path.join(dataDir, "secret.key"), keyHex, { mode: 0o600 });
+      // `LIBRARIAN_SECRET_KEY=` exported-but-empty must NOT shadow the on-disk key
+      // (a bare `??` would select "" → keyless → the very bug this fixes).
+      expect(resolveCliSecretKey(dataDir, { LIBRARIAN_SECRET_KEY: "" })?.toString("hex")).toBe(
+        keyHex,
+      );
+      expect(resolveCliSecretKey(dataDir, { LIBRARIAN_SECRET_KEY: "  " })?.toString("hex")).toBe(
+        keyHex,
+      );
+    } finally {
+      fs.rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("degrades to keyless (null, no throw) on a malformed key — never crashes the CLI", () => {
+    const dataDir = tempDataDir();
+    try {
+      fs.writeFileSync(path.join(dataDir, "secret.key"), "not-a-valid-key", { mode: 0o600 });
+      // A corrupt/hand-edited key must not throw out of the bin (AGENTS.md: no stack
+      // trace), even for verbs that need no secret.
+      expect(resolveCliSecretKey(dataDir, {})).toBeNull();
+      expect(resolveCliSecretKey(dataDir, { LIBRARIAN_SECRET_KEY: "also-not-valid" })).toBeNull();
+    } finally {
+      fs.rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
   it("a KEYED store reads the encrypted backup remote; a KEYLESS one cannot (the bug)", () => {
     const dataDir = tempDataDir();
     try {

--- a/packages/installer-cli/package.json
+++ b/packages/installer-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-librarian/cli",
-  "version": "1.0.0-rc.21",
+  "version": "1.0.0-rc.22",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/installer-cli/src/server/admin.ts
+++ b/packages/installer-cli/src/server/admin.ts
@@ -24,7 +24,7 @@
 // Everything goes through the injectable `docker.ts` seam, so tests assert the
 // exact argv without a real daemon or container.
 
-import { run } from "./docker.js";
+import { run, runInteractive } from "./docker.js";
 import { preflight } from "./preflight.js";
 import { redactSecrets } from "./redact.js";
 import { CONTAINER_NAME } from "./up.js";
@@ -120,15 +120,32 @@ export async function runAdmin(
   await preflight(options.platform ? { platform: options.platform } : {});
   await assertContainerRunning();
 
-  // `docker exec [-it] the-librarian the-librarian <verb> [args…]` — args verbatim.
-  const execArgs = [
-    "exec",
-    ...(options.interactive ? ["-it"] : []),
-    CONTAINER_NAME,
-    "the-librarian",
-    verb,
-    ...rest,
-  ];
+  // Interactive: inherit stdio so a `-it` exec can prompt the operator's real
+  // terminal (e.g. `restore` reading the secret key no-echo). The capture runner
+  // below uses `stdio:["ignore",…]`, so pairing it with `-t` only ever produced
+  // "the input device is not a TTY" — never a working prompt. Output streams live
+  // to the terminal, so there is nothing to capture or redact here.
+  if (options.interactive) {
+    const code = await runInteractive("docker", [
+      "exec",
+      "-it",
+      CONTAINER_NAME,
+      "the-librarian",
+      verb,
+      ...rest,
+    ]);
+    if (code !== 0) {
+      throw new AdminError(
+        `\`the-librarian ${verb}\` failed in the container (exit ${code ?? "signal"}).` +
+          `\n\nResolve the error above, then re-run \`librarian server admin ${verb}\`.`,
+      );
+    }
+    return { output: "" };
+  }
+
+  // Non-interactive: `docker exec the-librarian the-librarian <verb> [args…]` —
+  // args verbatim, NEVER `-it` (the runner ignores stdin). Output is captured.
+  const execArgs = ["exec", CONTAINER_NAME, "the-librarian", verb, ...rest];
   const result = await run("docker", execArgs);
 
   if (result.code !== 0) {

--- a/packages/installer-cli/src/server/admin.ts
+++ b/packages/installer-cli/src/server/admin.ts
@@ -120,12 +120,17 @@ export async function runAdmin(
   await preflight(options.platform ? { platform: options.platform } : {});
   await assertContainerRunning();
 
-  // Interactive: inherit stdio so a `-it` exec can prompt the operator's real
-  // terminal (e.g. `restore` reading the secret key no-echo). The capture runner
-  // below uses `stdio:["ignore",…]`, so pairing it with `-t` only ever produced
-  // "the input device is not a TTY" — never a working prompt. Output streams live
-  // to the terminal, so there is nothing to capture or redact here.
-  if (options.interactive) {
+  // A prompt is only needed when the run is interactive AND the operator hasn't
+  // already supplied the secret on the command line. With `--secret-key` present
+  // there is nothing to prompt for, so run non-interactively even on a TTY (SC-3:
+  // `restore --secret-key X` omits `-t`).
+  const willPrompt = options.interactive === true && !rest.includes("--secret-key");
+  if (willPrompt) {
+    // Inherit stdio so a `-it` exec can prompt the operator's real terminal (e.g.
+    // `restore` / `auth reset-password` reading a secret no-echo). The capture
+    // runner below uses `stdio:["ignore",…]`, so pairing it with `-t` only ever
+    // produced "the input device is not a TTY". Output streams live to the
+    // terminal — nothing to capture or redact here.
     const code = await runInteractive("docker", [
       "exec",
       "-it",
@@ -134,9 +139,11 @@ export async function runAdmin(
       verb,
       ...rest,
     ]);
-    if (code !== 0) {
+    // `null` = the process was signalled (e.g. the operator Ctrl-C'd the prompt) —
+    // a clean cancel, not a failure to surface.
+    if (code !== 0 && code !== null) {
       throw new AdminError(
-        `\`the-librarian ${verb}\` failed in the container (exit ${code ?? "signal"}).` +
+        `\`the-librarian ${verb}\` failed in the container (exit ${code}).` +
           `\n\nResolve the error above, then re-run \`librarian server admin ${verb}\`.`,
       );
     }

--- a/packages/installer-cli/src/server/docker.ts
+++ b/packages/installer-cli/src/server/docker.ts
@@ -181,3 +181,53 @@ export function setStreamer(streamer: Streamer): Streamer {
 export function resetStreamer(): void {
   currentStreamer = realStreamer;
 }
+
+// --- the interactive (inherited-stdio) exec seam --------------------------
+
+/**
+ * An exec that INHERITS the parent's stdio so the in-container process can prompt
+ * the operator's real terminal (e.g. `the-librarian restore` / `auth reset-password`
+ * reading a secret no-echo). The capture `run` above uses `stdio:["ignore",…]`, so
+ * it can NEVER carry a working `docker exec -t` — pairing them is exactly what
+ * produced "the input device is not a TTY". Interactive `server admin` uses this.
+ */
+export interface InteractiveRunner {
+  runInteractive(cmd: string, args: readonly string[], opts?: RunOptions): Promise<number | null>;
+}
+
+const realInteractiveRunner: InteractiveRunner = {
+  runInteractive(cmd, args, opts = {}) {
+    return new Promise<number | null>((resolve, reject) => {
+      const child = spawn(cmd, [...args], {
+        cwd: opts.cwd,
+        env: opts.env ? { ...process.env, ...opts.env } : process.env,
+        stdio: "inherit", // the whole point: a real TTY for `-it` + live prompts
+      });
+      child.on("error", reject);
+      child.on("close", (code) => resolve(code));
+    });
+  },
+};
+
+let currentInteractive: InteractiveRunner = realInteractiveRunner;
+
+/** Run an interactive (inherited-stdio) command through the current seam. */
+export function runInteractive(
+  cmd: string,
+  args: readonly string[],
+  opts?: RunOptions,
+): Promise<number | null> {
+  return currentInteractive.runInteractive(cmd, args, opts);
+}
+
+/** Swap in a fake interactive runner (tests). Returns the previous one. */
+export function setInteractiveRunner(runner: InteractiveRunner): InteractiveRunner {
+  const prev = currentInteractive;
+  currentInteractive = runner;
+  return prev;
+}
+
+/** Restore the real inherited-stdio interactive runner (tests). */
+export function resetInteractiveRunner(): void {
+  currentInteractive = realInteractiveRunner;
+}

--- a/packages/installer-cli/src/server/up.ts
+++ b/packages/installer-cli/src/server/up.ts
@@ -687,6 +687,7 @@ export async function waitForHealthy(options: HealthWaitOptions): Promise<void> 
   // logs` is empty too. We detect that distinct failure and teach, rather than
   // emit the misleading "did not become healthy … (no log output captured)".
   let sawAnyStatus = false;
+  let allInspectsOk = true;
   for (let i = 0; i < attempts; i += 1) {
     const result = await run("docker", [
       "inspect",
@@ -694,6 +695,7 @@ export async function waitForHealthy(options: HealthWaitOptions): Promise<void> 
       "{{.State.Health.Status}}",
       CONTAINER_NAME,
     ]);
+    if (result.code !== 0) allInspectsOk = false; // a failing inspect is NOT the snap signature
     const state = result.stdout.trim();
     if (state.length > 0) sawAnyStatus = true;
     if (state === "healthy") return;
@@ -710,10 +712,12 @@ export async function waitForHealthy(options: HealthWaitOptions): Promise<void> 
   const logs = await run("docker", ["logs", "--tail", String(tail), CONTAINER_NAME]);
   await run("docker", ["rm", "-f", CONTAINER_NAME]);
 
-  // Conservative snap-docker detection: every health read was empty (not a single
-  // "starting"/"healthy"/"unhealthy"). The container may well be running fine — we
-  // simply can't see it through snap's pipe confinement.
-  if (!sawAnyStatus) {
+  // Conservative snap-docker detection: every `docker inspect` SUCCEEDED (exit 0)
+  // yet returned empty output — never a single "starting"/"healthy"/"unhealthy".
+  // That exit-0-but-empty shape is snap's pipe confinement; a FAILING inspect
+  // (exit ≠ 0) is a different problem and falls through to the normal error below.
+  // The container may well be running fine — we just can't see it through snap.
+  if (!sawAnyStatus && allInspectsOk) {
     throw new UpError(
       `Could not read the container's health — every \`docker inspect\` returned empty ` +
         `output. That is the signature of snap docker, whose confinement does not emit ` +

--- a/packages/installer-cli/src/server/up.ts
+++ b/packages/installer-cli/src/server/up.ts
@@ -339,6 +339,31 @@ export function writeDeployEnvFile(deployDir: string, input: DeployEnvInput): st
   return file;
 }
 
+/**
+ * Parse an existing deploy env-file into a `KEY=VALUE` record, or `{}` when absent.
+ * `up` uses this to REUSE the master key across re-runs — re-minting it on every
+ * `up` orphaned every secret encrypted under the previous key (the curator token,
+ * the backup PAT). Mirrors how `update` preserves the key (it reads it back from
+ * the container; `up` has no container yet, so it reads the persisted env-file).
+ */
+export function readDeployEnvFile(deployDir: string): Record<string, string> {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(deployEnvFilePath(deployDir), "utf8");
+  } catch {
+    return {}; // absent/unreadable → first deploy (or a wiped deploy dir)
+  }
+  const out: Record<string, string> = {};
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) continue;
+    out[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1);
+  }
+  return out;
+}
+
 // --- the up flow ---------------------------------------------------------
 
 export interface UpResult {
@@ -373,8 +398,14 @@ export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult>
   //    CLI minting the master key (env wins in core's `env → file → generate`)
   //    is what keeps it OFF `/data/secret.key`. They ride only in the 0600
   //    deploy env-file fed to `--env-file`, never inline on argv.
+  //    The MASTER KEY must NOT be re-minted on a re-run — that orphans every
+  //    secret encrypted under the previous key. If the deploy env-file already
+  //    carries one, REUSE it; only a first deploy (no existing key) mints +
+  //    surfaces a new one. (Mirrors `update`'s preserve-don't-mint rule.)
   const agentToken = minter();
-  const masterKey = mintSecretKey();
+  const existingKey = readDeployEnvFile(deployDir).LIBRARIAN_SECRET_KEY?.trim() || undefined;
+  const masterKey = existingKey ?? mintSecretKey();
+  const mintedKey = existingKey === undefined;
   const envFile = writeDeployEnvFile(deployDir, { agentToken, secretKey: masterKey, host });
 
   // 5) Build the image, then run the container (secrets via `--env-file`).
@@ -425,7 +456,7 @@ export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult>
   }
 
   // 9) Close the loop: surface secrets/URLs + offer the local env write.
-  await closeTheLoop(lines, { host, agentToken, masterKey, options, deps });
+  await closeTheLoop(lines, { host, agentToken, masterKey, mintedKey, options, deps });
 
   return { output: lines.join("\n") };
 }
@@ -700,11 +731,13 @@ async function closeTheLoop(
     host: string;
     agentToken: string;
     masterKey: string;
+    /** True when this run freshly MINTED the master key (vs reused an existing one). */
+    mintedKey: boolean;
     options: UpOptions;
     deps: UpDeps;
   },
 ): Promise<void> {
-  const { host, agentToken, masterKey, options, deps } = ctx;
+  const { host, agentToken, masterKey, mintedKey, options, deps } = ctx;
   const mcpUrl = `http://${host}:3838/mcp`;
   const dashboardUrl = `http://${host}:3000`;
 
@@ -733,15 +766,19 @@ async function closeTheLoop(
     );
   }
 
-  lines.push(
-    "Paste the MCP URL + agent token into `librarian install` on your clients.",
-    "",
-    // The ONE-TIME master-key surfacing (the CLI-minted key — ADR 0008 P4).
+  lines.push("Paste the MCP URL + agent token into `librarian install` on your clients.", "");
+  if (mintedKey) {
+    // The ONE-TIME master-key surfacing (the freshly CLI-minted key — ADR 0008 P4).
     // Never written to any host file other than the 0600 deploy env-file.
-    `Master key (${SAVE_KEY_WARNING}):`,
-    `  ${masterKey}`,
-    "",
-  );
+    lines.push(`Master key (${SAVE_KEY_WARNING}):`, `  ${masterKey}`, "");
+  } else {
+    // A re-run reusing the existing key: do NOT re-display it (it's unchanged, and
+    // re-printing a previously-saved secret adds exposure without value).
+    lines.push(
+      "Reusing the existing master key from the deploy env-file (unchanged — not re-displayed).",
+      "",
+    );
+  }
 
   await offerLocalEnv(lines, { mcpUrl, agentToken, options, deps });
 }

--- a/packages/installer-cli/src/server/up.ts
+++ b/packages/installer-cli/src/server/up.ts
@@ -53,7 +53,7 @@ import type { Prompter } from "../prompt.js";
 import { fetchLatestVersion } from "../status.js";
 import { enableBoot } from "./boot.js";
 import { writeDeployState } from "./deploy-state.js";
-import { run, which, type RunResult } from "./docker.js";
+import { run, stream, which, type RunResult } from "./docker.js";
 import { preflight } from "./preflight.js";
 import { redactSecrets } from "./redact.js";
 
@@ -216,6 +216,13 @@ export interface UpDeps {
    * silently exposes the server beyond localhost. Default `true`.
    */
   interactive?: boolean | undefined;
+  /**
+   * Sink for human-facing PROGRESS lines (a multi-minute `up` was otherwise a
+   * blank line — no sense of what's happening or how long). Defaults to a
+   * `process.stderr` writer; progress is stderr so it never pollutes the stdout
+   * result (the master key). Tests inject a recorder / no-op.
+   */
+  log?: ((line: string) => void) | undefined;
 }
 
 /** A teaching error from `up`; the runtime renders `.message` as one stderr line. */
@@ -378,6 +385,10 @@ export interface UpResult {
  * interfaces); the bind choice drives the auth model (§6).
  */
 export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult> {
+  // Progress to stderr (the stdout result carries the master key) so a long `up`
+  // shows where it is + what remains, instead of a blank line.
+  const log = deps.log ?? ((line: string): void => void process.stderr.write(`${line}\n`));
+
   // 1) Preflight: docker (daemon reachable) + git, or a teaching error.
   await preflight(deps.platform ? { platform: deps.platform } : {});
 
@@ -390,7 +401,9 @@ export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult>
   const deployDir = options.dir ?? path.join(librarianDir(deps.home), "server");
 
   // 3) Resolve the ref (default = latest release tag), then the deploy dir.
+  log("[1/5] Resolving the latest release…");
   const tag = await resolveRef(options.ref);
+  log(`[2/5] Preparing the deploy directory at ${deployDir} (cloning the repository)…`);
   await prepareDeployDir(deployDir, tag);
 
   // 4) Mint the secrets the CLI owns (the loop-closer). Both are CSPRNG and
@@ -409,7 +422,13 @@ export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult>
   const envFile = writeDeployEnvFile(deployDir, { agentToken, secretKey: masterKey, host });
 
   // 5) Build the image, then run the container (secrets via `--env-file`).
+  log(
+    `[3/5] Building the image ${CONTAINER_NAME}:${tag} — the slow step: pulling the base ` +
+      `image, installing dependencies, and downloading the embeddings model. Expect several ` +
+      `minutes on a first run; live build output follows.`,
+  );
   await build(deployDir, tag);
+  log("[4/5] Starting the container…");
   await dockerRun(buildRunArgs({ host, dataVolume, tag, envFile }), deployDir);
 
   // 6+7) Wait for health. ANY failure in this post-`docker run` phase — a
@@ -423,8 +442,10 @@ export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult>
   //      (`docker exec cat /data/secret.key`) — the CLI minted it and supplied
   //      it via env, so the server never writes that file. We surface the
   //      key we minted.
+  log("[5/5] Waiting for the server to become healthy…");
   try {
     await waitForHealthy(options);
+    log("✓ The server is healthy.");
   } catch (error) {
     await run("docker", ["rm", "-f", CONTAINER_NAME]).catch(() => undefined);
     throw error;
@@ -640,12 +661,39 @@ function sameRepo(origin: string, repo: string): boolean {
   return norm(origin) === norm(repo);
 }
 
-/** Build the all-in-one image from the deploy dir (the VERIFIED build command). */
+/**
+ * Build the all-in-one image from the deploy dir, STREAMING docker's output live.
+ * This is the slow step (base-image pull, deps install, embeddings-model download);
+ * the capturing `run` used elsewhere left the user staring at a blank line for
+ * minutes. `--progress=plain` keeps the streamed output line-oriented in non-TTY
+ * logs. The build context carries NO secret (secrets ride `--env-file` at run-time,
+ * not build-time), so forwarding the raw output is safe.
+ */
 async function build(deployDir: string, tag: string): Promise<void> {
-  await dockerInDir(
-    ["build", "-f", "docker/all-in-one.Dockerfile", "-t", `${CONTAINER_NAME}:${tag}`, "."],
-    deployDir,
+  const args = [
+    "build",
+    "--progress=plain",
+    "-f",
+    "docker/all-in-one.Dockerfile",
+    "-t",
+    `${CONTAINER_NAME}:${tag}`,
+    ".",
+  ];
+  const forward = (chunk: string): void => void process.stderr.write(chunk);
+  const code = await stream(
+    "docker",
+    args,
+    { onStdout: forward, onStderr: forward },
+    {
+      cwd: deployDir,
+    },
   );
+  if (code !== 0) {
+    throw new UpError(
+      `\`docker build\` failed (exit ${code ?? "signal"}). ` +
+        "Fix the error shown above, then re-run `librarian server up`.",
+    );
+  }
 }
 
 /** Run the container (the assembled run argv) from the deploy dir. */

--- a/packages/installer-cli/src/server/up.ts
+++ b/packages/installer-cli/src/server/up.ts
@@ -681,6 +681,12 @@ export async function waitForHealthy(options: HealthWaitOptions): Promise<void> 
   const intervalMs = options.healthIntervalMs ?? 2000;
   const tail = options.logTailLines ?? 50;
 
+  // Track whether ANY poll yielded a non-empty status. Snap docker's confinement
+  // does not emit stdout to a non-TTY pipe, so every `docker inspect` comes back
+  // exit-0-but-EMPTY — health can never be read, the loop times out, and `docker
+  // logs` is empty too. We detect that distinct failure and teach, rather than
+  // emit the misleading "did not become healthy … (no log output captured)".
+  let sawAnyStatus = false;
   for (let i = 0; i < attempts; i += 1) {
     const result = await run("docker", [
       "inspect",
@@ -689,6 +695,7 @@ export async function waitForHealthy(options: HealthWaitOptions): Promise<void> 
       CONTAINER_NAME,
     ]);
     const state = result.stdout.trim();
+    if (state.length > 0) sawAnyStatus = true;
     if (state === "healthy") return;
     if (state === "unhealthy") break; // no point waiting out the bound
     if (i < attempts - 1) await sleepImpl(intervalMs);
@@ -702,6 +709,20 @@ export async function waitForHealthy(options: HealthWaitOptions): Promise<void> 
   // no half-up container survives.
   const logs = await run("docker", ["logs", "--tail", String(tail), CONTAINER_NAME]);
   await run("docker", ["rm", "-f", CONTAINER_NAME]);
+
+  // Conservative snap-docker detection: every health read was empty (not a single
+  // "starting"/"healthy"/"unhealthy"). The container may well be running fine — we
+  // simply can't see it through snap's pipe confinement.
+  if (!sawAnyStatus) {
+    throw new UpError(
+      `Could not read the container's health — every \`docker inspect\` returned empty ` +
+        `output. That is the signature of snap docker, whose confinement does not emit ` +
+        `stdout to a non-TTY pipe, so \`librarian server\` cannot read health or logs (the ` +
+        `container itself may be running fine). \`librarian server\` is not supported on snap ` +
+        `docker — use native Docker (docker-ce); see the "snap docker is unsupported" note in ` +
+        `DEPLOYMENT.md. The container was rolled back (the data volume is untouched).`,
+    );
+  }
 
   const detail = redactSecrets(logs.stdout.trim() || logs.stderr.trim());
   throw new UpError(

--- a/packages/installer-cli/tests/server-admin.test.ts
+++ b/packages/installer-cli/tests/server-admin.test.ts
@@ -14,7 +14,9 @@ import { afterEach, describe, expect, it } from "vitest";
 import { resetRunner } from "../src/exec.js";
 import { runCli } from "../src/runtime.js";
 import {
+  resetInteractiveRunner,
   resetRunner as resetDockerRunner,
+  setInteractiveRunner,
   setRunner as setDockerRunner,
 } from "../src/server/docker.js";
 import { FakeRunner, withTempHome } from "./helpers.js";
@@ -22,6 +24,7 @@ import { FakeRunner, withTempHome } from "./helpers.js";
 afterEach(() => {
   resetRunner();
   resetDockerRunner();
+  resetInteractiveRunner();
 });
 
 /** A runner with docker present, daemon reachable, and the container running. */
@@ -100,17 +103,30 @@ describe("server admin — dispatches the curated verbs into the container", () 
     });
   });
 
-  it("an interactive run adds `-it` so prompts (e.g. restore's secret-key) work", async () => {
+  it("an interactive run uses an inherited-stdio `-it` exec (NOT the capture runner)", async () => {
     await withTempHome(async (home) => {
       const runner = adminReady();
       setDockerRunner(runner);
+      // The interactive path must go through the inherited-stdio seam — pairing
+      // `-t` with the capture runner (stdin ignored) is the "input device is not a
+      // TTY" bug. Capture the inherited-exec argv here.
+      const interactiveCalls: string[][] = [];
+      setInteractiveRunner({
+        runInteractive: async (_cmd, args) => {
+          interactiveCalls.push([...args]);
+          return 0;
+        },
+      });
 
       const r = await runCli(["server", "admin", "restore"], { home, interactive: true });
       expect(r.exitCode).toBe(0);
 
-      expect(execCalls(runner)).toEqual([
+      // `-it` rides the inherited-stdio seam…
+      expect(interactiveCalls).toEqual([
         ["exec", "-it", "the-librarian", "the-librarian", "restore"],
       ]);
+      // …and the capture runner (which ignores stdin) issued NO exec.
+      expect(execCalls(runner)).toEqual([]);
     });
   });
 });

--- a/packages/installer-cli/tests/server-admin.test.ts
+++ b/packages/installer-cli/tests/server-admin.test.ts
@@ -129,6 +129,33 @@ describe("server admin — dispatches the curated verbs into the container", () 
       expect(execCalls(runner)).toEqual([]);
     });
   });
+
+  it("`--secret-key` makes the verb non-interactive even on a TTY (no -it; SC-3)", async () => {
+    await withTempHome(async (home) => {
+      const runner = adminReady();
+      setDockerRunner(runner);
+      let interactiveUsed = false;
+      setInteractiveRunner({
+        runInteractive: async () => {
+          interactiveUsed = true;
+          return 0;
+        },
+      });
+
+      // interactive:true, but the secret is already supplied → no prompt needed.
+      const r = await runCli(["server", "admin", "restore", "--secret-key", "abc"], {
+        home,
+        interactive: true,
+      });
+      expect(r.exitCode).toBe(0);
+
+      // Runs through the capture runner with NO -it; the inherited seam is untouched.
+      expect(interactiveUsed).toBe(false);
+      expect(execCalls(runner)).toEqual([
+        ["exec", "the-librarian", "the-librarian", "restore", "--secret-key", "abc"],
+      ]);
+    });
+  });
 });
 
 describe("server admin — only the curated verbs are exposed (spec §7)", () => {

--- a/packages/installer-cli/tests/server-boot-runtime.test.ts
+++ b/packages/installer-cli/tests/server-boot-runtime.test.ts
@@ -6,12 +6,14 @@
 // real systemd/sudo/docker is touched. Platform is injectable so the macOS
 // deferral is testable from a Linux host.
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { resetRunner } from "../src/exec.js";
 import { runCli } from "../src/runtime.js";
 import {
   resetRunner as resetDockerRunner,
+  resetStreamer,
   setRunner as setDockerRunner,
+  setStreamer,
 } from "../src/server/docker.js";
 import { resetSleep, resetTokenMinter, setSleep, setTokenMinter } from "../src/server/up.js";
 import { resetLatestFetcher, setLatestFetcher } from "../src/status.js";
@@ -24,9 +26,16 @@ const AGENT_TOKEN = "agent-token-deterministic-for-tests";
 const MASTER_KEY = "master-key-read-back-from-the-container-once";
 const LATEST = "1.4.2";
 
+// `up`'s image build now STREAMS (live output) via the streamer seam — stub it to
+// succeed so these boot tests never spawn a real `docker build`.
+beforeEach(() => {
+  setStreamer({ stream: async () => 0 });
+});
+
 afterEach(() => {
   resetRunner();
   resetDockerRunner();
+  resetStreamer();
   resetLatestFetcher();
   resetSleep();
   resetTokenMinter();

--- a/packages/installer-cli/tests/server-up.test.ts
+++ b/packages/installer-cli/tests/server-up.test.ts
@@ -1072,3 +1072,40 @@ function filesContaining(dir: string, needle: string): string[] {
   walk(dir);
   return hits;
 }
+
+describe("server up — master key reuse (P2)", () => {
+  it("REUSES an existing deploy.env master key on re-run (no re-mint, no re-surface)", async () => {
+    await withTempHome(async (home) => {
+      const deployDir = path.join(home, ".librarian", "server");
+      const EXISTING_KEY = "existing-master-key-from-a-prior-up-do-not-rotate";
+      // Seed a prior deploy's env-file (key + token), then mark the dir as OUR clone
+      // so prepareDeployDir takes the fetch+checkout path (not a fresh clone).
+      writeDeployEnvFile(deployDir, {
+        agentToken: "prior-agent-token",
+        secretKey: EXISTING_KEY,
+        host: "127.0.0.1",
+      });
+      fs.mkdirSync(path.join(deployDir, ".git"), { recursive: true });
+
+      const runner = healthyRunner().onRun(
+        "git",
+        ["-C", deployDir, "remote", "get-url", "origin"],
+        { stdout: "git@github.com:JimJafar/the-librarian.git\n", code: 0 },
+      );
+      setDockerRunner(runner);
+      stubSeams(); // MASTER_KEY is what the minter WOULD return — it must NOT be used
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
+
+      const r = await runCli(["server", "up"], { home, prompter });
+      expect(r.exitCode).toBe(0);
+
+      // The rewritten env-file keeps the EXISTING key — the minter was not consulted.
+      const body = fs.readFileSync(deployEnvFilePath(deployDir), "utf8");
+      expect(body).toContain(`LIBRARIAN_SECRET_KEY=${EXISTING_KEY}`);
+      expect(body).not.toContain(MASTER_KEY);
+      // A reused key is never re-surfaced; the output says so instead.
+      expect(r.stdout).not.toContain(MASTER_KEY);
+      expect(r.stdout).toContain("Reusing the existing master key");
+    });
+  });
+});

--- a/packages/installer-cli/tests/server-up.test.ts
+++ b/packages/installer-cli/tests/server-up.test.ts
@@ -8,14 +8,16 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { readEnvFile } from "../src/env.js";
 import { resetRunner } from "../src/exec.js";
 import { runCli } from "../src/runtime.js";
 import { deployStatePath, readDeployState } from "../src/server/deploy-state.js";
 import {
   resetRunner as resetDockerRunner,
+  resetStreamer,
   setRunner as setDockerRunner,
+  setStreamer,
 } from "../src/server/docker.js";
 import {
   buildRunArgs,
@@ -23,6 +25,7 @@ import {
   resetSecretKeyMinter,
   resetSleep,
   resetTokenMinter,
+  runUp,
   setSecretKeyMinter,
   setSleep,
   setTokenMinter,
@@ -40,9 +43,29 @@ const MASTER_KEY = "master-key-minted-by-the-cli-deterministic";
 const LATEST = "1.4.2"; // fetchLatestVersion returns the v-stripped version
 const LATEST_TAG = "v1.4.2";
 
+// The image build STREAMS its output live (so a multi-minute build isn't a blank
+// line) — it goes through the streamer seam, not the capture runner. Record the
+// streamed build invocation + stub success so no test ever spawns a real build.
+let buildStream: { cmd: string; args: string[]; opts?: { cwd?: string } }[];
+beforeEach(() => {
+  buildStream = [];
+  setStreamer({
+    stream: async (cmd, args, _handlers, opts) => {
+      buildStream.push({ cmd, args: [...args], opts });
+      return 0;
+    },
+  });
+});
+
+/** The streamed `docker build` argv (after `docker`), or undefined if none. */
+function streamedBuildArgs(): string[] | undefined {
+  return buildStream.find((c) => c.cmd === "docker" && c.args[0] === "build")?.args;
+}
+
 afterEach(() => {
   resetRunner();
   resetDockerRunner();
+  resetStreamer();
   resetLatestFetcher();
   resetSleep();
   resetTokenMinter();
@@ -113,17 +136,16 @@ describe("server up — fresh localhost happy path (exact argv)", () => {
         ]),
       ).toBe(true);
 
-      // docker build with the VERIFIED command.
-      expect(
-        runner.ran("docker", [
-          "build",
-          "-f",
-          "docker/all-in-one.Dockerfile",
-          "-t",
-          `the-librarian:${LATEST_TAG}`,
-          ".",
-        ]),
-      ).toBe(true);
+      // docker build with the VERIFIED command — STREAMED live (`--progress=plain`).
+      expect(streamedBuildArgs()).toEqual([
+        "build",
+        "--progress=plain",
+        "-f",
+        "docker/all-in-one.Dockerfile",
+        "-t",
+        `the-librarian:${LATEST_TAG}`,
+        ".",
+      ]);
 
       // docker run — the EXACT localhost argv. ADR 0008 P4: secrets ride in the
       // 0600 deploy env-file via `--env-file <path>`, NOT inline `-e`. No --init.
@@ -163,7 +185,7 @@ describe("server up — fresh localhost happy path (exact argv)", () => {
       await runCli(["server", "up"], { home, prompter });
 
       const deployDir = path.join(home, ".librarian", "server");
-      const build = runner.calls.find((c) => c.cmd === "docker" && c.args[0] === "build");
+      const build = buildStream.find((c) => c.args[0] === "build");
       const dRun = runner.calls.find((c) => c.cmd === "docker" && c.args[0] === "run");
       expect(build?.opts?.cwd).toBe(deployDir);
       expect(dRun?.opts?.cwd).toBe(deployDir);
@@ -201,17 +223,16 @@ describe("server up — flags reflected in argv", () => {
         ]),
       ).toBe(true);
 
-      // The image tag follows the ref; the volume is the override.
-      expect(
-        runner.ran("docker", [
-          "build",
-          "-f",
-          "docker/all-in-one.Dockerfile",
-          "-t",
-          "the-librarian:main",
-          ".",
-        ]),
-      ).toBe(true);
+      // The image tag follows the ref; the volume is the override. (Build streams.)
+      expect(streamedBuildArgs()).toEqual([
+        "build",
+        "--progress=plain",
+        "-f",
+        "docker/all-in-one.Dockerfile",
+        "-t",
+        "the-librarian:main",
+        ".",
+      ]);
       const runArgs = dockerRunArgs(runner);
       expect(runArgs).toContain("my_vol:/data");
       expect(runArgs?.[runArgs.length - 1]).toBe("the-librarian:main");
@@ -427,8 +448,9 @@ describe("server up — foreign deploy dir stops and asks (never clobbers)", () 
       expect(runner.calls.some((c) => c.cmd === "git" && c.args[0] === "clone")).toBe(false);
       expect(runner.calls.some((c) => c.cmd === "git" && c.args.includes("checkout"))).toBe(false);
       expect(runner.calls.some((c) => c.cmd === "git" && c.args.includes("fetch"))).toBe(false);
-      // And it never reached docker build/run.
-      expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "build")).toBe(false);
+      // And it never reached docker build/run (the build streams; none recorded).
+      expect(buildStream.length).toBe(0);
+      expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "run")).toBe(false);
     });
   });
 
@@ -1164,5 +1186,33 @@ describe("server up — snap-docker health-read detection (P5)", () => {
     await expect(waitForHealthy({ healthAttempts: 2, healthIntervalMs: 0 })).rejects.toThrow(
       /did not become healthy/i,
     );
+  });
+});
+
+describe("server up — progress feedback", () => {
+  it("emits numbered phase messages through the injected log", async () => {
+    await withTempHome(async (home) => {
+      setDockerRunner(healthyRunner());
+      stubSeams();
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
+      const lines: string[] = [];
+
+      const result = await runUp(
+        {},
+        { home, prompter, interactive: false, log: (line) => lines.push(line) },
+      );
+      // Sanity: the run actually completed (so the phases below really ran).
+      expect(result.output).toContain("up and healthy");
+
+      const joined = lines.join("\n");
+      expect(joined).toContain("[1/5]");
+      expect(joined).toContain("[2/5]");
+      expect(joined).toMatch(/\[3\/5\].*[Bb]uilding/);
+      expect(joined).toContain("[4/5]");
+      expect(joined).toContain("[5/5]");
+      // The slow step is flagged with a time expectation, so the user knows the wait.
+      expect(joined).toMatch(/several minutes/i);
+      expect(joined).toContain("✓ The server is healthy.");
+    });
   });
 });

--- a/packages/installer-cli/tests/server-up.test.ts
+++ b/packages/installer-cli/tests/server-up.test.ts
@@ -1147,4 +1147,22 @@ describe("server up — snap-docker health-read detection (P5)", () => {
       /did not become healthy/i,
     );
   });
+
+  it("a FAILING inspect (exit≠0, empty) is NOT snap — falls through to the normal error", async () => {
+    // Empty output but a non-zero exit is a different failure (container gone /
+    // daemon hiccup), not snap's exit-0-empty signature.
+    const runner = new FakeRunner()
+      .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", "the-librarian"], {
+        stdout: "",
+        code: 1,
+      })
+      .onRun("docker", ["logs", "--tail", "50", "the-librarian"], { stdout: "boom\n", code: 0 })
+      .onRun("docker", ["rm", "-f", "the-librarian"], { code: 0 });
+    setDockerRunner(runner);
+    setSleep(async () => undefined);
+
+    await expect(waitForHealthy({ healthAttempts: 2, healthIntervalMs: 0 })).rejects.toThrow(
+      /did not become healthy/i,
+    );
+  });
 });

--- a/packages/installer-cli/tests/server-up.test.ts
+++ b/packages/installer-cli/tests/server-up.test.ts
@@ -26,6 +26,7 @@ import {
   setSecretKeyMinter,
   setSleep,
   setTokenMinter,
+  waitForHealthy,
   writeDeployEnvFile,
 } from "../src/server/up.js";
 import { resetLatestFetcher, setLatestFetcher } from "../src/status.js";
@@ -1107,5 +1108,43 @@ describe("server up — master key reuse (P2)", () => {
       expect(r.stdout).not.toContain(MASTER_KEY);
       expect(r.stdout).toContain("Reusing the existing master key");
     });
+  });
+});
+
+describe("server up — snap-docker health-read detection (P5)", () => {
+  it("raises a snap-docker teaching error when every `docker inspect` is empty", async () => {
+    // Snap docker's hallmark: exit-0 but EMPTY stdout on a non-TTY pipe, so the
+    // health read never yields a status and `docker logs` is empty too.
+    const runner = new FakeRunner()
+      .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", "the-librarian"], {
+        stdout: "",
+        code: 0,
+      })
+      .onRun("docker", ["logs", "--tail", "50", "the-librarian"], { stdout: "", code: 0 })
+      .onRun("docker", ["rm", "-f", "the-librarian"], { code: 0 });
+    setDockerRunner(runner);
+    setSleep(async () => undefined);
+
+    await expect(waitForHealthy({ healthAttempts: 2, healthIntervalMs: 0 })).rejects.toThrow(
+      /snap docker/i,
+    );
+  });
+
+  it("still gives the normal timeout error when a status IS readable (not snap)", async () => {
+    // A readable "starting" that never reaches healthy → the ordinary timeout path,
+    // NOT the snap-docker message.
+    const runner = new FakeRunner()
+      .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", "the-librarian"], {
+        stdout: "starting\n",
+        code: 0,
+      })
+      .onRun("docker", ["logs", "--tail", "50", "the-librarian"], { stdout: "boot log\n", code: 0 })
+      .onRun("docker", ["rm", "-f", "the-librarian"], { code: 0 });
+    setDockerRunner(runner);
+    setSleep(async () => undefined);
+
+    await expect(waitForHealthy({ healthAttempts: 2, healthIntervalMs: 0 })).rejects.toThrow(
+      /did not become healthy/i,
+    );
   });
 });

--- a/packages/mcp-server/src/trpc/backup.ts
+++ b/packages/mcp-server/src/trpc/backup.ts
@@ -10,6 +10,7 @@ import {
   latestTerminalBackupRun,
   listBackupRuns,
   readBackupConfig,
+  resolveBackupRemote,
   runBackup,
   stageRestore,
   writeBackupConfig,
@@ -68,6 +69,12 @@ export const backupRouter = router({
         repo: ctx.store.getSetting("backup.github.repo") ?? "",
         hasToken: settingKeys.has("backup.github.token"),
       },
+      // Whether a restore CAN run: a backup remote is resolvable (repo + a
+      // decryptable token, or the env fallback). This — NOT "has a prior
+      // successful local run" — is what gates the dashboard Restore button, so a
+      // fresh deployment restoring from an existing remote (e.g. a host migration)
+      // can stage a restore.
+      canRestore: resolveBackupRemote(ctx.store) !== null,
       // The last *terminal* run drives the failure banner (an in-flight run isn't a
       // failure); lastSuccess drives the green "last backup" line.
       lastRun: latestTerminalBackupRun(ctx.store),

--- a/packages/mcp-server/tests/trpc/backup.test.ts
+++ b/packages/mcp-server/tests/trpc/backup.test.ts
@@ -122,6 +122,32 @@ describe("tRPC backup surface", () => {
     }
   });
 
+  it("canRestore reflects a configured remote, NOT prior run history (SC-4)", async () => {
+    const dataDir = makeTempDir();
+    const secretKey = "c".repeat(63) + "d"; // 64 hex chars, non-constant
+    const server = await startHttpServer({ dataDir, secretKey });
+    try {
+      type Cfg = { canRestore: boolean };
+      // Fresh deploy: no remote configured → nothing to restore from.
+      expect((await trpcGet<Cfg>(server, "backup.config")).canRestore).toBe(false);
+
+      // Configure a remote (repo + token) but run NO backup.
+      await trpcPost(server, "backup.setConfig", {
+        github: { repo: "me/backups", token: ["placeholder", "pat", "value"].join("-") },
+      });
+
+      // canRestore flips true purely from the resolvable remote — the dashboard
+      // Restore button must enable on a fresh deployment (e.g. a host migration),
+      // which the old `runs.some(ok)` gate made impossible.
+      expect((await trpcGet<Cfg>(server, "backup.config")).canRestore).toBe(true);
+      // …and there are genuinely zero runs, so the old gate would have been false.
+      expect(await trpcGet<unknown[]>(server, "backup.runs")).toEqual([]);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
   it("rejects a malformed GitHub repo with a teaching error, but allows owner/repo and unset", async () => {
     const dataDir = makeTempDir();
     const server = await startHttpServer({ dataDir });


### PR DESCRIPTION
## Why

A real migration (unprivileged-LXC + snap docker → native docker on a new host) surfaced a cluster of `librarian server` / admin-CLI bugs that made **restore-from-backup into a fresh deployment impossible** without manual `docker exec` workarounds. This PR fixes the code bugs and documents the one thing that isn't fixable (snap docker). Specced + built autonomously overnight; **please review before merging.** Spec: `docs/specs/2026-06-15-server-cli-hardening.md`.

(The `git checkout --end-of-options` bug from the same migration already shipped in #384 / rc.21 — out of scope here.)

## The five fixes

1. **The admin CLI couldn't read encrypted settings (root cause).** `the-librarian` built its store with **no master key**, so `getSetting` on a secret threw and was swallowed — `restore`'s `resolveBackupRemote` returned null → a false **"No backup remote configured"** on a deploy that *had* a remote configured. Now `bin.ts` resolves the key (`LIBRARIAN_SECRET_KEY` env → `<dataDir>/secret.key`, **never generating** one — it's a transient client) and passes it to the store. A malformed key degrades to keyless instead of crashing every command (incl. `--help`); an empty env value falls through to the file.
2. **`server up` re-minted the master key every run** → orphaned every secret encrypted under the old key (curator token, backup PAT). `up` now **reuses** an existing `deploy.env` key and only mints on a first deploy.
3. **`server admin` died with "the input device is not a TTY".** Its runner spawns with stdin ignored, so the old `-it` could never deliver a working prompt — only the cryptic error. Interactive verbs now use a new **inherited-stdio exec** seam (real TTY); non-interactive — including when `--secret-key` is supplied — runs without `-t`.
4. **The dashboard couldn't restore into a fresh deployment.** The Restore button was gated on `runs.some(status==="ok")` — local successful-run history — so a new deployment restoring from an existing remote (a host migration) could never enable it. `backup.config` now returns **`canRestore`** (remote resolvable) and the button gates on that.
5. **snap docker is now detected + documented.** Snap's confinement doesn't emit stdout to a non-TTY pipe, so `up`'s health/log capture came back empty → a false health timeout that **rolled back a running container**. `up` now raises a teaching error naming the cause; README + DEPLOYMENT document that `librarian server` needs **native Docker** (the hidden-dir build-context failure is also covered, with the `--dir` stopgap).

## Adversarial review

A fresh-context review pass ran against the diff; its Critical + Important findings were all fixed in `240cbfc` (empty-env regression, malformed-key crash, snap false-positive on a failing inspect, `--secret-key`→no-`-t`, and a docs claim that `update` rotates via `deploy.env` — it reads the key from the container, so the docs now say "no turn-key rotation").

## Tests

Each fix ships a regression test that fails on `main`: the **encrypted** settings path (the env-fallback tests never exercised it), deploy.env key reuse vs mint, inherited-stdio interactive exec, `canRestore` with zero runs, and the snap empty-read signature (incl. the failing-inspect negative case).

## Verification

Run per-suite (this box thrashes when all suites run at once — see note):

`build` ✓ · `lint` ✓ · `format:check` ✓ · `typecheck` ✓ · `check:release` ✓ (rc.22) · **cli 65 ✓ · installer-cli 268 ✓ · mcp-server 222 ✓ · dashboard 258 ✓ · root/healthcheck ✓**.

> **CI note:** running every suite concurrently on the dev box hit load-induced failures — healthcheck's server-start hook timed out at 60s (a clean run is ~8s) and vitest's json reporter hit `EPIPE`. Both pass cleanly in isolation; neither is an assertion failure. CI (which isn't sharing the box with a live migration) should be green, but worth a glance.

## Release

Root bumped to **rc.22** + dated CHANGELOG + compare-link; the published `@the-librarian/cli` is stamped to match. **Not merged — over to you.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
