### PR TITLE
Force harnesses/agents to use The Librarian

### DIFF
--- a/docs/adr/0009-integration-enforced-librarian-use.md
+++ b/docs/adr/0009-integration-enforced-librarian-use.md
@@ -1,0 +1,143 @@
+# ADR 0009 — Ship enforcement, not just advice: integration guardrails that redirect file-writes to the Librarian
+
+- **Status:** Proposed
+- **Date:** 2026-06-14
+- **Related:** ADR 0006 (agent-facing MCP surface), ADR 0007 (the rethink — the
+  primer as canonical teaching surface, D9; private mode, D11; in-tree
+  integrations, D14). Builds on the primer; does **not** change the 7-verb
+  surface, the protocols, or the memory state model.
+
+## Context
+
+The Librarian's whole value proposition is that it is **the** memory + handoff
+layer — the default an agent reaches for on any harness, any machine, instead of
+scribbling a file or using a harness's built-in note store. The teaching surface
+that's meant to make that happen is the **primer** (ADR 0007 D9): served as the
+MCP `initialize` `instructions` field and at `GET /primer.md`, plus each tool's
+protocol-bearing description. It says, in the connect-time instructions, *"If you
+have a different built in memory system, you must use the librarian instead."*
+
+**That advice does not reliably change agent behavior.** The evidence is our own:
+across three months of building this, agents — including the ones building it —
+default to files. In a single recent session, an agent asked to "write a handoff
+for a fresh session" wrote a flat `HANDOFF.md` into the repo **and** routed a
+durable lesson into the local Claude Code file-memory store, with the *"you must
+use the librarian instead"* instruction sitting in its context the entire time.
+It only used `store_handoff`/`remember` after the human asked, twice, *"why aren't
+you using the librarian?"* The mandate was present, injected, and ignored.
+
+The failure is structural, not attitudinal, and adding more advice won't fix it:
+
+1. **Advice competes with ingrained defaults and loses under load.** "Write a
+   file" is a single, always-available, zero-dependency action; using the
+   Librarian requires recalling the right verb and trusting the server is up.
+   Another sentence in the primer is the same kind of lever that already failed.
+2. **The MCP server cannot enforce client behavior.** It only ever sees MCP
+   calls. It has no visibility into, and no veto over, a `Write` the harness
+   performs. A purely server-side fix that makes an agent *unable* to write
+   `HANDOFF.md` is not physically possible — the enforcement point isn't the
+   server.
+3. **The only enforcement point is the harness boundary** — a pre-action hook
+   the harness runs regardless of what the model decides. And the Librarian
+   already owns a per-harness layer: the in-tree `integrations/<harness>/`
+   (ADR 0007 D14), distributed and kept current by `librarian install`. Today
+   those integrations ship only *advisory* surfaces (MCP config, the primer, the
+   slash commands). They ship **no enforcement**.
+
+So the gap is concrete: the place that *can* enforce (the integration) ships only
+advice, and advice has been empirically shown insufficient — by us, on our own
+product.
+
+## Decision
+
+**The Librarian's harness integrations ship enforcement, not just advice.** Each
+integration gains a **guardrail** that intercepts file-writes shaped like a
+handoff or a durable memory and steers the agent to `store_handoff` / `remember`
+instead — authored once in this repo, version-controlled, and distributed to
+every harness on every machine by `librarian install`. Specifically:
+
+1. **Where the harness supports a pre-action veto, the guard is authoritative.**
+   In Claude Code that is a `PreToolUse` hook on `Write`/`Edit`: a write of a
+   handoff/memory-shaped file is **denied**, with a teaching message naming the
+   verb to use instead. This is the reference implementation and the one that
+   would have prevented the triggering incident outright.
+2. **Where a harness has no pre-action veto, ship the strongest nudge it does
+   support** — and **say so honestly**. We publish a per-harness capability
+   matrix; no integration claims enforcement it doesn't have. "Enforced
+   everywhere we can, nudged everywhere we can't" beats a uniform fiction.
+3. **It lives in the Librarian, not on a machine.** The guard is part of each
+   integration and is installed/updated by the CLI like everything else. The
+   installed artifact does land on each machine — that is unavoidable, because
+   the block happens at the harness boundary — but its source of truth,
+   versioning, and distribution are the Librarian. That is the difference
+   between this and a bespoke hook a user hand-rolls on one box.
+4. **It obeys the existing sacred rules.** The guard is **fail-soft** (AGENTS.md):
+   if the guard itself errors, the user's tool call proceeds — it never blocks a
+   turn or crashes a hook. It honors **private mode** (ADR 0007 D11): it never
+   silently converts a suppressed file-write into server state. And it is a
+   **shared cross-harness contract** — changed across every `integrations/*` and
+   documented together, never in one harness unilaterally.
+
+This does **not** touch the 7-verb MCP surface, the handoff/takeover/learn/
+private-mode protocols, the memory state model, or the primer's role as canonical
+teaching. The primer stays — it's necessary. The guardrail is the enforcement the
+primer can't be.
+
+## Consequences
+
+**Positive**
+
+- The behavior the product depends on stops depending on agent discretion. On
+  harnesses with a veto, "use the Librarian" becomes the path of *only*
+  resistance for handoffs/memories, not the path of least resistance.
+- The fix is a Librarian feature, shipped and updated through `librarian install`
+  — it propagates to every harness and machine by construction, which is exactly
+  the property a per-machine hook lacks.
+- It dogfoods the product's own thesis: the system that curates an agent's memory
+  also makes the agent actually use it.
+
+**Negative / costs**
+
+- **Not uniform across harnesses.** Airtight where a pre-action veto exists
+  (Claude Code, likely Pi); nudge-only where it doesn't (Codex/OpenCode are
+  "config + instructions, no code"; Hermes' adapter can't veto arbitrary host
+  file-writes). We ship honesty over the appearance of uniformity, and the exact
+  per-harness primitive is a discovery task in the spec.
+- **False-positive risk.** A guard that blocks file-writes can block a
+  *legitimate* one (a real handoff template in `docs/`, a `memory/` source
+  directory in some other project). The matcher must be conservative,
+  allowlist-aware, and carry a deliberate escape hatch; getting this wrong makes
+  the guard infuriating, which gets it disabled, which is worse than nothing.
+- **Fail-open is a real tension.** Fail-soft means a buggy guard silently stops
+  enforcing rather than blocking the user — correct per doctrine, but it means
+  enforcement quietly degrades on guard error. We accept this and log to the
+  sidecar.
+- **Maintenance surface.** A guard per integration, plus per-harness hook
+  plumbing, plus the match patterns, is new code to own across five surfaces and
+  to keep behind the drift-guard discipline.
+
+**Threat model (explicit):** this targets the *accidental-default* failure — a
+cooperating agent that means well and reaches for a file out of habit. It is
+**not** an adversarial control: an agent that wants to evade it can (write to an
+unmatched path, disable the hook). That's fine; the goal is to make the right
+thing the default and the wrong thing require intent, not to defeat a hostile
+client.
+
+## Alternatives considered
+
+- **Sharpen the primer / add a SessionStart reminder (more advice).** Rejected:
+  this is the layer that already failed. The mandate is already injected every
+  session and was ignored; another injected sentence is the same failed lever.
+- **Enforce server-side.** Rejected as impossible: the MCP server sees only MCP
+  calls and cannot observe or veto a harness file-write. There is no server-only
+  fix.
+- **A user-authored hook in `~/.claude` (per machine).** Rejected by the owner:
+  it doesn't propagate across machines or harnesses, and it's the opposite of
+  "fixed in the Librarian." The enforcement must ship *with the product*.
+- **Detect-after-the-fact (PostToolUse): notice a written `HANDOFF.md` and
+  auto-ingest it.** Weaker and considered as a *fallback* for harnesses without a
+  pre-action veto, not the primary design — it can't prevent the file, only
+  react, and reacting reliably is itself a nudge.
+- **Make the verbs so frictionless that files aren't tempting (UX only).** Worth
+  doing regardless, but it doesn't *prevent* the lapse; ease reduces temptation,
+  it doesn't remove discretion. Complementary, not a substitute.

--- a/docs/specs/2026-06-14-integration-guardrails.md
+++ b/docs/specs/2026-06-14-integration-guardrails.md
@@ -1,0 +1,205 @@
+# Spec: integration guardrails — make Librarian use enforceable, not just advised (ADR 0009)
+
+**Status:** Phase 1 **ready to build** — Q1–Q4 resolved 2026-06-14 (§5); pending
+[ADR 0009](../adr/0009-integration-enforced-librarian-use.md) acceptance on merge.
+Phase 2 is gated on the P-D discovery. Written with the `sdlc-spec` method,
+grounded against the integrations on `main`.
+
+## 1. Objective
+
+Make "use The Librarian instead of a file" the enforced default on every harness
+the Librarian ships an integration for — starting with the one harness that can
+enforce it authoritatively (Claude Code), and being honest about the rest. The
+primer already *tells* agents to use the Librarian and that has been shown
+insufficient (ADR 0009 Context); this adds the enforcement the primer can't be.
+
+Grounded facts this builds on:
+
+- The integrations are in-tree under `integrations/<harness>/` (ADR 0007 D14) and
+  are wired into each harness by `librarian install` (the installer-cli).
+- The **Claude Code** integration today ships `integrations/claude/.mcp.json`, a
+  plugin manifest `integrations/claude/.claude-plugin/plugin.json`, the four
+  slash commands, and a README — and **no hooks** (verified: a tree-wide grep for
+  `hooks` / `PreToolUse` / `SessionStart` returns nothing under `integrations/`,
+  `.claude/`, `.claude-plugin/`).
+- The teaching surface is the primer (`vault/primer.md`, default in
+  `packages/core/src/primer.ts`), served as MCP `instructions` + `GET /primer.md`.
+- Sacred rules that constrain this work: **fail-soft** (never block the user's
+  turn), **private mode** `[librarian:private=on]` (no writes), the **7-verb**
+  surface + drift-guards (untouched), and **cross-harness contracts change
+  together** (AGENTS.md §2).
+
+## 2. Success criteria
+
+The acceptance bar; each becomes a test.
+
+1. **Authoritative block (Claude Code).** With the Librarian installed, a `Write`
+   (or `Edit`/`MultiEdit`) that creates a **handoff-shaped** file (e.g.
+   `HANDOFF.md`, `*-handoff*.md`, `*takeover*.md`) or a **durable-memory-shaped**
+   file (a write into a local agent memory store, e.g. `**/.claude/**/memory/**`,
+   `**/MEMORY.md` in that store) is **denied**; the file is not created; the
+   denial message names the verb to use (`store_handoff` / `remember`).
+2. **No false positives.** Writes to ordinary paths are **not** blocked: source
+   code, `docs/**`, `vault/primer.md`, a spec under `docs/specs/`, a project's
+   own `src/.../memory.ts`. Verified against a fixture set of legit paths.
+3. **Taught, in-band override (Q4).** The denial message states that this is a
+   heuristic block and that, **if it's a genuine false positive with a good
+   reason not to use the Librarian, the agent may override and write the file
+   anyway** by re-issuing the write with a recognized override marker (proposed:
+   an `<!-- librarian-guard: override — <reason> -->` sentinel in the content).
+   A write carrying the marker succeeds; the override is logged to the sidecar so
+   it's auditable. The message names *when* an override is legitimate, not just
+   *how*.
+4. **Fail-soft.** If the guard script errors or times out, the tool call
+   **proceeds** (the user's turn is never blocked) and the failure is logged to
+   the local sidecar, not surfaced as a stack trace. Verified by inducing a guard
+   error.
+5. **Private mode blocks too (Q2).** During `[librarian:private=on]`, a
+   handoff/memory-shaped write is **blocked**, with a message explaining that
+   nothing durable is being written **anywhere** — not to a file, not to the
+   Librarian (it can't be; private mode forbids server writes). The guard makes
+   **no** server call. The taught override (SC 3) still applies for a genuine
+   need.
+6. **Shipped + updatable by the CLI.** `librarian install` writes the guard into
+   the Claude Code config; re-running it updates the guard; the uninstall path
+   removes it. No hand-editing of machine settings is required or expected.
+7. **Honest capability matrix.** A documented table states, per harness
+   (Claude Code, Codex, OpenCode, Hermes, Pi), whether it gets **authoritative**
+   enforcement or **nudge-only**, and why. No integration's docs claim
+   enforcement it doesn't have.
+8. **Contracts intact + releasable.** The 7-verb surface, protocol docs, and
+   drift-guard tests are unchanged; `pnpm test` / `typecheck` / `lint` green; PR
+   bumps root version + dated CHANGELOG (`check:release`).
+
+## 3. Scope
+
+**Phase 1 (in):** the Claude Code authoritative guard — a `PreToolUse` hook that
+**blocks** handoff/memory-shaped writes with a teaching message (including the
+taught override and the private-mode variant), shipped via the integration and
+installed by the CLI; the conservative filename/path matcher; fail-soft; the
+capability-matrix doc seeded with Claude Code = authoritative.
+
+**Phase 2 (in):** extend to the other four harnesses at the **strongest primitive
+each supports** (discovery task P-D), filling in the matrix honestly; where a
+harness has a pre-action veto, an authoritative guard; where it doesn't, the best
+available nudge (and, optionally, a PostToolUse detect-and-warn).
+
+**Out of scope (this spec):**
+
+- **Intercept-and-redirect** — catching the write and *automatically* constructing
+  a valid `store_handoff`/`remember` call from its content. The better UX and the
+  eventual goal, but it carries real correctness risk (synthesizing a schema-valid
+  handoff from arbitrary prose) and depends on Phase 1 landing first. Deferred to
+  its own spec (Q1 resolved: Phase 1 ships block-with-teaching, which is safe).
+- Changing the primer's content, the 7-verb surface, or any protocol.
+- An adversarial control (ADR 0009 threat model): we are not trying to defeat an
+  agent that *wants* to evade the guard.
+
+## 4. Key decisions (from ADR 0009 + §5)
+
+- **Block-with-teaching, not auto-redirect (Q1).** Phase 1 denies the write and
+  tells the agent the right verb. Simple, safe, and would have prevented the
+  triggering incident. Auto-redirect is a later, separately-specced enhancement.
+- **Conservative, allowlist-aware matcher (Q3).** Match on a small, high-precision
+  set (handoff/takeover filenames; writes into a known agent memory-store path) —
+  never on vague "notes-shaped" content. Bias hard toward false-negatives over
+  false-positives. Patterns live in one shared place so all integrations agree.
+- **The override is taught, not configured (Q4).** No env var, no out-of-band
+  switch: the denial message itself teaches that a genuine false positive can be
+  overridden in-band (a recognized marker), and what counts as a good reason. The
+  guard nudges and educates; it never imprisons.
+- **Private mode blocks, never redirects (Q2).** In private mode the guard blocks
+  the matched write and explains that nothing durable is written anywhere; it
+  makes no server call.
+- **Fail-open on guard error.** Per fail-soft: the guard's own failure allows the
+  write. Enforcement that risks blocking the user's turn is worse than none.
+
+## 5. Resolved (were open questions, 2026-06-14)
+
+1. **Q1 — Phase 1 behavior → block-with-teaching.** Deny + name the verb. Reliable
+   and fast; auto-redirect (intercept-and-construct the call) is deferred to its
+   own spec once the guardrail is proven in practice. *(Owner, 2026-06-14.)*
+2. **Q2 — private mode → block it too.** A matched write under
+   `[librarian:private=on]` is blocked with "nothing durable is written anywhere
+   — not a file, not the Librarian." No server call. The taught override still
+   applies. *(Owner, 2026-06-14. Defines a corner of the private-mode contract —
+   carry it into the private-mode docs alongside the primer/slash-command set.)*
+3. **Q3 — matcher → conservative, filename/path-based.** Seed patterns:
+   filenames matching `/(^|[-_/])handoff/i` or `/(^|[-_/])takeover/i` with a `.md`
+   extension; writes under a local agent memory store
+   (`**/.claude/**/memory/**`, `**/MEMORY.md` therein, and the per-harness
+   equivalents found in P-D). Explicitly **not** matched: `vault/primer.md`,
+   `docs/**`, the server's own data dir, ordinary source. Ships with a fixture set
+   of must-block / must-allow paths. *(Owner, 2026-06-14.)*
+4. **Q4 — escape hatch → taught, in-band override.** No env var or external
+   switch. The denial message explains that the block is heuristic and that a
+   genuine false positive (a real reason not to use the Librarian) may be
+   overridden by re-issuing the write with a recognized marker (proposed
+   `<!-- librarian-guard: override — <reason> -->`); the override is logged to the
+   sidecar. The message teaches *when* this is legitimate, not only *how*.
+   *(Owner, 2026-06-14. Exact marker token confirmed at build in P2.)*
+
+**Still open (discovery, not an owner decision):**
+
+- **Q5 — per-harness enforcement primitives (Phase 2).** Which of Codex,
+  OpenCode, Hermes, Pi expose a *pre-action* veto vs. only instructions? Unknown
+  without per-harness investigation — that's task **P-D**, and it gates which
+  harnesses get authoritative guards vs. nudge-only.
+
+## 6. Task plan
+
+Vertically sliced, riskiest/most-valuable first. Each slice leaves the system
+working and shippable.
+
+### Phase 1 — the Claude Code authoritative guard
+
+- [ ] **P1 — match logic + fixtures (no harness wiring yet).** A small, pure
+      module: `classifyWrite(path, content?) → { blocked, verb, reason }` with the
+      §5-Q3 pattern list. Ship a fixture set: must-block (`HANDOFF.md`, a
+      `.claude/.../memory/x.md`) and must-allow (`vault/primer.md`,
+      `docs/specs/foo.md`, `src/memory.ts`). *Accept:* SC 1 (logic) + SC 2.
+      *(riskiest — the false-positive surface lives here.)*
+- [ ] **P2 — the Claude Code `PreToolUse` hook.** Wire P1 into a hook on
+      `Write`/`Edit`/`MultiEdit` that denies a matched write with the teaching
+      message + the taught-override mechanism (confirm the exact marker token
+      here), and **fails open** on its own error. Confirm the plugin-vs-settings
+      wiring for shipping a hook with the Claude integration. *Accept:* SC 1
+      (end-to-end), SC 3, SC 4.
+- [ ] **P3 — private-mode block.** Detect `[librarian:private=on]` and block with
+      the SC-5 message; make no server call. *Accept:* SC 5. *Depends:* P2.
+- [ ] **P4 — install/update/uninstall via the CLI.** `librarian install` writes
+      the hook into the Claude Code config; re-run updates it; uninstall removes
+      it. *Accept:* SC 6. *Depends:* P2.
+- [ ] **P5 — capability matrix doc (seed) + private-mode contract update.** The
+      matrix table (Claude Code = authoritative; others = TBD pending Phase 2),
+      pointed to from `integrations/claude/README.md`; fold the Q2 private-mode
+      behavior into the shared private-mode docs. *Accept:* SC 7 (Claude Code row).
+      *Depends:* P2.
+- [ ] **P6 — Phase 1 release gate.** tests/typecheck/lint green; 7-verb +
+      drift-guards untouched; version bump + CHANGELOG; PR. *Accept:* SC 8.
+      *Depends:* P1–P5.
+
+### Phase 2 — the other harnesses, honestly
+
+- [ ] **P-D — discovery: per-harness enforcement primitives** (answers Q5). For
+      Codex, OpenCode, Hermes, Pi: pre-action veto (→ authoritative) or
+      instructions-only (→ nudge)? Document findings. *Depends:* none — run early,
+      in parallel with Phase 1.
+- [ ] **P7 — authoritative guards where a veto exists** (e.g. Pi if its extension
+      supports a pre-tool hook), reusing the P1 match module. *Depends:* P-D, P1.
+- [ ] **P8 — strongest nudge where no veto exists** (Codex/OpenCode/Hermes per
+      P-D): a sharpened instruction line and/or a PostToolUse detect-and-warn
+      fallback where the harness allows it. *Depends:* P-D.
+- [ ] **P9 — complete + publish the capability matrix.** Every harness row filled,
+      honest, cross-referenced from each integration README. *Accept:* SC 7 (all
+      rows). *Depends:* P7, P8.
+- [ ] **P10 — Phase 2 release gate.** Gate + PR. *Depends:* P7–P9.
+
+## 7. Checkpoint
+
+Phase 1 is the high-leverage, independently-shippable slice: it makes the one
+harness that *can* enforce actually enforce. With Q1–Q4 resolved (§5), **P1–P6 are
+ready to hand to `sdlc-implement`** once ADR 0009 is accepted on merge. Phase 2 is
+gated on **P-D** — no integration should claim enforcement we haven't verified the
+harness can deliver. The intercept-and-redirect north star stays deferred to its
+own spec until Phase 1 proves the guardrail in practice.


### PR DESCRIPTION
docs(adr): ADR 0009 + spec — ship enforcement in integrations, not just advice

Agents (including the ones building this) default to writing files / the local memory store despite the primer's injected "you must use the librarian instead" — advice loses to ingrained defaults. The MCP server can't veto a client file-write, so enforcement must live at the harness boundary, shipped in integrations/<harness> and distributed by `librarian install`.
