### PR TITLE
docs(adr): ADR 0009 + Phase-1 spec — harness auto-capture + awareness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ AUTONOMOUS-BUILD-NOTES-*.md
 # The config (.impeccable/live/config.json) IS committed; only sessions are local.
 .impeccable/live/sessions/
 
+
+# orchestration scratch (never committed)
+ORCHESTRATE-NOTES-*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.23] — 2026-06-16
+
+Docs only — no shipped code, so the published `@the-librarian/cli` is unchanged.
+
+### Added
+
+- **ADR 0009 — make Librarian use automatic at the harness boundary**
+  (`docs/adr/0009-integration-enforced-librarian-use.md`): the primary lever for
+  agent adoption is automatic harness-driven capture + awareness injection, with a
+  narrow native-`MEMORY.md` write-block as a supplement — not a broad file-write veto.
+- **Spec `docs/specs/2026-06-16-harness-auto-capture.md`** — Claude-Code-first design
+  for automatic per-turn transcript capture into the existing inbox→curator engine,
+  awareness injection, and the narrow write-block, behind a uniform per-harness
+  server contract. Reuses the curator as the extraction engine; default-on,
+  private-mode gated, `LIBRARIAN_AUTO_SAVE=false` kill-switch. Grounded vs rc.22.
+
 ## [1.0.0-rc.22] — 2026-06-16
 
 A cluster of `librarian server` / admin-CLI fixes surfaced by a real LXC +
@@ -2613,6 +2629,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0-rc.23]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.22...v1.0.0-rc.23
 [1.0.0-rc.22]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.21...v1.0.0-rc.22
 [1.0.0-rc.21]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.20...v1.0.0-rc.21
 [1.0.0-rc.20]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.19...v1.0.0-rc.20

--- a/docs/adr/0009-integration-enforced-librarian-use.md
+++ b/docs/adr/0009-integration-enforced-librarian-use.md
@@ -1,0 +1,184 @@
+# ADR 0009 — Make Librarian use automatic at the harness boundary: deterministic capture + awareness injection, with a narrow write-block
+
+- **Status:** Proposed
+- **Date:** 2026-06-16
+- **Revises:** the 2026-06-14 draft of this ADR, which made a broad file-write
+  veto the *primary* mechanism. This rewrite inverts that: automatic capture +
+  awareness injection are the primary levers; the write-block narrows to a
+  supplement. The motivating evidence (below) is unchanged; the leverage analysis
+  is corrected.
+- **Related:** ADR 0006 (agent-facing MCP surface), ADR 0007 (the rethink — the
+  primer as canonical teaching surface D9; private mode D11; in-tree integrations
+  D14). Grounded in the 2026-06-05 working doc
+  `docs/research/harness-driven-capture-brainstorm.md` (idea A capture, idea B
+  awareness; decisions D6/D7/D8/D9; the §11.2 per-harness capability audit), whose
+  auto-capture track the owner shelved as "unsure + huge change" and this ADR
+  revives. Does **not** change the 7-verb surface, the protocols, or the memory
+  state model.
+
+## Context
+
+The Librarian's whole value proposition is that it is **the** memory + handoff
+layer — the default an agent reaches for on any harness, any machine, instead of
+scribbling a file or using a harness's built-in note store. The teaching surface
+meant to make that happen is the **primer** (ADR 0007 D9): served as the MCP
+`initialize` `instructions` field and at `GET /primer.md`, plus each tool's
+protocol-bearing description.
+
+**That advice does not reliably change agent behavior.** The evidence is our own:
+across three months of building this, agents — including the ones building it —
+default to files. In a single recent session, an agent asked to "write a handoff
+for a fresh session" wrote a flat `HANDOFF.md` into the repo **and** routed a
+durable lesson into the local Claude Code file-memory store, with the *"you must
+use the librarian instead"* instruction sitting in its context the entire time. It
+only used the verbs after the human asked, twice, *"why aren't you using the
+librarian?"* The mandate was present, injected, and ignored.
+
+The failure is structural, not attitudinal. But the **earlier draft of this ADR
+drew the wrong conclusion from it.** It reasoned: advice fails → the only
+enforcement point is the harness boundary → therefore **block the file-writes**.
+The first two steps are right; the third aims at the weakest available lever.
+
+Two corrections, learned from how this is actually solved elsewhere (mem0 ships
+exactly this for Claude Code in production) and from our own shelved 1A design:
+
+1. **Saving and recalling are different problems and must be solved oppositely.**
+   *Saving* is where agents are unreliable — they forget to call `remember`, or
+   do it inconsistently, or only when nagged. A hook never forgets. So capture
+   should be **automatic and deterministic**, taken off the agent entirely.
+   *Recalling* is a judgment the agent is actually well-placed to make (it has the
+   conversation; a hook script does not) — so recall should be **nudged and made
+   visible**, not forced.
+2. **A file-write block solves neither.** Denying a `Write` to `HANDOFF.md` does
+   not make the agent *recall* at the right moment, and it captures **nothing** the
+   agent didn't already decide to write down. It only closes one egress. In mem0's
+   shipping plugin the equivalent block exists but is deliberately narrow — it
+   intercepts only the *competing* native memory store (`MEMORY.md`), and the
+   actual driver of consistent use is automatic background capture plus awareness
+   injection. The block is a supplement, not the engine.
+
+So the gap is concrete and the fix is mis-aimed in the prior draft: the place that
+*can* act (the integration's harness hooks) should be made to **capture
+automatically and inject awareness**, with a *narrow* block guarding the one
+channel that competes with us — not a broad veto standing in for the whole
+strategy.
+
+## Decision
+
+**The Librarian's harness integrations make memory use automatic at the harness
+boundary**, in three layers — two primary, one supplementary — authored once in
+this repo, version-controlled, and distributed by `librarian install`.
+
+1. **Deterministic automatic capture (primary).** A per-turn hook ships the
+   conversation **delta** to the server; the server redacts secrets on intake,
+   appends to a per-conversation buffer, and — when the conversation **settles** —
+   runs a single curator pass over the whole buffer to extract durable facts into
+   the **existing** inbox→curator engine (the same async filing `remember` already
+   feeds; this is the Librarian's equivalent of mem0's server-side `infer`). The
+   agent spends **zero tokens** and makes **no decision** to save. Capture is
+   **default-on**, suppressed under private mode and by a `LIBRARIAN_AUTO_SAVE=false`
+   kill-switch.
+
+2. **Awareness injection (primary, paired).** Sharpen the server-sourced primer
+   and surface a deterministic, visible nudge so the agent *knows* it has
+   `recall`/`remember` and is prompted to recall when prior context may exist —
+   especially after compaction. Retrieval remains the agent's call (it has the
+   context to judge relevance); we nudge hard, we do not force.
+
+3. **Narrow write-block (supplement).** A pre-action hook blocks **only** writes
+   to the harness's *native* memory store (in Claude Code: `**/.claude/**/memory/**`
+   and `MEMORY.md` therein), redirecting to the Librarian. It does **not** police
+   handoff-shaped filenames or arbitrary notes — that breadth was the prior draft's
+   over-reach. It guards the single channel that competes with us, nothing more.
+
+**Architecture:** one **uniform server-side transcript-intake contract** plus
+**thin per-harness acquisition adapters**. Acquisition differs structurally by
+harness (Claude tails `transcript_path`; Pi/Hermes receive the completed turn
+in-payload; OpenCode brackets on idle — per the §11.2 audit), but the *output* —
+a per-turn delta, stably keyed — is uniform, so the server pipeline is built once.
+We build and **dogfood Claude-first**, then add adapters for Pi/Hermes/OpenCode
+against the same contract; Codex is deferred (no stable per-conversation id).
+
+This does **not** touch the 7-verb MCP surface, the handoff/takeover protocols, the
+memory state model, or the primer's role as canonical teaching. It obeys the sacred
+rules: **fail-soft** (a capture/guard error never blocks the user's turn — and on
+any uncertainty the capture path errs toward *not* capturing); **private mode**
+(per-turn `[librarian:private=on]` turns are skipped at acquisition, redaction runs
+before any disk write, and nothing is silently converted into server state); and
+**cross-harness contracts change together** (the server contract and the
+primer/private-mode touchpoints are designed for all harnesses now, even though the
+adapters land incrementally).
+
+## Consequences
+
+**Positive**
+
+- The behavior the product depends on **stops depending on agent discretion** at
+  the point where agents are unreliable (saving), while leaving judgment where the
+  agent is strong (recall). The old block-only approach closed neither gap.
+- **Reuses the existing engine.** The inbox→curator pipeline already does
+  async dedupe/merge/file; capture adds an intake door + a settle-sweep in front of
+  it, not a new extraction system. The Librarian's curator *is* the `infer` step.
+- **Dogfoods the thesis.** The system that curates an agent's memory also ensures
+  the agent feeds it — observed daily in the one harness the owner actually uses.
+- **Awareness + capture compose.** Together they address both "never saves" and
+  "never recalls"; the narrow block removes the one competing attractor.
+
+**Negative / costs**
+
+- **New server-side LLM cost** (extraction) that scales with transcript volume.
+  Accepted for the baseline: single-user, text-only, batched once per settled
+  conversation, and bounded by the settle-sweep (brainstorm D10). A multi-user
+  install may want a cap — documented as a scaling consideration, not built now.
+- **Raw conversation transits to the server automatically** — a real privacy
+  surface that the agent-mediated model didn't have. Mitigated by: per-turn private
+  skip, **redaction-on-intake before any write** (brainstorm D6), a **sidecar
+  buffer kept out of the git vault and deleted after extraction** (D8), and the
+  `LIBRARIAN_AUTO_SAVE=false` kill-switch. **Default-on is a deliberate choice that
+  reverses the 2026-06-05 D2 (default-off/opt-in)** — justified because default-off
+  perpetuates the exact "never used unless asked" failure this ADR exists to fix,
+  and because the mitigations above make automatic capture privacy-defensible.
+  Privacy is the product; this trade-off is made with eyes open and is reversible
+  via the kill-switch and (later) a dashboard toggle.
+- **Extraction-quality risk** (hallucinated or context-stripped memories). Bounded
+  by routing auto-captured candidates through the curator's normal **confidence
+  bands** — high-confidence applies, low-confidence proposes for review — plus
+  whole-conversation extraction and cross-segment merge to keep a lesson with its
+  context.
+- **Not uniform across harnesses.** Authoritative, in-payload capture on Pi/Hermes;
+  feasible-with-a-live-test on Claude/OpenCode; **Codex is blocked** (no stable
+  conv_id) and gets coarse/deferred treatment. We ship an honest capability matrix.
+- **Maintenance surface.** A server capture pipeline + the settle-sweep + per-harness
+  acquisition adapters + the narrow block — new code across the server and each
+  integration, under the drift-guard discipline.
+
+**Threat model (explicit):** this targets the *cooperating-agent-forgets* failure —
+a well-meaning agent that simply doesn't save or recall reliably. It is **not** an
+adversarial control: an agent (or user) that wants to evade capture can. That's
+fine; the goal is to make the right thing automatic, not to defeat a hostile client.
+
+## Alternatives considered
+
+- **A broad file-write veto as the primary mechanism (the 2026-06-14 draft).**
+  Rejected as the *primary* lever: blocking a write makes the agent neither recall
+  nor capture anything it didn't already decide to write; it closes one egress and
+  leaves the structural problem intact. **Demoted** to the narrow native-store block
+  (layer 3) — useful, but a supplement.
+- **More advice only (sharpen the primer / add a SessionStart reminder).** This is
+  the layer that already failed when relied on alone. **Kept** as the awareness
+  layer (it is necessary — a reliability floor, since the skill/plugin may not even
+  auto-load), but never relied on as the whole answer.
+- **Enforce server-side.** Impossible: the MCP server sees only MCP calls and cannot
+  observe or veto a harness file-write or a missed `remember`.
+- **Agent-driven capture (`/learn`, manual `remember`).** Rejected as primary:
+  unreliable (the agent forgets) and disruptive (it interrupts the user's
+  conversation pace to do extraction work). **Kept** as a manual escape hatch /
+  on-demand flush; its role narrows from *the* capture path to a fallback.
+- **Big-bang capture at session end.** Rejected: there is no reliable session-end
+  signal across harnesses (users close the app, `/clear`, abandon). Per-turn
+  incremental ingestion + a server-side settle-sweep loses at most the last turn and
+  needs no end event.
+- **Build all five harnesses at once.** Rejected: the plan would move at the speed
+  of its worst harness (Codex is blocked), and an untuned mechanism replicated five
+  ways means debugging the same edge cases in five places. Claude-first against a
+  uniform contract ships a dogfoodable slice without foreclosing the rest.

--- a/docs/specs/2026-06-16-harness-auto-capture.md
+++ b/docs/specs/2026-06-16-harness-auto-capture.md
@@ -1,0 +1,376 @@
+# Spec: harness-driven automatic capture + awareness injection (ADR 0009)
+
+**Status:** Phase 1 **ready to build**, Claude Code first — pending
+[ADR 0009](../adr/0009-integration-enforced-librarian-use.md) acceptance on merge.
+Written with the `sdlc-spec` method. Grounded against ADR 0009 and the 2026-06-05
+working doc `docs/research/harness-driven-capture-brainstorm.md` (idea A capture,
+idea B awareness; decisions D6/D7/D8/D9/D10; the §11.2 per-harness capability
+audit). Supersedes and replaces `2026-06-14-integration-guardrails.md` (the broad
+file-write veto — demoted to the narrow block here).
+
+## 1. Objective
+
+Make the Librarian the thing an agent's memory actually flows through, **without
+relying on the agent to remember to call the verbs** — starting with the one
+harness the owner uses daily (Claude Code). Two paired moves, plus a guard:
+
+- **Capture** durable lessons **automatically and deterministically** — a hook
+  ships the conversation to the server, which extracts facts via the existing
+  curator. Zero agent tokens, zero agent decisions.
+- **Awareness** — deterministically remind the agent it *has* `recall`/`remember`
+  and prompt it to recall when prior context may exist (especially post-compaction).
+- **Narrow block** — stop the agent fleeing to the one competing channel (the
+  native `MEMORY.md` store), and nothing broader.
+
+The primer already *tells* agents to use the Librarian; that has been shown
+insufficient (ADR 0009 Context). This adds the automation the primer can't be.
+
+Grounded facts this builds on:
+
+- The intake → curator engine already mines **arbitrary raw text** server-side:
+  `remember` → `submitToInbox(text, hints)` → `inbox/<ts>-<id>.md` → the intake
+  sweep → navigate → judge → apply (create/augment/supersede/archive/noop) with
+  confidence bands. **This is the extraction engine** — capture adds a *door and a
+  settle-sweep in front of it*, not a new extractor (brainstorm §2.2, §2.x).
+- Today there is **no HTTP transcript-intake surface**. The **public** listener
+  serves `/healthz`, `/primer.md`, `/mcp` (agent auth: `Bearer ${LIBRARIAN_AGENT_TOKEN}`);
+  `/trpc/*` moved to an **internal-only** listener (ADR 0008, landed). The new
+  `POST /transcript` is an agent-facing **public-listener** route using that same
+  agent-token auth. No server-side `learn` tool — `/learn` drives the *agent*
+  (brainstorm §2.1, §2.6).
+- The intake sweep is gated by **`curator.intake.enabled`** (a dashboard setting,
+  self-checked in the intake tick via `isIntakeEnabled(store)`; the legacy
+  `LIBRARIAN_CONSOLIDATOR` env now only *seeds* it). Secret redaction reuses
+  **`redactSecrets(text)`** (`grooming-redaction.ts`). *(§1 facts re-grounded vs
+  rc.22, 2026-06-16.)*
+- The Claude Code integration today ships `.mcp.json`, the plugin manifest, four
+  slash commands, a README — and **no hooks**. Claude plugins *can* ship hooks via
+  the plugin's own `hooks/hooks.json` (the marketplace install wires them) — so
+  Phase 1 needs **no** dependency on the not-yet-built installer-cli.
+- **Private mode is a pure in-conversation marker** (`[librarian:private=on|off]`)
+  with **no server-side state** a hook can read (brainstorm §2.5). The capture path
+  therefore reads the marker **from the transcript it is already reading** and skips
+  private turns per-turn.
+- Sacred rules (AGENTS.md §2): **fail-soft** (never block the user's turn), **private
+  mode** (no writes; never bypass), the **7-verb surface** + drift-guards
+  (untouched), **cross-harness contracts change together**, **every PR is a release**.
+
+## 2. Success criteria
+
+The acceptance bar; each becomes a test. (Claude Code unless noted.)
+
+1. **Automatic capture round-trip.** With the plugin installed and
+   `LIBRARIAN_AUTO_SAVE` unset (default-on), completing a substantial turn lands the
+   turn's text in the server buffer; when the conversation settles, one curator pass
+   runs and durable facts appear as memories (high-confidence) or proposals
+   (low-confidence) — with the **agent making zero memory calls**. Verified
+   end-to-end against a local server.
+2. **Incremental + idempotent.** The cursor advances **only on server ack**; a
+   dropped/failed POST re-ships on the next turn; re-shipped deltas do **not**
+   create duplicate memories (the curator dedups). Verified by simulating a failed
+   POST then a recovery turn.
+3. **Durable across an abrupt end.** Ending the session after N turns (no clean
+   stop, `/clear`, or app-close) still results in those turns' facts being extracted
+   — the **server settle-sweep fires on idle**, needing no end event; at most the
+   last un-acked turn is lost. Verified by ending without a clean stop.
+4. **Private-mode per-turn skip.** Turns under `[librarian:private=on]` are **never
+   shipped**; a private-then-public sequence **never retroactively ships** the
+   private turns (forward-only cursor + per-turn skip). The buffer and curator never
+   see a private turn. Verified with a private-span fixture (covers brainstorm
+   Scenarios B & C).
+5. **Redaction on intake.** Secrets in a captured turn are redacted **before** the
+   buffer file is written — no secret reaches the sidecar in clear, the inbox, or
+   any git history. Verified with a secret-shaped fixture (brainstorm D6, Scenario D).
+6. **Sidecar hygiene.** The buffer lives **outside the git vault**, is gitignored,
+   is atomically claimed (`→ .processing`) before extraction, and **deleted after**;
+   an orphaned `.processing` is reaped. Verified.
+7. **Kill-switch + gate coherence.** `LIBRARIAN_AUTO_SAVE=false` ⇒ nothing ships and
+   nothing buffers. Capture intake and the curator sweep are gated **coherently** —
+   capture never buffers into an inbox nothing will sweep (resolves brainstorm I5).
+   Verified by toggling each gate.
+8. **Narrow write-block.** A `Write`/`Edit`/`MultiEdit` to `**/.claude/**/memory/**`
+   or its `MEMORY.md` is **blocked** with a teaching message naming `remember`;
+   ordinary writes (source, `docs/**`, `vault/primer.md`) are **not** blocked; the
+   guard **fails open** on its own error. Verified against a must-block / must-allow
+   fixture set.
+9. **Awareness injection + status banner.** At conversation start the agent receives
+   a deterministic, server-sourced Librarian banner — it has `recall`/`remember`, plus
+   the current **capture status**. When capture is disabled (curator off server-side,
+   or `LIBRARIAN_AUTO_SAVE=false`) the banner **warns** and names the reason + fix.
+   The awareness nudge **survives compaction** and is visible/auditable. Verified for
+   the active state and both disabled states.
+10. **Fail-soft everywhere.** Any capture / guard / extraction error never blocks the
+    user's turn, never leaks a stack trace into the model's context, and is logged to
+    the local sidecar. On **any uncertainty**, the capture path errs toward **not**
+    capturing. Verified by inducing errors at each stage.
+11. **Uniform contract.** The server transcript-intake endpoint accepts a
+    **harness-agnostic** delta payload (`conv_id`, `harness`, sequence, `turns[]`,
+    `ended?`); the Claude adapter is the first consumer; a second (mock) harness
+    payload validates against the same contract. Verified by a contract test.
+12. **Shipped via the plugin.** The Claude hooks ship in
+    `integrations/claude/hooks/hooks.json` + `scripts/`; `/plugin install` wires
+    them; uninstall removes them. No machine hand-editing. (Installer-cli
+    integration is later/orthogonal.)
+13. **Contracts intact + releasable.** 7-verb surface, protocol docs, drift-guards
+    unchanged; `pnpm test` / `typecheck` / `lint` green; PR bumps root version +
+    dated CHANGELOG (`check:release`).
+14. **Honest capability matrix.** A documented per-harness table (capture mechanism,
+    conv_id stability, status) seeded: Claude = authoritative (pending the §6 live
+    test); Pi/Hermes = feasible (in-payload); OpenCode = feasible-with-caveats;
+    Codex = blocked (no stable conv_id).
+15. **Concurrent same-machine sessions.** With **N Claude sessions running at once on
+    one machine — including multiple in the same repo/cwd** — each captures
+    independently: no cross-session clobbering of cursors, buffers, counters, or
+    private state. Verified with ≥2 concurrent sessions in one cwd — distinct
+    `session_id`s ⇒ distinct cursors and distinct `transcripts/<conv_id>.md` buffers,
+    and a `[private=on]` toggle in one session does not affect the other.
+
+## 3. Scope
+
+**Phase 1 (in) — the server pipeline + the Claude adapter, dogfooded:**
+
+- **Server (harness-agnostic, built once):** the transcript-intake endpoint + the
+  uniform payload contract; redaction-on-intake; the per-conversation sidecar buffer;
+  the settle-sweep (idle / size / explicit-end) + reaper; the **extractor** (one
+  curator pass over the settled buffer → existing inbox → curator with confidence
+  bands); gate coherence with the existing sweep.
+- **Claude acquisition adapter:** the `Stop` hook (tail `transcript_path` from a
+  byte-offset cursor, per-turn private skip, POST the delta, advance on ack,
+  fail-soft), shipped via the plugin's `hooks/hooks.json` + `scripts/`.
+- **Narrow write-block:** `PreToolUse` on `Write`/`Edit`/`MultiEdit`, native-memory-
+  store only, teaching message, fail-open.
+- **Awareness injection:** sharpen the server-sourced primer + a deterministic nudge.
+- **Docs:** capability matrix (seeded), README, private-mode contract update.
+
+**Later phases (named, not detailed here):** Pi + Hermes in-payload adapters (no
+spike); OpenCode idle-bracket adapter (live-test gated); Codex (deferred pending an
+upstream stable id); the dashboard auto-learn toggle; cost caps for multi-user; and
+**active recall-injection** (pull relevant memory after compaction — D9 deferred the
+richer version; Phase 1 ships the passive primer).
+
+**Out of scope (this spec):**
+
+- The **broad handoff-shaped / arbitrary-notes file veto** of the prior draft —
+  explicitly dropped (ADR 0009 demotes it to the narrow native-store block).
+- **Intercept-and-redirect** — auto-constructing a `store_handoff`/`remember` call
+  from a blocked file write. Deferred to its own spec.
+- Changing the primer's protocols, the 7-verb surface, or the memory state model.
+- An adversarial control (ADR 0009 threat model).
+
+## 4. Key decisions (locked with owner; cites carry the rationale)
+
+1. **Capture is automatic + deterministic; recall is nudged.** The two are solved
+   oppositely — saving off the agent (a hook never forgets), recall left to the
+   agent's judgment but heavily nudged (ADR 0009; brainstorm D3).
+2. **Incremental per-turn ingestion, not big-bang at end.** Ship the delta since a
+   byte-offset cursor each turn; loses at most the last turn; needs no reliable
+   end event (brainstorm D7, §8.2).
+3. **Two decoupled clocks.** *Ingestion* is per-turn (durability, no LLM);
+   *extraction* is once-per-conversation when settled (full context, one curator
+   pass over the whole buffer). The curator never sees a lone turn (brainstorm D8).
+4. **Settle = idle-timeout (primary) + explicit-end (accelerator) + size-cap
+   (runaway guard).** Idle is the robust default — independent of any end event
+   (brainstorm D8).
+5. **Sidecar buffer, redacted, gitignored, deleted after extract.** Raw conversation
+   never enters the git vault; only extracted *facts* reach the committed
+   inbox→curator path (brainstorm D6, D8).
+6. **Auto-captured memories flow the normal curator path with confidence bands** —
+   high auto-applies, low proposes. *(Owner override of brainstorm D11's
+   proposals-only.)* Bounds noise via the existing review queue without a blanket
+   review burden.
+7. **Default-ON**, gated by **private mode** (per-turn skip) + **`LIBRARIAN_AUTO_SAVE=false`**
+   kill-switch. *(Owner override of brainstorm D2's default-off/opt-in — default-off
+   perpetuates the "never used unless asked" failure this exists to fix; mitigations
+   in D5/D6 make default-on privacy-defensible.)*
+8. **Narrow native-store block only.** `**/.claude/**/memory/**` + its `MEMORY.md`,
+   redirect to `remember`; nothing broader. Fail-open (ADR 0009 layer 3).
+9. **One uniform server contract + thin per-harness adapters; Claude-first.** Build
+   and dogfood Claude, then add adapters against the same contract (brainstorm §11.2).
+10. **Capture hooks ship in the plugin** (`hooks/hooks.json`), not via the
+    not-yet-built installer-cli.
+11. **All per-session state keyed by `session_id`; all per-conversation server state
+    by `conv_id` (= Claude `session_id`) — never by `$USER` or `cwd`.** This is what
+    makes concurrent same-machine sessions safe (the owner runs several at once,
+    often in one repo). It is exactly the corner mem0 cuts — its
+    `/tmp/mem0_*_${USER}` session-id and message-count files are per-user, so two
+    concurrent sessions clobber each other — and we explicitly do not copy it.
+    Buffers are per-`conv_id` (not per-`cwd`), so two sessions in one repo don't
+    collide; the settle-sweep claims each buffer atomically; the inbox already
+    tolerates concurrent producers; SessionStart pruning is age-based, never
+    clear-all. (Codex's cwd-keyed `conv_id` — brainstorm I2 — would collide here, a
+    further reason it's deferred.)
+
+## 5. Resolved decisions (were open questions; all settled with the owner 2026-06-16)
+
+All six are resolved; the only remaining pre-build gate is the §6 live test (a
+maintainer spike, not a decision).
+
+1. **Q-extract — extractor shape. RESOLVED → bespoke extraction stage (Option A,
+   owner 2026-06-16).** A new server-side LLM stage mines the settled buffer into N
+   discrete candidate facts; each is `submitToInbox`'d individually and flows through
+   the **unchanged** navigate→judge→apply (so the confidence bands of §4.6 apply per
+   fact). The existing judge is **not** modified — Option B (teach the judge to emit
+   N operations from one transcript) is rejected: `navigate` needs a concrete fact to
+   search merge-candidates for, but the facts are still inside the unextracted
+   transcript, forcing extraction-first anyway while enlarging the blast radius on the
+   core curator that `remember` depends on. This is brainstorm §4.4 option b — the
+   `/learn` extraction job moved server-side; long-term `/learn` can call the same
+   extractor. Build in T2.
+2. **Q-gate — the two gates. RESOLVED → couple to the one curator gate,
+   server-authoritative (owner 2026-06-16).** `LIBRARIAN_AUTO_SAVE=false` is the
+   per-machine client kill-switch (the hook ships nothing). The server transcript-
+   intake endpoint accepts/buffers **only if the intake gate that drains it is
+   enabled**; if off, it **refuses and buffers nothing** — no raw text at rest for a
+   dead pipeline (resolves brainstorm I5). The gate is **`curator.intake.enabled`**
+   (self-checked via `isIntakeEnabled(store)`, the same gate the intake tick reads —
+   so coherence is automatic; grooming is orthogonal); the legacy
+   `LIBRARIAN_CONSOLIDATOR` env now only *seeds* it. **When capture is disabled**
+   (intake gate off server-side, or `LIBRARIAN_AUTO_SAVE=false`), the **SessionStart banner warns the
+   agent**, naming the reason + the fix, mem0-style (see T5 / SC 9). Consequence:
+   capture is only *effective* when the curator is enabled, so "curator enabled" is a
+   stated precondition, surfaced in `doctor`/health and the banner. The independent
+   server-side auto-learn toggle is deferred to **P-Dashboard**. Build in T2.
+3. **Q-settle — defaults. RESOLVED (owner 2026-06-16).** Idle window
+   `LIBRARIAN_TRANSCRIPT_IDLE_MS` = **30 min** (longer than brainstorm's 20 to avoid
+   splitting a conversation across a natural pause; latency on abandoned convs is
+   cheap, and cleanly-ended convs use the explicit-end accelerator). Sweep tick
+   `LIBRARIAN_TRANSCRIPT_SWEEP_TICK_MS` = **5 min** (≪ idle window; aligns with the
+   backup tick). Size cap `LIBRARIAN_TRANSCRIPT_MAX_BYTES` = a **generous safety
+   valve**, kept — on exceed while still active, extract-and-rotate (with the Q4
+   overlap) and start a fresh segment; rarely fires given the 1M-context extractor,
+   but backstops total loss on a pathological session. All `LIBRARIAN_*`-configurable.
+   Build in T2.
+4. **Q-overlap — context carry-forward. RESOLVED → defer overlap; lean on the
+   curator's merge (owner 2026-06-16).** No carry-forward in v1. Framing: a segment
+   resuming after the 30-min idle gap is treated as a **new session that shares the
+   previous one's context** — and that shared context lives in the **vault** (segment
+   1's already-extracted facts), which segment 2's extraction reaches through the
+   curator's `navigate`/recall step, not through raw-transcript overlap. Split-lesson
+   risk degrades to an occasional low-confidence **proposal** (merge + confidence
+   bands), never corruption. Revisit overlap (likely the cheaper *summary* flavor)
+   only if dogfooding shows split-lessons in practice.
+5. **Q-cursor-home — where the cursor lives. RESOLVED (owner 2026-06-16).** A local
+   file in the Claude plugin data dir,
+   `${CLAUDE_PLUGIN_DATA:-$HOME/.librarian/claude-plugin-data}/cursors/<session_id>`
+   — idiomatic persistent plugin state, survives reboot, namespaced for uninstall.
+   The cursor is **non-critical**: if lost, the hook re-ships and dedup absorbs it
+   (turn-level dedup on the server buffer + fact-level dedup in the curator). Cleanup
+   is **age-based** (drop cursor files older than ~7 days) — **never "clear all on
+   SessionStart"** (that would clobber a concurrently-running session — see §4.11 /
+   SC 15). Confirm the exact turn-dedup key in T3.
+6. **Q-uncertainty-direction. RESOLVED → err toward not-capturing (owner 2026-06-16).**
+   On any uncertainty the capture path skips, in two flavors: **transient/infra**
+   (server unreachable, `transcript_path` unreadable) → **skip-and-retry** (don't
+   advance the cursor; re-ship next turn — no data lost); **content/privacy** (can't
+   establish a turn's private state, e.g. compaction dropped an `=off`) →
+   **skip-and-advance** (treat as private, never ship, move the cursor forward —
+   re-reading wouldn't resolve it). Capture **overrides the agent's compaction default
+   of OFF** and treats ambiguous privacy as private. Never leak a stack trace into the
+   model context; log skips to the sidecar. Lock in T3.
+
+## 6. Pre-build live test (maintainer-run, gates T3)
+
+One Claude-specific spike before the adapter is trusted (brainstorm §11.2, §11.1):
+
+- **Claude `Stop` + `transcript_path`:** confirm the `Stop` hook fires per
+  turn-end, that `transcript_path` is present and **append-only** (so a byte-offset
+  cursor is valid), and capture the JSONL shape of a completed turn. If
+  `transcript_path` is absent or rewritten, T3's acquisition strategy changes (fall
+  back to a `UserPromptSubmit`-driven delta).
+
+**Findings (2026-06-16 — data layer confirmed by direct inspection of a live
+session** at `~/.claude/projects/<launch-cwd>/<session_id>.jsonl`):
+
+- **Clean append-only JSONL** — every line a complete JSON object (322/322 parsed) →
+  the byte-offset cursor is valid.
+- **Per-turn typed entries** (`type` / `message.role` = user / assistant) with
+  **monotonic `timestamp`s** — sliceable by the cursor and idle-detectable for the
+  settle-sweep.
+- **Stable single `sessionId`** across the file (the cursor / `conv_id` key, §4.11);
+  **concurrent sessions write distinct `<session_id>.jsonl` files** — SC 15's premise
+  confirmed in the wild (two live top-level files plus separate `subagents/*.jsonl`).
+- **`cwd` is recorded per-entry and *changes within a session*** (a mid-session `cd`
+  produced two cwds in one transcript) — real-world vindication of keying the buffer
+  by `conv_id`, **not** `cwd` (§4.11): a cwd key would have split this very session.
+- **Bonus fields:** `gitBranch` per entry (free branch tag for captured memories);
+  the project dir is keyed by the **launch** cwd, but the hook receives
+  `transcript_path` directly, so the adapter never derives the path from cwd.
+- **Subagents are isolated:** subagent work is in separate `subagents/*.jsonl` files
+  and main-transcript entries are `isSidechain: false` — so capturing the top-level
+  `<session_id>.jsonl` gets the primary conversation **without** subagent internals
+  (T3 skips subagents in v1, mirroring mem0's `agent_id` skip).
+
+**Residual risk (small):** that the `Stop` hook *delivers* `transcript_path` to the
+hook process — the data existing doesn't prove the payload carries the path. mem0's
+shipping plugin consumes exactly `Stop` + `transcript_path` in Claude Code, so this is
+de-risked to a confirm-on-wiring in T3, not an open design risk.
+
+## 7. Task plan
+
+Vertically sliced, riskiest/most-valuable first; each slice leaves the system
+working and shippable. Server foundation → Claude adapter → guard → awareness → docs
+→ gate.
+
+### Phase 1 — server pipeline + Claude adapter
+
+- [ ] **T1 — transcript-intake endpoint + uniform contract + redaction.** A new
+      authed route (Bearer `LIBRARIAN_AGENT_TOKEN`) accepting the harness-agnostic
+      delta payload (`conv_id`, `harness`, seq, `turns[]`, `ended?`); redacts each
+      turn **on intake**; appends to the sidecar buffer. *Accept:* SC 11, SC 5
+      (redaction unit), SC 6 (write path). *(Riskiest contract surface — pin it
+      first.)*
+- [ ] **T2 — buffer lifecycle + settle-sweep + extractor → inbox.** Sidecar buffer
+      management (atomic claim, delete-after, reaper); settle detection (idle / size
+      / explicit-end); **one curator pass** over the settled buffer → candidate facts
+      → existing inbox → curator (confidence bands); gate coherence. *Resolves* Q-extract,
+      Q-gate, Q-settle. *Accept:* SC 1 (server half), SC 3, SC 6, SC 7. *Depends:* T1.
+- [ ] **T3 — Claude `Stop` acquisition adapter** (after the §6 live test). Tail the
+      **top-level** `transcript_path` (`<session_id>.jsonl`) from the byte-offset
+      cursor — skip `subagents/*` (entries are `isSidechain: false`) — **skip
+      `[private=on]` turns**, POST the delta, advance the cursor **on ack**, fail-soft
+      toward not-capturing; tag candidates with the per-entry `gitBranch` + `cwd`.
+      Ship via `integrations/claude/hooks/hooks.json` + `scripts/`. *Resolves*
+      Q-cursor-home, Q-uncertainty-direction. *Accept:* SC 1 (end-to-end), SC 2,
+      SC 4, SC 10, SC 12, SC 15. *Depends:* T2, §6.
+- [ ] **T4 — narrow write-block.** `PreToolUse` on `Write`/`Edit`/`MultiEdit`;
+      block only `**/.claude/**/memory/**` + its `MEMORY.md`; teaching message names
+      `remember`; **fail-open**; must-block / must-allow fixtures. *Accept:* SC 8.
+      *Depends:* T3 (shares the hooks wiring).
+- [ ] **T5 — awareness injection + status banner.** Sharpen the server-sourced
+      primer + a deterministic `SessionStart` banner (mem0-style) that survives
+      compaction. The banner queries server status and surfaces **capture state** —
+      active, or a warning naming the reason (curator disabled in server settings →
+      enable in the dashboard; or `LIBRARIAN_AUTO_SAVE=false` on this machine) + the
+      fix. *Accept:* SC 9. *Depends:* the primer/banner shell runs parallel to T1–T4;
+      wire the capture-status line after T2 (it reads the gate state).
+- [ ] **T6 — capability matrix + README + private-mode contract update.** Seed the
+      matrix (Claude authoritative-pending-live-test; Pi/Hermes feasible; OpenCode
+      caveats; Codex blocked); document the default-on + kill-switch + private-skip
+      behavior in the shared private-mode docs. *Accept:* SC 14. *Depends:* T3.
+- [ ] **T7 — Phase 1 release gate.** tests / typecheck / lint green; 7-verb +
+      drift-guards untouched; `.gitignore` covers the sidecar buffer; version bump +
+      CHANGELOG; PR. *Accept:* SC 13. *Depends:* T1–T6.
+
+### Later phases (separate specs/PRs)
+
+- [ ] **P-Pi / P-Hermes** — in-payload adapters against the T1 contract (no spike;
+      the §11.2 "proven floor").
+- [ ] **P-OpenCode** — idle-bracket adapter (live-test gated).
+- [ ] **P-Codex** — deferred pending an upstream stable conv_id; coarse per-cwd
+      fallback documented, not built.
+- [ ] **P-Dashboard** — admin auto-learn toggle (mirrors `curator.enabled`).
+- [ ] **P-Recall** — active recall-injection after compaction (D9's deferred upgrade).
+- [ ] **P-Cost** — extraction caps / cheap pre-classify for multi-user installs (D10
+      scaling caveat).
+
+## 8. Checkpoint
+
+Phase 1 is the high-leverage, independently-shippable slice: it makes capture
+automatic and awareness deterministic on the one harness the owner uses daily, on a
+server contract every other harness will reuse unchanged. **T1–T7 are ready to hand
+to `sdlc-implement`** once ADR 0009 is accepted on merge and the §6 live test passes;
+all §5 design questions are resolved (2026-06-16), leaving that live test as the only
+remaining pre-build gate.
+The other harnesses, the dashboard toggle, active recall, and cost caps are named,
+deferred, and gated — no integration claims capture we haven't proven the harness can
+deliver.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.22",
+  "version": "1.0.0-rc.23",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## What

- **ADR 0009 (rewritten direction):** the primary lever for getting agents to actually use the Librarian is **automatic harness-driven capture + awareness injection** — not a broad file-write veto. The block narrows to the native `MEMORY.md` / `.claude/memory` store.
- **Phase-1 spec (`2026-06-16-harness-auto-capture`):** Claude-Code-first design — per-turn transcript capture into the **existing** inbox→curator engine, awareness injection, the narrow block; behind a **uniform per-harness server contract**. Default-on, private-mode gated, `LIBRARIAN_AUTO_SAVE=false` kill-switch.

## Why

The advisory primer doesn't reliably change agent behaviour (ADR 0009 Context). This records the decision to make capture automatic (a hook never forgets) and recall heavily-nudged. Mirrors how mem0 ships this for Claude Code; reuses the curator as the extraction engine.

## Notes

- **Docs only** — no shipped code; `@the-librarian/cli` unchanged. Bumps rc.22 → rc.23.
- Re-grounded against rc.22 (the auth-secrets refactor / ADR 0008 landed; intake gate is `curator.intake.enabled`).
- Merging this **accepts ADR 0009** and unblocks the Phase-1 implementation (T1–T7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)