### PR TITLE
chore(claude): version the Claude plugin by git SHA so updates propagate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,8 +9,7 @@
     {
       "name": "the-librarian",
       "source": "./integrations/claude",
-      "description": "Librarian MCP server config + four optional slash commands (/handoff, /takeover, /learn, /toggle-private). The MCP config alone is fully functional; the commands are sugar.",
-      "version": "1.0.0-rc.2",
+      "description": "Durable memory for Claude Code: automatic transcript capture + recall-awareness hooks, a native-memory write-block, the MCP server config, and four slash commands (/handoff, /takeover, /learn, /toggle-private).",
       "license": "Apache-2.0",
       "keywords": ["memory", "handoff", "mcp", "librarian", "recall", "cross-harness"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.26] — 2026-06-16
+
+### Fixed
+
+- **Claude plugin updates now actually propagate.** Dropped the explicit `version`
+  field from the Claude plugin manifest (`integrations/claude/.claude-plugin/plugin.json`)
+  and the marketplace entry (`.claude-plugin/marketplace.json`), so Claude Code
+  versions the plugin by **git commit SHA** — every merge auto-updates instead of
+  being pinned to a stale `version` string (the rc.25 capture hooks were unreachable
+  because the manifest still declared `rc.1`). Refreshed the manifest descriptions to
+  reflect the automatic-capture + awareness hooks. Users update with
+  `claude plugin marketplace update the-librarian` → `claude plugin install` →
+  `/reload-plugins`.
+
 ## [1.0.0-rc.25] — 2026-06-16
 
 ### Added
@@ -2668,6 +2682,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0-rc.26]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.25...v1.0.0-rc.26
 [1.0.0-rc.25]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.24...v1.0.0-rc.25
 [1.0.0-rc.24]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.23...v1.0.0-rc.24
 [1.0.0-rc.23]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.22...v1.0.0-rc.23

--- a/integrations/claude/.claude-plugin/plugin.json
+++ b/integrations/claude/.claude-plugin/plugin.json
@@ -1,7 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.1",
-  "description": "Durable memory + cross-harness handoffs for Claude Code, backed by a remote Librarian MCP server. Optional sugar: the MCP config alone is fully functional.",
+  "description": "Durable memory for Claude Code, backed by your Librarian MCP server: automatic transcript capture + recall-awareness hooks, a native-memory write-block, and four slash commands. No version field — Claude versions this plugin by git commit, so every merge auto-updates.",
   "author": {
     "name": "Jim Sangwine",
     "email": "jim@sangwine.net"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.25",
+  "version": "1.0.0-rc.26",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",


### PR DESCRIPTION
The rc.25 capture hooks shipped in `integrations/claude/` but the **Claude plugin manifest still declared `version: 1.0.0-rc.1`** — and Claude Code caches a plugin by its declared version string, so an existing install would report "already up to date" and **never pull the new hooks**.

## Fix
- Drop the explicit `version` field from **both** `integrations/claude/.claude-plugin/plugin.json` and the `.claude-plugin/marketplace.json` plugin entry. With no version, Claude Code versions the plugin by **git commit SHA** (the docs' recommended model for repo-sourced plugins) — every merge auto-updates, no manual bumping.
- Refresh the stale manifest descriptions to mention automatic capture + recall-awareness hooks.

## Update path for existing installs (after this merges)
```
claude plugin marketplace update the-librarian
claude plugin install the-librarian@the-librarian
/reload-plugins
```

Docs-/manifest-only; no code change. Verified: release guard, naming-canon, repo-structure test, lint all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)