### PR TITLE
fix(claude): drive auto-capture from UserPromptSubmit (Claude Stop-hook bug #29767)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.27] — 2026-06-16
+
+### Fixed
+
+- **Auto-capture now actually fires (Claude `Stop`-hook bug workaround).** Claude Code
+  doesn't fire plugin-scoped `Stop` hooks
+  ([#29767](https://github.com/anthropics/claude-code/issues/29767)) — they register
+  but never execute — so the capture adapter never ran on real turns. Capture is now
+  driven by **`UserPromptSubmit`** (which fires from plugins); `Stop`/`SessionEnd` are
+  kept as supplementary triggers so capture self-heals when the upstream bug is fixed
+  (the cursor's advance-on-ack makes firing on multiple events idempotent).
+
 ## [1.0.0-rc.26] — 2026-06-16
 
 ### Fixed
@@ -2682,6 +2694,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0-rc.27]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.26...v1.0.0-rc.27
 [1.0.0-rc.26]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.25...v1.0.0-rc.26
 [1.0.0-rc.25]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.24...v1.0.0-rc.25
 [1.0.0-rc.24]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.23...v1.0.0-rc.24

--- a/docs/harness-capture-capability.md
+++ b/docs/harness-capture-capability.md
@@ -18,7 +18,7 @@ The three columns that decide whether a harness can capture at all:
 
 | Harness | Capture mechanism | conv_id stability | Status |
 |---|---|---|---|
-| **Claude Code** | `Stop` / `SessionEnd` hook → tail the top-level `transcript_path` JSONL from a **byte-offset cursor** (subagents skipped; private turns skipped) | **stable** — `session_id`; concurrent sessions write distinct `<session_id>.jsonl` files (§6) | **Authoritative** *(pending the §6 live `Stop`-delivers-`transcript_path` confirm — the data layer is confirmed; the residual is that the `Stop` payload carries the path, de-risked to a confirm-on-wiring)*. Shipped in `integrations/claude/hooks/hooks.json`. |
+| **Claude Code** | `UserPromptSubmit` hook (primary) → tail the top-level `transcript_path` JSONL from a **byte-offset cursor** (subagents skipped; private turns skipped); `Stop` / `SessionEnd` kept as supplementary | **stable** — `session_id`; concurrent sessions write distinct `<session_id>.jsonl` files (§6) | **Authoritative**. Driven by **`UserPromptSubmit`** because Claude bug [#29767](https://github.com/anthropics/claude-code/issues/29767) means plugin-scoped `Stop` hooks register but never fire; `Stop` / `SessionEnd` stay wired so capture **auto-recovers** when the bug is fixed. Shipped in `integrations/claude/hooks/hooks.json`. |
 | **Pi** | `turn_end` / `agent_end` event → completed `AgentMessage` **in-payload** (O(1), no cursor) | **stable** — `getSessionId()` | **Feasible (in-payload)** — proven floor, no spike. Adapter is a later phase (P-Pi). |
 | **Hermes** | `sync_turn(user, assistant)` → both halves handed in as args **in-payload** (O(1)) | **stable** — `session_id` | **Feasible (in-payload)** — the cleanest surface, no spike. Later phase (P-Hermes). |
 | **OpenCode** | `event` → `message.updated`, flush on `session.idle`; accumulate by id (avoid `session.messages()` — no cursor, O(n)) | **stable** — `sessionID` | **Feasible-with-caveats** — idle-bracketing needs a live test; the `event` hook is unwired upstream. Later phase (P-OpenCode). |
@@ -31,10 +31,18 @@ it. The §6 live test confirmed the data layer directly: the transcript is clean
 append-only JSONL (so a byte-offset cursor is valid), each entry carries a stable
 `sessionId`, concurrent sessions write distinct files, subagent work is isolated
 in separate `subagents/*.jsonl`, and `cwd` can change *within* a session — which
-is exactly why the buffer is keyed by `conv_id`, not `cwd`. The only residual is
-that the `Stop` hook *delivers* `transcript_path` to the hook process; mem0's
-shipping plugin consumes exactly `Stop` + `transcript_path`, so this is a
-confirm-on-wiring, not an open design risk.
+is exactly why the buffer is keyed by `conv_id`, not `cwd`.
+
+Capture is **driven by `UserPromptSubmit`**, not `Stop`. Claude bug
+[#29767](https://github.com/anthropics/claude-code/issues/29767) is that
+plugin-scoped `Stop` hooks register but never fire (a `SessionStart` from the same
+plugin *does* fire), so a `Stop`-only adapter would silently never run.
+`UserPromptSubmit` fires reliably and carries the same `session_id` +
+`transcript_path`, so the adapter reads the same per-turn delta — one turn behind
+(it fires just before the assistant reply), which spec §8.2 already tolerates. The
+`Stop` / `SessionEnd` entries stay wired as supplementary so capture
+**auto-recovers** the moment the bug is fixed; the cursor's advance-on-ack makes
+multiple firing events idempotent.
 
 ## Behavior shared by every adapter
 

--- a/integrations/claude/README.md
+++ b/integrations/claude/README.md
@@ -87,7 +87,7 @@ remember the verbs (spec `2026-06-16-harness-auto-capture`, ADR 0009):
 
 | Hook | Script | What it does |
 | --- | --- | --- |
-| `Stop`, `SessionEnd` | `on-stop.mjs` | Tail the conversation transcript from a byte-offset cursor and ship each turn's delta to the server (`POST /transcript`), which extracts durable lessons for you — **zero agent memory calls**. `SessionEnd` is the explicit-end accelerator (the server extracts immediately instead of waiting out the idle window). |
+| `UserPromptSubmit` (primary), `Stop`, `SessionEnd` | `on-stop.mjs` | Tail the conversation transcript from a byte-offset cursor and ship each turn's delta to the server (`POST /transcript`), which extracts durable lessons for you — **zero agent memory calls**. Driven by `UserPromptSubmit` because Claude bug [#29767](https://github.com/anthropics/claude-code/issues/29767) means plugin-scoped `Stop` hooks register but never fire; `Stop` / `SessionEnd` stay wired so capture **auto-recovers** when the bug is fixed. `SessionEnd` is the explicit-end accelerator (the server extracts immediately instead of waiting out the idle window). |
 | `PreToolUse` (`Write\|Edit\|MultiEdit`) | `block-memory-write.mjs` | Block writes to Claude's **native memory store** (`**/.claude/**/memory/**`) and redirect you to the `remember` tool — durable facts belong in the shared Librarian, not a local `MEMORY.md` the next session/agent/harness can't see. Narrow by design (only the native store) and **fail-open**. |
 | `SessionStart` | `on-session-start.mjs` | Inject a deterministic banner: you have `recall`/`remember`, plus the current **capture status** (warns, with the fix, when capture is off). Re-fires after a compaction, so the awareness survives it. |
 

--- a/integrations/claude/hooks/hooks.json
+++ b/integrations/claude/hooks/hooks.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/on-stop.mjs\"",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/integrations/claude/scripts/on-stop.mjs
+++ b/integrations/claude/scripts/on-stop.mjs
@@ -1,17 +1,40 @@
 #!/usr/bin/env node
-// Claude `Stop` / `SessionEnd` hook entry — the THIN shell over the testable pure
-// logic in scripts/lib/. Spec 2026-06-16-harness-auto-capture, T3 + PART A.
+// Claude capture hook entry — the THIN shell over the testable pure logic in
+// scripts/lib/. Spec 2026-06-16-harness-auto-capture, T3 + PART A.
 //
 // Wiring (integrations/claude/hooks/hooks.json): the marketplace install (`/plugin
-// install`) auto-discovers a plugin's `hooks/hooks.json`; BOTH the `Stop` and the
-// `SessionEnd` entries run `node ${CLAUDE_PLUGIN_ROOT}/scripts/on-stop.mjs`. `Stop`
-// fires per turn-end (the incremental ingestion clock); `SessionEnd` fires on a
-// true session end (close / `/clear`) and is the explicit-end accelerator —
-// `runCapture`'s `isSessionEnd()` reads `hook_event_name` to set `ended:true` so
-// the server settle-sweep extracts immediately instead of waiting out the idle
-// window (spec §4.4). Claude delivers the hook JSON on STDIN (`transcript_path`,
-// `session_id`, `cwd`, `hook_event_name`, and `agent_id` for a subagent Stop). We
-// read it, hand it to `runCapture`, and ALWAYS `exit 0`.
+// install`) auto-discovers a plugin's `hooks/hooks.json`; the `UserPromptSubmit`,
+// `Stop`, and `SessionEnd` entries ALL run `node ${CLAUDE_PLUGIN_ROOT}/scripts/
+// on-stop.mjs`. The same entry serves every trigger; `runCapture` is event-agnostic
+// (it reads the cursor delta from `transcript_path` and ships it), so no per-event
+// branching is needed beyond `isSessionEnd()`.
+//
+//   - `UserPromptSubmit` is the PRIMARY trigger. Claude Code bug #29767 means
+//     plugin-scoped `Stop` hooks register but never fire (a `SessionStart` from the
+//     same plugin DOES fire), so a `Stop`-only adapter would never run.
+//     `UserPromptSubmit` fires reliably — just before the assistant reply — so it
+//     ingests up to the PREVIOUS completed turn (one turn behind; per spec §8.2 that
+//     is fine — incremental ingestion loses at most the last un-acked turn anyway,
+//     and the next prompt catches it up). Its payload carries the same
+//     `session_id` + `transcript_path` + `cwd` a `Stop` would.
+//   - `Stop` / `SessionEnd` are SUPPLEMENTARY / self-healing. They stay wired so the
+//     moment Anthropic fixes #29767 they resume firing and contribute for free; the
+//     cursor's advance-on-ack makes multiple firing events idempotent (a re-read
+//     delta the server/curator dedup). `SessionEnd` is additionally the explicit-end
+//     accelerator — `runCapture`'s `isSessionEnd()` reads `hook_event_name` to set
+//     `ended:true` so the server settle-sweep extracts immediately instead of waiting
+//     out the idle window (spec §4.4). `UserPromptSubmit` and `Stop` never set
+//     `ended`.
+//
+// KNOWN TRADEOFF (deferred optimization): the ship is SYNCHRONOUS, so a slow or
+// unreachable server adds latency to the user's prompt up to the hook timeout (15s
+// for `UserPromptSubmit`) before failing soft. This is bounded and fail-soft — the
+// turn always proceeds — but backgrounding the ship (fire-and-forget) so the prompt
+// never waits is a deferred optimization, not yet done.
+//
+// Claude delivers the hook JSON on STDIN (`transcript_path`, `session_id`, `cwd`,
+// `hook_event_name`, and `agent_id` for a subagent Stop). We read it, hand it to
+// `runCapture`, and ALWAYS `exit 0`.
 //
 // FAIL-SOFT CONTRACT (AGENTS.md / SC10): this process must never block the user's
 // turn, never exit non-zero in a way that breaks Claude, never leak a stack trace

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.26",
+  "version": "1.0.0-rc.27",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/test/claude-stop-adapter.test.ts
+++ b/test/claude-stop-adapter.test.ts
@@ -721,6 +721,48 @@ describe("runCapture orchestration", () => {
     const payload = ok.calls[0] as { ended?: boolean };
     expect(payload.ended).toBeUndefined();
   });
+
+  it("ships the delta on a UserPromptSubmit hook exactly as Stop does, and does NOT set ended (Claude Stop-hook bug #29767)", async () => {
+    // Plugin-scoped `Stop` hooks register but never fire in Claude Code (bug
+    // #29767), so capture is driven primarily by `UserPromptSubmit` — which
+    // carries the same `session_id` + `transcript_path` + `cwd`. The adapter
+    // needs no per-event logic: it reads the cursor delta and ships it the same
+    // way. `UserPromptSubmit` is NOT a session end, so `ended` stays unset (only
+    // `SessionEnd` is the explicit-end accelerator); the server's idle
+    // settle-sweep owns the extraction timing.
+    fs.writeFileSync(
+      transcriptPath,
+      userLine("how do I run the linter?") + assistantLine("pnpm lint"),
+    );
+    const ok = fakePoster({ ok: true });
+    const result = await capture.runCapture(
+      {
+        hook_event_name: "UserPromptSubmit",
+        transcript_path: transcriptPath,
+        session_id: "sess-1",
+        cwd: "/repo",
+      },
+      { ...baseEnv, CLAUDE_PLUGIN_DATA: dataDir },
+      { post: ok.post },
+    );
+
+    // Shipped the same delta the Stop path would.
+    expect(result.posted).toBe(true);
+    expect(ok.calls).toHaveLength(1);
+    const payload = ok.calls[0] as {
+      turns: { text: string }[];
+      conv_id: string;
+      ended?: boolean;
+    };
+    expect(payload.conv_id).toBe("sess-1");
+    expect(payload.turns.map((t) => t.text)).toEqual(["how do I run the linter?", "pnpm lint"]);
+    // NOT a session end — only SessionEnd sets `ended`.
+    expect(payload.ended).toBeUndefined();
+    // Cursor advanced to EOF and seq bumped, identical to the Stop path.
+    const c = cursor.readCursor(dataDir, "sess-1");
+    expect(c.offset).toBe(fs.statSync(transcriptPath).size);
+    expect(c.seq).toBe(1);
+  });
 });
 
 // ── live-server end-to-end (SC1) ────────────────────────────────────────────


### PR DESCRIPTION
**Auto-capture never fired** because Claude Code doesn't execute plugin-scoped `Stop` hooks ([#29767](https://github.com/anthropics/claude-code/issues/29767)) — they register (show in `/hooks`) but never run, while `SessionStart` from the same plugin works. Diagnosed live: SessionStart fired, Stop didn't, `0 total hooks in registry`. Our hook code is correct (verified by invoking it manually).

## Fix
- Trigger capture from **`UserPromptSubmit`** (fires from plugins — mem0 relies on it). No adapter logic change: it reads `session_id`/`transcript_path` (both present) and `isSessionEnd()` correctly returns false. `UserPromptSubmit` fires before the assistant reply, so it ingests up to the previous completed turn — one turn behind, which the spec (§8.2) already accounts for.
- **Keep `Stop`/`SessionEnd`** as supplementary triggers so capture **self-heals** when Anthropic fixes #29767. The cursor's advance-on-ack makes firing on multiple events idempotent.
- Known tradeoff (documented): the ship is synchronous, so a slow/unreachable server adds prompt latency up to the hook timeout (fail-soft); backgrounding the ship is a deferred optimization.

## Verified
New test feeds a `UserPromptSubmit` payload and asserts it ships exactly like `Stop` with `ended` unset. Full gate green (test/typecheck/lint/naming-canon/no-secrets/test-count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)