### PR TITLE
fix(core): stop recording intake sweeps that processed 0 memories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.28] — 2026-06-16
+
+### Fixed
+
+- **Quieter intake sweeps.** The inbox sweep no longer records a run entry (the source
+  of dashboard/log noise) when it processed **0 memories** — an empty-inbox no-op is
+  silent. A run is recorded only when ≥1 inbox item was actually handled
+  (applied/proposed/skipped/rejected, a judge error, or a thrown error). The sweep
+  cadence is unchanged — the last-sweep timestamp still advances on an empty pass, and
+  genuine errors are still logged.
+
 ## [1.0.0-rc.27] — 2026-06-16
 
 ### Fixed
@@ -2694,6 +2705,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0-rc.28]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.27...v1.0.0-rc.28
 [1.0.0-rc.27]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.26...v1.0.0-rc.27
 [1.0.0-rc.26]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.25...v1.0.0-rc.26
 [1.0.0-rc.25]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.24...v1.0.0-rc.25

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.27",
+  "version": "1.0.0-rc.28",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/core/src/intake/intake.ts
+++ b/packages/core/src/intake/intake.ts
@@ -47,13 +47,20 @@ export interface IntakeInboxItemDeps {
   /** Optional sink for a swallowed apply error (forwarded to applyIntakeJudgment). */
   onError?: (error: unknown) => void;
   /**
-   * Optional intake decision-log writer (spec 043 C1) + the open run id to record
-   * this item's outcome against. Purely observational — every write is fail-soft
-   * (see decision-log.ts), so a throwing logger can never abort intake. The
-   * `logError` sink surfaces a swallowed log-write failure for debug only.
+   * Optional intake decision-log writer (spec 043 C1) + a lazy resolver for the run
+   * id to record this item's outcome against. Purely observational — every write is
+   * fail-soft (see decision-log.ts), so a throwing logger can never abort intake.
+   *
+   * `getIntakeRunId` is called ONLY on the path that actually records an op (a
+   * handled item), and the sweep opens the decision-log run on that first call —
+   * that laziness is what keeps an all-`claimed_by_other` (or empty) sweep from
+   * recording an empty no-op run (chore/quiet-empty-intake-runs). It returns
+   * `undefined` when logging is off / the open failed, which `recordIntakeDecision`
+   * treats as "skip". The `logError` sink surfaces a swallowed log-write failure for
+   * debug only.
    */
   intakeLog?: IntakeLogger;
-  intakeRunId?: string;
+  getIntakeRunId?: () => string | undefined;
   logError?: LogErrorSink;
 }
 
@@ -121,9 +128,12 @@ export async function intakeInboxItem(
   // proposed, skipped AND failed/rejected items are all recorded. Fail-soft: a
   // log-write throw is swallowed inside recordIntakeDecision, so it can
   // never change filing or abort the sweep. `claimed` is this item's source id.
+  // Resolve the run id NOW (not earlier): this is a handled item, so the sweep's
+  // lazy resolver opens the decision-log run on this first call — an empty /
+  // all-claimed-by-other sweep, which never reaches here, never opens one.
   recordIntakeDecision(
     deps.intakeLog,
-    deps.intakeRunId,
+    deps.getIntakeRunId?.(),
     judged.judgment,
     outcome,
     claimed,

--- a/packages/core/src/intake/sweep.ts
+++ b/packages/core/src/intake/sweep.ts
@@ -60,36 +60,61 @@ export async function runIntakeSweep(deps: IntakeSweepDeps): Promise<SweepSummar
     errored: 0,
   };
 
-  // Open a decision-log run (fail-soft: returns undefined if logging is off or the
-  // store threw, in which case every downstream log write is a no-op). `logError`
-  // surfaces swallowed log failures for debug; it never propagates.
-  const runId = openIntakeRun(
-    deps.intakeLog,
-    { trigger: deps.intakeTrigger ?? "manual" },
-    deps.logError,
-  );
-  const itemDeps: IntakeInboxItemDeps = {
-    ...deps,
-    ...(runId !== undefined ? { intakeRunId: runId } : {}),
+  // Open the decision-log run LAZILY (chore/quiet-empty-intake-runs): a sweep that
+  // processes 0 inbox items — an empty inbox, or one holding only another worker's
+  // claims — is the cadence's cheap no-op, and recording a `consolidated 0` run for
+  // it just spams the dashboard's intake-runs list. So we defer `openIntakeRun`
+  // until the FIRST item is actually HANDLED (claimed + judged: a consolidated,
+  // judge-error or errored item — NOT a `claimed_by_other`, which we never touched,
+  // and NOT a bare stale-claim reclaim, which is housekeeping, not LLM work). On the
+  // truly-empty no-op the run is never opened, so no row is written. `ensureRun`
+  // opens-once and caches the id; it stays fail-soft (undefined if logging is off or
+  // the store threw), so a throwing logger still never blocks or fails the sweep.
+  let runId: string | undefined;
+  let runOpened = false;
+  const ensureRun = (): string | undefined => {
+    if (!runOpened) {
+      runOpened = true;
+      runId = openIntakeRun(
+        deps.intakeLog,
+        { trigger: deps.intakeTrigger ?? "manual" },
+        deps.logError,
+      );
+    }
+    return runId;
   };
 
+  // The per-item deps carry the lazy resolver: `intakeInboxItem` records its per-op
+  // row against `ensureRun()`, which opens the run on the first call and reuses it
+  // after — so by the time the consolidated path records an op, the run exists.
+  const itemDeps: IntakeInboxItemDeps = { ...deps, getIntakeRunId: ensureRun };
+
   // Serial FIFO over the (reclaimed-inclusive) pending snapshot. One item at a time.
+  // The run is opened lazily by the first handled item; a sweep that only sees
+  // `claimed_by_other` items (or an empty inbox) never opens one — no real work.
   for (const pendingPath of listInbox(deps.vault)) {
     try {
       const result = await intakeInboxItem(pendingPath, itemDeps);
       if (result.status === "consolidated") summary.consolidated++;
-      else if (result.status === "judge_error") summary.judgeErrors++;
-      else summary.claimedByOther++;
+      else if (result.status === "judge_error") {
+        // Claimed + judged but the model output was unusable — real work, so the run
+        // IS recorded (auditable) even though no per-op row is written for it.
+        ensureRun();
+        summary.judgeErrors++;
+      } else summary.claimedByOther++;
     } catch (error) {
       // A thrown LLM/transport error leaves the claim in `.processing/` (the
-      // next sweep's reaper retries); never abort the rest of the batch.
+      // next sweep's reaper retries); never abort the rest of the batch. The item
+      // was claimed + handed to the model, so this run is recorded too.
+      ensureRun();
       deps.onError?.(error);
       summary.errored++;
     }
   }
 
   // Complete the run with the sweep summary (fail-soft, best-effort). A no-op when
-  // logging is off / the open failed.
+  // logging is off, the open failed, OR the sweep handled 0 items (the run was never
+  // opened) — that empty no-op is intentionally NOT recorded.
   completeIntakeRun(
     deps.intakeLog,
     runId,

--- a/packages/core/tests/intake-decision-log.test.ts
+++ b/packages/core/tests/intake-decision-log.test.ts
@@ -204,6 +204,90 @@ describe("intake decision log — full-outcome coverage", () => {
   });
 });
 
+describe("intake decision log — quiet no-op sweeps (0 memories processed)", () => {
+  it("an empty-inbox sweep records NO run (the no-op is quieted)", async () => {
+    // An empty inbox is the cadence's cheap no-op. It must NOT create a run row,
+    // so the dashboard's intake-runs list isn't spammed with consolidated-0 runs.
+    const store = logStore();
+
+    const summary = await runIntakeSweep(
+      deps(constantClient(CREATE_JUDGMENT), { intakeLog: store, intakeTrigger: "tick" }),
+    );
+
+    expect(summary).toMatchObject({ consolidated: 0, judgeErrors: 0, errored: 0 });
+    expect(store.listIntakeRuns()).toEqual([]); // no run recorded
+  });
+
+  it("an empty-inbox sweep never touches the store (no createIntakeRun call)", async () => {
+    // Assert via a spying logger that NONE of the run-lifecycle writes fire on the
+    // truly-empty no-op — not even createIntakeRun (so no file is written either).
+    const calls: string[] = [];
+    const real = logStore();
+    const spy: IntakeLogger = {
+      createIntakeRun: (i) => {
+        calls.push("create");
+        return real.createIntakeRun(i);
+      },
+      recordIntakeOperation: (i) => {
+        calls.push("record");
+        return real.recordIntakeOperation(i);
+      },
+      startIntakeRun: (id) => {
+        calls.push("start");
+        return real.startIntakeRun(id);
+      },
+      completeIntakeRun: (id, i) => {
+        calls.push("complete");
+        return real.completeIntakeRun(id, i);
+      },
+      failIntakeRun: (id, i) => {
+        calls.push("fail");
+        return real.failIntakeRun(id, i);
+      },
+    };
+
+    await runIntakeSweep(deps(constantClient(CREATE_JUDGMENT), { intakeLog: spy }));
+
+    expect(calls).toEqual([]); // the store was never written on an empty sweep
+    expect(fs.existsSync(path.join(dataDir, "intake-runs.json"))).toBe(false);
+  });
+
+  it("records a run when ≥1 item is handled, even if every item only noop'd (skipped)", async () => {
+    // A sweep that CLAIMED + judged a real item still records a run — even when the
+    // verdict is noop/skip. "Processed" = an inbox item was handled, not "applied".
+    write("skip-me", 1000, "a");
+    const store = logStore();
+
+    const summary = await runIntakeSweep(
+      deps(constantClient(NOOP_JUDGMENT), { intakeLog: store, intakeTrigger: "tick" }),
+    );
+
+    expect(summary).toMatchObject({ consolidated: 1 }); // claimed + completed (skipped outcome)
+    const runs = store.listIntakeRuns();
+    expect(runs).toHaveLength(1);
+    expect(runs[0]).toMatchObject({ trigger: "tick", status: "completed" });
+    const ops = store.getIntakeOperations(runs[0]!.id);
+    expect(ops).toHaveLength(1);
+    expect(ops[0]).toMatchObject({ outcome: "skipped" });
+  });
+
+  it("records a run for a sweep whose only item judge-errors (claimed + handled, no op row)", async () => {
+    // A judge-error item was still claimed and handed to the model — real work. The
+    // run IS recorded (so it's auditable), even though no per-op row is written.
+    write("bad", 1000, "a");
+    const store = logStore();
+
+    const summary = await runIntakeSweep(
+      deps(constantClient("not json"), { intakeLog: store, intakeTrigger: "tick" }),
+    );
+
+    expect(summary).toMatchObject({ judgeErrors: 1, consolidated: 0 });
+    const runs = store.listIntakeRuns();
+    expect(runs).toHaveLength(1);
+    expect(runs[0]).toMatchObject({ status: "completed", judge_errors: 1 });
+  });
+});
+
 describe("intake decision log — fail-soft (load-bearing)", () => {
   // A logger whose every method throws — modelling a corrupt/locked sidecar.
   function throwingLogger(): IntakeLogger {
@@ -274,9 +358,10 @@ describe("intake decision log — byte-identical filing", () => {
     const store = logStore();
     const b = await runIntakeSweep(deps(constantClient(CREATE_JUDGMENT), { intakeLog: store }));
 
-    // Both empty inboxes → identical no-op summary; the logger added a run but
-    // changed nothing about the (no-op) filing outcome.
+    // Both empty inboxes → identical no-op summary, and the logger changed nothing
+    // about the (no-op) filing outcome. The empty no-op records NO run (quieted).
     expect(b).toEqual(a);
+    expect(store.listIntakeRuns()).toEqual([]);
   });
 
   it("the filed memory is unchanged whether or not logging is on", async () => {

--- a/packages/core/tests/intake-tick.test.ts
+++ b/packages/core/tests/intake-tick.test.ts
@@ -127,6 +127,38 @@ describe("runIntakeTick — operational", () => {
     ).toContain("Anna");
   });
 
+  it("an empty-inbox tick still RAN (cadence advances) but records NO run", async () => {
+    // The noisy case: a scheduled tick over an empty inbox. It must report ran:true
+    // (so the scheduler stamps curator.intake.last_sweep_at and the cadence advances
+    // — no busy-loop), but it must NOT add a row to the intake-runs decision log.
+    configureLlm();
+    // No submitToInbox → the inbox is empty.
+    const buildClient = vi.fn(() => createJudgmentClient());
+
+    const result = await runIntakeTick({ store: store!, buildClient });
+
+    // ran:true → http.ts's runIntakeSweepIfDue stamps writeLastIntakeSweepAt(now),
+    // so isIntakeSweepDue advances and the poll doesn't busy-loop.
+    expect(result).toMatchObject({ ran: true, summary: { consolidated: 0 } });
+    // The empty no-op is quieted: no run lands in the dashboard's intake-runs list.
+    expect(store!.listIntakeRuns()).toEqual([]);
+  });
+
+  it("a tick that processes ≥1 item DOES record a run (no regression)", async () => {
+    configureLlm();
+    store!.submitToInbox("Anna moved to Berlin.");
+
+    const result = await runIntakeTick({
+      store: store!,
+      buildClient: () => createJudgmentClient(),
+    });
+
+    expect(result).toMatchObject({ ran: true, summary: { consolidated: 1 } });
+    const runs = store!.listIntakeRuns();
+    expect(runs).toHaveLength(1);
+    expect(runs[0]).toMatchObject({ status: "completed", consolidated: 1 });
+  });
+
   it("feeds the intake addendum from the committed vault file into the prompt (spec 044 D-2)", async () => {
     configureLlm();
     store!.submitToInbox("Anna moved to Berlin.");


### PR DESCRIPTION
The inbox sweep runs on a cadence; an empty inbox was still recording a run entry every pass, spamming the dashboard's intake-runs list and the logs.

## Fix
- A run is recorded **only when ≥1 inbox item was actually handled** (applied/proposed/skipped/rejected = consolidated, or a judge error, or a thrown error). An empty / all-claimed-by-another-worker sweep records nothing. Implemented by opening the decision-log run **lazily** (first handled item) instead of eagerly before the loop.
- **Cadence preserved:** `runIntakeTick` still returns `{ran:true}` on an empty sweep, so the scheduler advances the last-sweep timestamp and never busy-loops. Genuine errors still log + record.

## Verified
Test-first (fail-before/pass-after): empty sweep → no run + timestamp still advances; ≥1 handled (even all-noop) → recorded; judge-error → recorded; no regression. Full gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)