### PR TITLE
feat: server auto-update — host-scheduled, CLI + dashboard configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.29] — 2026-06-17
+
+### Added
+
+- **Server auto-update** (spec `docs/specs/2026-06-16-server-autoupdate.md`). Keep a
+  self-hosted Librarian current automatically, configurable from the **CLI** and the
+  **dashboard**. `librarian server autoupdate <enable|disable|uninstall|status>`
+  installs a host systemd timer (cron fallback) that runs a gated `--run` wrapper —
+  it updates only when enabled, the cadence (`daily`/`weekly`) is due, **and** the
+  server is reachable, reusing `server update`'s health-check + rollback and
+  serialized by a host lock so fires can never overlap and leave the server down. The
+  dashboard (Settings → Curator → **Server auto-update**) toggles the same
+  `server.autoupdate.*` settings via a new admin `autoupdate` tRPC router — so it
+  configures auto-update **without ever holding host/docker access** (the container
+  can't manage its own host).
+
 ## [1.0.0-rc.28] — 2026-06-16
 
 ### Fixed
@@ -2705,6 +2721,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0-rc.29]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.28...v1.0.0-rc.29
 [1.0.0-rc.28]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.27...v1.0.0-rc.28
 [1.0.0-rc.27]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.26...v1.0.0-rc.27
 [1.0.0-rc.26]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.25...v1.0.0-rc.26

--- a/apps/dashboard/app/curator/actions.ts
+++ b/apps/dashboard/app/curator/actions.ts
@@ -184,6 +184,26 @@ export async function setIntakeConfigAction(input: {
   }
 }
 
+// --- Server auto-update (spec 2026-06-16-server-autoupdate T4) -----------------
+// Write the auto-update config — the enablement toggle and/or the cadence
+// (daily|weekly) — via the admin `autoupdate.set` router. Both fields are optional
+// so the form can patch one without the other; a bad cadence comes back as a
+// server BAD_REQUEST and is surfaced inline by the form. The dashboard only ever
+// WRITES these settings (spec §2): the host timer performs the update, never the
+// dashboard.
+export async function setAutoUpdateConfigAction(input: {
+  enabled?: boolean;
+  cadence?: "daily" | "weekly";
+}): Promise<SaveConfigResult> {
+  try {
+    await serverTRPC.autoupdate.set.mutate(input);
+    revalidatePath("/settings/curator");
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: message(error) };
+  }
+}
+
 // Lazy per-run drill-down: the C1 decisions (action/outcome/confidence/rationale)
 // for one intake run, fetched on demand when an admin expands the row.
 export async function loadIntakeOperationsAction(runId: string): Promise<LoadOperationsResult> {

--- a/apps/dashboard/app/settings/curator/page.tsx
+++ b/apps/dashboard/app/settings/curator/page.tsx
@@ -12,11 +12,13 @@ import {
   runGroomingNowAction,
   runIntakeNowAction,
   saveGroomingConfigAction,
+  setAutoUpdateConfigAction,
   setConsumerConfigAction,
   setIntakeConfigAction,
   testConnectionAction,
   updateProviderAction,
 } from "@/app/curator/actions";
+import { AutoUpdateConfigForm } from "@/components/curator/autoupdate-config-form";
 import { GroomingConfigForm } from "@/components/curator/config-form";
 import { ConsumerModelSelector } from "@/components/curator/consumer-model-selector";
 import { IntakeConfigForm } from "@/components/curator/intake-config-form";
@@ -43,9 +45,10 @@ export default async function CuratorSettingsPage() {
   let intakeRuns: Awaited<ReturnType<typeof serverTRPC.intake.runs.query>> = [];
   let intakeConsumer: Awaited<ReturnType<typeof serverTRPC.llm.consumerConfig.query>> | null = null;
   let grooming: Awaited<ReturnType<typeof serverTRPC.llm.consumerConfig.query>> | null = null;
+  let autoupdate: Awaited<ReturnType<typeof serverTRPC.autoupdate.get.query>> | null = null;
   let error: string | null = null;
   try {
-    [config, runs, providers, intakeConfig, intakeRuns, intakeConsumer, grooming] =
+    [config, runs, providers, intakeConfig, intakeRuns, intakeConsumer, grooming, autoupdate] =
       await Promise.all([
         serverTRPC.grooming.config.query(),
         serverTRPC.grooming.runs.query({ limit: 50 }),
@@ -54,6 +57,7 @@ export default async function CuratorSettingsPage() {
         serverTRPC.intake.runs.query({ limit: 50 }),
         serverTRPC.llm.consumerConfig.query({ consumer: "intake" }),
         serverTRPC.llm.consumerConfig.query({ consumer: "grooming" }),
+        serverTRPC.autoupdate.get.query(),
       ]);
   } catch (err) {
     error = err instanceof Error ? err.message : String(err);
@@ -200,6 +204,32 @@ export default async function CuratorSettingsPage() {
           </section>
         }
       />
+
+      <Hairline />
+
+      {/* Server auto-update (spec 2026-06-16-server-autoupdate T4). A server-level
+          concern, not a curator job — so it sits below the two job tabs as its own
+          section. The dashboard only configures it; the host timer performs the
+          update (spec §2). */}
+      <section className="flex flex-col gap-3" aria-label="Server auto-update">
+        <header className="flex flex-col gap-1.5">
+          <SectionLabel as="h2">Server auto-update</SectionLabel>
+          <p className="text-sm text-foreground/60">
+            Keep the server current automatically. The dashboard configures auto-update; a timer on
+            the host machine performs the update on the cadence you set.
+          </p>
+        </header>
+        {autoupdate ? (
+          <AutoUpdateConfigForm
+            enabled={autoupdate.enabled}
+            cadence={autoupdate.cadence}
+            lastRunAt={autoupdate.lastRunAt}
+            version={autoupdate.version}
+            latest={autoupdate.latest}
+            onSave={setAutoUpdateConfigAction}
+          />
+        ) : null}
+      </section>
     </main>
   );
 }

--- a/apps/dashboard/components/curator/autoupdate-config-form.tsx
+++ b/apps/dashboard/components/curator/autoupdate-config-form.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+// Server auto-update config (spec 2026-06-16-server-autoupdate T4). Enable +
+// cadence, a read-only status line (last auto-update + an up-to-date /
+// update-available badge), and the SC6 host hint.
+//
+// IMPORTANT (spec §2 / SC6): the dashboard only CONFIGURES auto-update — it
+// writes the `enabled`/`cadence` settings via the admin tRPC `autoupdate.set`.
+// It never PERFORMS an update: a process inside the container can't recreate its
+// own container. The host-installed timer (`librarian server autoupdate enable`)
+// is what acts. So this form has no "update now" button by design — only the
+// toggle, the cadence, and a calm note that the settings take effect only once
+// the host timer is installed.
+//
+// Editorial rebuild mirroring IntakeConfigForm — no card chrome (the parent
+// section owns the container); SectionLabel field labels, ui-v2 Select + Button,
+// accent checkbox. The version/latest pair is rendered by the same status logic
+// the top-bar VersionBadge uses (one source of truth, see ./autoupdate-status).
+
+import { useRouter } from "next/navigation";
+import { useEffect, useState, useTransition } from "react";
+import type { SaveConfigResult } from "@/app/curator/actions";
+import { type LatestReleaseStatus, autoUpdateStatus } from "@/components/curator/autoupdate-status";
+import { Button } from "@/components/ui-v2/button";
+import { Pill } from "@/components/ui-v2/pill";
+import { SectionLabel } from "@/components/ui-v2/section-label";
+import { Select } from "@/components/ui-v2/select";
+
+type Cadence = "daily" | "weekly";
+
+const STATUS_LABEL: Record<ReturnType<typeof autoUpdateStatus>, string> = {
+  loading: "Checking…",
+  up_to_date: "Up to date",
+  behind: "Update available",
+  unknown: "Version unknown",
+};
+
+// Up-to-date wears the rubric accent (positive, the one lit state on the line);
+// behind wears copper (important hardware-tier, never destructive) — the same
+// tier/colours the top-bar VersionBadge uses.
+const STATUS_PILL: Record<ReturnType<typeof autoUpdateStatus>, "accent" | "default"> = {
+  loading: "default",
+  up_to_date: "accent",
+  behind: "default",
+  unknown: "default",
+};
+
+function formatLastRun(lastRunAt: string | null): string {
+  if (!lastRunAt) return "never";
+  const date = new Date(lastRunAt);
+  if (Number.isNaN(date.getTime())) return lastRunAt;
+  // Editorial: a human, locale-stable timestamp. `toISOString`'s date + minute
+  // is precise without leaking milliseconds.
+  return date
+    .toISOString()
+    .replace("T", " ")
+    .replace(/:\d\d\.\d+Z$/, " UTC");
+}
+
+export function AutoUpdateConfigForm({
+  enabled: initialEnabled,
+  cadence: initialCadence,
+  lastRunAt,
+  version,
+  latest,
+  onSave,
+}: {
+  enabled: boolean;
+  cadence: Cadence;
+  lastRunAt: string | null;
+  version: string;
+  latest: LatestReleaseStatus | undefined;
+  onSave: (input: { enabled?: boolean; cadence?: Cadence }) => Promise<SaveConfigResult>;
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [enabled, setEnabled] = useState(initialEnabled);
+  const [cadence, setCadence] = useState<Cadence>(initialCadence);
+
+  useEffect(() => {
+    if (!saved) return;
+    const id = window.setTimeout(() => setSaved(false), 5000);
+    return () => window.clearTimeout(id);
+  }, [saved]);
+
+  const clearStatus = () => {
+    setSaved(false);
+    setError(null);
+  };
+
+  const submit = (event: React.FormEvent) => {
+    event.preventDefault();
+    clearStatus();
+    startTransition(async () => {
+      const result = await onSave({ enabled, cadence });
+      if (result.ok) {
+        setSaved(true);
+        router.refresh();
+      } else {
+        setError(result.error);
+      }
+    });
+  };
+
+  const status = autoUpdateStatus(version, latest);
+
+  return (
+    <form
+      onSubmit={submit}
+      className="flex flex-col gap-4"
+      aria-label="Auto-update configuration form"
+      noValidate
+    >
+      <label className="inline-flex items-center gap-2 text-sm text-foreground">
+        <input
+          type="checkbox"
+          checked={enabled}
+          onChange={(e) => {
+            setEnabled(e.target.checked);
+            clearStatus();
+          }}
+          className="h-4 w-4 accent-ink-accent"
+        />
+        Enable automatic server updates
+      </label>
+
+      <div className="flex flex-col gap-1.5">
+        <SectionLabel as="label" htmlFor="autoupdate-cadence">
+          Cadence
+        </SectionLabel>
+        <Select
+          id="autoupdate-cadence"
+          aria-label="Cadence"
+          className="w-40"
+          value={cadence}
+          onChange={(e) => {
+            setCadence(e.target.value as Cadence);
+            clearStatus();
+          }}
+        >
+          <option value="daily">Daily</option>
+          <option value="weekly">Weekly</option>
+        </Select>
+        <p className="text-xs text-foreground/60">
+          How often the host timer checks whether an update is due.
+        </p>
+      </div>
+
+      {/* Read-only status line: last auto-update + the version/latest badge. */}
+      <dl className="flex flex-col gap-1.5 text-sm text-foreground">
+        <div className="flex flex-wrap items-baseline gap-2">
+          <dt className="text-foreground/60">Last auto-update:</dt>
+          <dd data-testid="autoupdate-last-run" className="font-mono text-xs">
+            {formatLastRun(lastRunAt)}
+          </dd>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <dt className="text-foreground/60">Server version:</dt>
+          <dd className="flex items-center gap-2">
+            <span className="font-mono text-xs">v{version}</span>
+            <Pill
+              variant={STATUS_PILL[status]}
+              data-testid="autoupdate-version-badge"
+              data-status={status}
+            >
+              {STATUS_LABEL[status]}
+            </Pill>
+          </dd>
+        </div>
+      </dl>
+
+      {/* SC6 host hint — calm, not alarming. The settings above only take effect
+          once the host timer is installed; the dashboard can't install it (the
+          container can't manage the host). */}
+      <p
+        data-testid="autoupdate-host-hint"
+        className="border-l-2 border-ink-copper-soft pl-3 text-xs text-foreground/60"
+      >
+        These settings only take effect once the auto-update timer is installed on the host. Run{" "}
+        <code className="rounded-none bg-foreground/[0.06] px-1 py-0.5 font-mono text-foreground/80">
+          librarian server autoupdate enable
+        </code>{" "}
+        on the host machine — the dashboard configures auto-update but can&rsquo;t install a host
+        timer from inside the container.
+      </p>
+
+      {error ? (
+        <p
+          role="alert"
+          className="border border-destructive/40 bg-destructive/[0.06] p-3 text-sm text-destructive"
+        >
+          Error: {error}
+        </p>
+      ) : null}
+      {saved ? (
+        <p
+          role="status"
+          className="border border-ink-accent/40 bg-ink-accent/[0.06] p-3 text-sm text-foreground"
+        >
+          Saved.
+        </p>
+      ) : null}
+
+      <Button type="submit" variant="primary" className="self-start" disabled={pending}>
+        {pending ? "Saving…" : "Save auto-update"}
+      </Button>
+    </form>
+  );
+}

--- a/apps/dashboard/components/curator/autoupdate-status.ts
+++ b/apps/dashboard/components/curator/autoupdate-status.ts
@@ -1,0 +1,62 @@
+// Shared running-version-vs-latest status logic (spec 2026-06-16-server-autoupdate
+// T4). The top-bar VersionBadge and the auto-update settings panel both render an
+// up-to-date / update-available indicator from a running version + a GitHub
+// `LatestReleaseStatus`; this is the single source of truth for that comparison so
+// the two never drift.
+
+// Mirrors the `LatestReleaseStatus` union from
+// `@librarian/mcp-server`'s github-release (the `autoupdate.get` / `health.info`
+// `latest` field). Kept as a local structural type so the client bundle doesn't
+// pull a server-only module just for a type.
+export type LatestReleaseStatus =
+  | {
+      kind: "ok";
+      release: { tag: string; htmlUrl?: string; publishedAt?: string };
+      cachedAt: string;
+    }
+  | { kind: "no_release"; cachedAt: string }
+  | { kind: "disabled" }
+  | { kind: "unavailable"; reason: string };
+
+export type VersionStatus = "loading" | "up_to_date" | "behind" | "unknown";
+
+// Strip a leading `v` and split into numeric parts. Anything non-numeric becomes
+// NaN, which `compareSemver` treats as "unknown" and falls back to "up to date"
+// rather than risking a noisy false-positive.
+function parseSemver(value: string): number[] {
+  return value
+    .replace(/^v/i, "")
+    .split(/[-+.]/)
+    .slice(0, 3)
+    .map((part) => Number.parseInt(part, 10));
+}
+
+export function compareSemver(a: string, b: string): -1 | 0 | 1 | null {
+  const pa = parseSemver(a);
+  const pb = parseSemver(b);
+  for (let i = 0; i < 3; i++) {
+    const av = pa[i];
+    const bv = pb[i];
+    if (av === undefined || bv === undefined || Number.isNaN(av) || Number.isNaN(bv)) {
+      return null;
+    }
+    if (av < bv) return -1;
+    if (av > bv) return 1;
+  }
+  return 0;
+}
+
+// `current` vs the GitHub `latest` status → a coarse update state. `undefined`
+// latest is the loading state (query not resolved); a non-`ok` latest (no
+// release / disabled / unreachable) is "unknown" — conservative: never claim an
+// update is available when we couldn't confirm one.
+export function autoUpdateStatus(
+  current: string,
+  latest: LatestReleaseStatus | undefined,
+): VersionStatus {
+  if (!latest) return "loading";
+  if (latest.kind !== "ok") return "unknown";
+  const cmp = compareSemver(current, latest.release.tag);
+  if (cmp === null) return "unknown";
+  return cmp < 0 ? "behind" : "up_to_date";
+}

--- a/apps/dashboard/components/version-badge.tsx
+++ b/apps/dashboard/components/version-badge.tsx
@@ -1,45 +1,10 @@
 "use client";
 
+import {
+  type VersionStatus as Status,
+  autoUpdateStatus as statusOf,
+} from "@/components/curator/autoupdate-status";
 import { trpc } from "@/lib/trpc-client";
-
-// Strip a leading `v` and split into numeric parts. Anything non-numeric
-// becomes NaN, which `compareSemver` treats as "unknown" and falls back to
-// "up to date" rather than risking a noisy false-positive.
-function parseSemver(value: string): number[] {
-  return value
-    .replace(/^v/i, "")
-    .split(/[-+.]/)
-    .slice(0, 3)
-    .map((part) => Number.parseInt(part, 10));
-}
-
-function compareSemver(a: string, b: string): -1 | 0 | 1 | null {
-  const pa = parseSemver(a);
-  const pb = parseSemver(b);
-  for (let i = 0; i < 3; i++) {
-    const av = pa[i];
-    const bv = pb[i];
-    if (av === undefined || bv === undefined || Number.isNaN(av) || Number.isNaN(bv)) {
-      return null;
-    }
-    if (av < bv) return -1;
-    if (av > bv) return 1;
-  }
-  return 0;
-}
-
-type Status = "loading" | "up_to_date" | "behind" | "unknown";
-
-function statusOf(
-  current: string,
-  latest: { kind: string; release?: { tag: string } } | undefined,
-): Status {
-  if (!latest) return "loading";
-  if (latest.kind !== "ok" || !latest.release) return "unknown";
-  const cmp = compareSemver(current, latest.release.tag);
-  if (cmp === null) return "unknown";
-  return cmp < 0 ? "behind" : "up_to_date";
-}
 
 // Status dot uses the brand palette — verdigris for up-to-date (positive),
 // copper for behind (important but not destructive — same tier the

--- a/apps/dashboard/tests/components/curator/autoupdate.test.tsx
+++ b/apps/dashboard/tests/components/curator/autoupdate.test.tsx
@@ -1,0 +1,120 @@
+// AutoUpdateConfigForm component tests (spec 2026-06-16-server-autoupdate T4).
+//
+// The form is presentational: it takes the current settings (enabled, cadence,
+// lastRunAt) + the version/latest pair the badge reads, plus an `onSave`
+// callback (the server action, mocked here exactly as the IntakeConfigForm test
+// mocks its `onSave`). We assert: the current settings render; toggling
+// `enabled` saves with the right arg; changing cadence saves with the right
+// arg; the update-available badge appears only when version !== latest; the
+// host hint (SC6) always renders.
+
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { AutoUpdateConfigForm } from "@/components/curator/autoupdate-config-form";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
+
+// A `kind: "ok"` latest-release status whose tag is the running version → the
+// server reports itself up to date.
+function latestOk(tag: string) {
+  return {
+    kind: "ok" as const,
+    release: {
+      tag,
+      htmlUrl: `https://github.com/JimJafar/the-librarian/releases/tag/${tag}`,
+      publishedAt: "2026-06-01T00:00:00Z",
+      bodyExcerpt: null,
+    },
+    cachedAt: "2026-06-01T00:00:00Z",
+  };
+}
+
+type OnSave = React.ComponentProps<typeof AutoUpdateConfigForm>["onSave"];
+
+function setup(
+  over: Partial<React.ComponentProps<typeof AutoUpdateConfigForm>> = {},
+  onSave: ReturnType<typeof vi.fn> = vi.fn<OnSave>(async () => ({ ok: true as const })),
+) {
+  const props: React.ComponentProps<typeof AutoUpdateConfigForm> = {
+    enabled: false,
+    cadence: "daily",
+    lastRunAt: null,
+    version: "1.0.0",
+    latest: latestOk("v1.0.0"),
+    onSave,
+    ...over,
+  };
+  return { onSave, ...render(<AutoUpdateConfigForm {...props} />) };
+}
+
+describe("AutoUpdateConfigForm", () => {
+  it("reflects the current enabled state and saves a toggle", async () => {
+    const { onSave } = setup({ enabled: false });
+
+    const toggle = screen.getByRole("checkbox", { name: /enable/i });
+    expect((toggle as HTMLInputElement).checked).toBe(false);
+
+    await userEvent.click(toggle);
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave.mock.calls[0]![0]).toEqual({ enabled: true, cadence: "daily" });
+    expect(await screen.findByText("Saved.")).toBeTruthy();
+  });
+
+  it("saves the chosen cadence", async () => {
+    const { onSave } = setup({ enabled: true, cadence: "daily" });
+
+    await userEvent.selectOptions(screen.getByRole("combobox", { name: /cadence/i }), "weekly");
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave.mock.calls[0]![0]).toEqual({ enabled: true, cadence: "weekly" });
+  });
+
+  it("renders the cadence select reflecting the current value", () => {
+    setup({ cadence: "weekly" });
+    const select = screen.getByRole("combobox", { name: /cadence/i }) as HTMLSelectElement;
+    expect(select.value).toBe("weekly");
+  });
+
+  it("shows 'never' when there has been no auto-update", () => {
+    setup({ lastRunAt: null });
+    const status = screen.getByTestId("autoupdate-last-run");
+    expect(status.textContent?.toLowerCase()).toContain("never");
+  });
+
+  it("shows the last auto-update time when present", () => {
+    setup({ lastRunAt: "2026-06-10T08:30:00.000Z" });
+    const status = screen.getByTestId("autoupdate-last-run");
+    expect(status.textContent?.toLowerCase()).not.toContain("never");
+    expect(status.textContent).toContain("2026");
+  });
+
+  it("shows an up-to-date badge when the running version matches latest", () => {
+    setup({ version: "1.0.0", latest: latestOk("v1.0.0") });
+    const badge = screen.getByTestId("autoupdate-version-badge");
+    expect(badge).toHaveAttribute("data-status", "up_to_date");
+  });
+
+  it("shows an update-available badge when version !== latest", () => {
+    setup({ version: "1.0.0", latest: latestOk("v1.1.0") });
+    const badge = screen.getByTestId("autoupdate-version-badge");
+    expect(badge).toHaveAttribute("data-status", "behind");
+    expect(badge.textContent?.toLowerCase()).toMatch(/update available/);
+  });
+
+  it("renders the host hint with the enable command (SC6)", () => {
+    setup();
+    const hint = screen.getByTestId("autoupdate-host-hint");
+    expect(within(hint).getByText(/librarian server autoupdate enable/)).toBeTruthy();
+  });
+
+  it("surfaces a save error", async () => {
+    const onSave = vi.fn(async () => ({ ok: false as const, error: "boom" }));
+    setup({ enabled: true }, onSave);
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("boom");
+  });
+});

--- a/docs/specs/2026-06-16-server-autoupdate.md
+++ b/docs/specs/2026-06-16-server-autoupdate.md
@@ -1,0 +1,104 @@
+# Spec: server auto-update — host-scheduled, CLI + dashboard configurable
+
+**Status:** Ready to build (owner-authorized overnight, 2026-06-16). Written with the
+`sdlc-spec` method, grounded against the `librarian server` command surface on `main`.
+
+## 1. Objective
+
+Let an operator keep their self-hosted Librarian server current automatically, and
+toggle/configure it from **both** the `librarian` CLI **and** the dashboard — without
+the dashboard ever holding host/docker privileges.
+
+## 2. The architectural constraint (drives the whole design)
+
+`librarian server update` is **host-level**: it rebuilds the image and `docker rm`s +
+recreates the container (data volume preserved). A process **inside** the container
+cannot recreate its own container, and the container has **no docker-socket access**
+(by design — a web-facing dashboard with `docker.sock` = host root). So:
+
+- The **act** of updating must run on the **host** (a scheduled job).
+- The dashboard can only ever **configure** auto-update (write a setting); it cannot
+  perform it.
+
+**Design:** a host-installed scheduler (systemd timer, cron fallback) runs frequently
+and invokes a wrapper `librarian server autoupdate --run`. The wrapper reads two
+**settings** from the server and a due-check, then conditionally calls
+`server update`. The dashboard (and CLI) write those settings. This decouples *what's
+configured* (settings, editable anywhere) from *who acts* (the host wrapper).
+
+## 3. Success criteria (each → a test)
+
+1. **CLI enable.** `librarian server autoupdate enable [--cadence daily|weekly]`
+   installs a systemd timer (oneshot service + timer unit) — or a cron entry where
+   systemd is unavailable — that periodically runs `librarian server autoupdate --run`;
+   sets the `enabled` + `cadence` settings; idempotent (re-run = no dup units).
+2. **CLI disable / uninstall.** `autoupdate disable` flips the setting off (timer
+   stays installed → next run no-ops). `autoupdate uninstall` removes the timer/cron
+   entirely. Both idempotent.
+3. **CLI status.** `autoupdate status` shows: timer installed?, enabled?, cadence,
+   last auto-update at, server up-to-date? (reuses `server status`' version/latest).
+4. **The wrapper (`--run`) is correctly gated.** It updates **iff** `enabled` **and**
+   the cadence has elapsed since the last auto-update (a due-check mirroring the
+   intake sweep's `isIntakeSweepDue`); otherwise it logs a one-line skip and exits 0.
+   On a successful update it stamps `last_run_at`. It reads the settings from the
+   running server (admin tRPC / a status read); **if the server is unreachable it
+   SKIPS** (conservative — never auto-update a server in an unknown state) and logs.
+5. **Settings exist + are admin-editable.** `server.autoupdate.enabled` (bool),
+   `server.autoupdate.cadence` (`daily|weekly`), `server.autoupdate.last_run_at`
+   (ISO) live in the settings store (plain settings, like `curator.intake.*`), with
+   read/write helpers + an admin tRPC route.
+6. **Dashboard configures it.** A settings panel (toggle + cadence select + a
+   read-only status line: timer-installed, last-run, update-available) reads/writes
+   the settings via tRPC. When the timer isn't installed it shows a hint to run
+   `librarian server autoupdate enable` on the host (the dashboard can't install it).
+7. **Rollback-safe.** The wrapper relies on `server update`'s existing
+   health-check-and-rollback; a failed update leaves the prior container running and
+   the wrapper logs the failure (and does NOT stamp `last_run_at`, so it retries).
+8. **Contracts + release.** Tests green (`pnpm test`/typecheck/lint/guards); version
+   bump + CHANGELOG.
+
+## 4. Key decisions
+
+- **Timer fires frequently (e.g. hourly); the cadence is a due-check, not the timer
+  period.** This lets the dashboard change cadence (a setting) with **no host
+  action** — the wrapper just changes when it considers itself due. (Mirrors the
+  intake sweep: fixed poll + `interval_minutes` setting + last-run timestamp.)
+- **systemd timer preferred, cron fallback.** Reuse the boot/systemd handling in
+  `packages/installer-cli/src/server/boot.ts` / `runtime.ts`. User vs system scope:
+  match how `boot.ts` installs persistence.
+- **Wrapper reads settings from the running server** (admin tRPC over the internal
+  listener, or a small read), not the docker volume directly (a named volume isn't a
+  clean host path). Server-unreachable → skip (SC 4).
+- **`enabled`/`cadence`/`last_run_at` are plain settings** (no master key needed),
+  consistent with `curator.intake.*`.
+- **Dashboard never performs the update** — only writes settings; the host timer acts.
+
+## 5. Out of scope
+
+- Pulling pre-built release images from a registry (the current `update` rebuilds
+  locally; a GHCR-publish + `docker pull` fast-path is a separate, adjacent spec).
+- A dashboard "Update now" button that *performs* an update (would need host access /
+  a sidecar — explicitly deferred; the toggle + the host timer is the safe path).
+
+## 6. Task plan
+
+- **T1 — settings + helpers (core).** `server.autoupdate.{enabled,cadence,last_run_at}`
+  keys + read/write helpers + an `isAutoUpdateDue(store)` due-check (mirror
+  `intake-config.ts`). Tests. *(@librarian/core)*
+- **T2 — admin tRPC.** A `autoupdate` tRPC router (or extend `health`/an existing
+  admin router): `get` (settings + timer-installed? + server version/latest) and
+  `set` (enabled, cadence). Tests. *(@librarian/mcp-server)*
+- **T3 — CLI `server autoupdate` + the timer.** `enable|disable|uninstall|status|--run`
+  in `packages/installer-cli/src/server/autoupdate.ts`, wired in `runtime.ts`/`server/index.ts`;
+  systemd unit+timer install (cron fallback) reusing `boot.ts`; the `--run` wrapper
+  (read settings via tRPC → due-check → `server update` → stamp). Tests with a fake
+  home/systemd + stub. *(installer-cli)*
+- **T4 — dashboard panel.** A settings UI (toggle + cadence + status) consuming the T2
+  tRPC; the "install on host" hint when the timer isn't present. Tests. *(apps/dashboard)*
+- **T5 — release gate.** version bump + CHANGELOG; full gate green; PR.
+
+## 7. Checkpoint
+
+T1→T3 are the functional core (auto-update works, CLI-controlled, dashboard-readable
+settings). T4 is the dashboard UX. Ship as one feature PR; if T4 is at risk, T1–T3 are
+independently complete and shippable, with T4 as a fast-follow.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.28",
+  "version": "1.0.0-rc.29",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -228,6 +228,22 @@ export {
   writeLastIntakeSweepAt,
 } from "./intake-config.js";
 export {
+  type AutoUpdateCadence,
+  AUTOUPDATE_CADENCES,
+  DEFAULT_AUTOUPDATE_CADENCE,
+  isAutoUpdateCadence,
+  isAutoUpdateDue,
+  isAutoUpdateEnabled,
+  readAutoUpdateCadence,
+  readLastAutoUpdateAt,
+  SERVER_AUTOUPDATE_CADENCE_KEY,
+  SERVER_AUTOUPDATE_ENABLED_KEY,
+  SERVER_AUTOUPDATE_LAST_RUN_KEY,
+  setAutoUpdateCadence,
+  setAutoUpdateEnabled,
+  writeLastAutoUpdateAt,
+} from "./server-autoupdate-config.js";
+export {
   ADDENDUM_MAX_BYTES,
   type AddendumStore,
   type CuratorJob,

--- a/packages/core/src/server-autoupdate-config.ts
+++ b/packages/core/src/server-autoupdate-config.ts
@@ -1,0 +1,148 @@
+// Server auto-update NON-LLM configuration, stored in the admin settings store.
+// Holds the auto-update enablement flag, the cadence (daily/weekly), and the
+// last-run timestamp — the knobs that gate and pace the host-scheduled
+// auto-update wrapper (`librarian server autoupdate --run`).
+//
+// The host scheduler (a systemd timer, cron fallback) fires frequently and runs
+// the wrapper; the wrapper reads these settings + a due-check, then conditionally
+// calls `server update` (spec 2026-06-16-server-autoupdate §2/§4). Keeping the
+// cadence as a stored due-check (rather than the timer period) is what lets the
+// dashboard change cadence with NO host action — the wrapper just changes when it
+// considers itself due (mirrors the intake sweep: fixed poll + last-run timestamp).
+//
+// All reads use plain settings only, so they work without the master key — the
+// admin dashboard can always render the configured state (mirrors intake-config.ts).
+
+import type { LlmConnectionReader, LlmConnectionWriter } from "./llm-connection.js";
+
+// Auto-update enablement key. Dashboard-editable string setting ("true"/"false").
+// The host wrapper updates IFF this is true AND the cadence has elapsed (§3 SC4).
+export const SERVER_AUTOUPDATE_ENABLED_KEY = "server.autoupdate.enabled";
+
+// Auto-update cadence: `"daily"` (default) or `"weekly"`. The due-check
+// (`isAutoUpdateDue`) reads it to decide whether enough time has elapsed since
+// the last run. Editing it takes effect on the next timer fire with no host action.
+export const SERVER_AUTOUPDATE_CADENCE_KEY = "server.autoupdate.cadence";
+
+// The timestamp (ISO-8601 string) of the last completed auto-update run. The host
+// wrapper stamps this only after a SUCCESSFUL `server update`; a failed update
+// leaves it unstamped so the next due-check still fires (so it retries) — §3 SC7.
+export const SERVER_AUTOUPDATE_LAST_RUN_KEY = "server.autoupdate.last_run_at";
+
+/** The two valid cadences (a const tuple so the type + the runtime guard agree). */
+export const AUTOUPDATE_CADENCES = ["daily", "weekly"] as const;
+
+/** The auto-update cadence — how often the wrapper considers itself due. */
+export type AutoUpdateCadence = (typeof AUTOUPDATE_CADENCES)[number];
+
+/** Default cadence when the setting is unset or corrupt: daily. */
+export const DEFAULT_AUTOUPDATE_CADENCE: AutoUpdateCadence = "daily";
+
+/** Whole-day span each cadence maps to in the due-check (daily = 1, weekly = 7). */
+const CADENCE_DAYS: Record<AutoUpdateCadence, number> = {
+  daily: 1,
+  weekly: 7,
+};
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+// The slices of the store this module needs. All keys are plain (non-secret)
+// settings; reuse the shared reader/writer interfaces (as intake-config does).
+type ConfigReader = LlmConnectionReader;
+type ConfigWriter = LlmConnectionWriter;
+
+/** True iff `value` is one of the two valid cadences. */
+export function isAutoUpdateCadence(value: string): value is AutoUpdateCadence {
+  return (AUTOUPDATE_CADENCES as readonly string[]).includes(value);
+}
+
+/**
+ * Auto-update enablement, read from the `server.autoupdate.enabled` setting.
+ * Default off — a host never auto-updates until an operator opts in (via the CLI
+ * `autoupdate enable` or the dashboard toggle). Reads plain settings only, so it
+ * works without the master key (the dashboard render + the host wrapper read).
+ */
+export function isAutoUpdateEnabled(store: ConfigReader): boolean {
+  return store.getSetting(SERVER_AUTOUPDATE_ENABLED_KEY) === "true";
+}
+
+/**
+ * Set auto-update enablement. Writes `server.autoupdate.enabled` as the canonical
+ * "true"/"false" string (mirrors `setIntakeEnabled`). The CLI `autoupdate
+ * enable`/`disable` and the dashboard toggle call it. Disabling leaves the timer
+ * installed (the next `--run` no-ops) — uninstalling the timer is a separate step.
+ */
+export function setAutoUpdateEnabled(store: ConfigWriter, enabled: boolean): void {
+  store.setSetting(SERVER_AUTOUPDATE_ENABLED_KEY, enabled ? "true" : "false");
+}
+
+/**
+ * Read the auto-update cadence from `server.autoupdate.cadence`, defaulting to
+ * `daily` when unset or holding an unrecognised value (so a corrupt setting can
+ * never wedge the wrapper into a bogus interval). Reads plain settings only.
+ */
+export function readAutoUpdateCadence(store: ConfigReader): AutoUpdateCadence {
+  const raw = store.getSetting(SERVER_AUTOUPDATE_CADENCE_KEY);
+  return raw !== null && isAutoUpdateCadence(raw) ? raw : DEFAULT_AUTOUPDATE_CADENCE;
+}
+
+/**
+ * Set the auto-update cadence (`daily` | `weekly`). Validates the value with a
+ * teaching error before touching the store (the single source of truth, mirroring
+ * `writeIntakeInterval`); persists under `server.autoupdate.cadence`. The wrapper
+ * picks the new cadence up on its next due-check — no host action, no restart.
+ */
+export function setAutoUpdateCadence(store: ConfigWriter, cadence: string): void {
+  if (!isAutoUpdateCadence(cadence)) {
+    throw new Error(`cadence must be one of ${AUTOUPDATE_CADENCES.join(" | ")}, got '${cadence}'`);
+  }
+  store.setSetting(SERVER_AUTOUPDATE_CADENCE_KEY, cadence);
+}
+
+/**
+ * The last completed auto-update timestamp, or null if no auto-update has ever
+ * run. Read by the host wrapper to feed `isAutoUpdateDue`. A corrupt
+ * (non-parseable) stored value is treated as "never run" (null) so a bad write
+ * can't wedge auto-update — it simply runs on the next due timer fire. Mirrors
+ * `readLastIntakeSweepAt`.
+ */
+export function readLastAutoUpdateAt(store: ConfigReader): Date | null {
+  const raw = store.getSetting(SERVER_AUTOUPDATE_LAST_RUN_KEY);
+  if (raw === null) return null;
+  const at = new Date(raw);
+  return Number.isNaN(at.getTime()) ? null : at;
+}
+
+/**
+ * Stamp the last completed auto-update timestamp. The host wrapper calls it ONLY
+ * after a successful `server update` so the next due-check advances; a failed
+ * update leaves it unstamped (so the wrapper retries on the next fire). Mirrors
+ * `writeLastIntakeSweepAt`.
+ */
+export function writeLastAutoUpdateAt(store: ConfigWriter, at: Date): void {
+  store.setSetting(SERVER_AUTOUPDATE_LAST_RUN_KEY, at.toISOString());
+}
+
+/**
+ * Is an auto-update due now? The gate the host wrapper applies (spec §3 SC4 /
+ * §4): auto-update runs IFF it is ENABLED **and** the cadence has elapsed since
+ * the last run. An elapsed-days gate (NOT a wall-clock schedule), mirroring the
+ * intake sweep's `isIntakeSweepDue` so editing the cadence takes effect on the
+ * next timer fire with no restart.
+ *
+ * - **Disabled**: never due (the wrapper no-ops + logs a one-line skip).
+ * - **Enabled + never run** (`last_run_at` unset/corrupt → null): due now, so a
+ *   freshly-enabled host updates on the first timer fire rather than waiting a
+ *   full cadence.
+ * - **Enabled + run before**: due once `now - last_run_at >= cadenceDays`.
+ *
+ * The frequent timer (≈hourly) is the resolution floor; this gate is what keeps
+ * the wrapper from updating more than once per cadence window.
+ */
+export function isAutoUpdateDue(store: ConfigReader, now: Date): boolean {
+  if (!isAutoUpdateEnabled(store)) return false;
+  const lastRunAt = readLastAutoUpdateAt(store);
+  if (lastRunAt === null) return true;
+  const cadenceDays = CADENCE_DAYS[readAutoUpdateCadence(store)];
+  return now.getTime() - lastRunAt.getTime() >= cadenceDays * MS_PER_DAY;
+}

--- a/packages/core/tests/server-autoupdate-config.test.ts
+++ b/packages/core/tests/server-autoupdate-config.test.ts
@@ -1,0 +1,224 @@
+// Server auto-update NON-LLM configuration (spec 2026-06-16-server-autoupdate T1)
+// over the settings store: the enablement flag (`server.autoupdate.enabled`), the
+// cadence (`server.autoupdate.cadence`, daily|weekly), and the last-run timestamp
+// (`server.autoupdate.last_run_at`). All plain settings — read paths work without
+// the master key (the dashboard render + the host wrapper read). The load-bearing
+// piece is `isAutoUpdateDue`: enabled AND cadence elapsed since last_run_at, with
+// never-run → due and disabled → never due (mirrors the intake sweep's due-check).
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type LibrarianStore,
+  createLibrarianStore,
+  DEFAULT_AUTOUPDATE_CADENCE,
+  isAutoUpdateDue,
+  isAutoUpdateEnabled,
+  readAutoUpdateCadence,
+  readLastAutoUpdateAt,
+  setAutoUpdateCadence,
+  setAutoUpdateEnabled,
+  writeLastAutoUpdateAt,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+interface Scope {
+  store: LibrarianStore;
+  dataDir: string;
+}
+
+function open(dataDir: string): LibrarianStore {
+  return createLibrarianStore({ dataDir });
+}
+
+function scope(): Scope {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-autoupdate-cfg-"));
+  return { store: open(dataDir), dataDir };
+}
+
+function teardown(s: Scope | null): void {
+  if (!s) return;
+  try {
+    s.store.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(s.dataDir, { recursive: true, force: true });
+}
+
+describe("server auto-update enablement (server.autoupdate.enabled)", () => {
+  let s: Scope | null = null;
+  beforeEach(() => {
+    s = scope();
+  });
+  afterEach(() => {
+    teardown(s);
+    s = null;
+  });
+
+  it("defaults to disabled (a host never auto-updates until opted in)", () => {
+    expect(isAutoUpdateEnabled(s!.store)).toBe(false);
+  });
+
+  it("round-trips the enablement toggle as the canonical true/false string", () => {
+    const { store } = s!;
+    setAutoUpdateEnabled(store, true);
+    expect(isAutoUpdateEnabled(store)).toBe(true);
+    expect(store.getSetting("server.autoupdate.enabled")).toBe("true");
+
+    setAutoUpdateEnabled(store, false);
+    expect(isAutoUpdateEnabled(store)).toBe(false);
+    expect(store.getSetting("server.autoupdate.enabled")).toBe("false");
+  });
+
+  it("reads enablement WITHOUT the master key (dashboard render path)", () => {
+    const { store, dataDir } = s!;
+    setAutoUpdateEnabled(store, true);
+    store.close();
+    const noKey = open(dataDir);
+    s!.store = noKey;
+    expect(isAutoUpdateEnabled(noKey)).toBe(true);
+  });
+});
+
+describe("server auto-update cadence (server.autoupdate.cadence)", () => {
+  let s: Scope | null = null;
+  beforeEach(() => {
+    s = scope();
+  });
+  afterEach(() => {
+    teardown(s);
+    s = null;
+  });
+
+  it("defaults the cadence to daily", () => {
+    expect(readAutoUpdateCadence(s!.store)).toBe("daily");
+    expect(DEFAULT_AUTOUPDATE_CADENCE).toBe("daily");
+  });
+
+  it("round-trips daily and weekly under server.autoupdate.cadence", () => {
+    const { store } = s!;
+    setAutoUpdateCadence(store, "weekly");
+    expect(readAutoUpdateCadence(store)).toBe("weekly");
+    expect(store.getSetting("server.autoupdate.cadence")).toBe("weekly");
+
+    setAutoUpdateCadence(store, "daily");
+    expect(readAutoUpdateCadence(store)).toBe("daily");
+  });
+
+  it("rejects an unknown cadence with a teaching error", () => {
+    const { store } = s!;
+    expect(() => setAutoUpdateCadence(store, "hourly")).toThrow(/cadence must be one of/i);
+    expect(() => setAutoUpdateCadence(store, "")).toThrow(/cadence must be one of/i);
+  });
+
+  it("defaults a corrupt stored cadence to daily rather than failing", () => {
+    const { store } = s!;
+    store.setSetting("server.autoupdate.cadence", "garbage");
+    expect(readAutoUpdateCadence(store)).toBe("daily");
+  });
+});
+
+describe("server auto-update last-run timestamp (server.autoupdate.last_run_at)", () => {
+  let s: Scope | null = null;
+  beforeEach(() => {
+    s = scope();
+  });
+  afterEach(() => {
+    teardown(s);
+    s = null;
+  });
+
+  it("reads null when no auto-update has ever run", () => {
+    expect(readLastAutoUpdateAt(s!.store)).toBeNull();
+  });
+
+  it("round-trips an ISO-8601 timestamp under server.autoupdate.last_run_at", () => {
+    const { store } = s!;
+    const at = new Date("2026-06-01T12:00:00.000Z");
+    writeLastAutoUpdateAt(store, at);
+    expect(readLastAutoUpdateAt(store)?.toISOString()).toBe(at.toISOString());
+    expect(store.getSetting("server.autoupdate.last_run_at")).toBe(at.toISOString());
+  });
+
+  it("treats a corrupt stored value as never-run (null) rather than wedging", () => {
+    const { store } = s!;
+    store.setSetting("server.autoupdate.last_run_at", "not-a-date");
+    expect(readLastAutoUpdateAt(store)).toBeNull();
+  });
+});
+
+describe("isAutoUpdateDue — enabled AND cadence elapsed since last_run_at", () => {
+  let s: Scope | null = null;
+  beforeEach(() => {
+    s = scope();
+  });
+  afterEach(() => {
+    teardown(s);
+    s = null;
+  });
+
+  const now = new Date("2026-06-16T03:00:00.000Z");
+  const hoursAgo = (h: number): Date => new Date(now.getTime() - h * 60 * 60 * 1000);
+
+  it("is NOT due when auto-update is disabled (even with no last run)", () => {
+    // Disabled is the gate the wrapper checks first — it never updates, regardless
+    // of how long it's been (the timer fires but the wrapper no-ops + logs a skip).
+    expect(isAutoUpdateDue(s!.store, now)).toBe(false);
+  });
+
+  it("is NOT due when disabled even if the last run was long ago", () => {
+    const { store } = s!;
+    setAutoUpdateEnabled(store, false);
+    setAutoUpdateCadence(store, "daily");
+    writeLastAutoUpdateAt(store, hoursAgo(72));
+    expect(isAutoUpdateDue(store, now)).toBe(false);
+  });
+
+  it("is due when enabled and never run (a freshly-enabled host updates first fire)", () => {
+    const { store } = s!;
+    setAutoUpdateEnabled(store, true);
+    expect(readLastAutoUpdateAt(store)).toBeNull();
+    expect(isAutoUpdateDue(store, now)).toBe(true);
+  });
+
+  it("daily: due when >= 24h have elapsed, not due before", () => {
+    const { store } = s!;
+    setAutoUpdateEnabled(store, true);
+    setAutoUpdateCadence(store, "daily");
+
+    writeLastAutoUpdateAt(store, hoursAgo(23));
+    expect(isAutoUpdateDue(store, now)).toBe(false);
+
+    writeLastAutoUpdateAt(store, hoursAgo(24));
+    expect(isAutoUpdateDue(store, now)).toBe(true);
+
+    writeLastAutoUpdateAt(store, hoursAgo(25));
+    expect(isAutoUpdateDue(store, now)).toBe(true);
+  });
+
+  it("weekly: due when >= 7 days have elapsed, not due at 6 days", () => {
+    const { store } = s!;
+    setAutoUpdateEnabled(store, true);
+    setAutoUpdateCadence(store, "weekly");
+
+    writeLastAutoUpdateAt(store, hoursAgo(6 * 24));
+    expect(isAutoUpdateDue(store, now)).toBe(false);
+
+    writeLastAutoUpdateAt(store, hoursAgo(7 * 24));
+    expect(isAutoUpdateDue(store, now)).toBe(true);
+  });
+
+  it("a daily-due run is NOT yet weekly-due (cadence governs the window)", () => {
+    const { store } = s!;
+    setAutoUpdateEnabled(store, true);
+    writeLastAutoUpdateAt(store, hoursAgo(48)); // 2 days ago
+
+    setAutoUpdateCadence(store, "daily");
+    expect(isAutoUpdateDue(store, now)).toBe(true);
+
+    setAutoUpdateCadence(store, "weekly");
+    expect(isAutoUpdateDue(store, now)).toBe(false);
+  });
+});

--- a/packages/installer-cli/src/runtime.ts
+++ b/packages/installer-cli/src/runtime.ts
@@ -19,6 +19,13 @@ import { allHarnesses } from "./harnesses/index.js";
 import { flagBool, flagString, parseArgs, type FlagMap } from "./parse-args.js";
 import { createPrompter, MissingValueError, type Prompter } from "./prompt.js";
 import { runAdmin } from "./server/admin.js";
+import {
+  autoUpdateStatus,
+  disableAutoUpdate,
+  enableAutoUpdate,
+  runAutoUpdate,
+  uninstallAutoUpdate,
+} from "./server/autoupdate.js";
 import { disableBoot, enableBoot } from "./server/boot.js";
 import { runDown } from "./server/down.js";
 import { serverUsage } from "./server/index.js";
@@ -241,6 +248,9 @@ async function runServerCommand(rest: string[], options: RuntimeOptions): Promis
   if (subcommand === "disable-boot") {
     return runServerDisableBootCommand(options);
   }
+  if (subcommand === "autoupdate") {
+    return runServerAutoUpdateCommand(subRest, options);
+  }
   if (subcommand === "admin") {
     return runServerAdminCommand(subRest, options);
   }
@@ -303,6 +313,54 @@ async function runServerEnableBootCommand(options: RuntimeOptions): Promise<CliR
 async function runServerDisableBootCommand(options: RuntimeOptions): Promise<CliResult> {
   const result = await disableBoot(options.platform ? { platform: options.platform } : {});
   return ok(result.output);
+}
+
+/**
+ * `librarian server autoupdate <enable|disable|uninstall|status> [--cadence …]`
+ * and the internal `--run` (T3). `enable` installs a host scheduler (systemd timer
+ * / cron fallback) that fires hourly and runs `--run`, plus writes enabled+cadence
+ * into the running server (so the dashboard reflects it). `disable` flips the
+ * setting off (timer stays). `uninstall` removes the timer/cron. `status` reports
+ * timer-installed + the server's enabled/cadence/last-run + up-to-date. `--run` is
+ * the wrapper the timer calls: it reads the settings from the running server,
+ * applies the due-check, and conditionally runs `server update` — FULLY fail-soft
+ * (never throws out of the timer). A real failure on the operator-facing verbs
+ * surfaces as one clean stderr line via the top-level catch.
+ */
+async function runServerAutoUpdateCommand(
+  subRest: string[],
+  options: RuntimeOptions,
+): Promise<CliResult> {
+  const { positionals, flags } = parseArgs(subRest);
+  const platformOpt = options.platform ? { platform: options.platform } : {};
+  const base = { home: options.home, dir: flagString(flags.dir), ...platformOpt };
+
+  // `--run` is the timer's wrapper. It is fail-soft by construction (it never
+  // throws) and always exits 0 so the timer's unit never fails; its one-line
+  // outcome is its stdout.
+  if (flagBool(flags.run)) {
+    const result = await runAutoUpdate(base);
+    return ok(result.output);
+  }
+
+  const [verb] = positionals;
+  if (verb === "enable") {
+    const result = await enableAutoUpdate({ ...base, cadence: flagString(flags.cadence) });
+    return ok(result.output);
+  }
+  if (verb === "disable") {
+    return ok((await disableAutoUpdate(base)).output);
+  }
+  if (verb === "uninstall") {
+    return ok((await uninstallAutoUpdate(base)).output);
+  }
+  if (verb === "status" || verb === undefined) {
+    return ok((await autoUpdateStatus(base)).output);
+  }
+  return err(
+    `Unknown autoupdate subcommand: ${verb}\n\n` +
+      "Usage: librarian server autoupdate <enable|disable|uninstall|status> [--cadence daily|weekly]",
+  );
 }
 
 /**

--- a/packages/installer-cli/src/server/autoupdate.ts
+++ b/packages/installer-cli/src/server/autoupdate.ts
@@ -36,7 +36,18 @@
 // same seam boot.ts uses), so tests assert the exact systemctl/crontab/docker
 // argv without a real systemd, cron, or docker.
 
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  closeSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+  writeSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
@@ -45,6 +56,7 @@ import {
   DEFAULT_AUTOUPDATE_CADENCE,
   isAutoUpdateCadence,
 } from "@librarian/core";
+import { librarianDir } from "../paths.js";
 import { run, which } from "./docker.js";
 import { redactSecrets } from "./redact.js";
 import { serverStatus } from "./status.js";
@@ -62,6 +74,14 @@ const SYSTEMD_SYSTEM_DIR = "/etc/systemd/system";
 
 /** A stable marker that tags OUR crontab line, so we can find/replace/remove it idempotently. */
 export const CRON_MARKER = "# the-librarian-autoupdate";
+
+/**
+ * The substring every OUR systemd unit's `Description=` carries (both the service
+ * and the timer descriptions start with it). `uninstall` reads a unit file and
+ * confirms this marker BEFORE deleting it (FIX I2) — so a same-named unit a human
+ * authored is never `rm`'d out from under them.
+ */
+export const UNIT_DESCRIPTION_MARKER = "The Librarian — auto-update";
 
 /** Fallback `librarian` path if `which librarian` can't be resolved (npm global bin). */
 const DEFAULT_LIBRARIAN_PATH = "/usr/local/bin/librarian";
@@ -139,6 +159,9 @@ export interface ServiceUnitInput {
  */
 export function generateServiceUnit(input: ServiceUnitInput): string {
   const { librarianPath } = input;
+  // The path is validated whitespace/metacharacter-free before it reaches here
+  // (see `assertSafeLibrarianPath` in `enableAutoUpdate`), so a bare (unquoted)
+  // `ExecStart` token is safe — systemd splits ExecStart on whitespace.
   return [
     "[Unit]",
     "Description=The Librarian — auto-update check (host-scheduled)",
@@ -147,6 +170,14 @@ export function generateServiceUnit(input: ServiceUnitInput): string {
     "",
     "[Service]",
     "Type=oneshot",
+    // ROOT is required (not a smell): `server update` drives the host docker
+    // daemon (build / stop / rm / run) and writes a 0600 deploy env-file under
+    // /etc — neither is reachable from an unprivileged unit. We do NOT downgrade
+    // the user; instead we add the defense-in-depth knob below.
+    // NoNewPrivileges: even running as root, forbid this oneshot from gaining
+    // ANY new privileges via setuid/setgid/capabilities on the binaries it execs
+    // (docker/git) — an auto-executing root unit should grant no more than it needs.
+    "NoNewPrivileges=true",
     // The wrapper reads the auto-update settings from the running container and,
     // if due, performs `server update`. It carries NO secret on this argv: the
     // settings + the container's credentials live in the container, reached via
@@ -206,6 +237,29 @@ export function cronLine(librarianPath: string): string {
 async function resolveLibrarianPath(): Promise<string> {
   const resolved = await which("librarian");
   return resolved && resolved.trim().length > 0 ? resolved.trim() : DEFAULT_LIBRARIAN_PATH;
+}
+
+/**
+ * Reject a `librarian` path that isn't safe to interpolate UNQUOTED into a systemd
+ * `ExecStart` / a cron line (FIX I1). systemd splits `ExecStart` on whitespace and
+ * cron passes the line to `/bin/sh`, so a path containing a space (e.g. an npm
+ * prefix under `/home/jane doe/`) or a shell metacharacter would silently break
+ * the timer — or worse, inject. Rather than wrap quoting rules around two different
+ * grammars, we REJECT at `enable` with a teaching error (the cleanest fix): the
+ * resolved binary path must contain none of these characters. The operator then
+ * symlinks/installs `librarian` to a clean path and re-runs.
+ */
+function assertSafeLibrarianPath(librarianPath: string): void {
+  // Whitespace OR any shell/systemd-significant metacharacter is rejected.
+  if (/\s/.test(librarianPath) || /["'`$\\;&|<>(){}*?!#~]/.test(librarianPath)) {
+    throw new AutoUpdateError(
+      `The resolved \`librarian\` path is not safe to schedule unquoted:\n  ${librarianPath}\n\n` +
+        "It contains whitespace or a shell/systemd metacharacter, which would break the " +
+        "systemd timer's ExecStart (or the cron line). Install or symlink `librarian` to a " +
+        "path with no spaces or special characters (e.g. `/usr/local/bin/librarian`) and " +
+        "re-run `librarian server autoupdate enable`.",
+    );
+  }
 }
 
 // --- platform helpers ----------------------------------------------------
@@ -409,6 +463,9 @@ export async function enableAutoUpdate(options: EnableOptions = {}): Promise<Aut
   const cadence = resolveCadence(options.cadence);
 
   const librarianPath = await resolveLibrarianPath();
+  // Reject a path that isn't safe to interpolate UNQUOTED into the unit/cron line
+  // BEFORE touching the host (a bad path is a teaching error, not a broken timer).
+  assertSafeLibrarianPath(librarianPath);
   const lines: string[] = [];
 
   if (await hasSystemd()) {
@@ -518,16 +575,22 @@ export async function uninstallAutoUpdate(
     if (disable.code !== 0 && !isUnitAbsent(disable.stderr)) {
       failIfNonZero("sudo", ["systemctl", "disable", "--now", AUTOUPDATE_TIMER_NAME], disable);
     }
-    // Remove both unit files (idempotent with -f), then daemon-reload.
-    await sudoRun(["rm", "-f", timerPath()]);
-    await sudoRun(["rm", "-f", servicePath()]);
+    // Remove each unit file ONLY after confirming it's ours (FIX I2): a file with
+    // our name that a human authored (no Librarian marker) is left untouched with a
+    // warning — we never `rm` an unrelated unit out from under the operator.
+    const lines: string[] = [];
+    const removedTimer = await removeOwnedUnit(timerPath(), lines);
+    const removedService = await removeOwnedUnit(servicePath(), lines);
     await sudoSystemctl(["daemon-reload"]);
-    return {
-      output: [
-        "Auto-update timer removed — both unit files deleted and systemd reloaded.",
-        "The server's auto-update setting is untouched; the container itself is unaffected.",
-      ].join("\n"),
-    };
+    lines.unshift(
+      removedTimer || removedService
+        ? "Auto-update timer removed — our unit file(s) deleted and systemd reloaded."
+        : "No Librarian auto-update unit files were removed (none of ours were present).",
+    );
+    lines.push(
+      "The server's auto-update setting is untouched; the container itself is unaffected.",
+    );
+    return { output: lines.join("\n") };
   }
 
   await removeCron();
@@ -535,6 +598,32 @@ export async function uninstallAutoUpdate(
     output:
       "Auto-update cron entry removed (systemd not found). The container itself is unaffected.",
   };
+}
+
+/**
+ * Remove a unit file at `unitPath` ONLY if it's ours (FIX I2). Reads it via
+ * `sudo cat` (the file is root-owned under /etc/systemd/system) and removes it
+ * iff the content carries {@link UNIT_DESCRIPTION_MARKER}. An ABSENT file is a
+ * clean no-op (idempotent). A PRESENT file that ISN'T ours is left in place and a
+ * one-line warning is appended to `notes` — we never delete an unrelated unit a
+ * human installed under the same name. Returns true iff we deleted it.
+ */
+async function removeOwnedUnit(unitPath: string, notes: string[]): Promise<boolean> {
+  const read = await run("sudo", ["cat", unitPath]);
+  if (read.code !== 0) {
+    // Non-zero `cat` → the file isn't there (already removed / never installed).
+    // Idempotent: nothing to remove, no warning.
+    return false;
+  }
+  if (!read.stdout.includes(UNIT_DESCRIPTION_MARKER)) {
+    notes.push(
+      `Skipped ${unitPath} — a unit with this name exists but is NOT the Librarian ` +
+        "auto-update unit (no Librarian marker). Left it untouched; remove it yourself if intended.",
+    );
+    return false;
+  }
+  await sudoRun(["rm", "-f", unitPath]);
+  return true;
 }
 
 // --- cron fallback (idempotent via CRON_MARKER) --------------------------
@@ -666,6 +755,109 @@ async function isTimerInstalled(): Promise<boolean> {
   return (await readCrontab()).some((l) => l.includes(CRON_MARKER));
 }
 
+// --- the exclusive host lock (serialize concurrent updates, FIX C1) ------
+
+/**
+ * After this many milliseconds an unrefreshed lockfile is treated as STALE and
+ * reclaimed — a crashed/killed update (the holder never released its lock) must
+ * not wedge auto-update forever. `server update` rebuilds + recreates, so a wide
+ * margin (1h) is safe: a real in-flight update is far shorter, and a lock older
+ * than this is from a dead process, not a slow one.
+ */
+const LOCK_STALE_MS = 60 * 60 * 1000;
+
+/** The fixed lock path: `~/.librarian/server/.autoupdate.lock` (no root needed). */
+export function autoUpdateLockPath(options: {
+  home?: string | undefined;
+  dir?: string | undefined;
+}): string {
+  const dir = options.dir ?? path.join(librarianDir(options.home), "server");
+  return path.join(dir, ".autoupdate.lock");
+}
+
+/** A held lock — call `release()` exactly once when the critical section ends. */
+interface HeldLock {
+  release(): void;
+}
+
+/**
+ * Acquire an EXCLUSIVE host lock so two timer fires (or a fire overlapping a
+ * manual `librarian server update`) can never both `docker stop`/`rm`/`run` the
+ * same container — a window with NO running container would take the server down
+ * (spec SC7). Implemented as an `O_CREAT|O_EXCL` lockfile (atomic on POSIX, no
+ * root, no external `flock`): the create succeeds for exactly one caller.
+ *
+ * Returns the held lock on success, or `null` when another update already holds
+ * it (the caller then SKIPS without stamping). A STALE lock (older than
+ * {@link LOCK_STALE_MS} — a crashed holder) is reclaimed once, then retried.
+ *
+ * FAIL-SOFT: any lock-subsystem error (a read-only FS, a permissions problem)
+ * throws here and is caught by `runAutoUpdate`'s outer guard, which logs + skips
+ * — a lock problem must never crash the timer or leave the server mid-recreate.
+ */
+function acquireUpdateLock(lockPath: string): HeldLock | null {
+  // Best-effort: ensure the directory exists (the deploy dir normally does).
+  mkdirSync(path.dirname(lockPath), { recursive: true });
+
+  const tryCreate = (): HeldLock | null => {
+    let fd: number;
+    try {
+      // O_CREAT|O_EXCL|O_WRONLY → fails with EEXIST if the lockfile already exists.
+      fd = openSync(lockPath, "wx");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") return null;
+      throw error; // a real FS error → fail-soft up in runAutoUpdate
+    }
+    // Record our pid + acquisition time (debuggable; carries NO secret).
+    try {
+      writeSync(fd, `${process.pid} ${Date.now()}\n`);
+    } finally {
+      closeSync(fd);
+    }
+    let released = false;
+    return {
+      release(): void {
+        if (released) return;
+        released = true;
+        try {
+          unlinkSync(lockPath);
+        } catch {
+          // Already gone (e.g. reclaimed as stale elsewhere) — nothing to do.
+        }
+      },
+    };
+  };
+
+  const held = tryCreate();
+  if (held) return held;
+
+  // The lock exists. If it's STALE (a crashed holder), reclaim it ONCE and retry.
+  if (isLockStale(lockPath)) {
+    try {
+      unlinkSync(lockPath);
+    } catch {
+      // Someone else reclaimed it first — fall through to a single retry anyway.
+    }
+    return tryCreate(); // null again ⇒ a live holder won the race → skip
+  }
+  return null; // a live update is in progress → skip
+}
+
+/** True iff the lockfile is older than {@link LOCK_STALE_MS} (a crashed holder). */
+function isLockStale(lockPath: string): boolean {
+  try {
+    // Prefer the timestamp written into the file; fall back to mtime.
+    const written = Number.parseInt(
+      readFileSync(lockPath, "utf8").trim().split(/\s+/)[1] ?? "",
+      10,
+    );
+    const acquiredAt = Number.isFinite(written) ? written : statSync(lockPath).mtimeMs;
+    return Date.now() - acquiredAt >= LOCK_STALE_MS;
+  } catch {
+    return false; // can't read it → don't reclaim (conservative: skip, don't steal)
+  }
+}
+
 // --- the `--run` wrapper (what the timer calls) --------------------------
 
 /**
@@ -711,7 +903,17 @@ export async function runAutoUpdate(options: RunOptions = {}): Promise<AutoUpdat
       return { output: line };
     }
 
-    // Due + enabled: run the existing host-level update flow.
+    // Due + enabled: take the EXCLUSIVE host lock before the actual update so two
+    // timer fires (or a fire overlapping a manual `server update`) can never both
+    // stop/rm/run the same container — a window with NO running container would
+    // take the server down (spec SC7). If another update already holds the lock,
+    // SKIP cleanly (do NOT stamp last_run_at — the in-flight update will stamp).
+    const lock = acquireUpdateLock(autoUpdateLockPath(options));
+    if (!lock) {
+      const line = "autoupdate: another update in progress — skipping.";
+      log(line);
+      return { output: line };
+    }
     try {
       const result = await runUpdate({
         ...(options.home !== undefined ? { home: options.home } : {}),
@@ -742,6 +944,10 @@ export async function runAutoUpdate(options: RunOptions = {}): Promise<AutoUpdat
       const line = `autoupdate: update failed — left the previous server running, did NOT stamp last_run_at (will retry next fire). ${firstLine(detail)}`;
       log(line);
       return { output: line };
+    } finally {
+      // Always release — a held lock that outlives the update would wedge the next
+      // fire until the stale-reclaim window elapses.
+      lock.release();
     }
   } catch (error) {
     // Belt-and-braces: ANY unexpected throw is swallowed so the timer never fails.

--- a/packages/installer-cli/src/server/autoupdate.ts
+++ b/packages/installer-cli/src/server/autoupdate.ts
@@ -1,0 +1,768 @@
+// `librarian server autoupdate <enable|disable|uninstall|status|--run>` — the
+// HOST half of the server auto-update feature (spec 2026-06-16-server-autoupdate
+// T3). The server settings + admin tRPC are T1/T2; this is the scheduler that
+// actually performs the update on the host.
+//
+// THE ARCHITECTURAL CONSTRAINT (spec §2). `server update` is host-level: it
+// rebuilds the image and `docker rm`s + recreates the container. A process INSIDE
+// the container cannot recreate its own container (no docker-socket access, by
+// design). So the act of updating MUST run on the host. This module installs a
+// host scheduler (a systemd timer; a cron fallback where systemd is absent) that
+// fires frequently (~hourly) and runs `librarian server autoupdate --run`. The
+// wrapper reads the auto-update settings from the RUNNING server, applies the
+// due-check, and conditionally calls `server update`. The dashboard/CLI only
+// WRITE the settings (enabled, cadence) — never the host action.
+//
+// HOW `--run` READS THE SETTINGS (decision). The settings live in the server's
+// data volume, and the admin tRPC that reads them is served only on the INTERNAL
+// listener (127.0.0.1:3840 inside the container — ADR 0008 P1/P3, no bearer
+// gate), which is NOT published to the host. A named docker volume is not a clean
+// host path either. So the wrapper reaches the settings the SAME way `server
+// admin` reaches in-container state: `docker exec the-librarian node -e <script>`,
+// where the script does a localhost `fetch` of the internal tRPC `autoupdate.get`
+// / `autoupdate.set` from inside the container. This is the cleanest mechanism —
+// it reuses the existing exec seam, needs no published port, and honours ADR
+// 0008's "the socket is the gate" model (the internal listener trusts loopback).
+//
+// FAIL-SOFT (AGENTS.md + spec §3 SC4/SC7). The `--run` wrapper NEVER throws out of
+// the timer: any failure (server unreachable, a non-zero update) is logged on one
+// line and the wrapper exits 0. Server unreachable → SKIP (conservative: never
+// auto-update a server in an unknown state). A successful update stamps
+// `last_run_at`; a FAILED update does NOT stamp it (so the next fire retries) and
+// relies on `server update`'s own health-check rollback to leave the prior
+// container running.
+//
+// Everything privileged routes through the injectable `docker.ts` runner (the
+// same seam boot.ts uses), so tests assert the exact systemctl/crontab/docker
+// argv without a real systemd, cron, or docker.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  AUTOUPDATE_CADENCES,
+  type AutoUpdateCadence,
+  DEFAULT_AUTOUPDATE_CADENCE,
+  isAutoUpdateCadence,
+} from "@librarian/core";
+import { run, which } from "./docker.js";
+import { redactSecrets } from "./redact.js";
+import { serverStatus } from "./status.js";
+import { CONTAINER_NAME } from "./up.js";
+import { runUpdate, UpdateError } from "./update.js";
+
+/** The oneshot service unit that runs the `--run` wrapper (single instance per host). */
+export const AUTOUPDATE_SERVICE_NAME = "the-librarian-autoupdate.service";
+
+/** The timer unit that fires the oneshot service ~hourly. */
+export const AUTOUPDATE_TIMER_NAME = "the-librarian-autoupdate.timer";
+
+/** The system-unit directory (a system timer fires without a login session). */
+const SYSTEMD_SYSTEM_DIR = "/etc/systemd/system";
+
+/** A stable marker that tags OUR crontab line, so we can find/replace/remove it idempotently. */
+export const CRON_MARKER = "# the-librarian-autoupdate";
+
+/** Fallback `librarian` path if `which librarian` can't be resolved (npm global bin). */
+const DEFAULT_LIBRARIAN_PATH = "/usr/local/bin/librarian";
+
+/** The internal tRPC listener inside the container (ADR 0008 P1 default). */
+const INTERNAL_TRPC_URL = "http://127.0.0.1:3840/trpc";
+
+/** The absolute path the oneshot service is installed at (system unit, via sudo). */
+export function servicePath(): string {
+  return path.join(SYSTEMD_SYSTEM_DIR, AUTOUPDATE_SERVICE_NAME);
+}
+
+/** The absolute path the timer is installed at (system unit, via sudo). */
+export function timerPath(): string {
+  return path.join(SYSTEMD_SYSTEM_DIR, AUTOUPDATE_TIMER_NAME);
+}
+
+/** A teaching error from autoupdate ops; the runtime renders `.message` as one stderr line. */
+export class AutoUpdateError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AutoUpdateError";
+  }
+}
+
+export interface AutoUpdateResult {
+  /** Human-readable report for stdout. */
+  output: string;
+}
+
+export interface AutoUpdateOptions {
+  /** Platform — gates the macOS deferral + systemd-vs-cron choice. Default `process.platform`. */
+  platform?: NodeJS.Platform | undefined;
+  /** Override home (tests). Threads into `server update`/`status`. */
+  home?: string | undefined;
+  /** Deploy dir override. Default: `~/.librarian/server`. Threads into update/status. */
+  dir?: string | undefined;
+}
+
+export interface EnableOptions extends AutoUpdateOptions {
+  /** Cadence to write into the running server. Default daily. Validated daily|weekly. */
+  cadence?: string | undefined;
+}
+
+export interface RunOptions extends AutoUpdateOptions {
+  /**
+   * Sink for the wrapper's one-line log entries (the timer's journal). Defaults
+   * to a `process.stderr` writer; tests inject a recorder. Every wrapper outcome
+   * (skip / update / failure) emits exactly one line here — and the wrapper never
+   * throws, so the timer's unit always exits 0.
+   */
+  log?: ((line: string) => void) | undefined;
+  /** Health-wait bound for the inner `server update` (small in tests). */
+  healthAttempts?: number | undefined;
+  /** Milliseconds between health polls for the inner update (0 in tests). */
+  healthIntervalMs?: number | undefined;
+  /** Injected current time for the due-check (tests). Default `new Date()`. */
+  now?: Date | undefined;
+}
+
+// --- pure unit generators (unit-tested directly) -------------------------
+
+/** Inputs to the pure service generator (only the librarian path — NEVER a secret). */
+export interface ServiceUnitInput {
+  /** Absolute path to the `librarian` binary the oneshot runs with `server autoupdate --run`. */
+  librarianPath: string;
+}
+
+/**
+ * Generate the oneshot service unit text. PURE + unit-tested. Contains NO secret —
+ * it runs `librarian server autoupdate --run`, which reads the settings from the
+ * running container itself (via `docker exec`), so nothing sensitive is written
+ * into this world-readable unit file. `Type=oneshot` because the wrapper runs to
+ * completion each fire (it is the timer's job to schedule, not the service's).
+ */
+export function generateServiceUnit(input: ServiceUnitInput): string {
+  const { librarianPath } = input;
+  return [
+    "[Unit]",
+    "Description=The Librarian — auto-update check (host-scheduled)",
+    "After=docker.service",
+    "Wants=network-online.target",
+    "",
+    "[Service]",
+    "Type=oneshot",
+    // The wrapper reads the auto-update settings from the running container and,
+    // if due, performs `server update`. It carries NO secret on this argv: the
+    // settings + the container's credentials live in the container, reached via
+    // `docker exec` at run time, not baked into this file.
+    `ExecStart=${librarianPath} server autoupdate --run`,
+    "",
+  ].join("\n");
+}
+
+/**
+ * Generate the timer unit text. PURE + unit-tested. Fires the oneshot service
+ * roughly hourly (`OnCalendar=hourly`, with `Persistent=true` so a missed fire
+ * while the host was off runs at next boot). The FREQUENT fire is deliberate: the
+ * cadence (daily/weekly) is a due-check IN the wrapper, NOT the timer period — so
+ * the dashboard can change cadence (a setting) with no host action (spec §4). A
+ * randomized delay spreads load and avoids every host updating on the exact hour.
+ */
+export function generateTimerUnit(): string {
+  return [
+    "[Unit]",
+    "Description=The Librarian — auto-update timer (fires the check hourly)",
+    "",
+    "[Timer]",
+    // Hourly poll; the cadence due-check inside the wrapper decides whether to act.
+    "OnCalendar=hourly",
+    // Run a missed fire (host was off) on next boot rather than skipping the window.
+    "Persistent=true",
+    // Spread load: fire up to 5 min after the hour rather than exactly on it.
+    "RandomizedDelaySec=300",
+    `Unit=${AUTOUPDATE_SERVICE_NAME}`,
+    "",
+    "[Install]",
+    "WantedBy=timers.target",
+    "",
+  ].join("\n");
+}
+
+/**
+ * The crontab line for the cron fallback (systemd absent). Fires the wrapper at
+ * minute 17 of every hour (off the top-of-hour to spread load), tagged with
+ * {@link CRON_MARKER} so it can be found/replaced/removed idempotently. NO secret
+ * — same reasoning as the systemd unit (the wrapper reads settings from the
+ * container at run time).
+ */
+export function cronLine(librarianPath: string): string {
+  return `17 * * * * ${librarianPath} server autoupdate --run ${CRON_MARKER}`;
+}
+
+// --- librarian-path resolution -------------------------------------------
+
+/**
+ * Resolve the absolute `librarian` path the scheduler invokes. Goes through the
+ * injectable runner (`which librarian`); falls back to the npm-global bin so a
+ * non-standard `which` output never breaks unit/cron generation. The path is
+ * non-secret, so a fallback is safe.
+ */
+async function resolveLibrarianPath(): Promise<string> {
+  const resolved = await which("librarian");
+  return resolved && resolved.trim().length > 0 ? resolved.trim() : DEFAULT_LIBRARIAN_PATH;
+}
+
+// --- platform helpers ----------------------------------------------------
+
+/** The one-line macOS-deferred notice (boot persistence + autoupdate are Linux-only for now). */
+export const MACOS_NOTICE =
+  "Host auto-update scheduling is Linux-only for now (systemd timer / cron). " +
+  "Skipping — on macOS, run `librarian server update` manually, or schedule it " +
+  "yourself (e.g. a launchd agent / cron) to run `librarian server autoupdate --run`.";
+
+/** True iff host scheduling is unsupported on this platform (macOS for now). */
+function isUnsupportedPlatform(platform: NodeJS.Platform): boolean {
+  return platform === "darwin";
+}
+
+/** True iff `systemctl` is on PATH (→ prefer the systemd timer over cron). */
+async function hasSystemd(): Promise<boolean> {
+  return (await which("systemctl")) !== null;
+}
+
+// --- the in-container settings bridge (docker exec node -e) ---------------
+
+/**
+ * A tiny Node script run INSIDE the container (`docker exec the-librarian node -e
+ * <script>`) that talks to the internal tRPC listener over loopback. `op` is
+ * `get` or `set`; for `set`, `input` is the JSON body. It prints the JSON result
+ * to stdout (for `get`) or "ok" (for `set`), and exits non-zero on any failure so
+ * the host wrapper can treat an unreachable/erroring server as a skip.
+ *
+ * Built as a single-line script with no string interpolation of untrusted data
+ * (the cadence is validated daily|weekly before it reaches here; enabled is a
+ * boolean), so there's no injection surface.
+ */
+function bridgeScript(
+  op: "get" | "set" | "stampRun",
+  input?: { enabled?: boolean; cadence?: AutoUpdateCadence },
+): string {
+  const base = `${INTERNAL_TRPC_URL}/autoupdate.${op}`;
+  if (op === "get") {
+    return (
+      `fetch(${JSON.stringify(base)})` +
+      `.then(r=>r.json())` +
+      `.then(j=>{if(j.error){process.exit(3)}process.stdout.write(JSON.stringify(j.result.data))})` +
+      `.catch(()=>process.exit(2))`
+    );
+  }
+  // POST mutations (`set` carries a JSON body; `stampRun` takes no input).
+  const bodyArg = op === "set" ? `,body:${JSON.stringify(JSON.stringify(input ?? {}))}` : "";
+  return (
+    `fetch(${JSON.stringify(base)},{method:"POST",headers:{"content-type":"application/json"}${bodyArg}})` +
+    `.then(r=>r.json())` +
+    `.then(j=>{if(j.error){process.exit(3)}process.stdout.write("ok")})` +
+    `.catch(()=>process.exit(2))`
+  );
+}
+
+/** The configured auto-update state read from the running server. */
+export interface RunningConfig {
+  enabled: boolean;
+  cadence: AutoUpdateCadence;
+  lastRunAt: string | null;
+}
+
+/**
+ * Read the auto-update config from the RUNNING server via `docker exec node -e`
+ * (the internal tRPC listener, loopback inside the container). Returns null when
+ * the container is down / the exec fails / the response is unusable — the caller
+ * treats null as "unreachable" and SKIPS (never auto-updates an unknown server).
+ * Never throws.
+ */
+export async function readRunningConfig(): Promise<RunningConfig | null> {
+  const result = await run("docker", ["exec", CONTAINER_NAME, "node", "-e", bridgeScript("get")]);
+  if (result.code !== 0) return null;
+  try {
+    const parsed = JSON.parse(result.stdout.trim()) as {
+      enabled?: unknown;
+      cadence?: unknown;
+      lastRunAt?: unknown;
+    };
+    const cadence =
+      typeof parsed.cadence === "string" && isAutoUpdateCadence(parsed.cadence)
+        ? parsed.cadence
+        : DEFAULT_AUTOUPDATE_CADENCE;
+    return {
+      enabled: parsed.enabled === true,
+      cadence,
+      lastRunAt: typeof parsed.lastRunAt === "string" ? parsed.lastRunAt : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write the auto-update config into the RUNNING server (so the dashboard reflects
+ * the CLI's enable/cadence) via `docker exec node -e` → internal tRPC `set`.
+ * Returns true on success, false when the container is down / the write failed.
+ * Never throws — a write failure during `enable` is surfaced as a non-fatal hint
+ * (the timer is still installed; the operator can toggle from the dashboard).
+ */
+export async function writeRunningConfig(input: {
+  enabled?: boolean;
+  cadence?: AutoUpdateCadence;
+}): Promise<boolean> {
+  const result = await run("docker", [
+    "exec",
+    CONTAINER_NAME,
+    "node",
+    "-e",
+    bridgeScript("set", input),
+  ]);
+  return result.code === 0;
+}
+
+/**
+ * Stamp `last_run_at` to NOW in the running server (the internal tRPC `stampRun`)
+ * after a SUCCESSFUL auto-update, so the next due-check advances by one cadence
+ * window. Returns true on success, false when the (freshly recreated) container
+ * isn't reachable yet / the call failed — a failed stamp is non-fatal (the update
+ * itself succeeded; the worst case is one extra due-check next fire). Never throws.
+ */
+export async function stampRunInServer(): Promise<boolean> {
+  const result = await run("docker", [
+    "exec",
+    CONTAINER_NAME,
+    "node",
+    "-e",
+    bridgeScript("stampRun"),
+  ]);
+  return result.code === 0;
+}
+
+// --- privileged systemd steps (every one through the injectable runner) ---
+
+/** Write a unit file to the system path via temp-file + `sudo cp` + `sudo chmod 644`. */
+async function installUnit(name: string, dest: string, unit: string): Promise<void> {
+  const dir = mkdtempSync(path.join(tmpdir(), "librarian-autoupdate-unit-"));
+  const tmp = path.join(dir, name);
+  writeFileSync(tmp, unit, "utf8");
+  try {
+    await sudoRun(["cp", tmp, dest]);
+    await sudoRun(["chmod", "644", dest]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/** Run `sudo systemctl <args…>`; a non-zero exit is a teaching error. */
+async function sudoSystemctl(args: string[]): Promise<void> {
+  await sudoRun(["systemctl", ...args]);
+}
+
+/** Run `sudo <args…>`; a non-zero exit is a teaching error. */
+async function sudoRun(args: string[]): Promise<void> {
+  const result = await run("sudo", args);
+  failIfNonZero("sudo", args, result);
+}
+
+/** True when a `systemctl disable` failure means the unit simply isn't loaded. */
+function isUnitAbsent(stderr: string): boolean {
+  return /does not exist|not loaded|no such file|not found/i.test(stderr);
+}
+
+function failIfNonZero(
+  cmd: string,
+  args: string[],
+  result: { code: number | null; stderr: string; stdout: string },
+): void {
+  if (result.code === 0) return;
+  const detail = result.stderr.trim() || result.stdout.trim();
+  throw new AutoUpdateError(
+    `\`${cmd} ${args[0]}\` failed (exit ${result.code ?? "signal"})` +
+      (detail ? `:\n${detail}` : ".") +
+      "\n\nResolve the error above (you may need sudo privileges), then re-run the command.",
+  );
+}
+
+// --- enable --------------------------------------------------------------
+
+/**
+ * Install the host scheduler + write the enabled/cadence settings into the running
+ * server. On Linux with systemd: write the oneshot service + the .timer to
+ * `/etc/systemd/system`, `daemon-reload`, then `enable --now` the TIMER (the
+ * service is oneshot — only the timer is enabled). Idempotent: re-running rewrites
+ * the SAME unit paths and re-enables, never duplicating. Where systemd is absent:
+ * install an hourly cron line (idempotent via {@link CRON_MARKER}). On macOS: print
+ * the deferred notice and skip cleanly.
+ *
+ * The settings write (enabled=true + cadence) is best-effort: a down server is a
+ * non-fatal hint (the timer is installed; the operator toggles from the dashboard
+ * once the server is up). The timer is what makes auto-update actually happen.
+ */
+export async function enableAutoUpdate(options: EnableOptions = {}): Promise<AutoUpdateResult> {
+  const platform = options.platform ?? process.platform;
+  if (isUnsupportedPlatform(platform)) {
+    return { output: MACOS_NOTICE };
+  }
+
+  // Validate the cadence BEFORE touching the host (a bad cadence is a teaching
+  // error, not a half-installed timer). Default daily.
+  const cadence = resolveCadence(options.cadence);
+
+  const librarianPath = await resolveLibrarianPath();
+  const lines: string[] = [];
+
+  if (await hasSystemd()) {
+    await installUnit(
+      AUTOUPDATE_SERVICE_NAME,
+      servicePath(),
+      generateServiceUnit({ librarianPath }),
+    );
+    await installUnit(AUTOUPDATE_TIMER_NAME, timerPath(), generateTimerUnit());
+    // daemon-reload BEFORE enable --now so systemd sees the (possibly rewritten)
+    // units. Only the TIMER is enabled (the service is oneshot, fired by the timer).
+    await sudoSystemctl(["daemon-reload"]);
+    await sudoSystemctl(["enable", "--now", AUTOUPDATE_TIMER_NAME]);
+    lines.push(
+      `Auto-update timer installed — ${AUTOUPDATE_TIMER_NAME} fires hourly and runs the due-check.`,
+      `  Units: ${servicePath()} + ${timerPath()} (no secret in either file).`,
+    );
+  } else {
+    await installCron(librarianPath);
+    lines.push(
+      "Auto-update cron entry installed — runs the due-check hourly (systemd not found).",
+      `  Tagged \`${CRON_MARKER}\` in your crontab (remove with \`librarian server autoupdate uninstall\`).`,
+    );
+  }
+
+  // Write the enabled + cadence settings into the running server so the dashboard
+  // reflects them. Best-effort — a down server is a hint, not a failure.
+  const wrote = await writeRunningConfig({ enabled: true, cadence });
+  if (wrote) {
+    lines.push(`Enabled auto-update in the running server (cadence: ${cadence}).`);
+  } else {
+    lines.push(
+      `Could not reach the running server to set enabled/cadence (is it up?). The timer is ` +
+        `installed; enable + set the ${cadence} cadence from the dashboard, or re-run this once ` +
+        `the server is up.`,
+    );
+  }
+
+  return { output: lines.join("\n") };
+}
+
+/** Validate + default the cadence; a bad value is a teaching error before any host change. */
+function resolveCadence(raw: string | undefined): AutoUpdateCadence {
+  if (raw === undefined || raw.trim().length === 0) return DEFAULT_AUTOUPDATE_CADENCE;
+  const c = raw.trim();
+  if (!isAutoUpdateCadence(c)) {
+    throw new AutoUpdateError(
+      `cadence must be one of ${AUTOUPDATE_CADENCES.join(" | ")}, got '${c}'.`,
+    );
+  }
+  return c;
+}
+
+// --- disable -------------------------------------------------------------
+
+/**
+ * Disable auto-update WITHOUT removing the timer (spec §3 SC2): flip
+ * `enabled=false` in the running server so the next `--run` no-ops, leaving the
+ * timer installed. Idempotent. A down server is a teaching error (we can't flip a
+ * setting on a server we can't reach) — the operator can also toggle it off from
+ * the dashboard.
+ */
+export async function disableAutoUpdate(
+  options: AutoUpdateOptions = {},
+): Promise<AutoUpdateResult> {
+  const platform = options.platform ?? process.platform;
+  if (isUnsupportedPlatform(platform)) {
+    return { output: MACOS_NOTICE };
+  }
+  const wrote = await writeRunningConfig({ enabled: false });
+  if (!wrote) {
+    throw new AutoUpdateError(
+      "Could not reach the running server to disable auto-update. Is it up " +
+        "(`librarian server status`)? You can also toggle auto-update off from the dashboard. " +
+        "The host timer is left installed; once disabled, the next fire will no-op.",
+    );
+  }
+  return {
+    output: [
+      "Auto-update disabled — the setting is off, so the next timer fire will no-op.",
+      "The host timer is left installed; remove it entirely with `librarian server autoupdate uninstall`.",
+    ].join("\n"),
+  };
+}
+
+// --- uninstall -----------------------------------------------------------
+
+/**
+ * Remove the host scheduler entirely (spec §3 SC2): on systemd, `disable --now`
+ * the timer (tolerating "not loaded"), remove BOTH unit files, then
+ * `daemon-reload`. Where systemd is absent, strip our tagged crontab line. Safe if
+ * already absent — idempotent, never a crash. Does NOT touch the server's
+ * `enabled` setting (the timer is gone, so it no longer matters; leaving the
+ * setting avoids a needless server round-trip on a down server). On macOS: notice.
+ */
+export async function uninstallAutoUpdate(
+  options: AutoUpdateOptions = {},
+): Promise<AutoUpdateResult> {
+  const platform = options.platform ?? process.platform;
+  if (isUnsupportedPlatform(platform)) {
+    return { output: MACOS_NOTICE };
+  }
+
+  if (await hasSystemd()) {
+    // disable --now the timer; tolerate "unit does not exist / not loaded".
+    const disable = await run("sudo", ["systemctl", "disable", "--now", AUTOUPDATE_TIMER_NAME]);
+    if (disable.code !== 0 && !isUnitAbsent(disable.stderr)) {
+      failIfNonZero("sudo", ["systemctl", "disable", "--now", AUTOUPDATE_TIMER_NAME], disable);
+    }
+    // Remove both unit files (idempotent with -f), then daemon-reload.
+    await sudoRun(["rm", "-f", timerPath()]);
+    await sudoRun(["rm", "-f", servicePath()]);
+    await sudoSystemctl(["daemon-reload"]);
+    return {
+      output: [
+        "Auto-update timer removed — both unit files deleted and systemd reloaded.",
+        "The server's auto-update setting is untouched; the container itself is unaffected.",
+      ].join("\n"),
+    };
+  }
+
+  await removeCron();
+  return {
+    output:
+      "Auto-update cron entry removed (systemd not found). The container itself is unaffected.",
+  };
+}
+
+// --- cron fallback (idempotent via CRON_MARKER) --------------------------
+
+/**
+ * Read the current user's crontab. `crontab -l` exits non-zero with "no crontab"
+ * when the user has none — that's an empty crontab, not an error. Returns the
+ * existing lines (never our marker line duplicated).
+ */
+async function readCrontab(): Promise<string[]> {
+  const result = await run("crontab", ["-l"]);
+  if (result.code !== 0) return []; // "no crontab for <user>" → empty
+  return result.stdout.split("\n").filter((l) => l.length > 0);
+}
+
+/** Install (or refresh) our hourly cron line idempotently — strip any prior marker line first. */
+async function installCron(librarianPath: string): Promise<void> {
+  if ((await which("crontab")) === null) {
+    throw new AutoUpdateError(
+      "Neither systemd nor crontab was found, so there's no host scheduler to install the " +
+        "auto-update timer into. Install systemd or cron, or schedule " +
+        "`librarian server autoupdate --run` to run hourly yourself.",
+    );
+  }
+  const kept = (await readCrontab()).filter((l) => !l.includes(CRON_MARKER));
+  const next = [...kept, cronLine(librarianPath)].join("\n") + "\n";
+  await writeCrontab(next);
+}
+
+/** Remove our tagged cron line (idempotent — a crontab without it is left as-is). */
+async function removeCron(): Promise<void> {
+  if ((await which("crontab")) === null) return; // nothing could have installed it
+  const lines = await readCrontab();
+  const kept = lines.filter((l) => !l.includes(CRON_MARKER));
+  if (kept.length === lines.length) return; // our line wasn't there — nothing to do
+  await writeCrontab(kept.length > 0 ? kept.join("\n") + "\n" : "");
+}
+
+/** Write a crontab via `crontab -` (reads the new content from a temp file on stdin-substitute). */
+async function writeCrontab(content: string): Promise<void> {
+  // `crontab <file>` installs the file as the new crontab. Write to a temp file
+  // and hand its path to crontab (the runner has no stdin pipe). NON-SECRET
+  // content (the marker line carries no token), so an ordinary temp file is fine.
+  const dir = mkdtempSync(path.join(tmpdir(), "librarian-autoupdate-cron-"));
+  const file = path.join(dir, "crontab");
+  writeFileSync(file, content, "utf8");
+  try {
+    const result = await run("crontab", [file]);
+    failIfNonZero("crontab", [file], result);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// --- status --------------------------------------------------------------
+
+/**
+ * Report the auto-update state (spec §3 SC3): is the timer/cron installed?, the
+ * server's enabled/cadence/last-run (read from the running server), and the
+ * up-to-date badge (reusing `server status`' deployed-vs-latest render). A down
+ * server degrades the server-side fields to "unknown (server unreachable)" but
+ * still reports the host-side timer state and exits 0.
+ */
+export async function autoUpdateStatus(options: AutoUpdateOptions = {}): Promise<AutoUpdateResult> {
+  const platform = options.platform ?? process.platform;
+  if (isUnsupportedPlatform(platform)) {
+    return { output: MACOS_NOTICE };
+  }
+
+  const timerInstalled = await isTimerInstalled();
+  const config = await readRunningConfig();
+
+  const lines = ["The Librarian auto-update:", ""];
+  lines.push(`  Timer installed: ${timerInstalled ? "yes" : "no"}`);
+  if (config) {
+    lines.push(
+      `  Enabled:         ${config.enabled ? "yes" : "no"}`,
+      `  Cadence:         ${config.cadence}`,
+      `  Last auto-update: ${config.lastRunAt ?? "never"}`,
+    );
+  } else {
+    lines.push(
+      "  Enabled:         unknown (server unreachable)",
+      "  Cadence:         unknown (server unreachable)",
+      "  Last auto-update: unknown (server unreachable)",
+    );
+  }
+
+  // Reuse `server status` for the deployed-vs-latest badge (offline-tolerant).
+  try {
+    const status = await serverStatus({
+      ...(options.home !== undefined ? { home: options.home } : {}),
+      ...(options.dir !== undefined ? { dir: options.dir } : {}),
+      ...(options.platform !== undefined ? { platform: options.platform } : {}),
+    });
+    lines.push("", status.output);
+  } catch {
+    // A preflight failure (no docker) shouldn't crash `autoupdate status` — the
+    // host-timer state above is still useful. Note it and exit 0.
+    lines.push("", "(could not read `server status` — is docker installed/running?)");
+  }
+
+  if (!timerInstalled) {
+    lines.push(
+      "",
+      "The host timer is not installed — auto-update won't run even if enabled. " +
+        "Install it with `librarian server autoupdate enable`.",
+    );
+  }
+
+  return { output: lines.join("\n") };
+}
+
+/**
+ * Is the host timer installed? On systemd, `systemctl list-unit-files <timer>`
+ * lists it when the unit file exists; on a cron-only host, our tagged line is
+ * present. Both probes go through the injectable runner. Returns false on any
+ * failure (a missing scheduler → not installed).
+ */
+async function isTimerInstalled(): Promise<boolean> {
+  if (await hasSystemd()) {
+    const result = await run("systemctl", ["list-unit-files", AUTOUPDATE_TIMER_NAME]);
+    // `list-unit-files <name>` prints the unit line when it exists; exit 0 + the
+    // name in stdout is the "installed" signal (exit code alone is unreliable
+    // across systemd versions for an absent unit).
+    return result.code === 0 && result.stdout.includes(AUTOUPDATE_TIMER_NAME);
+  }
+  if ((await which("crontab")) === null) return false;
+  return (await readCrontab()).some((l) => l.includes(CRON_MARKER));
+}
+
+// --- the `--run` wrapper (what the timer calls) --------------------------
+
+/**
+ * The wrapper the timer/cron fires (spec §3 SC4/SC7). Reads the auto-update
+ * settings from the RUNNING server, applies the due-check, and conditionally runs
+ * `server update`. FULLY FAIL-SOFT — it NEVER throws (the timer's unit always
+ * exits 0); every outcome is one log line:
+ *
+ *   - Server UNREACHABLE → SKIP (never auto-update a server in an unknown state).
+ *   - NOT (enabled && due) → SKIP (the no-op the disabled/not-due case wants).
+ *   - enabled && due → run `server update`. On SUCCESS, stamp `last_run_at`
+ *     (so the next due-check advances). On FAILURE (the update's own health-check
+ *     rollback left the prior container running), log + do NOT stamp (so the next
+ *     fire retries).
+ *
+ * The due-check is computed HOST-SIDE from the config the server returned (so the
+ * single source of truth — the core helper's logic — is mirrored here without a
+ * second round-trip): enabled AND the cadence has elapsed since `lastRunAt`
+ * (never-run → due).
+ */
+export async function runAutoUpdate(options: RunOptions = {}): Promise<AutoUpdateResult> {
+  const log = options.log ?? ((line: string): void => void process.stderr.write(`${line}\n`));
+  const now = options.now ?? new Date();
+
+  try {
+    const config = await readRunningConfig();
+    if (!config) {
+      const line =
+        "autoupdate: server unreachable — skipping (won't update a server in an unknown state).";
+      log(line);
+      return { output: line };
+    }
+
+    if (!config.enabled) {
+      const line = "autoupdate: disabled — skipping.";
+      log(line);
+      return { output: line };
+    }
+
+    if (!isDue(now, config)) {
+      const line = `autoupdate: not due yet (cadence: ${config.cadence}, last run: ${config.lastRunAt ?? "never"}) — skipping.`;
+      log(line);
+      return { output: line };
+    }
+
+    // Due + enabled: run the existing host-level update flow.
+    try {
+      const result = await runUpdate({
+        ...(options.home !== undefined ? { home: options.home } : {}),
+        ...(options.dir !== undefined ? { dir: options.dir } : {}),
+        ...(options.healthAttempts !== undefined ? { healthAttempts: options.healthAttempts } : {}),
+        ...(options.healthIntervalMs !== undefined
+          ? { healthIntervalMs: options.healthIntervalMs }
+          : {}),
+      });
+      // Stamp last_run_at ONLY on success. The server was recreated, so write the
+      // stamp through the (now-fresh) container's internal tRPC. A failed stamp is
+      // logged but not fatal — the update itself succeeded.
+      const stamped = await stampRunInServer();
+      const stampNote = stamped
+        ? ""
+        : " (note: could not stamp last_run_at — will re-check next fire)";
+      const line = `autoupdate: updated successfully${stampNote}.`;
+      log(line);
+      // The inner update's own output (carries an at-most-once fresh token note).
+      return { output: `${line}\n${redactSecrets(result.output)}` };
+    } catch (error) {
+      // The update failed — its own health-check rollback left the prior container
+      // running. Do NOT stamp last_run_at (so the next fire retries). Log + exit 0.
+      const detail =
+        error instanceof UpdateError || error instanceof Error
+          ? redactSecrets(error.message)
+          : String(error);
+      const line = `autoupdate: update failed — left the previous server running, did NOT stamp last_run_at (will retry next fire). ${firstLine(detail)}`;
+      log(line);
+      return { output: line };
+    }
+  } catch (error) {
+    // Belt-and-braces: ANY unexpected throw is swallowed so the timer never fails.
+    const detail = error instanceof Error ? redactSecrets(error.message) : String(error);
+    const line = `autoupdate: unexpected error — skipping (timer continues). ${firstLine(detail)}`;
+    log(line);
+    return { output: line };
+  }
+}
+
+/** The host-side due-check mirroring core's `isAutoUpdateDue` over the fetched config. */
+function isDue(now: Date, config: RunningConfig): boolean {
+  if (!config.enabled) return false;
+  if (config.lastRunAt === null) return true;
+  const last = new Date(config.lastRunAt);
+  if (Number.isNaN(last.getTime())) return true; // corrupt → treat as never-run
+  const days = config.cadence === "weekly" ? 7 : 1;
+  return now.getTime() - last.getTime() >= days * 24 * 60 * 60 * 1000;
+}
+
+/** The first line of a (possibly multi-line) message — keeps the journal entry one line. */
+function firstLine(text: string): string {
+  return text.split("\n")[0] ?? "";
+}

--- a/packages/installer-cli/src/server/autoupdate.ts
+++ b/packages/installer-cli/src/server/autoupdate.ts
@@ -50,18 +50,25 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import {
-  AUTOUPDATE_CADENCES,
-  type AutoUpdateCadence,
-  DEFAULT_AUTOUPDATE_CADENCE,
-  isAutoUpdateCadence,
-} from "@librarian/core";
 import { librarianDir } from "../paths.js";
 import { run, which } from "./docker.js";
 import { redactSecrets } from "./redact.js";
 import { serverStatus } from "./status.js";
 import { CONTAINER_NAME } from "./up.js";
 import { runUpdate, UpdateError } from "./update.js";
+
+// Cadence constants are defined LOCALLY here, NOT imported from `@librarian/core`, so
+// the public `@the-librarian/cli` stays lightweight — `core` pulls in node-llama-cpp /
+// the embeddings stack, which the CLI must never depend on. The server-side
+// `autoupdate.set` tRPC (which DOES use core) is the authoritative cadence validator;
+// this CLI-side copy is only a pre-touch UX check on `enable`. Keep in sync with
+// `packages/core/src/server-autoupdate-config.ts`.
+const AUTOUPDATE_CADENCES = ["daily", "weekly"] as const;
+type AutoUpdateCadence = (typeof AUTOUPDATE_CADENCES)[number];
+const DEFAULT_AUTOUPDATE_CADENCE: AutoUpdateCadence = "daily";
+function isAutoUpdateCadence(value: string): value is AutoUpdateCadence {
+  return (AUTOUPDATE_CADENCES as readonly string[]).includes(value);
+}
 
 /** The oneshot service unit that runs the `--run` wrapper (single instance per host). */
 export const AUTOUPDATE_SERVICE_NAME = "the-librarian-autoupdate.service";

--- a/packages/installer-cli/src/server/index.ts
+++ b/packages/installer-cli/src/server/index.ts
@@ -19,6 +19,7 @@ export const SERVER_SUBCOMMANDS = [
   "logs",
   "enable-boot",
   "disable-boot",
+  "autoupdate",
   "admin",
 ] as const;
 
@@ -40,6 +41,7 @@ export function serverUsage(): string {
     "  logs          Tail the container logs ([-f] [--service mcp|dashboard|all])",
     "  enable-boot   Start the server on boot (Linux systemd; macOS deferred)",
     "  disable-boot  Reverse enable-boot",
+    "  autoupdate    Schedule auto-updates on the host (enable|disable|uninstall|status)",
     "  admin         Run an admin command in the container (backup|restore|auth|rebuild)",
     "",
     "Run `librarian server <subcommand> --help` for flags (per subcommand).",

--- a/packages/installer-cli/tests/server-autoupdate.test.ts
+++ b/packages/installer-cli/tests/server-autoupdate.test.ts
@@ -1,0 +1,665 @@
+// T3 — `librarian server autoupdate <enable|disable|uninstall|status|--run>`: the
+// HOST half of server auto-update (spec 2026-06-16-server-autoupdate).
+//
+// Every test drives the seam: the pure unit/cron generators are asserted
+// directly, and enable/disable/uninstall/status/--run route systemctl / crontab /
+// docker through the injected `docker.ts` FakeRunner so the EXACT argv is asserted
+// — no real systemd, cron, docker, or container. The `docker exec the-librarian
+// node -e <script>` settings-bridge is intercepted by op (a get returns scripted
+// config JSON; a set/stampRun returns ok) without spawning a real container.
+//
+// HOST-DEPENDENCE NOTE (honesty, AGENTS.md): these tests prove the argv we WOULD
+// run + the fail-soft gating logic. Whether a real systemd timer fires hourly, a
+// real cron entry runs, and `docker exec node -e` reaches the in-container tRPC on
+// a live host is NOT provable here — it needs a real systemd/docker host. Those
+// integration properties are called out in the build report, not asserted here.
+
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { RunOptions, RunResult } from "../src/exec.js";
+import { resetRunner } from "../src/exec.js";
+import { runCli } from "../src/runtime.js";
+import {
+  AUTOUPDATE_SERVICE_NAME,
+  AUTOUPDATE_TIMER_NAME,
+  CRON_MARKER,
+  cronLine,
+  generateServiceUnit,
+  generateTimerUnit,
+  runAutoUpdate,
+} from "../src/server/autoupdate.js";
+import { writeDeployState } from "../src/server/deploy-state.js";
+import {
+  resetRunner as resetDockerRunner,
+  setRunner as setDockerRunner,
+} from "../src/server/docker.js";
+import {
+  resetSecretKeyMinter,
+  resetSleep,
+  resetTokenMinter,
+  setSecretKeyMinter,
+  setSleep,
+  setTokenMinter,
+} from "../src/server/up.js";
+import { resetLatestFetcher, setLatestFetcher } from "../src/status.js";
+import { FakeRunner, withTempHome } from "./helpers.js";
+
+const SERVICE_PATH = "/etc/systemd/system/the-librarian-autoupdate.service";
+const TIMER_PATH = "/etc/systemd/system/the-librarian-autoupdate.timer";
+
+afterEach(() => {
+  resetRunner();
+  resetDockerRunner();
+  resetLatestFetcher();
+  resetSleep();
+  resetTokenMinter();
+  resetSecretKeyMinter();
+});
+
+/** The config JSON a `get` bridge call returns, shaped like autoupdate.get's data. */
+interface RunningConfig {
+  enabled: boolean;
+  cadence: "daily" | "weekly";
+  lastRunAt: string | null;
+}
+
+/**
+ * Wrap a FakeRunner so any `docker exec the-librarian node -e <script>` call is
+ * answered by INSPECTING the embedded op (autoupdate.get / .set / .stampRun) and
+ * returning a scripted result — modelling the in-container tRPC bridge without a
+ * real container. Records every bridge op for assertions.
+ */
+function withBridge(
+  runner: FakeRunner,
+  opts: {
+    getConfig?: RunningConfig | null; // null → simulate an unreachable server (ALL exec ops fail)
+    bridgeOps: string[];
+    setScripts?: string[]; // each set/stampRun script captured, for body assertions
+  },
+): void {
+  const realRun = runner.run.bind(runner);
+  const down = opts.getConfig === null; // a down server fails every bridge op
+  runner.run = async (
+    cmd: string,
+    args: readonly string[],
+    runOpts?: RunOptions,
+  ): Promise<RunResult> => {
+    const isExecNode =
+      cmd === "docker" && args[0] === "exec" && args[2] === "node" && args[3] === "-e";
+    if (isExecNode) {
+      const script = String(args[4] ?? "");
+      const op = script.includes("autoupdate.get")
+        ? "get"
+        : script.includes("autoupdate.stampRun")
+          ? "stampRun"
+          : "set";
+      opts.bridgeOps.push(op);
+      if (op !== "get") opts.setScripts?.push(script);
+      runner.calls.push({ cmd, args: [...args], opts: runOpts });
+      // A down server makes every bridge op (get/set/stampRun) fail with exit 1.
+      if (down) return { stdout: "", stderr: "down", code: 1 };
+      if (op === "get") {
+        return { stdout: JSON.stringify(opts.getConfig ?? {}), stderr: "", code: 0 };
+      }
+      return { stdout: "ok", stderr: "", code: 0 };
+    }
+    return realRun(cmd, args, runOpts);
+  };
+}
+
+// ── pure generators ─────────────────────────────────────────────────────────
+
+describe("autoupdate unit/cron generators — NO secret, the right schedule", () => {
+  it("the oneshot service runs `server autoupdate --run` and carries no secret", () => {
+    const unit = generateServiceUnit({ librarianPath: "/usr/local/bin/librarian" });
+    expect(unit).toContain("Type=oneshot");
+    expect(unit).toContain("ExecStart=/usr/local/bin/librarian server autoupdate --run");
+    expect(unit).not.toMatch(/token|secret|key/i);
+    expect(unit).not.toContain("LIBRARIAN_AGENT_TOKEN");
+  });
+
+  it("the timer fires hourly (the cadence is a due-check, not the timer period)", () => {
+    const unit = generateTimerUnit();
+    expect(unit).toContain("[Timer]");
+    expect(unit).toContain("OnCalendar=hourly");
+    expect(unit).toContain("Persistent=true");
+    expect(unit).toContain(`Unit=${AUTOUPDATE_SERVICE_NAME}`);
+    expect(unit).toContain("WantedBy=timers.target");
+    expect(unit).not.toMatch(/token|secret|key/i);
+  });
+
+  it("the cron line runs the wrapper hourly, tagged with the marker, no secret", () => {
+    const line = cronLine("/usr/local/bin/librarian");
+    expect(line).toContain("/usr/local/bin/librarian server autoupdate --run");
+    expect(line).toContain(CRON_MARKER);
+    expect(line).toMatch(/^\d+ \* \* \* \*/); // a valid hourly cron schedule
+    expect(line).not.toMatch(/token|secret|key/i);
+  });
+});
+
+// ── enable (systemd) ─────────────────────────────────────────────────────────
+
+/** A FakeRunner with docker + systemctl + sudo present, all calls succeeding. */
+function systemdReady(): FakeRunner {
+  return new FakeRunner()
+    .withWhich("docker")
+    .withWhich("systemctl")
+    .withWhich("sudo")
+    .withWhich("librarian")
+    .withFallback({ code: 0 });
+}
+
+function ranSudo(runner: FakeRunner, ...match: string[]): boolean {
+  return runner.calls.some((c) => c.cmd === "sudo" && match.every((m) => c.args.includes(m)));
+}
+
+describe("autoupdate enable (systemd) — installs the timer + writes settings", () => {
+  it("writes both unit files, daemon-reloads, enables --now the TIMER, sets the running server", async () => {
+    const runner = systemdReady();
+    const bridgeOps: string[] = [];
+    // Capture the unit content handed to `sudo cp` (the FakeRunner doesn't move it).
+    const copied = new Map<string, string>();
+    const realRun = runner.run.bind(runner);
+    runner.run = async (cmd, args, opts) => {
+      if (cmd === "sudo" && args[0] === "cp") {
+        copied.set(args[2] as string, fs.readFileSync(args[1] as string, "utf8"));
+      }
+      return realRun(cmd, args, opts);
+    };
+    withBridge(runner, {
+      getConfig: { enabled: true, cadence: "daily", lastRunAt: null },
+      bridgeOps,
+    });
+    setDockerRunner(runner);
+
+    const r = await runCli(["server", "autoupdate", "enable"], { platform: "linux" });
+    expect(r.exitCode).toBe(0);
+
+    // Both unit files landed at the system paths with the right content (no secret).
+    expect(copied.get(SERVICE_PATH)).toContain("server autoupdate --run");
+    expect(copied.get(TIMER_PATH)).toContain("OnCalendar=hourly");
+    for (const content of copied.values()) expect(content).not.toMatch(/token|secret|key/i);
+
+    // daemon-reload, then enable --now the TIMER (not the oneshot service).
+    expect(ranSudo(runner, "systemctl", "daemon-reload")).toBe(true);
+    expect(ranSudo(runner, "systemctl", "enable", "--now", AUTOUPDATE_TIMER_NAME)).toBe(true);
+    // The oneshot service is NOT separately enabled (the timer fires it).
+    expect(ranSudo(runner, "systemctl", "enable", "--now", AUTOUPDATE_SERVICE_NAME)).toBe(false);
+
+    // It wrote enabled+cadence into the running server (the bridge `set`).
+    expect(bridgeOps).toContain("set");
+    expect(r.stdout).toMatch(/cadence: daily/i);
+  });
+
+  it("--cadence weekly is written through to the server set", async () => {
+    const runner = systemdReady();
+    const bridgeOps: string[] = [];
+    const setScripts: string[] = [];
+    withBridge(runner, {
+      getConfig: { enabled: true, cadence: "weekly", lastRunAt: null },
+      bridgeOps,
+      setScripts,
+    });
+    setDockerRunner(runner);
+
+    const r = await runCli(["server", "autoupdate", "enable", "--cadence", "weekly"], {
+      platform: "linux",
+    });
+    expect(r.exitCode).toBe(0);
+    // The set bridge script carried the weekly cadence in its POST body.
+    expect(setScripts.some((s) => s.includes("autoupdate.set") && s.includes("weekly"))).toBe(true);
+  });
+
+  it("rejects an invalid cadence BEFORE touching the host (no systemctl runs)", async () => {
+    const runner = systemdReady();
+    setDockerRunner(runner);
+
+    const r = await runCli(["server", "autoupdate", "enable", "--cadence", "hourly"], {
+      platform: "linux",
+    });
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toMatch(/cadence must be one of/i);
+    // Nothing was installed — a bad cadence is a pre-flight teaching error.
+    expect(runner.calls.some((c) => c.cmd === "sudo")).toBe(false);
+  });
+
+  it("is idempotent: enable twice targets the SAME unit paths, no duplicate units", async () => {
+    const runner = systemdReady();
+    const bridgeOps: string[] = [];
+    withBridge(runner, {
+      getConfig: { enabled: true, cadence: "daily", lastRunAt: null },
+      bridgeOps,
+    });
+    setDockerRunner(runner);
+
+    await runCli(["server", "autoupdate", "enable"], { platform: "linux" });
+    await runCli(["server", "autoupdate", "enable"], { platform: "linux" });
+
+    const enables = runner.calls.filter(
+      (c) => c.cmd === "sudo" && c.args[0] === "systemctl" && c.args.includes("enable"),
+    );
+    expect(enables.length).toBe(2);
+    for (const e of enables) expect(e.args).toContain(AUTOUPDATE_TIMER_NAME);
+    // No alternate unit name was ever created (no `-2.timer` etc).
+    expect(runner.calls.some((c) => c.args.some((a) => /-autoupdate-\d|\.timer\.\d/.test(a)))).toBe(
+      false,
+    );
+  });
+
+  it("a down server during enable is a non-fatal hint — the timer is still installed", async () => {
+    const runner = systemdReady();
+    const bridgeOps: string[] = [];
+    withBridge(runner, { getConfig: null, bridgeOps }); // server unreachable
+    setDockerRunner(runner);
+
+    const r = await runCli(["server", "autoupdate", "enable"], { platform: "linux" });
+    expect(r.exitCode).toBe(0); // not a failure — the timer is what matters
+    expect(ranSudo(runner, "systemctl", "enable", "--now", AUTOUPDATE_TIMER_NAME)).toBe(true);
+    expect(r.stdout).toMatch(/could not reach the running server/i);
+  });
+});
+
+// ── enable (cron fallback) ───────────────────────────────────────────────────
+
+describe("autoupdate enable (cron fallback) — systemd absent", () => {
+  it("installs our tagged hourly cron line via `crontab <file>`, idempotently", async () => {
+    const runner = new FakeRunner()
+      .withWhich("docker")
+      .withWhich("crontab")
+      .withWhich("librarian")
+      .withFallback({ code: 0 })
+      // An empty crontab to start (`crontab -l` exits non-zero with "no crontab").
+      .onRun("crontab", ["-l"], { code: 1, stderr: "no crontab for user\n" });
+    const bridgeOps: string[] = [];
+    let installedContent: string | undefined;
+    const realRun = runner.run.bind(runner);
+    runner.run = async (cmd, args, opts) => {
+      // `crontab <file>` (not `-l`) installs the new crontab — capture its content.
+      if (cmd === "crontab" && args[0] !== "-l") {
+        installedContent = fs.readFileSync(args[0] as string, "utf8");
+      }
+      return realRun(cmd, args, opts);
+    };
+    withBridge(runner, {
+      getConfig: { enabled: true, cadence: "daily", lastRunAt: null },
+      bridgeOps,
+    });
+    setDockerRunner(runner);
+
+    const r = await runCli(["server", "autoupdate", "enable"], { platform: "linux" });
+    expect(r.exitCode).toBe(0);
+    expect(installedContent).toContain("server autoupdate --run");
+    expect(installedContent).toContain(CRON_MARKER);
+    // No systemd path was taken.
+    expect(runner.calls.some((c) => c.cmd === "sudo")).toBe(false);
+    expect(r.stdout).toMatch(/cron/i);
+  });
+
+  it("does not duplicate our cron line when one already exists (idempotent)", async () => {
+    const existing = `0 1 * * * /usr/bin/other-job\n17 * * * * /usr/local/bin/librarian server autoupdate --run ${CRON_MARKER}`;
+    const runner = new FakeRunner()
+      .withWhich("docker")
+      .withWhich("crontab")
+      .withWhich("librarian")
+      .withFallback({ code: 0 })
+      .onRun("crontab", ["-l"], { code: 0, stdout: existing });
+    const bridgeOps: string[] = [];
+    let installedContent: string | undefined;
+    const realRun = runner.run.bind(runner);
+    runner.run = async (cmd, args, opts) => {
+      if (cmd === "crontab" && args[0] !== "-l") {
+        installedContent = fs.readFileSync(args[0] as string, "utf8");
+      }
+      return realRun(cmd, args, opts);
+    };
+    withBridge(runner, {
+      getConfig: { enabled: true, cadence: "daily", lastRunAt: null },
+      bridgeOps,
+    });
+    setDockerRunner(runner);
+
+    await runCli(["server", "autoupdate", "enable"], { platform: "linux" });
+    // Exactly ONE marker line, and the unrelated job is preserved.
+    const markerCount = (installedContent?.match(new RegExp(CRON_MARKER, "g")) ?? []).length;
+    expect(markerCount).toBe(1);
+    expect(installedContent).toContain("/usr/bin/other-job");
+  });
+});
+
+// ── disable / uninstall ──────────────────────────────────────────────────────
+
+describe("autoupdate disable — flips the setting off, leaves the timer", () => {
+  it("sets enabled=false in the running server and installs/removes NO unit", async () => {
+    const runner = systemdReady();
+    const bridgeOps: string[] = [];
+    withBridge(runner, {
+      getConfig: { enabled: false, cadence: "daily", lastRunAt: null },
+      bridgeOps,
+    });
+    setDockerRunner(runner);
+
+    const r = await runCli(["server", "autoupdate", "disable"], { platform: "linux" });
+    expect(r.exitCode).toBe(0);
+    expect(bridgeOps).toContain("set"); // wrote enabled=false
+    // No unit was touched (the timer stays installed; the next fire no-ops).
+    expect(runner.calls.some((c) => c.cmd === "sudo")).toBe(false);
+    expect(r.stdout).toMatch(/disabled/i);
+  });
+
+  it("a down server during disable is a teaching error (can't flip a setting we can't reach)", async () => {
+    const runner = systemdReady();
+    const bridgeOps: string[] = [];
+    withBridge(runner, { getConfig: null, bridgeOps });
+    setDockerRunner(runner);
+
+    const r = await runCli(["server", "autoupdate", "disable"], { platform: "linux" });
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toMatch(/could not reach the running server/i);
+  });
+});
+
+describe("autoupdate uninstall — removes the timer/cron entirely", () => {
+  it("disables --now the timer, removes both unit files, daemon-reloads", async () => {
+    const runner = systemdReady();
+    setDockerRunner(runner);
+
+    const r = await runCli(["server", "autoupdate", "uninstall"], { platform: "linux" });
+    expect(r.exitCode).toBe(0);
+    expect(ranSudo(runner, "systemctl", "disable", "--now", AUTOUPDATE_TIMER_NAME)).toBe(true);
+    expect(
+      runner.calls.some(
+        (c) => c.cmd === "sudo" && c.args[0] === "rm" && c.args.includes(TIMER_PATH),
+      ),
+    ).toBe(true);
+    expect(
+      runner.calls.some(
+        (c) => c.cmd === "sudo" && c.args[0] === "rm" && c.args.includes(SERVICE_PATH),
+      ),
+    ).toBe(true);
+    expect(ranSudo(runner, "systemctl", "daemon-reload")).toBe(true);
+  });
+
+  it("an already-absent timer is not a crash (tolerates 'not loaded')", async () => {
+    const runner = systemdReady().onRun(
+      "sudo",
+      ["systemctl", "disable", "--now", AUTOUPDATE_TIMER_NAME],
+      {
+        code: 1,
+        stderr: "Failed to disable unit: Unit the-librarian-autoupdate.timer does not exist.\n",
+      },
+    );
+    setDockerRunner(runner);
+
+    const r = await runCli(["server", "autoupdate", "uninstall"], { platform: "linux" });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).not.toMatch(/at \w+.*\(/); // no stack trace leaked
+  });
+
+  it("cron uninstall strips our tagged line and keeps the rest", async () => {
+    const existing = `0 1 * * * /usr/bin/keep-me\n17 * * * * /usr/local/bin/librarian server autoupdate --run ${CRON_MARKER}`;
+    const runner = new FakeRunner()
+      .withWhich("docker")
+      .withWhich("crontab")
+      .withFallback({ code: 0 })
+      .onRun("crontab", ["-l"], { code: 0, stdout: existing });
+    let installedContent: string | undefined;
+    const realRun = runner.run.bind(runner);
+    runner.run = async (cmd, args, opts) => {
+      if (cmd === "crontab" && args[0] !== "-l")
+        installedContent = fs.readFileSync(args[0] as string, "utf8");
+      return realRun(cmd, args, opts);
+    };
+    setDockerRunner(runner);
+
+    const r = await runCli(["server", "autoupdate", "uninstall"], { platform: "linux" });
+    expect(r.exitCode).toBe(0);
+    expect(installedContent).toContain("/usr/bin/keep-me");
+    expect(installedContent).not.toContain(CRON_MARKER);
+  });
+});
+
+// ── status ───────────────────────────────────────────────────────────────────
+
+describe("autoupdate status — timer-installed + server enabled/cadence/last-run + up-to-date", () => {
+  it("reports timer installed + the server's config + reuses `server status`", async () => {
+    const runner = systemdReady()
+      .withWhich("git") // `server status`' preflight needs git on PATH
+      // The timer-installed probe: list-unit-files lists it.
+      .onRun("systemctl", ["list-unit-files", AUTOUPDATE_TIMER_NAME], {
+        code: 0,
+        stdout: `UNIT FILE                          STATE\n${AUTOUPDATE_TIMER_NAME} enabled\n`,
+      })
+      .onRun("docker", ["info"], { code: 0 })
+      // `server status`' container probes.
+      .onRun("docker", ["inspect", "--format", "{{.State.Status}}", "the-librarian"], {
+        code: 0,
+        stdout: "running\n",
+      })
+      .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", "the-librarian"], {
+        code: 0,
+        stdout: "healthy\n",
+      });
+    const bridgeOps: string[] = [];
+    withBridge(runner, {
+      getConfig: { enabled: true, cadence: "weekly", lastRunAt: "2026-06-15T09:00:00.000Z" },
+      bridgeOps,
+    });
+    setDockerRunner(runner);
+    setLatestFetcher(async () => "1.5.0");
+
+    await withTempHome(async (home) => {
+      // Seed a deploy-state so `server status` reports a deployed version.
+      writeDeployState(path.join(home, ".librarian", "server"), {
+        containerName: "the-librarian",
+        host: "127.0.0.1",
+        dataVolume: "librarian_data",
+        ref: "v1.4.0",
+        imageTag: "the-librarian:v1.4.0",
+      });
+
+      const r = await runCli(["server", "autoupdate", "status"], { home, platform: "linux" });
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toMatch(/Timer installed: yes/i);
+      expect(r.stdout).toMatch(/Enabled:\s+yes/i);
+      expect(r.stdout).toMatch(/Cadence:\s+weekly/i);
+      expect(r.stdout).toMatch(/2026-06-15/);
+      // The reused `server status` block (deployed vs latest).
+      expect(r.stdout).toMatch(/Deployed:\s+v1\.4\.0/);
+      expect(r.stdout).toMatch(/update-available/);
+    });
+  });
+
+  it("a down server degrades the server fields to unknown but still reports the timer state", async () => {
+    const runner = systemdReady()
+      .onRun("systemctl", ["list-unit-files", AUTOUPDATE_TIMER_NAME], { code: 1, stdout: "" })
+      .onRun("docker", ["info"], { code: 0 });
+    const bridgeOps: string[] = [];
+    withBridge(runner, { getConfig: null, bridgeOps });
+    setDockerRunner(runner);
+    setLatestFetcher(async () => null);
+
+    const r = await runCli(["server", "autoupdate", "status"], { platform: "linux" });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toMatch(/Timer installed: no/i);
+    expect(r.stdout).toMatch(/Enabled:\s+unknown/i);
+    expect(r.stdout).toMatch(/not installed/i); // the install hint
+  });
+});
+
+// ── the `--run` wrapper (the timer's call) — gating + fail-soft ──────────────
+
+/** Seed a deploy-state so the inner `server update` has a deploy dir to read. */
+function seedDeployState(home: string, ref = "v1.4.2"): string {
+  const dir = path.join(home, ".librarian", "server");
+  fs.mkdirSync(path.join(dir, ".git"), { recursive: true });
+  writeDeployState(dir, {
+    containerName: "the-librarian",
+    host: "127.0.0.1",
+    dataVolume: "librarian_data",
+    ref,
+    imageTag: `the-librarian:${ref}`,
+  });
+  return dir;
+}
+
+describe("autoupdate --run — the gated, fail-soft wrapper the timer fires", () => {
+  it("server unreachable → SKIP (never update a server in an unknown state), exit 0", async () => {
+    const runner = new FakeRunner().withWhich("docker").withFallback({ code: 0 });
+    const bridgeOps: string[] = [];
+    withBridge(runner, { getConfig: null, bridgeOps });
+    setDockerRunner(runner);
+    const logs: string[] = [];
+
+    const result = await runAutoUpdate({ log: (l) => logs.push(l) });
+    expect(result.output).toMatch(/unreachable.*skipping/i);
+    // It NEVER reached the update flow (no build/run/rm).
+    expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "build")).toBe(false);
+    expect(logs).toHaveLength(1);
+  });
+
+  it("disabled → SKIP, exit 0, no update", async () => {
+    const runner = new FakeRunner().withWhich("docker").withFallback({ code: 0 });
+    const bridgeOps: string[] = [];
+    withBridge(runner, {
+      getConfig: { enabled: false, cadence: "daily", lastRunAt: null },
+      bridgeOps,
+    });
+    setDockerRunner(runner);
+    const logs: string[] = [];
+
+    const result = await runAutoUpdate({ log: (l) => logs.push(l) });
+    expect(result.output).toMatch(/disabled.*skipping/i);
+    expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "build")).toBe(false);
+  });
+
+  it("enabled but NOT due (cadence not elapsed) → SKIP, exit 0, no update", async () => {
+    const runner = new FakeRunner().withWhich("docker").withFallback({ code: 0 });
+    const bridgeOps: string[] = [];
+    // daily cadence, last run 1h ago → not due.
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    withBridge(runner, {
+      getConfig: { enabled: true, cadence: "daily", lastRunAt: oneHourAgo },
+      bridgeOps,
+    });
+    setDockerRunner(runner);
+    const logs: string[] = [];
+
+    const result = await runAutoUpdate({ log: (l) => logs.push(l), now: new Date() });
+    expect(result.output).toMatch(/not due yet.*skipping/i);
+    expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "build")).toBe(false);
+  });
+
+  it("enabled AND due → invokes `server update`, then stamps last_run_at on success", async () => {
+    await withTempHome(async (home) => {
+      const dir = seedDeployState(home);
+      const runner = new FakeRunner()
+        .withWhich("docker")
+        .withWhich("git")
+        .onRun("docker", ["info"], { code: 0 })
+        // The OLD container's env read-back (agent token + master key).
+        .onRun(
+          "docker",
+          ["inspect", "--format", "{{range .Config.Env}}{{println .}}{{end}}", "the-librarian"],
+          { code: 0, stdout: "LIBRARIAN_AGENT_TOKEN=tok\nLIBRARIAN_SECRET_KEY=key\n" },
+        )
+        .onRun("docker", ["inspect", "--format", "{{.State.Status}}", "the-librarian"], {
+          code: 0,
+          stdout: "running\n",
+        })
+        .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", "the-librarian"], {
+          code: 0,
+          stdout: "healthy\n",
+        })
+        .withFallback({ code: 0 });
+      const bridgeOps: string[] = [];
+      // Enabled + never run → due. (current ref differs from latest so update runs.)
+      withBridge(runner, {
+        getConfig: { enabled: true, cadence: "daily", lastRunAt: null },
+        bridgeOps,
+      });
+      setDockerRunner(runner);
+      setLatestFetcher(async () => "1.5.0"); // newer than v1.4.2 → an actual upgrade
+      setTokenMinter(() => "fresh-tok");
+      setSecretKeyMinter(() => "fresh-key");
+      setSleep(async () => undefined);
+      const logs: string[] = [];
+
+      const result = await runAutoUpdate({ home, log: (l) => logs.push(l), healthIntervalMs: 0 });
+
+      // The update flow ran (git fetch + docker build for the new tag).
+      expect(runner.ran("git", ["-C", dir, "fetch", "--tags", "origin"])).toBe(true);
+      expect(
+        runner.ran("docker", [
+          "build",
+          "-f",
+          "docker/all-in-one.Dockerfile",
+          "-t",
+          "the-librarian:v1.5.0",
+          ".",
+        ]),
+      ).toBe(true);
+      // And the stamp bridge fired AFTER the update succeeded.
+      expect(bridgeOps).toContain("stampRun");
+      expect(result.output).toMatch(/updated successfully/i);
+    });
+  });
+
+  it("update FAILS → logs, does NOT stamp last_run_at, exit 0 (retries next fire)", async () => {
+    await withTempHome(async (home) => {
+      seedDeployState(home);
+      const runner = new FakeRunner()
+        .withWhich("docker")
+        .withWhich("git")
+        .onRun("docker", ["info"], { code: 0 })
+        // The build fails → the update throws an UpdateError; the wrapper swallows it.
+        .onRun(
+          "docker",
+          ["build", "-f", "docker/all-in-one.Dockerfile", "-t", "the-librarian:v1.5.0", "."],
+          { code: 1, stderr: "build blew up" },
+        )
+        .withFallback({ code: 0 });
+      const bridgeOps: string[] = [];
+      withBridge(runner, {
+        getConfig: { enabled: true, cadence: "daily", lastRunAt: null },
+        bridgeOps,
+      });
+      setDockerRunner(runner);
+      setLatestFetcher(async () => "1.5.0");
+      setSleep(async () => undefined);
+      const logs: string[] = [];
+
+      const result = await runAutoUpdate({ home, log: (l) => logs.push(l), healthIntervalMs: 0 });
+      expect(result.output).toMatch(/update failed/i);
+      // CRUCIAL: a failed update must NOT stamp last_run_at (so it retries).
+      expect(bridgeOps).not.toContain("stampRun");
+      // It never threw — the wrapper resolved (the timer would exit 0).
+      expect(logs.some((l) => /update failed/i.test(l))).toBe(true);
+    });
+  });
+
+  it("--run is reachable through the CLI and exits 0 even when the server is down", async () => {
+    const runner = new FakeRunner().withWhich("docker").withFallback({ code: 0 });
+    const bridgeOps: string[] = [];
+    withBridge(runner, { getConfig: null, bridgeOps });
+    setDockerRunner(runner);
+
+    const r = await runCli(["server", "autoupdate", "--run"]);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toMatch(/unreachable.*skipping/i);
+  });
+
+  it("weekly cadence: 3 days since last run is NOT due (skips)", async () => {
+    const runner = new FakeRunner().withWhich("docker").withFallback({ code: 0 });
+    const bridgeOps: string[] = [];
+    const threeDaysAgo = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
+    withBridge(runner, {
+      getConfig: { enabled: true, cadence: "weekly", lastRunAt: threeDaysAgo },
+      bridgeOps,
+    });
+    setDockerRunner(runner);
+
+    const result = await runAutoUpdate({ now: new Date() });
+    expect(result.output).toMatch(/not due yet/i);
+  });
+});

--- a/packages/installer-cli/tests/server-autoupdate.test.ts
+++ b/packages/installer-cli/tests/server-autoupdate.test.ts
@@ -23,11 +23,13 @@ import { runCli } from "../src/runtime.js";
 import {
   AUTOUPDATE_SERVICE_NAME,
   AUTOUPDATE_TIMER_NAME,
+  autoUpdateLockPath,
   CRON_MARKER,
   cronLine,
   generateServiceUnit,
   generateTimerUnit,
   runAutoUpdate,
+  UNIT_DESCRIPTION_MARKER,
 } from "../src/server/autoupdate.js";
 import { writeDeployState } from "../src/server/deploy-state.js";
 import {
@@ -111,10 +113,15 @@ function withBridge(
 // ── pure generators ─────────────────────────────────────────────────────────
 
 describe("autoupdate unit/cron generators — NO secret, the right schedule", () => {
-  it("the oneshot service runs `server autoupdate --run` and carries no secret", () => {
+  it("the oneshot service runs `server autoupdate --run`, hardens with NoNewPrivileges, carries no secret", () => {
     const unit = generateServiceUnit({ librarianPath: "/usr/local/bin/librarian" });
     expect(unit).toContain("Type=oneshot");
     expect(unit).toContain("ExecStart=/usr/local/bin/librarian server autoupdate --run");
+    // FIX I1(b): defense-in-depth on the auto-executing root unit.
+    expect(unit).toContain("NoNewPrivileges=true");
+    // FIX I2: the unit carries our marker (Description=), which uninstall keys on
+    // to confirm a file is ours before deleting it.
+    expect(unit).toContain(UNIT_DESCRIPTION_MARKER);
     expect(unit).not.toMatch(/token|secret|key/i);
     expect(unit).not.toContain("LIBRARIAN_AGENT_TOKEN");
   });
@@ -221,6 +228,21 @@ describe("autoupdate enable (systemd) — installs the timer + writes settings",
     expect(r.exitCode).toBe(1);
     expect(r.stderr).toMatch(/cadence must be one of/i);
     // Nothing was installed — a bad cadence is a pre-flight teaching error.
+    expect(runner.calls.some((c) => c.cmd === "sudo")).toBe(false);
+  });
+
+  it("rejects a librarian path containing a space BEFORE touching the host (FIX I1)", async () => {
+    // `which librarian` resolves under an npm prefix in a home dir WITH A SPACE —
+    // an unquoted ExecStart / cron line would silently break. enable must reject it.
+    const runner = systemdReady();
+    runner.which = async (cmd: string) =>
+      cmd === "librarian" ? "/home/jane doe/.npm/bin/librarian" : `/usr/bin/${cmd}`;
+    setDockerRunner(runner);
+
+    const r = await runCli(["server", "autoupdate", "enable"], { platform: "linux" });
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toMatch(/not safe to schedule|whitespace|metacharacter/i);
+    // Nothing was installed — the unsafe path is a pre-flight teaching error.
     expect(runner.calls.some((c) => c.cmd === "sudo")).toBe(false);
   });
 
@@ -359,14 +381,30 @@ describe("autoupdate disable — flips the setting off, leaves the timer", () =>
   });
 });
 
+/** A systemdReady runner whose `sudo cat <unit>` returns OUR generated unit text. */
+function systemdReadyWithOurUnits(): FakeRunner {
+  return systemdReady()
+    .onRun("sudo", ["cat", TIMER_PATH], { code: 0, stdout: generateTimerUnit() })
+    .onRun("sudo", ["cat", SERVICE_PATH], {
+      code: 0,
+      stdout: generateServiceUnit({ librarianPath: "/usr/local/bin/librarian" }),
+    });
+}
+
 describe("autoupdate uninstall — removes the timer/cron entirely", () => {
-  it("disables --now the timer, removes both unit files, daemon-reloads", async () => {
-    const runner = systemdReady();
+  it("disables --now the timer, removes both unit files (after verifying ours), daemon-reloads", async () => {
+    const runner = systemdReadyWithOurUnits();
     setDockerRunner(runner);
 
     const r = await runCli(["server", "autoupdate", "uninstall"], { platform: "linux" });
     expect(r.exitCode).toBe(0);
     expect(ranSudo(runner, "systemctl", "disable", "--now", AUTOUPDATE_TIMER_NAME)).toBe(true);
+    // It read each unit (to confirm ownership) BEFORE removing it.
+    expect(
+      runner.calls.some(
+        (c) => c.cmd === "sudo" && c.args[0] === "cat" && c.args.includes(TIMER_PATH),
+      ),
+    ).toBe(true);
     expect(
       runner.calls.some(
         (c) => c.cmd === "sudo" && c.args[0] === "rm" && c.args.includes(TIMER_PATH),
@@ -380,20 +418,52 @@ describe("autoupdate uninstall — removes the timer/cron entirely", () => {
     expect(ranSudo(runner, "systemctl", "daemon-reload")).toBe(true);
   });
 
-  it("an already-absent timer is not a crash (tolerates 'not loaded')", async () => {
-    const runner = systemdReady().onRun(
-      "sudo",
-      ["systemctl", "disable", "--now", AUTOUPDATE_TIMER_NAME],
-      {
+  it("an already-absent timer is not a crash (tolerates 'not loaded' + a missing unit file)", async () => {
+    const runner = systemdReady()
+      .onRun("sudo", ["systemctl", "disable", "--now", AUTOUPDATE_TIMER_NAME], {
         code: 1,
         stderr: "Failed to disable unit: Unit the-librarian-autoupdate.timer does not exist.\n",
-      },
-    );
+      })
+      // `sudo cat <unit>` of an absent file → non-zero → a clean no-op (nothing removed).
+      .onRun("sudo", ["cat", TIMER_PATH], { code: 1, stderr: "No such file or directory\n" })
+      .onRun("sudo", ["cat", SERVICE_PATH], { code: 1, stderr: "No such file or directory\n" });
     setDockerRunner(runner);
 
     const r = await runCli(["server", "autoupdate", "uninstall"], { platform: "linux" });
     expect(r.exitCode).toBe(0);
     expect(r.stdout).not.toMatch(/at \w+.*\(/); // no stack trace leaked
+    // Nothing was removed (no unit of ours present) and it never `rm`'d blindly.
+    expect(runner.calls.some((c) => c.cmd === "sudo" && c.args[0] === "rm")).toBe(false);
+  });
+
+  it("leaves a same-named unit that is NOT ours untouched, with a warning (FIX I2)", async () => {
+    // A human authored `the-librarian-autoupdate.timer` for something else — it
+    // carries NO Librarian marker, so uninstall must NOT delete it.
+    const foreignTimer = "[Unit]\nDescription=Someone else's timer\n\n[Timer]\nOnCalendar=daily\n";
+    const runner = systemdReady()
+      .onRun("sudo", ["cat", TIMER_PATH], { code: 0, stdout: foreignTimer })
+      // The service file is genuinely ours (proves we still remove the real one).
+      .onRun("sudo", ["cat", SERVICE_PATH], {
+        code: 0,
+        stdout: generateServiceUnit({ librarianPath: "/usr/local/bin/librarian" }),
+      });
+    setDockerRunner(runner);
+
+    const r = await runCli(["server", "autoupdate", "uninstall"], { platform: "linux" });
+    expect(r.exitCode).toBe(0);
+    // The foreign timer was NOT removed; the warning was surfaced.
+    expect(
+      runner.calls.some(
+        (c) => c.cmd === "sudo" && c.args[0] === "rm" && c.args.includes(TIMER_PATH),
+      ),
+    ).toBe(false);
+    expect(r.stdout).toMatch(/not the Librarian|left it untouched/i);
+    // Our genuine service unit WAS removed (verify-before-remove, not remove-nothing).
+    expect(
+      runner.calls.some(
+        (c) => c.cmd === "sudo" && c.args[0] === "rm" && c.args.includes(SERVICE_PATH),
+      ),
+    ).toBe(true);
   });
 
   it("cron uninstall strips our tagged line and keeps the rest", async () => {
@@ -635,6 +705,91 @@ describe("autoupdate --run — the gated, fail-soft wrapper the timer fires", ()
       expect(bridgeOps).not.toContain("stampRun");
       // It never threw — the wrapper resolved (the timer would exit 0).
       expect(logs.some((l) => /update failed/i.test(l))).toBe(true);
+    });
+  });
+
+  it("a second --run while the update lock is held SKIPS without updating or stamping (FIX C1)", async () => {
+    await withTempHome(async (home) => {
+      seedDeployState(home);
+      // Simulate a concurrent update already running: hold the lock by creating
+      // the lockfile with a FRESH timestamp (so it isn't reclaimed as stale).
+      const lockPath = autoUpdateLockPath({ home });
+      fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+      fs.writeFileSync(lockPath, `99999 ${Date.now()}\n`, { flag: "wx" });
+
+      const runner = new FakeRunner()
+        .withWhich("docker")
+        .withWhich("git")
+        .onRun("docker", ["info"], { code: 0 })
+        .withFallback({ code: 0 });
+      const bridgeOps: string[] = [];
+      // Enabled + never run → DUE: the only thing stopping the update is the lock.
+      withBridge(runner, {
+        getConfig: { enabled: true, cadence: "daily", lastRunAt: null },
+        bridgeOps,
+      });
+      setDockerRunner(runner);
+      setLatestFetcher(async () => "1.5.0");
+      const logs: string[] = [];
+
+      const result = await runAutoUpdate({ home, log: (l) => logs.push(l), healthIntervalMs: 0 });
+
+      // It skipped on the lock — no build/run/rm, and NO stamp (the holder stamps).
+      expect(result.output).toMatch(/another update in progress.*skipping/i);
+      expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "build")).toBe(false);
+      expect(bridgeOps).not.toContain("stampRun");
+      expect(logs).toHaveLength(1);
+      // The held lockfile is left intact (the skipping run must not release it).
+      expect(fs.existsSync(lockPath)).toBe(true);
+    });
+  });
+
+  it("a stale lock (older than the reclaim window) is reclaimed so the update proceeds (FIX C1)", async () => {
+    await withTempHome(async (home) => {
+      const dir = seedDeployState(home);
+      // A crashed holder left a lockfile ~2h old → stale → reclaimed, update runs.
+      const lockPath = autoUpdateLockPath({ home });
+      fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+      const twoHoursAgo = Date.now() - 2 * 60 * 60 * 1000;
+      fs.writeFileSync(lockPath, `4242 ${twoHoursAgo}\n`, { flag: "wx" });
+
+      const runner = new FakeRunner()
+        .withWhich("docker")
+        .withWhich("git")
+        .onRun("docker", ["info"], { code: 0 })
+        .onRun(
+          "docker",
+          ["inspect", "--format", "{{range .Config.Env}}{{println .}}{{end}}", "the-librarian"],
+          { code: 0, stdout: "LIBRARIAN_AGENT_TOKEN=tok\nLIBRARIAN_SECRET_KEY=key\n" },
+        )
+        .onRun("docker", ["inspect", "--format", "{{.State.Status}}", "the-librarian"], {
+          code: 0,
+          stdout: "running\n",
+        })
+        .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", "the-librarian"], {
+          code: 0,
+          stdout: "healthy\n",
+        })
+        .withFallback({ code: 0 });
+      const bridgeOps: string[] = [];
+      withBridge(runner, {
+        getConfig: { enabled: true, cadence: "daily", lastRunAt: null },
+        bridgeOps,
+      });
+      setDockerRunner(runner);
+      setLatestFetcher(async () => "1.5.0");
+      setTokenMinter(() => "fresh-tok");
+      setSecretKeyMinter(() => "fresh-key");
+      setSleep(async () => undefined);
+
+      const result = await runAutoUpdate({ home, log: () => {}, healthIntervalMs: 0 });
+
+      // The stale lock did NOT block the update.
+      expect(runner.ran("git", ["-C", dir, "fetch", "--tags", "origin"])).toBe(true);
+      expect(result.output).toMatch(/updated successfully/i);
+      expect(bridgeOps).toContain("stampRun");
+      // The lock was released after the update (so the next fire isn't blocked).
+      expect(fs.existsSync(lockPath)).toBe(false);
     });
   });
 

--- a/packages/mcp-server/src/trpc/autoupdate.ts
+++ b/packages/mcp-server/src/trpc/autoupdate.ts
@@ -21,6 +21,7 @@ import {
   readLastAutoUpdateAt,
   setAutoUpdateCadence,
   setAutoUpdateEnabled,
+  writeLastAutoUpdateAt,
 } from "@librarian/core";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
@@ -81,4 +82,14 @@ export const autoupdateRouter = router({
       if (input.enabled !== undefined) setAutoUpdateEnabled(ctx.store, input.enabled);
       return gatherAutoUpdateConfig(ctx.store);
     }),
+
+  // Stamp `last_run_at` to NOW. Called by the host `--run` wrapper ONLY after a
+  // SUCCESSFUL `server update`, so the next due-check advances by one cadence
+  // window. Kept distinct from `set` (which the dashboard owns) so a dashboard
+  // toggle never accidentally moves the last-run clock. Admin-gated / internal
+  // listener only, like every procedure here. Returns the fresh readable config.
+  stampRun: adminProcedure.mutation(({ ctx }) => {
+    writeLastAutoUpdateAt(ctx.store, new Date());
+    return gatherAutoUpdateConfig(ctx.store);
+  }),
 });

--- a/packages/mcp-server/src/trpc/autoupdate.ts
+++ b/packages/mcp-server/src/trpc/autoupdate.ts
@@ -1,0 +1,84 @@
+// Server auto-update admin tRPC procedures (spec 2026-06-16-server-autoupdate T2).
+//
+// The dashboard (and the CLI `server autoupdate` command, and the host wrapper's
+// `--run`) read/write the auto-update settings through this router. It decouples
+// *what's configured* (these settings, editable anywhere) from *who acts* (the
+// host timer that performs the update) — the dashboard never holds host/docker
+// privileges, it only writes a setting (spec §2).
+//
+// `get` returns the configured state (enabled, cadence, lastRunAt) plus the
+// running build's version + the latest published release (reusing health's
+// `getLatestRelease`) so the dashboard can render an "update available?" line
+// next to the toggle. `set` patches the enablement flag and/or the cadence,
+// validating the cadence ∈ {daily, weekly} via the core helper (the single source
+// of truth). All admin-gated — served only on the trusted internal listener
+// (ADR 0008 P3); there is deliberately no consumer-agent surface for it.
+
+import type { LibrarianStore } from "@librarian/core";
+import {
+  isAutoUpdateEnabled,
+  readAutoUpdateCadence,
+  readLastAutoUpdateAt,
+  setAutoUpdateCadence,
+  setAutoUpdateEnabled,
+} from "@librarian/core";
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+import { getLatestRelease } from "../github-release.js";
+import { PACKAGE_VERSION } from "../version.js";
+import { adminProcedure, router } from "./trpc.js";
+
+/**
+ * The auto-update configured state in one read: the enablement flag, the cadence
+ * (default daily), and the last-run timestamp (ISO string, or null when never
+ * run). All plain settings — no master key needed. The dashboard pairs this with
+ * `version`/`latest` (added in the `get` query) for the status line.
+ */
+function gatherAutoUpdateConfig(store: LibrarianStore) {
+  const lastRunAt = readLastAutoUpdateAt(store);
+  return {
+    enabled: isAutoUpdateEnabled(store),
+    cadence: readAutoUpdateCadence(store),
+    lastRunAt: lastRunAt ? lastRunAt.toISOString() : null,
+  };
+}
+
+export const autoupdateRouter = router({
+  // The configured auto-update state + the version/latest the dashboard renders an
+  // "update available?" line from (reusing health's cached GitHub-release lookup).
+  // The latest-release lookup degrades gracefully (never throws) so a get always
+  // resolves even offline.
+  get: adminProcedure.query(async ({ ctx }) => ({
+    ...gatherAutoUpdateConfig(ctx.store),
+    version: PACKAGE_VERSION,
+    latest: await getLatestRelease(),
+  })),
+
+  // Patch the auto-update config: the enablement toggle and/or the cadence. Both
+  // fields are optional so the dashboard can patch one without the other. The
+  // cadence validation defers to the core `setAutoUpdateCadence` (the single
+  // source of truth: daily|weekly); its teaching error is surfaced as a BAD_REQUEST
+  // tRPC error rather than a 500. Returns the fresh readable config.
+  set: adminProcedure
+    .input(
+      z.strictObject({
+        enabled: z.boolean().optional(),
+        cadence: z.string().optional(),
+      }),
+    )
+    .mutation(({ ctx, input }) => {
+      if (input.cadence !== undefined) {
+        try {
+          setAutoUpdateCadence(ctx.store, input.cadence);
+        } catch (error) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: error instanceof Error ? error.message : String(error),
+            cause: error,
+          });
+        }
+      }
+      if (input.enabled !== undefined) setAutoUpdateEnabled(ctx.store, input.enabled);
+      return gatherAutoUpdateConfig(ctx.store);
+    }),
+});

--- a/packages/mcp-server/src/trpc/router.ts
+++ b/packages/mcp-server/src/trpc/router.ts
@@ -13,6 +13,7 @@
 import { activityRouter } from "./activity.js";
 import { addendumRouter } from "./addendum.js";
 import { authRouter } from "./auth.js";
+import { autoupdateRouter } from "./autoupdate.js";
 import { awarenessRouter } from "./awareness.js";
 import { backupRouter } from "./backup.js";
 import { groomingRouter } from "./grooming.js";
@@ -29,6 +30,7 @@ export const appRouter = router({
   activity: activityRouter,
   addendum: addendumRouter,
   auth: authRouter,
+  autoupdate: autoupdateRouter,
   awareness: awarenessRouter,
   backup: backupRouter,
   grooming: groomingRouter,

--- a/packages/mcp-server/tests/trpc/autoupdate.test.ts
+++ b/packages/mcp-server/tests/trpc/autoupdate.test.ts
@@ -1,0 +1,185 @@
+// Server auto-update admin tRPC procedure tests (spec 2026-06-16-server-autoupdate
+// T2). The dashboard/CLI/host-wrapper read+write the auto-update settings through
+// this router: admin gating on every procedure (served only on the internal
+// listener, ADR 0008 P3), the `get` aggregation (enabled, cadence, lastRunAt +
+// version/latest reused from health's release lookup), and the `set` toggle +
+// cadence round-trip with the core teaching error on a bad cadence.
+
+import { createLibrarianStore } from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanupTempDir, makeTempDir, startHttpServer } from "../../../../test/helpers.js";
+
+interface TrpcOk<T> {
+  result: { data: T };
+}
+interface TrpcErr {
+  error: unknown;
+}
+interface ServerHandle {
+  trpcUrl: string;
+  token: string;
+  stop: () => Promise<void>;
+}
+
+async function trpcGet<T>(server: ServerHandle, path: string, input?: unknown): Promise<T> {
+  const url = new URL(`${server.trpcUrl}/trpc/${path}`);
+  if (input !== undefined) url.searchParams.set("input", JSON.stringify(input));
+  const response = await fetch(url, { headers: { authorization: `Bearer ${server.token}` } });
+  const json = (await response.json()) as TrpcOk<T> | TrpcErr;
+  if (response.status >= 400 || "error" in json) {
+    throw new Error(`trpc GET ${path} failed: ${JSON.stringify(json)}`);
+  }
+  return (json as TrpcOk<T>).result.data;
+}
+
+async function trpcPost<T>(server: ServerHandle, path: string, input?: unknown): Promise<T> {
+  const response = await fetch(`${server.trpcUrl}/trpc/${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${server.token}` },
+    body: input === undefined ? undefined : JSON.stringify(input),
+  });
+  const json = (await response.json()) as TrpcOk<T> | TrpcErr;
+  if (response.status >= 400 || "error" in json) {
+    throw new Error(`trpc POST ${path} failed: ${JSON.stringify(json)}`);
+  }
+  return (json as TrpcOk<T>).result.data;
+}
+
+interface AutoUpdateConfig {
+  enabled: boolean;
+  cadence: "daily" | "weekly";
+  lastRunAt: string | null;
+}
+interface AutoUpdateGet extends AutoUpdateConfig {
+  version: string;
+  latest: { kind: string };
+}
+
+describe("tRPC autoupdate surface", () => {
+  let dataDir = "";
+  beforeEach(() => {
+    // Disable the GitHub version check so `get` never hits the network in CI.
+    process.env.LIBRARIAN_DISABLE_VERSION_CHECK = "true";
+    dataDir = makeTempDir();
+  });
+  afterEach(() => {
+    delete process.env.LIBRARIAN_DISABLE_VERSION_CHECK;
+    cleanupTempDir(dataDir);
+  });
+
+  it("every procedure is unreachable from the public (network) listener (ADR 0008 P3)", async () => {
+    const server = await startHttpServer({ dataDir });
+    try {
+      // Post-P3 the admin gate is the network boundary: the autoupdate procedures
+      // are served only on the internal listener and 404 on the public port — even
+      // for a network agent's bearer.
+      const getResp = await fetch(`${server.url}/trpc/autoupdate.get`, {
+        headers: { authorization: "Bearer agent-token" },
+      });
+      expect(getResp.status).toBe(404);
+
+      const setResp = await fetch(`${server.url}/trpc/autoupdate.set`, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: "Bearer agent-token" },
+        body: JSON.stringify({ enabled: true }),
+      });
+      expect(setResp.status).toBe(404);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("get returns the default config (disabled, daily, never run) plus version/latest", async () => {
+    const server = await startHttpServer({ dataDir });
+    try {
+      const config = await trpcGet<AutoUpdateGet>(server, "autoupdate.get");
+      expect(config.enabled).toBe(false);
+      expect(config.cadence).toBe("daily");
+      expect(config.lastRunAt).toBeNull();
+      // version is the running build; latest comes from health's release lookup
+      // (disabled in this test → `{ kind: "disabled" }`), proving the reuse wires up.
+      expect(typeof config.version).toBe("string");
+      expect(config.latest.kind).toBe("disabled");
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("set round-trips the enablement toggle (default off, authoritative)", async () => {
+    const server = await startHttpServer({ dataDir });
+    try {
+      const enabled = await trpcPost<AutoUpdateConfig>(server, "autoupdate.set", { enabled: true });
+      expect(enabled.enabled).toBe(true);
+      expect(await trpcGet<AutoUpdateGet>(server, "autoupdate.get").then((c) => c.enabled)).toBe(
+        true,
+      );
+
+      const disabled = await trpcPost<AutoUpdateConfig>(server, "autoupdate.set", {
+        enabled: false,
+      });
+      expect(disabled.enabled).toBe(false);
+      expect(await trpcGet<AutoUpdateGet>(server, "autoupdate.get").then((c) => c.enabled)).toBe(
+        false,
+      );
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("set persists the cadence (daily|weekly) and reads it back", async () => {
+    const server = await startHttpServer({ dataDir });
+    try {
+      const updated = await trpcPost<AutoUpdateConfig>(server, "autoupdate.set", {
+        cadence: "weekly",
+      });
+      expect(updated.cadence).toBe("weekly");
+      // Read-back through a fresh query proves it persisted, not just echoed.
+      const reread = await trpcGet<AutoUpdateGet>(server, "autoupdate.get");
+      expect(reread.cadence).toBe("weekly");
+      // The cadence is independent of the enablement toggle (a partial patch).
+      expect(reread.enabled).toBe(false);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("set rejects an invalid cadence with the core teaching error and persists nothing", async () => {
+    const server = await startHttpServer({ dataDir });
+    try {
+      const response = await fetch(`${server.trpcUrl}/trpc/autoupdate.set`, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: `Bearer ${server.token}` },
+        body: JSON.stringify({ enabled: true, cadence: "hourly" }),
+      });
+      expect(response.status).toBeGreaterThanOrEqual(400);
+      const json = (await response.json()) as { error?: { message?: string } };
+      expect(json.error?.message).toMatch(/cadence must be one of/i);
+
+      // The rejected patch persisted NOTHING — cadence is still default, and the
+      // `enabled: true` in the same call did not slip through (cadence validated first).
+      const config = await trpcGet<AutoUpdateGet>(server, "autoupdate.get");
+      expect(config.cadence).toBe("daily");
+      expect(config.enabled).toBe(false);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("get reflects a last-run timestamp stamped out of band (the host wrapper's stamp)", async () => {
+    // The host wrapper stamps `server.autoupdate.last_run_at` after a successful
+    // update; the dashboard reads it back through `get`. Seed it via a store on the
+    // same dataDir before boot to prove the read path surfaces the ISO string.
+    const seed = createLibrarianStore({ dataDir });
+    const at = new Date("2026-06-15T09:30:00.000Z");
+    seed.setSetting("server.autoupdate.last_run_at", at.toISOString());
+    seed.close();
+
+    const server = await startHttpServer({ dataDir });
+    try {
+      const config = await trpcGet<AutoUpdateGet>(server, "autoupdate.get");
+      expect(config.lastRunAt).toBe(at.toISOString());
+    } finally {
+      await server.stop();
+    }
+  });
+});

--- a/packages/mcp-server/tests/trpc/autoupdate.test.ts
+++ b/packages/mcp-server/tests/trpc/autoupdate.test.ts
@@ -182,4 +182,29 @@ describe("tRPC autoupdate surface", () => {
       await server.stop();
     }
   });
+
+  it("stampRun sets last_run_at to now (the host wrapper's post-update stamp)", async () => {
+    // The `--run` wrapper calls stampRun ONLY after a successful update. Before it,
+    // last_run_at is null (never run); after it, it's a recent ISO timestamp.
+    const server = await startHttpServer({ dataDir });
+    try {
+      expect(
+        await trpcGet<AutoUpdateGet>(server, "autoupdate.get").then((c) => c.lastRunAt),
+      ).toBeNull();
+
+      const before = Date.now();
+      const stamped = await trpcPost<AutoUpdateConfig>(server, "autoupdate.stampRun");
+      const after = Date.now();
+      expect(stamped.lastRunAt).not.toBeNull();
+      const stampedMs = new Date(stamped.lastRunAt as string).getTime();
+      expect(stampedMs).toBeGreaterThanOrEqual(before);
+      expect(stampedMs).toBeLessThanOrEqual(after);
+
+      // Persisted — a fresh read sees the same stamp.
+      const reread = await trpcGet<AutoUpdateGet>(server, "autoupdate.get");
+      expect(reread.lastRunAt).toBe(stamped.lastRunAt);
+    } finally {
+      await server.stop();
+    }
+  });
 });

--- a/packages/mcp-server/tests/trpc/autoupdate.test.ts
+++ b/packages/mcp-server/tests/trpc/autoupdate.test.ts
@@ -5,9 +5,12 @@
 // version/latest reused from health's release lookup), and the `set` toggle +
 // cadence round-trip with the core teaching error on a bad cadence.
 
-import { createLibrarianStore } from "@librarian/core";
+import { type LibrarianStore, createLibrarianStore } from "@librarian/core";
+import { appRouter, createCallerFactory } from "@librarian/mcp-server";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { cleanupTempDir, makeTempDir, startHttpServer } from "../../../../test/helpers.js";
+
+const createCaller = createCallerFactory(appRouter);
 
 interface TrpcOk<T> {
   result: { data: T };
@@ -86,6 +89,40 @@ describe("tRPC autoupdate surface", () => {
       expect(setResp.status).toBe(404);
     } finally {
       await server.stop();
+    }
+  });
+
+  it("every procedure is rejected UNAUTHORIZED for a NON-admin caller (the adminProcedure gate)", async () => {
+    // Belt to the network-boundary brace above: prove the role gate itself rejects
+    // a non-admin context (role !== "admin") rather than relying only on the
+    // listener split. A caller built with the anonymous role must be turned away
+    // from get / set / stampRun alike. (Mirrors auth-redeem.test's caller pattern.)
+    const store: LibrarianStore = createLibrarianStore({ dataDir });
+    try {
+      const nonAdmin = createCaller({
+        role: "anonymous",
+        store,
+        secretKey: null,
+        adminToken: "admin-token",
+      });
+
+      const expectUnauthorized = async (fn: () => Promise<unknown>, label: string) => {
+        await expect(fn(), label).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+      };
+      await expectUnauthorized(() => nonAdmin.autoupdate.get(), "get");
+      await expectUnauthorized(() => nonAdmin.autoupdate.set({ enabled: true }), "set");
+      await expectUnauthorized(() => nonAdmin.autoupdate.stampRun(), "stampRun");
+
+      // Sanity: the same calls succeed for an admin caller (the gate isn't a blanket deny).
+      const admin = createCaller({
+        role: "admin",
+        store,
+        secretKey: null,
+        adminToken: "admin-token",
+      });
+      await expect(admin.autoupdate.get()).resolves.toMatchObject({ enabled: false });
+    } finally {
+      store.close();
     }
   });
 


### PR DESCRIPTION
Keep a self-hosted Librarian current automatically (spec `docs/specs/2026-06-16-server-autoupdate.md`), configurable from **both** the CLI and the dashboard — without the dashboard ever holding host/docker access.

## The constraint that shaped it
`server update` is host-level (rebuilds + recreates the container). A process *inside* the container can't recreate its own container, and the container has no docker-socket access (by design). So: a **host timer** does the updating; the dashboard only **configures** it.

## What
- **`librarian server autoupdate <enable|disable|uninstall|status>`** (installer-cli) — installs a systemd timer (cron fallback) firing hourly; the cadence (`daily`/`weekly`) is a **due-check setting**, not the timer period, so it's editable anywhere.
- **`--run` wrapper** — updates only when **enabled AND due AND the server is reachable** (fail-closed; unreachable/disabled/not-due/parse-fail → skip), reuses `server update`'s health-check + rollback, stamps `last_run_at` only on success, and is **serialized by an `O_EXCL` host lock** so two fires (or a manual update) can't overlap and leave the server down.
- **`server.autoupdate.{enabled,cadence,last_run_at}` settings** (core) + admin **`autoupdate` tRPC** (mcp-server, internal listener only).
- **Dashboard panel** (Settings → Curator → Server auto-update) — toggle + cadence + status (last-run, update-available badge) + a host-install hint. No "update now" button by design.

## Security review (fresh-context, adversarial)
Found 1 CRITICAL (concurrency → server-down window) + 2 IMPORTANT — **all fixed test-first**: a host lock serializes updates; the binary path is validated (reject whitespace) + `NoNewPrivileges`; uninstall verifies the unit is ours before removing. Confirmed safe: fail-closed gating, no secret leak, injection-safe `docker exec` bridge, admin-only tRPC, no privileged dashboard action, rollback reliance.

## Verified
Full local gate green incl. build/smoke/healthcheck. **Honest scope:** the host integration (a real systemd timer firing, `docker exec`→in-container tRPC on a live box) is asserted by argv-equivalence/stub tests, not provable in CI — flagged in the test headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)