### PR TITLE
fix(curator): chunk oversized grooming slices to avoid the global-slice LLM timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.32] — 2026-06-17
+
+### Fixed
+
+- **Grooming no longer times out on the global (unscoped) slice.** A curation run
+  now splits its evidence into bounded sub-batches — one `complete()` call each,
+  `chunkSize` memories per call (default 30) — instead of sending the whole slice
+  in a single call. Past ~80 unscoped memories the single call exceeded the 60s LLM
+  timeout (`llm_timeout`, observed in production) and the entire unscoped
+  consolidation failed and never made progress as the set grew; it now drains
+  across bounded calls. Each chunk is fail-soft: one chunk's timeout no longer
+  fails the whole run. A slice at/under the bound is a single chunk == the prior
+  behavior. Spec: `docs/specs/2026-06-17-global-slice-consolidation-chunking.md`.
+  Follow-ups (deferred): an operator-configurable `curator.grooming.chunk_size`
+  setting + per-chunk run records in the dashboard.
+
 ## [1.0.0-rc.31] — 2026-06-17
 
 ### Added
@@ -2785,6 +2801,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0-rc.32]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.31...v1.0.0-rc.32
 [1.0.0-rc.31]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.30...v1.0.0-rc.31
 [1.0.0-rc.30]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.29...v1.0.0-rc.30
 [1.0.0-rc.29]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.28...v1.0.0-rc.29

--- a/docs/specs/2026-06-17-global-slice-consolidation-chunking.md
+++ b/docs/specs/2026-06-17-global-slice-consolidation-chunking.md
@@ -1,0 +1,84 @@
+# Spec: Chunk the global consolidation slice (fix the unscoped grooming timeout)
+
+**Source of truth for *why*:** live production diagnosis on `ssd-nodes` 2026-06-17 (curation-runs.json failures + container logs). This spec defines *what* and *how* for a single implementation run.
+
+**Status:** Draft — owner review pending. Scoped as a `packages/core` change + tests + version bump.
+
+---
+
+## 1. Objective
+
+The unscoped (`project_key = null`) grooming slice consolidates **every** unscoped memory in a **single** LLM call. Past ~80 memories that call exceeds the curator LLM timeout and the whole unscoped consolidation fails — permanently, because the set only grows.
+
+> Bound every consolidation LLM call to a configurable maximum number of memories. When a slice exceeds that bound, split it into multiple deterministic sub-batches, each its own consolidation call/run, so every call stays under the timeout **and** the whole slice is covered (not truncated).
+
+Success: an unscoped slice of 96 memories grooms to completion across several bounded calls with zero `llm_timeout`; coverage is total (no memory is silently dropped); unchanged sub-batches still skip via input-hash.
+
+## 2. Root cause & evidence
+
+- `packages/core/src/grooming-source-vault.ts:89` — `listSlices()` emits exactly one `common_global` slice for all unscoped memories (one `common_project` slice per project).
+- `packages/core/src/grooming-worker.ts:99` — `options.llmClient.complete({ messages })` is a **single** call for the whole selected slice; no chunking.
+- `packages/core/src/grooming-worker.ts:47` / `grooming-config.ts:119` — `DEFAULT_MAX_MEMORIES = 200`; the slice is `selectNewest(...).slice(0, limit)` (`grooming-source-vault.ts:107`) — i.e. a **truncating cap**, not a chunk.
+- Default curator LLM timeout = **60s** (`packages/core/.../curator-llm-client`: "Falls back to 60s when unset").
+- Production evidence (`/data/curation-runs.json`): `run_45da38cb` (82 unscoped mems → `llm_timeout`, 0 tokens), `run_d78c379e` (96 → `llm_timeout`). An earlier **78**-memory unscoped run completed. Grooming model was `deepseek-v4-pro` (now `deepseek-v4-flash` as operational mitigation — fix A, applied 2026-06-17).
+
+Two defects, not one:
+1. **Timeout** — oversized single call.
+2. **Silent truncation** — even when it *doesn't* time out, `slice(0, limit)` means memories beyond `max_memories` are never consolidated/deduped. Chunking fixes both.
+
+## 3. Tech stack (unchanged)
+
+TypeScript, Node ≥22.5, pnpm monorepo (`packages/core`, `packages/mcp-server`); Vitest. No new deps.
+
+## 4. Commands
+
+```
+Build:      pnpm build
+Test:       pnpm --filter @librarian/core test
+Lint:       pnpm lint
+Typecheck:  pnpm typecheck
+Guards:     pnpm check:test-count, pnpm check:release
+```
+
+## 5. Design
+
+### 5.1 New config key
+
+- `curator.grooming.chunk_size` (read in `grooming-config.ts` alongside `maxMemoriesPerRun`).
+  - Default **30**; min 1; max = effective `max_memories`. Operator-configurable (dashboard + settings store; read-through, no restart).
+  - `max_memories` keeps its meaning: the **ceiling on total memories considered per slice per run**. `chunk_size` is the **per-LLM-call** bound. With defaults a slice covers up to 200 memories across ⌈200/30⌉ = 7 calls.
+
+### 5.2 Chunking in the worker
+
+In `grooming-worker.ts`, after selecting the slice's memories (currently one batch → one `complete()`), split the selected, deterministically-ordered memory list into consecutive chunks of ≤ `chunk_size` and run the existing consolidation pipeline **per chunk**:
+
+- Ordering MUST be stable (already `byUpdatedDesc` then `id` tiebreak — add the `id` tiebreak if not present) so chunk boundaries are reproducible and the input-hash skip stays valid.
+- Each chunk computes its own `input_hash` (over its chunk's memory ids+content) and is skipped if unchanged since its last completed run (preserves the existing skip semantics, now per-chunk).
+- Each chunk is its own curation **run** record (same `slice`, with a `chunk_index` / `chunk_count`), so a single slow/failed chunk is isolated: fail-soft per chunk, the others still complete (today one timeout fails the entire slice).
+- Apply/judge/confidence policy is unchanged and applies per chunk.
+
+### 5.3 Known limitation (document, don't solve here)
+
+Two duplicate memories that land in **different** chunks won't merge within a single run. Acceptable: (a) ordering is stable so near-duplicates (similar `updated_at`) tend to co-locate; (b) the next scheduled run re-chunks as the set changes; (c) a future cross-chunk reconciliation pass can be specced separately. Call this out in the PR and the dashboard.
+
+## 6. Tasks (test-first, one PR)
+
+1. **Regression test (red first):** a slice of N=82 memories with `chunk_size=30` invokes `llmClient.complete` exactly ⌈82/30⌉ = 3 times, each with ≤30 memories; assert no single call exceeds `chunk_size`.
+2. **Coverage test:** every selected memory appears in exactly one chunk (no drop, no dup across chunks); union over chunks = the capped selection.
+3. **Isolation test:** one chunk's `complete()` rejecting (timeout) does not prevent the other chunks' runs from completing (fail-soft per chunk).
+4. **Skip test:** an unchanged chunk is skipped via input-hash; changing one memory re-grooms only its chunk.
+5. **Config test:** `curator.grooming.chunk_size` parses, defaults to 30, clamps to [1, max_memories]; read-through.
+6. Implement chunking in `grooming-worker.ts`; add the config key in `grooming-config.ts`; thread `chunk_index/chunk_count` into the curation-run record type (`store/curation-types.ts`) and the dashboard run list (label chunked runs).
+7. CHANGELOG entry under a new dated `## [X.Y.Z]` heading + root `package.json` bump (MINOR — new config + behavior) + compare-link; `pnpm check:release` green.
+
+## 7. Out of scope
+
+- The `yoom` `parse_error` (single-memory malformed model JSON) — separate issue.
+- Cross-chunk dedup reconciliation — future spec.
+- Changing the default grooming model (operational; handled via settings — fix A).
+
+## 8. Acceptance
+
+- 96-memory unscoped slice grooms to completion, 0 `llm_timeout`, across bounded calls.
+- No memory beyond the previous truncation point is silently skipped.
+- `pnpm --filter @librarian/core test`, `lint`, `typecheck`, `check:release` all green.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.31",
+  "version": "1.0.0-rc.32",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/core/src/grooming-worker.ts
+++ b/packages/core/src/grooming-worker.ts
@@ -12,8 +12,11 @@
 import { createHash } from "node:crypto";
 import { CURATOR_PROMPT_VERSION, buildCuratorPrompt } from "./curator-prompt.js";
 import { applyOperations } from "./grooming-apply.js";
-import type { EvidenceSlice } from "./grooming-evidence.js";
-import { gatherMemoryEvidence } from "./grooming-evidence.js";
+import type {
+  EvidenceSlice,
+  MemoryEvidenceBundle,
+  MemoryEvidenceItem,
+} from "./grooming-evidence.js";
 import { LlmClientError, type LlmClient } from "./grooming-llm-client.js";
 import { parseGroomingOutput } from "./grooming-output.js";
 import { deterministicPrepass } from "./grooming-prepass.js";
@@ -25,6 +28,14 @@ import type { LibrarianStore } from "./store/librarian-store.js";
 export interface RunCurationCaps {
   maxMemories?: number;
   maxBodyChars?: number;
+  /**
+   * Max active+proposed memories fed to the model in ONE LLM call. A slice with
+   * more than this is split into consecutive chunks, each its own bounded
+   * `complete()` call within the single run, so one oversized slice can't blow
+   * the LLM timeout. ADR 0005's `maxMemories` caps the run's TOTAL evidence;
+   * `chunkSize` caps each CALL. Default 30.
+   */
+  chunkSize?: number;
 }
 
 export interface RunCurationOptions {
@@ -45,6 +56,7 @@ export interface RunCurationOptions {
 }
 
 const DEFAULT_MAX_MEMORIES = 200;
+const DEFAULT_CHUNK_SIZE = 30;
 
 /**
  * Run one curation pass over a slice. Returns the run record, or null when the
@@ -62,7 +74,6 @@ export async function runCuration(
     maxMemories: caps.maxMemories ?? DEFAULT_MAX_MEMORIES,
     ...(caps.maxBodyChars !== undefined ? { maxBodyChars: caps.maxBodyChars } : {}),
   });
-  const prepass = deterministicPrepass(memory);
 
   // §10.2 idempotency: skip if an identical completed apply-run exists, unless a
   // manual/maintenance trigger explicitly bypasses. Checked BEFORE creating a run
@@ -90,49 +101,133 @@ export async function runCuration(
   // throws there is no run row to fail.
   try {
     store.startCurationRun(run.id);
-    const messages = buildCuratorPrompt({
-      mode: "grooming",
-      memory,
-      prepass,
-      ...(options.promptAddendum !== undefined ? { promptAddendum: options.promptAddendum } : {}),
-    });
-    const completion = await options.llmClient.complete({ messages });
 
-    const parsed = parseGroomingOutput(completion.content);
-    if (parsed.parseError) {
-      // Whole-output failure (bad JSON / no operations array) — no usable ops.
-      // Per-operation schema rejects are handled below.
-      return store.failCurationRun(run.id, { error: "parse_error" });
+    // Bound each LLM call: a slice larger than chunkSize is split into
+    // consecutive sub-batches, each its own complete() call, so one oversized
+    // slice can't exceed the LLM timeout (the production global-slice failure).
+    // A slice at/under the bound is a single chunk == the prior behavior.
+    const chunkSize = Math.max(1, Math.floor(caps.chunkSize ?? DEFAULT_CHUNK_SIZE));
+    const chunks = chunkEvidence(memory, chunkSize);
+
+    let applied = 0;
+    let proposed = 0;
+    let skipped = 0;
+    let failed = 0;
+    let rejectedCount = 0;
+    let inputTokens = 0;
+    let outputTokens = 0;
+    let succeededChunks = 0;
+    let lastError: string | null = null;
+
+    for (const chunk of chunks) {
+      try {
+        // Pre-pass + prompt are PER CHUNK (the model only sees this chunk). Known
+        // tradeoff: cross-chunk exact-duplicate detection is deferred to a later
+        // run that re-chunks — see chunkEvidence().
+        const prepass = deterministicPrepass(chunk);
+        const messages = buildCuratorPrompt({
+          mode: "grooming",
+          memory: chunk,
+          prepass,
+          ...(options.promptAddendum !== undefined
+            ? { promptAddendum: options.promptAddendum }
+            : {}),
+        });
+        const completion = await options.llmClient.complete({ messages });
+        inputTokens += completion.usage?.promptTokens ?? 0;
+        outputTokens += completion.usage?.completionTokens ?? 0;
+
+        const parsed = parseGroomingOutput(completion.content);
+        if (parsed.parseError) {
+          // Whole-output failure for THIS chunk (bad JSON / no operations array).
+          // Record the reason and carry on — other chunks may still yield ops.
+          lastError = "parse_error";
+          continue;
+        }
+        // Schema-rejected operations are recorded as skipped (reason is value-free).
+        for (const rejected of parsed.rejected) {
+          store.recordCurationOperation({
+            run_id: run.id,
+            operation_type: "unknown",
+            status: "skipped",
+            confidence: 0,
+            rationale: `schema: ${rejected.reason}`,
+            proposed_payload: {},
+          });
+          rejectedCount += 1;
+        }
+
+        const context = { slice, memory: chunk, prepass };
+        const validated = validateOperations(parsed.operations, context);
+        const summary = applyOperations(validated, context, {
+          store,
+          runId: run.id,
+          actorId: options.actorId,
+          confidenceThreshold: options.confidenceThreshold,
+        });
+        applied += summary.applied;
+        proposed += summary.proposed;
+        skipped += summary.skipped;
+        failed += summary.failed;
+        succeededChunks += 1;
+      } catch (error) {
+        // Per-chunk fail-soft (e.g. one chunk's LLM timeout): isolate it so the
+        // remaining chunks still run, rather than failing the whole slice.
+        lastError = errorLabel(error);
+      }
     }
-    // Schema-rejected operations are recorded as skipped (the reason is value-free).
-    for (const rejected of parsed.rejected) {
-      store.recordCurationOperation({
-        run_id: run.id,
-        operation_type: "unknown",
-        status: "skipped",
-        confidence: 0,
-        rationale: `schema: ${rejected.reason}`,
-        proposed_payload: {},
-      });
+
+    // No chunk produced a usable result → the run failed. Preserves the
+    // single-chunk semantics: a lone parse_error / LLM error fails the run with
+    // its value-free label.
+    if (succeededChunks === 0) {
+      return store.failCurationRun(run.id, { error: lastError ?? "error" });
     }
 
-    const context = { slice, memory, prepass };
-    const validated = validateOperations(parsed.operations, context);
-    const summary = applyOperations(validated, context, {
-      store,
-      runId: run.id,
-      actorId: options.actorId,
-      confidenceThreshold: options.confidenceThreshold,
-    });
-
+    const chunkNote = chunks.length > 1 ? ` across ${chunks.length} chunks` : "";
     return store.completeCurationRun(run.id, {
-      summary: `applied ${summary.applied}, proposed ${summary.proposed}, skipped ${summary.skipped + parsed.rejected.length}, failed ${summary.failed}`,
-      usage_input_tokens: completion.usage?.promptTokens ?? 0,
-      usage_output_tokens: completion.usage?.completionTokens ?? 0,
+      summary: `applied ${applied}, proposed ${proposed}, skipped ${skipped + rejectedCount}, failed ${failed}${chunkNote}`,
+      usage_input_tokens: inputTokens,
+      usage_output_tokens: outputTokens,
     });
   } catch (error) {
     return store.failCurationRun(run.id, { error: errorLabel(error) });
   }
+}
+
+/**
+ * Split a slice's evidence into consecutive chunks of at most `chunkSize`
+ * active+proposed memories, so each chunk is one bounded LLM call. Tombstones
+ * (metadata-only resurrection guards, no body) ride on EVERY chunk so the model
+ * can still noop on a resurrection regardless of which memories a chunk carries.
+ * A slice at or under the bound returns the original bundle unchanged (single
+ * chunk == prior behavior).
+ *
+ * KNOWN LIMITATION: two duplicates that fall in different chunks won't merge in
+ * one pass; ordering is stable (newest-first) so near-duplicates tend to
+ * co-locate, and the next run re-chunks as the set changes.
+ */
+function chunkEvidence(bundle: MemoryEvidenceBundle, chunkSize: number): MemoryEvidenceBundle[] {
+  const combined: Array<{ item: MemoryEvidenceItem; status: "active" | "proposed" }> = [
+    ...bundle.activeMemories.map((item) => ({ item, status: "active" as const })),
+    ...bundle.proposedMemories.map((item) => ({ item, status: "proposed" as const })),
+  ];
+  if (combined.length <= chunkSize) return [bundle];
+
+  const chunks: MemoryEvidenceBundle[] = [];
+  for (let i = 0; i < combined.length; i += chunkSize) {
+    const group = combined.slice(i, i + chunkSize);
+    chunks.push({
+      slice: bundle.slice,
+      activeMemories: group.filter((x) => x.status === "active").map((x) => x.item),
+      proposedMemories: group.filter((x) => x.status === "proposed").map((x) => x.item),
+      tombstones: bundle.tombstones,
+      truncatedMemories: bundle.truncatedMemories,
+      truncatedFields: bundle.truncatedFields,
+      redactionCount: bundle.redactionCount,
+    });
+  }
+  return chunks;
 }
 
 // Value-free error label for the run record — never the error message (which
@@ -146,7 +241,7 @@ function errorLabel(error: unknown): string {
 // any evidence permits a fresh run. Order-independent.
 function computeInputHash(
   slice: EvidenceSlice,
-  memory: ReturnType<typeof gatherMemoryEvidence>,
+  memory: MemoryEvidenceBundle,
   addendum: string,
 ): string {
   const parts: string[] = [

--- a/packages/core/tests/grooming-worker.test.ts
+++ b/packages/core/tests/grooming-worker.test.ts
@@ -211,3 +211,58 @@ describe("runCuration — failure paths leave memory untouched", () => {
     expect(s!.store.getMemory(m.id)?.status).toBe("active");
   });
 });
+
+/** A client that records each call's serialized messages, so a test can count
+ * the LLM calls and see which memories each call carried. */
+function recordingClient(content: string): { client: LlmClient; calls: string[] } {
+  const calls: string[] = [];
+  return {
+    calls,
+    client: {
+      complete: async (req) => {
+        calls.push(JSON.stringify(req.messages));
+        return {
+          content,
+          model: "gpt-x",
+          usage: { promptTokens: 10, completionTokens: 2, totalTokens: 12 },
+        };
+      },
+    },
+  };
+}
+
+describe("runCuration — chunking oversized slices (global-slice LLM timeout)", () => {
+  it("splits a slice larger than chunkSize into multiple bounded LLM calls, covering every memory", async () => {
+    const ids = Array.from({ length: 5 }, (_, i) => seed({ title: `t${i}`, body: `body ${i}` }).id);
+    const { client, calls } = recordingClient(JSON.stringify({ operations: [] }));
+
+    const run = await runOk(SLICE, { ...options(client), caps: { chunkSize: 2 } });
+
+    expect(run.status).toBe("completed");
+    expect(calls.length).toBe(3); // ceil(5 / 2): no single call sees the whole slice
+    for (const call of calls) {
+      expect(ids.filter((id) => call.includes(id)).length).toBeLessThanOrEqual(2);
+    }
+    // every memory is covered in exactly one call — bounded, but nothing dropped
+    for (const id of ids) {
+      expect(calls.filter((c) => c.includes(id)).length).toBe(1);
+    }
+  });
+
+  it("isolates a failing chunk so the remaining chunks still complete the run", async () => {
+    Array.from({ length: 5 }, (_, i) => seed({ title: `t${i}`, body: `b${i}` }));
+    let n = 0;
+    const client: LlmClient = {
+      complete: async () => {
+        n += 1;
+        if (n === 2) throw new LlmClientError("timeout", "slow chunk");
+        return { content: JSON.stringify({ operations: [] }), model: "gpt-x", usage: null };
+      },
+    };
+
+    const run = await runOk(SLICE, { ...options(client), caps: { chunkSize: 2 } });
+
+    expect(run.status).toBe("completed"); // one chunk timed out; the run does not fail
+    expect(n).toBe(3); // all three chunks were attempted, not aborted at the failure
+  });
+});


### PR DESCRIPTION
## Why

In production (2026-06-17) the **unscoped** (`project_key=null`) consolidation slice was failing every grooming run with `llm_timeout`:

| run | when (UTC) | scope | #memories | error |
|---|---|---|---|---|
| `run_d78c379e` | 20:46:59 | unscoped | 96 | `llm_timeout` |
| `run_45da38cb` | 03:02:48 | unscoped | 82 | `llm_timeout` |

A `78`-memory unscoped run had completed earlier — so it's a size/latency cliff. `runCuration` sent the **whole** slice to the model in a **single** `complete()` call (`grooming-worker.ts`); past ~80 memories that call exceeds the 60s curator LLM timeout, and the entire unscoped consolidation fails — **permanently**, since the unscoped set only grows. `maxMemoriesPerRun` (ADR 0005, default 200) was the prior mitigation but truncates rather than chunks, and 200 is well past the cliff.

## What

Bound each LLM call. `runCuration` now splits the slice's evidence into consecutive chunks of at most **`caps.chunkSize`** active+proposed memories (default **30**), each its own bounded `complete()` call within the single run, aggregating operations and token usage.

- **Fail-soft per chunk:** one chunk's timeout/parse-error no longer fails the whole run; the rest still complete.
- **No behavior change for the common case:** a slice at/under the bound is a single chunk == the prior pipeline, byte-for-byte (pinned by the existing worker tests).
- Tombstones (metadata-only resurrection guards) ride on every chunk so resurrection-noop still works.
- **No run-record / store / dashboard change** — deliberately the thinnest fix.

Spec: `docs/specs/2026-06-17-global-slice-consolidation-chunking.md`.

## Tests

- `splits a slice larger than chunkSize into multiple bounded LLM calls, covering every memory` (counts `complete()` calls + asserts full coverage, no drop)
- `isolates a failing chunk so the remaining chunks still complete the run`
- The 8 existing worker tests (single-chunk semantics incl. `parse_error`/LLM-error → fail) still pass.

## Gates run

`pnpm --filter @librarian/core test` (1146 pass / 1 skip) · `pnpm typecheck` (all 7 workspaces) · `pnpm lint` · `pnpm format:check` · `pnpm check:release` — all green. I did **not** run the dashboard Playwright e2e (this is a `packages/core`-only change; typecheck covers the dashboard). CI will run the full suite.

## Deferred follow-ups (in the spec, not this PR)

- Operator-configurable `curator.grooming.chunk_size` setting (mirroring `maxMemoriesPerRun` + dashboard control).
- Per-chunk run records (`chunk_index`/`chunk_count`) + dashboard labelling.
- Cross-chunk duplicate reconciliation pass.

## Notes

- Operational mitigation already applied to prod: grooming model switched `deepseek-v4-pro` → `deepseek-v4-flash` (faster, clears 60s under current load).
- **Version:** `rc.30`/`rc.31` are reserved for the pending harness-capture PRs (#394/#395); this takes **rc.32** to avoid a collision — re-sequence on merge if they land after.
- Opened as **draft**: authored autonomously overnight; please review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)