### PR TITLE
fix(claude): banner reflects real client shipping; correct stale #29767 note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.33] — 2026-06-17
+
+### Changed
+
+- **The Claude `SessionStart` banner now reflects whether THIS client is actually
+  shipping**, not just the server's intake gate. `buildBanner` takes an optional
+  `shipping` probe (new `probeShipping`): when the server gate is on but the resolved
+  `$CLAUDE_PLUGIN_DATA` shows the client has never shipped (no capture cursors), the
+  banner cautions and points at the cursors dir instead of claiming "Automatic capture
+  is active" — the false-positive that masked a non-firing per-turn hook for hours on
+  2026-06-17. Backward compatible: omitting `shipping` keeps the prior line (existing
+  callers/tests unchanged).
+
+### Fixed
+
+- **Corrected the stale `on-stop.mjs` rationale.** Its header claimed plugin-scoped
+  `Stop` hooks never fire (Claude Code bug #29767), which drove the `Stop` →
+  `UserPromptSubmit` switch. As of Claude Code 2.1.179 (verified 2026-06-17 with an
+  isolated single-purpose probe plugin) plugin-scoped `UserPromptSubmit` **and** `Stop`
+  both fire reliably — wiring all three is sound redundancy, not a #29767 workaround.
+  The capture failure that looked like a non-firing hook was a data-dir mismatch (live
+  hooks write under `$CLAUDE_PLUGIN_DATA`, not the manual-run fallback).
+
 ## [1.0.0-rc.32] — 2026-06-17
 
 ### Fixed
@@ -2801,6 +2824,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0-rc.33]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.32...v1.0.0-rc.33
 [1.0.0-rc.32]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.31...v1.0.0-rc.32
 [1.0.0-rc.31]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.30...v1.0.0-rc.31
 [1.0.0-rc.30]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.29...v1.0.0-rc.30

--- a/integrations/claude/scripts/lib/banner.mjs
+++ b/integrations/claude/scripts/lib/banner.mjs
@@ -15,8 +15,12 @@
 // does, the builder STILL emits the static awareness line — no warning (we don't
 // know capture is off), no throw. The hook entry never blocks the session.
 //
-// The builder is PURE over `{ status, env }` so the network probe (the impure
-// part) is injected by the hook entry and the banner text is unit-testable.
+// The builder is PURE over `{ status, env, shipping }` so the impure probes (the
+// network /healthz query and the local cursor read) are injected by the hook
+// entry and the banner text is unit-testable.
+
+import fs from "node:fs";
+import { cursorsDir } from "./cursor.mjs";
 
 /**
  * Derive the /healthz URL from LIBRARIAN_MCP_URL (same origin as /mcp, dropping
@@ -74,6 +78,31 @@ export async function probeStatus(env, deps = {}) {
   }
 }
 
+/**
+ * Has THIS client ever shipped a capture delta? Reads the cursors dir under the
+ * resolved plugin data dir (`$CLAUDE_PLUGIN_DATA`, which Claude Code sets for
+ * plugin hooks, else the fallback). ANY cursor file means the per-turn capture
+ * hook has run and acked at least once on this machine. NEVER throws — a missing
+ * dir / odd entry resolves to `{ everShipped: false }` (fail-soft). `fs` is
+ * injectable for tests.
+ *
+ * @param {string} dataDir
+ * @param {{fs?: typeof import("node:fs")}} [deps]
+ * @returns {{everShipped: boolean}}
+ */
+export function probeShipping(dataDir, deps = {}) {
+  const fsDep = deps.fs ?? fs;
+  try {
+    const names = fsDep.readdirSync(cursorsDir(dataDir));
+    // A real cursor file is a session id; ignore dotfiles and the atomic-write
+    // temp files (`<id>.tmp-<pid>`).
+    const real = names.filter((n) => n && !n.startsWith(".") && !n.includes(".tmp-"));
+    return { everShipped: real.length > 0 };
+  } catch {
+    return { everShipped: false };
+  }
+}
+
 /** The static awareness line — always present, the part that survives compaction. */
 export const AWARENESS_LINE =
   "The Librarian is this environment's durable memory: you have `recall` and " +
@@ -100,13 +129,18 @@ export function isAutoSaveOff(env) {
  * @param {{
  *   status: {reachable: boolean, captureEnabled?: boolean},
  *   env: Record<string,string|undefined>,
+ *   shipping?: {everShipped: boolean},
  * }} input
  *   - `status.reachable` — did the /healthz query succeed?
  *   - `status.captureEnabled` — when reachable, is the server's intake gate on?
  *   - `env` — the process env (read for the LIBRARIAN_AUTO_SAVE kill-switch).
+ *   - `shipping` — OPTIONAL local-capture probe (`probeShipping`). When present and
+ *     `everShipped:false`, the server gate is on but THIS client has never shipped,
+ *     so the banner cautions instead of claiming "active". Absent ⇒ historical
+ *     behavior (assume active when the gate is on).
  * @returns {string} the banner to inject. Never throws.
  */
-export function buildBanner({ status, env }) {
+export function buildBanner({ status, env, shipping }) {
   const lines = [AWARENESS_LINE];
   const e = env || {};
   const s = status || { reachable: false };
@@ -131,10 +165,25 @@ export function buildBanner({ status, env }) {
 
   // Reachable: report the server's capture gate.
   if (s.captureEnabled) {
-    lines.push(
-      "Automatic capture is active: your turns are captured and durable lessons " +
-        "filed for you — no need to call `remember` for routine facts.",
-    );
+    // The gate being ON ≠ THIS client shipping: the SessionStart hook (this
+    // banner) can fire while the per-turn capture hook does not. When the resolved
+    // $CLAUDE_PLUGIN_DATA shows no cursors (never shipped), caution instead of
+    // over-claiming "active" — the false-positive that masked a non-firing hook.
+    // `shipping` is OPTIONAL: absent (probe failed / older caller) keeps "active".
+    if (shipping && shipping.everShipped === false) {
+      lines.push(
+        "⚠ The Librarian server's intake gate is ON, but this client has not shipped " +
+          "any transcript yet (no capture cursors under $CLAUDE_PLUGIN_DATA). If capture " +
+          "does not begin after a turn or two, the per-turn capture hook may not be " +
+          "firing even though this SessionStart hook did — check the cursors dir. Until " +
+          "confirmed, `remember` durable facts explicitly so they are not lost.",
+      );
+    } else {
+      lines.push(
+        "Automatic capture is active: your turns are captured and durable lessons " +
+          "filed for you — no need to call `remember` for routine facts.",
+      );
+    }
   } else {
     lines.push(
       "⚠ Automatic capture is OFF server-side: the curator intake gate " +

--- a/integrations/claude/scripts/on-session-start.mjs
+++ b/integrations/claude/scripts/on-session-start.mjs
@@ -21,7 +21,8 @@
 // cross-origin.
 
 import process from "node:process";
-import { buildBanner, probeStatus } from "./lib/banner.mjs";
+import { buildBanner, probeShipping, probeStatus } from "./lib/banner.mjs";
+import { resolveDataDir } from "./lib/capture.mjs";
 
 async function main() {
   let status;
@@ -30,9 +31,18 @@ async function main() {
   } catch {
     status = { reachable: false };
   }
+  // Local capture-health: has THIS client ever shipped (any cursor under the
+  // resolved $CLAUDE_PLUGIN_DATA)? Fail-soft to undefined → the banner keeps its
+  // historical behavior, so a probe error never changes the awareness output.
+  let shipping;
+  try {
+    shipping = probeShipping(resolveDataDir(process.env));
+  } catch {
+    shipping = undefined;
+  }
   let text;
   try {
-    text = buildBanner({ status, env: process.env });
+    text = buildBanner({ status, env: process.env, shipping });
   } catch {
     // Last-resort: never throw out of the hook. Print nothing rather than a
     // partial/broken banner.

--- a/integrations/claude/scripts/on-stop.mjs
+++ b/integrations/claude/scripts/on-stop.mjs
@@ -9,22 +9,27 @@
 // (it reads the cursor delta from `transcript_path` and ships it), so no per-event
 // branching is needed beyond `isSessionEnd()`.
 //
-//   - `UserPromptSubmit` is the PRIMARY trigger. Claude Code bug #29767 means
-//     plugin-scoped `Stop` hooks register but never fire (a `SessionStart` from the
-//     same plugin DOES fire), so a `Stop`-only adapter would never run.
-//     `UserPromptSubmit` fires reliably — just before the assistant reply — so it
-//     ingests up to the PREVIOUS completed turn (one turn behind; per spec §8.2 that
-//     is fine — incremental ingestion loses at most the last un-acked turn anyway,
-//     and the next prompt catches it up). Its payload carries the same
+//   - `UserPromptSubmit` is the PRIMARY trigger: it fires just before the assistant
+//     reply, so it ingests up to the PREVIOUS completed turn (one turn behind; per
+//     spec §8.2 that is fine — incremental ingestion loses at most the last un-acked
+//     turn, and the next prompt catches it up). Its payload carries the same
 //     `session_id` + `transcript_path` + `cwd` a `Stop` would.
-//   - `Stop` / `SessionEnd` are SUPPLEMENTARY / self-healing. They stay wired so the
-//     moment Anthropic fixes #29767 they resume firing and contribute for free; the
-//     cursor's advance-on-ack makes multiple firing events idempotent (a re-read
-//     delta the server/curator dedup). `SessionEnd` is additionally the explicit-end
+//   - `Stop` / `SessionEnd` are SUPPLEMENTARY belt-and-suspenders; the cursor's
+//     advance-on-ack makes multiple firing events idempotent (a re-read delta the
+//     server/curator dedup). `SessionEnd` is additionally the explicit-end
 //     accelerator — `runCapture`'s `isSessionEnd()` reads `hook_event_name` to set
 //     `ended:true` so the server settle-sweep extracts immediately instead of waiting
-//     out the idle window (spec §4.4). `UserPromptSubmit` and `Stop` never set
-//     `ended`.
+//     out the idle window (spec §4.4). `UserPromptSubmit` and `Stop` never set `ended`.
+//
+//   HISTORY (do not regress): this adapter once drove capture from `Stop` only, then
+//   switched to `UserPromptSubmit` over Claude Code bug #29767 (plugin-scoped `Stop`
+//   hooks registering but not firing). As of Claude Code 2.1.179 — verified 2026-06-17
+//   with an isolated single-purpose probe plugin — plugin-scoped `UserPromptSubmit`
+//   AND `Stop` BOTH fire reliably. So wiring all three is sound redundancy, NOT a
+//   #29767 workaround; do not "simplify" to a single event on the assumption the
+//   others don't fire — they do. (The capture failure that looked like a non-firing
+//   hook was actually a data-dir mismatch: live hooks write under `$CLAUDE_PLUGIN_DATA`
+//   — see resolveDataDir in lib/capture.mjs and the SessionStart shipping probe.)
 //
 // KNOWN TRADEOFF (deferred optimization): the ship is SYNCHRONOUS, so a slow or
 // unreachable server adds latency to the user's prompt up to the hook timeout (15s

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.32",
+  "version": "1.0.0-rc.33",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/test/claude-session-start-banner.test.ts
+++ b/test/claude-session-start-banner.test.ts
@@ -18,6 +18,7 @@
 //   - status-unreachable: the /healthz query failed → STILL emits the static
 //                        awareness line, NO warning, NO throw (fail-soft).
 
+import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -185,5 +186,82 @@ describe("probe → banner against a live server (SC9)", () => {
     const text = banner.buildBanner({ status, env });
     expect(text).toMatch(/⚠/);
     expect(text).toMatch(/dashboard/i);
+  });
+});
+
+// ── client-shipping awareness (SC: banner tells the TRUTH about local capture) ─
+// The /healthz gate proves the SERVER accepts intake; it does NOT prove THIS
+// client's per-turn capture hook is firing. When the resolved $CLAUDE_PLUGIN_DATA
+// shows no cursors (the client has never shipped), the banner must not over-claim
+// "capture is active" — the false-positive that masked a non-firing hook for hours.
+
+describe("buildBanner — client-shipping awareness", () => {
+  it("intake ON + client HAS shipped → capture is active, no warning", () => {
+    const text = banner.buildBanner({
+      status: { reachable: true, captureEnabled: true },
+      env: {},
+      shipping: { everShipped: true },
+    });
+    expect(text).toMatch(/capture is active/i);
+    expect(text).not.toMatch(/⚠/);
+  });
+
+  it("intake ON but client has NEVER shipped → WARNS (not 'active'), names the data dir", () => {
+    const text = banner.buildBanner({
+      status: { reachable: true, captureEnabled: true },
+      env: {},
+      shipping: { everShipped: false },
+    });
+    expect(text).toMatch(/⚠/);
+    expect(text).not.toMatch(/capture is active/i);
+    expect(text).toMatch(/CLAUDE_PLUGIN_DATA|cursor/i);
+  });
+
+  it("omitting shipping keeps the historical 'capture is active' line (backward compatible)", () => {
+    const text = banner.buildBanner({
+      status: { reachable: true, captureEnabled: true },
+      env: {},
+    });
+    expect(text).toMatch(/capture is active/i);
+    expect(text).not.toMatch(/⚠/);
+  });
+});
+
+describe("probeShipping — has this client ever shipped a capture delta?", () => {
+  it("false when the cursors dir is missing (fail-soft, never throws)", () => {
+    const dir = makeTempDir();
+    try {
+      expect(banner.probeShipping(dir)).toEqual({ everShipped: false });
+    } finally {
+      cleanupTempDir(dir);
+    }
+  });
+
+  it("true when a real cursor file exists under cursors/", () => {
+    const dir = makeTempDir();
+    try {
+      const cdir = path.join(dir, "cursors");
+      fs.mkdirSync(cdir, { recursive: true });
+      fs.writeFileSync(
+        path.join(cdir, "11111111-2222-3333-4444-555555555555"),
+        JSON.stringify({ offset: 1, seq: 1, private: false }),
+      );
+      expect(banner.probeShipping(dir)).toEqual({ everShipped: true });
+    } finally {
+      cleanupTempDir(dir);
+    }
+  });
+
+  it("ignores tmp/dotfiles — only a real cursor counts as 'shipped'", () => {
+    const dir = makeTempDir();
+    try {
+      const cdir = path.join(dir, "cursors");
+      fs.mkdirSync(cdir, { recursive: true });
+      fs.writeFileSync(path.join(cdir, "sess-1.tmp-9999"), "x");
+      fs.writeFileSync(path.join(cdir, ".keep"), "");
+      expect(banner.probeShipping(dir)).toEqual({ everShipped: false });
+    } finally {
+      cleanupTempDir(dir);
+    }
   });
 });


### PR DESCRIPTION
Two capture-**trust** fixes for the Claude integration, both from the 2026-06-17 investigation where auto-capture *looked* broken for hours but never was — the trail was a directory mismatch and an over-claiming banner, not a real capture failure.

## 1. The SessionStart banner over-claimed

`buildBanner` printed **"Automatic capture is active"** whenever the server's `/healthz` intake gate was on — regardless of whether *this client's* per-turn hook actually ships. That's the exact false-positive that masked a non-firing hook.

- New `probeShipping(dataDir)` reads the cursors dir under the resolved **`$CLAUDE_PLUGIN_DATA`** (what Claude Code sets for plugin hooks, not the manual-run fallback). Any cursor ⇒ the per-turn hook has run + acked at least once on this machine.
- `buildBanner({ status, env, shipping })` — `shipping` **optional**. Server-gate-on **+ never-shipped** ⇒ caution naming the cursors dir, instead of "active". **Backward compatible:** omitting `shipping` keeps the prior line, so every existing caller/test is unchanged.
- `on-session-start.mjs` wires the probe **fail-soft** (probe error → `undefined` → historical behavior; the SessionStart hook never blocks/changes output on error).

## 2. Corrected the stale `#29767` rationale in `on-stop.mjs`

The header claimed plugin-scoped `Stop` hooks "register but never fire" (Claude Code bug #29767), which drove the original `Stop` → `UserPromptSubmit` switch. **Verified on Claude Code 2.1.179 (2026-06-17, isolated single-purpose probe plugin): plugin-scoped `UserPromptSubmit` AND `Stop` both fire reliably.** Wiring all three is sound redundancy, not a #29767 workaround — the comment now says so, and warns against "simplifying" back to one event. (The real failure was the data-dir mismatch, now addressed by #1.)

## Tests

- `buildBanner` shipping awareness: active-when-shipped / **warns-when-never-shipped (names the dir)** / backward-compatible-when-omitted.
- `probeShipping`: false on missing dir (fail-soft), true on a real cursor, ignores tmp/dotfiles.
- All existing banner / hook-entry / stop-adapter tests still pass (the entry's no-env path is unreachable→awareness-only, so it never hits the shipping branch).

## Gates run

`pnpm vitest run` (root `test/**`, 121 pass) · banner+hook-entries+stop-adapter (70 pass) · installer-cli `claude` test (8 pass) · `pnpm typecheck` (all workspaces) · eslint + prettier on changed files · `pnpm check:release` — all green.

## Notes

- Doc-path audit: the code (`capture.mjs`/`cursor.mjs`) and README already document `${CLAUDE_PLUGIN_DATA:-fallback}` correctly — the only wrong reference was a stored memory, already flagged + corrected out-of-band. No doc changes needed here.
- **Version:** branches independently from `main`; takes **rc.33** (`rc.30`/`rc.31` reserved for #394/#395, `rc.32` for the grooming-chunking PR #396). Re-sequence on merge.
- Opened as **draft**: authored autonomously overnight; the banner wording is user-facing — please review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)