### PR TITLE
fix(installer): derive harness version labels from cliVersion(); sync Pi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.34] — 2026-06-18
+
+### Fixed
+
+- **Harness version labels now track the CLI version, so `librarian status`/`update`
+  tell the truth.** OpenCode's managed marker and the Hermes adapter's `plugin.yaml`
+  were hardcoded to a static `1.0.0`, and Pi's `package.json` was pinned at a stale
+  `1.0.0-rc.2` — so `librarian update` reported "already at 1.0.0" after a real update,
+  and `librarian status` showed `UPDATE? no` against a newer pre-release (semver ranks
+  `1.0.0` above `1.0.0-rc.N`, so the static label looked newer than latest). Now:
+  - **OpenCode** stamps `cliVersion()` into its managed `_librarianVersion` marker
+    (instead of the `"1.0.0"` constant).
+  - **Hermes** stamps the installed `plugin.yaml` from `cliVersion()` at install time
+    (the git-tag-fetched source value is a placeholder); detect reads it back.
+  - **Pi** — `stamp-version.mjs` now also syncs the public `integrations/pi/package.json`
+    (`@the-librarian/pi-extension`) to the root version, and it's bumped from the stale
+    `rc.2` to `rc.34`.
+
+  The plugin *content* always updated on `librarian update`; only the version labels were
+  frozen — they now move with each release.
+
 ## [1.0.0-rc.33] — 2026-06-17
 
 ### Changed
@@ -2824,6 +2845,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0-rc.34]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.33...v1.0.0-rc.34
 [1.0.0-rc.33]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.32...v1.0.0-rc.33
 [1.0.0-rc.32]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.31...v1.0.0-rc.32
 [1.0.0-rc.31]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.30...v1.0.0-rc.31

--- a/integrations/pi/package.json
+++ b/integrations/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-librarian/pi-extension",
-  "version": "1.0.0-rc.2",
+  "version": "1.0.0-rc.34",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.33",
+  "version": "1.0.0-rc.34",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/installer-cli/src/harnesses/hermes.ts
+++ b/packages/installer-cli/src/harnesses/hermes.ts
@@ -5,9 +5,11 @@
 //   - set `memory.provider = librarian` in `~/.hermes/config.json`.
 //
 //   detect    plugin dir present AND provider set to "librarian"
-//             version comes from the adapter's `plugin.yaml`
+//             version is read from the installed `plugin.yaml`, which install
+//             stamps with the CLI version (the fetched tag's value is a static
+//             placeholder) so status/update can compare installed-vs-latest
 //   uninstall remove the plugin dir + unset the provider key
-//   update    re-fetch + re-copy the adapter (idempotent)
+//   update    re-fetch + re-copy the adapter, re-stamping the version (idempotent)
 //
 // ARTIFACT SOURCING. On a user's machine the adapter does NOT live in the
 // repo — the CLI must fetch it from a pinned release. We download a tarball
@@ -138,6 +140,24 @@ function copyDir(from: string, to: string): void {
   fs.cpSync(from, to, { recursive: true });
 }
 
+/**
+ * Overwrite the copied plugin.yaml's `version:` with the CLI version, so the
+ * INSTALLED adapter reports the version that installed it. The fetched tag's
+ * source `version` is a static placeholder; `librarian status`/`update` need the
+ * real version to compare installed-vs-latest honestly. Fail-soft: a missing or
+ * odd plugin.yaml is left as-is (detect just reports no version).
+ */
+function stampAdapterVersion(pluginDir: string, version: string): void {
+  const file = path.join(pluginDir, "plugin.yaml");
+  try {
+    const raw = fs.readFileSync(file, "utf8");
+    const next = raw.replace(/^(\s*version\s*:).*$/m, `$1 ${version}`);
+    if (next !== raw) fs.writeFileSync(file, next, "utf8");
+  } catch {
+    // no plugin.yaml / unreadable — nothing to stamp.
+  }
+}
+
 export const hermes: HarnessModule = {
   id: "hermes",
   displayName: "Hermes",
@@ -155,6 +175,9 @@ export const hermes: HarnessModule = {
     // so re-running is idempotent.
     const adapterDir = await fetcher(PINNED_REF);
     copyDir(adapterDir, hermesPluginDir());
+    // Stamp the installed plugin.yaml with the CLI version (the fetched tag's
+    // source value is a static placeholder) so detect() reports it honestly.
+    stampAdapterVersion(hermesPluginDir(), cliVersion());
 
     // Set memory.provider = librarian, preserving any other config keys.
     const config = readHermesConfig() ?? {};

--- a/packages/installer-cli/src/harnesses/opencode.ts
+++ b/packages/installer-cli/src/harnesses/opencode.ts
@@ -32,7 +32,11 @@ import type { HarnessConfig, HarnessModule } from "./types.js";
 
 const SERVER_ID = "librarian";
 const TOKEN_ENV_VAR = "LIBRARIAN_AGENT_TOKEN";
-const MANAGED_VERSION = "1.0.0";
+// Stamp the CLI's own version into the managed block (DERIVED, not hardcoded)
+// so `librarian status`/`update` can compare installed-vs-latest honestly. A
+// static literal would freeze the label and — since semver ranks `1.0.0` above
+// `1.0.0-rc.N` — make status report "no update" against a newer pre-release.
+const MANAGED_VERSION = cliVersion();
 const VERSION_KEY = "_librarianVersion";
 // The exact primer instruction we added, stamped into the managed block so
 // uninstall can target only it (and not a foreign `…/primer.md`).

--- a/packages/installer-cli/tests/hermes.test.ts
+++ b/packages/installer-cli/tests/hermes.test.ts
@@ -16,6 +16,7 @@ import {
   resetHomeOverride,
   setHomeOverride,
 } from "../src/paths.js";
+import { cliVersion } from "../src/version.js";
 import { withTempHome } from "./helpers.js";
 
 const CFG = {
@@ -116,8 +117,15 @@ describe("hermes harness", () => {
       };
       expect(cfg.memory?.provider).toBe("librarian");
 
-      // detect reads the version off the copied plugin.yaml.
-      await expect(hermes.detect()).resolves.toEqual({ installed: true, version: "1.0.0" });
+      // install stamps the copied plugin.yaml with the CLI version, so detect
+      // reports cliVersion() (the fetched tag's "1.0.0" is just a placeholder).
+      expect(fs.readFileSync(path.join(hermesPluginDir(home), "plugin.yaml"), "utf8")).toContain(
+        `version: ${cliVersion()}`,
+      );
+      await expect(hermes.detect()).resolves.toEqual({
+        installed: true,
+        version: cliVersion(),
+      });
 
       // Token never lands in the config file.
       expect(fs.readFileSync(hermesConfigPath(home), "utf8")).not.toContain(CFG.token);
@@ -137,7 +145,9 @@ describe("hermes harness", () => {
       });
       await hermes.install(CFG);
       expect(calledRef).toMatch(/^v\d+\.\d+\.\d+/);
-      await expect(hermes.detect()).resolves.toEqual({ installed: true, version: "9.9.9" });
+      // install stamps the version over the fixture's "9.9.9" placeholder, so
+      // detect reports cliVersion() — the version that installed it.
+      await expect(hermes.detect()).resolves.toEqual({ installed: true, version: cliVersion() });
     });
   });
 
@@ -226,8 +236,9 @@ describe("hermes harness", () => {
       // Sibling repo files outside the adapter subtree were not extracted.
       expect(fs.existsSync(path.join(hermesPluginDir(home), "README.md"))).toBe(false);
 
-      // The full round-trip: detect() reads the version off the copied plugin.yaml.
-      await expect(hermes.detect()).resolves.toEqual({ installed: true, version: "3.2.1" });
+      // The full round-trip: install stamps the copied plugin.yaml with the CLI
+      // version (over the tarball's "3.2.1"), so detect reports cliVersion().
+      await expect(hermes.detect()).resolves.toEqual({ installed: true, version: cliVersion() });
     });
   });
 

--- a/packages/installer-cli/tests/opencode.test.ts
+++ b/packages/installer-cli/tests/opencode.test.ts
@@ -13,6 +13,7 @@ import {
   resetHomeOverride,
   setHomeOverride,
 } from "../src/paths.js";
+import { cliVersion } from "../src/version.js";
 import { withTempHome } from "./helpers.js";
 
 const CFG = {
@@ -79,7 +80,10 @@ describe("opencode harness", () => {
     await withTempHome(async (home) => {
       setHomeOverride(home);
       await opencode.install(CFG);
-      await expect(opencode.detect()).resolves.toEqual({ installed: true, version: "1.0.0" });
+      await expect(opencode.detect()).resolves.toEqual({
+        installed: true,
+        version: cliVersion(),
+      });
     });
   });
 

--- a/scripts/stamp-version.mjs
+++ b/scripts/stamp-version.mjs
@@ -37,20 +37,38 @@ export function stampPackageJson(raw, rootVersion) {
 }
 
 /**
- * Stamp every public package under `packages/` to the root version. Returns the
- * root version and the list of package dirs that changed.
+ * Public, independently-published integration manifests that live OUTSIDE
+ * `packages/` and so aren't caught by the workspace walk. The Pi extension
+ * (`@the-librarian/pi-extension`) is published by hand from the workspace
+ * (docs/release-runbook.md), so keep its version in lockstep with the root here
+ * too — otherwise its npm version drifts and `librarian status` mis-reports the
+ * installed Pi extension (a static label semver-ranks ABOVE a newer pre-release).
+ */
+export const EXTRA_MANIFESTS = ["integrations/pi/package.json"];
+
+/**
+ * Stamp every public package under `packages/` PLUS the public integration
+ * manifests in `EXTRA_MANIFESTS` to the root version. Returns the root version
+ * and the list of manifests that changed.
  */
 export function stampAll(root = repoRoot) {
   const rootVersion = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8")).version;
-  const packagesDir = path.join(root, "packages");
   const changed = [];
-  for (const entry of fs.readdirSync(packagesDir)) {
-    const file = path.join(packagesDir, entry, "package.json");
-    if (!fs.existsSync(file)) continue;
+  const stamp = (file, label) => {
+    if (!fs.existsSync(file)) return;
     const next = stampPackageJson(fs.readFileSync(file, "utf8"), rootVersion);
-    if (next === null) continue;
+    if (next === null) return;
     fs.writeFileSync(file, next);
-    changed.push(entry);
+    changed.push(label);
+  };
+  const packagesDir = path.join(root, "packages");
+  if (fs.existsSync(packagesDir)) {
+    for (const entry of fs.readdirSync(packagesDir)) {
+      stamp(path.join(packagesDir, entry, "package.json"), `packages/${entry}`);
+    }
+  }
+  for (const rel of EXTRA_MANIFESTS) {
+    stamp(path.join(root, rel), rel);
   }
   return { rootVersion, changed };
 }

--- a/test/stamp-version.test.ts
+++ b/test/stamp-version.test.ts
@@ -4,8 +4,11 @@
 // publish silently no-op'ing on the stale version (npm froze at rc.5 while the
 // root reached rc.20+). See scripts/stamp-version.mjs.
 
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { stampPackageJson } from "../scripts/stamp-version.mjs";
+import { EXTRA_MANIFESTS, stampAll, stampPackageJson } from "../scripts/stamp-version.mjs";
 
 describe("stampPackageJson", () => {
   it("stamps a public package to the root version", () => {
@@ -30,5 +33,33 @@ describe("stampPackageJson", () => {
   it("is a no-op when already at the root version (returns null)", () => {
     const raw = JSON.stringify({ name: "@the-librarian/cli", version: "1.0.0-rc.21" });
     expect(stampPackageJson(raw, "1.0.0-rc.21")).toBeNull();
+  });
+});
+
+describe("stampAll — also syncs public integration manifests", () => {
+  it("includes the Pi extension in EXTRA_MANIFESTS", () => {
+    expect(EXTRA_MANIFESTS).toContain("integrations/pi/package.json");
+  });
+
+  it("stamps a public integration manifest (the Pi extension) to the root version", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "stampall-"));
+    try {
+      fs.writeFileSync(path.join(root, "package.json"), JSON.stringify({ version: "1.0.0-rc.34" }));
+      const piDir = path.join(root, "integrations", "pi");
+      fs.mkdirSync(piDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(piDir, "package.json"),
+        JSON.stringify({ name: "@the-librarian/pi-extension", version: "1.0.0-rc.2" }),
+      );
+
+      const { rootVersion, changed } = stampAll(root);
+
+      expect(rootVersion).toBe("1.0.0-rc.34");
+      expect(changed).toContain("integrations/pi/package.json");
+      const piPkg = JSON.parse(fs.readFileSync(path.join(piDir, "package.json"), "utf8"));
+      expect(piPkg.version).toBe("1.0.0-rc.34");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Why

`librarian update` reported **"already at 1.0.0"** for OpenCode and Hermes after a real update, and `librarian status` showed **`UPDATE? no`** against `LATEST 1.0.0-rc.33` — i.e. it told you that you were current when you weren't. Root cause: the harness version *labels* were static, not tied to the release.

| Harness | Was | Why it lied |
|---|---|---|
| OpenCode | `MANAGED_VERSION = "1.0.0"` (hardcoded const) | detect always reported `1.0.0` |
| Hermes | `version:` read from the git-tag-fetched `plugin.yaml` | source value is a static `1.0.0` placeholder; `stamp-version.mjs` only syncs `packages/*` |
| Pi | `integrations/pi/package.json` pinned at `1.0.0-rc.2` | never bumped |

And because semver ranks `1.0.0` (release) **above** `1.0.0-rc.N` (pre-release), the static label looked *newer* than latest → `status` concluded "no update". **The plugin content always updated on `librarian update` (verified: an installed Hermes `capture.py`/`provider.py` was byte-identical to the rc.33 source); only the labels were frozen.**

## What (fix per each harness's actual sourcing model)

- **OpenCode** — detect reads a marker the CLI stamps into the user's `opencode.json`, so just derive it: `MANAGED_VERSION = cliVersion()`.
- **Hermes** — adapter is fetched from the git tag (static source version), so **stamp the installed `plugin.yaml`'s `version:` from `cliVersion()` at install**; detect reads it back.
- **Pi** — npm-managed (`pi install npm:@the-librarian/pi-extension`), so its version is the npm package version: **`stamp-version.mjs` now also syncs the public `integrations/pi/package.json`** to the root version (guarded for a missing `packages/` dir so it's unit-testable), and the stale `rc.2` is bumped to `rc.34`.

No behavior change to capture/install beyond the version stamp; Codex already derives its marker, and Claude is SHA-versioned.

## Tests

- OpenCode + Hermes detect tests now assert against `cliVersion()` (incl. proving the install stamp **overwrites** a fixture's `9.9.9`/`3.2.1` placeholder).
- New `stampAll` test: a public integration manifest (the Pi extension) is synced to the root version; `EXTRA_MANIFESTS` includes it.

## Gates run

`pnpm --filter @the-librarian/cli test` (309) · `pnpm vitest run` (root, 200) · `pnpm typecheck` (all workspaces) · eslint + prettier · `pnpm check:release` — all green.

## Notes

- **rc.34**, dated 2026-06-18, follows #396/#397 (rc.32/rc.33) which are now merged.
- Opened as **draft** (authored autonomously) — please review before merge. After it lands, `librarian status`/`update` will finally report honest version transitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)