### PR TITLE
fix(installer): extract capture adapters portably (drop GNU-only tar --wildcards)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.35] — 2026-06-18
+
+### Fixed
+
+- **`librarian install` now wires the Codex/OpenCode/Hermes capture adapters on
+  non-GNU tar (macOS), not just on Linux.** The installer fetches each adapter from
+  the pinned release tarball and extracted one subtree with
+  `tar --strip-components=N --wildcards '*/integrations/<harness>/*'`. `--wildcards`
+  is a GNU-tar-only flag: BSD/libarchive tar (the `/usr/bin/tar` on macOS) rejects it
+  outright (`tar: Option --wildcards is not supported`) and busybox tar lacks it too,
+  so those three harnesses failed to install on every non-GNU box
+  (`Failed to extract <Harness> capture adapter: …`). Extraction now uses only the
+  universally-supported `-xzf`/`-C` flags and locates the wanted subtree on the
+  filesystem (new `packages/installer-cli/src/archive.ts`), with no tar-flavour
+  detection. Regression test round-trips a real codeload-shaped tarball through the
+  host `tar` and pins that the invocation carries none of the GNU-only flags.
+
 ## [1.0.0-rc.34] — 2026-06-18
 
 ### Fixed
@@ -2845,6 +2862,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0-rc.35]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.34...v1.0.0-rc.35
 [1.0.0-rc.34]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.33...v1.0.0-rc.34
 [1.0.0-rc.33]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.32...v1.0.0-rc.33
 [1.0.0-rc.32]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.31...v1.0.0-rc.32

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.34",
+  "version": "1.0.0-rc.35",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/installer-cli/src/archive.ts
+++ b/packages/installer-cli/src/archive.ts
@@ -1,0 +1,66 @@
+// Portable extraction of a single integration subtree out of a GitHub
+// codeload tarball.
+//
+// The harness capture adapters (Codex / OpenCode / Hermes) don't ship inside
+// their plugin packages — the installer downloads the pinned release tarball
+// from codeload and copies one `integrations/<harness>/…` subtree out of it.
+//
+// History: the original approach selected members directly with
+//   tar -xzf t -C out --strip-components=N --wildcards '*/integrations/<h>/*'
+// That is GNU-tar-only. BSD/libarchive tar (the `/usr/bin/tar` on macOS)
+// rejects the flag outright — `tar: Option --wildcards is not supported` —
+// and busybox tar lacks it too, so the Codex/OpenCode/Hermes steps failed on
+// every non-GNU box. (GNU tar needs `--wildcards` to glob member names on
+// extract; BSD tar globs by default and has no such flag — there is no single
+// flag set that means "glob members" on both.)
+//
+// Fix: extract the whole archive using only the universally-supported
+// `-xzf`/`-C` flags, then locate the wanted subtree with the filesystem. No
+// `--wildcards`, no `--strip-components`, no tar-flavour detection.
+
+import fs from "node:fs";
+import path from "node:path";
+import { run } from "./exec.js";
+
+/**
+ * Extract `subPath` (a POSIX path *inside* the repo root, e.g.
+ * `integrations/codex`) out of a codeload `.tar.gz` and return the absolute
+ * path to it. The returned directory's CONTENTS are the subtree's contents —
+ * matching the old `--strip-components` semantics, so callers copy from the
+ * returned path unchanged.
+ *
+ * @param tarball  path to the downloaded `.tar.gz`
+ * @param work     scratch dir to extract into (caller owns its lifecycle)
+ * @param subPath  POSIX subtree path inside the repo root, e.g. `integrations/codex`
+ * @throws if tar exits non-zero, the tarball layout is unexpected, or the
+ *         requested subtree is absent — with a message safe to show the user.
+ */
+export async function extractAdapterSubtree(
+  tarball: string,
+  work: string,
+  subPath: string,
+): Promise<string> {
+  const raw = path.join(work, "raw");
+  fs.mkdirSync(raw, { recursive: true });
+
+  // Only `-xzf`/`-C` — supported by GNU tar, BSD/libarchive tar, and busybox.
+  const extract = await run("tar", ["-xzf", tarball, "-C", raw]);
+  if (extract.code !== 0) {
+    throw new Error((extract.stderr || "").trim() || `tar exited with code ${extract.code}`);
+  }
+
+  // codeload wraps everything in a single top-level dir whose name depends on
+  // the ref (GitHub strips a leading `v` from tags: `v1.2.3` → `…-1.2.3`), so
+  // discover it rather than hardcode it.
+  const tops = fs.readdirSync(raw).filter((e) => !e.startsWith("."));
+  const top = tops.length === 1 ? tops[0] : tops.find((e) => e.startsWith("the-librarian-"));
+  if (!top) {
+    throw new Error(`unexpected tarball layout (top-level entries: ${tops.join(", ") || "none"})`);
+  }
+
+  const dir = path.join(raw, top, ...subPath.split("/"));
+  if (!fs.existsSync(dir)) {
+    throw new Error(`adapter path '${subPath}' not found under '${top}' in tarball`);
+  }
+  return dir;
+}

--- a/packages/installer-cli/src/harnesses/codex.ts
+++ b/packages/installer-cli/src/harnesses/codex.ts
@@ -19,6 +19,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { extractAdapterSubtree } from "../archive.js";
 import { run, which } from "../exec.js";
 import { codexCaptureDir, codexConfigPath, codexHooksPath } from "../paths.js";
 import { cliVersion } from "../version.js";
@@ -170,24 +171,15 @@ const defaultCaptureFetcher: CaptureFetcher = async (ref) => {
   }
   const buf = Buffer.from(await res.arrayBuffer());
   fs.writeFileSync(tarball, buf);
-  // codeload nests the integration at `the-librarian-<ref>/integrations/codex/**`
-  // — three leading path components. Strip them so `scripts/` + `hooks/` land at
-  // the extraction root, which is what the caller copies into ~/.librarian/.
-  const out = path.join(work, "adapter");
-  fs.mkdirSync(out, { recursive: true });
-  const extract = await run("tar", [
-    "-xzf",
-    tarball,
-    "-C",
-    out,
-    "--strip-components=3",
-    "--wildcards",
-    "*/integrations/codex/*",
-  ]);
-  if (extract.code !== 0) {
-    throw new Error(`Failed to extract Codex capture adapter: ${(extract.stderr || "").trim()}`);
+  // codeload nests the integration at `the-librarian-<ref>/integrations/codex/**`;
+  // the returned dir holds its contents (`scripts/` + `hooks/`), which is what
+  // the caller copies into ~/.librarian/.
+  try {
+    return await extractAdapterSubtree(tarball, work, "integrations/codex");
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to extract Codex capture adapter: ${msg}`);
   }
-  return out;
 };
 
 let captureFetcher: CaptureFetcher = defaultCaptureFetcher;

--- a/packages/installer-cli/src/harnesses/hermes.ts
+++ b/packages/installer-cli/src/harnesses/hermes.ts
@@ -23,7 +23,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { run } from "../exec.js";
+import { extractAdapterSubtree } from "../archive.js";
 import { hermesConfigPath, hermesHomeDir, hermesPluginDir } from "../paths.js";
 import { cliVersion } from "../version.js";
 import type { HarnessConfig, HarnessModule } from "./types.js";
@@ -58,24 +58,14 @@ const defaultFetcher: AdapterFetcher = async (ref) => {
   fs.writeFileSync(tarball, buf);
   // codeload nests the adapter at
   //   the-librarian-<ref>/integrations/hermes/librarian/**
-  // — four leading path components. Strip all four so the adapter's own
-  // files (plugin.yaml, …) land at the extraction root, which is what the
-  // caller copies into `~/.hermes/plugins/librarian/`.
-  const out = path.join(work, "adapter");
-  fs.mkdirSync(out, { recursive: true });
-  const extract = await run("tar", [
-    "-xzf",
-    tarball,
-    "-C",
-    out,
-    "--strip-components=4",
-    "--wildcards",
-    "*/integrations/hermes/librarian/*",
-  ]);
-  if (extract.code !== 0) {
-    throw new Error(`Failed to extract Hermes adapter: ${(extract.stderr || "").trim()}`);
+  // the returned dir holds its contents (the adapter's own files: plugin.yaml,
+  // …), which is what the caller copies into `~/.hermes/plugins/librarian/`.
+  try {
+    return await extractAdapterSubtree(tarball, work, "integrations/hermes/librarian");
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to extract Hermes adapter: ${msg}`);
   }
-  return out;
 };
 
 let fetcher: AdapterFetcher = defaultFetcher;

--- a/packages/installer-cli/src/harnesses/opencode.ts
+++ b/packages/installer-cli/src/harnesses/opencode.ts
@@ -25,7 +25,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { run } from "../exec.js";
+import { extractAdapterSubtree } from "../archive.js";
 import { opencodeCaptureDir, opencodeConfigPath } from "../paths.js";
 import { cliVersion } from "../version.js";
 import type { HarnessConfig, HarnessModule } from "./types.js";
@@ -151,24 +151,15 @@ const defaultCaptureFetcher: CaptureFetcher = async (ref) => {
   }
   const buf = Buffer.from(await res.arrayBuffer());
   fs.writeFileSync(tarball, buf);
-  // codeload nests the integration at `the-librarian-<ref>/integrations/opencode/**`
-  // — three leading path components. Strip them so `plugin/` lands at the
-  // extraction root, which is what the caller copies into ~/.librarian/.
-  const out = path.join(work, "adapter");
-  fs.mkdirSync(out, { recursive: true });
-  const extract = await run("tar", [
-    "-xzf",
-    tarball,
-    "-C",
-    out,
-    "--strip-components=3",
-    "--wildcards",
-    "*/integrations/opencode/*",
-  ]);
-  if (extract.code !== 0) {
-    throw new Error(`Failed to extract OpenCode capture adapter: ${(extract.stderr || "").trim()}`);
+  // codeload nests the integration at `the-librarian-<ref>/integrations/opencode/**`;
+  // the returned dir holds its contents (`plugin/`), which is what the caller
+  // copies into ~/.librarian/.
+  try {
+    return await extractAdapterSubtree(tarball, work, "integrations/opencode");
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to extract OpenCode capture adapter: ${msg}`);
   }
-  return out;
 };
 
 let captureFetcher: CaptureFetcher = defaultCaptureFetcher;

--- a/packages/installer-cli/tests/archive.test.ts
+++ b/packages/installer-cli/tests/archive.test.ts
@@ -1,0 +1,181 @@
+// Portable codeload-subtree extraction (src/archive.ts).
+//
+// Regression for the GNU-only `tar --wildcards` bug: the Codex/OpenCode/Hermes
+// capture-adapter fetchers selected members with
+//   tar --strip-components=N --wildcards '*/integrations/<h>/*'
+// which BSD/libarchive tar (macOS `/usr/bin/tar`) rejects outright
+//   tar: Option --wildcards is not supported
+// so `librarian install` failed every harness that fetched its adapter on a
+// non-GNU box. The fix extracts the whole archive with only `-xzf`/`-C` and
+// locates the subtree via the filesystem.
+//
+// Two layers of coverage:
+//   1. integration — round-trip a real codeload-shaped tarball through the host
+//      `tar` (GNU here, BSD on a contributor's mac) and assert the subtree lands.
+//   2. portability guard — assert the tar invocation carries NONE of the
+//      GNU-only flags. This one fails against the old code on EVERY platform,
+//      including the GNU-tar CI where the integration test alone would pass.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { extractAdapterSubtree } from "../src/archive.js";
+import { resetRunner, run, setRunner } from "../src/exec.js";
+import type { RunOptions, RunResult, Runner } from "../src/exec.js";
+
+const TOP = "the-librarian-1.0.0-rc.99"; // codeload strips the leading `v` from the tag
+const tmpDirs: string[] = [];
+
+function tmp(prefix: string): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tmpDirs.push(d);
+  return d;
+}
+
+/** Build a codeload-shaped `.tar.gz` (single top dir) with the REAL `tar`. */
+async function makeCodeloadTarball(): Promise<string> {
+  const stage = tmp("librarian-archive-stage-");
+  const repo = path.join(stage, TOP);
+  fs.mkdirSync(path.join(repo, "integrations", "codex", "scripts", "lib"), { recursive: true });
+  fs.mkdirSync(path.join(repo, "integrations", "codex", "hooks"), { recursive: true });
+  fs.mkdirSync(path.join(repo, "integrations", "hermes", "librarian"), { recursive: true });
+  fs.writeFileSync(path.join(repo, "README.md"), "# repo root, NOT part of any subtree\n");
+  fs.writeFileSync(
+    path.join(repo, "integrations", "codex", "scripts", "on-stop.mjs"),
+    "// entry\n",
+  );
+  fs.writeFileSync(path.join(repo, "integrations", "codex", "hooks", "codex-hooks.json"), "{}\n");
+  fs.writeFileSync(
+    path.join(repo, "integrations", "hermes", "librarian", "plugin.yaml"),
+    "name: x\n",
+  );
+
+  const tarball = path.join(stage, "src.tar.gz");
+  resetRunner(); // use the real, process-spawning runner
+  const res = await run("tar", ["-czf", tarball, "-C", stage, TOP]);
+  expect(res.code, `tar -czf failed: ${res.stderr}`).toBe(0);
+  return tarball;
+}
+
+afterEach(() => {
+  resetRunner();
+  while (tmpDirs.length) fs.rmSync(tmpDirs.pop() as string, { recursive: true, force: true });
+});
+
+describe("extractAdapterSubtree — real tar round-trip", () => {
+  it("returns the subtree's CONTENTS, not the repo root or the subtree dir", async () => {
+    const tarball = await makeCodeloadTarball();
+    const out = await extractAdapterSubtree(
+      tarball,
+      tmp("librarian-archive-out-"),
+      "integrations/codex",
+    );
+
+    // Strip semantics: the returned dir IS `integrations/codex`, so its
+    // immediate children are that subtree's children — and the repo-root
+    // README is nowhere underneath it.
+    expect(fs.readdirSync(out).sort()).toEqual(["hooks", "scripts"]);
+    expect(fs.existsSync(path.join(out, "scripts", "on-stop.mjs"))).toBe(true);
+    expect(fs.existsSync(path.join(out, "scripts", "lib"))).toBe(true);
+    expect(fs.readFileSync(path.join(out, "hooks", "codex-hooks.json"), "utf8")).toBe("{}\n");
+    expect(fs.existsSync(path.join(out, "README.md"))).toBe(false);
+  });
+
+  it("handles a deeper subtree (Hermes' integrations/hermes/librarian)", async () => {
+    const tarball = await makeCodeloadTarball();
+    const out = await extractAdapterSubtree(
+      tarball,
+      tmp("librarian-archive-out-"),
+      "integrations/hermes/librarian",
+    );
+    expect(fs.readFileSync(path.join(out, "plugin.yaml"), "utf8")).toBe("name: x\n");
+  });
+
+  it("throws a clear error when the requested subtree is absent", async () => {
+    const tarball = await makeCodeloadTarball();
+    await expect(
+      extractAdapterSubtree(tarball, tmp("librarian-archive-out-"), "integrations/nope"),
+    ).rejects.toThrow(/integrations\/nope.*not found/);
+  });
+});
+
+// A runner that records the tar invocation and fabricates the extraction it
+// implies (so the fs-discovery half of the helper still runs) — without
+// spawning anything. Lets us pin the EXACT flags on any platform.
+class ExtractFakeRunner implements Runner {
+  readonly calls: { cmd: string; args: string[] }[] = [];
+  // extra non-dot top-level siblings to drop alongside the repo dir (exercises
+  // the "more than one entry → pick the-librarian-*" discovery branch)
+  constructor(private readonly siblings: string[] = []) {}
+
+  async run(cmd: string, args: readonly string[], _opts?: RunOptions): Promise<RunResult> {
+    this.calls.push({ cmd, args: [...args] });
+    const dashC = args.indexOf("-C");
+    if (cmd === "tar" && dashC !== -1) {
+      const dest = args[dashC + 1] as string;
+      fs.mkdirSync(path.join(dest, TOP, "integrations", "codex", "scripts"), { recursive: true });
+      fs.writeFileSync(
+        path.join(dest, TOP, "integrations", "codex", "scripts", "on-stop.mjs"),
+        "x",
+      );
+      for (const s of this.siblings) fs.mkdirSync(path.join(dest, s), { recursive: true });
+    }
+    return { stdout: "", stderr: "", code: 0 };
+  }
+  async which(): Promise<string | null> {
+    return null;
+  }
+}
+
+describe("extractAdapterSubtree — portability guard (flags)", () => {
+  it("invokes tar with ONLY universally-supported flags — no --wildcards, no --strip-components", async () => {
+    const fake = new ExtractFakeRunner();
+    setRunner(fake);
+    await extractAdapterSubtree(
+      tmp("librarian-archive-out-") + "/src.tar.gz",
+      tmp("librarian-archive-out-"),
+      "integrations/codex",
+    );
+
+    const tarCalls = fake.calls.filter((c) => c.cmd === "tar");
+    expect(tarCalls).toHaveLength(1);
+    const args = tarCalls[0].args;
+    expect(args).toContain("-xzf");
+    expect(args).toContain("-C");
+    // The bug, and the flags that caused it:
+    expect(args).not.toContain("--wildcards");
+    expect(args.some((a) => a.startsWith("--strip-components"))).toBe(false);
+    // No member-glob pattern is passed to tar at all (we select via the fs).
+    expect(args.some((a) => a.includes("*/integrations/"))).toBe(false);
+  });
+
+  it("discovers the repo dir even when sibling top-level entries exist", async () => {
+    const fake = new ExtractFakeRunner(["pax_global_header_junk", "ignored-dir"]);
+    setRunner(fake);
+    const out = await extractAdapterSubtree(
+      tmp("librarian-archive-out-") + "/src.tar.gz",
+      tmp("librarian-archive-out-"),
+      "integrations/codex",
+    );
+    expect(fs.existsSync(path.join(out, "scripts", "on-stop.mjs"))).toBe(true);
+  });
+
+  it("wraps a non-zero tar exit in the error (stderr surfaced)", async () => {
+    setRunner({
+      async run() {
+        return { stdout: "", stderr: "tar: Option --wildcards is not supported", code: 1 };
+      },
+      async which() {
+        return null;
+      },
+    });
+    await expect(
+      extractAdapterSubtree(
+        "/nope/src.tar.gz",
+        tmp("librarian-archive-out-"),
+        "integrations/codex",
+      ),
+    ).rejects.toThrow(/Option --wildcards is not supported/);
+  });
+});


### PR DESCRIPTION
## Problem

`librarian install` wires up `claude` and `pi` fine but fails the Codex / OpenCode / Hermes capture adapters on **non-GNU tar** (notably macOS):

```
Failed codex: Failed to extract Codex capture adapter: tar: Option --wildcards is not supported
```

Each of those three fetchers downloads the pinned codeload release tarball and extracted one `integrations/<harness>/…` subtree with:

```
tar --strip-components=N --wildcards '*/integrations/<harness>/*'
```

`--wildcards` is a **GNU-tar-only** flag. BSD/libarchive tar (the `/usr/bin/tar` on macOS) rejects it outright, and busybox tar lacks it too. There is no single flag set meaning "glob members on extract" across GNU and BSD (GNU needs `--wildcards`; BSD globs by default and has no such flag), so the old path was GNU-only by accident.

It shipped untested because the default fetchers are injectable and every existing test stubbed them — the real extraction path never ran in CI.

## Fix

New `packages/installer-cli/src/archive.ts` → `extractAdapterSubtree(tarball, work, subPath)`:

- Extracts the whole archive with only the universally-supported `-xzf` / `-C` flags.
- Locates the wanted subtree on the filesystem, discovering the single codeload top-level dir (whose name has the leading `v` stripped from the tag).
- No `--wildcards`, no `--strip-components`, no tar-flavour detection.

The three `harnesses/{codex,opencode,hermes}.ts` fetchers now call it. User-facing error-message prefixes are preserved.

## Tests

New `tests/archive.test.ts` (6 tests):

- **Integration** — round-trips a real codeload-shaped tarball through the host `tar` and asserts the subtree (and only the subtree) lands.
- **Portability guard** — pins, via a recording runner, that the tar invocation carries none of the GNU-only flags. This assertion **fails against the old code even on GNU-tar CI**, where the integration test alone would have passed — closing the gap that let the bug ship.

Verified locally: full installer-cli suite **315 passing**, typecheck clean, eslint 0, prettier clean, `check:release` green.

## Release

Bumps root `package.json` rc.34 → **rc.35** with a dated, linked CHANGELOG entry (per the every-PR-is-a-release rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AUvAgc8mLAmd5mvtg2gB8f