### PR TITLE
fix(dashboard): vault history/tree + memories overlay UI fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.36] — 2026-06-18
+
+### Fixed
+
+- **Vault history: the "Restore this version" button no longer appears on the
+  latest version.** The current version is the head of the file's history, so
+  there is nothing to restore it to — the action now shows only on older
+  versions (`apps/dashboard/components/vault/file-history.tsx`).
+- **Vault file tree now opens collapsed.** Directories rendered expanded by
+  default; they now start collapsed and the user expands what they want. An
+  active filter still force-opens directories so matches stay visible
+  (`apps/dashboard/components/vault/file-tree.tsx`).
+- **`/memories`: the mobile detail bottom-sheet no longer duplicates the
+  desktop right rail.** The sheet is a Radix dialog that portals to `<body>`,
+  so the `lg:hidden` wrapper never reached it and an open dialog kept trapping
+  focus on desktop. Its `open` state is now gated on the `lg` breakpoint in JS
+  via a new `useMediaQuery` hook, so on desktop only the Inspector rail shows
+  (`apps/dashboard/components/memories/view.tsx`, `apps/dashboard/hooks/use-media-query.ts`).
+
 ## [1.0.0-rc.35] — 2026-06-18
 
 ### Fixed
@@ -2862,6 +2881,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0-rc.36]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.35...v1.0.0-rc.36
 [1.0.0-rc.35]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.34...v1.0.0-rc.35
 [1.0.0-rc.34]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.33...v1.0.0-rc.34
 [1.0.0-rc.33]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.32...v1.0.0-rc.33

--- a/apps/dashboard/components/memories/view.tsx
+++ b/apps/dashboard/components/memories/view.tsx
@@ -15,6 +15,7 @@ import { EmptyState } from "@/components/brand/empty-state";
 import { Button } from "@/components/ui-v2/button";
 import { KeyHint } from "@/components/ui-v2/key-hint";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui-v2/tabs";
+import { useMediaQuery } from "@/hooks/use-media-query";
 import { useSurfaceShortcuts } from "@/hooks/use-surface-shortcuts";
 import { trpc } from "@/lib/trpc-client";
 
@@ -38,6 +39,9 @@ export function MemoriesView() {
   const [bulkSelection, setBulkSelection] = useState<Set<string>>(new Set());
   const [showRehome, setShowRehome] = useState(false);
   const [rehomeToast, setRehomeToast] = useState<string | null>(null);
+  // lg breakpoint (1024px): on desktop the Inspector right rail shows the
+  // detail, so the mobile bottom sheet must stay closed (see its render below).
+  const isDesktop = useMediaQuery("(min-width: 1024px)");
 
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const recallInputRef = useRef<HTMLInputElement | null>(null);
@@ -425,23 +429,22 @@ export function MemoriesView() {
         />
       </div>
 
-      {/* Mobile detail-view — slides up from the bottom. Hidden at
-          lg+ via the parent grid (the Inspector right rail takes
-          over). Wrapped in `lg:hidden` so the sheet's portaled DOM
-          is also removed from the tree on desktop. */}
-      <div className="lg:hidden">
-        <MemoryBottomSheet
-          memory={selected}
-          open={!!selected}
-          onOpenChange={(next) => {
-            if (!next) setSelectedId(null);
-          }}
-          onMutated={() => {
-            listQuery.refetch();
-            if (recallResults) setRecallResults(null);
-          }}
-        />
-      </div>
+      {/* Mobile detail-view — slides up from the bottom. On lg+ the Inspector
+          right rail takes over, so the sheet must NOT open. A `lg:hidden`
+          wrapper can't do this: the sheet portals to <body>, so the class
+          never reaches it and an open Radix dialog would still trap focus on
+          desktop. Gate `open` on the breakpoint in JS instead. */}
+      <MemoryBottomSheet
+        memory={selected}
+        open={!!selected && !isDesktop}
+        onOpenChange={(next) => {
+          if (!next) setSelectedId(null);
+        }}
+        onMutated={() => {
+          listQuery.refetch();
+          if (recallResults) setRecallResults(null);
+        }}
+      />
 
       <RehomeModal
         open={showRehome}

--- a/apps/dashboard/components/vault/file-history.tsx
+++ b/apps/dashboard/components/vault/file-history.tsx
@@ -104,8 +104,11 @@ export function FileHistory({ path, actions }: { path: string; actions: HistoryA
 
   return (
     <ol aria-label="File history" className="flex min-w-0 flex-col border-t border-ink-hairline">
-      {commits.map((commit) => {
+      {commits.map((commit, index) => {
         const isOpen = expanded === commit.hash;
+        // Commits are newest-first, so index 0 is the current version — there's
+        // nothing to restore it to, so the Restore action is hidden there.
+        const isLatest = index === 0;
         const regionId = `commit-${commit.hash.slice(0, 12)}`;
         return (
           <li key={commit.hash} className="border-b border-ink-hairline">
@@ -140,11 +143,13 @@ export function FileHistory({ path, actions }: { path: string; actions: HistoryA
                   <span className="font-mono text-xs text-foreground/50">
                     What this version changed
                   </span>
-                  <RestoreVersionDialog
-                    path={path}
-                    hash={commit.hash}
-                    onRestore={actions.restoreVersion}
-                  />
+                  {isLatest ? null : (
+                    <RestoreVersionDialog
+                      path={path}
+                      hash={commit.hash}
+                      onRestore={actions.restoreVersion}
+                    />
+                  )}
                 </div>
                 {diff === null ? (
                   <p className="text-sm text-muted-foreground">Loading diff…</p>

--- a/apps/dashboard/components/vault/file-tree.tsx
+++ b/apps/dashboard/components/vault/file-tree.tsx
@@ -53,14 +53,14 @@ function TreeNode({
   forceOpen: boolean;
 }) {
   if (node.type === "dir") {
-    // Default: render `<details open>` (open by default, user can collapse).
-    // When `forceOpen` is true we re-mount via the `key` so any user-applied
-    // collapse is discarded and the dir's matches become visible — toggling
-    // the `open` attribute imperatively after user interaction desyncs with
-    // browser state, so re-mount is the predictable fix.
+    // Default: render `<details>` collapsed (the user expands what they want).
+    // When `forceOpen` is true (an active filter) we re-mount via the `key` and
+    // open the dir so its matches are visible — toggling the `open` attribute
+    // imperatively after user interaction desyncs with browser state, so
+    // re-mount is the predictable fix.
     return (
       <li>
-        <details key={forceOpen ? "forced-open" : "user"} open>
+        <details key={forceOpen ? "forced-open" : "user"} open={forceOpen}>
           <summary className="cursor-pointer select-none px-2 py-1 font-medium text-foreground/80 pointer-coarse:min-h-11 pointer-coarse:py-3 pointer-coarse:text-base">
             {node.name}/
           </summary>

--- a/apps/dashboard/hooks/use-media-query.ts
+++ b/apps/dashboard/hooks/use-media-query.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Track whether a CSS media query currently matches. SSR-safe: returns `false`
+ * on the server and on the first client render, then syncs after mount.
+ *
+ * Use this to gate behaviour that a CSS `lg:hidden` class can't reach — most
+ * notably portaled overlays (Radix Dialog/Popover render to `document.body`,
+ * so a breakpoint class on a wrapper never touches the portaled nodes, and an
+ * `open` dialog still traps focus even when visually hidden). Gate `open` on
+ * the query instead.
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() =>
+    typeof window === "undefined" ? false : window.matchMedia(query).matches,
+  );
+
+  useEffect(() => {
+    const mql = window.matchMedia(query);
+    const onChange = () => setMatches(mql.matches);
+    onChange();
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, [query]);
+
+  return matches;
+}

--- a/apps/dashboard/tests/components/hooks/use-media-query.test.tsx
+++ b/apps/dashboard/tests/components/hooks/use-media-query.test.tsx
@@ -1,0 +1,53 @@
+// useMediaQuery — SSR-safe media-query hook used to gate portaled overlays
+// (e.g. the /memories mobile bottom sheet must not open on desktop, where a
+// `lg:hidden` wrapper can't reach the portaled Radix dialog).
+
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useMediaQuery } from "@/hooks/use-media-query";
+
+/** Install a controllable matchMedia whose `matches` we can flip at will. */
+function installMatchMedia(initial: boolean) {
+  let matches = initial;
+  const listeners = new Set<() => void>();
+  const mql = {
+    get matches() {
+      return matches;
+    },
+    media: "",
+    onchange: null,
+    addEventListener: (_: string, cb: () => void) => listeners.add(cb),
+    removeEventListener: (_: string, cb: () => void) => listeners.delete(cb),
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  };
+  window.matchMedia = ((query: string) => {
+    mql.media = query;
+    return mql as unknown as MediaQueryList;
+  }) as typeof window.matchMedia;
+  return {
+    set(next: boolean) {
+      matches = next;
+      for (const cb of listeners) cb();
+    },
+  };
+}
+
+describe("useMediaQuery", () => {
+  it("returns the initial match state", () => {
+    installMatchMedia(true);
+    const { result } = renderHook(() => useMediaQuery("(min-width: 1024px)"));
+    expect(result.current).toBe(true);
+  });
+
+  it("updates when the media query starts/stops matching", () => {
+    const ctl = installMatchMedia(false);
+    const { result } = renderHook(() => useMediaQuery("(min-width: 1024px)"));
+    expect(result.current).toBe(false);
+    act(() => ctl.set(true));
+    expect(result.current).toBe(true);
+    act(() => ctl.set(false));
+    expect(result.current).toBe(false);
+  });
+});

--- a/apps/dashboard/tests/components/vault/file-history.test.tsx
+++ b/apps/dashboard/tests/components/vault/file-history.test.tsx
@@ -90,14 +90,15 @@ describe("FileHistory", () => {
   it("restore asks for confirmation before calling the action, then refreshes", async () => {
     const acts = actions();
     render(<FileHistory path="references/doc.md" actions={acts} />);
-    await userEvent.click(await screen.findByText("vault: edit references/doc.md"));
+    // Restore lives on older versions; the oldest commit ("create") is one.
+    await userEvent.click(await screen.findByText("vault: create references/doc.md"));
     await userEvent.click(await screen.findByRole("button", { name: "Restore this version" }));
     expect(acts.restoreVersion).not.toHaveBeenCalled(); // dialog first, never direct
     await userEvent.click(await screen.findByRole("button", { name: "Restore version" }));
     await vi.waitFor(() =>
       expect(acts.restoreVersion).toHaveBeenCalledWith({
         path: "references/doc.md",
-        hash: "b".repeat(40),
+        hash: "a".repeat(40),
       }),
     );
     await vi.waitFor(() => expect(refreshMock).toHaveBeenCalled());
@@ -112,10 +113,24 @@ describe("FileHistory", () => {
         "Open the file in the editor and bring the old content forward manually instead.",
     });
     render(<FileHistory path="memories/legacy.md" actions={acts} />);
-    await userEvent.click(await screen.findByText("vault: edit references/doc.md"));
+    await userEvent.click(await screen.findByText("vault: create references/doc.md"));
     await userEvent.click(await screen.findByRole("button", { name: "Restore this version" }));
     await userEvent.click(await screen.findByRole("button", { name: "Restore version" }));
     expect(await screen.findByRole("alert")).toHaveTextContent(/bring the old content forward/);
+  });
+
+  it("hides Restore on the latest version — there's nothing to restore it to", async () => {
+    render(<FileHistory path="references/doc.md" actions={actions()} />);
+    // Commits are newest-first, so the first row is the current version.
+    await userEvent.click(await screen.findByText("vault: edit references/doc.md"));
+    expect(await screen.findByLabelText("Unified diff")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Restore this version" })).not.toBeInTheDocument();
+  });
+
+  it("shows Restore on older versions", async () => {
+    render(<FileHistory path="references/doc.md" actions={actions()} />);
+    await userEvent.click(await screen.findByText("vault: create references/doc.md"));
+    expect(await screen.findByRole("button", { name: "Restore this version" })).toBeInTheDocument();
   });
 });
 

--- a/apps/dashboard/tests/components/vault/file-tree.test.tsx
+++ b/apps/dashboard/tests/components/vault/file-tree.test.tsx
@@ -48,4 +48,14 @@ describe("FileTree", () => {
     render(<FileTree nodes={[]} selectedPath={null} />);
     expect(screen.getByText(/vault is empty/i)).toBeInTheDocument();
   });
+
+  it("renders directories collapsed by default", () => {
+    render(<FileTree nodes={tree} selectedPath={null} />);
+    expect(screen.getByText("memories/").closest("details")).not.toHaveAttribute("open");
+  });
+
+  it("opens directories when forceOpen is set (active filter)", () => {
+    render(<FileTree nodes={tree} selectedPath={null} forceOpen />);
+    expect(screen.getByText("memories/").closest("details")).toHaveAttribute("open");
+  });
 });

--- a/apps/dashboard/tests/setup.ts
+++ b/apps/dashboard/tests/setup.ts
@@ -2,6 +2,23 @@ import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
 import { afterEach } from "vitest";
 
+// jsdom doesn't implement matchMedia; provide a no-op default (matches: false)
+// so components that read a media query (useMediaQuery) render in tests.
+// Individual tests can override window.matchMedia with a controllable mock.
+if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
+  window.matchMedia = (query: string) =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }) as MediaQueryList;
+}
+
 afterEach(() => {
   cleanup();
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.35",
+  "version": "1.0.0-rc.36",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Three independent, low-risk dashboard UI fixes (items 1, 5, 7 of a batch).

## 1. Vault history — hide "Restore this version" on the latest version
The current version is the head of the file's history, so there's nothing to restore it to. The Restore action now renders only on older versions.
`apps/dashboard/components/vault/file-history.tsx`

## 2. Vault file tree — collapsed by default
Directories rendered expanded (`<details open>`); they now start collapsed and the user expands what they want. An active filter still force-opens directories (via the existing `forceOpen` re-mount) so matches stay visible.
`apps/dashboard/components/vault/file-tree.tsx`

## 3. /memories — mobile bottom-sheet duplicated the desktop right rail
The bottom sheet is a Radix dialog that **portals to `<body>`**, so the intended `lg:hidden` wrapper never reached the portaled nodes — and an `open` dialog kept **trapping focus** on desktop even if visually hidden. A CSS class can't fix a portaled, focus-trapping dialog, so its `open` state is now gated on the `lg` breakpoint in JS via a new SSR-safe `useMediaQuery` hook; the inert wrapper is removed. On desktop only the Inspector rail shows.
`apps/dashboard/components/memories/view.tsx`, `apps/dashboard/hooks/use-media-query.ts`

## Tests
- file-history: latest-hides / older-shows Restore coverage (and existing restore tests retargeted to an older commit).
- file-tree: collapsed-by-default + force-open coverage.
- useMediaQuery: unit test with a controllable matchMedia.
- Adds a jsdom `matchMedia` no-op default to `tests/setup.ts` so media-query components render in tests.

Verified locally: dashboard typecheck clean, affected tests pass (17), eslint + prettier clean, `check:release` green. Bumps rc.35 → rc.36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AUvAgc8mLAmd5mvtg2gB8f