### PR TITLE
feat(dashboard): curator chat suggestions match real capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.37] — 2026-06-18
+
+### Changed
+
+- **Curator chat "Try asking" suggestions now match what the chat can actually
+  do.** The prompts offered things the chat has no way to answer — it has no
+  tools and no live data access (no inbox query, no run logs, no corpus search) —
+  e.g. "What's in the inbox right now?" and "Why was the last grooming run
+  skipped?". They're replaced with capability-aligned prompts chosen by context:
+  questions about the grounded memory (and the merge/split/update proposals the
+  chat can raise) when opened from a memory, and job-understanding / addendum
+  drafting in the general chat (`apps/dashboard/components/curator/chat-panel.tsx`).
+
 ## [1.0.0-rc.36] — 2026-06-18
 
 ### Fixed
@@ -2881,6 +2894,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0-rc.37]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.36...v1.0.0-rc.37
 [1.0.0-rc.36]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.35...v1.0.0-rc.36
 [1.0.0-rc.35]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.34...v1.0.0-rc.35
 [1.0.0-rc.34]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.33...v1.0.0-rc.34

--- a/apps/dashboard/components/curator/chat-panel.tsx
+++ b/apps/dashboard/components/curator/chat-panel.tsx
@@ -52,16 +52,32 @@ interface ActionEntry {
 
 type Entry = { kind: "text"; role: "user" | "assistant" | "system"; text: string } | ActionEntry;
 
-const EXAMPLE_PROMPTS: Record<ChatJob, readonly string[]> = {
+// Suggestions the curator can ACTUALLY act on. The chat has no tools and no
+// live data access — no inbox query, no run logs, no corpus-wide search. It can
+// only (a) reason about the one memory it's grounded in, when opened from one,
+// and (b) draft/refine the job's operator-guidance addendum, or explain how the
+// job decides. Prompts are chosen to match that, so they don't over-promise.
+//
+// Grounded chat (opened from a specific memory) — about THAT memory, and the
+// merge/split/update proposals the chat can put up for confirmation.
+const GROUNDED_PROMPTS: readonly string[] = [
+  "Is this memory still accurate and worth keeping?",
+  "Propose a tighter title and body for it.",
+  "Does it combine two separate facts? Propose a split if so.",
+];
+
+// General chat (no memory grounding) — understanding the job and tuning its
+// addendum, which is the real lever the operator has here.
+const ADDENDUM_PROMPTS: Record<ChatJob, readonly string[]> = {
   grooming: [
-    "What memories duplicate each other?",
-    "Why was the last grooming run skipped?",
-    "Draft an addendum to reduce false-positive flags.",
+    "How do you decide whether two memories are duplicates?",
+    'Draft grooming guidance to stop merging memories tagged "identity".',
+    "Refine the grooming addendum to reduce false-positive duplicate flags.",
   ],
   intake: [
-    "What's in the inbox right now?",
-    "Why did the last intake skip these submissions?",
-    "Draft an addendum to teach the intake curator about my project naming.",
+    "What makes you accept or reject an inbox submission?",
+    "Draft an intake rule to always keep error and postmortem notes.",
+    "Refine the intake addendum to teach my project-naming convention.",
   ],
 };
 
@@ -239,7 +255,12 @@ export function ChatPanel({
         </header>
 
         {entries.length === 0 ? (
-          <EmptyState job={job} disabled={pending} onPick={(prompt) => send(prompt)} />
+          <EmptyState
+            job={job}
+            grounded={!!memoryId}
+            disabled={pending}
+            onPick={(prompt) => send(prompt)}
+          />
         ) : null}
 
         {entries.length > 0 ? (
@@ -405,18 +426,21 @@ function TextTurn({ role, text }: { role: "user" | "assistant" | "system"; text:
 
 function EmptyState({
   job,
+  grounded,
   disabled,
   onPick,
 }: {
   job: ChatJob;
+  grounded: boolean;
   disabled: boolean;
   onPick: (prompt: string) => void;
 }) {
+  const prompts = grounded ? GROUNDED_PROMPTS : ADDENDUM_PROMPTS[job];
   return (
     <div className="flex flex-col gap-3 border border-dashed border-ink-hairline p-4">
       <SectionLabel as="p">Try asking</SectionLabel>
       <div className="flex flex-col gap-2">
-        {EXAMPLE_PROMPTS[job].map((prompt) => (
+        {prompts.map((prompt) => (
           <Button
             key={prompt}
             type="button"

--- a/apps/dashboard/tests/components/curator/chat-panel.test.tsx
+++ b/apps/dashboard/tests/components/curator/chat-panel.test.tsx
@@ -130,6 +130,26 @@ describe("ChatPanel", () => {
     await waitFor(() => expect(chat.action).toHaveBeenCalled());
   });
 
+  it("suggests addendum/policy prompts in the general (ungrounded) chat", async () => {
+    renderPanel({ job: "grooming" });
+    // Capability-aligned: the curator can explain its policy and draft addenda…
+    expect(
+      screen.getByRole("button", {
+        name: /how do you decide whether two memories are duplicates/i,
+      }),
+    ).toBeTruthy();
+    // …and must NOT offer memory-grounded prompts when nothing is grounded.
+    expect(screen.queryByRole("button", { name: /is this memory still accurate/i })).toBeNull();
+  });
+
+  it("suggests memory-grounded prompts when opened from a memory", async () => {
+    renderPanel({ memoryId: "mem-42", memoryTitle: "Some memory", job: "grooming" });
+    expect(screen.getByRole("button", { name: /is this memory still accurate/i })).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: /how do you decide whether two memories/i }),
+    ).toBeNull();
+  });
+
   it("commits the addendum draft only on an explicit Commit click", async () => {
     const onSetAddendum = vi.fn(async () => ({
       ok: true as const,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.36",
+  "version": "1.0.0-rc.37",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",


### PR DESCRIPTION
The "Try asking" prompts in the curator chat suggested things the chat **cannot do** — it has no tools and no live data access (no inbox query, no run logs, no corpus-wide search), yet offered:

- "What's in the inbox right now?"
- "Why was the last grooming run skipped?" / "Why did the last intake skip these submissions?"

These are replaced with prompts the chat can actually act on, chosen by context:

- **Grounded chat** (opened from a specific memory): questions about *that* memory, and the merge/split/update proposals the chat can put up for confirmation.
- **General chat** (no grounding): understanding the job and drafting/refining its operator-guidance addendum — the real lever available there.

`EmptyState` now selects grounded vs general prompts from `memoryId`.

Tests: two new chat-panel tests asserting grounded vs general suggestions render (and the opposite set does not).

Verified: dashboard typecheck, chat-panel tests (10), eslint + prettier, `check:release` green. Bumps rc.36 → rc.37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AUvAgc8mLAmd5mvtg2gB8f