### PR TITLE
ci: raise Dashboard e2e (Playwright) job timeout to 30 min

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,12 @@ jobs:
     name: Dashboard e2e (Playwright)
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # This job's 15 min budget has to cover install + workspace build + Playwright
+    # browser install BEFORE the suite even starts, so a cold run (uncached
+    # browser) routinely hit the cap and was cancelled mid-suite — surfacing as a
+    # flaky "cancelled" check that blocked otherwise-green PRs. 30 min gives the
+    # suite real headroom while still catching a genuine hang.
+    timeout-minutes: 30
 
     steps:
       - name: Check out repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.38] — 2026-06-18
+
+### Fixed
+
+- **CI: the Dashboard e2e (Playwright) job no longer flakes out on a timeout
+  cancellation.** Its 15-minute budget had to cover install + workspace build +
+  Playwright browser install *before* the suite even started, so a cold run
+  routinely hit the cap and was cancelled mid-suite — surfacing as a flaky
+  "cancelled" required check that blocked otherwise-green PRs and stalled
+  auto-merge. Raised the job `timeout-minutes` to 30 (`.github/workflows/ci.yml`).
+
 ## [1.0.0-rc.37] — 2026-06-18
 
 ### Changed
@@ -2894,6 +2905,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0-rc.38]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.37...v1.0.0-rc.38
 [1.0.0-rc.37]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.36...v1.0.0-rc.37
 [1.0.0-rc.36]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.35...v1.0.0-rc.36
 [1.0.0-rc.35]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.34...v1.0.0-rc.35

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.37",
+  "version": "1.0.0-rc.38",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",


### PR DESCRIPTION
The **Dashboard e2e (Playwright)** job's `timeout-minutes: 15` had to cover install + workspace build + Playwright browser install **before** the suite even started, so a cold run (uncached browser) routinely hit the cap and was **cancelled mid-suite**. That surfaced as a flaky "cancelled" required check that blocked otherwise-green PRs and stalled auto-merge (it happened on #401 in this very batch).

Raised the job `timeout-minutes` to **30** — enough headroom for the suite while still catching a genuine hang.

Landing this early in the batch so the remaining queued PRs stop flaking. Bumps rc.37 → rc.38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AUvAgc8mLAmd5mvtg2gB8f