### PR TITLE
feat(dashboard): move auto-update to /settings/dashboard; fix prerelease version compare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.39] — 2026-06-18
+
+### Changed
+
+- **Server auto-update settings moved to a new `/settings/dashboard` page.** They
+  lived on `/settings/curator` (a curation-job page) but are an instance-level
+  concern; the new "Dashboard" entry sits at the top of the settings nav.
+
+### Fixed
+
+- **The version status no longer reports "up to date" when a newer prerelease
+  exists.** The dashboard's own semver comparator dropped the prerelease segment,
+  so `rc.29` and `rc.33` both parsed to `[1,0,0]` and compared equal — the
+  auto-update panel AND the menu-bar version badge (both route through
+  `autoUpdateStatus`) falsely said "up to date". The comparator is now
+  prerelease-aware (mirrors `installer-cli/src/semver.ts`), staying conservative:
+  an unparseable version reads as "unknown", never a false "update available"
+  (`apps/dashboard/components/curator/autoupdate-status.ts`).
+
 ## [1.0.0-rc.38] — 2026-06-18
 
 ### Fixed
@@ -2905,6 +2924,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0-rc.39]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.38...v1.0.0-rc.39
 [1.0.0-rc.38]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.37...v1.0.0-rc.38
 [1.0.0-rc.37]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.36...v1.0.0-rc.37
 [1.0.0-rc.36]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.35...v1.0.0-rc.36

--- a/apps/dashboard/app/curator/actions.ts
+++ b/apps/dashboard/app/curator/actions.ts
@@ -197,7 +197,7 @@ export async function setAutoUpdateConfigAction(input: {
 }): Promise<SaveConfigResult> {
   try {
     await serverTRPC.autoupdate.set.mutate(input);
-    revalidatePath("/settings/curator");
+    revalidatePath("/settings/dashboard");
     return { ok: true };
   } catch (error) {
     return { ok: false, error: message(error) };

--- a/apps/dashboard/app/settings/curator/page.tsx
+++ b/apps/dashboard/app/settings/curator/page.tsx
@@ -12,13 +12,11 @@ import {
   runGroomingNowAction,
   runIntakeNowAction,
   saveGroomingConfigAction,
-  setAutoUpdateConfigAction,
   setConsumerConfigAction,
   setIntakeConfigAction,
   testConnectionAction,
   updateProviderAction,
 } from "@/app/curator/actions";
-import { AutoUpdateConfigForm } from "@/components/curator/autoupdate-config-form";
 import { GroomingConfigForm } from "@/components/curator/config-form";
 import { ConsumerModelSelector } from "@/components/curator/consumer-model-selector";
 import { IntakeConfigForm } from "@/components/curator/intake-config-form";
@@ -45,10 +43,9 @@ export default async function CuratorSettingsPage() {
   let intakeRuns: Awaited<ReturnType<typeof serverTRPC.intake.runs.query>> = [];
   let intakeConsumer: Awaited<ReturnType<typeof serverTRPC.llm.consumerConfig.query>> | null = null;
   let grooming: Awaited<ReturnType<typeof serverTRPC.llm.consumerConfig.query>> | null = null;
-  let autoupdate: Awaited<ReturnType<typeof serverTRPC.autoupdate.get.query>> | null = null;
   let error: string | null = null;
   try {
-    [config, runs, providers, intakeConfig, intakeRuns, intakeConsumer, grooming, autoupdate] =
+    [config, runs, providers, intakeConfig, intakeRuns, intakeConsumer, grooming] =
       await Promise.all([
         serverTRPC.grooming.config.query(),
         serverTRPC.grooming.runs.query({ limit: 50 }),
@@ -57,7 +54,6 @@ export default async function CuratorSettingsPage() {
         serverTRPC.intake.runs.query({ limit: 50 }),
         serverTRPC.llm.consumerConfig.query({ consumer: "intake" }),
         serverTRPC.llm.consumerConfig.query({ consumer: "grooming" }),
-        serverTRPC.autoupdate.get.query(),
       ]);
   } catch (err) {
     error = err instanceof Error ? err.message : String(err);
@@ -204,32 +200,6 @@ export default async function CuratorSettingsPage() {
           </section>
         }
       />
-
-      <Hairline />
-
-      {/* Server auto-update (spec 2026-06-16-server-autoupdate T4). A server-level
-          concern, not a curator job — so it sits below the two job tabs as its own
-          section. The dashboard only configures it; the host timer performs the
-          update (spec §2). */}
-      <section className="flex flex-col gap-3" aria-label="Server auto-update">
-        <header className="flex flex-col gap-1.5">
-          <SectionLabel as="h2">Server auto-update</SectionLabel>
-          <p className="text-sm text-foreground/60">
-            Keep the server current automatically. The dashboard configures auto-update; a timer on
-            the host machine performs the update on the cadence you set.
-          </p>
-        </header>
-        {autoupdate ? (
-          <AutoUpdateConfigForm
-            enabled={autoupdate.enabled}
-            cadence={autoupdate.cadence}
-            lastRunAt={autoupdate.lastRunAt}
-            version={autoupdate.version}
-            latest={autoupdate.latest}
-            onSave={setAutoUpdateConfigAction}
-          />
-        ) : null}
-      </section>
     </main>
   );
 }

--- a/apps/dashboard/app/settings/dashboard/page.tsx
+++ b/apps/dashboard/app/settings/dashboard/page.tsx
@@ -1,0 +1,66 @@
+// Dashboard settings — server-level controls that aren't a curator job. Today
+// this hosts server auto-update (spec 2026-06-16-server-autoupdate T4), moved
+// off the Curator page so it lives with instance-level settings rather than a
+// curation job. The dashboard only CONFIGURES auto-update; a timer on the host
+// machine performs the update on the cadence set here (spec §2).
+
+// `setAutoUpdateConfigAction` lives in the curator actions module (its only
+// consumer now); it revalidates this route after a write.
+import { setAutoUpdateConfigAction } from "@/app/curator/actions";
+import { AutoUpdateConfigForm } from "@/components/curator/autoupdate-config-form";
+import { SectionLabel } from "@/components/ui-v2/section-label";
+import { serverTRPC } from "@/lib/trpc-server";
+
+export const dynamic = "force-dynamic";
+
+export default async function DashboardSettingsPage() {
+  let autoupdate: Awaited<ReturnType<typeof serverTRPC.autoupdate.get.query>> | null = null;
+  let error: string | null = null;
+  try {
+    autoupdate = await serverTRPC.autoupdate.get.query();
+  } catch (err) {
+    error = err instanceof Error ? err.message : String(err);
+  }
+
+  return (
+    <main className="flex flex-col gap-5 p-6">
+      <header className="flex flex-col gap-1.5">
+        <h1 className="font-display text-xl text-foreground">Dashboard</h1>
+        <p className="text-sm text-foreground/60">
+          Server-level settings for this Librarian instance.
+        </p>
+      </header>
+
+      {error ? (
+        <p
+          role="alert"
+          className="border border-destructive/40 bg-destructive/[0.06] p-3 text-sm text-destructive"
+        >
+          Failed to load settings: {error}
+        </p>
+      ) : null}
+
+      {/* Server auto-update (spec 2026-06-16-server-autoupdate T4). The dashboard
+          only configures it; the host timer performs the update (spec §2). */}
+      <section className="flex flex-col gap-3" aria-label="Server auto-update">
+        <header className="flex flex-col gap-1.5">
+          <SectionLabel as="h2">Server auto-update</SectionLabel>
+          <p className="text-sm text-foreground/60">
+            Keep the server current automatically. The dashboard configures auto-update; a timer on
+            the host machine performs the update on the cadence you set.
+          </p>
+        </header>
+        {autoupdate ? (
+          <AutoUpdateConfigForm
+            enabled={autoupdate.enabled}
+            cadence={autoupdate.cadence}
+            lastRunAt={autoupdate.lastRunAt}
+            version={autoupdate.version}
+            latest={autoupdate.latest}
+            onSave={setAutoUpdateConfigAction}
+          />
+        ) : null}
+      </section>
+    </main>
+  );
+}

--- a/apps/dashboard/components/curator/autoupdate-status.ts
+++ b/apps/dashboard/components/curator/autoupdate-status.ts
@@ -20,28 +20,69 @@ export type LatestReleaseStatus =
 
 export type VersionStatus = "loading" | "up_to_date" | "behind" | "unknown";
 
-// Strip a leading `v` and split into numeric parts. Anything non-numeric becomes
-// NaN, which `compareSemver` treats as "unknown" and falls back to "up to date"
-// rather than risking a noisy false-positive.
-function parseSemver(value: string): number[] {
-  return value
-    .replace(/^v/i, "")
-    .split(/[-+.]/)
-    .slice(0, 3)
-    .map((part) => Number.parseInt(part, 10));
+// Prerelease-aware comparison (subset of semver §11). The monorepo ships
+// prerelease tags (`1.0.0-rc.29`, `1.0.0-rc.33`), so the comparison MUST look at
+// the prerelease segment — an earlier version that dropped it compared
+// `rc.29` and `rc.33` as equal (both `[1,0,0]`) and falsely reported
+// "up to date". Mirrors `packages/installer-cli/src/semver.ts`; kept local so
+// the client bundle doesn't pull a CLI module. Unparseable → `null` ("unknown"),
+// so we never claim an update we couldn't confirm.
+interface ParsedVersion {
+  release: number[];
+  prerelease: string[];
+}
+
+function parseSemver(value: string): ParsedVersion | null {
+  const trimmed = value.trim().replace(/^v/i, "");
+  if (!trimmed) return null;
+  const [core, ...preParts] = trimmed.split("-");
+  const prerelease = preParts.join("-").split("+")[0] ?? "";
+  const coreNoBuild = (core ?? "").split("+")[0] ?? "";
+  const release = coreNoBuild.split(".").map((n) => Number.parseInt(n, 10));
+  if (release.length === 0 || release.some((n) => Number.isNaN(n))) return null;
+  return { release, prerelease: prerelease.length > 0 ? prerelease.split(".") : [] };
 }
 
 export function compareSemver(a: string, b: string): -1 | 0 | 1 | null {
   const pa = parseSemver(a);
   const pb = parseSemver(b);
-  for (let i = 0; i < 3; i++) {
-    const av = pa[i];
-    const bv = pb[i];
-    if (av === undefined || bv === undefined || Number.isNaN(av) || Number.isNaN(bv)) {
-      return null;
+  if (!pa || !pb) return null;
+
+  const len = Math.max(pa.release.length, pb.release.length);
+  for (let i = 0; i < len; i++) {
+    const av = pa.release[i] ?? 0;
+    const bv = pb.release[i] ?? 0;
+    if (av !== bv) return av < bv ? -1 : 1;
+  }
+
+  // Equal release fields: a version WITH a prerelease ranks below one without
+  // (1.0.0-rc.1 < 1.0.0); otherwise compare prerelease identifiers.
+  const aPre = pa.prerelease.length > 0;
+  const bPre = pb.prerelease.length > 0;
+  if (aPre && !bPre) return -1;
+  if (!aPre && bPre) return 1;
+  if (!aPre && !bPre) return 0;
+  return comparePrerelease(pa.prerelease, pb.prerelease);
+}
+
+function comparePrerelease(a: string[], b: string[]): -1 | 0 | 1 {
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    // A longer prerelease list (all-else-equal) ranks higher (rc.1 < rc.1.1).
+    if (i >= a.length) return -1;
+    if (i >= b.length) return 1;
+    const ai = a[i] ?? "";
+    const bi = b[i] ?? "";
+    const an = /^\d+$/.test(ai);
+    const bn = /^\d+$/.test(bi);
+    if (an && bn) {
+      const na = Number.parseInt(ai, 10);
+      const nb = Number.parseInt(bi, 10);
+      if (na !== nb) return na < nb ? -1 : 1;
+      continue;
     }
-    if (av < bv) return -1;
-    if (av > bv) return 1;
+    if (an !== bn) return an ? -1 : 1; // numeric identifiers rank below alphanumeric
+    if (ai !== bi) return ai < bi ? -1 : 1;
   }
   return 0;
 }

--- a/apps/dashboard/components/site-nav.tsx
+++ b/apps/dashboard/components/site-nav.tsx
@@ -36,9 +36,11 @@ const TABS = [
   { href: "/archive", label: "Archive", match: (p: string) => p === "/archive" },
 ] as const;
 
-// Setup-flow order: secure access, teach the system, configure the curator,
-// issue agent tokens, schedule backups.
+// Dashboard (instance-level settings) first, then the setup flow: secure
+// access, teach the system, configure the curator, issue agent tokens,
+// schedule backups.
 const SETTINGS_ITEMS = [
+  { href: "/settings/dashboard", label: "Dashboard" },
   { href: "/settings/auth", label: "Auth" },
   { href: "/settings/primer", label: "Primer" },
   { href: "/settings/curator", label: "Curator" },

--- a/apps/dashboard/tests/autoupdate-status.test.ts
+++ b/apps/dashboard/tests/autoupdate-status.test.ts
@@ -1,0 +1,48 @@
+// Running-version-vs-latest comparison (shared by the top-bar VersionBadge and
+// the auto-update settings panel). Regression for the prerelease bug: an earlier
+// comparator dropped the `-rc.N` segment, so `rc.29` and `rc.33` compared equal
+// and both surfaces falsely reported "up to date".
+
+import { describe, expect, it } from "vitest";
+import { autoUpdateStatus, compareSemver } from "@/components/curator/autoupdate-status";
+
+describe("compareSemver", () => {
+  it("orders release fields numerically", () => {
+    expect(compareSemver("1.2.0", "1.10.0")).toBe(-1);
+    expect(compareSemver("1.0.0", "1.0.0")).toBe(0);
+    expect(compareSemver("2.0.0", "1.9.9")).toBe(1);
+  });
+
+  it("ranks a prerelease below the same released version", () => {
+    expect(compareSemver("1.0.0-rc.1", "1.0.0")).toBe(-1);
+    expect(compareSemver("1.0.0", "1.0.0-rc.1")).toBe(1);
+  });
+
+  it("compares prerelease identifiers — the rc.29 < rc.33 regression", () => {
+    expect(compareSemver("1.0.0-rc.29", "v1.0.0-rc.33")).toBe(-1);
+    expect(compareSemver("1.0.0-rc.33", "1.0.0-rc.33")).toBe(0);
+    expect(compareSemver("1.0.0-rc.40", "1.0.0-rc.9")).toBe(1); // numeric, not lexical
+  });
+
+  it("returns null for unparseable input (conservative 'unknown')", () => {
+    expect(compareSemver("not-a-version", "1.0.0")).toBeNull();
+    expect(compareSemver("1.0.0", "")).toBeNull();
+  });
+});
+
+describe("autoUpdateStatus", () => {
+  const ok = (tag: string) => ({ kind: "ok" as const, release: { tag }, cachedAt: "x" });
+
+  it("reports 'behind' across prereleases of the same core version (the bug)", () => {
+    expect(autoUpdateStatus("1.0.0-rc.29", ok("v1.0.0-rc.33"))).toBe("behind");
+  });
+
+  it("reports 'up_to_date' when equal", () => {
+    expect(autoUpdateStatus("1.0.0-rc.33", ok("v1.0.0-rc.33"))).toBe("up_to_date");
+  });
+
+  it("is 'loading' when latest is undefined and 'unknown' on a non-ok latest", () => {
+    expect(autoUpdateStatus("1.0.0", undefined)).toBe("loading");
+    expect(autoUpdateStatus("1.0.0", { kind: "unavailable", reason: "x" })).toBe("unknown");
+  });
+});

--- a/apps/dashboard/tests/components/curator/autoupdate.test.tsx
+++ b/apps/dashboard/tests/components/curator/autoupdate.test.tsx
@@ -105,6 +105,12 @@ describe("AutoUpdateConfigForm", () => {
     expect(badge.textContent?.toLowerCase()).toMatch(/update available/);
   });
 
+  it("shows update-available across prereleases of the same core version (rc.29 → rc.33)", () => {
+    setup({ version: "1.0.0-rc.29", latest: latestOk("v1.0.0-rc.33") });
+    const badge = screen.getByTestId("autoupdate-version-badge");
+    expect(badge).toHaveAttribute("data-status", "behind");
+  });
+
   it("renders the host hint with the enable command (SC6)", () => {
     setup();
     const hint = screen.getByTestId("autoupdate-host-hint");

--- a/apps/dashboard/tests/components/site-nav.test.tsx
+++ b/apps/dashboard/tests/components/site-nav.test.tsx
@@ -86,17 +86,18 @@ describe("SiteNav", () => {
     expect(trigger).toHaveAttribute("aria-expanded", "false");
     fireEvent.click(trigger);
     expect(trigger).toHaveAttribute("aria-expanded", "true");
-    // The 5 children appear in setup-flow order.
+    // Dashboard (instance settings) first, then the setup-flow order.
     const items = screen.getAllByRole("menuitem");
     expect(items.map((el) => el.textContent)).toEqual([
+      "Dashboard",
       "Auth",
       "Primer",
       "Curator",
       "Tokens",
       "Backups",
     ]);
-    expect(items[0]).toHaveAttribute("href", "/settings/auth");
-    expect(items[4]).toHaveAttribute("href", "/settings/backups");
+    expect(items[0]).toHaveAttribute("href", "/settings/dashboard");
+    expect(items[5]).toHaveAttribute("href", "/settings/backups");
   });
 
   it("marks the Settings trigger active for any /settings/* route", () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.38",
+  "version": "1.0.0-rc.39",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Two related settings/version changes (items 2 & 3 of the batch).

## Move auto-update to /settings/dashboard
The server auto-update controls lived on `/settings/curator` (a curation-job page) but are an instance-level concern. New `/settings/dashboard` page hosts them, and "Dashboard" is added to the **top** of the settings nav. The `AutoUpdateConfigForm` is presentational so the lift is clean; `setAutoUpdateConfigAction` now revalidates `/settings/dashboard`.

## Fix the "up to date" version bug
The dashboard's own semver comparator (`autoupdate-status.ts`) **dropped the prerelease segment**, so `rc.29` and `rc.33` both parsed to `[1,0,0]` and compared equal → both the auto-update panel and the **menu-bar version badge** (both route through `autoUpdateStatus`) falsely reported "up to date". The comparator is now prerelease-aware (mirrors `installer-cli/src/semver.ts`), staying conservative — unparseable reads as "unknown", never a false "update available". One fix repairs both surfaces.

## Tests
- `compareSemver`/`autoUpdateStatus` unit test covering the rc.29 < rc.33 regression + precedence rules.
- Badge integration test for the same case.

Verified: dashboard typecheck, autoupdate tests (17), eslint + prettier, `check:release` green. Bumps rc.38 → rc.39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AUvAgc8mLAmd5mvtg2gB8f