### PR TITLE
docs: recommend npx over a global install for the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.40] — 2026-06-18
+
+### Changed
+
+- **Docs now recommend `npx @the-librarian/cli` over a global install.** The CLI
+  ships a `librarian` bin, so `npx @the-librarian/cli <cmd>` runs with no global
+  install or sudo. README, DEPLOYMENT.md, and the installer-cli README now lead
+  with npx and keep `npm i -g` as the optional "you'll run it often" path.
+
 ## [1.0.0-rc.39] — 2026-06-18
 
 ### Changed
@@ -2924,6 +2933,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0-rc.40]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.39...v1.0.0-rc.40
 [1.0.0-rc.39]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.38...v1.0.0-rc.39
 [1.0.0-rc.38]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.37...v1.0.0-rc.38
 [1.0.0-rc.37]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.36...v1.0.0-rc.37

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -7,11 +7,12 @@ This deployment is designed for a low-traffic personal VPS or a remote host.
 The lowest-friction path. The `librarian` CLI drives the all-in-one container
 end to end: it builds and runs the image, manages the data volume, surfaces the
 secrets, and hands you the MCP URL + agent token to paste into clients. You never
-hand-write a `docker run` or an `.env` for the happy path.
+hand-write a `docker run` or an `.env` for the happy path. Run it with `npx` —
+no global install needed (or `npm i -g @the-librarian/cli` if you'll use it
+often):
 
 ```sh
-npm i -g @the-librarian/cli
-librarian server up
+npx @the-librarian/cli server up
 ```
 
 `server up` (on a host with Docker + git):

--- a/README.md
+++ b/README.md
@@ -24,12 +24,15 @@ It runs as a small self-hosted server, reachable locally or over the network.
 
 The `librarian` CLI's `server` command group stands up the server for you — it
 builds and runs the all-in-one container, surfaces the master key once, and hands
-you the MCP URL + agent token to paste into clients:
+you the MCP URL + agent token to paste into clients. Run it with `npx` — no
+install needed:
 
 ```sh
-npm i -g @the-librarian/cli
-librarian server up
+npx @the-librarian/cli server up
 ```
+
+(Or `npm i -g @the-librarian/cli` once and call `librarian server up` directly,
+if you'll run it often.)
 
 `server up`/`update`/`down`/`status`/`logs`, Linux boot persistence
 (`enable-boot`), and host-side admin (`server admin backup|restore|auth|rebuild`)
@@ -45,12 +48,14 @@ are all covered in the
 
 Once your server is running, the `librarian` CLI wires The Librarian into your
 harnesses and keeps them up to date — the package-manager-style tool you keep.
-Any harness already has Node, so installing is two commands:
+Any harness already has Node, so one command does it:
 
 ```sh
-npm i -g @the-librarian/cli
-librarian install
+npx @the-librarian/cli install
 ```
+
+(Or install it globally once — `npm i -g @the-librarian/cli` — then re-run
+`librarian install` whenever you add a harness.)
 
 See [`packages/installer-cli`](./packages/installer-cli/README.md) for the
 full command reference and what it writes to your environment.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.39",
+  "version": "1.0.0-rc.40",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/installer-cli/README.md
+++ b/packages/installer-cli/README.md
@@ -10,7 +10,14 @@ Harnesses it manages: **Claude Code, Codex, OpenCode, Hermes, Pi.**
 
 ## Install
 
-Install the CLI globally, then run the interactive setup:
+Run it straight from npm with `npx` — no global install needed:
+
+```sh
+npx @the-librarian/cli install
+```
+
+Prefer a persistent command? Install it globally once and call `librarian`
+directly:
 
 ```sh
 npm i -g @the-librarian/cli


### PR DESCRIPTION
The published `@the-librarian/cli` ships a `librarian` bin, so `npx @the-librarian/cli <cmd>` runs with no global install and no sudo (the `npm i -g` path needs sudo when the global prefix is root-owned).

Updated the install/self-host instructions in **README.md**, **DEPLOYMENT.md**, and **packages/installer-cli/README.md** to lead with `npx`, keeping `npm i -g` as the optional "you'll run it often" path. Docs-only. Bumps rc.39 → rc.40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AUvAgc8mLAmd5mvtg2gB8f