### PR TITLE
feat(dashboard): analytics overhaul — totals + curator LLM usage; drop dead "By project"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.41] — 2026-06-18
+
+### Changed
+
+- **Analytics page rebuilt around data that actually exists.** It showed three
+  current-snapshot tallies, one of which ("By project") is always empty because
+  memory `project_key` is never populated. Now: top-line stat tiles (total
+  memories, curator runs, input/output tokens), a new **Curator LLM usage**
+  section (total tokens + completed-run count, broken down by model, from the
+  grooming runs' recorded usage), and "By agent" / "By status" / "By priority"
+  breakdowns. The dead "By project" dimension is gone. No "recalls over time" —
+  recall tracking was retired in D16, so that data doesn't exist
+  (`apps/dashboard/app/(memories)/analytics/page.tsx`).
+
 ## [1.0.0-rc.40] — 2026-06-18
 
 ### Changed
@@ -2933,6 +2947,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0-rc.41]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.40...v1.0.0-rc.41
 [1.0.0-rc.40]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.39...v1.0.0-rc.40
 [1.0.0-rc.39]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.38...v1.0.0-rc.39
 [1.0.0-rc.38]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.37...v1.0.0-rc.38

--- a/apps/dashboard/app/(memories)/analytics/page.tsx
+++ b/apps/dashboard/app/(memories)/analytics/page.tsx
@@ -1,7 +1,11 @@
-// Analytics — the memory corpus broken down by agent / project / status.
-// Editorial rebuild (Phase 4): one bordered surface with three
-// hairline-separated dimension sections, not three identical cards.
+// Analytics — a live snapshot of the corpus and the curator's LLM usage.
+// Editorial rebuild: top-line stat tiles, then hairline-separated breakdown
+// dimensions, then curator token usage. The dead "By project" dimension is
+// gone (project_key is never populated for memories); recall-frequency stats
+// are deliberately absent (recordRecall was retired in D16, so the data to
+// chart "recalls over time" doesn't exist).
 
+import { summariseCuratorUsage } from "@/components/analytics/usage";
 import { Hairline } from "@/components/ui-v2/hairline";
 import { SectionLabel } from "@/components/ui-v2/section-label";
 import { serverTRPC } from "@/lib/trpc-server";
@@ -13,19 +17,31 @@ interface Slice {
   count: number;
 }
 
+// Grooming runs are capped at 200 server-side; token usage is summarised over
+// that newest-runs window (labelled as such in the UI).
+const RUN_WINDOW = 200;
+
 export default async function AnalyticsPage() {
-  let aggregates: Awaited<ReturnType<typeof serverTRPC.memories.aggregates.query>> | null = null;
-  let error: string | null = null;
-  try {
-    aggregates = await serverTRPC.memories.aggregates.query();
-  } catch (err) {
-    error = err instanceof Error ? err.message : String(err);
-  }
+  const [aggRes, runsRes] = await Promise.allSettled([
+    serverTRPC.memories.aggregates.query(),
+    serverTRPC.grooming.runs.query({ limit: RUN_WINDOW }),
+  ]);
+
+  const aggregates = aggRes.status === "fulfilled" ? aggRes.value : null;
+  const error =
+    aggRes.status === "rejected"
+      ? aggRes.reason instanceof Error
+        ? aggRes.reason.message
+        : String(aggRes.reason)
+      : null;
+  const runs = runsRes.status === "fulfilled" ? runsRes.value : [];
+  const usage = summariseCuratorUsage(runs);
+
   const dimensions = aggregates
     ? [
         { label: "By agent", data: aggregates.agents as Slice[] },
-        { label: "By project", data: aggregates.projects as Slice[] },
         { label: "By status", data: aggregates.statuses as Slice[] },
+        { label: "By priority", data: aggregates.priorities as Slice[] },
       ]
     : [];
 
@@ -34,8 +50,8 @@ export default async function AnalyticsPage() {
       <header className="flex flex-col gap-1.5">
         <h1 className="font-display text-xl text-foreground">Analytics</h1>
         <p className="text-sm text-foreground/60">
-          The memory corpus broken down by agent, project, and lifecycle status. Live snapshot —
-          refresh for current numbers.
+          A live snapshot of the corpus and the curator&rsquo;s LLM usage. Refresh for current
+          numbers.
         </p>
       </header>
 
@@ -48,6 +64,18 @@ export default async function AnalyticsPage() {
         </p>
       ) : null}
 
+      {aggregates ? (
+        <section
+          aria-label="Totals"
+          className="grid grid-cols-2 gap-px border border-ink-hairline bg-ink-hairline sm:grid-cols-4"
+        >
+          <StatTile label="Memories" value={aggregates.total} />
+          <StatTile label={`Curator runs (last ${RUN_WINDOW})`} value={usage.runs} />
+          <StatTile label="Input tokens" value={usage.inputTokens} />
+          <StatTile label="Output tokens" value={usage.outputTokens} />
+        </section>
+      ) : null}
+
       {dimensions.length > 0 ? (
         <section
           className="flex flex-col gap-6 border border-ink-hairline bg-ink-surface p-5"
@@ -58,7 +86,62 @@ export default async function AnalyticsPage() {
           ))}
         </section>
       ) : null}
+
+      {usage.runs > 0 ? (
+        <section
+          className="flex flex-col gap-3 border border-ink-hairline bg-ink-surface p-5"
+          aria-label="Curator LLM usage"
+        >
+          <header className="flex items-baseline justify-between gap-3">
+            <SectionLabel as="h2">Curator LLM usage</SectionLabel>
+            <span className="font-mono text-xs text-foreground/60">
+              {usage.totalTokens.toLocaleString()} tokens · {usage.completed.toLocaleString()}/
+              {usage.runs.toLocaleString()} runs completed
+            </span>
+          </header>
+          <p className="text-xs text-foreground/60">
+            Tokens consumed by the grooming curator across the most recent {RUN_WINDOW} runs, by
+            model.
+          </p>
+          {usage.byModel.length === 0 ? (
+            <p className="text-sm text-foreground/60">No curator runs have recorded usage yet.</p>
+          ) : (
+            <ul className="flex flex-col gap-2 text-sm">
+              {usage.byModel.map((m) => {
+                const pct =
+                  usage.totalTokens === 0 ? 0 : Math.round((m.tokens / usage.totalTokens) * 100);
+                return (
+                  <li key={m.model} className="flex flex-col gap-1">
+                    <div className="flex items-baseline justify-between gap-3">
+                      <span className="min-w-0 truncate text-foreground" title={m.model}>
+                        {m.model}
+                      </span>
+                      <span className="font-mono text-xs tabular-nums text-foreground/70">
+                        {m.tokens.toLocaleString()} · {m.runs.toLocaleString()} runs
+                      </span>
+                    </div>
+                    <div aria-hidden className="h-0.5 w-full overflow-hidden bg-foreground/[0.08]">
+                      <div className="h-full bg-ink-accent" style={{ width: `${pct}%` }} />
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </section>
+      ) : null}
     </main>
+  );
+}
+
+function StatTile({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="flex flex-col gap-1 bg-ink-surface p-4">
+      <span className="font-mono text-2xl tabular-nums text-foreground">
+        {value.toLocaleString()}
+      </span>
+      <span className="text-xs text-foreground/60">{label}</span>
+    </div>
   );
 }
 

--- a/apps/dashboard/components/analytics/usage.ts
+++ b/apps/dashboard/components/analytics/usage.ts
@@ -1,0 +1,62 @@
+// Curator (grooming) LLM-usage aggregation for the analytics page. Pure +
+// unit-tested. Token usage is the one genuinely interesting LLM stat the system
+// captures: each curation run records its input/output tokens and the model it
+// used (recall-frequency stats were retired in D16 — recordRecall is a no-op —
+// so there is no "recalls over time" to chart).
+
+export interface CuratorRunLike {
+  status: string;
+  model_name?: string | null;
+  usage_input_tokens?: number;
+  usage_output_tokens?: number;
+}
+
+export interface ModelUsage {
+  model: string;
+  tokens: number;
+  runs: number;
+}
+
+export interface CuratorUsage {
+  /** Runs in the window (newest ≤200 grooming runs). */
+  runs: number;
+  /** Of those, how many completed (vs skipped/failed/pending). */
+  completed: number;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  /** Token spend grouped by model, largest first. */
+  byModel: ModelUsage[];
+}
+
+export function summariseCuratorUsage(runs: readonly CuratorRunLike[]): CuratorUsage {
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let completed = 0;
+  const models = new Map<string, { tokens: number; runs: number }>();
+
+  for (const run of runs) {
+    const input = run.usage_input_tokens ?? 0;
+    const output = run.usage_output_tokens ?? 0;
+    inputTokens += input;
+    outputTokens += output;
+    if (run.status === "completed") completed += 1;
+
+    const model = run.model_name?.trim() || "unknown";
+    const prev = models.get(model) ?? { tokens: 0, runs: 0 };
+    models.set(model, { tokens: prev.tokens + input + output, runs: prev.runs + 1 });
+  }
+
+  const byModel = [...models.entries()]
+    .map(([model, v]) => ({ model, tokens: v.tokens, runs: v.runs }))
+    .sort((a, b) => b.tokens - a.tokens);
+
+  return {
+    runs: runs.length,
+    completed,
+    inputTokens,
+    outputTokens,
+    totalTokens: inputTokens + outputTokens,
+    byModel,
+  };
+}

--- a/apps/dashboard/tests/analytics-usage.test.ts
+++ b/apps/dashboard/tests/analytics-usage.test.ts
@@ -1,0 +1,82 @@
+// Curator LLM-usage aggregation for the analytics page.
+
+import { describe, expect, it } from "vitest";
+import { summariseCuratorUsage } from "@/components/analytics/usage";
+
+describe("summariseCuratorUsage", () => {
+  it("sums input/output tokens and counts completed runs", () => {
+    const u = summariseCuratorUsage([
+      {
+        status: "completed",
+        model_name: "deepseek-v4-flash",
+        usage_input_tokens: 100,
+        usage_output_tokens: 40,
+      },
+      {
+        status: "completed",
+        model_name: "deepseek-v4-flash",
+        usage_input_tokens: 60,
+        usage_output_tokens: 10,
+      },
+      {
+        status: "skipped",
+        model_name: "deepseek-v4-flash",
+        usage_input_tokens: 0,
+        usage_output_tokens: 0,
+      },
+    ]);
+    expect(u.runs).toBe(3);
+    expect(u.completed).toBe(2);
+    expect(u.inputTokens).toBe(160);
+    expect(u.outputTokens).toBe(50);
+    expect(u.totalTokens).toBe(210);
+  });
+
+  it("groups token spend by model, largest first", () => {
+    const u = summariseCuratorUsage([
+      {
+        status: "completed",
+        model_name: "big-model",
+        usage_input_tokens: 500,
+        usage_output_tokens: 500,
+      },
+      {
+        status: "completed",
+        model_name: "small-model",
+        usage_input_tokens: 10,
+        usage_output_tokens: 5,
+      },
+      {
+        status: "completed",
+        model_name: "big-model",
+        usage_input_tokens: 100,
+        usage_output_tokens: 0,
+      },
+    ]);
+    expect(u.byModel).toEqual([
+      { model: "big-model", tokens: 1100, runs: 2 },
+      { model: "small-model", tokens: 15, runs: 1 },
+    ]);
+  });
+
+  it("tolerates missing token fields and blank model names", () => {
+    const u = summariseCuratorUsage([
+      { status: "failed" },
+      { status: "completed", model_name: "  ", usage_input_tokens: 7 },
+    ]);
+    expect(u.inputTokens).toBe(7);
+    expect(u.outputTokens).toBe(0);
+    expect(u.byModel).toEqual([{ model: "unknown", tokens: 7, runs: 2 }]);
+  });
+
+  it("is all-zeros for an empty run list", () => {
+    expect(summariseCuratorUsage([])).toEqual({
+      runs: 0,
+      completed: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+      byModel: [],
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.40",
+  "version": "1.0.0-rc.41",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Item 6a. The analytics page showed three current-snapshot tallies, one of which ("By project") is **always empty** because memory `project_key` is never populated. Rebuilt with available data only:

- **Top-line stat tiles:** total memories, curator runs (recent window), input tokens, output tokens.
- **New "Curator LLM usage" section:** total tokens + completed-run count, broken down **by model** — sourced from the grooming runs' recorded `usage_input_tokens`/`usage_output_tokens` (the one genuinely interesting LLM stat captured).
- **Breakdowns:** "By agent", "By status", plus "By priority" (free from `getAggregates`). Dropped the dead "By project" dimension.

No "recalls over time" — recall tracking was retired in D16 (`recordRecall` is a no-op), so that data doesn't exist; deliberately not faked.

No server changes — composed from existing tRPC (`memories.aggregates` + `grooming.runs`). Token aggregation is a pure, unit-tested helper.

Verified: full dashboard suite (287 passed), typecheck, eslint + prettier, `check:release` green. Bumps rc.40 → rc.41.

> Note: the now-always-empty `getAggregates().projects` field and the underlying `project_key` removal are handled in the separate dead-keys PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AUvAgc8mLAmd5mvtg2gB8f