### PR TITLE
feat(dashboard): retrieval testers — References tab + Recall hybrid-engine fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.44] — 2026-06-19
+
+### Added
+
+- **Dashboard "References" tab — test the `search_references` verb from the
+  admin UI.** A third tab on the Memories page (Browse · Recall · References)
+  runs the agents' `search_references` retrieval verb against the live server
+  vault and shows exactly what an agent receives: ranked hits with vault path
+  (linking into the vault explorer), score, heading anchor, character range, and
+  the matched section, plus a raw-JSON disclosure of the agent payload. The
+  empty state tells **"no reference documents filed"** apart from **"filed, but
+  none matched your query"** — so a query that returns nothing (e.g. a doc filed
+  under a misspelt title, or missing from this server's vault) is diagnosable
+  rather than a mystery. Backed by a new admin `vault.searchReferences` tRPC
+  procedure that is a thin pass-through to the same `store.searchReferences` the
+  MCP tool calls — parity pinned by test, so what the dashboard shows is what
+  the agent sees.
+
+### Fixed
+
+- **The Memories → Recall tab now uses the same hybrid recall engine agents
+  use.** It previously ran keyword-only `searchMemories`, while agents' `recall`
+  MCP tool runs `store.recall` (keyword + vector + backlink graph, RRF-fused) —
+  so the tab could surface a different set of memories, in a different order,
+  than agents actually get, and the semantic signal never appeared. The tab now
+  calls `store.recall` and exposes the agent's other knobs: an any-match `tags`
+  filter and a result `limit`.
+
 ## [1.0.0-rc.43] — 2026-06-19
 
 ### Changed
@@ -3008,6 +3036,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0-rc.44]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.43...v1.0.0-rc.44
 [1.0.0-rc.43]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.42...v1.0.0-rc.43
 [1.0.0-rc.42]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.41...v1.0.0-rc.42
 [1.0.0-rc.41]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.40...v1.0.0-rc.41

--- a/apps/dashboard/app/(memories)/actions.ts
+++ b/apps/dashboard/app/(memories)/actions.ts
@@ -161,10 +161,21 @@ export async function purgeMemoriesAction(ids: string[]): Promise<PurgeResult> {
 
 export type RecallResult = { ok: true; memories: MemoryRow[] } | { ok: false; error: string };
 
-export async function recallAction(query: string): Promise<RecallResult> {
+// Recall via the hybrid engine (the server procedure calls store.recall). `tags`
+// (any-match) and `limit` are the same knobs the recall MCP tool gives agents,
+// so the operator can reproduce a specific agent's recall; both are omitted when
+// absent so the default limit (12) applies.
+export async function recallAction(
+  query: string,
+  opts?: { tags?: string[]; limit?: number },
+): Promise<RecallResult> {
   if (!query.trim()) return { ok: false, error: "Recall query is empty." };
   try {
-    const result = await serverTRPC.memories.recall.mutate({ query, limit: 12 });
+    const result = await serverTRPC.memories.recall.mutate({
+      query,
+      ...(opts?.tags && opts.tags.length > 0 ? { tags: opts.tags } : {}),
+      limit: opts?.limit ?? 12,
+    });
     revalidatePath("/");
     return { ok: true, memories: result.memories as MemoryRow[] };
   } catch (err) {

--- a/apps/dashboard/app/(memories)/actions.ts
+++ b/apps/dashboard/app/(memories)/actions.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { type MemoryRow, type RouterInputs } from "@/components/memories/types";
+import { type MemoryRow, type ReferenceHit, type RouterInputs } from "@/components/memories/types";
 import { serverTRPC } from "@/lib/trpc-server";
 
 type CreateInput = NonNullable<RouterInputs["memories"]["create"]>;
@@ -167,6 +167,30 @@ export async function recallAction(query: string): Promise<RecallResult> {
     const result = await serverTRPC.memories.recall.mutate({ query, limit: 12 });
     revalidatePath("/");
     return { ok: true, memories: result.memories as MemoryRow[] };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export type SearchReferencesResult =
+  | { ok: true; references: ReferenceHit[] }
+  | { ok: false; error: string };
+
+// The References retrieval tester. Calls vault.searchReferences — the same store
+// method the search_references MCP tool runs — so the operator sees exactly what
+// an agent sees. `limit` is omitted when absent so the server applies its default
+// (12); a pure read, so no revalidation.
+export async function searchReferencesAction(
+  query: string,
+  limit?: number,
+): Promise<SearchReferencesResult> {
+  if (!query.trim()) return { ok: false, error: "Reference query is empty." };
+  try {
+    const result = await serverTRPC.vault.searchReferences.mutate({
+      query,
+      ...(limit !== undefined ? { limit } : {}),
+    });
+    return { ok: true, references: result.references };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };
   }

--- a/apps/dashboard/app/(memories)/actions.ts
+++ b/apps/dashboard/app/(memories)/actions.ts
@@ -173,13 +173,15 @@ export async function recallAction(query: string): Promise<RecallResult> {
 }
 
 export type SearchReferencesResult =
-  | { ok: true; references: ReferenceHit[] }
+  | { ok: true; references: ReferenceHit[]; searched: number }
   | { ok: false; error: string };
 
 // The References retrieval tester. Calls vault.searchReferences — the same store
 // method the search_references MCP tool runs — so the operator sees exactly what
-// an agent sees. `limit` is omitted when absent so the server applies its default
-// (12); a pure read, so no revalidation.
+// an agent sees. `searched` (the count of reference docs in the vault) is passed
+// through so the UI can tell "none filed" from "filed but none matched". `limit`
+// is omitted when absent so the server applies its default (12); a pure read, so
+// no revalidation.
 export async function searchReferencesAction(
   query: string,
   limit?: number,
@@ -190,7 +192,7 @@ export async function searchReferencesAction(
       query,
       ...(limit !== undefined ? { limit } : {}),
     });
-    return { ok: true, references: result.references };
+    return { ok: true, references: result.references, searched: result.searched };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };
   }

--- a/apps/dashboard/components/memories/reference-hits.tsx
+++ b/apps/dashboard/components/memories/reference-hits.tsx
@@ -1,0 +1,132 @@
+import type { ReferenceHit } from "@/components/memories/types";
+
+// The result half of the Memories → References tab. Pure + presentational
+// (the sibling of MemoriesList): it renders exactly what search_references
+// returned, so the operator sees what an agent sees. The empty state tells
+// "no references filed" (searched 0) apart from "filed but none matched"
+// (searched > 0, zero hits) — the diagnostic the tab exists for.
+
+export interface ReferenceSearchResult {
+  query: string;
+  references: ReferenceHit[];
+  searched: number;
+}
+
+const META = "font-mono text-[11px] uppercase tracking-wider text-foreground/45";
+
+function plural(n: number): string {
+  return n === 1 ? "" : "s";
+}
+
+export function ReferenceHits({
+  result,
+  isLoading,
+  error,
+}: {
+  result: ReferenceSearchResult | null;
+  isLoading: boolean;
+  error: string | null;
+}) {
+  if (error) {
+    return (
+      <p
+        role="alert"
+        className="border border-destructive/40 bg-destructive/[0.06] p-3 text-sm text-destructive"
+      >
+        Reference search failed: {error}. Try again, or refine the query.
+      </p>
+    );
+  }
+
+  if (isLoading) {
+    return <p className="text-sm text-foreground/55">Searching references…</p>;
+  }
+
+  if (!result) {
+    return (
+      <p className="text-sm text-foreground/55">
+        Run a query above to see what agents retrieve from{" "}
+        <span className="font-mono text-foreground/80">references/</span>.
+      </p>
+    );
+  }
+
+  const { query, references, searched } = result;
+
+  if (references.length === 0) {
+    return (
+      <p className="text-sm text-foreground/60">
+        {searched === 0 ? (
+          <>
+            No reference documents in the vault&rsquo;s{" "}
+            <span className="font-mono text-foreground/80">references/</span> folder yet — nothing
+            to search.
+          </>
+        ) : (
+          <>
+            Searched {searched} reference{plural(searched)}, none matched &ldquo;{query}&rdquo;. The
+            document may be filed under a different word, or not in this server&rsquo;s vault at
+            all.
+          </>
+        )}
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div
+        role="status"
+        className="border border-ink-accent/40 bg-ink-accent/[0.06] px-3 py-2 text-sm text-foreground"
+      >
+        Showing {references.length} of {searched} reference{plural(searched)} for &ldquo;{query}
+        &rdquo;, best-ranked first.
+      </div>
+
+      <ol className="flex min-w-0 flex-col gap-3">
+        {references.map((ref, i) => (
+          <li
+            key={`${ref.id}#${i}`}
+            className="flex min-w-0 flex-col gap-2 border border-ink-hairline p-3"
+          >
+            <div className="flex items-baseline justify-between gap-3">
+              <a
+                href={`/?path=${encodeURIComponent(ref.id)}`}
+                className="truncate font-mono text-sm text-ink-accent hover:underline"
+                title={ref.id}
+              >
+                {ref.id}
+              </a>
+              <span className="shrink-0 font-mono text-[11px] text-foreground/55">
+                score {ref.score.toFixed(4)}
+              </span>
+            </div>
+
+            <div className={META}>
+              {ref.anchor ? ref.anchor : "(preamble)"}
+              {typeof ref.startChar === "number" && typeof ref.endChar === "number"
+                ? ` · chars ${ref.startChar}–${ref.endChar}`
+                : ""}
+            </div>
+
+            <pre className="overflow-x-auto whitespace-pre-wrap break-words font-mono text-xs leading-relaxed text-foreground/80">
+              {ref.section}
+            </pre>
+          </li>
+        ))}
+      </ol>
+
+      <details className="border border-ink-hairline">
+        <summary className="cursor-pointer select-none px-3 py-2 font-mono text-[11px] uppercase tracking-wider text-foreground/55">
+          Raw payload — what the agent receives
+        </summary>
+        <pre
+          data-testid="references-raw-json"
+          className="overflow-x-auto border-t border-ink-hairline px-3 py-2 font-mono text-xs text-foreground/70"
+        >
+          {JSON.stringify({ references }, null, 2)}
+        </pre>
+      </details>
+    </div>
+  );
+}

--- a/apps/dashboard/components/memories/types.ts
+++ b/apps/dashboard/components/memories/types.ts
@@ -4,6 +4,9 @@ import type { inferRouterInputs, inferRouterOutputs } from "@trpc/server";
 export type RouterInputs = inferRouterInputs<AppRouter>;
 export type RouterOutputs = inferRouterOutputs<AppRouter>;
 export type MemoryRow = RouterOutputs["memories"]["list"]["memories"][number];
+// A single search_references hit — the same shape the agent's verb returns
+// (vault path id, score, matched section, heading anchor, char range).
+export type ReferenceHit = RouterOutputs["vault"]["searchReferences"]["references"][number];
 
 export type MemoryStatus = "active" | "proposed" | "archived";
 

--- a/apps/dashboard/components/memories/view.tsx
+++ b/apps/dashboard/components/memories/view.tsx
@@ -7,10 +7,11 @@ import { MemoriesList } from "./list";
 import { MemoryBottomSheet } from "./memory-bottom-sheet";
 import { MemoryInspector } from "./memory-inspector";
 import { NewMemoryForm } from "./new-form";
+import { ReferenceHits, type ReferenceSearchResult } from "./reference-hits";
 import { RehomeModal } from "./rehome-modal";
 import { SortBar, type SortState } from "./sort-bar";
 import type { MemoryRow } from "./types";
-import { recallAction } from "@/app/(memories)/actions";
+import { recallAction, searchReferencesAction } from "@/app/(memories)/actions";
 import { EmptyState } from "@/components/brand/empty-state";
 import { Button } from "@/components/ui-v2/button";
 import { KeyHint } from "@/components/ui-v2/key-hint";
@@ -22,7 +23,7 @@ import { trpc } from "@/lib/trpc-client";
 const PAGE_SIZE = 25;
 const LEGACY_AGENT_ID = "unknown-agent";
 
-type Tab = "browse" | "recall";
+type Tab = "browse" | "recall" | "references";
 
 export function MemoriesView() {
   const [tab, setTab] = useState<Tab>("browse");
@@ -36,6 +37,10 @@ export function MemoriesView() {
   const [recallResults, setRecallResults] = useState<MemoryRow[] | null>(null);
   const [recallError, setRecallError] = useState<string | null>(null);
   const [recalling, startRecall] = useTransition();
+  const [refQuery, setRefQuery] = useState("");
+  const [refResult, setRefResult] = useState<ReferenceSearchResult | null>(null);
+  const [refError, setRefError] = useState<string | null>(null);
+  const [searching, startSearch] = useTransition();
   const [bulkSelection, setBulkSelection] = useState<Set<string>>(new Set());
   const [showRehome, setShowRehome] = useState(false);
   const [rehomeToast, setRehomeToast] = useState<string | null>(null);
@@ -45,6 +50,7 @@ export function MemoriesView() {
 
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const recallInputRef = useRef<HTMLInputElement | null>(null);
+  const refInputRef = useRef<HTMLInputElement | null>(null);
 
   // Toast auto-dismiss with proper cleanup. Same minimum-viable shape
   // as the legacy view; next phase swaps to a real toast library.
@@ -105,6 +111,21 @@ export function MemoriesView() {
     });
   };
 
+  const handleSearchReferences = (query: string) => {
+    const q = query.trim();
+    if (!q) return;
+    startSearch(async () => {
+      const result = await searchReferencesAction(q);
+      if (result.ok) {
+        setRefError(null);
+        setRefResult({ query: q, references: result.references, searched: result.searched });
+      } else {
+        setRefError(result.error);
+        setRefResult(null);
+      }
+    });
+  };
+
   const setFilter = (key: string, value: string, display: string) => {
     setFilters((prev) => {
       const next = prev.filter((f) => f.key !== key);
@@ -147,7 +168,12 @@ export function MemoriesView() {
   // recall results → no-op). Hook handles skip-when-in-input.
   useSurfaceShortcuts({
     "/": () => {
-      const target = tab === "recall" ? recallInputRef.current : searchInputRef.current;
+      const target =
+        tab === "references"
+          ? refInputRef.current
+          : tab === "recall"
+            ? recallInputRef.current
+            : searchInputRef.current;
       target?.focus();
       target?.select();
     },
@@ -170,6 +196,10 @@ export function MemoriesView() {
       if (recallResults) {
         setRecallResults(null);
         setRecallError(null);
+      }
+      if (refResult || refError) {
+        setRefResult(null);
+        setRefError(null);
       }
     },
   });
@@ -228,6 +258,7 @@ export function MemoriesView() {
                 Recall
                 <KeyHint shortcut="R" />
               </TabsTrigger>
+              <TabsTrigger value="references">References</TabsTrigger>
             </TabsList>
 
             <TabsContent value="browse" className="flex flex-col gap-4">
@@ -409,6 +440,58 @@ export function MemoriesView() {
                     )
                   }
                 />
+              </section>
+            </TabsContent>
+
+            <TabsContent value="references" className="flex flex-col gap-4">
+              <form
+                className="flex flex-col gap-2"
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  handleSearchReferences(refQuery);
+                }}
+              >
+                <label className="flex flex-col gap-1.5">
+                  <span className="font-mono text-[11px] uppercase tracking-wider text-foreground/55">
+                    search_references query
+                  </span>
+                  <div className="flex gap-2">
+                    <input
+                      ref={refInputRef}
+                      type="text"
+                      value={refQuery}
+                      onChange={(e) => setRefQuery(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Escape") {
+                          if (refResult || refError) {
+                            setRefResult(null);
+                            setRefError(null);
+                          } else {
+                            setRefQuery("");
+                          }
+                          e.currentTarget.blur();
+                        }
+                      }}
+                      placeholder="What an agent would look up — e.g. gentle coding…"
+                      className="flex-1 border border-ink-hairline bg-transparent px-3 py-2 text-sm text-foreground placeholder:text-foreground/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ink-accent pointer-coarse:min-h-11 pointer-coarse:text-base"
+                    />
+                    <Button
+                      type="submit"
+                      variant="primary"
+                      disabled={searching || !refQuery.trim()}
+                    >
+                      {searching ? "Searching…" : "Search"}
+                    </Button>
+                  </div>
+                </label>
+                <p className="text-xs text-foreground/50">
+                  Runs the agents&rsquo; <span className="font-mono">search_references</span> verb
+                  against this server&rsquo;s vault — the results below are exactly what an agent
+                  sees.
+                </p>
+              </form>
+              <section className="min-w-0 flex-1 [&>*]:min-w-0">
+                <ReferenceHits result={refResult} isLoading={searching} error={refError} />
               </section>
             </TabsContent>
           </Tabs>

--- a/apps/dashboard/components/memories/view.tsx
+++ b/apps/dashboard/components/memories/view.tsx
@@ -34,6 +34,8 @@ export function MemoriesView() {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [showNewForm, setShowNewForm] = useState(false);
   const [recallQuery, setRecallQuery] = useState("");
+  const [recallTags, setRecallTags] = useState("");
+  const [recallLimit, setRecallLimit] = useState("");
   const [recallResults, setRecallResults] = useState<MemoryRow[] | null>(null);
   const [recallError, setRecallError] = useState<string | null>(null);
   const [recalling, startRecall] = useTransition();
@@ -100,8 +102,14 @@ export function MemoriesView() {
   const handleRecall = (query: string) => {
     const q = query.trim();
     if (!q) return;
+    const tags = recallTags
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+    const parsedLimit = Number.parseInt(recallLimit, 10);
+    const limit = Number.isFinite(parsedLimit) && parsedLimit > 0 ? parsedLimit : undefined;
     startRecall(async () => {
-      const result = await recallAction(q);
+      const result = await recallAction(q, { tags, ...(limit !== undefined ? { limit } : {}) });
       if (result.ok) {
         setRecallError(null);
         setRecallResults(result.memories);
@@ -384,6 +392,36 @@ export function MemoriesView() {
                     </Button>
                   </div>
                 </label>
+                {/* The agent's other recall knobs — any-match tags + result limit
+                    — so the operator can reproduce a specific agent's recall. */}
+                <div className="flex flex-wrap gap-2">
+                  <label className="flex min-w-[12rem] flex-1 flex-col gap-1.5">
+                    <span className="font-mono text-[11px] uppercase tracking-wider text-foreground/55">
+                      Tags (any-match, comma-separated)
+                    </span>
+                    <input
+                      type="text"
+                      value={recallTags}
+                      onChange={(e) => setRecallTags(e.target.value)}
+                      placeholder="optional — e.g. preference, deploy"
+                      className="border border-ink-hairline bg-transparent px-3 py-2 text-sm text-foreground placeholder:text-foreground/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ink-accent pointer-coarse:min-h-11 pointer-coarse:text-base"
+                    />
+                  </label>
+                  <label className="flex w-24 flex-col gap-1.5">
+                    <span className="font-mono text-[11px] uppercase tracking-wider text-foreground/55">
+                      Limit
+                    </span>
+                    <input
+                      type="number"
+                      min={1}
+                      max={50}
+                      value={recallLimit}
+                      onChange={(e) => setRecallLimit(e.target.value)}
+                      placeholder="12"
+                      className="border border-ink-hairline bg-transparent px-3 py-2 text-sm text-foreground placeholder:text-foreground/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ink-accent pointer-coarse:min-h-11 pointer-coarse:text-base"
+                    />
+                  </label>
+                </div>
                 {recallError ? (
                   <p
                     role="alert"

--- a/apps/dashboard/tests/components/reference-hits.test.tsx
+++ b/apps/dashboard/tests/components/reference-hits.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+// ReferenceHits is the pure presentational half of the Memories → References
+// tab: it renders what `search_references` returned, with the loading / error /
+// empty states. The empty state must tell "no references filed" (searched 0)
+// apart from "filed but none matched" (searched > 0, zero hits) — the whole
+// point of the diagnostic.
+const { ReferenceHits } = await import("@/components/memories/reference-hits");
+
+function hit(over: Record<string, unknown> = {}) {
+  return {
+    id: "references/AI/Gentle Codeing.md",
+    score: 0.0328,
+    // Section deliberately omits the phrase "Gentle coding" so the anchor is the
+    // only element carrying it (keeps getByText unambiguous).
+    section: "Write the smallest change that teaches the model.",
+    anchor: "Gentle coding",
+    startChar: 0,
+    endChar: 62,
+    ...over,
+  };
+}
+
+describe("ReferenceHits", () => {
+  it("renders each hit with its path, score, anchor and section", () => {
+    render(
+      <ReferenceHits
+        result={{ query: "gentle coding", references: [hit()], searched: 12 }}
+        isLoading={false}
+        error={null}
+      />,
+    );
+    // Every value is also echoed in the raw-JSON disclosure (in the DOM even
+    // when collapsed), so scope the card assertions to the results list.
+    const list = within(screen.getByRole("list"));
+    expect(list.getByText("references/AI/Gentle Codeing.md")).toBeInTheDocument();
+    expect(list.getByText("score 0.0328")).toBeInTheDocument();
+    expect(list.getByText(/^Gentle coding/)).toBeInTheDocument();
+    expect(list.getByText(/smallest change that teaches/)).toBeInTheDocument();
+  });
+
+  it("links each hit path into the vault explorer (/?path=...)", () => {
+    render(
+      <ReferenceHits
+        result={{ query: "gentle coding", references: [hit()], searched: 12 }}
+        isLoading={false}
+        error={null}
+      />,
+    );
+    const link = screen.getByRole("link", { name: /Gentle Codeing\.md/ });
+    expect(link).toHaveAttribute(
+      "href",
+      `/?path=${encodeURIComponent("references/AI/Gentle Codeing.md")}`,
+    );
+  });
+
+  it("distinguishes an empty vault from a no-match result", () => {
+    const { rerender } = render(
+      <ReferenceHits
+        result={{ query: "anything", references: [], searched: 0 }}
+        isLoading={false}
+        error={null}
+      />,
+    );
+    // searched 0 → there are simply no reference docs filed.
+    expect(screen.getByText(/no reference documents/i)).toBeInTheDocument();
+
+    rerender(
+      <ReferenceHits
+        result={{ query: "gentle coding", references: [], searched: 12 }}
+        isLoading={false}
+        error={null}
+      />,
+    );
+    // searched 12, zero hits → they exist but none matched (the real diagnosis).
+    expect(screen.getByText(/12/)).toBeInTheDocument();
+    expect(screen.getByText(/none matched/i)).toBeInTheDocument();
+  });
+
+  it("exposes the exact agent payload under a raw-JSON disclosure", () => {
+    render(
+      <ReferenceHits
+        result={{ query: "gentle coding", references: [hit()], searched: 12 }}
+        isLoading={false}
+        error={null}
+      />,
+    );
+    // The disclosure shows { references: [...] } — what the agent actually gets,
+    // not the dashboard-only `searched` field.
+    const raw = screen.getByTestId("references-raw-json").textContent ?? "";
+    expect(raw).toContain('"references"');
+    expect(raw).toContain("references/AI/Gentle Codeing.md");
+    expect(raw).not.toContain("searched");
+  });
+
+  it("renders the error state", () => {
+    render(<ReferenceHits result={null} isLoading={false} error="index boom" />);
+    expect(screen.getByRole("alert")).toHaveTextContent(/index boom/);
+  });
+
+  it("prompts before any search has run", () => {
+    render(<ReferenceHits result={null} isLoading={false} error={null} />);
+    expect(screen.getByText(/run a query/i)).toBeInTheDocument();
+  });
+});

--- a/apps/dashboard/tests/memories-actions.test.ts
+++ b/apps/dashboard/tests/memories-actions.test.ts
@@ -83,6 +83,12 @@ describe("memories actions", () => {
     expect(recallMock).toHaveBeenCalledWith({ query: "hello", limit: 12 });
   });
 
+  it("recallAction forwards tags and an explicit limit when given", async () => {
+    recallMock.mockResolvedValueOnce({ memories: [] });
+    await actions.recallAction("hello", { tags: ["drink"], limit: 5 });
+    expect(recallMock).toHaveBeenCalledWith({ query: "hello", tags: ["drink"], limit: 5 });
+  });
+
   it("recallAction rejects empty queries", async () => {
     const result = await actions.recallAction("   ");
     expect(result.ok).toBe(false);

--- a/apps/dashboard/tests/memories-actions.test.ts
+++ b/apps/dashboard/tests/memories-actions.test.ts
@@ -90,13 +90,13 @@ describe("memories actions", () => {
     expect(recallMock).not.toHaveBeenCalled();
   });
 
-  it("searchReferencesAction returns ok and references on success", async () => {
+  it("searchReferencesAction returns ok, references and the searched count", async () => {
     const references = [
       { id: "references/AI/Gentle Codeing.md", score: 0.9, section: "## Gentle coding" },
     ];
-    searchRefsMock.mockResolvedValueOnce({ references });
+    searchRefsMock.mockResolvedValueOnce({ references, searched: 12 });
     const result = await actions.searchReferencesAction("gentle coding");
-    expect(result).toEqual({ ok: true, references });
+    expect(result).toEqual({ ok: true, references, searched: 12 });
     expect(searchRefsMock).toHaveBeenCalledWith({ query: "gentle coding" });
   });
 

--- a/apps/dashboard/tests/memories-actions.test.ts
+++ b/apps/dashboard/tests/memories-actions.test.ts
@@ -5,6 +5,7 @@ const updateMock = vi.fn();
 const archiveMock = vi.fn();
 const recallMock = vi.fn();
 const bulkUpdateMock = vi.fn();
+const searchRefsMock = vi.fn();
 const revalidateMock = vi.fn();
 
 vi.mock("@/lib/trpc-server", () => ({
@@ -15,6 +16,9 @@ vi.mock("@/lib/trpc-server", () => ({
       archive: { mutate: archiveMock },
       recall: { mutate: recallMock },
       bulkUpdate: { mutate: bulkUpdateMock },
+    },
+    vault: {
+      searchReferences: { mutate: searchRefsMock },
     },
   },
 }));
@@ -38,6 +42,7 @@ describe("memories actions", () => {
     archiveMock.mockReset();
     recallMock.mockReset();
     bulkUpdateMock.mockReset();
+    searchRefsMock.mockReset();
     revalidateMock.mockReset();
   });
 
@@ -83,6 +88,36 @@ describe("memories actions", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error).toMatch(/empty/i);
     expect(recallMock).not.toHaveBeenCalled();
+  });
+
+  it("searchReferencesAction returns ok and references on success", async () => {
+    const references = [
+      { id: "references/AI/Gentle Codeing.md", score: 0.9, section: "## Gentle coding" },
+    ];
+    searchRefsMock.mockResolvedValueOnce({ references });
+    const result = await actions.searchReferencesAction("gentle coding");
+    expect(result).toEqual({ ok: true, references });
+    expect(searchRefsMock).toHaveBeenCalledWith({ query: "gentle coding" });
+  });
+
+  it("searchReferencesAction forwards an explicit limit", async () => {
+    searchRefsMock.mockResolvedValueOnce({ references: [] });
+    await actions.searchReferencesAction("gentle coding", 5);
+    expect(searchRefsMock).toHaveBeenCalledWith({ query: "gentle coding", limit: 5 });
+  });
+
+  it("searchReferencesAction rejects empty queries", async () => {
+    const result = await actions.searchReferencesAction("   ");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/empty/i);
+    expect(searchRefsMock).not.toHaveBeenCalled();
+  });
+
+  it("searchReferencesAction surfaces upstream errors", async () => {
+    searchRefsMock.mockRejectedValueOnce(new Error("index boom"));
+    const result = await actions.searchReferencesAction("gentle coding");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe("index boom");
   });
 
   it("createMemoryAction surfaces upstream errors", async () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.43",
+  "version": "1.0.0-rc.44",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -83,6 +83,13 @@ export interface LibrarianStore
   /** Tier-0 reference lookup over the vault's references/ (backend-independent). */
   searchReferences(query: string, limit?: number): Promise<ReferenceHit[]>;
   /**
+   * How many reference documents the vault holds — the denominator the
+   * dashboard's reference tester uses to tell "no references filed" apart from
+   * "references exist but none matched". Counts exactly what searchReferences
+   * indexes (the markdown under references/).
+   */
+  countReferences(): number;
+  /**
    * Memory recall — index-backed (hybrid keyword+vector, backlink-aware). A
    * filter-only (no-query) call falls back to the keyword searchMemories.
    */
@@ -339,6 +346,9 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Libra
         cache: embeddingCache,
         ...(limit !== undefined ? { limit } : {}),
       }),
+    // "references" mirrors corpus-index's REFERENCES_DIR — the exact set
+    // searchReferences indexes, so this is a faithful "searched" denominator.
+    countReferences: () => vault.listMarkdown("references").length,
     recall: storeRecall,
     submitToInbox: (text: string, hints?: InboxSubmissionHints) => {
       const ref = writeInbox(vault, text, hints ? { hints } : {});

--- a/packages/mcp-server/src/trpc/memories.ts
+++ b/packages/mcp-server/src/trpc/memories.ts
@@ -13,13 +13,7 @@
 // follow-up; the casts at this boundary are safe because the Zod input
 // schemas validate before the cast runs.
 
-import {
-  DEFAULT_AGENT_ID,
-  type SplitReplacement,
-  SYSTEM_ACTOR_IDS,
-  mergeMemory,
-  splitMemory,
-} from "@librarian/core";
+import { type SplitReplacement, SYSTEM_ACTOR_IDS, mergeMemory, splitMemory } from "@librarian/core";
 import { MemoryInputSchema, MemoryPatchSchema, MemoryStatusSchema } from "@librarian/core/schemas";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
@@ -157,6 +151,8 @@ const RejectProposalInputSchema = z.object({
 const RecallInputSchema = z.object({
   agent_id: z.string().optional(),
   query: z.string().optional(),
+  // Any-match tag narrowing — the same knob the recall MCP tool exposes.
+  tags: z.array(z.string()).optional(),
   include_private: z.boolean().optional(),
   limit: z.number().int().min(1).max(50).optional(),
 });
@@ -409,13 +405,16 @@ export const memoriesRouter = router({
         ) as unknown as MemoryShape,
     ),
 
-  recall: adminProcedure.input(RecallInputSchema.optional()).mutation(({ ctx, input }) => {
-    const agentId = input?.agent_id ?? DEFAULT_AGENT_ID;
-    const query = input?.query ?? "";
-    const memories = ctx.store.searchMemories({
-      agent_id: agentId,
-      query,
-      include_private: input?.include_private ?? true,
+  recall: adminProcedure.input(RecallInputSchema.optional()).mutation(async ({ ctx, input }) => {
+    // Use the SAME hybrid engine the recall MCP tool gives agents (keyword +
+    // vector + backlink graph, RRF-fused) — store.recall, NOT keyword-only
+    // store.searchMemories — so the dashboard's Recall tab shows exactly what an
+    // agent sees. Post-D8 there is one shared corpus with no agent-visibility
+    // scoping, so agent_id/include_private don't change which memories are
+    // eligible; query + tags + limit are the live knobs.
+    const memories = await ctx.store.recall({
+      query: input?.query ?? "",
+      ...(input?.tags ? { tags: input.tags } : {}),
       limit: input?.limit ?? RECALL_DEFAULT_LIMIT,
     });
     return { memories: memories as unknown as MemoryShape[] };

--- a/packages/mcp-server/src/trpc/vault.ts
+++ b/packages/mcp-server/src/trpc/vault.ts
@@ -136,7 +136,13 @@ export const vaultRouter = router({
         });
       }
       const references = await ctx.store.searchReferences(input.query, input.limit);
-      return { references };
+      // `searched` is the count of reference docs in the vault — the dashboard
+      // uses it to tell "no references filed" apart from "filed but none
+      // matched" (the hybrid index drops a doc with neither keyword overlap nor
+      // positive cosine, so an empty `references` does NOT imply an empty
+      // vault). `references` is byte-identical to the MCP tool's payload; the
+      // extra field is dashboard-only diagnostics and doesn't affect parity.
+      return { references, searched: ctx.store.countReferences() };
     }),
 
   /** Overwrite an existing file — validated for its kind, optionally compare-and-swap. */

--- a/packages/mcp-server/src/trpc/vault.ts
+++ b/packages/mcp-server/src/trpc/vault.ts
@@ -45,6 +45,13 @@ const HashSchema = z
   .regex(/^[0-9a-f]{7,40}$/i, "expected a git commit hash (7-40 hex characters)");
 
 const ReadInputSchema = z.object({ path: VaultPathSchema });
+// Reference lookup input. `limit` mirrors the `search_references` MCP tool's
+// declared 1–100 bound; the store re-clamps, so an out-of-range value is a
+// boundary error here, not a silent surprise downstream.
+const SearchReferencesInputSchema = z.object({
+  query: z.string(),
+  limit: z.number().int().min(1).max(100).optional(),
+});
 const AtCommitInputSchema = z.object({ path: VaultPathSchema, hash: HashSchema });
 const DiffInputSchema = z.object({
   path: VaultPathSchema,
@@ -107,6 +114,30 @@ export const vaultRouter = router({
   resolve: adminProcedure.input(ResolveInputSchema).query(({ ctx, input }) => ({
     path: ctx.store.vaultFiles.resolveLink(input.target),
   })),
+
+  /**
+   * Tier-0 reference lookup — the dashboard's "References" retrieval tester.
+   * A thin pass-through to `store.searchReferences`, the SAME method the
+   * `search_references` MCP tool calls, so what the operator sees here is
+   * exactly what an agent sees. A mutation (not a query) to mirror the sibling
+   * `memories.recall`: this is a user-triggered "run the verb", not a cacheable
+   * read, and tRPC query-caching must not mask a re-run.
+   */
+  searchReferences: adminProcedure
+    .input(SearchReferencesInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      // Mirror the MCP tool's guard: reject a whitespace-only query with a
+      // teaching message, and pass the ORIGINAL (untrimmed) query through so
+      // results match the tool byte-for-byte.
+      if (!input.query.trim()) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "search_references needs a non-empty query — got only whitespace.",
+        });
+      }
+      const references = await ctx.store.searchReferences(input.query, input.limit);
+      return { references };
+    }),
 
   /** Overwrite an existing file — validated for its kind, optionally compare-and-swap. */
   write: adminProcedure.input(WriteInputSchema).mutation(({ ctx, input }) => {

--- a/packages/mcp-server/tests/trpc/recall-engine.test.ts
+++ b/packages/mcp-server/tests/trpc/recall-engine.test.ts
@@ -1,0 +1,72 @@
+// memories.recall must run the HYBRID engine (store.recall — keyword + vector +
+// backlink graph, RRF-fused), the SAME engine the recall MCP tool gives agents
+// — not keyword-only store.searchMemories. Regression for the dashboard's Recall
+// tab showing a different result set/order than agents actually get (spec
+// 2026-06-19, Task 4). In-process caller (not the HTTP server) so the store can
+// be spied.
+
+import { createLibrarianStore } from "@librarian/core";
+import { appRouter, createCallerFactory } from "@librarian/mcp-server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanupTempDir, makeTempDir } from "../../../../test/helpers.js";
+
+const createCaller = createCallerFactory(appRouter);
+
+function admin(store: unknown) {
+  return createCaller({
+    role: "admin",
+    store: store as never,
+    secretKey: null,
+    adminToken: "admin-token",
+  });
+}
+
+describe("memories.recall engine (spec 2026-06-19 Task 4)", () => {
+  let dataDir = "";
+  beforeEach(() => {
+    dataDir = makeTempDir();
+  });
+  afterEach(() => {
+    cleanupTempDir(dataDir);
+  });
+
+  it("recalls via the hybrid store.recall, not keyword store.searchMemories", async () => {
+    const store = createLibrarianStore({ dataDir });
+    try {
+      store.createMemory({
+        title: "Coffee preferences",
+        body: "Espresso, no sugar.",
+        agent_id: "bede",
+      });
+      const recallSpy = vi.spyOn(store, "recall");
+      const keywordSpy = vi.spyOn(store, "searchMemories");
+
+      const { memories } = await admin(store).memories.recall({ query: "coffee" });
+
+      expect(recallSpy).toHaveBeenCalled(); // the hybrid engine
+      expect(keywordSpy).not.toHaveBeenCalled(); // NOT the keyword-only path
+      expect(memories.some((m) => m.title === "Coffee preferences")).toBe(true);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("forwards a tags filter to the hybrid recall", async () => {
+    const store = createLibrarianStore({ dataDir });
+    try {
+      store.createMemory({
+        title: "Coffee",
+        body: "Espresso.",
+        agent_id: "bede",
+        tags: ["drink"],
+      });
+      const recallSpy = vi.spyOn(store, "recall");
+
+      await admin(store).memories.recall({ query: "coffee", tags: ["drink"] });
+
+      expect(recallSpy).toHaveBeenCalledWith(expect.objectContaining({ tags: ["drink"] }));
+    } finally {
+      store.close();
+    }
+  });
+});

--- a/packages/mcp-server/tests/trpc/vault-search-references.test.ts
+++ b/packages/mcp-server/tests/trpc/vault-search-references.test.ts
@@ -56,11 +56,25 @@ describe("tRPC vault.searchReferences (spec 2026-06-19 Task 1)", () => {
       );
       writeReference(dataDir, "sailing.md", "navigating boats across open water");
 
-      const { references } = await admin(store).vault.searchReferences({ query: "piano tuning" });
+      const { references, searched } = await admin(store).vault.searchReferences({
+        query: "piano tuning",
+      });
 
       expect(references[0]!.id).toBe("references/piano-manual.md");
       expect(references[0]!.section).toContain("## Tuning");
       expect(references[0]!.section).not.toContain("## Cleaning");
+      // `searched` counts the reference docs in the vault (both we wrote).
+      expect(searched).toBe(2);
+    });
+  });
+
+  it("reports searched=0 for an empty vault so 'no refs' is distinguishable from 'no match'", async () => {
+    await withStore(async (store: unknown) => {
+      const { references, searched } = await admin(store).vault.searchReferences({
+        query: "anything",
+      });
+      expect(references).toEqual([]);
+      expect(searched).toBe(0);
     });
   });
 

--- a/packages/mcp-server/tests/trpc/vault-search-references.test.ts
+++ b/packages/mcp-server/tests/trpc/vault-search-references.test.ts
@@ -1,0 +1,105 @@
+// vault.searchReferences tRPC procedure (spec 2026-06-19 — dashboard retrieval
+// testers, Task 1). The dashboard's "References" tab runs the same Tier-0
+// reference lookup an agent's `search_references` MCP tool runs — so the
+// operator sees exactly what the agent sees. Parity is the whole point: this
+// procedure is a thin pass-through to `store.searchReferences`, the identical
+// store method the MCP tool calls. The tests below run BOTH surfaces against
+// one store and assert the references match.
+
+import fs from "node:fs";
+import path from "node:path";
+import { appRouter, createCallerFactory, handleMcpPayload } from "@librarian/mcp-server";
+import { describe, expect, it } from "vitest";
+import { withStore } from "../../../../test/helpers.js";
+
+const createCaller = createCallerFactory(appRouter);
+
+function admin(store: unknown) {
+  return createCaller({
+    role: "admin",
+    store: store as never,
+    secretKey: null,
+    adminToken: "admin-token",
+  });
+}
+
+function writeReference(dataDir: string, name: string, body: string): void {
+  const dir = path.join(dataDir, "vault", "references");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, name), body);
+}
+
+interface ReferenceHit {
+  id: string;
+  score: number;
+  section: string;
+}
+
+/** The agent-facing payload: parse the MCP tool's text result. */
+async function mcpSearch(store: unknown, query: string): Promise<ReferenceHit[]> {
+  const res = (await handleMcpPayload(store as never, {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: { name: "search_references", arguments: { query } },
+  })) as { result: { content: { text: string }[] } };
+  return JSON.parse(res.result.content[0]!.text).references as ReferenceHit[];
+}
+
+describe("tRPC vault.searchReferences (spec 2026-06-19 Task 1)", () => {
+  it("returns the matching reference's path + relevant section", async () => {
+    await withStore(async (store: unknown, dataDir: string) => {
+      writeReference(
+        dataDir,
+        "piano-manual.md",
+        "## Tuning\nthe grand piano needs tuning twice a year\n\n## Cleaning\nwipe the keys",
+      );
+      writeReference(dataDir, "sailing.md", "navigating boats across open water");
+
+      const { references } = await admin(store).vault.searchReferences({ query: "piano tuning" });
+
+      expect(references[0]!.id).toBe("references/piano-manual.md");
+      expect(references[0]!.section).toContain("## Tuning");
+      expect(references[0]!.section).not.toContain("## Cleaning");
+    });
+  });
+
+  it("is identical to the search_references MCP tool for the same query+vault", async () => {
+    await withStore(async (store: unknown, dataDir: string) => {
+      writeReference(
+        dataDir,
+        "piano-manual.md",
+        "## Tuning\nthe grand piano needs tuning twice a year\n\n## Cleaning\nwipe the keys",
+      );
+      writeReference(dataDir, "sailing.md", "navigating boats across open water");
+
+      const agentSees = await mcpSearch(store, "piano tuning");
+      const { references } = await admin(store).vault.searchReferences({ query: "piano tuning" });
+
+      // What the dashboard shows IS what the agent sees — same ids, order, sections.
+      expect(references).toEqual(agentSees);
+    });
+  });
+
+  it("rejects an empty / whitespace query with a teaching BAD_REQUEST", async () => {
+    await withStore(async (store: unknown) => {
+      await expect(admin(store).vault.searchReferences({ query: "   " })).rejects.toMatchObject({
+        code: "BAD_REQUEST",
+      });
+    });
+  });
+
+  it("is admin-gated — an anonymous caller is turned away", async () => {
+    await withStore(async (store: unknown) => {
+      const anon = createCaller({
+        role: "anonymous",
+        store: store as never,
+        secretKey: null,
+        adminToken: "admin-token",
+      });
+      await expect(anon.vault.searchReferences({ query: "piano" })).rejects.toMatchObject({
+        code: "UNAUTHORIZED",
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Why

There was no way to test the agents' **`search_references`** retrieval verb from the dashboard, so when an agent's `search_references: "gentle coding"` returned nothing for `references/AI/Gentle Codeing.md`, there was no instrument to tell whether the file was *absent from the server's vault*, *present but unindexed*, or *merely ranked below the cut*.

Investigating that surfaced a second, related defect: the **Memories → Recall tab didn't run recall.** It called `store.searchMemories` (keyword only), while agents' `recall` MCP tool runs `store.recall` (keyword + vector + backlink graph, RRF-fused) — so the tab showed a different result set/order than agents actually get, and the semantic signal never appeared.

Both are the same problem: the dashboard's retrieval surfaces didn't faithfully reproduce what agents see. This PR adds a References tab built for parity, and corrects the Recall tab to match.

## What

- **`vault.searchReferences` tRPC procedure** — admin-gated, a thin pass-through to the *same* `store.searchReferences` the MCP tool calls. A parity test runs both surfaces against one store and asserts identical references.
- **`store.countReferences()` + `searched`** — returned alongside `references` (dashboard-only; `references` stays byte-identical to the MCP payload). Lets the UI tell *"no references filed"* from *"filed but none matched"* — the hybrid index drops a doc with neither keyword overlap nor positive cosine, so an empty result does **not** imply an empty vault.
- **"References" tab** on the Memories page (Browse · Recall · References): ranked hits with vault path (linking into the explorer), score, heading anchor, char range, matched section, a raw-JSON disclosure of the agent payload, and the empty-state distinction above. `/` focuses the input; Escape clears.
- **Recall tab fix** — `memories.recall` now calls `store.recall` (hybrid), not `store.searchMemories`, and exposes the agent's `tags` (any-match) + `limit` knobs. A regression test (in-process caller + store spies) pins that recall uses `store.recall`, never `store.searchMemories`.

## Test plan

- `core` 1136 ✓ (1 skipped) · `mcp-server` 258 ✓ · `dashboard` 298 ✓ · root `test/` 200 ✓
- Full `pnpm test` (build + all packages + root) exits 0; `lint`, repo `typecheck`, `check:release` all clean.
- Manual: open Memories → References, query against your vault, confirm the verdict for `Gentle Codeing.md`.

## Notes

- **Merging publishes `1.0.0-rc.44`** (the merge cuts the tag + release automatically). Out of scope by design: any *ranking/scoring* change to reference retrieval — this tab is the instrument to decide whether one is needed.
- The spec lives locally under `docs/specs/` and is intentionally **not** in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)