### PR TITLE
feat(dashboard): vault path picker + Move (replaces Rename)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.45] — 2026-06-19
+
+### Added
+
+- **Vault page: pick where a file lands instead of typing the path.** The
+  New-file dialog now has a folder picker — a combobox over the vault's existing
+  directories (type to filter, click or keyboard-pick, or type a brand-new
+  folder) — plus a filename field, so you choose a location without typing the
+  whole vault-relative path or scanning the tree.
+
+### Changed
+
+- **The file view's "Rename" is now "Move".** The same dialog gains the folder
+  picker and an editable filename, with a live preview of the resulting path: a
+  folder change moves the file, a filename change renames it. Both still go
+  through the wikilink-rewriting `git mv` (`vault.rename`), so behaviour is
+  unchanged — only the affordance is clearer and no longer needs a hand-typed
+  path.
+
 ## [1.0.0-rc.44] — 2026-06-19
 
 ### Added
@@ -3036,6 +3055,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0-rc.45]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.44...v1.0.0-rc.45
 [1.0.0-rc.44]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.43...v1.0.0-rc.44
 [1.0.0-rc.43]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.42...v1.0.0-rc.43
 [1.0.0-rc.42]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.41...v1.0.0-rc.42

--- a/apps/dashboard/components/vault/file-view.tsx
+++ b/apps/dashboard/components/vault/file-view.tsx
@@ -2,9 +2,9 @@
 
 // The vault file view (rethink T18/T19): rendered markdown with clickable
 // wikilinks, the frontmatter property table, the backlinks pane, and the
-// write-side chrome — edit toggle, rename + delete behind confirm dialogs.
-// Plus the History tab (rethink T20): per-file commit list, diff view, and
-// restore-as-a-new-commit.
+// write-side chrome — edit toggle, move (folder picker + rename) + delete
+// behind confirm dialogs. Plus the History tab (rethink T20): per-file commit
+// list, diff view, and restore-as-a-new-commit.
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -31,7 +31,9 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui-v2/tab
 import { VaultEditor } from "@/components/vault/editor";
 import { FileHistory, type HistoryActions } from "@/components/vault/file-history";
 import { MarkdownContent } from "@/components/vault/markdown-content";
+import { composePath } from "@/components/vault/new-file-dialog";
 import type { VaultFile } from "@/components/vault/types";
+import { VaultPathPicker } from "@/components/vault/vault-path-picker";
 import { useSurfaceShortcuts } from "@/hooks/use-surface-shortcuts";
 
 export interface VaultActions extends HistoryActions {
@@ -47,13 +49,22 @@ export interface VaultActions extends HistoryActions {
 
 type FileViewMode = "view" | "edit" | "history";
 
-export function FileView({ file, actions }: { file: VaultFile; actions: VaultActions }) {
+export function FileView({
+  file,
+  actions,
+  directories,
+}: {
+  file: VaultFile;
+  actions: VaultActions;
+  /** Folder option list for the Move dialog's path picker. */
+  directories: string[];
+}) {
   const [mode, setMode] = useState<FileViewMode>("view");
   const deleteTriggerRef = useRef<HTMLButtonElement | null>(null);
 
   // Per-file shortcuts: E switches to Edit, D opens the delete confirm.
-  // The Tabs own their own arrow-key cycling natively (Radix), so we
-  // don't compete.
+  // Move/Delete stay role=button (they open dialogs); the Read/Edit/History
+  // tabs own their own arrow-key cycling natively (Radix), so we don't compete.
   useSurfaceShortcuts({
     e: () => setMode("edit"),
     d: () => deleteTriggerRef.current?.click(),
@@ -67,7 +78,7 @@ export function FileView({ file, actions }: { file: VaultFile; actions: VaultAct
           {file.kind}
         </Pill>
         <span className="ml-auto flex items-center gap-2">
-          <RenameDialog path={file.path} onRename={actions.rename} />
+          <MoveDialog path={file.path} directories={directories} onMove={actions.rename} />
           <DeleteDialog path={file.path} onDelete={actions.remove} triggerRef={deleteTriggerRef} />
         </span>
       </header>
@@ -172,17 +183,41 @@ function BacklinksPane({ backlinks }: { backlinks: string[] }) {
   );
 }
 
-function RenameDialog({ path, onRename }: { path: string; onRename: VaultActions["rename"] }) {
+/** Split a vault path into its folder + filename (a root file → empty folder). */
+function splitPath(path: string): { folder: string; filename: string } {
+  const i = path.lastIndexOf("/");
+  return i === -1
+    ? { folder: "", filename: path }
+    : { folder: path.slice(0, i), filename: path.slice(i + 1) };
+}
+
+// Move (and rename) a file: pick a destination folder with the path picker and
+// adjust the filename. Both go through vault.rename — the wikilink-rewriting
+// git mv — so a folder change moves and a filename change renames, in one
+// control (spec 2026-06-19, Task 3 — replaces the old Rename dialog).
+function MoveDialog({
+  path,
+  directories,
+  onMove,
+}: {
+  path: string;
+  directories: string[];
+  onMove: VaultActions["rename"];
+}) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
-  const [to, setTo] = useState(path);
+  const here = splitPath(path);
+  const [folder, setFolder] = useState(here.folder);
+  const [filename, setFilename] = useState(here.filename);
   const [error, setError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
+
+  const to = composePath(folder, filename);
 
   const submit = (event: React.FormEvent) => {
     event.preventDefault();
     startTransition(async () => {
-      const result = await onRename({ from: path, to: to.trim() });
+      const result = await onMove({ from: path, to });
       if (!result.ok) {
         setError(result.error);
         return;
@@ -198,30 +233,49 @@ function RenameDialog({ path, onRename }: { path: string; onRename: VaultActions
       open={open}
       onOpenChange={(next) => {
         setOpen(next);
-        if (next) setTo(path);
+        // Reset the picker to the file's current location each time it opens.
+        if (next) {
+          const current = splitPath(path);
+          setFolder(current.folder);
+          setFilename(current.filename);
+          setError(null);
+        }
       }}
     >
       <Button variant="outline" onClick={() => setOpen(true)}>
-        Rename
+        Move
       </Button>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Rename file</DialogTitle>
+          <DialogTitle>Move file</DialogTitle>
           <DialogDescription>
-            Wikilinks pointing at the old filename are rewritten across the vault, so nothing
-            dangles.
+            Pick a destination folder (or type a new one) and adjust the filename if you like.
+            Wikilinks pointing at the old path are rewritten across the vault, so nothing dangles.
           </DialogDescription>
         </DialogHeader>
         <form onSubmit={submit} className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1 text-sm">
+            Folder
+            <VaultPathPicker
+              label="Folder"
+              directories={directories}
+              value={folder}
+              onChange={setFolder}
+              placeholder="references/AI (leave blank for the vault root)"
+            />
+          </div>
           <label className="flex flex-col gap-1 text-sm">
-            New path
+            File name
             <Input
               variant="mono"
-              value={to}
-              onChange={(e) => setTo(e.target.value)}
-              aria-label="New file path"
+              value={filename}
+              onChange={(e) => setFilename(e.target.value)}
+              aria-label="File name"
             />
           </label>
+          <p className="font-mono text-xs text-foreground/55">
+            → <span className="text-foreground/80">{to}</span>
+          </p>
           {error ? <p className="text-sm text-destructive">{error}</p> : null}
           <DialogFooter>
             <Button type="button" variant="ghost" onClick={() => setOpen(false)}>
@@ -230,9 +284,9 @@ function RenameDialog({ path, onRename }: { path: string; onRename: VaultActions
             <Button
               type="submit"
               variant="primary"
-              disabled={pending || !to.trim() || to.trim() === path}
+              disabled={pending || !filename.trim() || to === path}
             >
-              {pending ? "Renaming…" : "Rename file"}
+              {pending ? "Moving…" : "Move file"}
             </Button>
           </DialogFooter>
         </form>

--- a/apps/dashboard/components/vault/new-file-dialog.tsx
+++ b/apps/dashboard/components/vault/new-file-dialog.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+// New-file dialog (spec 2026-06-19): choose where the file lands with the
+// VaultPathPicker folder combobox + a filename field, instead of hand-typing
+// the whole vault-relative path. Extracted from vault-explorer so it's testable
+// in isolation and can share the picker with the Move dialog.
+
+import { useRouter } from "next/navigation";
+import { type FormEvent, type Ref, useState, useTransition } from "react";
+import { Button } from "@/components/ui-v2/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui-v2/dialog";
+import { Input } from "@/components/ui-v2/input";
+import { KeyHint } from "@/components/ui-v2/key-hint";
+import type { VaultActions } from "@/components/vault/file-view";
+import { VaultPathPicker } from "@/components/vault/vault-path-picker";
+
+/** Join folder + filename into a vault-relative path (root folder → bare name). */
+export function composePath(folder: string, filename: string): string {
+  const dir = folder.trim().replace(/\/+$/, "");
+  const name = filename.trim();
+  return dir ? `${dir}/${name}` : name;
+}
+
+export function NewFileDialog({
+  onCreate,
+  directories,
+  triggerRef,
+}: {
+  onCreate: VaultActions["create"];
+  directories: string[];
+  triggerRef?: Ref<HTMLButtonElement>;
+}) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [folder, setFolder] = useState("");
+  const [filename, setFilename] = useState("");
+  const [raw, setRaw] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const path = composePath(folder, filename);
+
+  const submit = (event: FormEvent) => {
+    event.preventDefault();
+    startTransition(async () => {
+      const result = await onCreate({ path, raw });
+      if (!result.ok) {
+        setError(result.error);
+        return;
+      }
+      setOpen(false);
+      setError(null);
+      router.push(`/?path=${encodeURIComponent(path)}`);
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <Button ref={triggerRef} variant="outline" onClick={() => setOpen(true)}>
+        New file
+        <KeyHint shortcut="N" />
+      </Button>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>New vault file</DialogTitle>
+          <DialogDescription>
+            Pick a folder (or type a new one) and name the file. Memories and handoffs are validated
+            against their schemas on save.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={submit} className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1 text-sm">
+            Folder
+            <VaultPathPicker
+              label="Folder"
+              directories={directories}
+              value={folder}
+              onChange={setFolder}
+              placeholder="references/AI (leave blank for the vault root)"
+            />
+          </div>
+          <label className="flex flex-col gap-1 text-sm">
+            File name
+            <Input
+              variant="mono"
+              value={filename}
+              onChange={(e) => setFilename(e.target.value)}
+              placeholder="style-guide.md"
+              aria-label="File name"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            Content
+            <textarea
+              aria-label="New file content"
+              className="min-h-[120px] border border-ink-hairline bg-ink-mono-fill p-2 font-mono text-xs text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ink-accent"
+              value={raw}
+              onChange={(e) => setRaw(e.target.value)}
+            />
+          </label>
+          {error ? <p className="text-sm text-destructive">{error}</p> : null}
+          <DialogFooter>
+            <Button type="button" variant="ghost" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" variant="primary" disabled={pending || !filename.trim()}>
+              {pending ? "Creating…" : "Create"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/dashboard/components/vault/vault-explorer.tsx
+++ b/apps/dashboard/components/vault/vault-explorer.tsx
@@ -229,7 +229,7 @@ export function VaultExplorer({
         {fileError ? (
           <p className="text-sm text-destructive">{fileError}</p>
         ) : file ? (
-          <FileView file={file} actions={actions} />
+          <FileView file={file} actions={actions} directories={directories} />
         ) : (
           <EmptyState title="The vault, at rest.">
             <p>

--- a/apps/dashboard/components/vault/vault-explorer.tsx
+++ b/apps/dashboard/components/vault/vault-explorer.tsx
@@ -7,22 +7,13 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useCallback, useMemo, useRef, useState, useTransition } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { EmptyState } from "@/components/brand/empty-state";
-import { Button } from "@/components/ui-v2/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-  DialogFooter,
-} from "@/components/ui-v2/dialog";
-import { Input } from "@/components/ui-v2/input";
 import { KeyHint } from "@/components/ui-v2/key-hint";
 import { FileTree } from "@/components/vault/file-tree";
 import { FileView } from "@/components/vault/file-view";
 import type { VaultActions } from "@/components/vault/file-view";
+import { NewFileDialog } from "@/components/vault/new-file-dialog";
 import type { VaultFile, VaultTreeNode } from "@/components/vault/types";
 import { useSurfaceShortcuts } from "@/hooks/use-surface-shortcuts";
 
@@ -68,6 +59,23 @@ export function filterTree(nodes: VaultTreeNode[], query: string): VaultTreeNode
   return walk(nodes);
 }
 
+/** Every directory path in the tree, plus the vault root (""), sorted with root
+ *  first — the option list for the New-file and Move path pickers. Exported for
+ *  direct unit testing. */
+export function collectDirectories(nodes: VaultTreeNode[]): string[] {
+  const dirs: string[] = [];
+  const walk = (list: VaultTreeNode[]): void => {
+    for (const node of list) {
+      if (node.type === "dir") {
+        dirs.push(node.path);
+        if (node.children) walk(node.children);
+      }
+    }
+  };
+  walk(nodes);
+  return ["", ...dirs.sort()];
+}
+
 export function VaultExplorer({
   tree,
   treeError,
@@ -93,6 +101,10 @@ export function VaultExplorer({
   // both memos pass through unchanged.
   const filteredTree = useMemo(() => filterTree(tree, filter), [tree, filter]);
   const flatPaths = useMemo(() => flattenFiles(filteredTree), [filteredTree]);
+  // Folder option list for the path pickers (New file + Move) — from the full
+  // tree, not the filtered view, so placement choices aren't narrowed by the
+  // sidebar filter.
+  const directories = useMemo(() => collectDirectories(tree), [tree]);
 
   // j/k cycles the selected file through the flattened tree. No selection
   // yet (?path= unset) lands on the first file. Wraps at both ends — vim
@@ -133,7 +145,11 @@ export function VaultExplorer({
       <aside className="flex flex-col gap-3">
         <div className="flex items-center justify-between gap-3">
           <h1 className="font-display text-xl text-foreground">Vault</h1>
-          <NewFileDialog onCreate={actions.create} triggerRef={newFileTriggerRef} />
+          <NewFileDialog
+            onCreate={actions.create}
+            directories={directories}
+            triggerRef={newFileTriggerRef}
+          />
         </div>
         {/* The audit trail (rethink T21): the vault's git history + restore. */}
         <Link href="/activity" className="text-sm underline">
@@ -230,82 +246,5 @@ export function VaultExplorer({
         )}
       </section>
     </div>
-  );
-}
-
-function NewFileDialog({
-  onCreate,
-  triggerRef,
-}: {
-  onCreate: VaultActions["create"];
-  triggerRef?: React.Ref<HTMLButtonElement>;
-}) {
-  const router = useRouter();
-  const [open, setOpen] = useState(false);
-  const [path, setPath] = useState("");
-  const [raw, setRaw] = useState("");
-  const [error, setError] = useState<string | null>(null);
-  const [pending, startTransition] = useTransition();
-
-  const submit = (event: React.FormEvent) => {
-    event.preventDefault();
-    startTransition(async () => {
-      const result = await onCreate({ path: path.trim(), raw });
-      if (!result.ok) {
-        setError(result.error);
-        return;
-      }
-      setOpen(false);
-      setError(null);
-      router.push(`/?path=${encodeURIComponent(path.trim())}`);
-    });
-  };
-
-  return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <Button ref={triggerRef} variant="outline" onClick={() => setOpen(true)}>
-        New file
-        <KeyHint shortcut="N" />
-      </Button>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>New vault file</DialogTitle>
-          <DialogDescription>
-            A vault-relative markdown path (e.g. references/style-guide.md). Memories and handoffs
-            are validated against their schemas on save.
-          </DialogDescription>
-        </DialogHeader>
-        <form onSubmit={submit} className="flex flex-col gap-3">
-          <label className="flex flex-col gap-1 text-sm">
-            Path
-            <Input
-              variant="mono"
-              value={path}
-              onChange={(e) => setPath(e.target.value)}
-              placeholder="references/new-doc.md"
-              aria-label="New file path"
-            />
-          </label>
-          <label className="flex flex-col gap-1 text-sm">
-            Content
-            <textarea
-              aria-label="New file content"
-              className="min-h-[120px] border border-ink-hairline bg-ink-mono-fill p-2 font-mono text-xs text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ink-accent"
-              value={raw}
-              onChange={(e) => setRaw(e.target.value)}
-            />
-          </label>
-          {error ? <p className="text-sm text-destructive">{error}</p> : null}
-          <DialogFooter>
-            <Button type="button" variant="ghost" onClick={() => setOpen(false)}>
-              Cancel
-            </Button>
-            <Button type="submit" variant="primary" disabled={pending || !path.trim()}>
-              {pending ? "Creating…" : "Create"}
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
   );
 }

--- a/apps/dashboard/components/vault/vault-path-picker.tsx
+++ b/apps/dashboard/components/vault/vault-path-picker.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+// A folder combobox over the vault's existing directories (spec 2026-06-19):
+// type to filter the list, click or keyboard-pick a folder, or type a
+// brand-new one (it suggests, never restricts). Shared by the New-file dialog
+// and the Move dialog so "pick where this lands" is one consistent control.
+//
+// Controlled + presentational: `directories` + `value` in, `onChange` out — the
+// host owns the data (derived from vault.tree) and the value. Selection fires on
+// mouseDown, not click, so it lands before the input's blur closes the list
+// (the classic combobox ordering trap). Order is preserved from `directories`;
+// the host sorts if it wants a sorted menu.
+
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+
+export function VaultPathPicker({
+  label,
+  directories,
+  value,
+  onChange,
+  placeholder,
+}: {
+  label: string;
+  directories: string[];
+  value: string;
+  onChange: (folder: string) => void;
+  placeholder?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const listId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const filtered = useMemo(() => {
+    const q = value.trim().toLowerCase();
+    if (!q) return directories;
+    return directories.filter((dir) => dir.toLowerCase().includes(q));
+  }, [directories, value]);
+
+  // Reshaping the list resets the highlight to the top, so Enter never fires a
+  // stale row that scrolled out from under it.
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [value]);
+
+  const select = (dir: string) => {
+    onChange(dir);
+    setOpen(false);
+    inputRef.current?.focus();
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setOpen(true);
+      setActiveIndex((i) => Math.min(filtered.length - 1, i + 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIndex((i) => Math.max(0, i - 1));
+    } else if (e.key === "Enter") {
+      const target = filtered[activeIndex];
+      if (open && target !== undefined) {
+        e.preventDefault();
+        select(target);
+      }
+    } else if (e.key === "Escape") {
+      if (open) {
+        e.preventDefault();
+        setOpen(false);
+      }
+    }
+  };
+
+  return (
+    <div className="relative">
+      <input
+        ref={inputRef}
+        type="text"
+        role="combobox"
+        aria-label={label}
+        aria-expanded={open}
+        aria-controls={listId}
+        aria-autocomplete="list"
+        value={value}
+        onChange={(e) => {
+          onChange(e.target.value);
+          setOpen(true);
+        }}
+        onFocus={() => setOpen(true)}
+        onBlur={() => setOpen(false)}
+        onKeyDown={onKeyDown}
+        placeholder={placeholder}
+        className="w-full border border-ink-hairline bg-ink-surface px-2 py-1.5 font-mono text-xs text-foreground placeholder:text-foreground/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ink-accent pointer-coarse:min-h-11 pointer-coarse:py-2.5 pointer-coarse:text-sm"
+      />
+      {open && filtered.length > 0 ? (
+        <ul
+          role="listbox"
+          id={listId}
+          aria-label={label}
+          className="absolute z-50 mt-1 max-h-56 w-full overflow-y-auto border border-ink-hairline bg-background shadow-lg"
+        >
+          {filtered.map((dir, i) => (
+            <li
+              key={dir === "" ? "(root)" : dir}
+              role="option"
+              aria-selected={i === activeIndex}
+              onMouseEnter={() => setActiveIndex(i)}
+              // mouseDown, not click: fire selection before the input blurs.
+              onMouseDown={(e) => {
+                e.preventDefault();
+                select(dir);
+              }}
+              className={`cursor-pointer px-2 py-1.5 font-mono text-xs pointer-coarse:min-h-11 pointer-coarse:py-2.5 pointer-coarse:text-sm ${
+                i === activeIndex ? "bg-ink-accent/10 text-foreground" : "text-foreground/90"
+              }`}
+            >
+              {dir === "" ? "(vault root)" : dir}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/dashboard/tests/components/vault-path-picker.test.tsx
+++ b/apps/dashboard/tests/components/vault-path-picker.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// VaultPathPicker is a folder combobox over the vault's existing directories:
+// type to filter, pick a folder (or type a brand-new one). Shared by the
+// New-file dialog and the Move dialog (spec 2026-06-19). Controlled +
+// presentational — no server.
+const { VaultPathPicker } = await import("@/components/vault/vault-path-picker");
+
+const DIRS = ["memories", "references", "references/AI", "handoffs"];
+
+describe("VaultPathPicker", () => {
+  it("filters the directory list by the current value (substring)", () => {
+    render(<VaultPathPicker label="Folder" directories={DIRS} value="ref" onChange={vi.fn()} />);
+    fireEvent.focus(screen.getByRole("combobox", { name: "Folder" }));
+    const list = within(screen.getByRole("listbox"));
+    expect(list.getByRole("option", { name: "references" })).toBeInTheDocument();
+    expect(list.getByRole("option", { name: "references/AI" })).toBeInTheDocument();
+    expect(list.queryByRole("option", { name: "memories" })).not.toBeInTheDocument();
+    expect(list.queryByRole("option", { name: "handoffs" })).not.toBeInTheDocument();
+  });
+
+  it("fires onChange with the chosen directory when an option is clicked", () => {
+    const onChange = vi.fn();
+    render(<VaultPathPicker label="Folder" directories={DIRS} value="ref" onChange={onChange} />);
+    fireEvent.focus(screen.getByRole("combobox", { name: "Folder" }));
+    // mouseDown (not click) so selection beats the input's blur.
+    fireEvent.mouseDown(screen.getByRole("option", { name: "references/AI" }));
+    expect(onChange).toHaveBeenCalledWith("references/AI");
+  });
+
+  it("selects the highlighted option with ArrowDown + Enter", () => {
+    const onChange = vi.fn();
+    render(<VaultPathPicker label="Folder" directories={DIRS} value="" onChange={onChange} />);
+    const input = screen.getByRole("combobox", { name: "Folder" });
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: "ArrowDown" }); // highlight index 1
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onChange).toHaveBeenCalledWith(DIRS[1]);
+  });
+
+  it("lets the operator type a brand-new folder not in the list", () => {
+    const onChange = vi.fn();
+    render(<VaultPathPicker label="Folder" directories={DIRS} value="" onChange={onChange} />);
+    fireEvent.change(screen.getByRole("combobox", { name: "Folder" }), {
+      target: { value: "research/new" },
+    });
+    expect(onChange).toHaveBeenCalledWith("research/new");
+  });
+});

--- a/apps/dashboard/tests/components/vault/file-view.test.tsx
+++ b/apps/dashboard/tests/components/vault/file-view.test.tsx
@@ -1,7 +1,7 @@
 // Vault file view (rethink T18/T19): rendered markdown with clickable
 // wikilinks, the frontmatter property table, the backlinks pane, the editor
 // (byte budget on primer/.curator, inline save errors, compare-and-swap hash),
-// and the rename/delete confirm dialogs.
+// and the move (folder picker + rename) / delete confirm dialogs.
 
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -29,6 +29,8 @@ const memoryFile: VaultFile = {
   links: [{ target: "Trash Over rm", path: "memories/trash-over-rm-2.md" }],
   backlinks: ["references/schedule.md"],
 };
+
+const DIRS = ["", "memories", "references", "references/AI", "handoffs"];
 
 const actions = () => ({
   save: vi.fn().mockResolvedValue({ ok: true, hash: "h2" }),
@@ -67,7 +69,7 @@ describe("MarkdownContent", () => {
 
 describe("FileView", () => {
   it("shows the frontmatter property table and the backlinks pane", () => {
-    render(<FileView file={memoryFile} actions={actions()} />);
+    render(<FileView file={memoryFile} actions={actions()} directories={DIRS} />);
     const properties = screen.getByRole("region", { name: "Frontmatter" });
     expect(properties).toHaveTextContent("mem_1");
     expect(properties).toHaveTextContent("people, music");
@@ -78,30 +80,46 @@ describe("FileView", () => {
   });
 
   it("Edit toggles the raw editor pre-filled with the file text", async () => {
-    render(<FileView file={memoryFile} actions={actions()} />);
+    render(<FileView file={memoryFile} actions={actions()} directories={DIRS} />);
     // Edit / Read / History are now tabs (D1.x polish) — Radix renders them
-    // as role=tab; Rename + Delete stay role=button since they open dialogs.
+    // as role=tab; Move + Delete stay role=button since they open dialogs.
     await userEvent.click(screen.getByRole("tab", { name: "Edit" }));
     expect(screen.getByLabelText("Raw markdown")).toHaveValue(memoryFile.raw);
   });
 
   it("delete asks for confirmation before calling the action", async () => {
     const acts = actions();
-    render(<FileView file={memoryFile} actions={acts} />);
+    render(<FileView file={memoryFile} actions={acts} directories={DIRS} />);
     await userEvent.click(screen.getByRole("button", { name: "Delete" }));
     expect(acts.remove).not.toHaveBeenCalled(); // dialog first, never direct
     await userEvent.click(await screen.findByRole("button", { name: "Delete file" }));
     await vi.waitFor(() => expect(acts.remove).toHaveBeenCalledWith({ path: memoryFile.path }));
   });
 
-  it("rename sends from + to through the dialog", async () => {
+  it("move relocates the file to the chosen folder (keeping the filename)", async () => {
     const acts = actions();
-    render(<FileView file={memoryFile} actions={acts} />);
-    await userEvent.click(screen.getByRole("button", { name: "Rename" }));
-    const input = await screen.findByLabelText("New file path");
-    await userEvent.clear(input);
-    await userEvent.type(input, "memories/anna-renamed-1.md");
-    await userEvent.click(screen.getByRole("button", { name: "Rename file" }));
+    render(<FileView file={memoryFile} actions={acts} directories={DIRS} />);
+    await userEvent.click(screen.getByRole("button", { name: "Move" }));
+    const folder = await screen.findByRole("combobox", { name: "Folder" });
+    await userEvent.clear(folder);
+    await userEvent.type(folder, "references");
+    await userEvent.click(screen.getByRole("button", { name: "Move file" }));
+    await vi.waitFor(() =>
+      expect(acts.rename).toHaveBeenCalledWith({
+        from: "memories/anna-1.md",
+        to: "references/anna-1.md",
+      }),
+    );
+  });
+
+  it("move also renames — editing the filename keeps the folder", async () => {
+    const acts = actions();
+    render(<FileView file={memoryFile} actions={acts} directories={DIRS} />);
+    await userEvent.click(screen.getByRole("button", { name: "Move" }));
+    const filename = await screen.findByRole("textbox", { name: "File name" });
+    await userEvent.clear(filename);
+    await userEvent.type(filename, "anna-renamed-1.md");
+    await userEvent.click(screen.getByRole("button", { name: "Move file" }));
     await vi.waitFor(() =>
       expect(acts.rename).toHaveBeenCalledWith({
         from: "memories/anna-1.md",

--- a/apps/dashboard/tests/components/vault/new-file-dialog.test.tsx
+++ b/apps/dashboard/tests/components/vault/new-file-dialog.test.tsx
@@ -1,0 +1,47 @@
+// New-file dialog (spec 2026-06-19, Task 2): the path is now chosen with the
+// VaultPathPicker folder combobox + a filename field, instead of typing the
+// whole vault-relative path by hand.
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const pushMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+const { NewFileDialog } = await import("@/components/vault/new-file-dialog");
+
+const DIRS = ["", "memories", "references", "references/AI", "handoffs"];
+
+afterEach(() => vi.clearAllMocks());
+
+describe("NewFileDialog", () => {
+  it("composes the chosen folder + filename into the created path", async () => {
+    const onCreate = vi.fn().mockResolvedValue({ ok: true });
+    render(<NewFileDialog onCreate={onCreate} directories={DIRS} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /New file/ }));
+    await userEvent.type(await screen.findByRole("combobox", { name: "Folder" }), "references/AI");
+    await userEvent.type(screen.getByRole("textbox", { name: "File name" }), "style.md");
+    await userEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await vi.waitFor(() =>
+      expect(onCreate).toHaveBeenCalledWith({ path: "references/AI/style.md", raw: "" }),
+    );
+  });
+
+  it("creates at the vault root when no folder is chosen", async () => {
+    const onCreate = vi.fn().mockResolvedValue({ ok: true });
+    render(<NewFileDialog onCreate={onCreate} directories={DIRS} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /New file/ }));
+    await userEvent.type(await screen.findByRole("textbox", { name: "File name" }), "root-note.md");
+    await userEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await vi.waitFor(() =>
+      expect(onCreate).toHaveBeenCalledWith({ path: "root-note.md", raw: "" }),
+    );
+  });
+});

--- a/apps/dashboard/tests/components/vault/vault-explorer.test.tsx
+++ b/apps/dashboard/tests/components/vault/vault-explorer.test.tsx
@@ -5,7 +5,7 @@
 import { describe, expect, it } from "vitest";
 import type { VaultTreeNode } from "@/components/vault/types";
 
-const { filterTree } = await import("@/components/vault/vault-explorer");
+const { filterTree, collectDirectories } = await import("@/components/vault/vault-explorer");
 
 const tree: VaultTreeNode[] = [
   {
@@ -79,5 +79,29 @@ describe("filterTree", () => {
     const out = filterTree(tree, ".md");
     // every file matches; every dir survives; primer stays at root.
     expect(out.map((n) => n.name).sort()).toEqual(["memories", "primer.md", "references"]);
+  });
+});
+
+describe("collectDirectories", () => {
+  it("lists every directory recursively, vault root first, sorted, files excluded", () => {
+    const nested: VaultTreeNode[] = [
+      {
+        name: "references",
+        path: "references",
+        type: "dir",
+        children: [
+          {
+            name: "AI",
+            path: "references/AI",
+            type: "dir",
+            children: [{ name: "x.md", path: "references/AI/x.md", type: "file", mtime: "t" }],
+          },
+          { name: "style.md", path: "references/style.md", type: "file", mtime: "t" },
+        ],
+      },
+      { name: "memories", path: "memories", type: "dir", children: [] },
+      { name: "primer.md", path: "primer.md", type: "file", mtime: "t" },
+    ];
+    expect(collectDirectories(nested)).toEqual(["", "memories", "references", "references/AI"]);
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.44",
+  "version": "1.0.0-rc.45",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",


### PR DESCRIPTION
> **Stacked on #409** (the dashboard retrieval testers). Base is
> `feat/dashboard-retrieval-testers` so the version bump stays sequential
> (rc.45 on top of rc.44). **Retarget this to `main` once #409 merges.**

## Why

Two Vault-page friction points:

1. **New file** made you type the full vault-relative path by hand.
2. **Moving a file** had no obvious affordance — though it secretly worked via
   the **Rename** dialog (`vault.rename` is a cross-directory `git mv` +
   wikilink rewrite), labelled "Rename", buried in the header, and needing a
   hand-typed path.

Both reduce to one missing piece: a way to **pick** a vault location.

## What

- **`VaultPathPicker`** — a folder combobox over the vault's existing
  directories (`vault.tree`): type to filter, click or keyboard-pick
  (↑/↓/Enter/Esc), or type a brand-new folder. Controlled + presentational.
- **New-file dialog** now composes the picker (folder) + a filename field, so
  you choose where a file lands without typing the whole path or scanning the
  tree. (Extracted to its own file for testability.)
- **"Rename" → "Move"** in the file view: the same dialog gains the folder
  picker + an editable filename and a live destination preview. A folder change
  moves, a filename change renames — both still go through `vault.rename`, so
  behaviour is unchanged; only the affordance improves.

**No server changes** — `vault.create` / `vault.rename` already do everything.
**No new dependency** — built from existing primitives. Any move is allowed (the
store's write-time validation is the guard).

## Test plan

- New unit/component tests: `VaultPathPicker` (filter/select/keyboard/new-folder),
  `collectDirectories`, New-file path composition, Move (relocate + rename via
  the one dialog). Dashboard suite 306 ✓.
- Full `pnpm test` (build + all packages + root) exits 0; `lint`, repo
  `typecheck`, `check:release` all clean.

## Notes

- **Merging publishes `1.0.0-rc.45`.**
- The spec lives locally under `docs/specs/` and is intentionally not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)