### PR TITLE
feat(core): BM25 + exact-phrase ranking — fix the 'gentle coding' failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.46] — 2026-06-19
+
+### Changed
+
+- **Better retrieval ranking — `recall` and `search_references` now reward
+  matching *all* your words, not just repeating one.** Two fixes to the shared
+  hybrid ranker:
+  - **BM25 keyword scoring** (was raw summed term-frequency). The old scorer had
+    no IDF, no length normalisation, and no coverage, so a document that spammed
+    one common query word outranked one that matched every query word. IDF now
+    down-weights common terms, term-frequency saturates, and length is
+    normalised.
+  - **An exact-phrase signal** fused into the ranking (RRF): a document
+    containing your query as a contiguous phrase gets a boost, ranked by how
+    many times it occurs.
+
+  Together these fix the observed case where `search_references "gentle coding"`
+  ranked a doc that says *"coding"* thirteen times (and never *"gentle"*) above
+  the doc that actually says *"gentle coding"*. Because the ranker is shared,
+  `recall` gets the same improvement. No new dependency; the intake-eval quality
+  gates are unchanged.
+
 ## [1.0.0-rc.45] — 2026-06-19
 
 ### Added
@@ -3055,6 +3077,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0-rc.46]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.45...v1.0.0-rc.46
 [1.0.0-rc.45]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.44...v1.0.0-rc.45
 [1.0.0-rc.44]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.43...v1.0.0-rc.44
 [1.0.0-rc.43]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.42...v1.0.0-rc.43

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.45",
+  "version": "1.0.0-rc.46",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/core/src/store/index/hybrid-index.ts
+++ b/packages/core/src/store/index/hybrid-index.ts
@@ -64,6 +64,23 @@ export interface HybridIndex {
   search(query: string, limit?: number): Promise<HybridHit[]>;
 }
 
+/** How many times `needle` appears as a contiguous run of tokens in `hay`. */
+function countContiguous(hay: string[], needle: string[]): number {
+  if (needle.length === 0 || needle.length > hay.length) return 0;
+  let count = 0;
+  for (let i = 0; i + needle.length <= hay.length; i++) {
+    let match = true;
+    for (let j = 0; j < needle.length; j++) {
+      if (hay[i + j] !== needle[j]) {
+        match = false;
+        break;
+      }
+    }
+    if (match) count++;
+  }
+  return count;
+}
+
 export async function buildHybridIndex(
   documents: { id: string; text: string; vector?: number[] }[],
   embedder: Embedder,
@@ -71,10 +88,14 @@ export async function buildHybridIndex(
 ): Promise<HybridIndex> {
   const rrfK = options.rrfK ?? 60;
   const keyword = buildKeywordIndex(documents.map((doc) => ({ id: doc.id, text: doc.text })));
+  // Token sequences per doc, for the exact-phrase signal (a contiguous match of
+  // the query's tokens is a strong relevance cue keyword+vector both miss).
+  const tokensById = new Map<string, string[]>();
   const vectors: { id: string; vector: number[] }[] = [];
   // A doc may arrive with a precomputed vector (the persistent embedding cache
   // resolves them upstream, where the file identity lives); only embed the rest.
   for (const doc of documents) {
+    tokensById.set(doc.id, tokenize(doc.text));
     vectors.push({ id: doc.id, vector: doc.vector ?? (await embedder.embed(doc.text)) });
   }
   const vector = buildVectorIndex(vectors);
@@ -90,9 +111,22 @@ export async function buildHybridIndex(
       // Only positive cosine counts as a semantic match (drop orthogonal/opposite).
       const vectorHits = vector.search(queryVector).filter((hit) => hit.score > 0);
 
+      // Exact-phrase signal: docs containing the query's tokens contiguously,
+      // ranked by occurrence count. Only for multi-token queries — a single
+      // token is already the keyword signal, so there's no phrase to add.
+      const queryTokens = tokenize(query);
+      const phraseHits: { id: string; count: number }[] = [];
+      if (queryTokens.length >= 2) {
+        for (const [id, toks] of tokensById) {
+          const count = countContiguous(toks, queryTokens);
+          if (count > 0) phraseHits.push({ id, count });
+        }
+        phraseHits.sort((a, b) => b.count - a.count || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+      }
+
       // RRF: a doc's fused score is the sum of 1/(k + rank) across the lists
       // it appears in. No score normalization needed; docs ranking high in
-      // both signals win.
+      // multiple signals win.
       const fused = new Map<string, number>();
       const contribute = (hits: { id: string }[]): void => {
         hits.forEach((hit, rank) => {
@@ -101,6 +135,7 @@ export async function buildHybridIndex(
       };
       contribute(keywordHits);
       contribute(vectorHits);
+      contribute(phraseHits);
 
       const ranked = [...fused.entries()].map(([id, score]) => ({ id, score }));
       ranked.sort((a, b) => b.score - a.score || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));

--- a/packages/core/src/store/index/keyword-index.ts
+++ b/packages/core/src/store/index/keyword-index.ts
@@ -1,9 +1,12 @@
-// Keyword index for the disposable index (plan 036 Phase 3 / spec 035 §F2).
-// A deterministic, dependency-free inverted index over the corpus, reusing
-// the shared tokenizer so keyword relevance matches the rest of the system.
-// `search` scores each doc by the summed term-frequency of the matching
-// query terms. Rebuildable from the markdown at any time (the index is
-// disposable). MiniSearch/FlexSearch remain a drop-in option if richer
+// Keyword index for the disposable index (plan 036 Phase 3 / spec 035 §F2;
+// BM25 upgrade 2026-06-19). A deterministic, dependency-free inverted index over
+// the corpus, reusing the shared tokenizer so keyword relevance matches the rest
+// of the system. `search` scores each doc by Okapi BM25 — IDF (rare query terms
+// outweigh common ones) × saturating term-frequency, length-normalised — so a
+// doc that matches ALL the query terms beats one that merely spams a single
+// common term (the old summed-tf failure: "gentle coding" lost to a doc with
+// "coding"×13 and no "gentle"). Rebuildable from the markdown at any time (the
+// index is disposable). MiniSearch/FlexSearch remain a drop-in option if richer
 // ranking is later needed — the index is swappable.
 
 import { tokenize } from "../memory-tokenize.js";
@@ -14,17 +17,29 @@ export interface KeywordHit {
 }
 
 export interface KeywordIndex {
-  /** Docs matching any query term, ranked by summed tf (desc), id tie-break. */
+  /** Docs matching any query term, ranked by BM25 (desc), id tie-break. */
   search(query: string, limit?: number): KeywordHit[];
 }
+
+// Okapi BM25 free parameters. k1 controls term-frequency saturation (how fast
+// extra occurrences stop helping); b controls length normalisation (0 = none,
+// 1 = full). 1.2 / 0.75 are the standard, robust defaults.
+const K1 = 1.2;
+const B = 0.75;
 
 export function buildKeywordIndex(documents: { id: string; text: string }[]): KeywordIndex {
   // term → (docId → term frequency)
   const postings = new Map<string, Map<string, number>>();
+  // docId → token count, for BM25 length normalisation.
+  const docLength = new Map<string, number>();
+  let totalLength = 0;
 
   for (const doc of documents) {
+    const tokens = tokenize(doc.text);
+    docLength.set(doc.id, tokens.length);
+    totalLength += tokens.length;
     const counts = new Map<string, number>();
-    for (const term of tokenize(doc.text)) counts.set(term, (counts.get(term) ?? 0) + 1);
+    for (const term of tokens) counts.set(term, (counts.get(term) ?? 0) + 1);
     for (const [term, tf] of counts) {
       let posting = postings.get(term);
       if (!posting) {
@@ -35,13 +50,25 @@ export function buildKeywordIndex(documents: { id: string; text: string }[]): Ke
     }
   }
 
+  const docCount = documents.length;
+  const avgdl = docCount > 0 ? totalLength / docCount : 0;
+
   return {
     search(query, limit) {
       const scores = new Map<string, number>();
       for (const term of new Set(tokenize(query))) {
         const posting = postings.get(term);
         if (!posting) continue;
-        for (const [id, tf] of posting) scores.set(id, (scores.get(id) ?? 0) + tf);
+        const df = posting.size;
+        // BM25 IDF — the always-non-negative variant, so a term in every doc
+        // contributes ~0 rather than going negative and penalising a match.
+        const idf = Math.log(1 + (docCount - df + 0.5) / (df + 0.5));
+        for (const [id, tf] of posting) {
+          const len = docLength.get(id) ?? 0;
+          const norm = avgdl > 0 ? 1 - B + (B * len) / avgdl : 1;
+          const contribution = idf * ((tf * (K1 + 1)) / (tf + K1 * norm));
+          scores.set(id, (scores.get(id) ?? 0) + contribution);
+        }
       }
       const hits = [...scores.entries()].map(([id, score]) => ({ id, score }));
       hits.sort((a, b) => b.score - a.score || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));

--- a/packages/core/tests/store/index/hybrid-index.test.ts
+++ b/packages/core/tests/store/index/hybrid-index.test.ts
@@ -12,6 +12,10 @@ const docs = [
   { id: "cal", text: "calendar tuesdays and thursdays" },
 ];
 
+// A zero-vector embedder: cosine is 0 for every doc, so the vector signal drops
+// out and ranking is keyword (BM25) + phrase only — isolates the phrase boost.
+const keywordOnly: Embedder = { embed: async () => [0] };
+
 describe("createHashEmbedder", () => {
   it("is deterministic and gives shared-token texts a positive cosine", async () => {
     const e = createHashEmbedder();
@@ -75,5 +79,26 @@ describe("buildHybridIndex", () => {
     expect(roles).toContain("doc:pnpm workspace"); // document embedded via embed()
     expect(roles).toContain("query:pnpm"); // query embedded via embedQuery()
     expect(roles).not.toContain("doc:pnpm"); // the query did NOT go through embed()
+  });
+
+  it("boosts a doc with the exact query phrase over one with the terms scattered", async () => {
+    // Both docs carry gentle x2 + coding x2 in 8 tokens → identical BM25, so
+    // without a phrase signal the id tie-break wins and "1-scattered" (sorts
+    // first) ranks #1. Only "2-phrase" has "gentle coding" contiguous (x2); the
+    // phrase signal must overturn the tie-break and rank it first.
+    const phraseDocs = [
+      { id: "1-scattered", text: "gentle alpha coding beta gentle gamma coding delta" },
+      { id: "2-phrase", text: "gentle coding alpha beta gentle coding gamma delta" },
+    ];
+    const index = await buildHybridIndex(phraseDocs, keywordOnly);
+    const hits = await index.search("gentle coding");
+    expect(hits[0]!.id).toBe("2-phrase");
+  });
+
+  it("leaves a single-token query unchanged (no phrase signal)", async () => {
+    // A 1-token query has no phrase; ranking is keyword+vector as before.
+    const index = await buildHybridIndex(docs, createHashEmbedder());
+    const hits = await index.search("pnpm");
+    expect(hits[0]!.id).toBe("pnpm");
   });
 });

--- a/packages/core/tests/store/index/keyword-index.test.ts
+++ b/packages/core/tests/store/index/keyword-index.test.ts
@@ -1,13 +1,16 @@
-// Keyword index tests (plan 036 Phase 3 / spec 035 §F2). A deterministic,
-// dependency-free inverted index over the corpus (reusing the shared
-// tokenizer): term → {docId → term-frequency}; search scores by summed tf of
-// the matching query terms. Rebuildable from the markdown (disposable index).
+// Keyword index tests (plan 036 Phase 3 / spec 035 §F2; BM25 upgrade
+// 2026-06-19). A deterministic, dependency-free inverted index over the corpus
+// (reusing the shared tokenizer). Scoring is BM25 (IDF + TF saturation + length
+// normalisation), so a doc matching ALL the query terms beats one that spams a
+// single common term — the "gentle coding" failure. Assertions are ranking-based
+// (BM25 magnitudes aren't magic numbers worth pinning); the invariants that
+// matter are order, exclusion, tie-break, and the empty case.
 
 import { buildKeywordIndex } from "@librarian/core";
 import { describe, expect, it } from "vitest";
 
 describe("buildKeywordIndex", () => {
-  it("returns docs that match the query, ranked by term frequency", () => {
+  it("returns only the docs that match the query, with a positive score", () => {
     const index = buildKeywordIndex([
       { id: "pnpm", text: "use pnpm for the monorepo; pnpm pnpm pnpm" },
       { id: "npm", text: "npm is fine too" },
@@ -15,16 +18,50 @@ describe("buildKeywordIndex", () => {
     ]);
     const hits = index.search("pnpm");
     expect(hits.map((h) => h.id)).toEqual(["pnpm"]);
-    expect(hits[0]!.score).toBe(4); // four occurrences of "pnpm"
+    expect(hits[0]!.score).toBeGreaterThan(0);
   });
 
-  it("sums tf across multiple query terms; more-relevant docs rank higher", () => {
+  it("ranks a doc matching more query terms above one matching fewer", () => {
     const index = buildKeywordIndex([
       { id: "a", text: "deploy deploy command notes" },
       { id: "b", text: "deploy once" },
     ]);
-    const hits = index.search("deploy command");
-    expect(hits.map((h) => h.id)).toEqual(["a", "b"]); // a: 2+1=3, b: 1
+    expect(index.search("deploy command").map((h) => h.id)).toEqual(["a", "b"]);
+  });
+
+  it("ranks a doc matching all query terms above one that spams a single common term", () => {
+    // 'coding' is common across the corpus (low IDF); 'gentle' is rare (high
+    // IDF). The target matches both; the spam doc repeats only the common term.
+    // Raw summed-tf would rank the spam doc first (7 > 2+2); BM25 must not.
+    const index = buildKeywordIndex([
+      { id: "spam", text: "coding coding coding coding coding coding coding" },
+      { id: "target", text: "gentle coding is gentle careful coding work" },
+      { id: "c1", text: "coding standards matter" },
+      { id: "c2", text: "more coding examples here" },
+      { id: "c3", text: "coding again today" },
+    ]);
+    const hits = index.search("gentle coding");
+    expect(hits[0]!.id).toBe("target");
+  });
+
+  it("rewards a rarer term: a single rare match outranks many common matches", () => {
+    const index = buildKeywordIndex([
+      { id: "rare", text: "telescope observations" },
+      { id: "common1", text: "notes notes notes notes" },
+      { id: "common2", text: "more notes" },
+      { id: "common3", text: "notes again" },
+    ]);
+    // 'telescope' appears in one doc (high IDF); 'notes' is everywhere (low IDF).
+    const hits = index.search("telescope notes");
+    expect(hits[0]!.id).toBe("rare");
+  });
+
+  it("normalises by length: with equal term frequency the shorter doc wins", () => {
+    const index = buildKeywordIndex([
+      { id: "short", text: "alpha alpha" },
+      { id: "long", text: "alpha alpha bravo charlie delta echo foxtrot golf hotel" },
+    ]);
+    expect(index.search("alpha").map((h) => h.id)).toEqual(["short", "long"]);
   });
 
   it("excludes non-matching docs and respects the limit", () => {

--- a/packages/core/tests/store/reference-search.test.ts
+++ b/packages/core/tests/store/reference-search.test.ts
@@ -77,6 +77,32 @@ describe("searchReferences (chunked, cache-backed)", () => {
     expect(typeof hits[0]?.score).toBe("number");
   });
 
+  it("ranks the doc that says 'gentle coding' above one that merely spams 'coding'", async () => {
+    // The real-world failure the References tab surfaced: 'Coding Is Dead'
+    // repeats 'coding' a dozen times but never says 'gentle'; the target says
+    // the phrase 'gentle coding'. Under raw summed-tf it tied/won on 'coding'
+    // count. BM25 (IDF down-weights the common 'coding') + the exact-phrase
+    // signal must rank the real match first. The c*.md docs make 'coding' common.
+    writeReference(
+      "coding-is-dead.md",
+      "# Coding Is Dead\n\ncoding coding coding coding coding coding coding coding coding coding coding coding coding programming",
+    );
+    writeReference(
+      "gentle-codeing.md",
+      "# Gentle Codeing\n\ngentle coding is a gentle coding practice; gentle coding stays gentle coding",
+    );
+    writeReference("c1.md", "coding standards matter");
+    writeReference("c2.md", "more coding examples");
+    writeReference("c3.md", "coding tips today");
+
+    const hits = await searchReferences(
+      createVault({ dataDir }),
+      createHashEmbedder(),
+      "gentle coding",
+    );
+    expect(hits[0]?.id).toBe("references/gentle-codeing.md");
+  });
+
   it("collapses multiple matching chunks of one file into a single hit per file", async () => {
     writeReference("doc.md", "## One\nzebra fact alpha\n\n## Two\nzebra fact beta");
     writeReference("other.md", "## Other\nnothing relevant here");
@@ -186,6 +212,38 @@ describe("searchReferences (chunked, cache-backed)", () => {
     const { embedder, calls } = countingEmbedder();
     expect(await searchReferences(createVault({ dataDir }), embedder, "anything")).toEqual([]);
     expect(calls.embed + calls.embedQuery).toBe(0);
+  });
+});
+
+describe("buildCorpusIndex recall ranking (shared BM25 + phrase signal)", () => {
+  it("ranks a both-terms memory above a memory that spams a single common term", async () => {
+    // The same fix reaches recall (shared hybrid index): 'coding' is common
+    // across memories (low IDF), 'gentle' is rare; the spam memory matches only
+    // 'coding'. Under raw summed-tf the spam (coding x6) outranked the real
+    // match (gentle x2 + coding x2 = 4). BM25 + phrase must flip it.
+    const store = createLibrarianStore({ dataDir });
+    let gentleId = "";
+    try {
+      store.createMemory({
+        agent_id: "x",
+        title: "Coding spam",
+        body: "coding coding coding coding coding coding",
+      });
+      gentleId = store.createMemory({
+        agent_id: "x",
+        title: "Gentle coding",
+        body: "gentle coding is a gentle coding habit",
+      }).memory.id;
+      store.createMemory({ agent_id: "x", title: "c1", body: "coding one here" });
+      store.createMemory({ agent_id: "x", title: "c2", body: "coding two there" });
+    } finally {
+      store.close();
+    }
+    const index = await buildCorpusIndex(createVault({ dataDir }), {
+      embedder: createHashEmbedder(),
+    });
+    const hits = await index.recall("gentle coding");
+    expect(hits[0]?.id).toBe(gentleId);
   });
 });
 


### PR DESCRIPTION
## Why

Using the new References tab, `search_references "gentle coding"` ranked **"Coding Is Dead, Long Live Programming.md"** (`coding`×13, no `gentle`) at/above **"Gentle Codeing.md"** (`gentle`×4 + the literal phrase `gentle coding`×4), both ~0.0320.

Root cause, read from the code: the shared keyword scorer was **raw summed term-frequency** — no IDF, no length normalisation, no coverage — so `coding`×13 (score 13) beat `gentle`×4+`coding`×4 (score 8); then RRF (rank-only, k=60) collapsed the magnitude so the better match couldn't pull ahead, and the tie broke alphabetically.

## What

Two fixes to the **shared** hybrid ranker (`buildHybridIndex`, used by *both* `search_references` and `recall`):

1. **BM25 keyword scoring** (`keyword-index.ts`) — IDF down-weights common terms, TF saturates, length normalises (k1=1.2, b=0.75). A doc matching all distinct query terms now beats single-common-term spam.
2. **Exact-phrase RRF signal** (`hybrid-index.ts`) — a third fused list: docs containing the query's tokens contiguously, ranked by occurrence count. Multi-token queries only.

Because the ranker is shared, **recall gets the same fix** (confirmed scope). No new dependency. RRF fusion and the hash embedder are untouched (lowering k / weighted fusion = option 3, real embeddings = option 4, positional proximity = option 2b — all deferred).

## Test plan

- Unit: BM25 (IDF / coverage / length-norm, the `gentle coding`-shaped case); phrase boost overturns a keyword tie toward the exact-phrase doc; single-token query unchanged. Existing keyword tests rewritten from absolute-score to ranking-based.
- Integration (full pipeline, real hash embedder): `searchReferences("gentle coding")` ranks the target first; `recall("gentle coding")` ranks the both-terms memory above the spam memory.
- **No recall regression:** `intake-eval` 39/39 green; its gate pattern is unchanged (the lone `Gate: FAIL` is an intentional test of the gate's own failure-detection).
- Full `pnpm test` exit 0 (core 1143, mcp-server 258, dashboard 306, …); `lint` / `typecheck` / `check:release` clean.

## Notes

- **Merging publishes `1.0.0-rc.46`.**
- Spec is local under `docs/specs/`, intentionally not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)