### PR TITLE
docs: lead integration READMEs with the librarian CLI; refresh main README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.47] — 2026-06-20
+
+### Documentation
+
+- **READMEs lead with the `librarian` CLI.** Each of the five integration
+  READMEs (`integrations/{claude,codex,opencode,hermes,pi}`) now documents
+  `npx @the-librarian/cli install` / `update` as the recommended path, with the
+  manual configuration kept below it.
+- **Accuracy fixes.** Claude: the `UserPromptSubmit` capture wiring is described
+  as primary-plus-redundancy and Claude bug #29767 is noted as fixed in Claude
+  Code 2.1.179. OpenCode: the manual setup now exports `LIBRARIAN_MCP_URL` (the
+  auto-capture plugin reads it). Hermes and Pi note that the CLI covers them.
+- **Main README:** add the project banner (`assets/The Librarian.png`), npm
+  version + weekly-downloads badges, and a prominent link to the project website
+  (<https://codeministry.net/the-librarian/>), surface `librarian update`, and
+  trim duplicated configuration prose.
+
 ## [1.0.0-rc.46] — 2026-06-19
 
 ### Changed
@@ -3077,6 +3094,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0-rc.47]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.46...v1.0.0-rc.47
 [1.0.0-rc.46]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.45...v1.0.0-rc.46
 [1.0.0-rc.45]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.44...v1.0.0-rc.45
 [1.0.0-rc.44]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.43...v1.0.0-rc.44

--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
 # The Librarian
 
+![The Librarian](./assets/The%20Librarian.png)
+
 [![CI](https://github.com/JimJafar/the-librarian/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/JimJafar/the-librarian/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/@the-librarian/cli?color=3f9c8e&label=npm)](https://www.npmjs.com/package/@the-librarian/cli)
+[![npm downloads](https://img.shields.io/npm/dw/@the-librarian/cli?color=3f9c8e)](https://www.npmjs.com/package/@the-librarian/cli)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![Website](https://img.shields.io/badge/website-codeministry.net-3f9c8e)](https://codeministry.net/the-librarian/)
+
+> **[See the illustrated project website →](https://codeministry.net/the-librarian/)** — what The Librarian is, how it works, and why you'd want it.
 
 **The Librarian is a living, markdown-native knowledge graph for AI agents — with
 a resident curator that tends it.** It is a markdown+git vault of three note
@@ -48,25 +55,29 @@ are all covered in the
 
 Once your server is running, the `librarian` CLI wires The Librarian into your
 harnesses and keeps them up to date — the package-manager-style tool you keep.
-Any harness already has Node, so one command does it:
+It covers all five harnesses (Claude Code, Codex, OpenCode, Hermes, Pi), drives
+each one's native install path, and wires automatic capture where supported. Any
+harness already has Node, so one command does it:
 
 ```sh
-npx @the-librarian/cli install
+npx @the-librarian/cli install      # wire your harnesses; prompts for the MCP URL + token
+npx @the-librarian/cli update       # later: bring every installed integration up to date
 ```
 
-(Or install it globally once — `npm i -g @the-librarian/cli` — then re-run
-`librarian install` whenever you add a harness.)
+(Or install it globally once — `npm i -g @the-librarian/cli` — then run
+`librarian install` / `librarian update` whenever you add or refresh a harness.)
 
 See [`packages/installer-cli`](./packages/installer-cli/README.md) for the
 full command reference and what it writes to your environment.
 
 ## Harness integrations
 
-Run the server, then add one config block per harness. Claude Code, Codex, and
-OpenCode need **no plugin code at all** — the MCP config (plus, for OpenCode,
-one `instructions` line pointing at the server's `GET /primer.md`) is a full
-integration. Hermes and Pi get thin in-tree adapters. Each harness's exact
-config and install steps live in its README:
+`librarian install` above wires all five for you; this section is the manual
+reference for each. Run the server, then add one config block per harness. Claude
+Code, Codex, and OpenCode need **no plugin code at all** — the MCP config (plus,
+for OpenCode, one `instructions` line pointing at the server's `GET /primer.md`)
+is a full integration. Hermes and Pi get thin in-tree adapters. Each harness's
+exact config and install steps live in its README:
 
 | Harness | Integration | Shape |
 |---|---|---|
@@ -117,12 +128,11 @@ cp .env.example .env   # optional — auth/secret vars auto-generate
 docker compose --env-file .env -f docker/docker-compose.yml up -d --build
 ```
 
-A fresh install needs **zero** auth/secret env vars: there is **no admin token**
-(the admin tRPC API is internal-only — ADR 0008), and `LIBRARIAN_SECRET_KEY`
-auto-generates on first boot (watch the log for the one-time value) or — better —
-is supplied off the data volume. Set `LIBRARIAN_AGENT_TOKEN` so remote agents can
-authenticate `/mcp`, and enable owner login from the dashboard. Full deploy
-guide: [DEPLOYMENT.md](./DEPLOYMENT.md).
+A fresh install needs **zero** auth/secret env vars — `LIBRARIAN_SECRET_KEY`
+auto-generates on first boot (watch the log for the one-time value). Set
+`LIBRARIAN_AGENT_TOKEN` so remote agents can authenticate `/mcp`, then enable
+owner login from the dashboard. Details in [Configuration](#configuration) and
+[DEPLOYMENT.md](./DEPLOYMENT.md).
 
 Then connect a harness: pick yours under [`integrations/`](./integrations) and
 add the config block from its README.

--- a/integrations/claude/README.md
+++ b/integrations/claude/README.md
@@ -19,6 +19,23 @@ server's conv_state surface. The plugin now ships a new, fail-soft set of hooks
 for **automatic capture** and **awareness** (see
 [Automatic capture & awareness](#automatic-capture--awareness) below).
 
+## Install with the Librarian CLI (recommended)
+
+One command wires Claude Code in — the plugin, the MCP config, and the
+auto-capture hooks — and keeps it current:
+
+```sh
+npx @the-librarian/cli install      # choose Claude Code; paste your MCP URL + token
+npx @the-librarian/cli update       # later: pull the latest plugin + hooks
+```
+
+`install` drives Claude's native `plugin install`, so you get everything in
+[Option B](#option-b--the-plugin-option-a--slash-commands) without the manual
+steps; it prompts for the MCP URL and agent token printed by
+`librarian server up`. Run it with `npx`, or `npm i -g @the-librarian/cli` once
+and call `librarian install` / `librarian update` directly. Prefer to wire it by
+hand? The two manual options below do the same thing.
+
 ## Option A — plain MCP config (no plugin)
 
 Add the server to any scope you like. Project scope (`.mcp.json` in your
@@ -117,7 +134,7 @@ remember the verbs (spec `2026-06-16-harness-auto-capture`, ADR 0009):
 
 | Hook | Script | What it does |
 | --- | --- | --- |
-| `UserPromptSubmit` (primary), `Stop`, `SessionEnd` | `on-stop.mjs` | Tail the conversation transcript from a byte-offset cursor and ship each turn's delta to the server (`POST /transcript`), which extracts durable lessons for you — **zero agent memory calls**. Driven by `UserPromptSubmit` because Claude bug [#29767](https://github.com/anthropics/claude-code/issues/29767) means plugin-scoped `Stop` hooks register but never fire; `Stop` / `SessionEnd` stay wired so capture **auto-recovers** when the bug is fixed. `SessionEnd` is the explicit-end accelerator (the server extracts immediately instead of waiting out the idle window). |
+| `UserPromptSubmit` (primary), `Stop`, `SessionEnd` | `on-stop.mjs` | Tail the conversation transcript from a byte-offset cursor and ship each turn's delta to the server (`POST /transcript`), which extracts durable lessons for you — **zero agent memory calls**. Driven by `UserPromptSubmit` (primary), with `Stop` / `SessionEnd` wired for redundancy; `SessionEnd` is the explicit-end accelerator (the server extracts immediately instead of waiting out the idle window). The `UserPromptSubmit` routing also worked around Claude bug [#29767](https://github.com/anthropics/claude-code/issues/29767), where plugin-scoped `Stop` hooks didn't fire — since fixed in Claude Code 2.1.179. |
 | `PreToolUse` (`Write\|Edit\|MultiEdit`) | `block-memory-write.mjs` | Block writes to Claude's **native memory store** (`**/.claude/**/memory/**`) and redirect you to the `remember` tool — durable facts belong in the shared Librarian, not a local `MEMORY.md` the next session/agent/harness can't see. Narrow by design (only the native store) and **fail-open**. |
 | `SessionStart` | `on-session-start.mjs` | Inject a deterministic banner: you have `recall`/`remember`, plus the current **capture status** (warns, with the fix, when capture is off). Re-fires after a compaction, so the awareness survives it. |
 

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -14,7 +14,24 @@ couldn't take an env-var URL for a remote MCP server, and its hook existed
 only for per-turn conv-state injection — both needs are gone (conv_state was
 retired server-side; Codex now supports HTTP MCP servers directly).
 
-## Install
+## Install with the Librarian CLI (recommended)
+
+One command wires Codex in and keeps it current:
+
+```sh
+npx @the-librarian/cli install      # choose Codex; paste your MCP URL + token
+npx @the-librarian/cli update       # later: refresh the integration
+```
+
+`install` writes the `[mcp_servers.librarian]` block for you (via `codex mcp
+add`) and installs the auto-capture hooks into `~/.codex/hooks.json`. One manual
+step remains: Codex won't **fire** hooks until you enable the feature — add
+`codex_hooks = true` under `[features]` in `~/.codex/config.toml` (see
+[Automatic capture](#automatic-capture-default-on-with-two-gates)). Run it with
+`npx`, or `npm i -g @the-librarian/cli` once and call `librarian install` /
+`librarian update` directly. Prefer to wire it by hand? See below.
+
+## Manual setup
 
 Add to `~/.codex/config.toml`:
 

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -36,6 +36,20 @@ dependencies).
 
 ## Install
 
+### The easy way — the Librarian CLI (recommended)
+
+```sh
+npx @the-librarian/cli install      # choose Hermes; paste your MCP URL + token
+npx @the-librarian/cli update       # later: refresh the provider
+```
+
+`install` copies the provider into `~/.hermes/plugins/librarian` and sets
+`memory.provider = librarian` in your Hermes config for you. Run it with `npx`,
+or `npm i -g @the-librarian/cli` once and call `librarian install` /
+`librarian update` directly. Prefer to wire it by hand? See below.
+
+### Manual setup
+
 The plugin is the `librarian/` directory in this folder — Hermes loads memory
 providers by directory scan, not pip. Per the `MemoryProvider` ABC: *"Plugins
 ship in `plugins/memory/<name>/` and are activated via the `memory.provider`

--- a/integrations/opencode/README.md
+++ b/integrations/opencode/README.md
@@ -17,7 +17,22 @@ server-side; the primer now rides opencode's own remote-URL `instructions`
 config, and the plugin's slash commands were optional sugar — shipped here
 as plain markdown files instead (see [Optional commands](#optional-commands)).
 
-## Install
+## Install with the Librarian CLI (recommended)
+
+One command wires opencode in and keeps it current:
+
+```sh
+npx @the-librarian/cli install      # choose OpenCode; paste your MCP URL + token
+npx @the-librarian/cli update       # later: refresh the integration
+```
+
+`install` edits your `opencode.json` (the MCP block + the `/primer.md`
+`instructions` line), installs the auto-capture plugin, and persists
+`LIBRARIAN_MCP_URL` + `LIBRARIAN_AGENT_TOKEN` for you. Run it with `npx`, or
+`npm i -g @the-librarian/cli` once and call `librarian install` /
+`librarian update` directly. Prefer to wire it by hand? See below.
+
+## Manual setup
 
 Add to your `opencode.json` (global `~/.config/opencode/opencode.json` or
 per-project), replacing `librarian.example.com` with your server:
@@ -45,8 +60,16 @@ Set the token in your shell profile and restart opencode:
 export LIBRARIAN_AGENT_TOKEN="<your-token>"
 ```
 
-That's everything. The 7 Librarian tools appear under `librarian`, and the
-primer loads into the model's instructions at session start.
+That's everything for the tools + primer. The 7 Librarian tools appear under
+`librarian`, and the primer loads into the model's instructions at session start.
+
+If you also wire [automatic capture](#automatic-capture) by hand, export
+`LIBRARIAN_MCP_URL` too — the capture plugin reads it to find the `/transcript`
+endpoint (the `librarian install` CLI persists it for you):
+
+```sh
+export LIBRARIAN_MCP_URL="https://librarian.example.com/mcp"
+```
 
 ### Why this exact shape (sources)
 

--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -39,6 +39,20 @@ Librarian primer into the system prompt. One install, zero config files.
 
 ## Install
 
+### The easy way — the Librarian CLI (recommended)
+
+```sh
+npx @the-librarian/cli install      # choose Pi; paste your MCP URL + token
+npx @the-librarian/cli update       # later: pull the latest extension
+```
+
+`install` runs Pi's native `pi install` for you and persists your server URL +
+token. Run it with `npx`, or `npm i -g @the-librarian/cli` once and call
+`librarian install` / `librarian update` directly. Prefer to wire it by hand?
+See below.
+
+### Manual setup
+
 From npm (once published — see "Publishing" below):
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.46",
+  "version": "1.0.0-rc.47",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## What

Refreshes all six READMEs.

**All five integration READMEs** (Claude, Codex, OpenCode, Hermes, Pi) now lead with the `librarian` CLI as the recommended path — `npx @the-librarian/cli install` / `update` — with the manual configuration kept below it. None of them mentioned the CLI before, despite it covering all five harnesses.

**Accuracy fixes (verified against the code):**
- **Claude** — the `UserPromptSubmit` capture wiring is reframed as primary-plus-redundancy, and bug #29767 is noted as fixed in Claude Code 2.1.179 (the README still described it as open).
- **OpenCode** — the manual setup now exports `LIBRARIAN_MCP_URL`; the auto-capture plugin reads it to find `/transcript`, and a hand-install per the old README shipped no capture.
- **Hermes / Pi** — note that `librarian install`/`update` cover them (the CLI has harness modules for both).

**Main README:**
- Adds the project banner (`assets/The Librarian.png`).
- Adds npm version + weekly-downloads badges and a prominent link to the new project website, https://codeministry.net/the-librarian/.
- Surfaces `librarian update` and trims a duplicated configuration paragraph.

## Release
Bumps the version to `1.0.0-rc.47` with a dated CHANGELOG entry + compare link (`check:release` passes locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01JYbcJZ29dVpfXGvWWVe9iA