### PR TITLE
chore(cli): refresh the @the-librarian/cli npm description; shorten README site link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.48] — 2026-06-20
+
+### Changed
+
+- **`@the-librarian/cli` npm description** refreshed — it now states the CLI
+  self-hosts the server and installs The Librarian into your agents (Claude Code,
+  Codex, OpenCode, Hermes, Pi), rather than just a "cross-harness installer". The
+  publish job stamps the root version into the package, so this ships on release.
+- Main README: shorten the project-website link text to "Project site".
+
 ## [1.0.0-rc.47] — 2026-06-20
 
 ### Documentation
@@ -3094,6 +3104,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0-rc.48]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.47...v1.0.0-rc.48
 [1.0.0-rc.47]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.46...v1.0.0-rc.47
 [1.0.0-rc.46]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.45...v1.0.0-rc.46
 [1.0.0-rc.45]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.44...v1.0.0-rc.45

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Website](https://img.shields.io/badge/website-codeministry.net-3f9c8e)](https://codeministry.net/the-librarian/)
 
-> **[See the illustrated project website →](https://codeministry.net/the-librarian/)** — what The Librarian is, how it works, and why you'd want it.
+> **[Project site →](https://codeministry.net/the-librarian/)** — what The Librarian is, how it works, and why you'd want it.
 
 **The Librarian is a living, markdown-native knowledge graph for AI agents — with
 a resident curator that tends it.** It is a markdown+git vault of three note

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.47",
+  "version": "1.0.0-rc.48",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/installer-cli/package.json
+++ b/packages/installer-cli/package.json
@@ -6,7 +6,7 @@
     "access": "public"
   },
   "type": "module",
-  "description": "Cross-harness installer CLI for The Librarian. Bin: librarian.",
+  "description": "The Librarian CLI: self-host the server and install it into your AI coding agents (Claude Code, Codex, OpenCode, Hermes, Pi).",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {


### PR DESCRIPTION
## What

- **npm description for `@the-librarian/cli`** — was *"Cross-harness installer CLI for The Librarian. Bin: librarian."*, which undersold it. Now: *"The Librarian CLI: self-host the server and install it into your AI coding agents (Claude Code, Codex, OpenCode, Hermes, Pi)."*
- **Main README** — shortened the project-website link text from "See the illustrated project website" to "Project site".

## How it reaches npm
`release.yml`'s `publish-npm` job stamps the **root** version into every public workspace package before publishing, so `@the-librarian/cli` ships at the root version regardless of its own (drifted) `package.json` version. So this just needs the description change + the standard root version bump.

## Release
Bumps the root version to `1.0.0-rc.48` with a dated CHANGELOG entry + compare link (`check:release` and prettier pass locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01JYbcJZ29dVpfXGvWWVe9iA