### PR TITLE
feat(dashboard): read-only view of the intake/grooming curator prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.49] — 2026-06-20
+
+### Added
+
+- **Read-only view of the curator prompts.** The Curator cockpit now shows the
+  base intake/grooming prompt — the static CORE + mode section the addendum
+  augments — in a collapsed, read-only disclosure above the addendum editor, with
+  the prompt version. Backed by a new admin-gated `addendum.getBasePrompt` tRPC
+  query and an exported `buildBaseCuratorPrompt` core helper; a test asserts the
+  view matches the system message the curator actually sends.
+
 ## [1.0.0-rc.48] — 2026-06-20
 
 ### Changed
@@ -3104,6 +3115,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0-rc.49]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.48...v1.0.0-rc.49
 [1.0.0-rc.48]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.47...v1.0.0-rc.48
 [1.0.0-rc.47]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.46...v1.0.0-rc.47
 [1.0.0-rc.46]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.45...v1.0.0-rc.46

--- a/apps/dashboard/app/curator/page.tsx
+++ b/apps/dashboard/app/curator/page.tsx
@@ -21,11 +21,17 @@ export const dynamic = "force-dynamic";
 export default async function CuratorPage() {
   let groomingAddendum: Awaited<ReturnType<typeof serverTRPC.addendum.get.query>> | null = null;
   let intakeAddendum: Awaited<ReturnType<typeof serverTRPC.addendum.get.query>> | null = null;
+  let groomingPrompt: Awaited<ReturnType<typeof serverTRPC.addendum.getBasePrompt.query>> | null =
+    null;
+  let intakePrompt: Awaited<ReturnType<typeof serverTRPC.addendum.getBasePrompt.query>> | null =
+    null;
   let error: string | null = null;
   try {
-    [groomingAddendum, intakeAddendum] = await Promise.all([
+    [groomingAddendum, intakeAddendum, groomingPrompt, intakePrompt] = await Promise.all([
       serverTRPC.addendum.get.query({ job: "grooming" }),
       serverTRPC.addendum.get.query({ job: "intake" }),
+      serverTRPC.addendum.getBasePrompt.query({ job: "grooming" }),
+      serverTRPC.addendum.getBasePrompt.query({ job: "intake" }),
     ]);
   } catch (err) {
     error = err instanceof Error ? err.message : String(err);
@@ -56,16 +62,20 @@ export default async function CuratorPage() {
         </p>
       ) : null}
 
-      {groomingAddendum && intakeAddendum ? (
+      {groomingAddendum && intakeAddendum && groomingPrompt && intakePrompt ? (
         <GroomingChatWorkspace
           jobs={{
             grooming: {
               content: groomingAddendum.content,
               version: groomingAddendum.version,
+              basePrompt: groomingPrompt.basePrompt,
+              promptVersion: groomingPrompt.version,
             },
             intake: {
               content: intakeAddendum.content,
               version: intakeAddendum.version,
+              basePrompt: intakePrompt.basePrompt,
+              promptVersion: intakePrompt.version,
             },
           }}
           actions={{

--- a/apps/dashboard/components/curator/chat-panel.tsx
+++ b/apps/dashboard/components/curator/chat-panel.tsx
@@ -97,6 +97,8 @@ export function ChatPanel({
   initialAddendum = "",
   draft: controlledDraft,
   onDraftChange,
+  basePrompt = "",
+  promptVersion = "",
 }: {
   onChat: (input: {
     messages: ChatMessage[];
@@ -111,6 +113,8 @@ export function ChatPanel({
   initialAddendum?: string;
   draft?: string;
   onDraftChange?: (next: string) => void;
+  basePrompt?: string;
+  promptVersion?: string;
 }) {
   const router = useRouter();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -349,6 +353,21 @@ export function ChatPanel({
             Operator guidance for the {job} curator. Committed addenda apply on the job's next run.
           </p>
         </header>
+
+        {basePrompt ? (
+          <details className="border border-ink-hairline">
+            <summary className="cursor-pointer select-none px-3 py-2 font-mono text-[0.6875rem] uppercase tracking-[0.08em] text-foreground/60 hover:text-foreground">
+              View the {job} prompt (read-only){promptVersion ? ` · ${promptVersion}` : ""}
+            </summary>
+            <p className="border-t border-ink-hairline px-3 py-2 text-xs text-foreground/55">
+              The base prompt the curator runs. Your addendum below is appended to it as advisory
+              guidance.
+            </p>
+            <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-words bg-ink-mono-fill p-3 font-mono text-xs leading-relaxed text-foreground/80">
+              {basePrompt}
+            </pre>
+          </details>
+        ) : null}
 
         <div className="flex flex-col gap-1.5">
           <SectionLabel as="label" htmlFor="curator-addendum">

--- a/apps/dashboard/components/curator/chat-workspace.tsx
+++ b/apps/dashboard/components/curator/chat-workspace.tsx
@@ -24,6 +24,8 @@ import { Select } from "@/components/ui-v2/select";
 export interface JobAddendumState {
   content: string;
   version: string | null;
+  basePrompt: string;
+  promptVersion: string;
 }
 
 export interface ChatWorkspaceActions {
@@ -110,6 +112,8 @@ export function GroomingChatWorkspace({
         onSetAddendum={actions.onSetAddendum}
         draft={draft}
         onDraftChange={setDraft}
+        basePrompt={current.basePrompt}
+        promptVersion={current.promptVersion}
       />
 
       <div className="flex flex-wrap items-center justify-end gap-3" aria-label="Addendum history">

--- a/apps/dashboard/tests/components/curator/chat-panel.test.tsx
+++ b/apps/dashboard/tests/components/curator/chat-panel.test.tsx
@@ -46,6 +46,19 @@ describe("ChatPanel", () => {
     expect(chat.calls[0]!.messages.at(-1)).toEqual({ role: "user", content: "hi" });
   });
 
+  it("shows the base curator prompt read-only above the addendum, collapsed by default", () => {
+    renderPanel({
+      job: "grooming",
+      basePrompt: "BASE-PROMPT-MARKER: preserve, do not destroy.",
+      promptVersion: "v5.4",
+    });
+    expect(screen.getByText(/view the grooming prompt \(read-only\) · v5\.4/i)).toBeTruthy();
+    // Closed <details> still renders its children in the DOM.
+    expect(screen.getByText(/BASE-PROMPT-MARKER/)).toBeTruthy();
+    // Read-only: the prompt is not held in an editable field.
+    expect(screen.queryByDisplayValue(/BASE-PROMPT-MARKER/)).toBeNull();
+  });
+
   it("renders a proposed_action as a Confirm card and does NOT auto-execute it", async () => {
     const action: ProposedAction = {
       type: "update",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.48",
+  "version": "1.0.0-rc.49",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/core/src/curator-prompt.ts
+++ b/packages/core/src/curator-prompt.ts
@@ -140,12 +140,21 @@ export type CuratorPromptInput =
  * + the mode's contract/rules, then the redacted, untrusted-framed user
  * evidence. Pure string assembly — no LLM call, no store access.
  */
+/**
+ * The base curator prompt for a job — the static system message (CORE + the
+ * job's mode section) that the operator addendum augments, WITHOUT the addendum
+ * or any evidence. Surfaced read-only in the dashboard so operators can see what
+ * their addendum is added to. Pure static text; no secrets, no store access.
+ */
+export function buildBaseCuratorPrompt(mode: "intake" | "grooming"): string {
+  return `${CORE}\n\n${mode === "intake" ? INTAKE_MODE : GROOMING_MODE}`;
+}
+
 export function buildCuratorPrompt(input: CuratorPromptInput): LlmMessage[] {
-  const modeSection = input.mode === "intake" ? INTAKE_MODE : GROOMING_MODE;
   const userContent =
     input.mode === "intake" ? buildIntakeUserContent(input) : buildGroomingUserContent(input);
   return [
-    { role: "system", content: `${CORE}\n\n${modeSection}` },
+    { role: "system", content: buildBaseCuratorPrompt(input.mode) },
     { role: "user", content: userContent },
   ];
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,6 +32,7 @@ export {
 export {
   type CuratorPromptInput,
   CURATOR_PROMPT_VERSION,
+  buildBaseCuratorPrompt,
   buildCuratorPrompt,
 } from "./curator-prompt.js";
 export {

--- a/packages/core/tests/curator-prompt.test.ts
+++ b/packages/core/tests/curator-prompt.test.ts
@@ -13,6 +13,7 @@ import {
   CURATOR_PROMPT_VERSION,
   GroomingOperationSchema,
   IntakeJudgmentSchema,
+  buildBaseCuratorPrompt,
   buildCuratorPrompt,
 } from "@librarian/core";
 import { describe, expect, it } from "vitest";
@@ -106,6 +107,21 @@ function wireShape(option: z.ZodObject, discriminator: string) {
 }
 
 // ── shared core ───────────────────────────────────────────────────────────────
+
+describe("buildBaseCuratorPrompt — read-only base prompt", () => {
+  it("matches the system message buildCuratorPrompt sends (no addendum, no evidence)", () => {
+    expect(buildBaseCuratorPrompt("intake")).toBe(intakeSystem);
+    expect(buildBaseCuratorPrompt("grooming")).toBe(groomingSystem);
+  });
+
+  it("carries no operator-addendum framing and differs by mode", () => {
+    for (const mode of ["intake", "grooming"] as const) {
+      expect(buildBaseCuratorPrompt(mode).length).toBeGreaterThan(100);
+      expect(buildBaseCuratorPrompt(mode)).not.toMatch(/OPERATOR GUIDANCE/i);
+    }
+    expect(buildBaseCuratorPrompt("intake")).not.toBe(buildBaseCuratorPrompt("grooming"));
+  });
+});
 
 describe("buildCuratorPrompt — shared core", () => {
   it("emits a system message then a user message in both modes", () => {

--- a/packages/mcp-server/src/trpc/addendum.ts
+++ b/packages/mcp-server/src/trpc/addendum.ts
@@ -16,7 +16,12 @@
 // consumer-agent surface for curation.
 
 import type { CuratorJob } from "@librarian/core";
-import { readJobAddendum, setJobAddendum } from "@librarian/core";
+import {
+  CURATOR_PROMPT_VERSION,
+  buildBaseCuratorPrompt,
+  readJobAddendum,
+  setJobAddendum,
+} from "@librarian/core";
 import { z } from "zod";
 import { adminProcedure, router } from "./trpc.js";
 
@@ -37,6 +42,14 @@ export const addendumRouter = router({
   get: adminProcedure
     .input(JobInputSchema)
     .query(({ ctx, input }) => readJobAddendum(ctx.store, input.job)),
+
+  // Read a job's base prompt — the static CORE + mode section the addendum
+  // augments — for read-only display above the addendum editor. Pure static
+  // text (no secrets, no store access); admin-gated like the rest.
+  getBasePrompt: adminProcedure.input(JobInputSchema).query(({ input }) => ({
+    version: CURATOR_PROMPT_VERSION,
+    basePrompt: buildBaseCuratorPrompt(input.job),
+  })),
 
   // Commit a new addendum for a job — it applies immediately (rethink D4): the
   // job's next run reads the new text. Works whether the job is enabled or not

--- a/packages/mcp-server/tests/trpc/addendum.test.ts
+++ b/packages/mcp-server/tests/trpc/addendum.test.ts
@@ -232,4 +232,28 @@ describe("tRPC addendum admin surface (spec 044 D-1 / rethink D4)", () => {
       await server.stop();
     }
   });
+
+  it("getBasePrompt returns the base prompt + version, and 404s on the public listener", async () => {
+    const server = await startHttpServer({ dataDir });
+    try {
+      const result = await trpcGet<{ version: string; basePrompt: string }>(
+        server,
+        "addendum.getBasePrompt",
+        { job: "intake" },
+      );
+      expect(result.version).toMatch(/^v\d/);
+      expect(result.basePrompt.length).toBeGreaterThan(100);
+      expect(result.basePrompt).not.toMatch(/OPERATOR GUIDANCE/i);
+
+      // Admin-gated: unreachable from the public network listener (ADR 0008 P3).
+      const input = encodeURIComponent(JSON.stringify({ job: "intake" }));
+      const agent = await fetch(`${server.url}/trpc/addendum.getBasePrompt?input=${input}`, {
+        method: "GET",
+        headers: { authorization: "Bearer agent-token" },
+      });
+      expect(agent.status).toBe(404);
+    } finally {
+      await server.stop();
+    }
+  });
 });


### PR DESCRIPTION
## What

The Curator cockpit now lets you **read the base prompt** for the selected job. A collapsed, read-only `<details>` disclosure sits **above the addendum editor**, showing the static `CORE` + mode section that your addendum augments, labelled with the prompt version (e.g. *View the grooming prompt (read-only) · v5.4*).

The cockpit shows one job at a time (the existing job picker), so the view switches with the selected job.

## How

- **core** — export `buildBaseCuratorPrompt(mode)`; `buildCuratorPrompt` now reuses it for its system message, so the read-only view can never drift from what the curator actually sends.
- **mcp-server** — new admin-gated `addendum.getBasePrompt` query returning `{ version, basePrompt }`. Static text, no secrets, no store access; served only on the internal listener like the rest of the curator surface.
- **dashboard** — fetch the base prompt per job (`page → chat-workspace → chat-panel`) and render it with a native `<details>` disclosure (the established idiom in this file). No length cap or counter — kept visually distinct from the 2 KB addendum budget.

## Tests
- core: the view equals the system message `buildCuratorPrompt` sends; no addendum framing; differs by mode.
- mcp-server: `addendum.getBasePrompt` returns the prompt + version and 404s on the public listener (admin-gated).
- dashboard: the disclosure renders the prompt read-only above the textarea.

All green locally: core (22), mcp-server addendum (8), dashboard chat-panel (11); full `typecheck`, prettier, eslint pass.

## Release
Bumps to `1.0.0-rc.48` with a dated CHANGELOG entry. **Heads-up:** PR #414 also targets `rc.48`; whichever merges second will need a one-line version rebase (happy to do it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01JYbcJZ29dVpfXGvWWVe9iA