### PR TITLE
feat(cli): server up --data-dir — choose the data directory, run as its owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0-rc.50] — 2026-06-20
+
+### Added
+
+- **`librarian server up --data-dir <path>`.** Self-host the vault in a host
+  directory you choose, instead of the default Docker named volume — to back it
+  up, put it on a specific disk, or move it between hosts. The directory is
+  bind-mounted at `/data` and the container runs **as the directory's owner**
+  (`--user uid:gid`), so the data stays owned by, and writable by, the operator
+  rather than the image user. `server update` reuses it (persisted in the
+  non-secret deploy-state), and `--data-dir` / `--data-volume` are mutually
+  exclusive.
+
+### Documentation
+
+- The `@the-librarian/cli` npm README now documents the **server** command group
+  (`server up` / `update` / …), not just the client-side `install`; the main
+  README and DEPLOYMENT.md gain the `--data-dir` option.
+
 ## [1.0.0-rc.49] — 2026-06-20
 
 ### Added
@@ -3115,6 +3134,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0-rc.50]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.49...v1.0.0-rc.50
 [1.0.0-rc.49]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.48...v1.0.0-rc.49
 [1.0.0-rc.48]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.47...v1.0.0-rc.48
 [1.0.0-rc.47]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.46...v1.0.0-rc.47

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -20,7 +20,8 @@ npx @the-librarian/cli server up
 1. Clones the monorepo at the latest release tag into `~/.librarian/server`
    (the deploy dir; `--dir` overrides) and builds `the-librarian:<tag>`.
 2. Runs the all-in-one container (named `the-librarian`) on the named data volume
-   `librarian_data` (`--data-volume` overrides), waits for **both** services to
+   `librarian_data` (`--data-volume` overrides; or `--data-dir` for a host
+   directory — see [Data location](#data-location---data-dir)), waits for **both** services to
    report healthy, and rolls the container back if they don't (the data volume is
    never touched).
 3. **Mints** the **master key** and writes it (with the agent token) into a
@@ -84,6 +85,36 @@ on that port at all: it lives on a separate internal listener (loopback in the
 all-in-one), so there is **no admin token** (ADR 0008 — see
 [The auth model](#the-auth-model-adr-0008) below). Still put port 3838 behind
 **TLS** (a reverse proxy) on any host reachable beyond loopback.
+
+### Data location (`--data-dir`)
+
+By default the vault lives in a Docker-managed named volume (`librarian_data`;
+`--data-volume <name>` picks a different volume name). To keep the data at a host
+path **you** control — to back it up with your own tooling, put it on a specific
+disk/mount, or copy it to another machine — pass an absolute directory instead:
+
+```sh
+librarian server up --data-dir /srv/librarian
+```
+
+This bind-mounts the directory at the container's `/data` and runs the container
+**as the directory's owner** (`--user <uid>:<gid>`), so the vault stays owned by —
+and writable by — you rather than the image's user. (A bind-mount shadows the
+image's build-time `chown`, so otherwise the host directory's ownership would win
+and the server couldn't write to it; running as the owner is what avoids both a
+manual `chown` and locking you out of your own data.) The directory is created if
+absent, and `--data-dir` and `--data-volume` are **mutually exclusive**.
+
+`server update` / `down` / `status` reuse the chosen directory automatically (it's
+recorded in the non-secret `deploy-state.json`), and it is just as **sacred** as a
+named volume — recreate removes the container only, never the data. To move an
+existing named-volume deploy onto a host directory, copy the volume's contents
+across first, then re-`up`:
+
+```sh
+docker run --rm -v librarian_data:/from -v /srv/librarian:/to busybox cp -a /from/. /to/
+librarian server up --data-dir /srv/librarian
+```
 
 ### Pinning and updates
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ npx @the-librarian/cli server up
 (Or `npm i -g @the-librarian/cli` once and call `librarian server up` directly,
 if you'll run it often.)
 
+Want the data at a path you choose — to back it up, put it on a specific disk, or
+move it between hosts? Add `--data-dir`; it bind-mounts a host directory at `/data`
+and runs the container as its owner, so the vault stays yours to read and write:
+
+```sh
+npx @the-librarian/cli server up --data-dir /srv/librarian
+```
+
 `server up`/`update`/`down`/`status`/`logs`, Linux boot persistence
 (`enable-boot`), and host-side admin (`server admin backup|restore|auth|rebuild`)
 are all covered in the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.49",
+  "version": "1.0.0-rc.50",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/installer-cli/README.md
+++ b/packages/installer-cli/README.md
@@ -1,12 +1,15 @@
 # `@the-librarian/cli` — the `librarian` installer
 
-A small cross-harness CLI that installs, updates, and tracks
-[The Librarian](https://github.com/JimJafar/the-librarian)'s integrations across
-all your harnesses and machines. Think of it as the package manager for your
-Librarian setup: one tool you keep, driving each harness's **native** install
-path rather than hand-editing five config formats.
+A small CLI that does two jobs for
+[The Librarian](https://github.com/JimJafar/the-librarian): it **wires it into
+your AI agents** (installs/updates the integration for each harness, across all
+your machines) and **self-hosts the server** they talk to (`server up` /
+`update`). Think of it as the package manager for your Librarian setup: one tool
+you keep, driving each harness's **native** install path rather than hand-editing
+five config formats.
 
-Harnesses it manages: **Claude Code, Codex, OpenCode, Hermes, Pi.**
+Harnesses it manages: **Claude Code, Codex, OpenCode, Hermes, Pi.** For the
+server side, see [Self-host the server](#self-host-the-server).
 
 ## Install
 
@@ -43,6 +46,12 @@ librarian config                 Show or set MCP URL, token, server URL
 librarian self-update            Update the CLI itself (coming in a later release)
 librarian report                 Push this machine's state to the server
                                   (coming in a later release)
+
+librarian server up              Self-host the server with Docker; prints the
+                                  MCP URL + agent token to paste into `install`
+librarian server update          Upgrade the server to the latest release
+                                  (your data is preserved)
+librarian server down|status|logs  Stop / inspect / tail the running server
 ```
 
 Useful flags: `--mcp-url <url>`, `--token <token>` (never printed),
@@ -50,6 +59,36 @@ Useful flags: `--mcp-url <url>`, `--token <token>` (never printed),
 `-v/--version`. Harness ids: `claude`, `codex`, `opencode`, `hermes`, `pi`. A
 harness whose CLI isn't installed is reported `not-detected` and skipped — not
 an error.
+
+## Self-host the server
+
+The Librarian needs a server to talk to. `server up` stands one up with Docker —
+it builds the all-in-one image, mints your secrets, waits for health, and prints
+the MCP URL + agent token to paste into `librarian install`:
+
+```sh
+npx @the-librarian/cli server up
+```
+
+By default the vault lives in a Docker-managed named volume (`librarian_data`).
+To keep your data at a path **you** choose — so you can back it up, put it on a
+specific disk, or move it between hosts — pass `--data-dir`:
+
+```sh
+npx @the-librarian/cli server up --data-dir /srv/librarian
+```
+
+With `--data-dir`, the server bind-mounts that directory at `/data` and runs the
+container **as the directory's owner**, so the vault stays owned by — and
+writable by — you, not a container user. The directory is created if it doesn't
+exist, and `server update` reuses it automatically. (`--data-dir` and
+`--data-volume` are mutually exclusive.)
+
+Other server commands: `server update` (upgrade to the latest release, preserving
+your data), `server down` / `status` / `logs`, and `server enable-boot` (Linux
+systemd) to start it on boot. Run it on a private network / behind a VPN, or
+expose it with auth — see the
+[deployment guide](https://github.com/JimJafar/the-librarian/blob/main/DEPLOYMENT.md).
 
 ## What it writes to your environment
 

--- a/packages/installer-cli/src/runtime.ts
+++ b/packages/installer-cli/src/runtime.ts
@@ -278,6 +278,7 @@ async function runServerUpCommand(rest: string[], options: RuntimeOptions): Prom
         dir: flagString(flags.dir),
         host: flagString(flags.host),
         dataVolume: flagString(flags["data-volume"]),
+        dataDir: flagString(flags["data-dir"]),
         enableBoot: flagBool(flags["enable-boot"]),
         yes: flagBool(flags.yes),
       },

--- a/packages/installer-cli/src/server/deploy-state.ts
+++ b/packages/installer-cli/src/server/deploy-state.ts
@@ -7,8 +7,9 @@
 // config in the deploy dir (default `~/.librarian/server/deploy-state.json`).
 //
 // SECURITY (AGENTS.md / spec §11): this file is NON-SECRET by construction. It
-// carries ONLY the five fields below — a bind host, a volume name, a ref, an
-// image tag, and the container name. It NEVER carries a bearer token, master
+// carries ONLY non-secret fields — a bind host, a volume name (and an optional
+// host data dir), a ref, an image tag, and the container name. It NEVER carries
+// a bearer token, master
 // key, or admin token. `writeDeployState` whitelists exactly those fields, so a
 // caller that accidentally passes extra keys (a smuggled secret) cannot leak
 // them into the file. The master key / admin token are surfaced to stdout once
@@ -28,6 +29,13 @@ export interface DeployState {
   host: string;
   /** The named data volume mounted at `/data` (sacred across `down`/`update`). */
   dataVolume: string;
+  /**
+   * A host directory bind-mounted at `/data` instead of the named volume, when the
+   * operator chose one via `--data-dir`. Optional — absent on named-volume deploys
+   * and on states written before this field existed. When set, `update` reuses it
+   * and runs the container as its owner.
+   */
+  dataDir?: string | undefined;
   /** The deployed ref — a `vX.Y.Z` tag or `main` (what was checked out + built). */
   ref: string;
   /** The built image tag (`the-librarian:<ref>`). */
@@ -60,6 +68,9 @@ export function writeDeployState(dir: string, state: DeployState): void {
     ref: state.ref,
     imageTag: state.imageTag,
   };
+  // Only persist the optional host data dir when one was chosen — a named-volume
+  // deploy keeps the original field set (and old states stay byte-compatible).
+  if (state.dataDir) safe.dataDir = state.dataDir;
   fs.writeFileSync(deployStatePath(dir), `${JSON.stringify(safe, null, 2)}\n`, "utf8");
 }
 
@@ -86,11 +97,15 @@ export function readDeployState(dir: string): DeployState | null {
   for (const key of STATE_KEYS) {
     if (typeof obj[key] !== "string") return null;
   }
-  return {
+  const result: DeployState = {
     containerName: obj.containerName as string,
     host: obj.host as string,
     dataVolume: obj.dataVolume as string,
     ref: obj.ref as string,
     imageTag: obj.imageTag as string,
   };
+  // Optional, back-compatible: present only on `--data-dir` deploys written after
+  // this field existed; left undefined otherwise (old states still validate).
+  if (typeof obj.dataDir === "string") result.dataDir = obj.dataDir;
+  return result;
 }

--- a/packages/installer-cli/src/server/up.ts
+++ b/packages/installer-cli/src/server/up.ts
@@ -188,6 +188,15 @@ export interface UpOptions {
   /** Named data volume. Default: `librarian_data`. */
   dataVolume?: string | undefined;
   /**
+   * Bind-mount a host directory at `/data` instead of a Docker named volume — so
+   * the vault lives at a path you choose (back it up, put it on a specific disk,
+   * copy it to another host). The container runs as the directory's owner
+   * (uid:gid) so the data stays owned by, and writable by, the operator rather
+   * than the image user. Absolute path; created if missing. Mutually exclusive
+   * with `dataVolume`.
+   */
+  dataDir?: string | undefined;
+  /**
    * Enable boot persistence after a successful `up` (S6). On Linux, installs +
    * enables the systemd unit; on macOS, prints the deferred notice and the `up`
    * still succeeds. Opt-in: a plain `up` never enables boot silently.
@@ -238,6 +247,10 @@ export class UpError extends Error {
 export interface RunArgsInput {
   host: string;
   dataVolume: string;
+  /** Absolute host path bind-mounted at `/data` instead of the named volume (when set). */
+  dataDir?: string | undefined;
+  /** `uid:gid` to run the container as — set for a bind-mount so files stay host-owned. */
+  runAsUser?: string | undefined;
   tag: string;
   /**
    * Absolute path to the 0600 deploy env-file ({@link writeDeployEnvFile}). The
@@ -265,8 +278,8 @@ export interface RunArgsInput {
  * {@link writeDeployEnvFile}), not on this argv.
  */
 export function buildRunArgs(input: RunArgsInput): string[] {
-  const { host, dataVolume, tag, envFile } = input;
-  return [
+  const { host, dataVolume, dataDir, runAsUser, tag, envFile } = input;
+  const args = [
     "run",
     "-d",
     "--name",
@@ -277,12 +290,36 @@ export function buildRunArgs(input: RunArgsInput): string[] {
     `${host}:3000:3000`,
     "-p",
     `${host}:3838:3838`,
+    // A host data dir (bind-mount) takes precedence over the named volume.
     "-v",
-    `${dataVolume}:/data`,
+    `${dataDir ?? dataVolume}:/data`,
     "--env-file",
     envFile,
-    `${CONTAINER_NAME}:${tag}`,
   ];
+  // For a bind-mount, run as the directory's owner so the vault stays owned by —
+  // and writable by — the operator, not the image's default user.
+  if (runAsUser) args.push("--user", runAsUser);
+  args.push(`${CONTAINER_NAME}:${tag}`);
+  return args;
+}
+
+/**
+ * Resolve a user-supplied `--data-dir` to an absolute host path, creating it if
+ * absent. Absolute because docker treats a RELATIVE `-v` source as a volume name.
+ */
+function resolveHostDataDir(input: string): string {
+  const abs = path.resolve(input);
+  fs.mkdirSync(abs, { recursive: true });
+  return abs;
+}
+
+/**
+ * The `uid:gid` that owns a path — the user the container runs as for a
+ * bind-mounted data dir, so the vault stays host-owned and operator-writable.
+ */
+export function dirOwner(dir: string): string {
+  const st = fs.statSync(dir);
+  return `${st.uid}:${st.gid}`;
 }
 
 /** The secrets the deploy env-file carries (off argv, into `--env-file`). */
@@ -400,6 +437,20 @@ export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult>
   const dataVolume = options.dataVolume ?? DEFAULT_DATA_VOLUME;
   const deployDir = options.dir ?? path.join(librarianDir(deps.home), "server");
 
+  // Optional host data directory (bind-mount) instead of the named volume.
+  // Mutually exclusive with --data-volume; resolved to an absolute path (docker
+  // treats a RELATIVE `-v` source as a volume NAME, not a path) and created if
+  // missing. The container then runs as the directory's owner, so the vault stays
+  // owned by — and writable by — the operator (a bind-mount shadows the image's
+  // build-time chown, so the host ownership is what wins).
+  if (options.dataDir && options.dataVolume) {
+    throw new UpError(
+      "Pass either --data-dir (a host directory) or --data-volume (a Docker volume), not both.",
+    );
+  }
+  const dataDir = options.dataDir ? resolveHostDataDir(options.dataDir) : undefined;
+  const runAsUser = dataDir ? dirOwner(dataDir) : undefined;
+
   // 3) Resolve the ref (default = latest release tag), then the deploy dir.
   log("[1/5] Resolving the latest release…");
   const tag = await resolveRef(options.ref);
@@ -429,7 +480,7 @@ export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult>
   );
   await build(deployDir, tag);
   log("[4/5] Starting the container…");
-  await dockerRun(buildRunArgs({ host, dataVolume, tag, envFile }), deployDir);
+  await dockerRun(buildRunArgs({ host, dataVolume, dataDir, runAsUser, tag, envFile }), deployDir);
 
   // 6+7) Wait for health. ANY failure in this post-`docker run` phase — a
   //      timeout/unhealthy report or an exception from `docker inspect`/`sleep`
@@ -461,6 +512,7 @@ export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult>
     containerName: CONTAINER_NAME,
     host,
     dataVolume,
+    dataDir,
     ref: tag,
     imageTag: `${CONTAINER_NAME}:${tag}`,
   });

--- a/packages/installer-cli/src/server/update.ts
+++ b/packages/installer-cli/src/server/update.ts
@@ -70,6 +70,7 @@ import { redactSecrets } from "./redact.js";
 import {
   buildRunArgs,
   CONTAINER_NAME,
+  dirOwner,
   mintAgentToken,
   waitForHealthy,
   writeDeployEnvFile,
@@ -184,6 +185,10 @@ export async function runUpdate(options: UpdateOptions = {}): Promise<UpdateResu
     buildRunArgs({
       host: state.host,
       dataVolume: state.dataVolume,
+      // Reuse the same storage: a bind-mounted host dir (run as its owner) when
+      // the deploy chose one, else the named volume. The data is sacred either way.
+      dataDir: state.dataDir,
+      runAsUser: state.dataDir ? dirOwner(state.dataDir) : undefined,
       tag: targetRef,
       envFile,
     }),
@@ -203,6 +208,7 @@ export async function runUpdate(options: UpdateOptions = {}): Promise<UpdateResu
     containerName: state.containerName,
     host: state.host,
     dataVolume: state.dataVolume,
+    dataDir: state.dataDir,
     ref: targetRef,
     imageTag: `${CONTAINER_NAME}:${targetRef}`,
   });

--- a/packages/installer-cli/tests/server-deploy-state.test.ts
+++ b/packages/installer-cli/tests/server-deploy-state.test.ts
@@ -35,6 +35,34 @@ describe("deploy-state — round-trip under a fake home", () => {
     });
   });
 
+  it("round-trips the optional host data dir when present", async () => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".librarian", "server");
+      const withDir: DeployState = { ...SAMPLE, dataDir: "/srv/librarian" };
+      writeDeployState(dir, withDir);
+      expect(readDeployState(dir)).toEqual(withDir);
+      const parsed = JSON.parse(fs.readFileSync(deployStatePath(dir), "utf8")) as Record<
+        string,
+        unknown
+      >;
+      expect(parsed.dataDir).toBe("/srv/librarian");
+    });
+  });
+
+  it("a named-volume state omits dataDir and an older (dataDir-less) file still parses", async () => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".librarian", "server");
+      writeDeployState(dir, SAMPLE); // no dataDir
+      const parsed = JSON.parse(fs.readFileSync(deployStatePath(dir), "utf8")) as Record<
+        string,
+        unknown
+      >;
+      expect("dataDir" in parsed).toBe(false);
+      // A state written before dataDir existed must still read back cleanly.
+      expect(readDeployState(dir)).toEqual(SAMPLE);
+    });
+  });
+
   it("writes to <dir>/deploy-state.json and creates the dir if absent", async () => {
     await withTempHome(async (home) => {
       const dir = path.join(home, ".librarian", "server");

--- a/packages/installer-cli/tests/server-up.test.ts
+++ b/packages/installer-cli/tests/server-up.test.ts
@@ -238,6 +238,52 @@ describe("server up — flags reflected in argv", () => {
       expect(runArgs?.[runArgs.length - 1]).toBe("the-librarian:main");
     });
   });
+
+  it("--data-dir bind-mounts a host directory and runs the container as its owner", async () => {
+    await withTempHome(async (home) => {
+      const runner = healthyRunner();
+      setDockerRunner(runner);
+      stubSeams();
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
+
+      const dataDir = path.join(home, "my-vault");
+      const r = await runCli(["server", "up", "--data-dir", dataDir], { home, prompter });
+      expect(r.exitCode).toBe(0);
+
+      const runArgs = dockerRunArgs(runner) ?? [];
+      // Bind-mount the ABSOLUTE host path at /data — not the named volume.
+      expect(runArgs).toContain(`${dataDir}:/data`);
+      expect(runArgs).not.toContain("librarian_data:/data");
+      // Run as the directory's owner so the vault stays host-owned + writable.
+      const owner = `${process.getuid?.()}:${process.getgid?.()}`;
+      const u = runArgs.indexOf("--user");
+      expect(u).toBeGreaterThan(-1);
+      expect(runArgs[u + 1]).toBe(owner);
+      // --user is an option (precedes the image, the final arg).
+      expect(u).toBeLessThan(runArgs.length - 1);
+      // The directory was created, and deploy-state records it so `update` reuses it.
+      expect(fs.existsSync(dataDir)).toBe(true);
+      expect(readDeployState(path.join(home, ".librarian", "server"))?.dataDir).toBe(dataDir);
+    });
+  });
+
+  it("--data-dir and --data-volume together is a teaching error (no docker run)", async () => {
+    await withTempHome(async (home) => {
+      const runner = healthyRunner();
+      setDockerRunner(runner);
+      stubSeams();
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
+
+      const r = await runCli(
+        ["server", "up", "--data-dir", path.join(home, "v"), "--data-volume", "my_vol"],
+        { home, prompter },
+      );
+      expect(r.exitCode).toBe(1);
+      expect(r.stderr).toMatch(/either --data-dir.*--data-volume|not both/i);
+      // It aborts before recreating anything.
+      expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "run")).toBe(false);
+    });
+  });
 });
 
 describe("server up — health-wait failure rolls back (no half-up)", () => {

--- a/packages/installer-cli/tests/server-update.test.ts
+++ b/packages/installer-cli/tests/server-update.test.ts
@@ -329,6 +329,46 @@ describe("server update — upgrade path argv sequence (SC 5)", () => {
   });
 });
 
+describe("server update — reuses a bind-mounted data dir (run as its owner)", () => {
+  it("recreates with the host data dir at /data and --user <owner> from deploy-state", async () => {
+    await withTempHome(async (home) => {
+      const dir = deployDirOf(home);
+      fs.mkdirSync(path.join(dir, ".git"), { recursive: true });
+      const dataDir = path.join(home, "vault");
+      fs.mkdirSync(dataDir, { recursive: true });
+      // A deploy that chose a host data dir (rather than the named volume).
+      writeDeployState(dir, {
+        containerName: "the-librarian",
+        host: "127.0.0.1",
+        dataVolume: "librarian_data",
+        dataDir,
+        ref: OLD_REF,
+        imageTag: `the-librarian:${OLD_REF}`,
+      });
+      const runner = upgradeRunner();
+      setDockerRunner(runner);
+      stubSeams();
+
+      const r = await runCli(["server", "update"], { home });
+      expect(r.exitCode).toBe(0);
+
+      const runArgs = dockerRunArgs(runner) ?? [];
+      // Reuse the SAME bind-mount — never silently fall back to the named volume.
+      expect(runArgs).toContain(`${dataDir}:/data`);
+      expect(runArgs).not.toContain("librarian_data:/data");
+      // Recreate runs as the directory's owner so the vault stays operator-writable.
+      const owner = `${process.getuid?.()}:${process.getgid?.()}`;
+      const u = runArgs.indexOf("--user");
+      expect(u).toBeGreaterThan(-1);
+      expect(runArgs[u + 1]).toBe(owner);
+      // The data dir survives in deploy-state across the update.
+      expect(readDeployState(dir)?.dataDir).toBe(dataDir);
+      // The data is sacred either way — no volume-destructive op ran.
+      expect(ranVolumeDestructive(runner)).toBe(false);
+    });
+  });
+});
+
 describe("server update — --ref reflected in checkout + build tag", () => {
   it("--ref main checks out + builds main", async () => {
     await withTempHome(async (home) => {


### PR DESCRIPTION
## What

`librarian server up --data-dir <path>` lets you self-host the vault in a **host directory you choose** instead of the default Docker named volume — so you can back it up with your own tooling, put it on a specific disk/mount, or copy it to another machine.

```sh
npx @the-librarian/cli server up --data-dir /srv/librarian
```

The directory is bind-mounted at the container's `/data`, and — the key bit — the container runs **as the directory's owner** (`--user uid:gid`). A bind-mount shadows the image's build-time `chown`, so without this the host directory's ownership would win and the server couldn't write; running as the owner means the data stays owned by, and writable by, **you**, with no `chown` and no lockout. (In the common single-user case the owner is you; if you pass a dir owned by someone else, it runs as that owner.)

- Created if missing; `--data-dir` and `--data-volume` are mutually exclusive (teaching error).
- `server update` reuses it automatically — persisted in the non-secret `deploy-state.json` as an **optional, back-compatible** field (old volume deploys and pre-existing state files are unaffected).
- The data is as sacred as a named volume — recreate removes the container only.

## Docs (incl. the npm page)

The `@the-librarian/cli` npm README only covered the client-side `install`; it now documents the whole **server** command group (`server up`/`update`/`down`/`status`/`logs`) and the `--data-dir` option. The main README and `DEPLOYMENT.md` gain `--data-dir` too (DEPLOYMENT also gets the volume→host-dir migration recipe).

## Tests
- **up**: argv bind-mounts the absolute host path at `/data` and adds `--user <owner>`; `--data-dir` + `--data-volume` together aborts before any `docker run`.
- **update**: a `dataDir` deploy-state recreates with the bind-mount + `--user`, preserves it, and runs no volume-destructive op.
- **deploy-state**: round-trips `dataDir`; a named-volume state omits it and an older (dataDir-less) file still parses.

Full installer-cli suite green (320), typecheck + prettier + eslint pass.

## Release
Bumps to `1.0.0-rc.50` with a dated CHANGELOG entry. (Off current `main` — no version overlap this time.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01JYbcJZ29dVpfXGvWWVe9iA