### PR TITLE
chore(release): 1.0.0 — promote rc.52 to stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.0] — 2026-06-21
+
+First stable release. 🎉
+
+The Librarian is a portable, agent-agnostic memory + handoff layer for AI coding
+agents: durable cross-session memory with an LLM curator (intake + grooming),
+cross-harness handoffs, a self-hosted MCP server, a Next.js admin dashboard, a
+CLI, and integrations for Claude Code, Codex, Hermes, OpenCode, and Pi.
+
+A no-change promotion of `1.0.0-rc.52` to a stable 1.0.0. The full path to 1.0 —
+every feature, fix, and decision across the `rc.1`–`rc.52` series — is catalogued
+in the entries below.
+
 ## [1.0.0-rc.52] — 2026-06-21
 
 ### Changed
@@ -3178,6 +3191,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.0]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.52...v1.0.0
 [1.0.0-rc.52]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.51...v1.0.0-rc.52
 [1.0.0-rc.51]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.50...v1.0.0-rc.51
 [1.0.0-rc.50]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.49...v1.0.0-rc.50

--- a/integrations/pi/package.json
+++ b/integrations/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-librarian/pi-extension",
-  "version": "1.0.0-rc.52",
+  "version": "1.0.0",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0-rc.52",
+  "version": "1.0.0",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/installer-cli/package.json
+++ b/packages/installer-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-librarian/cli",
-  "version": "1.0.0-rc.52",
+  "version": "1.0.0",
   "private": false,
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## 🎉 The Librarian 1.0.0 — stable

A **no-change promotion** of `1.0.0-rc.52` to stable. rc.52 is already shipped and verified on npm (`@the-librarian/cli@1.0.0-rc.52` is current `latest`); this just drops the prerelease suffix.

### Diff vs `main` (rc.52)
Version strings only + the CHANGELOG 1.0.0 entry — **zero code/test changes**. The privacy scrub and portability fixes were baked in rc.52.

- root `package.json`, `@the-librarian/cli`, Pi → `1.0.0`
- CHANGELOG `## [1.0.0]` milestone entry + compare-link. `check:release` green.

### What merging does (release.yml)
- Tags `v1.0.0` + cuts the GitHub release.
- Publishes **`@the-librarian/cli@1.0.0`** to npm (dist-tag `latest`).
- Claude Code plugin auto-updates (marketplace tracks `main`); Hermes adapter carries 1.0.0 via the CLI.

### ⚠️ Manual post-merge step
**Pi (`@the-librarian/pi-extension@1.0.0`) is published by hand** — the workflow only auto-publishes the CLI. I'll prep the exact `npm publish` command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01Ed6Qj51acmujWe1B4x5gjD
