### PR TITLE
build(ts): add TypeScript project references for cross-package source resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.0.1] — 2026-06-28
+
+### Changed
+
+- **Build: TypeScript project references.** Added `composite` + `references`
+  across the workspace tsconfigs and a root solution `tsconfig.json`, so
+  cross-package `@librarian/*` imports resolve to source instead of each
+  package's built `dist`. Editor and tooling navigation — go-to-definition,
+  find-all-references, and rename — now traverses package boundaries; before,
+  it stopped at `dist/*.d.ts` and silently omitted cross-package consumers
+  (e.g. a `find-references` on a `@librarian/core` symbol missed its
+  `mcp-server` usages). No source or runtime changes — `pnpm -r build`,
+  `pnpm -r run typecheck`, `tsc -b`, and the package test suites stay green.
+
 ## [1.0.0] — 2026-06-21
 
 First stable release. 🎉
@@ -3191,6 +3205,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.0.1]: https://github.com/JimJafar/the-librarian/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.52...v1.0.0
 [1.0.0-rc.52]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.51...v1.0.0-rc.52
 [1.0.0-rc.51]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.50...v1.0.0-rc.51

--- a/apps/dashboard/tsconfig.json
+++ b/apps/dashboard/tsconfig.json
@@ -17,6 +17,7 @@
     },
     "plugins": [{ "name": "next" }]
   },
+  "references": [{ "path": "../../packages/mcp-server" }],
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules", ".next", "dist"]
 }

--- a/integrations/pi/package.json
+++ b/integrations/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-librarian/pi-extension",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/integrations/pi/tsconfig.json
+++ b/integrations/pi/tsconfig.json
@@ -7,5 +7,6 @@
     "declarationMap": false,
     "sourceMap": false
   },
+  "references": [{ "path": "../../packages/mcp-server" }],
   "include": ["extensions/**/*.ts", "tests/**/*.ts", "vitest.config.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,9 +1,11 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "composite": true,
     "rootDir": "./src",
     "outDir": "./dist"
   },
+  "references": [{ "path": "../core" }, { "path": "../mcp-server" }],
   "include": ["src/**/*.ts"],
   "exclude": ["dist", "node_modules", "tests"]
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "composite": true,
     "rootDir": "./src",
     "outDir": "./dist"
   },

--- a/packages/installer-cli/package.json
+++ b/packages/installer-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-librarian/cli",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/installer-cli/tsconfig.json
+++ b/packages/installer-cli/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "composite": true,
     "rootDir": "./src",
     "outDir": "./dist"
   },

--- a/packages/intake-eval/tsconfig.json
+++ b/packages/intake-eval/tsconfig.json
@@ -1,10 +1,12 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "composite": true,
     "rootDir": "./src",
     "outDir": "./dist",
     "resolveJsonModule": true
   },
+  "references": [{ "path": "../core" }],
   "include": ["src/**/*.ts"],
   "exclude": ["dist", "node_modules", "tests"]
 }

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -1,9 +1,11 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "composite": true,
     "rootDir": "./src",
     "outDir": "./dist"
   },
+  "references": [{ "path": "../core" }],
   "include": ["src/**/*.ts"],
   "exclude": ["dist", "node_modules", "tests"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./packages/core" },
+    { "path": "./packages/mcp-server" },
+    { "path": "./packages/cli" },
+    { "path": "./packages/intake-eval" },
+    { "path": "./packages/installer-cli" }
+  ]
+}


### PR DESCRIPTION
## What

Adds TypeScript **project references** across the monorepo (no source changes — 8 tsconfig files):

- `composite: true` on the tsc-built packages (`core`, `mcp-server`, `cli`, `intake-eval`, `installer-cli`)
- `references` edges mirroring the workspace dependency graph (mcp-server→core, cli→core+mcp-server, intake-eval→core, dashboard→mcp-server, pi→mcp-server)
- a new root solution `tsconfig.json` (`{ files: [], references: [...] }`) enabling `tsc -b`

`declarationMap` was already enabled in `tsconfig.base.json`, which is what lets the emitted `.d.ts` map back to source.

## Why

Without project references, cross-package imports of `@librarian/*` resolve through each package's built `dist/*.d.ts`, not its source. That means editor/tooling features — **go-to-definition, find-all-references, and rename — do not traverse package boundaries**: e.g. asking for references of a `@librarian/core` symbol silently omits its consumers in `mcp-server`, `cli`, etc. Project references make the language server redirect `@librarian/*` resolution to source, so cross-package navigation and refactors work correctly.

Concretely, before vs after on `find_referencing_symbols` for `core`'s `redactSecrets`:
- **before:** 11 sites, all in `packages/core/src` — the `packages/mcp-server` consumer is missing
- **after:** 12 sites, now including `packages/mcp-server/src/http/transcript-intake.ts`

## Verification (all green)

- `pnpm -r build` → exit 0
- `pnpm -r run typecheck` → exit 0
- `pnpm exec tsc -b` (root solution) → exit 0; builds all 5 composite projects in dep order; emits `.d.ts.map`
- vitest: `@librarian/core` 1164 passed / `@librarian/mcp-server` 264 passed
- TS language-service go-to-definition on imported `@librarian/core` symbols now lands in `packages/core/src/*` (was `dist/*.d.ts`)

## Scope notes

- `apps/dashboard` (next-built) and `integrations/pi` (`noEmit`, typecheck-only) are kept **non-composite** but carry `references` so they still get the source-redirect benefit for tooling; they are intentionally not `tsc -b` build targets (a solution build can only reference composite/emitting projects).
- Build artifacts (`dist/`, `*.tsbuildinfo`) remain gitignored.
- Follow-up (not in this PR): test files are excluded from the package tsconfigs' `include`, so references *from tests* still aren't surfaced by the language server — addressing that is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
