### PR TITLE
fix(core): bound ingest-log + rate-bucket growth — issue #423 (1.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.1.2] — 2026-06-29
+
+### Fixed
+
+- **Ingest-log + rate-limit retention (issue #423).** The capture log and the
+  per-token rate buckets share the settings sidecar (read + rewritten wholesale
+  per op) and grew without bound, making every capture — and the dashboard's
+  Captures view — progressively more expensive (O(n²) over time). The ingest log
+  now keeps only the **100 most-recent** attempts (pruned on write), and stale
+  prior-day rate buckets are garbage-collected on each accepted capture (incl.
+  revoked tokens'). Trade-off: URL dedup now spans only the last 100 captures —
+  re-capturing an older URL files a fresh reference instead of overwriting it.
+
 ## [1.1.1] — 2026-06-29
 
 ### Added
@@ -3280,6 +3293,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.1.2]: https://github.com/JimJafar/the-librarian/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/JimJafar/the-librarian/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/JimJafar/the-librarian/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/JimJafar/the-librarian/compare/v1.0.0...v1.0.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/core/src/ingest/ingest-log.ts
+++ b/packages/core/src/ingest/ingest-log.ts
@@ -25,6 +25,17 @@ import { redactSecrets } from "../grooming-redaction.js";
 const KEY_PREFIX = "ingest_log:";
 
 /**
+ * Retention cap (issue #423). The log shares the settings sidecar, which is read
+ * and rewritten wholesale on every op — so unbounded growth makes every capture
+ * (and every other settings write) O(n) and the dashboard's listRecent / dedup
+ * lookups O(n²). Keep only the most-recent N attempts, pruning older rows on
+ * write. Trade-off: dedup (`lookupByUrl`) only "remembers" the last N URLs — a
+ * re-capture of an older URL mints a fresh reference instead of overwriting,
+ * which is acceptable (dedup is best-effort).
+ */
+const MAX_LOG_ROWS = 100;
+
+/**
  * Lifecycle of a capture attempt. `pending` is written synchronously at accept
  * time (D22); the background worker transitions it to `success` (with a
  * `result_path`) or `failed` (with a redacted `error`). Only `success` carries a
@@ -158,6 +169,20 @@ function byNewestFirst(a: IngestLogRecord, b: IngestLogRecord): number {
 }
 
 /**
+ * Drop capture rows beyond the {@link MAX_LOG_ROWS} most recent (oldest first) —
+ * the retention bound (issue #423). Called after each new attempt is written, so
+ * the row count (and thus the per-op scan/rewrite cost) stays bounded. No-op if
+ * the store can't delete.
+ */
+function pruneLog(store: SettingsLike): void {
+  if (!store.deleteSetting) return;
+  const stale = allRecords(store).sort(byNewestFirst).slice(MAX_LOG_ROWS);
+  for (const record of stale) {
+    store.deleteSetting(KEY_PREFIX + record.id);
+  }
+}
+
+/**
  * Record a `pending` capture attempt and return its id. Written synchronously
  * before any background fetch (D22) so a crash mid-capture still leaves a
  * recorded attempt the dashboard can surface. `source` is redacted before it is
@@ -186,6 +211,7 @@ export function recordPending(
     created_at: new Date().toISOString(),
   };
   store.setSetting(KEY_PREFIX + id, JSON.stringify(record));
+  pruneLog(store);
   return id;
 }
 

--- a/packages/core/src/ingest/rate-limit.ts
+++ b/packages/core/src/ingest/rate-limit.ts
@@ -60,6 +60,23 @@ function utcDate(now: number): string {
   return new Date(now).toISOString().slice(0, 10);
 }
 
+/**
+ * Delete every rate bucket that isn't for `today` (issue #423). Buckets are keyed
+ * `ingest_rate:<tokenId>:<UTC-date>` and only today's is ever read, so prior days
+ * (incl. revoked tokens') are pure dead weight in the shared settings sidecar.
+ * Run on the accept path; it's self-limiting — once swept, only today's keys
+ * remain, so subsequent sweeps are cheap. No-op if the store can't delete.
+ */
+function gcStaleBuckets(store: SettingsLike, today: string): void {
+  if (!store.deleteSetting) return;
+  const suffix = `:${today}`;
+  for (const { key } of store.listSettings()) {
+    if (key.startsWith(KEY_PREFIX) && !key.endsWith(suffix)) {
+      store.deleteSetting(key);
+    }
+  }
+}
+
 function readBucket(store: SettingsLike, key: string, today: string): RateBucket {
   let raw: string | null = null;
   try {
@@ -130,6 +147,8 @@ export function checkIngestRateLimit(
   const next: RateBucket = { date: today, count: bucket.count + 1, recent };
   try {
     store.setSetting(key, JSON.stringify(next));
+    // Opportunistic GC of prior-day buckets (issue #423) — bounded + self-limiting.
+    gcStaleBuckets(store, today);
   } catch {
     // Fail-soft: a write failure doesn't block the capture (the row just doesn't
     // persist this tick). The endpoint must never throw to the caller.

--- a/packages/core/tests/ingest-log.test.ts
+++ b/packages/core/tests/ingest-log.test.ts
@@ -234,3 +234,38 @@ describe("ingest log — secret redaction (D25)", () => {
     expect(raw).not.toContain("sk-ant-superlongsecrettokenvalue1234");
   });
 });
+
+describe("ingest log — retention cap (issue #423)", () => {
+  it("keeps only the most-recent 100 attempts", () => {
+    const store = fakeSettings();
+    for (let i = 0; i < 105; i += 1) {
+      recordPending(store, { source: `https://example.com/${i}`, via: "extension" });
+    }
+    expect(listRecent(store, 1000)).toHaveLength(100);
+  });
+
+  it("prunes the oldest row, so dedup forgets a pruned URL", () => {
+    const store = fakeSettings();
+    const oldUrl = "https://example.com/old";
+    const oldId = recordPending(store, { source: oldUrl, via: "extension" });
+    markSuccess(store, oldId, "references/web/old.md");
+    // Pin it as unambiguously the oldest row (created_at is the sort key).
+    const raw = JSON.parse(store.getSetting(`ingest_log:${oldId}`) as string);
+    store.setSetting(
+      `ingest_log:${oldId}`,
+      JSON.stringify({ ...raw, created_at: "2020-01-01T00:00:00.000Z" }),
+    );
+    expect(lookupByUrl(store, oldUrl)).toBe("references/web/old.md"); // still present (1 row)
+
+    // 100 newer captures push the old one past the cap (101 → pruned back to 100).
+    let lastUrl = "";
+    for (let i = 0; i < 100; i += 1) {
+      lastUrl = `https://example.com/new-${i}`;
+      const id = recordPending(store, { source: lastUrl, via: "extension" });
+      markSuccess(store, id, `references/web/new-${i}.md`);
+    }
+    expect(listRecent(store, 1000)).toHaveLength(100);
+    expect(lookupByUrl(store, oldUrl)).toBeNull(); // pruned → dedup forgets it
+    expect(lookupByUrl(store, lastUrl)).toBe("references/web/new-99.md"); // recent kept
+  });
+});

--- a/packages/core/tests/ingest-rate-limit.test.ts
+++ b/packages/core/tests/ingest-rate-limit.test.ts
@@ -85,3 +85,26 @@ describe("ingest rate limit — daily quota (D19)", () => {
     expect(checkIngestRateLimit(store, "d", { ...opts, now: nextDay }).allowed).toBe(true);
   });
 });
+
+describe("ingest rate limit — stale-bucket GC (issue #423)", () => {
+  it("deletes prior-day buckets (across tokens) on an accepted capture", () => {
+    const store = fakeSettings();
+    store.setSetting(
+      "ingest_rate:tok-1:2026-06-01",
+      JSON.stringify({ date: "2026-06-01", count: 5, recent: [] }),
+    );
+    store.setSetting(
+      "ingest_rate:tok-2:2026-06-10",
+      JSON.stringify({ date: "2026-06-10", count: 9, recent: [] }),
+    );
+    const now = Date.UTC(2026, 5, 29, 12, 0, 0); // 2026-06-29
+    expect(checkIngestRateLimit(store, "tok-1", { now }).allowed).toBe(true);
+
+    // Only today's bucket for the active token remains; the dead ones are swept.
+    const rateKeys = store
+      .listSettings()
+      .map((s) => s.key)
+      .filter((k) => k.startsWith("ingest_rate:"));
+    expect(rateKeys).toEqual(["ingest_rate:tok-1:2026-06-29"]);
+  });
+});


### PR DESCRIPTION
Closes #423. The quick-win retention pass for the reference-ingest storage. **→ 1.1.2 on merge.**

## Problem
The capture log (`ingest_log:*`) and per-token rate buckets (`ingest_rate:*`) live in the settings sidecar, which is read + rewritten wholesale on every op. Unbounded growth therefore made every capture — and the dashboard's `listRecent`/dedup lookups — progressively O(n)/O(n²), and co-located a high-churn log with low-churn secrets/config.

## Fix
- **Cap the ingest log at the 100 most-recent attempts**, pruned on write (`recordPending`). Keeps the per-op scan/rewrite cost bounded. Trade-off: URL dedup now spans only the last 100 captures — re-capturing an older URL files a fresh reference instead of overwriting it (dedup is best-effort).
- **GC stale prior-day rate buckets** on each accepted capture, across all tokens (so revoked tokens' buckets are reclaimed too). Self-limiting — once swept, only today's keys remain.

## Verification
- New tests: log caps at 100 + prunes the oldest (dedup forgets a pruned URL); stale buckets swept on accept leaving only today's. Targeted suites green (28); full core suite green apart from the known pre-existing `git-ops.test.ts` timeout flake (passes 7/7 in isolation).

## Merge ordering
Branched off `main` (1.1.0) and versioned **1.1.2** to sit after #422 (1.1.1). **Merge #422 first**, then this rebases cleanly onto the new `main` — which also carries #422's `git-ops` timeout fix, so this PR's CI will stop hitting that flake after the rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)