### PR TITLE
fix(deploy): unblock Cloudflare Pages — stray worktree gitlink + docs canonical URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,9 @@ AUTONOMOUS-BUILD-NOTES-*.md
 
 # orchestration scratch (never committed)
 ORCHESTRATE-NOTES-*.md
+
+# Claude Code agent worktrees — machine-local working copies. Never commit:
+# they carry their own .git, so a stray add records a gitlink (submodule
+# pointer) with no .gitmodules, which breaks submodule-aware checkouts like
+# Cloudflare Pages' build clone.
+/.claude/worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ changes from this point forward are catalogued here.
   sitemap rather than skipping them. Repo-side preparation for the Cloudflare
   Pages go-live; no user-visible change until the site is published.
 
+### Fixed
+
+- **Cloudflare Pages (and any submodule-aware clone) no longer aborts on
+  checkout.** Removed a stray gitlink at
+  `.claude/worktrees/agent-a6282d3c0bf0d483c` — a Claude Code agent worktree
+  accidentally committed as a submodule pointer (the repo has no `.gitmodules`),
+  which made `git submodule` init fail with `No url found for submodule path`.
+  Added `/.claude/worktrees/` to `.gitignore` so agent worktrees can't be
+  committed again.
+
 ## [1.2.0] — 2026-06-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.2.1] — 2026-06-30
+
+### Changed
+
+- **Docs site canonical URL.** Set the Astro `site` to
+  `https://librarian-docs.codeministry.net` (the chosen docs subdomain, spec
+  OQ1), so the built site emits absolute canonical / Open Graph URLs and a
+  sitemap rather than skipping them. Repo-side preparation for the Cloudflare
+  Pages go-live; no user-visible change until the site is published.
+
 ## [1.2.0] — 2026-06-30
 
 ### Added
@@ -3373,6 +3383,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.2.1]: https://github.com/JimJafar/the-librarian/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/JimJafar/the-librarian/compare/v1.1.4...v1.2.0
 [1.1.4]: https://github.com/JimJafar/the-librarian/compare/v1.1.3...v1.1.4
 [1.1.3]: https://github.com/JimJafar/the-librarian/compare/v1.1.2...v1.1.3

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -7,6 +7,10 @@ import starlightLinksValidator from "starlight-links-validator";
 // by Cloudflare Pages (spec K2), so the output is pinned explicitly.
 // https://docs.astro.build/en/reference/configuration-reference/
 export default defineConfig({
+  // The canonical production origin (spec OQ1). Drives absolute canonical/OG
+  // URLs and the generated sitemap; without it Astro skips the sitemap and
+  // emits relative canonicals. Served at the subdomain root, so no `base`.
+  site: "https://librarian-docs.codeministry.net",
   output: "static",
   integrations: [
     starlight({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Two changes that together unblock the docs-site go-live on Cloudflare Pages. One release, **1.2.1** (PATCH).

## 1. Fix: remove a stray worktree gitlink that breaks the Cloudflare checkout

`main` tracked a **gitlink** (submodule pointer, mode `160000`) at
`.claude/worktrees/agent-a6282d3c0bf0d483c` — a Claude Code agent worktree
accidentally committed in `11ae37a`. The repo has **no `.gitmodules`**, so
Cloudflare's submodule-aware clone aborts with:

```
fatal: No url found for submodule path '.claude/worktrees/agent-a6282d3c0bf0d483c' in .gitmodules
```

…before the build can even start. This PR untracks the gitlink (`git rm
--cached`; working copy untouched) and adds `/.claude/worktrees/` to
`.gitignore` so agent worktrees can't be committed again. No gitlinks remain in
the tree. **This is the change that makes the deploy possible at all.**

## 2. Set the docs canonical site URL

Sets the Astro `site` in `apps/docs/astro.config.mjs` to the chosen docs
subdomain — **`https://librarian-docs.codeministry.net`** (spec OQ1). Without it
the build warned `[@astrojs/sitemap] requires the 'site' option. Skipping.` and
emitted **relative** canonical / Open Graph URLs; it now emits an absolute
canonical and a **sitemap** (`sitemap-index.xml` + `sitemap-0.xml`). Served at
the subdomain root, so no `base`.

## Verification (run locally)

- `pnpm --filter @librarian/docs build` → 35 pages, **all internal links valid**,
  sitemap now generated (warning gone).
- `git ls-files -s | awk '$1==160000'` → empty (no gitlinks remain).
- `pnpm check:release` → OK: v1.2.1 is the top CHANGELOG entry, dated, linked.
- `pnpm check:docs` → generated reference pages in sync.
- `eslint` + `prettier --check` on the changed files → clean.

## Cloudflare Pages build settings (for reference)

Build command `pnpm --filter @librarian/docs build`; output dir `apps/docs/dist`;
root directory left at repo root; `NODE_VERSION=22`.

## Follow-ups (not in this PR)

Once the site is confirmed live at the subdomain: set `NEXT_PUBLIC_DOCS_URL` on
the dashboard deploy (lights the "Docs" nav link), drop the "once it ships"
wording in `AGENTS.md` / `CONTRIBUTING.md` (T1.6), then thin the marketing
functional sections to links into the live site (T4.3, in the `codeministry`
repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JVTe8bYb5FP97F3LNYBnoQ
