### PR TITLE
docs(site): finalise go-live — light-default restyle, screenshot lightbox, live-docs wording

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,8 +138,9 @@ commands and flags, the MCP verbs and their schemas, dashboard pages and flows,
 install / deployment / auth steps, harness setup, the slash commands, or any
 behaviour the docs already describe. Changed one of those and touched no docs?
 The PR is incomplete — update the relevant user-facing docs (`README.md`,
-`DEPLOYMENT.md`, the integration READMEs, `docs/`; the docs-as-code site is
-their canonical home once it ships), or state in the PR why none was needed.
+`DEPLOYMENT.md`, the integration READMEs, `docs/`; the
+[docs site](https://librarian-docs.codeministry.net) is the canonical home),
+or state in the PR why none was needed.
 Internal-only work — refactors, tests, build plumbing — is exempt, but still
 takes its CHANGELOG PATCH.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@ changes from this point forward are catalogued here.
   editorial index. Verified in light and dark, with the existing axe-core a11y
   gate still green over both palettes.
 
+### Added
+
+- **Click-to-enlarge screenshots.** Content images (the dashboard-tour
+  screenshots) open enlarged in a dependency-free native `<dialog>` lightbox —
+  activated by click or keyboard (Enter/Space), dismissed by Esc / backdrop /
+  close button, with focus returned to the image. A copper-mounted frame and a
+  theme-aware scrim mirror the marketing site's lightbox idiom; the open
+  animation respects `prefers-reduced-motion`.
+
 ## [1.2.1] — 2026-06-30
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.2.2] — 2026-06-30
+
+### Changed
+
+- **Docs-update rule now names the live docs site.** With
+  `https://librarian-docs.codeministry.net` live, `AGENTS.md` and
+  `CONTRIBUTING.md` drop the "once it ships" conditional and point the
+  user-facing-docs rule at the docs site as its canonical home (spec T1.6).
+
 ## [1.2.1] — 2026-06-30
 
 ### Changed
@@ -3393,6 +3402,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.2.2]: https://github.com/JimJafar/the-librarian/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/JimJafar/the-librarian/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/JimJafar/the-librarian/compare/v1.1.4...v1.2.0
 [1.1.4]: https://github.com/JimJafar/the-librarian/compare/v1.1.3...v1.1.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ changes from this point forward are catalogued here.
   `https://librarian-docs.codeministry.net` live, `AGENTS.md` and
   `CONTRIBUTING.md` drop the "once it ships" conditional and point the
   user-facing-docs rule at the docs site as its canonical home (spec T1.6).
+- **Docs site brought on-brand with the dashboard and marketing surfaces.** An
+  impeccable design critique found the Starlight docs read as a recoloured
+  default theme. Fixes (`apps/docs`): default to light **Manuscript** for new
+  visitors instead of following the OS — matching the other two surfaces — via a
+  `ThemeProvider` override; collapse Starlight's five rainbow hue families (cards
+  **and** asides) onto the verdigris-rubric + copper-structure two-metal system;
+  flat and sharp throughout (no drop shadows, squared cards / buttons / search /
+  code-frames); add the missing copper structural accent (header rule, code
+  frames, home); retire the callout side-stripe for a full framed aside; drop the
+  faux terminal window-dots; and replace the stock card-grid home with a bespoke
+  editorial index. Verified in light and dark, with the existing axe-core a11y
+  gate still green over both palettes.
 
 ## [1.2.1] — 2026-06-30
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,7 +160,7 @@ Lefthook runs the lint + prettier on staged files in `pre-commit` (configured in
 - **400 LOC per file (production source).** Tests are exempt. If a file gets close, look for an extraction. This is a PR-template checkbox; CI doesn't enforce it.
 - **No `any`, no `@ts-ignore` in production source.** See [`docs/adr/0003-no-any.md`](./docs/adr/0003-no-any.md). One `any` is allowed in test helpers with an inline disable + rationale.
 - **Test-count floor.** `scripts/check-test-count.mjs` rejects PRs that drop below the workspace baseline.
-- **Docs updated for user-facing changes.** A change to CLI, MCP verbs/schemas, dashboard, install/deploy, harness setup, or slash commands updates its docs in the same PR (`README.md` / `DEPLOYMENT.md` / integration READMEs / `docs/`; the docs-as-code site once it ships). Internal-only changes are exempt. PR-template checkbox; not CI-enforced.
+- **Docs updated for user-facing changes.** A change to CLI, MCP verbs/schemas, dashboard, install/deploy, harness setup, or slash commands updates its docs in the same PR (`README.md` / `DEPLOYMENT.md` / integration READMEs / `docs/`; the [docs site](https://librarian-docs.codeministry.net) is the canonical home). Internal-only changes are exempt. PR-template checkbox; not CI-enforced.
 
 ## PR conventions
 

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -22,6 +22,9 @@ export default defineConfig({
         // following the OS, matching the dashboard + marketing surfaces. See the
         // component header for the reasoning.
         ThemeProvider: "./src/components/ThemeProvider.astro",
+        // Reuses the default footer and adds a dependency-free image lightbox
+        // (content images enlarge in a native <dialog>).
+        Footer: "./src/components/Footer.astro",
       },
       // Fails the build on broken INTERNAL links/anchors over the built site.
       // External links are never network-checked (they'd flake), satisfying

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -17,6 +17,12 @@ export default defineConfig({
       title: "The Librarian",
       description:
         "Operating guide for The Librarian — a portable memory + handoff layer for AI agents.",
+      components: {
+        // Default to light (Manuscript) for first-time visitors instead of
+        // following the OS, matching the dashboard + marketing surfaces. See the
+        // component header for the reasoning.
+        ThemeProvider: "./src/components/ThemeProvider.astro",
+      },
       // Fails the build on broken INTERNAL links/anchors over the built site.
       // External links are never network-checked (they'd flake), satisfying
       // spec success criterion 6.

--- a/apps/docs/src/components/Footer.astro
+++ b/apps/docs/src/components/Footer.astro
@@ -1,0 +1,112 @@
+---
+/*
+ * Footer override — reuses Starlight's default footer and appends a tiny,
+ * dependency-free image lightbox. Every content image (`.sl-markdown-content
+ * img` — in practice the dashboard-tour screenshots) becomes click- and
+ * keyboard-activatable and opens enlarged in a native <dialog>. The <dialog>
+ * gives us a modal focus trap and Esc-to-close for free; the rest is ~40 lines.
+ * Styling (the copper-mounted frame + theme-aware scrim) lives in
+ * `src/styles/reading-room.css`. This mirrors the marketing site's own
+ * native-<dialog> lightbox idiom so the product feels consistent across
+ * surfaces.
+ */
+import Default from "@astrojs/starlight/components/Footer.astro";
+---
+
+<Default {...Astro.props}><slot /></Default>
+
+<script>
+  (() => {
+    const SELECTOR = ".sl-markdown-content img";
+    let dialog: HTMLDialogElement | null = null;
+    let dialogImg: HTMLImageElement | null = null;
+    let lastTrigger: HTMLElement | null = null;
+
+    /** The highest-resolution candidate, so the lightbox shows the full-size
+     *  webp rather than the column-constrained one the layout displays. */
+    function largestSrc(img: HTMLImageElement): string {
+      const set = img.getAttribute("srcset");
+      if (set) {
+        const best = set
+          .split(",")
+          .map((part) => {
+            const [url, width] = part.trim().split(/\s+/);
+            return { url, width: parseInt(width || "0", 10) || 0 };
+          })
+          .sort((a, b) => b.width - a.width)[0];
+        if (best?.url) return best.url;
+      }
+      return img.currentSrc || img.src;
+    }
+
+    function ensureDialog(): HTMLDialogElement {
+      if (dialog) return dialog;
+      dialog = document.createElement("dialog");
+      dialog.className = "rr-lightbox";
+      dialog.setAttribute("aria-label", "Enlarged image");
+
+      const figure = document.createElement("figure");
+      figure.className = "rr-lightbox-figure";
+
+      const close = document.createElement("button");
+      close.type = "button";
+      close.className = "rr-lightbox-close";
+      close.setAttribute("aria-label", "Close enlarged image");
+      close.innerHTML =
+        '<svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M6 6l12 12M18 6 6 18"/></svg>';
+
+      dialogImg = document.createElement("img");
+      dialogImg.className = "rr-lightbox-img";
+      dialogImg.alt = "";
+
+      figure.append(close, dialogImg);
+      dialog.append(figure);
+      document.body.append(dialog);
+
+      close.addEventListener("click", () => dialog!.close());
+      // Click on the backdrop or the frame padding (but not the image) closes.
+      dialog.addEventListener("click", (event) => {
+        if (event.target === dialog || event.target === figure) dialog!.close();
+      });
+      dialog.addEventListener("close", () => {
+        if (dialogImg) dialogImg.removeAttribute("src");
+        lastTrigger?.focus();
+        lastTrigger = null;
+      });
+      return dialog;
+    }
+
+    function open(img: HTMLImageElement) {
+      const dlg = ensureDialog();
+      lastTrigger = img;
+      dialogImg!.src = largestSrc(img);
+      dialogImg!.alt = img.alt || "";
+      dlg.showModal();
+    }
+
+    function enhance(img: HTMLImageElement) {
+      if (img.dataset.rrLightbox) return;
+      img.dataset.rrLightbox = "1";
+      img.setAttribute("role", "button");
+      img.setAttribute("tabindex", "0");
+      img.setAttribute("aria-label", `Enlarge: ${img.alt || "image"}`);
+      img.addEventListener("click", () => open(img));
+      img.addEventListener("keydown", (event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          open(img);
+        }
+      });
+    }
+
+    function init() {
+      document.querySelectorAll<HTMLImageElement>(SELECTOR).forEach(enhance);
+    }
+
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", init);
+    } else {
+      init();
+    }
+  })();
+</script>

--- a/apps/docs/src/components/ThemeProvider.astro
+++ b/apps/docs/src/components/ThemeProvider.astro
@@ -1,0 +1,73 @@
+---
+/*
+ * Reading Room override of Starlight's built-in ThemeProvider.
+ *
+ * The dashboard and marketing surfaces hard-default to LIGHT (Manuscript) and
+ * do NOT follow the OS: see `apps/dashboard/app/layout.tsx`
+ * (`defaultTheme="light" enableSystem={false}`) and the marketing site's
+ * `var theme = stored || 'light'`. Stock Starlight instead follows
+ * `prefers-color-scheme`, so the docs were the only one of the three surfaces
+ * that went dark/teal for a dark-OS visitor — the brand inconsistency this
+ * override fixes.
+ *
+ * `localStorage.getItem('starlight-theme')` distinguishes three states, which
+ * lets us default to light WITHOUT breaking an explicit "auto" choice:
+ *   - `null`            → never chose: default to light (Manuscript) and persist
+ *                          it, so ThemeSelect's own hydration agrees on the next
+ *                          read instead of re-resolving to the system scheme.
+ *   - `''`              → explicitly chose "auto": follow the system, as stock
+ *                          Starlight does (ThemeSelect stores auto as the empty
+ *                          string).
+ *   - `'light'`/`'dark'`→ explicit: honour it.
+ *
+ * Kept inline (`is:inline`) to run before first paint and avoid a flash. The
+ * `<template>` is consumed by `<ThemeSelect />`; it is reproduced verbatim from
+ * the default component so the picker keeps working.
+ */
+import { Icon } from "@astrojs/starlight/components";
+---
+
+<script is:inline>
+  window.StarlightThemeProvider = (() => {
+    const stored =
+      typeof localStorage !== "undefined" ? localStorage.getItem("starlight-theme") : null;
+    let theme;
+    if (stored === "light" || stored === "dark") {
+      theme = stored;
+    } else if (stored === "") {
+      // Explicit "auto" — follow the system, exactly as stock Starlight does.
+      theme = window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark";
+    } else {
+      // Never chose — default to light (Manuscript) and persist so the picker
+      // and ThemeSelect's hydration read the same value.
+      theme = "light";
+      if (typeof localStorage !== "undefined") localStorage.setItem("starlight-theme", "light");
+    }
+    document.documentElement.dataset.theme = theme === "dark" ? "dark" : "light";
+    return {
+      updatePickers(
+        value = stored === "light" || stored === "dark" ? stored : stored === "" ? "auto" : "light",
+      ) {
+        document.querySelectorAll("starlight-theme-select").forEach((picker) => {
+          const select = picker.querySelector("select");
+          if (select) select.value = value;
+          /** @type {HTMLTemplateElement | null} */
+          const tmpl = document.querySelector(`#theme-icons`);
+          const newIcon = tmpl && tmpl.content.querySelector("." + value);
+          if (newIcon) {
+            const oldIcon = picker.querySelector("svg.label-icon");
+            if (oldIcon) {
+              oldIcon.replaceChildren(...newIcon.cloneNode(true).childNodes);
+            }
+          }
+        });
+      },
+    };
+  })();
+</script>
+
+<template id="theme-icons">
+  <Icon name="sun" class="light" />
+  <Icon name="moon" class="dark" />
+  <Icon name="laptop" class="auto" />
+</template>

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -2,6 +2,9 @@
 title: The Librarian
 description: Operating guide for The Librarian — a portable memory + handoff layer for AI agents.
 template: splash
+head:
+  - tag: title
+    content: The Librarian — operating guide
 hero:
   tagline: A portable memory + handoff layer for your AI agents. This is the operating guide.
   actions:
@@ -15,43 +18,40 @@ hero:
       variant: minimal
 ---
 
-import { Card, CardGrid, LinkCard } from "@astrojs/starlight/components";
+<div class="rr-home">
 
-This is the operating guide for The Librarian — written for the person **running**
-it, not reading its source. Plain language, screenshots of the real interface, and
-task-by-task walkthroughs. New here? Start with
-[What is The Librarian?](/start-here/what-is-the-librarian/)
+<p class="rr-home-intro">
+  This is the operating guide for The Librarian — written for the person who
+  <strong>runs</strong> it, not the person reading its source. Plain language,
+  screenshots of the real interface, and task-by-task walkthroughs. New here?
+  Begin with <a href="/start-here/what-is-the-librarian/">what it is</a>.
+</p>
 
-<CardGrid>
-  <Card title="Start here" icon="open-book">
-    What The Librarian is, how to [install](/start-here/install/) a server, and
-    what to expect in your [first run](/start-here/first-run/).
-  </Card>
-  <Card title="Connect your agent" icon="puzzle">
-    One page each for [Claude Code](/connect/claude-code/),
-    [Codex](/connect/codex/), [OpenCode](/connect/opencode/),
-    [Hermes](/connect/hermes/), and [Pi](/connect/pi/).
-  </Card>
-  <Card title="Using the dashboard" icon="laptop">
-    A guided [tour](/dashboard/) of every area — memories, proposals, the curator,
-    the vault, and settings.
-  </Card>
-  <Card title="Operating guides" icon="approve-check">
-    Task walkthroughs: [reviewing proposals](/guides/reviewing-proposals/),
-    [handoffs](/guides/handoff-takeover/), [private mode](/guides/private-mode/),
-    and [backups](/guides/backups-restore/).
-  </Card>
-</CardGrid>
+<nav class="rr-home-index" aria-label="Where to start">
+  <a class="rr-home-entry" href="/start-here/what-is-the-librarian/">
+    <span class="rr-home-entry-title">What is The Librarian?</span>
+    <span class="rr-home-entry-desc">What it is, how it keeps your agents' memory, and why you'd run one.</span>
+  </a>
+  <a class="rr-home-entry" href="/start-here/install/">
+    <span class="rr-home-entry-title">Install a server</span>
+    <span class="rr-home-entry-desc">Stand up the server and dashboard, then connect your first agent — in a few commands.</span>
+  </a>
+  <a class="rr-home-entry" href="/connect/claude-code/">
+    <span class="rr-home-entry-title">Connect your agent</span>
+    <span class="rr-home-entry-desc">One page each for Claude Code, Codex, OpenCode, Hermes, and Pi.</span>
+  </a>
+  <a class="rr-home-entry" href="/dashboard/">
+    <span class="rr-home-entry-title">Tour the dashboard</span>
+    <span class="rr-home-entry-desc">A guided walk through every area — memories, proposals, the curator, the vault, and settings.</span>
+  </a>
+  <a class="rr-home-entry" href="/guides/reviewing-proposals/">
+    <span class="rr-home-entry-title">Operating guides</span>
+    <span class="rr-home-entry-desc">Task walkthroughs: reviewing proposals, handoffs, private mode, and backups.</span>
+  </a>
+  <a class="rr-home-entry" href="/reference/mcp-verbs/">
+    <span class="rr-home-entry-title">Reference</span>
+    <span class="rr-home-entry-desc">The generated technical appendix — the seven MCP verbs, the CLIs, the primer, and the capture matrix.</span>
+  </a>
+</nav>
 
-## First steps
-
-<LinkCard
-  title="Install"
-  description="Stand up a server and connect your first agent, in a few commands."
-  href="/start-here/install/"
-/>
-<LinkCard
-  title="Self-host & operate"
-  description="The full operator guide: networking, data location, updates, auth, and secrets."
-  href="/deploy-and-operate/self-host/"
-/>
+</div>

--- a/apps/docs/src/styles/reading-room.css
+++ b/apps/docs/src/styles/reading-room.css
@@ -313,3 +313,91 @@ site-search button[data-open-modal] {
 :root {
   --ec-frm-trmTtbDotsOpa: 0;
 }
+
+/* ---- Image lightbox (native <dialog>; see components/Footer.astro) ------ */
+
+/* A theme-aware veil behind the enlarged image. */
+:root,
+::backdrop {
+  --reading-room-scrim: rgba(6, 27, 34, 0.74); /* deep-teal (Scriptorium) */
+}
+:root[data-theme="light"],
+[data-theme="light"] ::backdrop {
+  --reading-room-scrim: rgba(26, 22, 18, 0.62); /* ink veil over warm paper */
+}
+
+/* The zoom-in affordance on enlargeable content images. */
+.sl-markdown-content img[data-rr-lightbox] {
+  cursor: zoom-in;
+}
+
+dialog.rr-lightbox {
+  max-width: 94vw;
+  max-height: 94vh;
+  margin: auto;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  overflow: visible;
+}
+dialog.rr-lightbox::backdrop {
+  background: var(--reading-room-scrim);
+  backdrop-filter: blur(2px);
+}
+
+/* The enlarged image sits in a copper-mounted frame, echoing the gilt-mounted
+ * figures on the marketing site. Sharp corners, flat. */
+.rr-lightbox-figure {
+  position: relative;
+  margin: 0;
+  padding: clamp(8px, 1vw, 14px);
+  background: var(--sl-color-bg);
+  border: 1px solid var(--reading-room-copper-soft);
+}
+.rr-lightbox-img {
+  display: block;
+  width: auto;
+  height: auto;
+  max-width: 100%;
+  max-height: calc(94vh - 2rem);
+}
+.rr-lightbox-close {
+  position: absolute;
+  top: clamp(8px, 1vw, 14px);
+  right: clamp(8px, 1vw, 14px);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  color: var(--sl-color-white);
+  background: var(--sl-color-bg);
+  border: 1px solid var(--reading-room-copper-soft);
+  cursor: pointer;
+}
+.rr-lightbox-close:hover,
+.rr-lightbox-close:focus-visible {
+  color: var(--sl-color-text-accent);
+  border-color: var(--reading-room-copper);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  dialog.rr-lightbox[open] {
+    animation: rr-lightbox-in 180ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+  dialog.rr-lightbox[open]::backdrop {
+    animation: rr-lightbox-fade 180ms ease;
+  }
+}
+@keyframes rr-lightbox-in {
+  from {
+    opacity: 0;
+    transform: scale(0.985);
+  }
+}
+@keyframes rr-lightbox-fade {
+  from {
+    opacity: 0;
+  }
+}

--- a/apps/docs/src/styles/reading-room.css
+++ b/apps/docs/src/styles/reading-room.css
@@ -129,3 +129,187 @@ h6,
   --ec-frm-edTabBarBg: #0b242e;
   --ec-frm-trmBg: #0b242e;
 }
+
+/* ---- On-brand pass: retire the "default Starlight" tells ---------------- */
+
+/*
+ * The mapping above wires the neutral ramp, accent, surfaces and fonts, but
+ * several Starlight defaults still showed through (impeccable critique,
+ * 2026-06-30): rainbow card/aside hues, rounded + drop-shadowed cards, no
+ * copper structural accent, and rounded search/code frames. The dashboard and
+ * marketing surfaces are flat, sharp-cornered, and spend exactly two metals —
+ * a verdigris rubric (action/state) and copper (structure). This section
+ * brings the docs into line. Contrast of every new combination is re-checked
+ * by tests/a11y.spec.ts over both palettes.
+ */
+
+/* Copper — the structural-hardware accent, identical to the dashboard
+ * (`apps/dashboard/styles/tokens.css` --ink-copper) and the marketing site
+ * (`--copper`). Verdigris is its oxidised form; copper carries gilt rules and
+ * frames, never action or state. */
+:root,
+::backdrop {
+  --reading-room-copper: #d49872; /* polished copper for the cool field */
+  --reading-room-copper-soft: rgba(212, 152, 114, 0.34);
+}
+:root[data-theme="light"],
+[data-theme="light"] ::backdrop {
+  --reading-room-copper: #b87333; /* structural copper on warm paper */
+  --reading-room-copper-soft: rgba(184, 115, 51, 0.32);
+}
+
+/* Flat by default (DESIGN.md retires drop shadows for hairlines) and sharp
+ * corners everywhere Starlight exposes a radius token. */
+:root {
+  --sl-shadow-sm: none;
+  --sl-shadow-md: none;
+  --sl-shadow-lg: none;
+  --sl-search-corners: 0px;
+  --header-border-radius: 0px;
+  --ec-brdRad: 0px; /* Expressive-Code frame corners */
+}
+
+/* Collapse Starlight's five semantic hue families — used by BOTH the home
+ * <CardGrid> and prose asides — onto the two-metal system. Informational hues
+ * (note/tip) → verdigris; cautionary hues (caution/danger) → copper. Each
+ * aside keeps its title + icon, so meaning never rests on colour alone. The
+ * values reference theme tokens, so one block serves both palettes. */
+:root,
+::backdrop {
+  --sl-color-blue: var(--sl-color-accent);
+  --sl-color-green: var(--sl-color-accent);
+  --sl-color-purple: var(--sl-color-accent);
+  --sl-color-orange: var(--reading-room-copper);
+  --sl-color-red: var(--reading-room-copper);
+
+  --sl-color-blue-low: var(--sl-color-gray-6);
+  --sl-color-green-low: var(--sl-color-gray-6);
+  --sl-color-purple-low: var(--sl-color-gray-6);
+  --sl-color-orange-low: var(--sl-color-gray-6);
+  --sl-color-red-low: var(--sl-color-gray-6);
+
+  --sl-color-blue-high: var(--sl-color-white);
+  --sl-color-green-high: var(--sl-color-white);
+  --sl-color-purple-high: var(--sl-color-white);
+  --sl-color-orange-high: var(--sl-color-white);
+  --sl-color-red-high: var(--sl-color-white);
+}
+
+/* Sharp + flat on the components Starlight ships rounded/lifted. */
+.sl-link-card,
+.card,
+.sl-link-button,
+.sl-badge,
+.card .icon,
+.sl-link-card .icon,
+site-search button[data-open-modal] {
+  border-radius: 0;
+}
+.sl-link-card,
+.card {
+  box-shadow: none;
+}
+
+/* The home card titles are <p class="title">, not headings, so they miss the
+ * Fraunces selector list above — route them to the display face. */
+.card .title,
+.sl-link-card .title {
+  font-family: var(--reading-room-display);
+  font-weight: 500;
+  letter-spacing: -0.01em;
+}
+
+/* A thin gilt rule under the top nav, echoing the marketing chapter rules. */
+.header {
+  border-bottom-color: var(--reading-room-copper-soft);
+}
+
+/* ---- Bespoke home (splash template) ------------------------------------ */
+
+/*
+ * Replace Starlight's stock rainbow card grid with an editorial index that
+ * echoes the marketing long-scroll: a copper rule, a plain-language intro, and
+ * a hairline-separated list of entries — scenes, not tiles. The frontmatter
+ * `hero` (wordmark + tagline + two actions) is kept and inherits the skin.
+ */
+.rr-home {
+  max-width: 50rem;
+  margin-inline: auto;
+}
+.rr-home-intro {
+  font-size: var(--sl-text-lg);
+  line-height: 1.6;
+  color: var(--sl-color-text);
+  border-top: 2px solid var(--reading-room-copper-soft);
+  padding-top: 1.5rem;
+  margin-top: 0;
+}
+.rr-home-index {
+  margin-top: 2.75rem;
+  border-top: 1px solid var(--sl-color-hairline);
+}
+.rr-home-entry {
+  display: grid;
+  gap: 0.3rem;
+  padding: 1.15rem 2.25rem 1.15rem 0;
+  border-bottom: 1px solid var(--sl-color-hairline);
+  text-decoration: none;
+  color: var(--sl-color-text);
+  position: relative;
+  transition: border-color 0.2s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.rr-home-entry-title {
+  font-family: var(--reading-room-display);
+  font-weight: 500;
+  font-size: var(--sl-text-xl);
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  color: var(--sl-color-white);
+}
+.rr-home-entry-desc {
+  color: var(--sl-color-text);
+  line-height: 1.5;
+}
+.rr-home-entry::after {
+  content: "→";
+  position: absolute;
+  top: 1.15rem;
+  right: 0.25rem;
+  color: var(--reading-room-copper);
+  transition: transform 0.2s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.rr-home-entry:hover,
+.rr-home-entry:focus-visible {
+  border-bottom-color: var(--reading-room-copper);
+}
+.rr-home-entry:hover .rr-home-entry-title,
+.rr-home-entry:focus-visible .rr-home-entry-title {
+  color: var(--sl-color-text-accent);
+}
+.rr-home-entry:hover::after,
+.rr-home-entry:focus-visible::after {
+  transform: translateX(0.35rem);
+}
+@media (prefers-reduced-motion: reduce) {
+  .rr-home-entry,
+  .rr-home-entry::after {
+    transition: none;
+  }
+}
+
+/* Asides: retire Starlight's thick coloured side-stripe (an impeccable absolute
+ * ban for callouts, and it spends the rubric accent decoratively) in favour of
+ * a full hairline-weight frame in the semantic metal. The background tint, the
+ * icon, and the bold title still carry the meaning — so it never rests on a
+ * stripe colour alone. */
+.starlight-aside {
+  border-inline-start: none;
+  border: 1px solid var(--sl-color-asides-border);
+}
+
+/* Flatten Expressive-Code's terminal frame: drop the faux window-button "traffic
+ * light" dots (decorative chrome) to match the bare, hairline-bounded command
+ * block on the marketing site. Corners are already squared via --ec-brdRad. */
+:root {
+  --ec-frm-trmTtbDotsOpa: 0;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Finalises the docs-site go-live in three steps. One release, **1.2.2** (PATCH — all docs-site work).

## 1. Point the docs-update rule at the live site (T1.6)

With `https://librarian-docs.codeministry.net` live, `AGENTS.md` and `CONTRIBUTING.md` drop the "once it ships" conditional and name the docs site as the canonical home for user-facing docs.

## 2. Bring the docs on-brand with the dashboard + marketing

An impeccable design critique (scored 25/40) found the Starlight docs read as a *recoloured default theme*. Fixes in `apps/docs`:

- **Default to light Manuscript** for new visitors instead of following the OS — matching the dashboard (`defaultTheme="light" enableSystem={false}`) and the marketing site — via a `ThemeProvider` override (an explicit *auto* choice still follows the system).
- **One palette, two metals:** collapse Starlight's five rainbow hue families (home cards **and** prose asides) onto the verdigris rubric + copper structure system; informational asides verdigris, cautionary copper, meaning preserved by each callout's icon + title.
- **Flat + sharp:** no drop shadows; squared cards, buttons, search, and code-frames.
- **Copper structural accent** added (header rule, code-frame borders, the home).
- **Editorial home:** the stock hero + rainbow card grid replaced by a hairline-separated index — scenes, not tiles.
- Minors: framed asides instead of the banned side-stripe; faux terminal window-dots dropped; duplicated `<title>` fixed.

## 3. Click-to-enlarge screenshots (native `<dialog>` lightbox)

Content images open enlarged in a dependency-free native `<dialog>`: click or keyboard (Enter/Space), Esc / backdrop / close-button to dismiss, focus returned to the trigger, highest-resolution source shown. Copper-mounted frame + theme-aware scrim, mirroring the marketing site's lightbox idiom; `prefers-reduced-motion`-aware.

## Verification (run locally)

- `pnpm --filter @librarian/docs build` → 35 pages, **all internal links valid**.
- **axe-core a11y gate: 58/58 over both palettes** (the recolour holds WCAG AA), re-run after each change.
- Visually verified home + a content page + the lightbox, in **light and dark**, by driving Playwright.

## Notes

- Screenshots are captured at 1280×800, so the lightbox enlarges to that (crisp, much bigger than inline) — not beyond native resolution.
- A deliberate, reversible call: asides lost their per-type rainbow colours in favour of the two-metal system (icon + title still carry meaning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JVTe8bYb5FP97F3LNYBnoQ
