### PR TITLE
feat(dashboard): default the "Docs" link to the public docs site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.2.3] — 2026-06-30
+
+### Changed
+
+- **Dashboard "Docs" link defaults to the public docs site.** The contextual
+  "Docs" nav link previously stayed hidden until `NEXT_PUBLIC_DOCS_URL` was set at
+  build time, so a self-hoster on the prebuilt image never saw it. It now defaults
+  to `https://librarian-docs.codeministry.net` for every deployment, with
+  `NEXT_PUBLIC_DOCS_URL` kept as an optional override (e.g. a private docs fork).
+
 ## [1.2.2] — 2026-06-30
 
 ### Changed
@@ -3423,6 +3433,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.2.3]: https://github.com/JimJafar/the-librarian/compare/v1.2.2...v1.2.3
 [1.2.2]: https://github.com/JimJafar/the-librarian/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/JimJafar/the-librarian/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/JimJafar/the-librarian/compare/v1.1.4...v1.2.0

--- a/apps/dashboard/components/docs-link.tsx
+++ b/apps/dashboard/components/docs-link.tsx
@@ -1,17 +1,17 @@
 "use client";
 
 import { usePathname } from "next/navigation";
-import { docsUrlForPath } from "@/lib/docs-map";
+import { DEFAULT_DOCS_URL, docsUrlForPath } from "@/lib/docs-map";
 
 // Contextual "Docs" deep-link in the top nav (docs-site spec, Phase 4 / OQ2).
 // It opens the docs page for the CURRENT route — one global affordance that is
-// also per-page contextual. It stays DARK (renders nothing) until
-// NEXT_PUBLIC_DOCS_URL is set at go-live (OQ1), so the dashboard never offers a
-// link to a docs site that isn't deployed yet. NEXT_PUBLIC_* is inlined at
-// build, so flipping it on is a rebuild, not a code change.
+// also per-page contextual. It defaults to the public docs site
+// (DEFAULT_DOCS_URL), so every deployment gets the link with nothing to
+// configure; NEXT_PUBLIC_DOCS_URL overrides the base for a private docs fork
+// (NEXT_PUBLIC_* is inlined at build, so changing it is a rebuild).
 export function DocsLink() {
   const pathname = usePathname() ?? "/";
-  const href = docsUrlForPath(process.env.NEXT_PUBLIC_DOCS_URL, pathname);
+  const href = docsUrlForPath(process.env.NEXT_PUBLIC_DOCS_URL || DEFAULT_DOCS_URL, pathname);
   if (!href) return null;
   return (
     <a

--- a/apps/dashboard/lib/docs-map.ts
+++ b/apps/dashboard/lib/docs-map.ts
@@ -47,9 +47,15 @@ export function docsSlugForPath(pathname: string): string {
   return DOCS_FALLBACK_SLUG;
 }
 
-/** The absolute docs URL for a pathname, or null when no docs base is
- *  configured — so the in-dashboard "Docs" link stays dark until go-live points
- *  NEXT_PUBLIC_DOCS_URL at the deployed site (OQ1). */
+/** The public docs site — the default the dashboard "Docs" link points at, so
+ *  every deployment gets the link with nothing to configure. An operator can
+ *  override the base (e.g. a private docs fork) with NEXT_PUBLIC_DOCS_URL. */
+export const DEFAULT_DOCS_URL = "https://librarian-docs.codeministry.net";
+
+/** The absolute docs URL for a pathname, or null when called with an empty
+ *  base. The dashboard's <DocsLink> defaults the base to DEFAULT_DOCS_URL and
+ *  lets NEXT_PUBLIC_DOCS_URL override it, so this returns null only when given
+ *  no base directly. */
 export function docsUrlForPath(base: string | undefined, pathname: string): string | null {
   if (!base) return null;
   return `${base.replace(/\/+$/, "")}/${docsSlugForPath(pathname)}/`;

--- a/apps/dashboard/tests/components/docs-link.test.tsx
+++ b/apps/dashboard/tests/components/docs-link.test.tsx
@@ -18,13 +18,25 @@ afterEach(() => {
 });
 
 describe("DocsLink", () => {
-  it("renders nothing when no docs base URL is configured (pre-go-live)", () => {
+  it("defaults to the public docs site when NEXT_PUBLIC_DOCS_URL is unset", () => {
     delete process.env.NEXT_PUBLIC_DOCS_URL;
-    const { container } = render(<DocsLink />);
-    expect(container).toBeEmptyDOMElement();
+    render(<DocsLink />);
+    expect(screen.getByRole("link", { name: "Docs" })).toHaveAttribute(
+      "href",
+      "https://librarian-docs.codeministry.net/dashboard/memories/",
+    );
   });
 
-  it("deep-links to the docs page for the current route when configured", () => {
+  it("treats an empty NEXT_PUBLIC_DOCS_URL as unset and still defaults", () => {
+    process.env.NEXT_PUBLIC_DOCS_URL = "";
+    render(<DocsLink />);
+    expect(screen.getByRole("link", { name: "Docs" })).toHaveAttribute(
+      "href",
+      "https://librarian-docs.codeministry.net/dashboard/memories/",
+    );
+  });
+
+  it("lets NEXT_PUBLIC_DOCS_URL override the base (e.g. a private docs fork)", () => {
     process.env.NEXT_PUBLIC_DOCS_URL = "https://docs.example.com";
     render(<DocsLink />);
     const link = screen.getByRole("link", { name: "Docs" });

--- a/apps/dashboard/tests/docs-map.test.ts
+++ b/apps/dashboard/tests/docs-map.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { DOCS_SLUGS, docsSlugForPath, docsUrlForPath } from "@/lib/docs-map";
+import { DEFAULT_DOCS_URL, DOCS_SLUGS, docsSlugForPath, docsUrlForPath } from "@/lib/docs-map";
 
 // Cross-surface link guard (docs-site spec T4.1). The dashboard deep-links into
 // the docs site; every target must resolve to a real docs page, or a rename /
@@ -33,9 +33,16 @@ describe("dashboard → docs cross-surface links", () => {
     }
   });
 
-  it("stays dark until a docs base URL is configured (go-live / OQ1)", () => {
+  it("returns null for an empty base (callers supply the default)", () => {
     expect(docsUrlForPath(undefined, "/memories")).toBeNull();
     expect(docsUrlForPath("", "/memories")).toBeNull();
+  });
+
+  it("defaults to the public docs site", () => {
+    expect(DEFAULT_DOCS_URL).toBe("https://librarian-docs.codeministry.net");
+    expect(docsUrlForPath(DEFAULT_DOCS_URL, "/memories")).toBe(
+      "https://librarian-docs.codeministry.net/dashboard/memories/",
+    );
   });
 
   it("builds an absolute docs URL when a base is configured", () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## What

The dashboard's contextual **"Docs"** nav link now **defaults to the public docs site** (`https://librarian-docs.codeministry.net`) for every deployment, instead of staying hidden until `NEXT_PUBLIC_DOCS_URL` is set.

## Why

`NEXT_PUBLIC_*` is inlined at dashboard **build** time, so the old "dark until set" behaviour meant a self-hoster on the prebuilt image never saw the link — even though the docs are the same public site for everyone. Defaulting it in code lights the link for all deployments with nothing to configure. `NEXT_PUBLIC_DOCS_URL` is kept as an optional **override** (e.g. a private docs fork).

## Changes

- `lib/docs-map.ts` — export `DEFAULT_DOCS_URL`.
- `components/docs-link.tsx` — resolve `process.env.NEXT_PUBLIC_DOCS_URL || DEFAULT_DOCS_URL`.
- Tests — unset/empty env now defaults to the public site; an explicit value overrides; a guard pins the default constant.

## Verification (local)

- `vitest` docs-link + docs-map → **9/9 pass**.
- dashboard `tsc --noEmit` clean; prettier clean; `check:release` OK (**1.2.3**).

## Trade-off

The link is now always present, so a fully air-gapped deployment would show a "Docs" link to an unreachable public host. If that ever matters, an explicit opt-out sentinel can be added — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JVTe8bYb5FP97F3LNYBnoQ
