### PR TITLE
fix(curator): distill must opt out of JSON mode — HTTP 400 on distill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.3.1] — 2026-07-02
+
+### Fixed
+
+- **"Distill example" no longer fails with HTTP 400 on real providers.** The
+  shared curator LLM client defaults every request to OpenAI JSON mode
+  (`response_format: json_object`) — right for every other curator call, wrong
+  for the distill call, which asks for plain markdown; OpenAI-compatible
+  providers reject JSON mode when the prompt never mentions JSON. Both distill
+  completions now opt out explicitly, pinned by a regression test.
+
 ## [1.3.0] — 2026-07-02
 
 ### Added
@@ -3472,6 +3483,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.3.1]: https://github.com/JimJafar/the-librarian/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/JimJafar/the-librarian/compare/v1.2.3...v1.3.0
 [1.2.3]: https://github.com/JimJafar/the-librarian/compare/v1.2.2...v1.2.3
 [1.2.2]: https://github.com/JimJafar/the-librarian/compare/v1.2.1...v1.2.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/core/src/curator-distill.ts
+++ b/packages/core/src/curator-distill.ts
@@ -95,7 +95,14 @@ export async function distillIntakeExamples(
     { role: "user", content: buildUserContent(input) },
   ];
 
-  const first = stripCodeFence((await input.client.complete({ messages })).content);
+  // jsonResponse: false is LOAD-BEARING. The shared curator client defaults to
+  // OpenAI json mode (response_format: json_object) because every other
+  // curator call returns JSON — but distill wants plain markdown, and json
+  // mode with a prompt that never mentions JSON is an HTTP 400 on
+  // OpenAI-compatible providers.
+  const first = stripCodeFence(
+    (await input.client.complete({ messages, jsonResponse: false })).content,
+  );
   if (!first) {
     throw new Error("The curator returned an empty examples document — nothing to preview.");
   }
@@ -114,6 +121,7 @@ export async function distillIntakeExamples(
             content: `That draft is ${firstBytes} bytes — over the ${input.maxBytes}-byte budget. Condense harder (merge entries, shorter phrasing) and respond with ONLY the updated whole document, under ${input.maxBytes} bytes.`,
           },
         ],
+        jsonResponse: false, // plain markdown — see the first call
       })
     ).content,
   );

--- a/packages/core/tests/curator-distill.test.ts
+++ b/packages/core/tests/curator-distill.test.ts
@@ -14,12 +14,18 @@
 import { type LlmClient, distillIntakeExamples } from "@librarian/core";
 import { describe, expect, it } from "vitest";
 
-function scriptedClient(completions: string[]): { client: LlmClient; prompts: string[] } {
+function scriptedClient(completions: string[]): {
+  client: LlmClient;
+  prompts: string[];
+  jsonFlags: (boolean | undefined)[];
+} {
   const prompts: string[] = [];
+  const jsonFlags: (boolean | undefined)[] = [];
   let i = 0;
   const client: LlmClient = {
     complete: async (request) => {
       prompts.push(request.messages.map((m) => `${m.role}: ${m.content}`).join("\n---\n"));
+      jsonFlags.push(request.jsonResponse);
       return {
         content: completions[Math.min(i++, completions.length - 1)]!,
         model: "m",
@@ -27,7 +33,7 @@ function scriptedClient(completions: string[]): { client: LlmClient; prompts: st
       };
     },
   };
-  return { client, prompts };
+  return { client, prompts, jsonFlags };
 }
 
 const submission = {
@@ -65,6 +71,16 @@ describe("distillIntakeExamples", () => {
       maxBytes: 4096,
     });
     expect(prompts[0]!).not.toContain("fake-distill-secret");
+  });
+
+  it("requests PLAIN TEXT, never JSON mode — on the first draft AND the condense retry", async () => {
+    // Regression: the shared LLM client defaults jsonResponse to true, which
+    // sends OpenAI's response_format json_object. Distill wants markdown, and
+    // json mode with a no-JSON prompt is an HTTP 400 on OpenAI-compatible
+    // providers — the client must opt out explicitly on every distill call.
+    const { client, jsonFlags } = scriptedClient(["x".repeat(200), "- condensed."]);
+    await distillIntakeExamples({ client, currentDoc: "", submission, maxBytes: 100 });
+    expect(jsonFlags).toEqual([false, false]);
   });
 
   it("strips a markdown code fence from the completion", async () => {


### PR DESCRIPTION
## Why

"Distill example" (the Reject & make an example flow, shipped in v1.3.0) fails with **LLM request failed: HTTP 400** against real providers. The shared curator LLM client defaults every request to OpenAI JSON mode (`response_format: {type: "json_object"}`) — correct for every other curator call, which all return JSON, but distill asks for plain markdown, and OpenAI-compatible providers reject JSON mode when the prompt never mentions JSON. The test stubs ignore `response_format`, so the suite stayed green.

This fix was pushed to the v1.3.0 branch as `3127659` but raced the auto-merge and missed the release — cherry-picked here onto main.

## What

- Both distill completions (first draft + condense retry) pass `jsonResponse: false`, with a load-bearing comment.
- Regression test pins the flag on both calls (fails without the fix).
- PATCH bump to 1.3.1 + dated CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NGk4T3qPg9uv1Bs1mV7z3W