### PR TITLE
fix(core): make curator output contracts unambiguous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.10.1] — 2026-07-19
+
+### Fixed
+
+- **Curator responses now restate the strict fields production accepts.**
+  Intake explicitly limits tags to creates and split replacements, preventing
+  otherwise useful supersede judgments from being discarded for an extra
+  `tags` field. Grooming now distinguishes numeric operation confidence from
+  the `tentative` / `working` / `strong` stored-memory confidence enum, and
+  gives the complete nested memory shapes including array-only `applies_to`
+  and `tags`.
+
 ## [1.10.0] — 2026-07-17
 
 ### Added
@@ -3912,6 +3924,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.10.1]: https://github.com/JimJafar/the-librarian/compare/v1.10.0...v1.10.1
 [1.10.0]: https://github.com/JimJafar/the-librarian/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/JimJafar/the-librarian/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/JimJafar/the-librarian/compare/v1.7.0...v1.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@ changes from this point forward are catalogued here.
   `tags` field. Grooming now distinguishes numeric operation confidence from
   the `tentative` / `working` / `strong` stored-memory confidence enum, and
   gives the complete nested memory shapes including array-only `applies_to`
-  and `tags`.
+  and `tags`. The shared tagging guidance no longer conflicts with action
+  shapes that omit tags, and every complete grooming replacement now explicitly
+  requires the production `visibility: "common"` field.
 
 ## [1.10.0] — 2026-07-17
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/core/src/curator-prompt.ts
+++ b/packages/core/src/curator-prompt.ts
@@ -51,7 +51,10 @@ import type { IntakeCandidates } from "./intake/navigate.js";
 // shapes explicit after a valid operation was discarded for emitting a scalar
 // `applies_to`. v5.8 makes exact intake fields and the two grooming confidence
 // types explicit after strict validation discarded otherwise useful outputs.
-export const CURATOR_PROMPT_VERSION = "v5.8";
+// v5.9 removes a shared tagging instruction that contradicted mode-specific
+// shapes and makes the required visibility field explicit for every complete
+// grooming MemoryInput.
+export const CURATOR_PROMPT_VERSION = "v5.9";
 
 // ── the shared core ───────────────────────────────────────────────────────────
 
@@ -78,7 +81,7 @@ HOW TO CURATE — the judgement behind every choice:
 - Add, don't duplicate. If the new information says nothing the store doesn't already hold, noop. If it adds even a little that is genuinely new, file it.
 - Split SPARINGLY, and only to un-overload an EXISTING doc that has become a grab-bag conflating two or more distinct entities — spin it into focused per-entity docs. NEVER split single-entity content; that is over-fragmentation, the opposite of curation. When in doubt, do NOT split.
 - File durable knowledge, not transient noise. Memory is for what will be worth recalling later: stable facts about people, projects, preferences, conventions, infrastructure, decisions. Content that is OBVIOUSLY transient or low-value — a one-off task note, an already-resolved bug or typo, an ephemeral status update — has no lasting recall value. (When the lasting value is genuinely unclear, keep a lean note rather than discard — bias toward discarding only the obvious noise.)
-- Tag for finding. Tags are the corpus's organising signal: give each doc a few lowercase tags — roughly the entity plus the kind of value (a project or person name, plus "decision", "lesson", "preference", "direction") — and reuse tags already visible in the EVIDENCE rather than inventing near-synonyms.
+- Tag only when the exact output shape includes "tags". Tags are the corpus's organising signal: when that field is available, give a new or rewritten doc a few lowercase tags — roughly the entity plus the kind of value (a project or person name, plus "decision", "lesson", "preference", "direction") — and reuse tags already visible in the EVIDENCE rather than inventing near-synonyms. Never invent a "tags" field for a shape that omits it; existing tags remain unchanged unless the contract explicitly permits changing them.
 - Title for a human browsing the files. A doc's title is ALSO its filename, so make it a concise, specific noun phrase that NAMES the thing and leads with the entity (e.g. "work team", "Trash Over rm", "Elaine — Piano Teacher"). Avoid category prefixes ("Preference:", "Convention:", "Note:"), avoid colons, and avoid sentence- or status-style titles ("AI Engineering Progress: Exercise 01 Complete"). Aim for ~3–6 words. Titles are also link targets — rename an existing doc only when its current title genuinely misleads.
 - Rationale is for the human reviewer. State the claim, point at the evidence that supports it (candidate ids, or a short quoted fragment), and note what would make it wrong. A proposal whose rationale can be checked in seconds earns a fast approval; a vague one earns a rejection.
 - Changing nothing is a valid success. A submission with no lasting value, or a slice already in good order, deserves a confident noop — never invent work to appear useful.
@@ -140,6 +143,7 @@ Each Operation is exactly one of:
 
 MemoryInput = { "title": string, "body": string, "visibility": "common", "applies_to"?: string[], "confidence"?: "tentative" | "working" | "strong", "tags"?: string[] }
 MemoryPatch has the same fields and types, with every field optional.
+Every MemoryInput MUST include "visibility": "common" — in "memory", "replacement", and every item in "replacements". MemoryPatch may omit "visibility"; do not use a patch to change it.
 "applies_to" and "tags" are arrays even for one value; use [] or omit the field when empty, never a scalar.
 Operation confidence is the operation-level "confidence" number in [0, 1].
 Stored-memory confidence is nested inside "memory", "replacement", "replacements", or "patch" and, if present, is exactly "tentative", "working", or "strong". Omit it when unnecessary. Never copy numeric operation confidence into a nested memory.

--- a/packages/core/src/curator-prompt.ts
+++ b/packages/core/src/curator-prompt.ts
@@ -47,8 +47,10 @@ import type { IntakeCandidates } from "./intake/navigate.js";
 // rides the intake user content when non-empty); grooming assembly untouched,
 // but the shared version bumps so the change is visible in run provenance.
 // v5.6 attempts to improve judgement by adding a value hierarchy, defining brittle
-// vs durable, and a few other optimisations.
-export const CURATOR_PROMPT_VERSION = "v5.6";
+// vs durable, and a few other optimisations. v5.7 makes the nested grooming memory
+// shapes explicit after a valid operation was discarded for emitting a scalar
+// `applies_to`.
+export const CURATOR_PROMPT_VERSION = "v5.7";
 
 // ── the shared core ───────────────────────────────────────────────────────────
 
@@ -133,7 +135,9 @@ Each Operation is exactly one of:
 - { "type": "split", "source_memory_id": string, "replacements": MemoryInput[], "rationale": string, "confidence": number }
 - { "type": "create", "memory": MemoryInput, "rationale": string, "confidence": number }
 
-MemoryInput / MemoryPatch use ONLY these fields: title, body, visibility, applies_to, confidence, tags. "visibility" is always "common". The stored "confidence" field is an enum — "tentative", "working", or "strong" — and is NOT the operation's numeric confidence: writing a number there gets the operation discarded.
+MemoryInput = { "title": string, "body": string, "visibility": "common", "applies_to"?: string[], "confidence"?: "tentative" | "working" | "strong", "tags"?: string[] }
+MemoryPatch has the same fields and types, with every field optional.
+"applies_to" and "tags" are arrays even for one value; use [] or omit the field when empty, never a scalar. The stored "confidence" field is the enum above and is NOT the operation's numeric confidence: writing a number there gets the operation discarded.
 
 RULES (re-checked in code after you respond — an operation that breaks one is discarded, so don't waste it):
 - Reference ONLY ids that appear in the EVIDENCE. Never invent an id.

--- a/packages/core/src/curator-prompt.ts
+++ b/packages/core/src/curator-prompt.ts
@@ -49,8 +49,9 @@ import type { IntakeCandidates } from "./intake/navigate.js";
 // v5.6 attempts to improve judgement by adding a value hierarchy, defining brittle
 // vs durable, and a few other optimisations. v5.7 makes the nested grooming memory
 // shapes explicit after a valid operation was discarded for emitting a scalar
-// `applies_to`.
-export const CURATOR_PROMPT_VERSION = "v5.7";
+// `applies_to`. v5.8 makes exact intake fields and the two grooming confidence
+// types explicit after strict validation discarded otherwise useful outputs.
+export const CURATOR_PROMPT_VERSION = "v5.8";
 
 // ── the shared core ───────────────────────────────────────────────────────────
 
@@ -103,11 +104,13 @@ OUTPUT CONTRACT — respond with a single JSON object and nothing else, exactly 
 - { "action": "archive", "target_id": string, "rationale": string, "confidence": number } — an existing doc is now stale, with no replacement.
 - { "action": "split", "target_id": string, "replacements": [{ "title": string, "body": string, "tags": string[] }, …], "rationale": string, "confidence": number } — RARE. An existing CANDIDATE doc ("target_id") has become an overloaded grab-bag conflating ≥2 distinct entities, and this submission belongs to one of them; spin that doc into ≥2 focused per-entity docs ("replacements"). Use ONLY when the submission is primarily about a different, already well-supported candidate entity. "target_id" MUST be one of the CANDIDATE ids. Always proposed for a human to approve — never silently applied. Do NOT split a single-entity / non-overloaded submission.
 - { "action": "noop", "rationale": string, "confidence": number } — nothing worth filing: a duplicate, OR a submission that is obviously transient or low-value with no lasting recall value.
+These shapes are exact: use exactly the fields shown for that action and no others. Tags belong only in "create" and inside "split" replacements.
 (Cross-doc merge is not an intake judgment — grooming consolidates docs. A submission that merely duplicates an existing doc is a noop.)
 
 RULES (re-checked in code after you respond — a judgment that breaks one is discarded):
 - "target_id" MUST be an id that appears in the EVIDENCE (a candidate or toc entry). Never invent an id. A split's "target_id" MUST be one of the CANDIDATES (not merely a toc entry) and it needs ≥2 "replacements".
 - Link related entities with [[wikilinks]] in "body"/"addition": write [[Title]] to point at another doc by its title.
+- Use exactly the fields shown for that action. A "supersede" judgment never has "tags"; the existing target's tags are preserved by the update.
 - Never put secrets or credentials in any field.
 - confidence is a number in [0, 1].
 - Every judgment needs a non-empty rationale stating WHY — including, when you claim two things are the same, why you believe it.`;
@@ -137,7 +140,9 @@ Each Operation is exactly one of:
 
 MemoryInput = { "title": string, "body": string, "visibility": "common", "applies_to"?: string[], "confidence"?: "tentative" | "working" | "strong", "tags"?: string[] }
 MemoryPatch has the same fields and types, with every field optional.
-"applies_to" and "tags" are arrays even for one value; use [] or omit the field when empty, never a scalar. The stored "confidence" field is the enum above and is NOT the operation's numeric confidence: writing a number there gets the operation discarded.
+"applies_to" and "tags" are arrays even for one value; use [] or omit the field when empty, never a scalar.
+Operation confidence is the operation-level "confidence" number in [0, 1].
+Stored-memory confidence is nested inside "memory", "replacement", "replacements", or "patch" and, if present, is exactly "tentative", "working", or "strong". Omit it when unnecessary. Never copy numeric operation confidence into a nested memory.
 
 RULES (re-checked in code after you respond — an operation that breaks one is discarded, so don't waste it):
 - Reference ONLY ids that appear in the EVIDENCE. Never invent an id.
@@ -146,7 +151,7 @@ RULES (re-checked in code after you respond — an operation that breaks one is 
 - A memory marked "has_open_curator_flag": true already has a curator archive proposal awaiting human review — do not propose archiving it again; noop it instead.
 - A memory flagged "requires_approval" never auto-applies: any operation touching one becomes a human proposal. You may still suggest it.
 - Never put secrets or credentials in any field.
-- confidence is a number in [0, 1]. Every operation needs a non-empty rationale.
+- Operation confidence is a number in [0, 1]. Stored-memory confidence, if present, is "tentative", "working", or "strong"; never copy the numeric operation confidence into a nested memory. Every operation needs a non-empty rationale.
 - Do not recreate content listed under "tombstones" — it was deliberately archived. "prepass_findings" flags resurrection risks.
 - If nothing should change, return { "operations": [] }.`;
 

--- a/packages/core/tests/curator-prompt.test.ts
+++ b/packages/core/tests/curator-prompt.test.ts
@@ -169,8 +169,8 @@ describe("buildCuratorPrompt — shared core", () => {
     }
   });
 
-  it("pins the v5.8 prompt version (v5.8 distinguishes strict intake fields and confidence types)", () => {
-    expect(CURATOR_PROMPT_VERSION).toBe("v5.8");
+  it("pins the v5.9 prompt version (v5.9 removes tagging and visibility ambiguity)", () => {
+    expect(CURATOR_PROMPT_VERSION).toBe("v5.9");
   });
 });
 
@@ -208,6 +208,11 @@ describe("buildCuratorPrompt — intake mode", () => {
     expect(intakeSystem).toMatch(/use exactly the fields shown for that action/i);
     expect(intakeSystem).toMatch(/a "supersede" judgment never has "tags"/i);
     expect(intakeSystem).toMatch(/existing target's tags are preserved/i);
+  });
+
+  it("qualifies tagging by the exact output shape instead of requiring tags everywhere", () => {
+    expect(intakeSystem).toMatch(/tag only when the exact output shape includes "tags"/i);
+    expect(intakeSystem).toMatch(/never invent a "tags" field for a shape that omits it/i);
   });
 
   it("frames the untrusted submission + evidence in the user message", () => {
@@ -329,6 +334,11 @@ describe("buildCuratorPrompt — grooming mode", () => {
       "MemoryPatch has the same fields and types, with every field optional.",
     );
     expect(groomingSystem).toMatch(/"applies_to" and "tags" are arrays even for one value/i);
+  });
+
+  it("requires common visibility on every complete nested memory but not on patches", () => {
+    expect(groomingSystem).toMatch(/every MemoryInput must include "visibility": "common"/i);
+    expect(groomingSystem).toMatch(/MemoryPatch may omit "visibility"/i);
   });
 
   it("distinguishes numeric operation confidence from enum stored-memory confidence", () => {

--- a/packages/core/tests/curator-prompt.test.ts
+++ b/packages/core/tests/curator-prompt.test.ts
@@ -169,8 +169,8 @@ describe("buildCuratorPrompt — shared core", () => {
     }
   });
 
-  it("pins the v5.7 prompt version (v5.7 makes nested grooming field types explicit)", () => {
-    expect(CURATOR_PROMPT_VERSION).toBe("v5.7");
+  it("pins the v5.8 prompt version (v5.8 distinguishes strict intake fields and confidence types)", () => {
+    expect(CURATOR_PROMPT_VERSION).toBe("v5.8");
   });
 });
 
@@ -202,6 +202,12 @@ describe("buildCuratorPrompt — intake mode", () => {
 
   it("carries the rules-rechecked-in-code notice", () => {
     expect(intakeSystem).toMatch(/re-checked in code/i);
+  });
+
+  it("forbids fields outside an intake action's exact wire shape", () => {
+    expect(intakeSystem).toMatch(/use exactly the fields shown for that action/i);
+    expect(intakeSystem).toMatch(/a "supersede" judgment never has "tags"/i);
+    expect(intakeSystem).toMatch(/existing target's tags are preserved/i);
   });
 
   it("frames the untrusted submission + evidence in the user message", () => {
@@ -323,6 +329,12 @@ describe("buildCuratorPrompt — grooming mode", () => {
       "MemoryPatch has the same fields and types, with every field optional.",
     );
     expect(groomingSystem).toMatch(/"applies_to" and "tags" are arrays even for one value/i);
+  });
+
+  it("distinguishes numeric operation confidence from enum stored-memory confidence", () => {
+    expect(groomingSystem).toMatch(/operation confidence.*number in \[0, 1\]/i);
+    expect(groomingSystem).toMatch(/stored-memory confidence.*"tentative".*"working".*"strong"/i);
+    expect(groomingSystem).toMatch(/never copy.*numeric operation confidence.*nested memory/i);
   });
 
   it("does not teach intake wire shapes (the parser would reject them)", () => {

--- a/packages/core/tests/curator-prompt.test.ts
+++ b/packages/core/tests/curator-prompt.test.ts
@@ -169,8 +169,8 @@ describe("buildCuratorPrompt — shared core", () => {
     }
   });
 
-  it("pins the v5.6 prompt version (v5.6 adds the value hierarchy + durable-vs-brittle guidance)", () => {
-    expect(CURATOR_PROMPT_VERSION).toBe("v5.6");
+  it("pins the v5.7 prompt version (v5.7 makes nested grooming field types explicit)", () => {
+    expect(CURATOR_PROMPT_VERSION).toBe("v5.7");
   });
 });
 
@@ -313,6 +313,16 @@ describe("buildCuratorPrompt — grooming mode", () => {
       expect(groomingSystem).toContain(`"type": "${value}"`);
       for (const key of keys) expect(groomingSystem).toContain(`"${key}"`);
     }
+  });
+
+  it("states the exact MemoryInput and MemoryPatch field types, including array-only fields", () => {
+    expect(groomingSystem).toContain(
+      'MemoryInput = { "title": string, "body": string, "visibility": "common", "applies_to"?: string[], "confidence"?: "tentative" | "working" | "strong", "tags"?: string[] }',
+    );
+    expect(groomingSystem).toContain(
+      "MemoryPatch has the same fields and types, with every field optional.",
+    );
+    expect(groomingSystem).toMatch(/"applies_to" and "tags" are arrays even for one value/i);
   });
 
   it("does not teach intake wire shapes (the parser would reject them)", () => {


### PR DESCRIPTION
## What changed

- Makes the grooming `MemoryInput` and `MemoryPatch` wire shapes explicit, including array-only fields.
- Distinguishes numeric operation confidence from the stored-memory confidence enum.
- Limits intake tags to action shapes that actually accept them.
- Requires `visibility: "common"` on every complete grooming memory input while allowing partial patches to omit it.
- Bumps the Curator prompt to v5.9 and records the v1.10.1 release note.

## Why

The expanded 15-case curator suite found useful production outputs being discarded for three formatting mistakes: scalar `applies_to`, numeric nested memory confidence, and forbidden tags on supersede judgments. A first prompt pass exposed a remaining contradiction—the shared guidance said to tag every document even when the selected action shape omitted tags—and DeepSeek omitted required visibility from two complete replacements.

The final wording removes those contradictions instead of relying on repeated downstream warnings.

## Impact

Production parsing and validation are unchanged and continue to fail closed. The prompt now teaches the exact existing contracts more consistently, reducing otherwise useful judgments lost to formatting errors.

Across Qwen3.5-9B, Qwen3.5-4B, and DeepSeek V4 Flash, the frozen rerun completed 45/45 cases on the first attempt. All 15 intake judgments passed the production contract and no grooming operation was schema-rejected. Semantic quality remains a separate blind-review question.

## Validation

- Focused Curator prompt tests: 29/29
- `pnpm check:release`
- `pnpm lint`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- Frozen 15-case suite on all three candidate models
