### PR TITLE
fix(core): improve curator memory selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.10.2] — 2026-07-19
+
+### Changed
+
+- **Auto-capture now selects durable knowledge instead of repository trivia.**
+  Transcript harvesting prioritises user intent, learned constraints, relevant
+  history, and future direction while rejecting facts an agent can cheaply
+  recover from the repository, such as package managers, commands, paths,
+  branches, ports, filenames, versions, and test status. A decision and its
+  rationale remain one coherent candidate rather than fragmented memories.
+- **Grooming now consolidates focused retrieval units, not entity-wide
+  dossiers.** Shared project or entity names alone no longer justify merging
+  memories. Before replacing sources, the curator must account for every
+  source's durable claims, preserve exact status and polarity, avoid treating
+  metadata timestamps as event dates, and keep code-only details out of durable
+  business memories.
+
 ## [1.10.1] — 2026-07-19
 
 ### Fixed
@@ -3926,6 +3943,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.10.2]: https://github.com/JimJafar/the-librarian/compare/v1.10.1...v1.10.2
 [1.10.1]: https://github.com/JimJafar/the-librarian/compare/v1.10.0...v1.10.1
 [1.10.0]: https://github.com/JimJafar/the-librarian/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/JimJafar/the-librarian/compare/v1.8.0...v1.9.0

--- a/integrations/pi/package.json
+++ b/integrations/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-librarian/pi-extension",
-  "version": "1.10.0",
+  "version": "1.10.2",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/core/src/curator-prompt.ts
+++ b/packages/core/src/curator-prompt.ts
@@ -54,9 +54,8 @@ import type { IntakeCandidates } from "./intake/navigate.js";
 // v5.9 removes a shared tagging instruction that contradicted mode-specific
 // shapes and makes the required visibility field explicit for every complete
 // grooming MemoryInput. v5.10 adds lossless-supersede, temporal-scope, and
-// bundled-submission accounting gates to intake. v5.10.1 clarifies that
-// preservation is historical accounting, not continuation of obsolete rules.
-export const CURATOR_PROMPT_VERSION = "v5.10.1";
+// bundled-submission accounting gates to intake.
+export const CURATOR_PROMPT_VERSION = "v5.10";
 
 // ── the shared core ───────────────────────────────────────────────────────────
 
@@ -99,9 +98,9 @@ const INTAKE_MODE = `MODE: INTAKE — a single new SUBMISSION has arrived. Using
 JUDGEMENT IN THIS MODE:
 - Extract the kernel. A submission often wraps one durable sentence in session narration, tool output, or pleasantries. Judge — and file — the durable core; drop the wrapper, and say in the rationale what you dropped. A submission that is ALL wrapper is a noop.
 - Choosing augment vs supersede: augment when everything the doc already says stays true and the submission adds to it; supersede only when the submission contradicts or replaces what the doc actually claims. A statement that was true for an earlier, explicitly scoped period ("during launch", "in the pilot", "until 2025") is not contradicted by a later current state — augment the dated transition instead. Never invent an ongoing role or policy to bridge the two periods.
-- PRESERVATION AUDIT before every supersede: account for every useful claim in the existing target. This is an accounting check, NOT an instruction to copy every old sentence. Preserve still-true context, dates, owners, and prior states with explicit historical/current scope. An operational instruction or mechanic tied to a replaced role or process is obsolete unless the submission reaffirms it: preserve that it existed and why, never present it as current. If the existing target records a plan or option that the submission rejects, the replacement body itself MUST preserve the rejected plan or option and why it was rejected; mentioning the reversal only in the rationale does not preserve library history. Omit an old claim only when the submission explicitly corrects it or it is an exact duplicate of clearer replacement prose. Carry the arc forward: record what changed, from when (absolute date), and why.
+- PRESERVATION AUDIT before every supersede: account for every useful claim in the existing target. The replacement must retain still-true context, dates, owners, prior states, and any rejected plan or option with why it was rejected. Omit an old claim only when the submission explicitly corrects it or it is an exact duplicate of clearer replacement prose. Carry the arc forward: record what changed, from when (absolute date), and why.
 - A bundled submission (several unrelated durable facts in one) cannot become several docs here: file the most valuable fact under its entity and weave in another only where it genuinely belongs (with [[wikilinks]]). In the rationale, account for every durable fact as FILED in the chosen body, LINKED to a related memory, or UNFILED for separate review. Do not silently discard a durable fact merely because this mode returns one judgment.
-- Weigh the four values from above: a decision-with-why, a correction, an arc, or a stated direction outranks a bare fact; a recurring pattern outranks its latest instance. A code-recoverable detail is NEVER filed, even when it accompanies a durable submission or appears to be a stable identifier: strip paths, table and field names, config keys, line numbers, snippets, and timeout constants while preserving the reason they mattered.
+- Weigh the four values from above: a decision-with-why, a correction, an arc, or a stated direction outranks a bare fact; a recurring pattern outranks its latest instance; brittle code detail (paths, line numbers, snippets) is stripped even from an otherwise durable submission.
 
 OUTPUT CONTRACT — respond with a single JSON object and nothing else, exactly one of:
 - { "action": "create", "title": string, "body": string, "tags": string[], "rationale": string, "confidence": number } — a novel fact with no good existing home; file a new doc.

--- a/packages/core/src/curator-prompt.ts
+++ b/packages/core/src/curator-prompt.ts
@@ -54,8 +54,9 @@ import type { IntakeCandidates } from "./intake/navigate.js";
 // v5.9 removes a shared tagging instruction that contradicted mode-specific
 // shapes and makes the required visibility field explicit for every complete
 // grooming MemoryInput. v5.10 adds lossless-supersede, temporal-scope, and
-// bundled-submission accounting gates to intake.
-export const CURATOR_PROMPT_VERSION = "v5.10";
+// bundled-submission accounting gates to intake. v5.10.1 clarifies that
+// preservation is historical accounting, not continuation of obsolete rules.
+export const CURATOR_PROMPT_VERSION = "v5.10.1";
 
 // ── the shared core ───────────────────────────────────────────────────────────
 
@@ -98,9 +99,9 @@ const INTAKE_MODE = `MODE: INTAKE — a single new SUBMISSION has arrived. Using
 JUDGEMENT IN THIS MODE:
 - Extract the kernel. A submission often wraps one durable sentence in session narration, tool output, or pleasantries. Judge — and file — the durable core; drop the wrapper, and say in the rationale what you dropped. A submission that is ALL wrapper is a noop.
 - Choosing augment vs supersede: augment when everything the doc already says stays true and the submission adds to it; supersede only when the submission contradicts or replaces what the doc actually claims. A statement that was true for an earlier, explicitly scoped period ("during launch", "in the pilot", "until 2025") is not contradicted by a later current state — augment the dated transition instead. Never invent an ongoing role or policy to bridge the two periods.
-- PRESERVATION AUDIT before every supersede: account for every useful claim in the existing target. The replacement must retain still-true context, dates, owners, prior states, and any rejected plan or option with why it was rejected. Omit an old claim only when the submission explicitly corrects it or it is an exact duplicate of clearer replacement prose. Carry the arc forward: record what changed, from when (absolute date), and why.
+- PRESERVATION AUDIT before every supersede: account for every useful claim in the existing target. This is an accounting check, NOT an instruction to copy every old sentence. Preserve still-true context, dates, owners, and prior states with explicit historical/current scope. An operational instruction or mechanic tied to a replaced role or process is obsolete unless the submission reaffirms it: preserve that it existed and why, never present it as current. If the existing target records a plan or option that the submission rejects, the replacement body itself MUST preserve the rejected plan or option and why it was rejected; mentioning the reversal only in the rationale does not preserve library history. Omit an old claim only when the submission explicitly corrects it or it is an exact duplicate of clearer replacement prose. Carry the arc forward: record what changed, from when (absolute date), and why.
 - A bundled submission (several unrelated durable facts in one) cannot become several docs here: file the most valuable fact under its entity and weave in another only where it genuinely belongs (with [[wikilinks]]). In the rationale, account for every durable fact as FILED in the chosen body, LINKED to a related memory, or UNFILED for separate review. Do not silently discard a durable fact merely because this mode returns one judgment.
-- Weigh the four values from above: a decision-with-why, a correction, an arc, or a stated direction outranks a bare fact; a recurring pattern outranks its latest instance; brittle code detail (paths, line numbers, snippets) is stripped even from an otherwise durable submission.
+- Weigh the four values from above: a decision-with-why, a correction, an arc, or a stated direction outranks a bare fact; a recurring pattern outranks its latest instance. A code-recoverable detail is NEVER filed, even when it accompanies a durable submission or appears to be a stable identifier: strip paths, table and field names, config keys, line numbers, snippets, and timeout constants while preserving the reason they mattered.
 
 OUTPUT CONTRACT — respond with a single JSON object and nothing else, exactly one of:
 - { "action": "create", "title": string, "body": string, "tags": string[], "rationale": string, "confidence": number } — a novel fact with no good existing home; file a new doc.

--- a/packages/core/src/curator-prompt.ts
+++ b/packages/core/src/curator-prompt.ts
@@ -53,8 +53,9 @@ import type { IntakeCandidates } from "./intake/navigate.js";
 // types explicit after strict validation discarded otherwise useful outputs.
 // v5.9 removes a shared tagging instruction that contradicted mode-specific
 // shapes and makes the required visibility field explicit for every complete
-// grooming MemoryInput.
-export const CURATOR_PROMPT_VERSION = "v5.9";
+// grooming MemoryInput. v5.10 replaces entity-wide grooming with focused
+// retrieval-unit, entailment, and source-preservation gates.
+export const CURATOR_PROMPT_VERSION = "v5.10";
 
 // ── the shared core ───────────────────────────────────────────────────────────
 
@@ -124,9 +125,12 @@ RULES (re-checked in code after you respond — a judgment that breaks one is di
 const GROOMING_MODE = `MODE: GROOMING — you operate on ONE slice of the corpus at a time. Review the existing memories in the EVIDENCE and return the operations that improve the store: merge near-duplicates, archive obsolete memories, split overloaded ones, correct stale ones — or none, when the slice is already well curated.
 
 JUDGEMENT IN THIS MODE:
-- Groom toward entity narratives, not event piles. Several small notes about one entity are a merge candidate; the goal is one doc per entity telling its story so far, linked to its neighbours. Consolidate around the stable thing (a project, a person, a practice), never around the occasions on which it was mentioned.
-- A merge replacement must carry the union of its sources — every nuance, date, and why — under the best of the source titles. When correcting a stale fact, keep the arc: "was A; now B (date) because C", never a silent deletion. If a merge would force dropping any source's substance, score it low or don't propose it.
-- De-brittle as you pass: where a doc leans on code specifics (file paths, line numbers, function names, snippets), rewrite toward the durable intent those specifics served, keeping only identifiers stable over months (ports, URLs, hostnames, repo names, commands). A doc whose ONLY content is rediscoverable-from-code detail is an archive candidate; a doc holding a decision, correction, lesson, or preference is not — age it with dates instead.
+- Groom toward FOCUSED RETRIEVAL UNITS: merge memories only when they answer the same future recall question and can form one coherent, specific note. A shared entity or project is NOT sufficient reason to merge; one project may need separate decision, incident, ownership, policy, and open-question memories. Link related focused notes instead of building an entity-wide dossier.
+- Before merge, split, or update, run a SOURCE-BY-SOURCE PRESERVATION AUDIT: for each source, list mentally every claim, date, rationale, owner, uncertainty, and status that must survive. A replacement must carry the useful union without narrowing, generalising, or silently deleting any source. If the focused result cannot preserve every source cleanly, do not combine them.
+- Every replacement claim must be entailed by the listed source memory bodies. Never add a name, relationship, date, cause, policy, or conclusion merely because it seems plausible. A metadata timestamp is NOT an event date and must never be presented as when the remembered event occurred.
+- Preserve the exact polarity and status of knowledge: PROPOSED, REJECTED, CURRENT, and OPEN are materially different. Never turn a rejected option into a recommendation, a proposal into a decision, an open question into an assignment, or a historical rule into a current one.
+- De-brittle as you pass: where a doc mixes code specifics with durable intent, remove the paths, table/field/function names, snippets, and constants while preserving the stated reason. A CODE-ONLY memory is an archive candidate and must NEVER be merged into a business decision, policy, incident, or ownership memory. A doc holding a decision, correction, lesson, or preference is not an archive candidate — age it with dates instead.
+- When correcting a stale fact, keep the arc: "was A; now B (date) because C", never a silent deletion. A date may be used only when a source body states or unambiguously anchors it.
 - While touching a doc anyway: sharpen its title toward the entity it names (renames sparingly — titles are link targets), add missing [[wikilinks]], convert relative dates to absolute, and keep any stated direction ("next:", "open question:") visible.
 - Prefer a few high-value operations over many marginal ones, and remember the ideal outcome for a tidy slice is { "operations": [] } — returning it is good curation, not failure.
 

--- a/packages/core/src/curator-prompt.ts
+++ b/packages/core/src/curator-prompt.ts
@@ -53,9 +53,8 @@ import type { IntakeCandidates } from "./intake/navigate.js";
 // types explicit after strict validation discarded otherwise useful outputs.
 // v5.9 removes a shared tagging instruction that contradicted mode-specific
 // shapes and makes the required visibility field explicit for every complete
-// grooming MemoryInput. v5.10 adds lossless-supersede, temporal-scope, and
-// bundled-submission accounting gates to intake.
-export const CURATOR_PROMPT_VERSION = "v5.10";
+// grooming MemoryInput.
+export const CURATOR_PROMPT_VERSION = "v5.9";
 
 // ── the shared core ───────────────────────────────────────────────────────────
 
@@ -97,9 +96,8 @@ const INTAKE_MODE = `MODE: INTAKE — a single new SUBMISSION has arrived. Using
 
 JUDGEMENT IN THIS MODE:
 - Extract the kernel. A submission often wraps one durable sentence in session narration, tool output, or pleasantries. Judge — and file — the durable core; drop the wrapper, and say in the rationale what you dropped. A submission that is ALL wrapper is a noop.
-- Choosing augment vs supersede: augment when everything the doc already says stays true and the submission adds to it; supersede only when the submission contradicts or replaces what the doc actually claims. A statement that was true for an earlier, explicitly scoped period ("during launch", "in the pilot", "until 2025") is not contradicted by a later current state — augment the dated transition instead. Never invent an ongoing role or policy to bridge the two periods.
-- PRESERVATION AUDIT before every supersede: account for every useful claim in the existing target. The replacement must retain still-true context, dates, owners, prior states, and any rejected plan or option with why it was rejected. Omit an old claim only when the submission explicitly corrects it or it is an exact duplicate of clearer replacement prose. Carry the arc forward: record what changed, from when (absolute date), and why.
-- A bundled submission (several unrelated durable facts in one) cannot become several docs here: file the most valuable fact under its entity and weave in another only where it genuinely belongs (with [[wikilinks]]). In the rationale, account for every durable fact as FILED in the chosen body, LINKED to a related memory, or UNFILED for separate review. Do not silently discard a durable fact merely because this mode returns one judgment.
+- Choosing augment vs supersede: augment when everything the doc already says stays true and the submission adds to it; supersede when the submission contradicts or replaces what the doc says — and in the replacement body, carry the arc forward: record what changed, from when (absolute date), and why, so the correction preserves the history instead of erasing it.
+- A bundled submission (several unrelated durable facts in one) cannot become several docs here: file the most valuable fact under its entity, weave in the others only where they genuinely relate (with [[wikilinks]]), and name any fact you had to leave unfiled in the rationale so the human can see it.
 - Weigh the four values from above: a decision-with-why, a correction, an arc, or a stated direction outranks a bare fact; a recurring pattern outranks its latest instance; brittle code detail (paths, line numbers, snippets) is stripped even from an otherwise durable submission.
 
 OUTPUT CONTRACT — respond with a single JSON object and nothing else, exactly one of:

--- a/packages/core/src/curator-prompt.ts
+++ b/packages/core/src/curator-prompt.ts
@@ -53,8 +53,9 @@ import type { IntakeCandidates } from "./intake/navigate.js";
 // types explicit after strict validation discarded otherwise useful outputs.
 // v5.9 removes a shared tagging instruction that contradicted mode-specific
 // shapes and makes the required visibility field explicit for every complete
-// grooming MemoryInput.
-export const CURATOR_PROMPT_VERSION = "v5.9";
+// grooming MemoryInput. v5.10 adds lossless-supersede, temporal-scope, and
+// bundled-submission accounting gates to intake.
+export const CURATOR_PROMPT_VERSION = "v5.10";
 
 // ── the shared core ───────────────────────────────────────────────────────────
 
@@ -96,8 +97,9 @@ const INTAKE_MODE = `MODE: INTAKE — a single new SUBMISSION has arrived. Using
 
 JUDGEMENT IN THIS MODE:
 - Extract the kernel. A submission often wraps one durable sentence in session narration, tool output, or pleasantries. Judge — and file — the durable core; drop the wrapper, and say in the rationale what you dropped. A submission that is ALL wrapper is a noop.
-- Choosing augment vs supersede: augment when everything the doc already says stays true and the submission adds to it; supersede when the submission contradicts or replaces what the doc says — and in the replacement body, carry the arc forward: record what changed, from when (absolute date), and why, so the correction preserves the history instead of erasing it.
-- A bundled submission (several unrelated durable facts in one) cannot become several docs here: file the most valuable fact under its entity, weave in the others only where they genuinely relate (with [[wikilinks]]), and name any fact you had to leave unfiled in the rationale so the human can see it.
+- Choosing augment vs supersede: augment when everything the doc already says stays true and the submission adds to it; supersede only when the submission contradicts or replaces what the doc actually claims. A statement that was true for an earlier, explicitly scoped period ("during launch", "in the pilot", "until 2025") is not contradicted by a later current state — augment the dated transition instead. Never invent an ongoing role or policy to bridge the two periods.
+- PRESERVATION AUDIT before every supersede: account for every useful claim in the existing target. The replacement must retain still-true context, dates, owners, prior states, and any rejected plan or option with why it was rejected. Omit an old claim only when the submission explicitly corrects it or it is an exact duplicate of clearer replacement prose. Carry the arc forward: record what changed, from when (absolute date), and why.
+- A bundled submission (several unrelated durable facts in one) cannot become several docs here: file the most valuable fact under its entity and weave in another only where it genuinely belongs (with [[wikilinks]]). In the rationale, account for every durable fact as FILED in the chosen body, LINKED to a related memory, or UNFILED for separate review. Do not silently discard a durable fact merely because this mode returns one judgment.
 - Weigh the four values from above: a decision-with-why, a correction, an arc, or a stated direction outranks a bare fact; a recurring pattern outranks its latest instance; brittle code detail (paths, line numbers, snippets) is stripped even from an otherwise durable submission.
 
 OUTPUT CONTRACT — respond with a single JSON object and nothing else, exactly one of:

--- a/packages/core/src/transcript-extract.ts
+++ b/packages/core/src/transcript-extract.ts
@@ -34,13 +34,23 @@ const ExtractionSchema = z.object({
 
 const SYSTEM = `You are the Memory Extractor for The Librarian. You read a single AI-coding-assistant CONVERSATION TRANSCRIPT and distill it into a list of DISCRETE, DURABLE candidate facts worth remembering long-term.
 
-A good candidate fact is:
-- DURABLE — a stable fact about the user, a project, a preference, a convention, an infrastructure detail, or a decision that will be worth recalling in a future, unrelated conversation.
-- DISCRETE — exactly one fact per list entry. Split compound observations into separate entries.
-- SELF-CONTAINED — understandable on its own, without the transcript. Name the entity it is about (e.g. "The <repo> repo uses pnpm", not "we use pnpm").
+VALUE TEST — prefer the few things whose future recall will change understanding or action:
+- INTENT — goals, constraints, trade-offs, decisions, and the reasons behind them.
+- LEARNING — what worked or failed, corrections, and why.
+- HISTORY — meaningful changes from an earlier state to a later one.
+- DIRECTION — priorities, plans, open questions, and what remains unsettled.
+A stable personal preference or relationship can also be valuable when it will matter outside this conversation.
+
+A candidate fact must also be:
+- DURABLE — likely to remain useful in a future, unrelated conversation.
+- SELF-CONTAINED — understandable on its own, without the transcript. Name the entity it is about (e.g. "The Atlas launch kept manual approval because refund risk outweighed speed", not "we kept it").
 - GROUNDED — stated in the transcript. Never invent, infer beyond what is said, or speculate.
 
-Do NOT extract transient noise: one-off task status, an already-resolved bug or typo, ephemeral chatter, or anything with no lasting recall value. When a conversation holds nothing durable, return an EMPTY list — that is the correct, common answer.
+Default to REJECTING facts cheaply recoverable from the owner's artefacts: code, config, dependency or lock files, tests, command output, Git history, or repository metadata. This includes a package manager, commands, paths, branches, ports, filenames, function names, version numbers, and current test or build status. Preserve the durable reason such a detail mattered only when the transcript states it.
+
+Do NOT extract transient noise: one-off task status, an already-resolved bug or typo, ephemeral chatter, tool narration, or anything with no lasting recall value.
+
+Return the SMALLEST SET that preserves the high-value knowledge. A decision and its rationale are ONE coherent candidate, not separate atomised facts. Do not split context away from the claim it explains. Prefer a precise synthesis over a transcript inventory. When in doubt, return an EMPTY list — that is a correct and common answer.
 
 Output STRICT JSON only, exactly: {"facts": ["fact one", "fact two", ...]}. No prose, no markdown. An empty conversation is {"facts": []}.
 

--- a/packages/core/tests/curator-prompt.test.ts
+++ b/packages/core/tests/curator-prompt.test.ts
@@ -169,8 +169,8 @@ describe("buildCuratorPrompt — shared core", () => {
     }
   });
 
-  it("pins the v5.9 prompt version (v5.9 removes tagging and visibility ambiguity)", () => {
-    expect(CURATOR_PROMPT_VERSION).toBe("v5.9");
+  it("pins the v5.10 prompt version (v5.10 adds intake preservation gates)", () => {
+    expect(CURATOR_PROMPT_VERSION).toBe("v5.10");
   });
 });
 
@@ -208,6 +208,14 @@ describe("buildCuratorPrompt — intake mode", () => {
     expect(intakeSystem).toMatch(/use exactly the fields shown for that action/i);
     expect(intakeSystem).toMatch(/a "supersede" judgment never has "tags"/i);
     expect(intakeSystem).toMatch(/existing target's tags are preserved/i);
+  });
+
+  it("requires lossless supersedes, temporally scoped augmentation, and bundle accounting", () => {
+    expect(intakeSystem).toMatch(/preservation audit/i);
+    expect(intakeSystem).toMatch(/every useful claim.*existing target/is);
+    expect(intakeSystem).toMatch(/rejected (plan|option).*why/is);
+    expect(intakeSystem).toMatch(/true for an earlier.*period.*augment/is);
+    expect(intakeSystem).toMatch(/every durable fact.*filed.*linked.*unfiled/is);
   });
 
   it("qualifies tagging by the exact output shape instead of requiring tags everywhere", () => {

--- a/packages/core/tests/curator-prompt.test.ts
+++ b/packages/core/tests/curator-prompt.test.ts
@@ -169,8 +169,8 @@ describe("buildCuratorPrompt — shared core", () => {
     }
   });
 
-  it("pins the v5.10 prompt version (v5.10 adds intake preservation gates)", () => {
-    expect(CURATOR_PROMPT_VERSION).toBe("v5.10");
+  it("pins the v5.9 prompt version (v5.9 removes tagging and visibility ambiguity)", () => {
+    expect(CURATOR_PROMPT_VERSION).toBe("v5.9");
   });
 });
 
@@ -208,14 +208,6 @@ describe("buildCuratorPrompt — intake mode", () => {
     expect(intakeSystem).toMatch(/use exactly the fields shown for that action/i);
     expect(intakeSystem).toMatch(/a "supersede" judgment never has "tags"/i);
     expect(intakeSystem).toMatch(/existing target's tags are preserved/i);
-  });
-
-  it("requires lossless supersedes, temporally scoped augmentation, and bundle accounting", () => {
-    expect(intakeSystem).toMatch(/preservation audit/i);
-    expect(intakeSystem).toMatch(/every useful claim.*existing target/is);
-    expect(intakeSystem).toMatch(/rejected (plan|option).*why/is);
-    expect(intakeSystem).toMatch(/true for an earlier.*period.*augment/is);
-    expect(intakeSystem).toMatch(/every durable fact.*filed.*linked.*unfiled/is);
   });
 
   it("qualifies tagging by the exact output shape instead of requiring tags everywhere", () => {

--- a/packages/core/tests/curator-prompt.test.ts
+++ b/packages/core/tests/curator-prompt.test.ts
@@ -169,8 +169,8 @@ describe("buildCuratorPrompt — shared core", () => {
     }
   });
 
-  it("pins the v5.10 prompt version (v5.10 adds intake preservation gates)", () => {
-    expect(CURATOR_PROMPT_VERSION).toBe("v5.10");
+  it("pins the v5.10.1 prompt version (v5.10.1 scopes intake preservation)", () => {
+    expect(CURATOR_PROMPT_VERSION).toBe("v5.10.1");
   });
 });
 
@@ -216,6 +216,10 @@ describe("buildCuratorPrompt — intake mode", () => {
     expect(intakeSystem).toMatch(/rejected (plan|option).*why/is);
     expect(intakeSystem).toMatch(/true for an earlier.*period.*augment/is);
     expect(intakeSystem).toMatch(/every durable fact.*filed.*linked.*unfiled/is);
+    expect(intakeSystem).toMatch(/accounting check.*not.*copy/is);
+    expect(intakeSystem).toMatch(/operational (instruction|mechanic).*obsolete/is);
+    expect(intakeSystem).toMatch(/replacement body.*rejected.*why/is);
+    expect(intakeSystem).toMatch(/code-recoverable detail.*never.*filed/is);
   });
 
   it("qualifies tagging by the exact output shape instead of requiring tags everywhere", () => {

--- a/packages/core/tests/curator-prompt.test.ts
+++ b/packages/core/tests/curator-prompt.test.ts
@@ -169,8 +169,8 @@ describe("buildCuratorPrompt — shared core", () => {
     }
   });
 
-  it("pins the v5.9 prompt version (v5.9 removes tagging and visibility ambiguity)", () => {
-    expect(CURATOR_PROMPT_VERSION).toBe("v5.9");
+  it("pins the v5.10 prompt version (v5.10 adds focused grooming gates)", () => {
+    expect(CURATOR_PROMPT_VERSION).toBe("v5.10");
   });
 });
 
@@ -345,6 +345,16 @@ describe("buildCuratorPrompt — grooming mode", () => {
     expect(groomingSystem).toMatch(/operation confidence.*number in \[0, 1\]/i);
     expect(groomingSystem).toMatch(/stored-memory confidence.*"tentative".*"working".*"strong"/i);
     expect(groomingSystem).toMatch(/never copy.*numeric operation confidence.*nested memory/i);
+  });
+
+  it("gates consolidation by retrieval question, source entailment, and preservation", () => {
+    expect(groomingSystem).toMatch(/same future recall question/i);
+    expect(groomingSystem).toMatch(/shared (entity|project).*not.*sufficient.*merge/is);
+    expect(groomingSystem).toMatch(/code-only memory.*archive.*never.*merge/is);
+    expect(groomingSystem).toMatch(/every replacement claim.*entailed.*source/is);
+    expect(groomingSystem).toMatch(/metadata timestamp.*not.*event date/is);
+    expect(groomingSystem).toMatch(/preserve.*proposed.*rejected.*current.*open/is);
+    expect(groomingSystem).toMatch(/source-by-source preservation audit/i);
   });
 
   it("does not teach intake wire shapes (the parser would reject them)", () => {

--- a/packages/core/tests/curator-prompt.test.ts
+++ b/packages/core/tests/curator-prompt.test.ts
@@ -169,8 +169,8 @@ describe("buildCuratorPrompt — shared core", () => {
     }
   });
 
-  it("pins the v5.10.1 prompt version (v5.10.1 scopes intake preservation)", () => {
-    expect(CURATOR_PROMPT_VERSION).toBe("v5.10.1");
+  it("pins the v5.10 prompt version (v5.10 adds intake preservation gates)", () => {
+    expect(CURATOR_PROMPT_VERSION).toBe("v5.10");
   });
 });
 
@@ -216,10 +216,6 @@ describe("buildCuratorPrompt — intake mode", () => {
     expect(intakeSystem).toMatch(/rejected (plan|option).*why/is);
     expect(intakeSystem).toMatch(/true for an earlier.*period.*augment/is);
     expect(intakeSystem).toMatch(/every durable fact.*filed.*linked.*unfiled/is);
-    expect(intakeSystem).toMatch(/accounting check.*not.*copy/is);
-    expect(intakeSystem).toMatch(/operational (instruction|mechanic).*obsolete/is);
-    expect(intakeSystem).toMatch(/replacement body.*rejected.*why/is);
-    expect(intakeSystem).toMatch(/code-recoverable detail.*never.*filed/is);
   });
 
   it("qualifies tagging by the exact output shape instead of requiring tags everywhere", () => {

--- a/packages/core/tests/transcript-extract.test.ts
+++ b/packages/core/tests/transcript-extract.test.ts
@@ -50,6 +50,27 @@ describe("extractTranscriptFacts — one LLM pass → N candidate facts", () => 
     expect(captured).toContain("MARKER-BUFFER-CONTENT the whole conversation");
   });
 
+  it("prioritises high-value memory and rejects facts cheaply recoverable from a repository", async () => {
+    let captured = "";
+    const client: LlmClient = {
+      complete: async (request: LlmCompletionRequest) => {
+        captured = request.messages[0]?.content ?? "";
+        return { content: JSON.stringify({ facts: [] }), model: "m", usage: null };
+      },
+    };
+
+    await extractTranscriptFacts("### user\n\nWe chose queues because retries must be durable.\n", {
+      llmClient: client,
+    });
+
+    expect(captured).toMatch(/intent.*learning.*history.*direction/is);
+    expect(captured).toMatch(/recoverable.*code.*config/is);
+    expect(captured).toMatch(/package manager.*commands.*paths.*branches.*ports/is);
+    expect(captured).toMatch(/decision.*rationale.*one coherent candidate/is);
+    expect(captured).toMatch(/smallest set/i);
+    expect(captured).toMatch(/when in doubt.*empty/i);
+  });
+
   it("returns no facts for an empty/whitespace buffer (no LLM call)", async () => {
     let called = false;
     const client: LlmClient = {

--- a/packages/installer-cli/package.json
+++ b/packages/installer-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-librarian/cli",
-  "version": "1.10.0",
+  "version": "1.10.2",
   "private": false,
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

- make transcript harvesting favour durable intent, learning, history, and direction over repository facts that are cheap to rediscover
- keep decisions and their rationale together and ask for the smallest useful candidate set
- make grooming operate on focused retrieval units rather than entity-wide dossiers
- require source entailment, claim preservation, exact status/polarity, and explicit handling of code-only memories
- prepare release 1.10.2

This is stacked on #437, which first makes the production output contracts unambiguous.

## Prompt experiments

Each job was changed and evaluated independently against the five challenge cases on both local candidate models. A change was retained only when the semantic judgments improved.

| Job | Previous | Candidate | Decision |
| --- | --- | --- | --- |
| Harvesting, Qwen 9B | 56% accepted precision; 7 missed | 95% accepted precision; 6 missed | Keep |
| Harvesting, Qwen 4B | 51% accepted precision; 12 missed | 73% accepted precision; 6 missed | Keep |
| Intake, both models | 9/10 action, 3/10 content, 2 destructive errors | 8/10 action, 4/10 content, 3 destructive errors | Roll back |
| Grooming, both models | 0 improved, 3 neutral, 7 worse | 1 improved, 6 neutral, 3 worse | Keep |

The retained grooming prompt also reduced preservation errors from 4 to 1. Corruption errors remained at 3. Qwen 4B became safely conservative on these cases; Qwen 9B still damaged some of the hardest compound slices, so the prompt is an improvement rather than a solved problem.

The intake experiment and its refinement are deliberately represented by commits followed by reverts: the final tree contains no intake prompt change.

DeepSeek was not rerun because these challenge cases derive from a private corpus and the evaluation environment requires explicit approval before transmitting them to an external provider.

## Verification

- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm smoke`
- `pnpm healthcheck`
- `pnpm check:release`
- `pnpm check:test-count`
- `pnpm check:no-secrets-in-vault`
- `pnpm check:naming-canon`
- `pnpm check:docs`
