### PR TITLE
Proposal staleness & grooming dedup (spec 072)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,41 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.16.0] — 2026-07-24
+
+### Fixed
+
+- **Approving two proposals about the same memory no longer leaves two divergent
+  memories.** Two open proposals could each supersede the same memory; approving
+  both activated both and archived the source only once (the second archive
+  silently no-ops), leaving the corpus with two live memories claiming to replace
+  it. Approving an update, supersede or merge now withdraws every other open
+  proposal that would have replaced the memories it just archived — archived with
+  a note recording which approval superseded them, never deleted. Split
+  replacements are untouched: a split archives nothing, so nothing it does can
+  make its siblings stale.
+- **A proposal can no longer silently overwrite an edit made while it waited.**
+  Proposals now record a content digest of each memory they supersede at the
+  moment they are drafted. If one of those memories changes before the proposal
+  is reviewed, the card marks it **Out of date**, names the memory that moved,
+  and approve is refused — with no override, because a warning you can click past
+  is one you learn to click past. Rejecting is the way out and costs nothing: the
+  edit itself is what brings the curator back to that memory on its next grooming
+  run. Proposals drafted before this release have nothing recorded to compare
+  against, so they are neither marked nor blocked.
+- **Grooming no longer re-proposes what is already in the queue.** A filed
+  proposal used to change the run's input hash, so the very next sweep looked
+  novel and spent an LLM call re-deriving the judgement it had just filed.
+  Proposals are now evidence rather than a trigger — still shown to the curator,
+  no longer a reason to re-run — and a run that reaches an identical judgement
+  (same action, same memories) records an audited skip instead of filing a
+  duplicate.
+- **Discussing a proposal now shows the curator what that proposal replaces.**
+  Proposal-grounded chat read an intake-only key that grooming proposals never
+  set, so merges and updates — the ones most worth discussing — reached the model
+  without the memories under discussion. It now carries their current text,
+  bounded so a wide merge cannot blow out the prompt.
+
 ## [1.15.0] — 2026-07-24
 
 ### Added
@@ -4125,6 +4160,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.16.0]: https://github.com/JimJafar/the-librarian/compare/v1.15.0...v1.16.0
 [1.15.0]: https://github.com/JimJafar/the-librarian/compare/v1.14.0...v1.15.0
 [1.14.0]: https://github.com/JimJafar/the-librarian/compare/v1.13.0...v1.14.0
 [1.13.0]: https://github.com/JimJafar/the-librarian/compare/v1.12.0...v1.13.0

--- a/apps/dashboard/components/memories/proposal-card.tsx
+++ b/apps/dashboard/components/memories/proposal-card.tsx
@@ -58,6 +58,14 @@ export function ProposalCard({
   const plan = row.plan ?? null;
   const move = row.move ?? null;
   const actorDisplay = row.actorDisplay;
+  // Drift (spec 072 SC 7): a memory this proposal supersedes changed while the
+  // proposal waited, so approving it would archive the newer text and drop that
+  // edit from the active corpus. Read defensively — rows serialized before 072
+  // lack the key, and `unknown` (nothing recorded to compare) must never block.
+  const driftedMemories = (row.drift?.sources ?? []).filter((s) => s.drifted);
+  const isDrifted = row.drift?.status === "drifted";
+  /** Guards every affordance that activates the proposal — never Reject. */
+  const approvalBlocked = pending || isDrifted;
 
   const badge = proposalBadge({ action, targetCount: targets.length });
   const approveLabel = approveConsequenceLabel({ action, targetCount: targets.length });
@@ -214,6 +222,47 @@ export function ProposalCard({
         <IntakeBody proposal={proposal} plan={plan} />
       )}
 
+      {/* Drift (spec 072 SC 7 / D3). The block is stated, not merely styled:
+          the operator has to know WHICH memory moved, and — the part that must
+          never be dropped — that rejecting costs nothing, because the curator
+          re-reads it next sweep. Without that sentence a refusal reads as
+          losing the curator's work, and the operator goes hunting for a way
+          round a gate that deliberately has none. */}
+      {isDrifted ? (
+        <section
+          role="alert"
+          aria-label="This proposal is out of date"
+          className="relative flex flex-col gap-2 border border-ink-hairline bg-foreground/[0.02] p-3 pl-[14px] before:absolute before:inset-y-0 before:left-0 before:w-[2px] before:bg-destructive before:content-['']"
+        >
+          <SectionLabel>Out of date</SectionLabel>
+          <p className="text-sm leading-relaxed text-foreground/80">
+            {driftedMemories.length === 1 ? (
+              <>
+                <strong>
+                  {driftedMemories[0]!.title
+                    ? `“${driftedMemories[0]!.title}”`
+                    : driftedMemories[0]!.id}
+                </strong>{" "}
+                has changed
+              </>
+            ) : (
+              <>
+                <strong>{driftedMemories.length} of the memories</strong> this proposal replaces
+                have changed
+              </>
+            )}{" "}
+            since the curator drafted this. Approving it would discard{" "}
+            {driftedMemories.length === 1 ? "that edit" : "those edits"}, so it can no longer be
+            applied.
+          </p>
+          <p className="text-sm leading-relaxed text-foreground/60">
+            Rejecting costs nothing: the curator re-reads{" "}
+            {driftedMemories.length === 1 ? "this memory" : "these memories"} on its next grooming
+            run, and may well propose a similar change against your current version.
+          </p>
+        </section>
+      ) : null}
+
       {/* A guard failure from apply-the-plan teaches here (F3) — the plan
           couldn't be executed, the other resolutions remain. */}
       {error ? (
@@ -244,9 +293,14 @@ export function ProposalCard({
           )}
           {new Date(proposal.updated_at).toLocaleDateString()}
         </span>
+        {/* Every path that ACTIVATES this proposal is disabled while it is
+            drifted — there is deliberately no "approve anyway" (D3). Reject,
+            Discuss and Teach below stay live: they are how a stale proposal
+            leaves the queue. The server refuses too; this is the honest UI of
+            that refusal, not the enforcement. */}
         {isMove ? (
           executableMove ? (
-            <Button variant="primary" disabled={pending} onClick={applyPlan}>
+            <Button variant="primary" disabled={approvalBlocked} onClick={applyPlan}>
               Apply move
             </Button>
           ) : null
@@ -254,13 +308,13 @@ export function ProposalCard({
           <>
             <Button
               variant="primary"
-              disabled={pending || executablePlan.disabled}
+              disabled={approvalBlocked || executablePlan.disabled}
               onClick={applyPlan}
             >
               {executablePlan.label}
             </Button>
             <Button
-              disabled={pending}
+              disabled={approvalBlocked}
               onClick={() => run(() => approveProposalAction(proposal.id))}
             >
               Approve as new
@@ -270,13 +324,13 @@ export function ProposalCard({
           <>
             <Button
               variant="primary"
-              disabled={pending}
+              disabled={approvalBlocked}
               onClick={() => run(() => approveProposalAction(proposal.id, createPatch))}
             >
               Approve curated version
             </Button>
             <Button
-              disabled={pending}
+              disabled={approvalBlocked}
               onClick={() => run(() => approveProposalAction(proposal.id))}
             >
               Approve raw submission
@@ -285,7 +339,7 @@ export function ProposalCard({
         ) : (
           <Button
             variant="primary"
-            disabled={pending}
+            disabled={approvalBlocked}
             onClick={() => run(() => approveProposalAction(proposal.id))}
           >
             {approveLabel}

--- a/apps/dashboard/tests/components/proposal-card.test.tsx
+++ b/apps/dashboard/tests/components/proposal-card.test.tsx
@@ -712,3 +712,67 @@ describe("ProposalCard — fail-soft", () => {
     expect(screen.getByText("New — needs filing")).toBeInTheDocument();
   });
 });
+
+// Spec 072 SC 7 — a proposal whose superseded memory changed while it sat in
+// the queue. The card states it, names what moved, and closes every path that
+// would activate the proposal. There is deliberately no "approve anyway": an
+// override that exists is one that gets clicked through (D3).
+function drift(
+  over: Partial<NonNullable<ProposalReviewRow["drift"]>> = {},
+): NonNullable<ProposalReviewRow["drift"]> {
+  return {
+    status: "clean",
+    sources: [{ id: "mem_target", title: "Coffee", drifted: false }],
+    ...over,
+  } as NonNullable<ProposalReviewRow["drift"]>;
+}
+
+const DRIFTED = drift({
+  status: "drifted",
+  sources: [{ id: "mem_target", title: "Coffee", drifted: true }],
+});
+
+describe("ProposalCard — drift (spec 072 SC 7)", () => {
+  it("says the memory changed and names it", () => {
+    render(<ProposalCard row={row({ action: "update", drift: DRIFTED })} />);
+
+    const warning = screen.getByRole("alert", { name: "This proposal is out of date" });
+    expect(warning).toHaveTextContent("Coffee");
+    expect(warning).toHaveTextContent(/has changed/);
+  });
+
+  it("promises the curator will re-read it, so rejecting reads as routine", () => {
+    render(<ProposalCard row={row({ action: "update", drift: DRIFTED })} />);
+
+    expect(screen.getByRole("alert", { name: "This proposal is out of date" })).toHaveTextContent(
+      /next grooming run/,
+    );
+  });
+
+  it("disables Approve and offers no way through", () => {
+    render(<ProposalCard row={row({ action: "update", drift: DRIFTED })} />);
+
+    expect(screen.getByRole("button", { name: /Approve/ })).toBeDisabled();
+    expect(screen.queryByRole("button", { name: /anyway/i })).not.toBeInTheDocument();
+  });
+
+  it("leaves Reject live — it is how a stale proposal leaves the queue", () => {
+    render(<ProposalCard row={row({ action: "update", drift: DRIFTED })} />);
+
+    expect(screen.getByRole("button", { name: /Reject/ })).not.toBeDisabled();
+  });
+
+  it("says nothing and blocks nothing when the sources are clean", () => {
+    render(<ProposalCard row={row({ action: "update", drift: drift() })} />);
+
+    expect(screen.queryByRole("alert", { name: "This proposal is out of date" })).toBeNull();
+    expect(screen.getByRole("button", { name: /Approve/ })).not.toBeDisabled();
+  });
+
+  it("does not block a legacy proposal whose drift cannot be determined", () => {
+    render(<ProposalCard row={row({ action: "update", drift: drift({ status: "unknown" }) })} />);
+
+    expect(screen.queryByRole("alert", { name: "This proposal is out of date" })).toBeNull();
+    expect(screen.getByRole("button", { name: /Approve/ })).not.toBeDisabled();
+  });
+});

--- a/apps/docs/src/content/docs/guides/reviewing-proposals.md
+++ b/apps/docs/src/content/docs/guides/reviewing-proposals.md
@@ -41,6 +41,43 @@ human glance, and nothing else.
 4. **Tidy up a split.** When a split has produced good replacement memories, use the
    **Archive original** button beneath them to retire the source.
 
+## When a proposal goes out of date
+
+A proposal is a judgement about specific memories, frozen at the moment the
+curator wrote it. If one of those memories changes while the proposal waits —
+you edited it, or an agent filed something that changed it — the proposal no
+longer describes the memory it would replace. Approving it would archive your
+newer version and put back text written against the old one.
+
+The Librarian will not let that happen. A card whose sources have changed is
+marked **Out of date**, names which memory moved, and has its Approve buttons
+disabled. There is no override, deliberately: a warning you can click past is a
+warning you learn to click past.
+
+**Reject it — that costs you nothing.** Editing a memory is exactly the kind of
+change that brings the curator back to it, so on its next grooming run it re-reads
+your current version and may well propose something similar against the text you
+actually have. To talk it through first, **Discuss this proposal** still works,
+and shows the curator the current state of every memory the proposal would
+replace.
+
+Proposals created before this behaviour existed have nothing recorded to compare
+against, so they are neither marked nor blocked; they clear as you work the queue.
+
+## When two proposals cover the same memory
+
+The curator will not file a proposal identical to one already waiting — same
+action, same memories. It may still propose something genuinely *different* about
+a memory that already has a proposal open (a merge with a neighbour, say,
+alongside a pending update), because those are separate judgements and both
+deserve your eyes.
+
+Approve one of them and any other open proposal that would have replaced the same
+memory is withdrawn for you — it was a decision about a memory that is no longer
+in your active set. Withdrawn proposals are archived with a note recording which
+approval superseded them, so nothing disappears silently, and if the curator still
+believes the other change is right it will propose it again against the new text.
+
 ## How to judge a proposal
 
 - **Archive proposals** — ask "is this really stale or wrong?" Archiving is

--- a/integrations/pi/package.json
+++ b/integrations/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-librarian/pi-extension",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/core/src/formatters/memory-diff.ts
+++ b/packages/core/src/formatters/memory-diff.ts
@@ -12,6 +12,7 @@
 // (it dims `---`/`+++`/`@@`/`diff `/`index `, not `Index:`/`===`). We strip
 // that preamble so the returned string starts at the `--- `/`+++ `/`@@` headers
 // DiffView dims. Source: Context7 /kpdecker/jsdiff README + llms.txt (2026-06-20).
+import { createHash } from "node:crypto";
 import { createTwoFilesPatch } from "diff";
 
 // The minimal shape we diff — anything carrying a title + body (the store's
@@ -25,6 +26,23 @@ export interface DiffableMemory {
 // markdown store persists, so the diff reads like the document, not a struct.
 function renderDocText(memory: DiffableMemory): string {
   return `# ${memory.title}\n\n${memory.body}`;
+}
+
+/**
+ * Fingerprint of a memory's reviewable content — spec 072 D1.
+ *
+ * Lives here, sharing `renderDocText` with the diff, so the two can never
+ * disagree: whatever "the digest changed" reports, `unifiedMemoryDiff` can
+ * always show. A proposal stamps one of these per superseded source at draft
+ * time; review recomputes them to tell whether the corpus moved underneath it.
+ *
+ * Deliberately NOT a timestamp comparison: every persist bumps `updated_at`
+ * (resolving a flag, archiving, a status change), so an `updated_at` check
+ * would report drift when no content moved — and a safety gate that cries wolf
+ * is one the operator learns to click through.
+ */
+export function memoryContentDigest(memory: DiffableMemory): string {
+  return createHash("sha256").update(renderDocText(memory), "utf8").digest("hex");
 }
 
 /**

--- a/packages/core/src/grooming-apply.ts
+++ b/packages/core/src/grooming-apply.ts
@@ -53,6 +53,14 @@ export interface ApplyStore {
   // auto-applies, and there is no replacement doc to file as a proposal).
   flagMemory: (id: string, reason: string, agent_id?: string) => unknown;
   getMemory: (id: string) => StoredMemory | null;
+  // Open proposals in the shelf this run writes to — read to suppress an exact
+  // repeat (spec 072 D6). UNCAPPED on purpose: `listMemories` clamps at 200, and
+  // the evidence bundle shares a 200-memory budget that ACTIVE rows consume
+  // first, so either source would silently miss a pending proposal on a large
+  // vault and re-file the duplicate this exists to prevent.
+  listMemoriesUncapped: (filters?: Record<string, unknown>) => {
+    memories: { curator_note?: Record<string, unknown> | null }[];
+  };
   recordCurationOperation: (input: RecordCurationOperationInput) => unknown;
 }
 
@@ -119,6 +127,24 @@ export function applyOperations(
     }
     try {
       if (decision === "propose") {
+        // Spec 072 D6: don't file a proposal the queue already holds. TIGHT by
+        // design — same action over the same source set, so a pending update{A}
+        // does not block a merge{A,B} (different judgments; the operator should
+        // see both, and approving either withdraws the other). Inside the try so
+        // a store error during the scan records a failed op rather than killing
+        // the sweep.
+        if (openProposalCovers(deps.store, operation)) {
+          record(
+            deps,
+            operation,
+            "skipped",
+            "skipped: open proposal already covers these sources",
+            [],
+            payload,
+          );
+          summary.skipped++;
+          continue;
+        }
         const targets = proposeOp(operation, exec);
         // Archive idempotency (Phase 1 review F2): when every source already
         // carries an open curator flag, the re-proposal flagged nothing — record
@@ -146,6 +172,46 @@ export function applyOperations(
     }
   }
   return summary;
+}
+
+// The memories an operation proposes to replace — the identity D6 dedups on.
+// `create` has no sources to match against, and `archive` rides the flag-review
+// queue, which carries its own per-actor idempotency (review F2).
+function proposalSourceIds(op: GroomingOperation): string[] | null {
+  switch (op.type) {
+    case "update":
+    case "split":
+      return [op.source_memory_id];
+    case "merge":
+      return op.source_memory_ids;
+    default:
+      return null;
+  }
+}
+
+function sameSourceSet(a: string[], b: string[]): boolean {
+  const left = new Set(a);
+  const right = new Set(b);
+  if (left.size !== right.size) return false;
+  for (const id of left) if (!right.has(id)) return false;
+  return true;
+}
+
+// True when an open proposal is already the same judgment about the same
+// memories — matched as a SET, so source order never decides it.
+function openProposalCovers(store: ApplyStore, op: GroomingOperation): boolean {
+  const sources = proposalSourceIds(op);
+  if (sources === null || sources.length === 0) return false;
+  return store.listMemoriesUncapped({ status: "proposed" }).memories.some((proposal) => {
+    const note = proposal.curator_note;
+    if (!note || note.proposed_action !== op.type) return false;
+    const supersedes = note.supersedes;
+    if (!Array.isArray(supersedes)) return false;
+    return sameSourceSet(
+      supersedes.filter((id): id is string => typeof id === "string"),
+      sources,
+    );
+  });
 }
 
 // Auto-apply an operation the D13 rule cleared; returns the target memory ids.

--- a/packages/core/src/grooming-apply.ts
+++ b/packages/core/src/grooming-apply.ts
@@ -20,6 +20,7 @@
 //     redacted as defence-in-depth.
 
 import { decideApplication } from "./curator-apply-policy.js";
+import { memoryContentDigest } from "./formatters/memory-diff.js";
 import type { GroomingMemoryPatch, GroomingOperation } from "./grooming-output.js";
 import { redactSecrets } from "./grooming-redaction.js";
 import type { ValidatedOperation, ValidationContext } from "./grooming-validate.js";
@@ -361,7 +362,22 @@ function buildCreateCall(
   prov?: Provenance,
 ): SplitReplacement {
   const curatorNote: Record<string, unknown> = { run_id: c.runId };
-  if (supersedes.length > 0) curatorNote.supersedes = supersedes;
+  if (supersedes.length > 0) {
+    curatorNote.supersedes = supersedes;
+    // Spec 072 T3: fingerprint each source AS DRAFTED, so review can tell later
+    // whether the memory moved underneath the proposal. Proposals only — an
+    // auto-applied write has no queue wait in which to go stale. Digest the
+    // AUTHORITATIVE store record, never the evidence projection: evidence is
+    // redacted and body-truncated, so its digest could never match a recompute.
+    if (options.requiresApproval === true) {
+      const digests: Record<string, string> = {};
+      for (const sourceId of supersedes) {
+        const source = c.store.getMemory(sourceId);
+        if (source) digests[sourceId] = memoryContentDigest(source);
+      }
+      if (Object.keys(digests).length > 0) curatorNote.source_digests = digests;
+    }
+  }
   // Self-describing provenance on the PROPOSE path only — auto-apply callers
   // omit `prov`, so their curator_note keeps its existing { run_id, supersedes? }
   // shape (no source/proposed_action/rationale).

--- a/packages/core/src/grooming-chat.ts
+++ b/packages/core/src/grooming-chat.ts
@@ -85,6 +85,14 @@ export interface ChatProposalGrounding {
   } | null;
   /** The plan's guessed target, resolved; null when it no longer resolves. */
   guessed_target: { id: string; title: string; body: string; status: string } | null;
+  /**
+   * The memories this proposal REPLACES, resolved to their current text (spec
+   * 072 SC 9). `guessed_target` comes from an intake-only key that grooming
+   * proposals never set, so without this the merge/update proposals most worth
+   * discussing reached the model without the very memories under discussion.
+   * Capped and body-truncated (D6) so a wide merge cannot blow out the prompt.
+   */
+  superseded_sources: { id: string; title: string; body: string; status: string }[];
 }
 
 /** The grounding bundle: the memory under discussion + its decision history. */
@@ -306,6 +314,14 @@ export function buildGroundedMessages(input: BuildGroundedMessagesInput): LlmMes
                     body: redact(p.guessed_target.body),
                     status: p.guessed_target.status,
                   },
+            // The memories this proposal would replace (spec 072 SC 9) — what
+            // the operator is actually asking the curator to re-think.
+            superseded_sources: (p.superseded_sources ?? []).map((s) => ({
+              id: s.id,
+              title: redact(s.title),
+              body: redact(s.body),
+              status: s.status,
+            })),
           },
           null,
           2,

--- a/packages/core/src/grooming-worker.ts
+++ b/packages/core/src/grooming-worker.ts
@@ -248,9 +248,21 @@ function errorLabel(error: unknown): string {
   return error instanceof LlmClientError ? `llm_${error.kind}` : "error";
 }
 
-// Input hash (§10.2): slice + memory ids/updated/status + tombstone fingerprints
-// + a prompt version + the (redacted) admin addendum, so editing the addendum or
-// any evidence permits a fresh run. Order-independent.
+// Input hash (§10.2): slice + ACTIVE memory ids/updated/status + tombstone
+// fingerprints + a prompt version + the (redacted) admin addendum, so editing
+// the addendum or any evidence permits a fresh run. Order-independent.
+//
+// Proposals are deliberately EXCLUDED (spec 072, D7). They remain evidence in
+// the prompt — the curator must see what is already pending — but they must not
+// re-trigger a run: a filed proposal used to perturb this hash, so the very next
+// sweep looked novel and spent an LLM call re-deriving the judgment it had just
+// filed. If the active set is unchanged there is nothing left to derive, because
+// the earlier completed run saw exactly that evidence and applied everything it
+// found. Skipping also stays conservative in the other direction: more visible
+// pending proposals can only make the curator propose LESS (it is instructed
+// never to operate on a proposed memory), so a skip can forgo work but cannot
+// cause a wrong write. Approving or rejecting changes the ACTIVE set, so the
+// next sweep re-runs — which is what makes the drift refusal's promise true.
 function computeInputHash(
   slice: EvidenceSlice,
   memory: MemoryEvidenceBundle,
@@ -264,7 +276,7 @@ function computeInputHash(
     `prompt:${CURATOR_PROMPT_VERSION}`,
     `addendum:${redactSecrets(addendum).redacted}`,
   ];
-  for (const m of [...memory.activeMemories, ...memory.proposedMemories]) {
+  for (const m of memory.activeMemories) {
     parts.push(`m:${m.id}:${m.updatedAt}:${m.status}`);
   }
   for (const t of memory.tombstones) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -354,7 +354,11 @@ export {
   backfillCallerIds,
 } from "./caller-backfill.js";
 export { formatRecall } from "./formatters/index.js";
-export { type DiffableMemory, unifiedMemoryDiff } from "./formatters/memory-diff.js";
+export {
+  type DiffableMemory,
+  memoryContentDigest,
+  unifiedMemoryDiff,
+} from "./formatters/memory-diff.js";
 export {
   type CorpusDocument,
   type CorpusFrontmatter,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -360,6 +360,13 @@ export {
   unifiedMemoryDiff,
 } from "./formatters/memory-diff.js";
 export {
+  type ProposalDrift,
+  type ProposalDriftStatus,
+  type ProposalSourceDrift,
+  driftedSources,
+  proposalDrift,
+} from "./store/proposal-drift.js";
+export {
   type CorpusDocument,
   type CorpusFrontmatter,
   type InboxDeps,

--- a/packages/core/src/schemas/memory.ts
+++ b/packages/core/src/schemas/memory.ts
@@ -10,6 +10,11 @@ import { ConfidenceSchema, IdSchema, IsoTimestampSchema, MemoryStatusSchema } fr
 export const CuratorNoteSchema = z.object({
   text: z.string().optional(),
   supersedes: z.array(z.string()).optional(),
+  // Content digest of each superseded source AS DRAFTED, keyed by memory id
+  // (spec 072 D1/T3). Review recomputes these to tell whether a source moved
+  // underneath the proposal while it sat in the queue; a proposal without them
+  // (drafted before 072) reads as `unknown` and is never blocked (D2).
+  source_digests: z.record(z.string(), z.string()).optional(),
   run_id: z.string().optional(),
   operation_id: z.string().optional(),
   // Self-describing proposal provenance (spec 2026-06-20 proposal-review-ux, D2).

--- a/packages/core/src/store/markdown/markdown-memory-store.ts
+++ b/packages/core/src/store/markdown/markdown-memory-store.ts
@@ -371,14 +371,44 @@ export function createMarkdownMemoryStore(deps: MarkdownMemoryStoreDeps): Memory
     const supersedes = note?.supersedes;
     const replacesSources =
       proposedAction === "update" || proposedAction === "supersede" || proposedAction === "merge";
+    const archivedSourceIds: string[] = [];
     if (replacesSources && Array.isArray(supersedes)) {
       for (const sourceId of supersedes) {
         if (typeof sourceId !== "string" || sourceId.length === 0) continue;
         if (!getMemory(sourceId)) continue; // unknown id — fail-soft skip
         archiveMemory(sourceId, agent_id); // idempotent on an already-archived source
+        archivedSourceIds.push(sourceId);
       }
     }
+    // Cascade (spec 072, D4/D5): archiving those sources invalidated every OTHER
+    // open proposal about them. Keyed on what was ARCHIVED rather than on what
+    // was approved — which is exactly what keeps a split's sibling replacements
+    // (they all supersede the same source by construction) alive when one of
+    // them is approved: split archives nothing, so nothing cascades.
+    if (archivedSourceIds.length > 0) withdrawInvalidatedProposals(id, archivedSourceIds, agent_id);
     return approved;
+  }
+
+  // Spec 072 (SC 1-3). Before this, two open proposals could supersede the same
+  // memory M, and approving BOTH left two active memories each claiming to
+  // replace M — silently, because the second archive of M no-ops
+  // (`archiveMemory` is idempotent). Withdrawal reuses `resolveProposal`, so the
+  // peer is archived WITH provenance and survives in git; grooming re-proposes
+  // next sweep if the judgment still stands. Fail-soft throughout: a peer with a
+  // malformed `supersedes` is skipped, never thrown on.
+  function withdrawInvalidatedProposals(
+    approvedId: string,
+    archivedSourceIds: string[],
+    agent_id: string,
+  ): void {
+    const archived = new Set(archivedSourceIds);
+    for (const peer of listAll({ status: MemoryStatus.Proposed })) {
+      if (peer.id === approvedId) continue;
+      const supersedes = peer.curator_note?.supersedes;
+      if (!Array.isArray(supersedes)) continue;
+      if (!supersedes.some((s) => typeof s === "string" && archived.has(s))) continue;
+      resolveProposal(peer.id, `superseded_by_approval:${approvedId}`, agent_id);
+    }
   }
 
   // Resolve a proposal OUT of the queue with provenance (proposal-review

--- a/packages/core/src/store/proposal-drift.ts
+++ b/packages/core/src/store/proposal-drift.ts
@@ -1,0 +1,95 @@
+// Proposal drift — spec 072 (D1/D8, SC 5).
+//
+// A proposal is a judgment about specific memories, frozen at draft time and
+// then left in a queue for a human. While it waits, those memories can change:
+// an agent files something, or the operator edits by hand. Approving afterwards
+// archives the edited source and activates text written against the version
+// that no longer exists — silently dropping the newer edit from the active
+// corpus (it survives only in git).
+//
+// T3 stamps a content digest per superseded source at draft time. This module
+// is the other half: recompute those digests against the corpus now and say
+// whether anything moved.
+//
+// The three states, and why the ordering between them matters:
+//   drifted — a source's content changed. Refuses approve (D3, no override).
+//   unknown — cannot be determined: the proposal predates digests (D2), or the
+//             source no longer resolves. NEVER blocks. Treating unknown as
+//             drifted would make every proposal already in the queue
+//             unapprovable on upgrade, which is why D2 chose to let those drain.
+//   clean   — every source still digests to what was recorded.
+// `drifted` outranks `unknown`, so a proposal with one changed source and one
+// uncheckable source is still refused.
+//
+// Read defensively throughout: `curator_note` is a free-form record on the
+// markdown document, so every field here may be absent or the wrong shape.
+
+import { type DiffableMemory, memoryContentDigest } from "../formatters/memory-diff.js";
+
+export type ProposalDriftStatus = "clean" | "drifted" | "unknown";
+
+export interface ProposalSourceDrift {
+  id: string;
+  /** The source's CURRENT title, or null when it no longer resolves. */
+  title: string | null;
+  /** True only when a recorded digest exists and no longer matches. */
+  drifted: boolean;
+}
+
+export interface ProposalDrift {
+  status: ProposalDriftStatus;
+  sources: ProposalSourceDrift[];
+}
+
+/** The memory shape drift needs: enough to digest, plus an id to report. */
+type DriftReadable = DiffableMemory & { id?: string };
+
+/**
+ * Compare a proposal's recorded source digests against the corpus now.
+ *
+ * `getMemory` resolves ids through whatever scope the caller is entitled to —
+ * an id the caller cannot see reads as `unknown`, never as `clean`.
+ */
+export function proposalDrift(
+  curatorNote: Record<string, unknown> | null | undefined,
+  getMemory: (id: string) => DriftReadable | null,
+): ProposalDrift {
+  const supersedes = curatorNote?.supersedes;
+  if (!Array.isArray(supersedes)) return { status: "clean", sources: [] };
+  const sourceIds = supersedes.filter(
+    (id): id is string => typeof id === "string" && id.length > 0,
+  );
+  if (sourceIds.length === 0) return { status: "clean", sources: [] };
+
+  const rawDigests = curatorNote?.source_digests;
+  const digests =
+    typeof rawDigests === "object" && rawDigests !== null
+      ? (rawDigests as Record<string, unknown>)
+      : {};
+
+  const sources: ProposalSourceDrift[] = [];
+  let anyDrifted = false;
+  let anyUnknown = false;
+
+  for (const id of sourceIds) {
+    const recorded = digests[id];
+    const current = getMemory(id);
+    if (typeof recorded !== "string" || current === null) {
+      // No baseline, or nothing left to compare it against.
+      anyUnknown = true;
+      sources.push({ id, title: current?.title ?? null, drifted: false });
+      continue;
+    }
+    const drifted = memoryContentDigest(current) !== recorded;
+    if (drifted) anyDrifted = true;
+    sources.push({ id, title: current.title, drifted });
+  }
+
+  const status: ProposalDriftStatus = anyDrifted ? "drifted" : anyUnknown ? "unknown" : "clean";
+  return { status, sources };
+}
+
+/** The changed sources, for a refusal message that names what moved. */
+export function driftedSources(drift: ProposalDrift): ProposalSourceDrift[] {
+  return drift.sources.filter((source) => source.drifted);
+}

--- a/packages/core/tests/curator-note-digests.test.ts
+++ b/packages/core/tests/curator-note-digests.test.ts
@@ -1,0 +1,235 @@
+// Proposal source digests — spec 072 T3 (SC 4).
+//
+// A proposal stored NOTHING about the memories it was drafted against, so
+// approving one silently archived whatever those memories had since become —
+// dropping a hand edit from the active corpus with no warning. Every proposal
+// that supersedes something now fingerprints those sources as drafted, which is
+// what lets review tell later whether the corpus moved underneath it.
+//
+// D1: a content digest, not a timestamp. Every persist bumps `updated_at`
+// (resolving a flag, archiving, a status change), so a timestamp comparison
+// would report drift when no content moved — and false "your edit will be lost"
+// warnings are worse than none, because they teach the operator to click
+// through the gate.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type LibrarianStore,
+  type ValidatedOperation,
+  type ValidationContext,
+  applyOperations,
+  createLibrarianStore,
+  createVaultGroomingMemorySource,
+  gatherMemoryEvidence,
+  memoryContentDigest,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+interface Scope {
+  store: LibrarianStore;
+  dataDir: string;
+  runId: string;
+}
+
+let s: Scope | null = null;
+
+beforeEach(() => {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-digests-"));
+  const store = createLibrarianStore({ dataDir });
+  const run = store.createCurationRun({
+    trigger: "manual",
+    visibility: "common",
+    input_hash: "hash",
+    project_key: "proj-x",
+  });
+  s = { store, dataDir, runId: run.id };
+});
+afterEach(() => {
+  if (!s) return;
+  try {
+    s.store.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(s.dataDir, { recursive: true, force: true });
+  s = null;
+});
+
+function seed(over: Record<string, unknown> = {}) {
+  return s!.store.createMemory({
+    agent_id: "agent-a",
+    title: "title",
+    body: "body",
+    visibility: "common",
+    project_key: "proj-x",
+    confidence: "working",
+    ...over,
+  }).memory;
+}
+
+function context(maxBodyChars?: number): ValidationContext {
+  const slice = { kind: "common_project" as const, projectKey: "proj-x" };
+  return {
+    slice,
+    memory: gatherMemoryEvidence(createVaultGroomingMemorySource(s!.store), slice, {
+      maxMemories: 100,
+      ...(maxBodyChars !== undefined ? { maxBodyChars } : {}),
+    }),
+    prepass: { findings: [] },
+  };
+}
+
+function deps() {
+  return {
+    store: s!.store,
+    runId: s!.runId,
+    actorId: "system-memory-curator",
+    confidenceThreshold: 0.8,
+  };
+}
+
+const accept = () =>
+  ({ decision: "accept", targetRequiresApproval: false }) as ValidatedOperation["outcome"];
+
+function updateOp(id: string, confidence: number): ValidatedOperation {
+  return {
+    operation: {
+      type: "update",
+      source_memory_id: id,
+      patch: { title: "Corrected" },
+      rationale: "fix",
+      confidence,
+    },
+    outcome: accept(),
+  } as ValidatedOperation;
+}
+
+/** The one proposal in the store, with its curator_note. */
+function theProposal() {
+  const proposals = s!.store.listMemories({ status: "proposed" }).memories;
+  expect(proposals).toHaveLength(1);
+  return proposals[0]!;
+}
+
+const digestsOf = (m: { curator_note?: Record<string, unknown> | null }) =>
+  (m.curator_note?.source_digests ?? null) as Record<string, string> | null;
+
+describe("memoryContentDigest (spec 072 D1)", () => {
+  it("is deterministic for the same content", () => {
+    const a = memoryContentDigest({ title: "T", body: "B" });
+    const b = memoryContentDigest({ title: "T", body: "B" });
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("changes when the title or the body changes", () => {
+    const base = memoryContentDigest({ title: "T", body: "B" });
+    expect(memoryContentDigest({ title: "T2", body: "B" })).not.toBe(base);
+    expect(memoryContentDigest({ title: "T", body: "B2" })).not.toBe(base);
+  });
+
+  it("does not collide across the title/body boundary", () => {
+    expect(memoryContentDigest({ title: "AB", body: "" })).not.toBe(
+      memoryContentDigest({ title: "A", body: "B" }),
+    );
+  });
+});
+
+describe("proposals stamp source digests (spec 072 SC 4)", () => {
+  it("fingerprints the source of a proposed update", () => {
+    const m = seed({ title: "Fact", body: "old value" });
+
+    applyOperations([updateOp(m.id, 0.5)], context(), deps());
+
+    const digests = digestsOf(theProposal());
+    expect(digests).not.toBeNull();
+    expect(digests![m.id]).toBe(memoryContentDigest({ title: "Fact", body: "old value" }));
+  });
+
+  it("recomputing over an unmodified source reproduces the stored digest", () => {
+    const m = seed({ title: "Fact", body: "old value" });
+    applyOperations([updateOp(m.id, 0.5)], context(), deps());
+
+    const stored = s!.store.getMemory(m.id)!;
+    expect(digestsOf(theProposal())![m.id]).toBe(memoryContentDigest(stored));
+  });
+
+  it("fingerprints every source of a proposed merge", () => {
+    const a = seed({ title: "A", body: "a body" });
+    const b = seed({ title: "B", body: "b body" });
+
+    applyOperations(
+      [
+        {
+          operation: {
+            type: "merge",
+            source_memory_ids: [a.id, b.id],
+            replacement: {
+              title: "Merged",
+              body: "merged",
+              tags: [],
+              applies_to: [],
+              confidence: "working",
+            },
+            rationale: "dedupe",
+            confidence: 0.5,
+          },
+          outcome: accept(),
+        } as ValidatedOperation,
+      ],
+      context(),
+      deps(),
+    );
+
+    const digests = digestsOf(theProposal());
+    expect(Object.keys(digests ?? {}).sort()).toEqual([a.id, b.id].sort());
+  });
+
+  it("digests the authoritative store record, not the truncated evidence", () => {
+    const body = "x".repeat(500);
+    const m = seed({ title: "Long", body });
+
+    // Evidence trims bodies to maxBodyChars; digesting THAT would never match a
+    // later recompute from the store.
+    applyOperations([updateOp(m.id, 0.5)], context(10), deps());
+
+    expect(digestsOf(theProposal())![m.id]).toBe(memoryContentDigest({ title: "Long", body }));
+  });
+
+  it("stamps nothing on a proposal that supersedes nothing", () => {
+    applyOperations(
+      [
+        {
+          operation: {
+            type: "create",
+            memory: {
+              title: "New",
+              body: "new body",
+              tags: [],
+              applies_to: [],
+              confidence: "working",
+            },
+            rationale: "worth keeping",
+            confidence: 0.5,
+          },
+          outcome: accept(),
+        } as ValidatedOperation,
+      ],
+      context(),
+      deps(),
+    );
+
+    expect(digestsOf(theProposal())).toBeNull();
+  });
+
+  it("stamps nothing on an auto-applied update — there is no proposal to go stale", () => {
+    const m = seed({ title: "Fact", body: "old value" });
+
+    applyOperations([updateOp(m.id, 0.95)], context(), deps());
+
+    expect(s!.store.listMemories({ status: "proposed" }).total).toBe(0);
+    expect(s!.store.getMemory(m.id)!.title).toBe("Corrected");
+  });
+});

--- a/packages/core/tests/grooming-apply-dedup.test.ts
+++ b/packages/core/tests/grooming-apply-dedup.test.ts
@@ -1,0 +1,221 @@
+// Grooming proposal suppression — spec 072 T2 (SC 8).
+//
+// Grooming had no dedup at all: every sweep that reached the same judgment
+// filed another proposal about the same memory. T2b removes most of the
+// pressure (a filed proposal no longer re-triggers the next sweep), so this is
+// the backstop for the runs that happen anyway — a manual/bypass trigger, or a
+// neighbouring memory changing and pulling this one back into the slice.
+//
+// D6 keeps the rule TIGHT: suppress only an exact repeat — same action over the
+// same set of source ids. A pending update{A} must NOT block a merge{A,B};
+// those are different judgments and the operator should see both. Two live
+// proposals about A are fine, because approving either withdraws the other
+// (T1's cascade).
+//
+// The scan reads the store UNCAPPED, not the evidence bundle: evidence shares a
+// 200-memory budget that fills with ACTIVE memories first, so on a large vault
+// no proposal reaches evidence at all and suppression would silently never fire.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type LibrarianStore,
+  type ValidatedOperation,
+  type ValidationContext,
+  applyOperations,
+  createLibrarianStore,
+  createVaultGroomingMemorySource,
+  gatherMemoryEvidence,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+interface Scope {
+  store: LibrarianStore;
+  dataDir: string;
+  runId: string;
+}
+
+let s: Scope | null = null;
+
+beforeEach(() => {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-apply-dedup-"));
+  const store = createLibrarianStore({ dataDir });
+  const run = store.createCurationRun({
+    trigger: "manual",
+    visibility: "common",
+    input_hash: "hash",
+    project_key: "proj-x",
+  });
+  s = { store, dataDir, runId: run.id };
+});
+afterEach(() => {
+  if (!s) return;
+  try {
+    s.store.close();
+  } catch {
+    /* ignore */
+  }
+  fs.rmSync(s.dataDir, { recursive: true, force: true });
+  s = null;
+});
+
+function seed(over: Record<string, unknown> = {}) {
+  return s!.store.createMemory({
+    agent_id: "agent-a",
+    title: "title",
+    body: "body",
+    visibility: "common",
+    project_key: "proj-x",
+    confidence: "working",
+    ...over,
+  }).memory;
+}
+
+function context(): ValidationContext {
+  const slice = { kind: "common_project" as const, projectKey: "proj-x" };
+  return {
+    slice,
+    memory: gatherMemoryEvidence(createVaultGroomingMemorySource(s!.store), slice, {
+      maxMemories: 100,
+    }),
+    prepass: { findings: [] },
+  };
+}
+
+function deps() {
+  return {
+    store: s!.store,
+    runId: s!.runId,
+    actorId: "system-memory-curator",
+    confidenceThreshold: 0.8,
+  };
+}
+
+const accept = () =>
+  ({ decision: "accept", targetRequiresApproval: false }) as ValidatedOperation["outcome"];
+
+/** Below the 0.8 knob, so every op here routes to a proposal rather than an apply. */
+const PROPOSE_CONFIDENCE = 0.5;
+
+function updateOp(id: string, title = "Corrected"): ValidatedOperation {
+  return {
+    operation: {
+      type: "update",
+      source_memory_id: id,
+      patch: { title },
+      rationale: "fix",
+      confidence: PROPOSE_CONFIDENCE,
+    },
+    outcome: accept(),
+  } as ValidatedOperation;
+}
+
+function mergeOp(ids: string[]): ValidatedOperation {
+  return {
+    operation: {
+      type: "merge",
+      source_memory_ids: ids,
+      replacement: {
+        title: "Merged",
+        body: "merged body",
+        tags: [],
+        applies_to: [],
+        confidence: "working",
+      },
+      rationale: "dedupe",
+      confidence: PROPOSE_CONFIDENCE,
+    },
+    outcome: accept(),
+  } as ValidatedOperation;
+}
+
+const proposedCount = () => s!.store.listMemories({ status: "proposed" }).total;
+
+const skippedForDuplicate = () =>
+  s!.store
+    .getCurationOperations(s!.runId)
+    .filter((o) => o.status === "skipped" && /open proposal already covers/.test(o.rationale));
+
+describe("grooming proposal suppression (spec 072 SC 8)", () => {
+  it("suppresses an exact repeat and says so in the audit", () => {
+    const m = seed({ title: "Fact" });
+
+    applyOperations([updateOp(m.id)], context(), deps());
+    expect(proposedCount()).toBe(1);
+
+    // The same judgment again — one sweep later, or after a manual trigger.
+    const summary = applyOperations([updateOp(m.id)], context(), deps());
+
+    expect(proposedCount()).toBe(1); // no second proposal
+    expect(summary.proposed).toBe(0);
+    expect(summary.skipped).toBe(1);
+    expect(skippedForDuplicate()).toHaveLength(1);
+  });
+
+  it("does not suppress a different action over the same source", () => {
+    const a = seed({ title: "A" });
+    const b = seed({ title: "B" });
+
+    applyOperations([updateOp(a.id)], context(), deps());
+    const summary = applyOperations([mergeOp([a.id, b.id])], context(), deps());
+
+    expect(summary.proposed).toBe(1);
+    expect(proposedCount()).toBe(2); // update{A} and merge{A,B} coexist
+  });
+
+  it("does not suppress the same action over a different source set", () => {
+    const a = seed({ title: "A" });
+    const b = seed({ title: "B" });
+    const c = seed({ title: "C" });
+
+    applyOperations([mergeOp([a.id, b.id])], context(), deps());
+    const summary = applyOperations([mergeOp([a.id, c.id])], context(), deps());
+
+    expect(summary.proposed).toBe(1);
+    expect(proposedCount()).toBe(2);
+  });
+
+  it("matches the source set regardless of order", () => {
+    const a = seed({ title: "A" });
+    const b = seed({ title: "B" });
+
+    applyOperations([mergeOp([a.id, b.id])], context(), deps());
+    const summary = applyOperations([mergeOp([b.id, a.id])], context(), deps());
+
+    expect(summary.skipped).toBe(1);
+    expect(proposedCount()).toBe(1);
+  });
+
+  it("leaves a first-time proposal alone", () => {
+    const m = seed({ title: "Fact" });
+
+    const summary = applyOperations([updateOp(m.id)], context(), deps());
+
+    expect(summary.proposed).toBe(1);
+    expect(skippedForDuplicate()).toHaveLength(0);
+  });
+
+  it("does not suppress the sibling replacements of a single split operation", () => {
+    const m = seed({ title: "Two facts", body: "first. second." });
+    const splitOp = {
+      operation: {
+        type: "split",
+        source_memory_id: m.id,
+        replacements: [
+          { title: "First", body: "first.", tags: [], applies_to: [], confidence: "working" },
+          { title: "Second", body: "second.", tags: [], applies_to: [], confidence: "working" },
+        ],
+        rationale: "two facts in one memory",
+        confidence: PROPOSE_CONFIDENCE,
+      },
+      outcome: accept(),
+    } as ValidatedOperation;
+
+    const summary = applyOperations([splitOp], context(), deps());
+
+    // One operation, N proposals — the replacements must not suppress each other.
+    expect(summary.proposed).toBe(1);
+    expect(proposedCount()).toBe(2);
+  });
+});

--- a/packages/core/tests/grooming-apply.test.ts
+++ b/packages/core/tests/grooming-apply.test.ts
@@ -441,6 +441,9 @@ describe("applyOperations — merge partial failure (no data loss)", () => {
       },
       flagMemory: () => null,
       getMemory: () => null,
+      // Spec 072 D6's suppression scan. This operation auto-applies, so the scan
+      // is never reached — but the mock must satisfy the interface it claims.
+      listMemoriesUncapped: () => ({ memories: [] }),
       recordCurationOperation: (op) => {
         recordedOps.push({ status: op.status });
         return op;

--- a/packages/core/tests/grooming-worker.test.ts
+++ b/packages/core/tests/grooming-worker.test.ts
@@ -174,6 +174,54 @@ describe("runCuration — input-hash idempotency (§10.2)", () => {
     expect(bypassed).not.toBeNull();
     expect(bypassed!.id).not.toBe(first.id);
   });
+
+  // Spec 072 D7: proposals are EVIDENCE, not a trigger. They still reach the
+  // prompt (the curator must see what is pending), they just no longer perturb
+  // the skip hash — before this, filing a proposal made the very next sweep look
+  // novel, so it spent another LLM call re-deriving the judgment it had just
+  // filed, and (without T2's suppression) filed it a second time.
+  it("does not re-trigger the next scheduled sweep just because a proposal was filed", async () => {
+    const m = seed({ title: "Fact", body: "old value" });
+    // Below the 0.8 confidence knob → routed to a proposal: a new proposed
+    // memory appears and the source stays active.
+    const proposeOnce = fakeClient(
+      JSON.stringify({
+        operations: [
+          {
+            type: "update",
+            source_memory_id: m.id,
+            patch: { title: "Fact, corrected" },
+            rationale: "fix",
+            confidence: 0.5,
+          },
+        ],
+      }),
+    );
+
+    const first = await runOk(SLICE, { ...options(proposeOnce), trigger: "schedule" });
+    expect(first.status).toBe("completed");
+    expect(s!.store.getMemory(m.id)!.status).toBe("active");
+
+    const skipped = await runCuration(SLICE, {
+      ...options(fakeClient(JSON.stringify({ operations: [] }))),
+      trigger: "schedule",
+    });
+    expect(skipped).toBeNull();
+  });
+
+  // The other half of D7, and the mechanism D3's copy promises the operator:
+  // "the curator re-reads this memory on its next grooming run". Editing a
+  // source — which is exactly what makes a proposal drift — must still re-run.
+  it("still re-runs when an active memory actually changes", async () => {
+    const m = seed({ title: "Fact", body: "old value" });
+    const noOp = () => fakeClient(JSON.stringify({ operations: [] }));
+    await runOk(SLICE, { ...options(noOp()), trigger: "schedule" });
+
+    s!.store.updateMemory(m.id, { body: "edited by hand" });
+
+    const rerun = await runCuration(SLICE, { ...options(noOp()), trigger: "schedule" });
+    expect(rerun).not.toBeNull();
+  });
 });
 
 describe("runCuration — failure paths leave memory untouched", () => {

--- a/packages/core/tests/proposal-drift.test.ts
+++ b/packages/core/tests/proposal-drift.test.ts
@@ -1,0 +1,105 @@
+// Proposal drift — spec 072 T4 (SC 5).
+//
+// Given a proposal's curator_note (which carries source_digests from T3) and a
+// way to read memories now, decide whether the corpus moved underneath the
+// proposal while it sat in the queue.
+//
+// Three states, and the ordering between them is the whole design:
+//   drifted — a source's content changed since drafting. Blocks approve (D3).
+//   unknown — we cannot tell: no digest (drafted before 072, D2) or the source
+//             no longer resolves. NEVER blocks; treating unknown as drifted
+//             would make every proposal already in the queue unapprovable.
+//   clean   — every source still digests to what was recorded.
+// "drifted" wins over "unknown" so a mixed proposal is still refused.
+
+import { type ProposalDrift, memoryContentDigest, proposalDrift } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+const SOURCE = { id: "m1", title: "Deploy policy", body: "never deploy on a Friday" };
+const OTHER = { id: "m2", title: "Other", body: "other body" };
+
+const corpus = (...memories: { id: string; title: string; body: string }[]) => {
+  const byId = new Map(memories.map((m) => [m.id, m]));
+  return (id: string) => byId.get(id) ?? null;
+};
+
+const noteFor = (...memories: { id: string; title: string; body: string }[]) => ({
+  proposed_action: "update",
+  supersedes: memories.map((m) => m.id),
+  source_digests: Object.fromEntries(memories.map((m) => [m.id, memoryContentDigest(m)])),
+});
+
+const statusOf = (drift: ProposalDrift) => drift.status;
+
+describe("proposalDrift (spec 072 SC 5)", () => {
+  it("reports clean when the source still digests to what was recorded", () => {
+    const drift = proposalDrift(noteFor(SOURCE), corpus(SOURCE));
+    expect(statusOf(drift)).toBe("clean");
+    expect(drift.sources).toEqual([{ id: "m1", title: "Deploy policy", drifted: false }]);
+  });
+
+  it("reports drifted when the body changed since drafting", () => {
+    const edited = { ...SOURCE, body: "never deploy after 3pm on a Friday" };
+    const drift = proposalDrift(noteFor(SOURCE), corpus(edited));
+    expect(statusOf(drift)).toBe("drifted");
+    expect(drift.sources[0]!.drifted).toBe(true);
+  });
+
+  it("reports drifted when only the title changed", () => {
+    const edited = { ...SOURCE, title: "Deployment policy" };
+    expect(statusOf(proposalDrift(noteFor(SOURCE), corpus(edited)))).toBe("drifted");
+  });
+
+  it("reports unknown for a proposal drafted before digests existed", () => {
+    const legacy = { proposed_action: "update", supersedes: ["m1"] };
+    expect(statusOf(proposalDrift(legacy, corpus(SOURCE)))).toBe("unknown");
+  });
+
+  it("reports unknown when the source no longer resolves", () => {
+    expect(statusOf(proposalDrift(noteFor(SOURCE), corpus()))).toBe("unknown");
+  });
+
+  it("reports clean for a proposal that supersedes nothing", () => {
+    const create = { proposed_action: "create", source: "intake" };
+    const drift = proposalDrift(create, corpus(SOURCE));
+    expect(statusOf(drift)).toBe("clean");
+    expect(drift.sources).toEqual([]);
+  });
+
+  it("lets drifted win over unknown on a mixed proposal", () => {
+    // m1 drifted; m2 has no recorded digest, so it cannot be checked.
+    const note = {
+      proposed_action: "merge",
+      supersedes: [SOURCE.id, OTHER.id],
+      source_digests: { [SOURCE.id]: memoryContentDigest(SOURCE) },
+    };
+    const drift = proposalDrift(note, corpus({ ...SOURCE, body: "changed" }, OTHER));
+    expect(statusOf(drift)).toBe("drifted");
+  });
+
+  it("reports every source, not just the first", () => {
+    const note = {
+      proposed_action: "merge",
+      supersedes: [SOURCE.id, OTHER.id],
+      source_digests: {
+        [SOURCE.id]: memoryContentDigest(SOURCE),
+        [OTHER.id]: memoryContentDigest(OTHER),
+      },
+    };
+    const drift = proposalDrift(note, corpus({ ...SOURCE, body: "changed" }, OTHER));
+    expect(drift.sources).toHaveLength(2);
+    expect(drift.sources.find((s) => s.id === "m1")!.drifted).toBe(true);
+    expect(drift.sources.find((s) => s.id === "m2")!.drifted).toBe(false);
+  });
+
+  it("tolerates a null note and malformed shapes without throwing", () => {
+    expect(statusOf(proposalDrift(null, corpus(SOURCE)))).toBe("clean");
+    expect(statusOf(proposalDrift(undefined, corpus(SOURCE)))).toBe("clean");
+    expect(statusOf(proposalDrift({ supersedes: "m1", source_digests: 7 }, corpus(SOURCE)))).toBe(
+      "clean",
+    );
+    expect(
+      statusOf(proposalDrift({ supersedes: ["m1"], source_digests: null }, corpus(SOURCE))),
+    ).toBe("unknown");
+  });
+});

--- a/packages/core/tests/store/approve-proposal-cascade.test.ts
+++ b/packages/core/tests/store/approve-proposal-cascade.test.ts
@@ -1,0 +1,270 @@
+// Approve-cascade — spec 072 T1 (SC 1, 2, 3).
+//
+// Spec 058 (D4) made a SINGLE approval correct: approving an
+// update/supersede/merge archives the sources it replaces. It left
+// CONCURRENCY between proposals unhandled — two open proposals may supersede
+// the same memory M, and approving both used to leave TWO active memories both
+// claiming to replace M (the second archive of M no-ops, because archiveMemory
+// is idempotent, so nothing objected).
+//
+// The cascade is keyed on what was ARCHIVED, not on what was approved: only the
+// update/supersede/merge arm archives sources, so only it can invalidate peers.
+// create and split archive nothing, so nothing cascades — which is what keeps a
+// split's sibling replacements (they all supersede the same source, by
+// construction) alive when one of them is approved.
+//
+// Withdrawal reuses the resolveProposal seam: the peer is archived WITH
+// provenance (curator_note.resolution) and stays in git, not deleted.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type Memory,
+  createMarkdownMemoryStore,
+  createVault,
+  serializeMemoryDocument,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-approve-cascade-"));
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+const NOW = "2026-07-24T00:00:00.000Z";
+
+function setup() {
+  const vault = createVault({ dataDir });
+  const store = createMarkdownMemoryStore({ vault, now: () => NOW });
+  const seed = (over: Partial<Memory> & { id: string }): Memory => {
+    const memory: Memory = {
+      id: over.id,
+      title: over.title ?? over.id,
+      body: over.body ?? "body",
+      agent_id: over.agent_id ?? "codex",
+      confidence: "working",
+      tags: [],
+      applies_to: [],
+      supersedes: [],
+      conflicts_with: [],
+      flags: [],
+      status: over.status ?? "active",
+      is_global: false,
+      requires_approval: over.requires_approval ?? false,
+      created_at: "2026-06-01T00:00:00.000Z",
+      updated_at: "2026-06-01T00:00:00.000Z",
+      curator_note: over.curator_note ?? null,
+    };
+    vault.writeText(`memories/${memory.id}.md`, serializeMemoryDocument(memory));
+    return memory;
+  };
+  return { vault, store, seed };
+}
+
+describe("approveProposal — cascade over invalidated peers (spec 072 SC 1/2)", () => {
+  it("withdraws an open peer proposal that superseded the same source", () => {
+    const { store, seed } = setup();
+    seed({ id: "t", status: "active", title: "fact", body: "old value" });
+    seed({
+      id: "a",
+      status: "proposed",
+      body: "new value A",
+      curator_note: { proposed_action: "update", supersedes: ["t"] },
+    });
+    seed({
+      id: "b",
+      status: "proposed",
+      body: "new value B",
+      curator_note: { proposed_action: "update", supersedes: ["t"] },
+    });
+
+    store.approveProposal("a", "approve");
+
+    expect(store.getMemory("a")!.status).toBe("active");
+    expect(store.getMemory("t")!.status).toBe("archived");
+    const peer = store.getMemory("b")!;
+    expect(peer.status).toBe("archived");
+    expect(peer.curator_note!.resolution).toBe("superseded_by_approval:a");
+  });
+
+  it("leaves exactly one open proposal and one active descendant of the source", () => {
+    const { store, seed } = setup();
+    seed({ id: "t", status: "active" });
+    seed({
+      id: "a",
+      status: "proposed",
+      curator_note: { proposed_action: "update", supersedes: ["t"] },
+    });
+    seed({
+      id: "b",
+      status: "proposed",
+      curator_note: { proposed_action: "update", supersedes: ["t"] },
+    });
+
+    store.approveProposal("a", "approve");
+
+    expect(store.listMemories({ status: "proposed" }).total).toBe(0);
+    expect(store.listMemories({ status: "active" }).total).toBe(1);
+  });
+
+  it("makes the double-approve divergence unreachable", () => {
+    const { store, seed } = setup();
+    seed({ id: "t", status: "active" });
+    seed({
+      id: "a",
+      status: "proposed",
+      curator_note: { proposed_action: "update", supersedes: ["t"] },
+    });
+    seed({
+      id: "b",
+      status: "proposed",
+      curator_note: { proposed_action: "update", supersedes: ["t"] },
+    });
+
+    store.approveProposal("a", "approve");
+    expect(() => store.approveProposal("b", "approve")).toThrow(/not proposed/);
+  });
+
+  it("withdraws peers pointing at ANY source of an approved merge", () => {
+    const { store, seed } = setup();
+    seed({ id: "x", status: "active" });
+    seed({ id: "y", status: "active" });
+    seed({ id: "z", status: "active" });
+    seed({
+      id: "m",
+      status: "proposed",
+      curator_note: { proposed_action: "merge", supersedes: ["x", "y"] },
+    });
+    // Overlaps on y only — still invalidated, y is gone.
+    seed({
+      id: "p",
+      status: "proposed",
+      curator_note: { proposed_action: "update", supersedes: ["y"] },
+    });
+    // Touches z, which the merge never archived — must survive.
+    seed({
+      id: "q",
+      status: "proposed",
+      curator_note: { proposed_action: "update", supersedes: ["z"] },
+    });
+
+    store.approveProposal("m", "approve");
+
+    expect(store.getMemory("p")!.status).toBe("archived");
+    expect(store.getMemory("p")!.curator_note!.resolution).toBe("superseded_by_approval:m");
+    expect(store.getMemory("q")!.status).toBe("proposed");
+  });
+
+  it("does not withdraw a peer whose source was never archived", () => {
+    const { store, seed } = setup();
+    seed({ id: "t", status: "active" });
+    seed({ id: "u", status: "active" });
+    seed({
+      id: "a",
+      status: "proposed",
+      curator_note: { proposed_action: "update", supersedes: ["t"] },
+    });
+    seed({
+      id: "b",
+      status: "proposed",
+      curator_note: { proposed_action: "update", supersedes: ["u"] },
+    });
+
+    store.approveProposal("a", "approve");
+
+    expect(store.getMemory("b")!.status).toBe("proposed");
+  });
+
+  it("does not cascade when rejecting — the source stays live, so peers stay valid", () => {
+    const { store, seed } = setup();
+    seed({ id: "t", status: "active" });
+    seed({
+      id: "a",
+      status: "proposed",
+      curator_note: { proposed_action: "update", supersedes: ["t"] },
+    });
+    seed({
+      id: "b",
+      status: "proposed",
+      curator_note: { proposed_action: "update", supersedes: ["t"] },
+    });
+
+    store.approveProposal("a", "reject");
+
+    expect(store.getMemory("t")!.status).toBe("active");
+    expect(store.getMemory("b")!.status).toBe("proposed");
+  });
+
+  it("does not cascade for a create, which archives nothing", () => {
+    const { store, seed } = setup();
+    seed({ id: "t", status: "active" });
+    seed({
+      id: "a",
+      status: "proposed",
+      curator_note: { proposed_action: "create", source: "intake" },
+    });
+    seed({
+      id: "b",
+      status: "proposed",
+      curator_note: { proposed_action: "update", supersedes: ["t"] },
+    });
+
+    store.approveProposal("a", "approve");
+
+    expect(store.getMemory("b")!.status).toBe("proposed");
+  });
+});
+
+describe("approveProposal — split siblings survive (spec 072 SC 3)", () => {
+  it("leaves the other replacements of the same split open", () => {
+    const { store, seed } = setup();
+    seed({ id: "s", status: "active" });
+    for (const id of ["r1", "r2", "r3"]) {
+      seed({
+        id,
+        status: "proposed",
+        curator_note: { proposed_action: "split", supersedes: ["s"], run_id: "run-1" },
+      });
+    }
+
+    store.approveProposal("r1", "approve");
+
+    expect(store.getMemory("r1")!.status).toBe("active");
+    expect(store.getMemory("s")!.status).toBe("active");
+    expect(store.getMemory("r2")!.status).toBe("proposed");
+    expect(store.getMemory("r3")!.status).toBe("proposed");
+  });
+
+  it("withdraws pending splits of a source that an approved update archived", () => {
+    const { store, seed } = setup();
+    seed({ id: "s", status: "active" });
+    seed({
+      id: "u",
+      status: "proposed",
+      curator_note: { proposed_action: "update", supersedes: ["s"] },
+    });
+    seed({
+      id: "r1",
+      status: "proposed",
+      curator_note: { proposed_action: "split", supersedes: ["s"] },
+    });
+    seed({
+      id: "r2",
+      status: "proposed",
+      curator_note: { proposed_action: "split", supersedes: ["s"] },
+    });
+
+    store.approveProposal("u", "approve");
+
+    // s is archived, so its pending split replacements are decisions about a
+    // memory that no longer exists in the active corpus.
+    expect(store.getMemory("r1")!.status).toBe("archived");
+    expect(store.getMemory("r2")!.status).toBe("archived");
+  });
+});

--- a/packages/installer-cli/package.json
+++ b/packages/installer-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-librarian/cli",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/mcp-server/src/trpc/grooming.ts
+++ b/packages/mcp-server/src/trpc/grooming.ts
@@ -65,6 +65,13 @@ const ChatInputSchema = z.strictObject({
 // grounding context, not an audit — recent decisions are what matter).
 const CHAT_HISTORY_RUN_SCAN = 100;
 
+// Bounds on the superseded sources a proposal-grounded chat carries (spec 072
+// D6). A merge can name many memories; the prompt must stay finite. Five is
+// enough to reason about a consolidation, and the body cap matches the grooming
+// evidence limit so a source reads the same here as it does to the curator.
+const MAX_GROUNDED_SOURCES = 5;
+const MAX_GROUNDED_SOURCE_BODY_CHARS = 4000;
+
 /**
  * Gather a memory's grounding bundle — the memory itself + its grooming decisions
  * (curation ops whose source/target memory ids include it) + its intake decisions
@@ -139,6 +146,24 @@ function gatherChatGrounding(store: LibrarianStore, memoryId: string): ChatMemor
         guessed_target: target
           ? { id: target.id, title: target.title, body: target.body, status: target.status }
           : null,
+        // The memories this proposal REPLACES, at their CURRENT text (spec 072
+        // SC 9). `guessed_target_id` above is an intake-only key, so a grooming
+        // merge/update used to reach the model without the very memories under
+        // discussion — leaving "Discuss" unable to do the one thing the
+        // operator opens it for. Capped and truncated (D6): a wide merge must
+        // not blow out the prompt. Ids that no longer resolve are dropped
+        // fail-soft, exactly as the review row does.
+        superseded_sources: (Array.isArray(note.supersedes) ? note.supersedes : [])
+          .filter((id): id is string => typeof id === "string" && id.length > 0)
+          .slice(0, MAX_GROUNDED_SOURCES)
+          .map((id) => store.getMemory(id))
+          .filter((m): m is NonNullable<typeof m> => m !== null)
+          .map((m) => ({
+            id: m.id,
+            title: m.title,
+            body: m.body.slice(0, MAX_GROUNDED_SOURCE_BODY_CHARS),
+            status: m.status,
+          })),
       };
     }
 

--- a/packages/mcp-server/src/trpc/memories.ts
+++ b/packages/mcp-server/src/trpc/memories.ts
@@ -20,6 +20,7 @@
 import {
   type LibrarianStore,
   type Principal,
+  type ProposalDrift,
   type Shelf,
   MemoryAlreadyOnShelfError,
   MemoryMoveDestinationExistsError,
@@ -28,9 +29,11 @@ import {
   ShelfNotWritableError,
   type SplitReplacement,
   augmentBody,
+  driftedSources,
   mergeMemory,
   normaliseCallerId,
   preservesOriginal,
+  proposalDrift,
   redactSecrets,
   splitMemory,
   unifiedMemoryDiff,
@@ -432,6 +435,10 @@ export interface ProposalReviewRow {
   diff: string | null;
   plan: ReviewPlan | null;
   move: ReviewMove | null;
+  // Whether the memories this proposal supersedes have changed since it was
+  // drafted (spec 072 SC 5). `drifted` refuses approve; `unknown` (a legacy row
+  // with no recorded digests) never does.
+  drift: ProposalDrift;
   actorDisplay?: string;
 }
 
@@ -517,8 +524,14 @@ export const memoriesRouter = router({
         (id) => ctx.store.getMemoryForPrincipal(ctx.principal, id) as unknown as MemoryShape | null,
       );
       const move = enrichMove(ctx.store, ctx.principal, note, action);
+      // Resolved through the caller's OWN scope, so a source they cannot see
+      // reads as `unknown` rather than silently `clean`.
+      const drift = proposalDrift(
+        note,
+        (id) => ctx.store.getMemoryForPrincipal(ctx.principal, id) as unknown as MemoryShape | null,
+      );
 
-      return { proposal, action, source, rationale, targets, diff, plan, move };
+      return { proposal, action, source, rationale, targets, diff, plan, move, drift };
     });
     const actorDisplays = resolveActorDisplays(
       ctx.actorDisplayProvider,
@@ -1052,6 +1065,37 @@ export const memoriesRouter = router({
         code: "BAD_REQUEST",
         message: "A move proposal has no content to activate — Apply the move, or Reject.",
       });
+    }
+    // Drift refusal (spec 072 D3): the memories this proposal supersedes have
+    // changed since it was drafted, so activating it would archive the newer
+    // text and drop that edit from the active corpus. HARD block — no override
+    // input, by decision: an escape hatch that exists is one that gets clicked
+    // through, and habituation is what makes a safety gate worthless. The
+    // message must carry the re-groom reassurance, or a refusal reads as losing
+    // the curator's work and the operator goes looking for a way round it.
+    // (`unknown` — a proposal drafted before digests existed — never blocks, D2.)
+    if (proposal?.status === "proposed") {
+      const drift = proposalDrift(
+        proposal.curator_note as Record<string, unknown> | null | undefined,
+        (id) => ctx.store.getMemoryForPrincipal(ctx.principal, id) as unknown as MemoryShape | null,
+      );
+      if (drift.status === "drifted") {
+        const changed = driftedSources(drift);
+        const names = changed.map((s) => (s.title === null ? s.id : `“${s.title}”`));
+        const subject =
+          names.length === 1
+            ? `${names[0]} has changed`
+            : `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]} have changed`;
+        const those = names.length === 1 ? "this memory" : "these memories";
+        const edits = names.length === 1 ? "that edit" : "those edits";
+        throw new TRPCError({
+          code: "CONFLICT",
+          message:
+            `${subject} since this proposal was drafted, so approving it would discard ${edits}. ` +
+            `Reject it — the curator re-reads ${those} on its next grooming run and may well ` +
+            `propose a similar change against your current version.`,
+        });
+      }
     }
     return rethrowAsNotFound(
       () =>

--- a/packages/mcp-server/tests/trpc/grooming-chat.test.ts
+++ b/packages/mcp-server/tests/trpc/grooming-chat.test.ts
@@ -395,3 +395,87 @@ describe("tRPC grooming.chat — corpus search", () => {
     }
   });
 });
+
+// Spec 072 T7 (SC 9). "Discuss" is the operator's way to ask the curator to
+// re-think a proposal — which it cannot do without seeing the memories the
+// proposal REPLACES. Grounding read only `guessed_target_id`, an intake key
+// that grooming proposals never set, so exactly the merge/update proposals most
+// likely to be discussed were grounded without their sources.
+function seedProposalWithSources(
+  dataDir: string,
+  stubUrl: string,
+): { proposalId: string; sourceBodies: string[] } {
+  const store = createLibrarianStore({ dataDir, secretKey: SECRET_KEY });
+  const provider = addProvider(store, {
+    name: "stub",
+    endpoint: stubUrl,
+    token: "dummy-stub-token",
+  });
+  writeConsumerConfig(store, "grooming", { providerId: provider.id, model: "gpt-x" });
+
+  const sourceBodies = [
+    "Deploys are frozen on Fridays after 3pm.",
+    "Release trains leave on Tuesday mornings.",
+  ];
+  const sources = sourceBodies.map(
+    (body, i) =>
+      (
+        store.createMemory({
+          agent_id: "agent-a",
+          title: `Release policy ${i + 1}`,
+          body,
+        }) as unknown as { memory: { id: string } }
+      ).memory.id,
+  );
+
+  const proposal = store.createMemory(
+    {
+      agent_id: "system-memory-curator",
+      title: "Release policy",
+      body: "Consolidated release policy.",
+    },
+    {
+      requires_approval: true,
+      curator_note: {
+        source: "grooming",
+        proposed_action: "merge",
+        rationale: "two halves of one policy",
+        supersedes: sources,
+      },
+    },
+  ) as unknown as { memory: { id: string } };
+
+  store.close();
+  return { proposalId: proposal.memory.id, sourceBodies };
+}
+
+describe("grooming.chat grounds a proposal on what it replaces (spec 072 SC 9)", () => {
+  let dataDir = "";
+  beforeEach(() => {
+    dataDir = makeTempDir();
+  });
+  afterEach(() => {
+    cleanupTempDir(dataDir);
+  });
+
+  it("puts the superseded sources' current text in front of the model", async () => {
+    const stub = await startStubLlm([JSON.stringify({ kind: "message", text: "Looks right." })]);
+    const { proposalId, sourceBodies } = seedProposalWithSources(dataDir, stub.url);
+
+    const server = await startHttpServer({ dataDir, secretKey: SECRET_KEY_HEX });
+    try {
+      await trpcPost<ChatResult>(server, "grooming.chat", {
+        messages: [{ role: "user", content: "is this merge still right?" }],
+        memoryId: proposalId,
+      });
+
+      const prompt = stub.prompts.join("\n");
+      for (const body of sourceBodies) {
+        expect(prompt).toContain(body);
+      }
+    } finally {
+      await server.stop();
+      await stub.stop();
+    }
+  });
+});

--- a/packages/mcp-server/tests/trpc/proposal-drift.test.ts
+++ b/packages/mcp-server/tests/trpc/proposal-drift.test.ts
@@ -1,0 +1,246 @@
+// Proposal drift over the wire — spec 072 T4/T5 (SC 5, SC 6).
+//
+// End-to-end through the real HTTP bin: a proposal records digests of the
+// memories it supersedes when drafted; if one of those memories changes while
+// the proposal waits in the queue, review says so and approve REFUSES.
+//
+// D3: hard block, no override. Rejecting is the only exit, and the refusal has
+// to say why that costs nothing — the curator re-reads the memory on its next
+// grooming run and may well propose a similar change against the new version.
+// Without that sentence the operator reads a refusal as losing the curator's
+// work and goes looking for a way around it.
+
+import { createLibrarianStore, memoryContentDigest } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+import { cleanupTempDir, makeTempDir, startHttpServer } from "../../../../test/helpers.js";
+
+interface MemoryRow {
+  id: string;
+  title: string;
+  body: string;
+  status: string;
+}
+
+interface SourceDrift {
+  id: string;
+  title: string | null;
+  drifted: boolean;
+}
+
+interface ReviewRow {
+  proposal: MemoryRow;
+  action: string | null;
+  targets: MemoryRow[];
+  drift: { status: "clean" | "drifted" | "unknown"; sources: SourceDrift[] };
+}
+
+interface ServerHandle {
+  trpcUrl: string;
+  token: string;
+  stop: () => Promise<void>;
+}
+
+interface TrpcOk<T> {
+  result: { data: T };
+}
+
+async function trpcGet<T>(server: ServerHandle, path: string): Promise<T> {
+  const response = await fetch(new URL(`${server.trpcUrl}/trpc/${path}`), {
+    headers: { authorization: `Bearer ${server.token}` },
+  });
+  const json = (await response.json()) as TrpcOk<T> | { error: unknown };
+  if (response.status >= 400 || "error" in json) {
+    throw new Error(`trpc GET ${path} failed: ${JSON.stringify(json)}`);
+  }
+  return (json as TrpcOk<T>).result.data;
+}
+
+/** POST that returns the raw envelope, so a test can assert on the error. */
+async function trpcPostRaw(
+  server: ServerHandle,
+  path: string,
+  input: unknown,
+): Promise<{ status: number; body: string }> {
+  const response = await fetch(`${server.trpcUrl}/trpc/${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: `Bearer ${server.token}` },
+    body: JSON.stringify(input),
+  });
+  return { status: response.status, body: await response.text() };
+}
+
+function seedMemory(dataDir: string, title: string, body: string): MemoryRow {
+  const store = createLibrarianStore({ dataDir });
+  try {
+    return store.createMemory({ agent_id: "bede", title, body }).memory as MemoryRow;
+  } finally {
+    store.close();
+  }
+}
+
+/** A grooming-style proposal superseding `sources`, digested as they are NOW. */
+function seedProposal(dataDir: string, sources: MemoryRow[], stampDigests = true): MemoryRow {
+  const store = createLibrarianStore({ dataDir });
+  try {
+    const curatorNote: Record<string, unknown> = {
+      proposed_action: "update",
+      source: "grooming",
+      rationale: "tightened the wording",
+      supersedes: sources.map((s) => s.id),
+    };
+    if (stampDigests) {
+      curatorNote.source_digests = Object.fromEntries(
+        sources.map((s) => [s.id, memoryContentDigest(s)]),
+      );
+    }
+    return store.createMemory(
+      { agent_id: "scribe", title: sources[0]!.title, body: "the curator's replacement text" },
+      { requires_approval: true, curator_note: curatorNote },
+    ).memory as MemoryRow;
+  } finally {
+    store.close();
+  }
+}
+
+function editMemory(dataDir: string, id: string, body: string): void {
+  const store = createLibrarianStore({ dataDir });
+  try {
+    store.updateMemory(id, { body });
+  } finally {
+    store.close();
+  }
+}
+
+function statusOf(dataDir: string, id: string): string | undefined {
+  const store = createLibrarianStore({ dataDir });
+  try {
+    return store.getMemory(id)?.status;
+  } finally {
+    store.close();
+  }
+}
+
+describe("proposal drift on the review row (spec 072 SC 5)", () => {
+  it("reports clean while the source is untouched", async () => {
+    const dataDir = makeTempDir();
+    const target = seedMemory(dataDir, "Deploy policy", "never deploy on a Friday");
+    seedProposal(dataDir, [target]);
+    const server = await startHttpServer({ dataDir });
+    try {
+      const [row] = await trpcGet<ReviewRow[]>(server, "memories.proposalsForReview");
+      expect(row!.drift.status).toBe("clean");
+      expect(row!.drift.sources).toEqual([
+        { id: target.id, title: "Deploy policy", drifted: false },
+      ]);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("reports drifted once the source is edited", async () => {
+    const dataDir = makeTempDir();
+    const target = seedMemory(dataDir, "Deploy policy", "never deploy on a Friday");
+    seedProposal(dataDir, [target]);
+    editMemory(dataDir, target.id, "never deploy after 3pm on a Friday");
+    const server = await startHttpServer({ dataDir });
+    try {
+      const [row] = await trpcGet<ReviewRow[]>(server, "memories.proposalsForReview");
+      expect(row!.drift.status).toBe("drifted");
+      expect(row!.drift.sources[0]!.drifted).toBe(true);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("reports unknown for a proposal drafted before digests existed", async () => {
+    const dataDir = makeTempDir();
+    const target = seedMemory(dataDir, "Deploy policy", "never deploy on a Friday");
+    seedProposal(dataDir, [target], false);
+    const server = await startHttpServer({ dataDir });
+    try {
+      const [row] = await trpcGet<ReviewRow[]>(server, "memories.proposalsForReview");
+      expect(row!.drift.status).toBe("unknown");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+});
+
+describe("approve refuses a drifted proposal (spec 072 SC 6)", () => {
+  it("refuses, names the changed memory, and promises the curator will re-read it", async () => {
+    const dataDir = makeTempDir();
+    const target = seedMemory(dataDir, "Deploy policy", "never deploy on a Friday");
+    const proposal = seedProposal(dataDir, [target]);
+    editMemory(dataDir, target.id, "never deploy after 3pm on a Friday");
+    const server = await startHttpServer({ dataDir });
+    try {
+      const refusal = await trpcPostRaw(server, "memories.approve", { id: proposal.id });
+
+      expect(refusal.status).toBeGreaterThanOrEqual(400);
+      expect(refusal.body).toContain("CONFLICT");
+      // Names what moved, so the operator knows which edit is at stake.
+      expect(refusal.body).toContain("Deploy policy");
+      // The reassurance that makes a hard block acceptable (D3).
+      expect(refusal.body).toMatch(/grooming run/i);
+
+      // Nothing happened: the proposal is still open and the source still live.
+      expect(statusOf(dataDir, proposal.id)).toBe("proposed");
+      expect(statusOf(dataDir, target.id)).toBe("active");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("still approves a clean proposal", async () => {
+    const dataDir = makeTempDir();
+    const target = seedMemory(dataDir, "Deploy policy", "never deploy on a Friday");
+    const proposal = seedProposal(dataDir, [target]);
+    const server = await startHttpServer({ dataDir });
+    try {
+      const result = await trpcPostRaw(server, "memories.approve", { id: proposal.id });
+      expect(result.status).toBeLessThan(400);
+      expect(statusOf(dataDir, proposal.id)).toBe("active");
+      expect(statusOf(dataDir, target.id)).toBe("archived");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("does not block a legacy proposal that carries no digests", async () => {
+    const dataDir = makeTempDir();
+    const target = seedMemory(dataDir, "Deploy policy", "never deploy on a Friday");
+    const proposal = seedProposal(dataDir, [target], false);
+    editMemory(dataDir, target.id, "edited since — but nothing recorded the old text");
+    const server = await startHttpServer({ dataDir });
+    try {
+      const result = await trpcPostRaw(server, "memories.approve", { id: proposal.id });
+      expect(result.status).toBeLessThan(400);
+      expect(statusOf(dataDir, proposal.id)).toBe("active");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("does not block rejecting a drifted proposal — reject is the way out", async () => {
+    const dataDir = makeTempDir();
+    const target = seedMemory(dataDir, "Deploy policy", "never deploy on a Friday");
+    const proposal = seedProposal(dataDir, [target]);
+    editMemory(dataDir, target.id, "never deploy after 3pm on a Friday");
+    const server = await startHttpServer({ dataDir });
+    try {
+      const result = await trpcPostRaw(server, "memories.reject", { id: proposal.id });
+      expect(result.status).toBeLessThan(400);
+      expect(statusOf(dataDir, proposal.id)).toBe("archived");
+      expect(statusOf(dataDir, target.id)).toBe("active");
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+});


### PR DESCRIPTION
Closes the last open item in the vault TODO: *"If grooming runs before a proposal is reviewed, a duplicate / similar proposal gets made… Does approving both corrupt the memory?"*

Traced 24/07/2026 — it does. This is the sequel to spec 058, which made a *single* approval correct (archive what you replace) and left **concurrency between proposals** unhandled. Spec: `Work/The Librarian/specs/072-proposal-staleness-and-dedup.md`.

## The three defects, all silent

**1. Divergence on double-approve.** Two open proposals could each supersede memory M. Approve both: the second `archiveMemory(M)` no-ops (it's idempotent, correctly), so both activate and you end up with two live memories each claiming to replace M. Nothing warned.

**2. Drift overwritten without a word.** A proposal recorded *nothing* about what it superseded — no version, hash, or revision anywhere. Edit M by hand, approve a proposal drafted before your edit, and M is archived as-is: your edit leaves the active corpus, surviving only in git.

**3. The queue piles up.** No dedup on the grooming path. Worse, the input hash counted pending proposals, so *filing* a proposal made the next sweep look novel — the mechanism meant to prevent repeat work guaranteed it.

## What changed

- **T1 — cascade.** Approving an update/supersede/merge withdraws every other open proposal whose sources it just archived, via the existing `resolveProposal` seam (archived with `resolution: superseded_by_approval:<id>`, never deleted). Keyed on what was **archived**, not what was approved — which is exactly what keeps a split's sibling replacements alive, since a split archives nothing.
- **T2 — suppression.** Grooming skips an operation identical to one already pending (same action, same source set, order-independent) and records an audited skip. Deliberately tight: a pending `update{A}` must not block a `merge{A,B}`.
- **T2b — proposals are evidence, not a trigger.** Dropped from the skip hash. They still reach the prompt; they no longer cost an LLM call re-deriving what was just filed.
- **T3/T4/T5 — drift.** Proposals stamp a content digest per superseded source at draft time; review recomputes and reports `clean` / `drifted` / `unknown`; approve refuses on `drifted`. A digest, not a timestamp — every persist bumps `updated_at`, so a timestamp check would cry wolf.
- **T6 — the card** states which memory moved, disables every approve path, and leaves Reject/Discuss live.
- **T7 — Discuss** now grounds on the memories a proposal *replaces* (it read an intake-only key grooming never sets, so merges reached the model without their sources).

## Two decisions worth reviewing

**No override on the drift refusal** (spec §7 Q1, Jim's call). Reject is the only exit. An override that exists is one that gets clicked through, and habituation is what makes a safety gate worthless. That is only acceptable because the refusal *says* rejecting costs nothing — the curator re-reads the memory next sweep. T2b is what makes that promise true: editing a source changes the active set, so the sweep runs.

**`unknown` never blocks** (D2). Proposals drafted before this release have nothing to compare against; treating them as drifted would make every currently-queued proposal unapprovable on upgrade. They drain naturally.

## Verification

Full gate green: build, typecheck, lint, format, `check:release`, `check:docs`, and **3,343 tests** across all packages (core 1591 · mcp-server 572 · dashboard 568 · installer-cli 332 · pi 136 · cli 74 · intake-eval 41 · chromium-extension 29).

**Not run / pre-existing:** three Playwright specs in `e2e/proposals.spec.ts` fail — the page never renders. **Verified identical on `main`**, so pre-existing and out of scope here; flagged for separate triage rather than folded into this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tNsUuUqDxcKkd1dmrRYVr