### PR TITLE
fix: server auto-update fires in the wrong host context — runs as the enabling user against the baked deploy dir (spec 074)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,44 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.17.1] — 2026-07-26
+
+### Fixed
+
+- **Server auto-update actually runs now.** The host timer installed by
+  `librarian server autoupdate enable` ran as root, so it looked for the
+  deploy in root's home — on any server set up as a normal user, every hourly
+  fire failed with "No deploy-state found", silently (the wrapper is fail-soft
+  by design and the failure only appeared in the root-readable system
+  journal, while `autoupdate status` reported everything healthy). The
+  generated unit now runs as the enabling user with the deploy dir pinned
+  explicitly (`--dir`), which also fixes git's dubious-ownership refusal and
+  uses that user's docker access. **Existing installs: upgrade the CLI and
+  re-run `librarian server autoupdate enable` once, as the user who ran
+  `server up`** — re-running rewrites the units in place. `enable` now also
+  refuses up front, with an explanation, when it can't find the deploy state
+  where it's looking — the silent 3 a.m. failure is now a loud enable-time
+  error.
+- **A manual `server update` and an auto-update fire can no longer collide.**
+  The exclusive update lock was only taken by the timer wrapper, despite its
+  own comment claiming otherwise — a manual update could interleave
+  stop/rm/run with a fire and leave a window with no running container. The
+  lock now lives inside `server update` itself: one acquisition point covers
+  every caller, a held lock is a clear "another update is already in
+  progress" message, and the lock is released on success and failure alike.
+- **Auto-update outcomes no longer appear twice in the journal.** The wrapper
+  logged each outcome to stderr while the CLI printed the same line to
+  stdout; systemd journals both streams. One line per fire now.
+
+### Docs
+
+- The Settings page no longer claims the dashboard toggle alone keeps the
+  server updated (the host timer is what acts) and no longer offers a
+  "monthly" cadence that never existed (daily|weekly). The self-host guide
+  gains an **Automatic updates** walkthrough: enabling as the right user,
+  status/disable/uninstall, the rollback guarantee, and the
+  `sudo journalctl` diagnostic for "auto-update seems to do nothing".
+
 ## [1.17.0] — 2026-07-25
 
 ### Added
@@ -4208,6 +4246,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.17.1]: https://github.com/JimJafar/the-librarian/compare/v1.17.0...v1.17.1
 [1.17.0]: https://github.com/JimJafar/the-librarian/compare/v1.16.1...v1.17.0
 [1.16.1]: https://github.com/JimJafar/the-librarian/compare/v1.16.0...v1.16.1
 [1.16.0]: https://github.com/JimJafar/the-librarian/compare/v1.15.0...v1.16.0

--- a/apps/docs/src/content/docs/dashboard/settings.md
+++ b/apps/docs/src/content/docs/dashboard/settings.md
@@ -83,6 +83,17 @@ in [Backups & restore](/guides/backups-restore/).
 ## Dashboard
 
 **Settings → Dashboard** holds instance-level options — currently **server
-auto-update**. Turn it on, choose a cadence (daily, weekly, or monthly), and the
-server keeps itself up to date; the page also shows the current version, the latest
-available, and when it last ran.
+auto-update**. The toggle and cadence (daily or weekly) are *settings*: they tell
+the host's update timer what to do, but the dashboard cannot perform an update
+itself — a server can't recreate its own container from inside it. Auto-update
+actually runs once the host timer is installed, on the machine running the
+server, as the user who ran `server up`:
+
+```sh
+librarian server autoupdate enable
+```
+
+The page also shows the current version, the latest available, and when
+auto-update last ran. The full walkthrough — including what to check when
+auto-update seems to do nothing — is in
+[Automatic updates](/deploy-and-operate/self-host/#automatic-updates).

--- a/apps/docs/src/content/docs/deploy-and-operate/self-host.md
+++ b/apps/docs/src/content/docs/deploy-and-operate/self-host.md
@@ -214,6 +214,53 @@ burn flag refuses claims until the operator removes it.
 - **`--ref <tag|main>`** pins `up`/`update` to a specific release or to `main`
   (default: the latest release).
 
+### Automatic updates
+
+`server update` is manual. To have the server keep itself current, install the
+host auto-update timer — **on the machine running the server, as the user who
+ran `server up`**:
+
+```sh
+librarian server autoupdate enable                   # daily due-check (default)
+librarian server autoupdate enable --cadence weekly
+```
+
+This installs a systemd timer (or an hourly cron line where systemd is absent)
+that fires hourly and performs a `server update` when the cadence says one is
+due. The timer runs as the enabling user against their deploy dir — which is
+why the user matters: `enable` refuses, with an explanation, if it can't find
+the deploy state where it's looking.
+
+The dashboard's [Settings → Dashboard](/dashboard/settings/#dashboard) page
+holds the enable toggle and the cadence as *settings*; the host timer is what
+acts on them. Flipping the toggle without installing the timer updates nothing
+— the dashboard can't recreate the server's own container from inside it.
+
+- **`autoupdate status`** — is the timer installed, is the setting on, the
+  cadence, the last auto-update, and the up-to-date badge.
+- **`autoupdate disable`** — flips the setting off; the timer stays installed
+  and the next fire no-ops.
+- **`autoupdate uninstall`** — removes the timer/cron entirely.
+
+A failed auto-update (an unreachable server, a failed health check) leaves the
+previous container running and retries at the next fire — the same rollback
+guarantees as a manual `server update`.
+
+:::note[If auto-update seems to do nothing]
+The timer logs one line per hourly fire to the **system** journal, which needs
+sudo to read:
+
+```sh
+sudo journalctl -u the-librarian-autoupdate.service -n 20 --no-pager
+```
+
+That line says exactly what happened: not due yet, skipped, updated, or why an
+update failed. If the timer was installed by a CLI older than v1.17.1, it ran
+as root against root's home and every fire failed with "No deploy-state found"
+— upgrade the CLI and re-run `librarian server autoupdate enable` as the user
+who ran `server up`.
+:::
+
 ### Start on boot (Linux)
 
 `librarian server enable-boot` (or `server up --enable-boot`) installs a systemd unit

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/installer-cli/src/server/autoupdate.ts
+++ b/packages/installer-cli/src/server/autoupdate.ts
@@ -126,10 +126,12 @@ export interface EnableOptions extends AutoUpdateOptions {
 
 export interface RunOptions extends AutoUpdateOptions {
   /**
-   * Sink for the wrapper's one-line log entries (the timer's journal). Defaults
-   * to a `process.stderr` writer; tests inject a recorder. Every wrapper outcome
-   * (skip / update / failure) emits exactly one line here — and the wrapper never
-   * throws, so the timer's unit always exits 0.
+   * Sink for the wrapper's one-line log entries. Defaults to SILENT (spec 074
+   * SC8): the runtime prints the wrapper's returned output to stdout, and
+   * systemd/cron send stdout and stderr to the same journal/mail — so a stderr
+   * default wrote every outcome twice. Tests inject a recorder. Every wrapper
+   * outcome (skip / update / failure) emits exactly one line here — and the
+   * wrapper never throws, so the timer's unit always exits 0.
    */
   log?: ((line: string) => void) | undefined;
   /** Health-wait bound for the inner `server update` (small in tests). */
@@ -832,7 +834,10 @@ async function isTimerInstalled(): Promise<boolean> {
  * (never-run → due).
  */
 export async function runAutoUpdate(options: RunOptions = {}): Promise<AutoUpdateResult> {
-  const log = options.log ?? ((line: string): void => void process.stderr.write(`${line}\n`));
+  // Default sink is SILENT (spec 074 SC8): the outcome reaches the journal once,
+  // via the runtime's stdout print of the returned output. A stderr default
+  // duplicated every line (systemd journals both streams).
+  const log = options.log ?? ((): void => undefined);
   const now = options.now ?? new Date();
 
   try {
@@ -893,7 +898,16 @@ export async function runAutoUpdate(options: RunOptions = {}): Promise<AutoUpdat
         error instanceof UpdateError || error instanceof Error
           ? redactSecrets(error.message)
           : String(error);
-      const line = `autoupdate: update failed — left the previous server running, did NOT stamp last_run_at (will retry next fire). ${firstLine(detail)}`;
+      // SPEC 074 SC6: a no-deploy-state failure from the TIMER means the unit
+      // predates 074 (it ran as root against root's home — the silent hourly
+      // failure this spec killed). Anyone seeing this line has the broken unit;
+      // teach the migration inline.
+      const migrationHint = /No deploy-state found/.test(detail)
+        ? " If this timer was installed by an older CLI (it ran as root against root's home), " +
+          "upgrade the CLI and re-run `librarian server autoupdate enable` as the user who ran " +
+          "`server up`."
+        : "";
+      const line = `autoupdate: update failed — left the previous server running, did NOT stamp last_run_at (will retry next fire). ${firstLine(detail)}${migrationHint}`;
       log(line);
       return { output: line };
     }

--- a/packages/installer-cli/src/server/autoupdate.ts
+++ b/packages/installer-cli/src/server/autoupdate.ts
@@ -36,18 +36,7 @@
 // same seam boot.ts uses), so tests assert the exact systemctl/crontab/docker
 // argv without a real systemd, cron, or docker.
 
-import {
-  closeSync,
-  mkdirSync,
-  mkdtempSync,
-  openSync,
-  readFileSync,
-  rmSync,
-  statSync,
-  unlinkSync,
-  writeFileSync,
-  writeSync,
-} from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir, userInfo } from "node:os";
 import path from "node:path";
 import { librarianDir } from "../paths.js";
@@ -56,6 +45,7 @@ import { run, which } from "./docker.js";
 import { redactSecrets } from "./redact.js";
 import { serverStatus } from "./status.js";
 import { CONTAINER_NAME } from "./up.js";
+import { UpdateInProgressError } from "./update-lock.js";
 import { runUpdate, UpdateError } from "./update.js";
 
 // Cadence constants are defined LOCALLY here, NOT imported from `@librarian/core`, so
@@ -821,109 +811,6 @@ async function isTimerInstalled(): Promise<boolean> {
   return (await readCrontab()).some((l) => l.includes(CRON_MARKER));
 }
 
-// --- the exclusive host lock (serialize concurrent updates, FIX C1) ------
-
-/**
- * After this many milliseconds an unrefreshed lockfile is treated as STALE and
- * reclaimed — a crashed/killed update (the holder never released its lock) must
- * not wedge auto-update forever. `server update` rebuilds + recreates, so a wide
- * margin (1h) is safe: a real in-flight update is far shorter, and a lock older
- * than this is from a dead process, not a slow one.
- */
-const LOCK_STALE_MS = 60 * 60 * 1000;
-
-/** The fixed lock path: `~/.librarian/server/.autoupdate.lock` (no root needed). */
-export function autoUpdateLockPath(options: {
-  home?: string | undefined;
-  dir?: string | undefined;
-}): string {
-  const dir = options.dir ?? path.join(librarianDir(options.home), "server");
-  return path.join(dir, ".autoupdate.lock");
-}
-
-/** A held lock — call `release()` exactly once when the critical section ends. */
-interface HeldLock {
-  release(): void;
-}
-
-/**
- * Acquire an EXCLUSIVE host lock so two timer fires (or a fire overlapping a
- * manual `librarian server update`) can never both `docker stop`/`rm`/`run` the
- * same container — a window with NO running container would take the server down
- * (spec SC7). Implemented as an `O_CREAT|O_EXCL` lockfile (atomic on POSIX, no
- * root, no external `flock`): the create succeeds for exactly one caller.
- *
- * Returns the held lock on success, or `null` when another update already holds
- * it (the caller then SKIPS without stamping). A STALE lock (older than
- * {@link LOCK_STALE_MS} — a crashed holder) is reclaimed once, then retried.
- *
- * FAIL-SOFT: any lock-subsystem error (a read-only FS, a permissions problem)
- * throws here and is caught by `runAutoUpdate`'s outer guard, which logs + skips
- * — a lock problem must never crash the timer or leave the server mid-recreate.
- */
-function acquireUpdateLock(lockPath: string): HeldLock | null {
-  // Best-effort: ensure the directory exists (the deploy dir normally does).
-  mkdirSync(path.dirname(lockPath), { recursive: true });
-
-  const tryCreate = (): HeldLock | null => {
-    let fd: number;
-    try {
-      // O_CREAT|O_EXCL|O_WRONLY → fails with EEXIST if the lockfile already exists.
-      fd = openSync(lockPath, "wx");
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "EEXIST") return null;
-      throw error; // a real FS error → fail-soft up in runAutoUpdate
-    }
-    // Record our pid + acquisition time (debuggable; carries NO secret).
-    try {
-      writeSync(fd, `${process.pid} ${Date.now()}\n`);
-    } finally {
-      closeSync(fd);
-    }
-    let released = false;
-    return {
-      release(): void {
-        if (released) return;
-        released = true;
-        try {
-          unlinkSync(lockPath);
-        } catch {
-          // Already gone (e.g. reclaimed as stale elsewhere) — nothing to do.
-        }
-      },
-    };
-  };
-
-  const held = tryCreate();
-  if (held) return held;
-
-  // The lock exists. If it's STALE (a crashed holder), reclaim it ONCE and retry.
-  if (isLockStale(lockPath)) {
-    try {
-      unlinkSync(lockPath);
-    } catch {
-      // Someone else reclaimed it first — fall through to a single retry anyway.
-    }
-    return tryCreate(); // null again ⇒ a live holder won the race → skip
-  }
-  return null; // a live update is in progress → skip
-}
-
-/** True iff the lockfile is older than {@link LOCK_STALE_MS} (a crashed holder). */
-function isLockStale(lockPath: string): boolean {
-  try {
-    // Prefer the timestamp written into the file; fall back to mtime.
-    const written = Number.parseInt(
-      readFileSync(lockPath, "utf8").trim().split(/\s+/)[1] ?? "",
-      10,
-    );
-    const acquiredAt = Number.isFinite(written) ? written : statSync(lockPath).mtimeMs;
-    return Date.now() - acquiredAt >= LOCK_STALE_MS;
-  } catch {
-    return false; // can't read it → don't reclaim (conservative: skip, don't steal)
-  }
-}
-
 // --- the `--run` wrapper (what the timer calls) --------------------------
 
 /**
@@ -969,17 +856,9 @@ export async function runAutoUpdate(options: RunOptions = {}): Promise<AutoUpdat
       return { output: line };
     }
 
-    // Due + enabled: take the EXCLUSIVE host lock before the actual update so two
-    // timer fires (or a fire overlapping a manual `server update`) can never both
-    // stop/rm/run the same container — a window with NO running container would
-    // take the server down (spec SC7). If another update already holds the lock,
-    // SKIP cleanly (do NOT stamp last_run_at — the in-flight update will stamp).
-    const lock = acquireUpdateLock(autoUpdateLockPath(options));
-    if (!lock) {
-      const line = "autoupdate: another update in progress — skipping.";
-      log(line);
-      return { output: line };
-    }
+    // Due + enabled: run the update. `runUpdate` itself holds the exclusive host
+    // lock (spec 074 SC5 — one acquisition point covers manual runs and timer
+    // fires alike); a lock already held surfaces as the typed refusal below.
     try {
       const result = await runUpdate({
         ...(options.home !== undefined ? { home: options.home } : {}),
@@ -1001,6 +880,13 @@ export async function runAutoUpdate(options: RunOptions = {}): Promise<AutoUpdat
       // The inner update's own output (carries an at-most-once fresh token note).
       return { output: `${line}\n${redactSecrets(result.output)}` };
     } catch (error) {
+      // Another update (a manual run, an overlapping fire) holds the lock: SKIP
+      // cleanly and do NOT stamp last_run_at — the in-flight holder stamps.
+      if (error instanceof UpdateInProgressError) {
+        const line = "autoupdate: another update in progress — skipping.";
+        log(line);
+        return { output: line };
+      }
       // The update failed — its own health-check rollback left the prior container
       // running. Do NOT stamp last_run_at (so the next fire retries). Log + exit 0.
       const detail =
@@ -1010,10 +896,6 @@ export async function runAutoUpdate(options: RunOptions = {}): Promise<AutoUpdat
       const line = `autoupdate: update failed — left the previous server running, did NOT stamp last_run_at (will retry next fire). ${firstLine(detail)}`;
       log(line);
       return { output: line };
-    } finally {
-      // Always release — a held lock that outlives the update would wedge the next
-      // fire until the stale-reclaim window elapses.
-      lock.release();
     }
   } catch (error) {
     // Belt-and-braces: ANY unexpected throw is swallowed so the timer never fails.

--- a/packages/installer-cli/src/server/autoupdate.ts
+++ b/packages/installer-cli/src/server/autoupdate.ts
@@ -48,9 +48,10 @@ import {
   writeFileSync,
   writeSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
+import { tmpdir, userInfo } from "node:os";
 import path from "node:path";
 import { librarianDir } from "../paths.js";
+import { readDeployState } from "./deploy-state.js";
 import { run, which } from "./docker.js";
 import { redactSecrets } from "./redact.js";
 import { serverStatus } from "./status.js";
@@ -151,24 +152,29 @@ export interface RunOptions extends AutoUpdateOptions {
 
 // --- pure unit generators (unit-tested directly) -------------------------
 
-/** Inputs to the pure service generator (only the librarian path — NEVER a secret). */
+/** Inputs to the pure service generator (a path, a username, a dir — NEVER a secret). */
 export interface ServiceUnitInput {
   /** Absolute path to the `librarian` binary the oneshot runs with `server autoupdate --run`. */
   librarianPath: string;
+  /** The host user the oneshot runs as — the ENABLING user, who owns the deploy (spec 074). */
+  user: string;
+  /** The deploy dir baked into ExecStart as `--dir`, resolved at enable time (spec 074). */
+  deployDir: string;
 }
 
 /**
  * Generate the oneshot service unit text. PURE + unit-tested. Contains NO secret —
  * it runs `librarian server autoupdate --run`, which reads the settings from the
  * running container itself (via `docker exec`), so nothing sensitive is written
- * into this world-readable unit file. `Type=oneshot` because the wrapper runs to
- * completion each fire (it is the timer's job to schedule, not the service's).
+ * into this world-readable unit file (a username and a directory path are not
+ * secrets). `Type=oneshot` because the wrapper runs to completion each fire (it
+ * is the timer's job to schedule, not the service's).
  */
 export function generateServiceUnit(input: ServiceUnitInput): string {
-  const { librarianPath } = input;
-  // The path is validated whitespace/metacharacter-free before it reaches here
-  // (see `assertSafeLibrarianPath` in `enableAutoUpdate`), so a bare (unquoted)
-  // `ExecStart` token is safe — systemd splits ExecStart on whitespace.
+  const { librarianPath, user, deployDir } = input;
+  // Every interpolated token is validated whitespace/metacharacter-free before it
+  // reaches here (see `assertSafeSchedulerToken` in `enableAutoUpdate`), so bare
+  // (unquoted) tokens are safe — systemd splits ExecStart on whitespace.
   return [
     "[Unit]",
     "Description=The Librarian — auto-update check (host-scheduled)",
@@ -177,19 +183,23 @@ export function generateServiceUnit(input: ServiceUnitInput): string {
     "",
     "[Service]",
     "Type=oneshot",
-    // ROOT is required (not a smell): `server update` drives the host docker
-    // daemon (build / stop / rm / run) and writes a 0600 deploy env-file under
-    // /etc — neither is reachable from an unprivileged unit. We do NOT downgrade
-    // the user; instead we add the defense-in-depth knob below.
-    // NoNewPrivileges: even running as root, forbid this oneshot from gaining
-    // ANY new privileges via setuid/setgid/capabilities on the binaries it execs
-    // (docker/git) — an auto-executing root unit should grant no more than it needs.
+    // NOT root (spec 074): a system unit defaults to root, whose home holds no
+    // deploy-state — every fire failed with "No deploy-state found" while
+    // `autoupdate status` looked healthy. The ENABLING user is the one context
+    // where everything resolves: their `~/.librarian/server` is the deploy dir,
+    // they own the git clone (root git would refuse the dubious-ownership
+    // check), and they have docker access by construction (they ran `server up`).
+    `User=${user}`,
+    // NoNewPrivileges: forbid this oneshot from gaining ANY new privileges via
+    // setuid/setgid/capabilities on the binaries it execs (docker/git) — an
+    // auto-executing unit should grant no more than it needs.
     "NoNewPrivileges=true",
     // The wrapper reads the auto-update settings from the running container and,
-    // if due, performs `server update`. It carries NO secret on this argv: the
-    // settings + the container's credentials live in the container, reached via
-    // `docker exec` at run time, not baked into this file.
-    `ExecStart=${librarianPath} server autoupdate --run`,
+    // if due, performs `server update`. The deploy dir is pinned explicitly so
+    // the fire never depends on whose home the unit happens to resolve. It
+    // carries NO secret on this argv: the settings + the container's credentials
+    // live in the container, reached via `docker exec` at run time.
+    `ExecStart=${librarianPath} server autoupdate --run --dir ${deployDir}`,
     "",
   ].join("\n");
 }
@@ -225,12 +235,14 @@ export function generateTimerUnit(): string {
 /**
  * The crontab line for the cron fallback (systemd absent). Fires the wrapper at
  * minute 17 of every hour (off the top-of-hour to spread load), tagged with
- * {@link CRON_MARKER} so it can be found/replaced/removed idempotently. NO secret
- * — same reasoning as the systemd unit (the wrapper reads settings from the
- * container at run time).
+ * {@link CRON_MARKER} so it can be found/replaced/removed idempotently. Cron
+ * already fires as the enabling user (their crontab), but the deploy dir is
+ * baked explicitly anyway (spec 074 SC2) so a custom `--dir` passed to `enable`
+ * is honoured here too. NO secret — same reasoning as the systemd unit (the
+ * wrapper reads settings from the container at run time).
  */
-export function cronLine(librarianPath: string): string {
-  return `17 * * * * ${librarianPath} server autoupdate --run ${CRON_MARKER}`;
+export function cronLine(librarianPath: string, deployDir: string): string {
+  return `17 * * * * ${librarianPath} server autoupdate --run --dir ${deployDir} ${CRON_MARKER}`;
 }
 
 // --- librarian-path resolution -------------------------------------------
@@ -247,24 +259,23 @@ async function resolveLibrarianPath(): Promise<string> {
 }
 
 /**
- * Reject a `librarian` path that isn't safe to interpolate UNQUOTED into a systemd
- * `ExecStart` / a cron line (FIX I1). systemd splits `ExecStart` on whitespace and
- * cron passes the line to `/bin/sh`, so a path containing a space (e.g. an npm
+ * Reject a token that isn't safe to interpolate UNQUOTED into a systemd
+ * `ExecStart` / a cron line / a unit directive (FIX I1, extended by spec 074 to
+ * the deploy dir and the username). systemd splits `ExecStart` on whitespace and
+ * cron passes the line to `/bin/sh`, so a value containing a space (e.g. an npm
  * prefix under `/home/jane doe/`) or a shell metacharacter would silently break
- * the timer — or worse, inject. Rather than wrap quoting rules around two different
- * grammars, we REJECT at `enable` with a teaching error (the cleanest fix): the
- * resolved binary path must contain none of these characters. The operator then
- * symlinks/installs `librarian` to a clean path and re-runs.
+ * the timer — or worse, inject (a newline in a value could even smuggle a unit
+ * directive). Rather than wrap quoting rules around two different grammars, we
+ * REJECT at `enable` with a teaching error: the value must contain none of these
+ * characters. `remedy` tells the operator how to get a clean value.
  */
-function assertSafeLibrarianPath(librarianPath: string): void {
+function assertSafeSchedulerToken(value: string, label: string, remedy: string): void {
   // Whitespace OR any shell/systemd-significant metacharacter is rejected.
-  if (/\s/.test(librarianPath) || /["'`$\\;&|<>(){}*?!#~]/.test(librarianPath)) {
+  if (/\s/.test(value) || /["'`$\\;&|<>(){}*?!#~]/.test(value)) {
     throw new AutoUpdateError(
-      `The resolved \`librarian\` path is not safe to schedule unquoted:\n  ${librarianPath}\n\n` +
+      `The resolved ${label} is not safe to schedule unquoted:\n  ${value}\n\n` +
         "It contains whitespace or a shell/systemd metacharacter, which would break the " +
-        "systemd timer's ExecStart (or the cron line). Install or symlink `librarian` to a " +
-        "path with no spaces or special characters (e.g. `/usr/local/bin/librarian`) and " +
-        "re-run `librarian server autoupdate enable`.",
+        `systemd timer's ExecStart (or the cron line). ${remedy}`,
     );
   }
 }
@@ -451,9 +462,17 @@ function failIfNonZero(
  * server. On Linux with systemd: write the oneshot service + the .timer to
  * `/etc/systemd/system`, `daemon-reload`, then `enable --now` the TIMER (the
  * service is oneshot — only the timer is enabled). Idempotent: re-running rewrites
- * the SAME unit paths and re-enables, never duplicating. Where systemd is absent:
- * install an hourly cron line (idempotent via {@link CRON_MARKER}). On macOS: print
- * the deferred notice and skip cleanly.
+ * the SAME unit paths and re-enables, never duplicating — which is also the
+ * MIGRATION for units installed before spec 074 (they ran as root against root's
+ * home and failed every fire). Where systemd is absent: install an hourly cron
+ * line (idempotent via {@link CRON_MARKER}). On macOS: print the deferred notice
+ * and skip cleanly.
+ *
+ * SPEC 074: the fire context is resolved and VALIDATED here, at enable time —
+ * the unit runs as the enabling user against the deploy dir resolved from THEIR
+ * context (or an explicit `--dir`). No deploy-state at that dir is a hard
+ * teaching refusal: installing anyway would reproduce the silent hourly failure
+ * this spec exists to kill.
  *
  * The settings write (enabled=true + cadence) is best-effort: a down server is a
  * non-fatal hint (the timer is installed; the operator toggles from the dashboard
@@ -470,16 +489,54 @@ export async function enableAutoUpdate(options: EnableOptions = {}): Promise<Aut
   const cadence = resolveCadence(options.cadence);
 
   const librarianPath = await resolveLibrarianPath();
-  // Reject a path that isn't safe to interpolate UNQUOTED into the unit/cron line
-  // BEFORE touching the host (a bad path is a teaching error, not a broken timer).
-  assertSafeLibrarianPath(librarianPath);
+  // Reject any value that isn't safe to interpolate UNQUOTED into the unit/cron
+  // line BEFORE touching the host (a bad value is a teaching error, not a broken
+  // timer): the binary path, the deploy dir, and the username all ride unquoted.
+  assertSafeSchedulerToken(
+    librarianPath,
+    "`librarian` path",
+    "Install or symlink `librarian` to a path with no spaces or special characters " +
+      "(e.g. `/usr/local/bin/librarian`) and re-run `librarian server autoupdate enable`.",
+  );
+  const deployDir = options.dir ?? path.join(librarianDir(options.home), "server");
+  assertSafeSchedulerToken(
+    deployDir,
+    "deploy dir",
+    "Move the deploy dir to a path with no spaces or special characters and re-run " +
+      "`librarian server autoupdate enable --dir <path>`.",
+  );
+  const user = userInfo().username;
+  assertSafeSchedulerToken(
+    user,
+    "username",
+    "Run `librarian server autoupdate enable` as a user whose name has no special characters.",
+  );
+
+  // SPEC 074 SC3 — the hard gate. A timer installed against a dir with no
+  // deploy-state fails silently on every fire (fail-soft by design, root-only
+  // journal); refuse NOW, loudly, while a human is watching.
+  if (!readDeployState(deployDir)) {
+    const sudoUser = process.env.SUDO_USER;
+    throw new AutoUpdateError(
+      `No deploy-state found at ${deployDir} — the auto-update timer must run as the user ` +
+        "who ran `librarian server up` (it reads that user's deploy dir and git clone, with " +
+        "their docker access).\n" +
+        "Re-run `librarian server autoupdate enable` as that user" +
+        (sudoUser
+          ? ` — you appear to be under sudo, so likely as \`${sudoUser}\` without the leading sudo ` +
+            "(the command sudos where it needs to)"
+          : "") +
+        " — or pass `--dir <path>` to point at the deploy dir.",
+    );
+  }
+
   const lines: string[] = [];
 
   if (await hasSystemd()) {
     await installUnit(
       AUTOUPDATE_SERVICE_NAME,
       servicePath(),
-      generateServiceUnit({ librarianPath }),
+      generateServiceUnit({ librarianPath, user, deployDir }),
     );
     await installUnit(AUTOUPDATE_TIMER_NAME, timerPath(), generateTimerUnit());
     // daemon-reload BEFORE enable --now so systemd sees the (possibly rewritten)
@@ -488,12 +545,14 @@ export async function enableAutoUpdate(options: EnableOptions = {}): Promise<Aut
     await sudoSystemctl(["enable", "--now", AUTOUPDATE_TIMER_NAME]);
     lines.push(
       `Auto-update timer installed — ${AUTOUPDATE_TIMER_NAME} fires hourly and runs the due-check.`,
+      `  Runs as \`${user}\` against ${deployDir} (the deploy this user owns).`,
       `  Units: ${servicePath()} + ${timerPath()} (no secret in either file).`,
     );
   } else {
-    await installCron(librarianPath);
+    await installCron(librarianPath, deployDir);
     lines.push(
       "Auto-update cron entry installed — runs the due-check hourly (systemd not found).",
+      `  Runs as \`${user}\` against ${deployDir} (the deploy this user owns).`,
       `  Tagged \`${CRON_MARKER}\` in your crontab (remove with \`librarian server autoupdate uninstall\`).`,
     );
   }
@@ -647,7 +706,7 @@ async function readCrontab(): Promise<string[]> {
 }
 
 /** Install (or refresh) our hourly cron line idempotently — strip any prior marker line first. */
-async function installCron(librarianPath: string): Promise<void> {
+async function installCron(librarianPath: string, deployDir: string): Promise<void> {
   if ((await which("crontab")) === null) {
     throw new AutoUpdateError(
       "Neither systemd nor crontab was found, so there's no host scheduler to install the " +
@@ -656,7 +715,7 @@ async function installCron(librarianPath: string): Promise<void> {
     );
   }
   const kept = (await readCrontab()).filter((l) => !l.includes(CRON_MARKER));
-  const next = [...kept, cronLine(librarianPath)].join("\n") + "\n";
+  const next = [...kept, cronLine(librarianPath, deployDir)].join("\n") + "\n";
   await writeCrontab(next);
 }
 

--- a/packages/installer-cli/src/server/update-lock.ts
+++ b/packages/installer-cli/src/server/update-lock.ts
@@ -1,0 +1,141 @@
+// The exclusive host update lock (FIX C1, moved here by spec 074 SC5).
+//
+// Two updates interleaving `docker stop` / `rm` / `run` on the same container
+// leave a window with NO running container — the server would simply be down.
+// Before 074 only the auto-update TIMER wrapper took this lock, so a manual
+// `librarian server update` could still interleave with a timer fire (the lock's
+// own doc claimed otherwise). The lock now lives in `runUpdate` itself — ONE
+// acquisition point covering every caller — and this module exists so both
+// `update.ts` (acquires) and `autoupdate.ts` (catches the typed refusal) can
+// share it without a circular import.
+//
+// Implemented as an `O_CREAT|O_EXCL` lockfile (atomic on POSIX, no root, no
+// external `flock`): the create succeeds for exactly one caller. A STALE lock
+// (a crashed holder that never released) is reclaimed after {@link LOCK_STALE_MS}.
+
+import {
+  closeSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+  writeSync,
+} from "node:fs";
+import path from "node:path";
+import { librarianDir } from "../paths.js";
+
+/**
+ * After this many milliseconds an unrefreshed lockfile is treated as STALE and
+ * reclaimed — a crashed/killed update (the holder never released its lock) must
+ * not wedge updates forever. `server update` rebuilds + recreates, so a wide
+ * margin (1h) is safe: a real in-flight update is far shorter, and a lock older
+ * than this is from a dead process, not a slow one.
+ */
+const LOCK_STALE_MS = 60 * 60 * 1000;
+
+/** The fixed lock path: `<deployDir>/.autoupdate.lock` (no root needed). */
+export function updateLockPath(options: {
+  home?: string | undefined;
+  dir?: string | undefined;
+}): string {
+  const dir = options.dir ?? path.join(librarianDir(options.home), "server");
+  return path.join(dir, ".autoupdate.lock");
+}
+
+/**
+ * The typed refusal `runUpdate` throws when another update holds the lock. The
+ * manual CLI surfaces `.message` as a teaching line; the auto-update wrapper
+ * catches the TYPE and logs its skip line instead (without stamping — the
+ * in-flight holder stamps).
+ */
+export class UpdateInProgressError extends Error {
+  constructor(lockPath: string) {
+    super(
+      `Another update is already in progress (lock: ${lockPath}).\n` +
+        "A concurrent `librarian server update` or auto-update timer fire holds the exclusive " +
+        "update lock — wait for it to finish and re-run. If a previous update CRASHED, the " +
+        "lock is reclaimed automatically after 1 hour; remove the file yourself only if " +
+        "you're certain nothing is updating right now.",
+    );
+    this.name = "UpdateInProgressError";
+  }
+}
+
+/** A held lock — call `release()` exactly once when the critical section ends. */
+export interface HeldLock {
+  release(): void;
+}
+
+/**
+ * Acquire the EXCLUSIVE host update lock. Returns the held lock on success, or
+ * `null` when another update already holds it. A STALE lock (older than
+ * {@link LOCK_STALE_MS} — a crashed holder) is reclaimed once, then retried.
+ *
+ * Any lock-subsystem error (a read-only FS, a permissions problem) THROWS — the
+ * manual path surfaces it as an ordinary failure; the auto-update wrapper's
+ * outer fail-soft guard logs + skips (a lock problem must never crash the timer
+ * or leave the server mid-recreate).
+ */
+export function acquireUpdateLock(lockPath: string): HeldLock | null {
+  // Best-effort: ensure the directory exists (the deploy dir normally does).
+  mkdirSync(path.dirname(lockPath), { recursive: true });
+
+  const tryCreate = (): HeldLock | null => {
+    let fd: number;
+    try {
+      // O_CREAT|O_EXCL|O_WRONLY → fails with EEXIST if the lockfile already exists.
+      fd = openSync(lockPath, "wx");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") return null;
+      throw error; // a real FS error → the caller decides (fail vs fail-soft)
+    }
+    // Record our pid + acquisition time (debuggable; carries NO secret).
+    try {
+      writeSync(fd, `${process.pid} ${Date.now()}\n`);
+    } finally {
+      closeSync(fd);
+    }
+    let released = false;
+    return {
+      release(): void {
+        if (released) return;
+        released = true;
+        try {
+          unlinkSync(lockPath);
+        } catch {
+          // Already gone (e.g. reclaimed as stale elsewhere) — nothing to do.
+        }
+      },
+    };
+  };
+
+  const held = tryCreate();
+  if (held) return held;
+
+  // The lock exists. If it's STALE (a crashed holder), reclaim it ONCE and retry.
+  if (isLockStale(lockPath)) {
+    try {
+      unlinkSync(lockPath);
+    } catch {
+      // Someone else reclaimed it first — fall through to a single retry anyway.
+    }
+    return tryCreate(); // null again ⇒ a live holder won the race → skip
+  }
+  return null; // a live update is in progress → skip
+}
+
+/** True iff the lockfile is older than {@link LOCK_STALE_MS} (a crashed holder). */
+function isLockStale(lockPath: string): boolean {
+  try {
+    // Prefer the timestamp written into the file; fall back to mtime.
+    const written = Number.parseInt(
+      readFileSync(lockPath, "utf8").trim().split(/\s+/)[1] ?? "",
+      10,
+    );
+    const acquiredAt = Number.isFinite(written) ? written : statSync(lockPath).mtimeMs;
+    return Date.now() - acquiredAt >= LOCK_STALE_MS;
+  } catch {
+    return false; // can't read it → don't reclaim (conservative: skip, don't steal)
+  }
+}

--- a/packages/installer-cli/src/server/update.ts
+++ b/packages/installer-cli/src/server/update.ts
@@ -62,7 +62,7 @@
 import path from "node:path";
 import { librarianDir } from "../paths.js";
 import { fetchLatestVersion } from "../status.js";
-import { readDeployState, writeDeployState } from "./deploy-state.js";
+import { type DeployState, readDeployState, writeDeployState } from "./deploy-state.js";
 import { run, type RunResult } from "./docker.js";
 import { preflight } from "./preflight.js";
 import { redactSecrets } from "./redact.js";
@@ -76,6 +76,7 @@ import {
   waitForHealthy,
   writeDeployEnvFile,
 } from "./up.js";
+import { acquireUpdateLock, UpdateInProgressError, updateLockPath } from "./update-lock.js";
 
 export interface UpdateOptions {
   /** Pinned ref (`vX.Y.Z` tag or `main`). Default: the latest release tag. */
@@ -133,6 +134,29 @@ export async function runUpdate(options: UpdateOptions = {}): Promise<UpdateResu
     );
   }
 
+  // SPEC 074 SC5: ONE exclusive lock serialises EVERY update — manual runs and
+  // auto-update timer fires alike — so two can never interleave stop/rm/run on
+  // the same container (a window with no running container takes the server
+  // down). Before 074 only the timer wrapper locked, so a manual update could
+  // race a fire. Held around everything from ref resolution to deploy-state
+  // write; released on success AND failure (a failure must not wedge the next
+  // fire — the stale-reclaim window is for crashes, not ordinary errors).
+  const lockPath = updateLockPath({ home: options.home, dir: options.dir });
+  const lock = acquireUpdateLock(lockPath);
+  if (!lock) throw new UpdateInProgressError(lockPath);
+  try {
+    return await performUpdate(options, deployDir, state);
+  } finally {
+    lock.release();
+  }
+}
+
+/** The locked body of {@link runUpdate} — everything after preflight/state/lock. */
+async function performUpdate(
+  options: UpdateOptions,
+  deployDir: string,
+  state: DeployState,
+): Promise<UpdateResult> {
   // 2) Resolve the target ref (explicit `--ref` wins; else the latest tag).
   const targetRef = await resolveRef(options.ref);
 

--- a/packages/installer-cli/tests/server-autoupdate.test.ts
+++ b/packages/installer-cli/tests/server-autoupdate.test.ts
@@ -15,6 +15,7 @@
 // integration properties are called out in the build report, not asserted here.
 
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import type { RunOptions, RunResult } from "../src/exec.js";
@@ -113,11 +114,22 @@ function withBridge(
 // ── pure generators ─────────────────────────────────────────────────────────
 
 describe("autoupdate unit/cron generators — NO secret, the right schedule", () => {
-  it("the oneshot service runs `server autoupdate --run`, hardens with NoNewPrivileges, carries no secret", () => {
-    const unit = generateServiceUnit({ librarianPath: "/usr/local/bin/librarian" });
+  it("the oneshot service runs AS THE ENABLING USER against the baked deploy dir (spec 074 SC1)", () => {
+    const unit = generateServiceUnit({
+      librarianPath: "/usr/local/bin/librarian",
+      user: "deploy-owner",
+      deployDir: "/home/deploy-owner/.librarian/server",
+    });
     expect(unit).toContain("Type=oneshot");
-    expect(unit).toContain("ExecStart=/usr/local/bin/librarian server autoupdate --run");
-    // FIX I1(b): defense-in-depth on the auto-executing root unit.
+    // Spec 074: the unit must NOT run as root — root's home has no deploy-state,
+    // root git fails the dubious-ownership check in a user-owned clone. The
+    // enabling user (who ran `server up`) is the one context where home, git
+    // ownership, and docker-group access all resolve.
+    expect(unit).toContain("User=deploy-owner");
+    expect(unit).toContain(
+      "ExecStart=/usr/local/bin/librarian server autoupdate --run --dir /home/deploy-owner/.librarian/server",
+    );
+    // FIX I1(b): defense-in-depth on the auto-executing unit.
     expect(unit).toContain("NoNewPrivileges=true");
     // FIX I2: the unit carries our marker (Description=), which uninstall keys on
     // to confirm a file is ours before deleting it.
@@ -136,9 +148,13 @@ describe("autoupdate unit/cron generators — NO secret, the right schedule", ()
     expect(unit).not.toMatch(/token|secret|key/i);
   });
 
-  it("the cron line runs the wrapper hourly, tagged with the marker, no secret", () => {
-    const line = cronLine("/usr/local/bin/librarian");
-    expect(line).toContain("/usr/local/bin/librarian server autoupdate --run");
+  it("the cron line runs the wrapper hourly against the baked deploy dir, tagged, no secret", () => {
+    const line = cronLine("/usr/local/bin/librarian", "/home/deploy-owner/.librarian/server");
+    // Spec 074 SC2: cron already fires as the enabling user, but the dir is baked
+    // explicitly so a custom `--dir` passed to `enable` is honoured there too.
+    expect(line).toContain(
+      "/usr/local/bin/librarian server autoupdate --run --dir /home/deploy-owner/.librarian/server",
+    );
     expect(line).toContain(CRON_MARKER);
     expect(line).toMatch(/^\d+ \* \* \* \*/); // a valid hourly cron schedule
     expect(line).not.toMatch(/token|secret|key/i);
@@ -162,7 +178,7 @@ function ranSudo(runner: FakeRunner, ...match: string[]): boolean {
 }
 
 describe("autoupdate enable (systemd) — installs the timer + writes settings", () => {
-  it("writes both unit files, daemon-reloads, enables --now the TIMER, sets the running server", async () => {
+  it("writes both unit files (User= + --dir baked in), daemon-reloads, enables the TIMER, sets the server", async () => {
     const runner = systemdReady();
     const bridgeOps: string[] = [];
     // Capture the unit content handed to `sudo cp` (the FakeRunner doesn't move it).
@@ -180,23 +196,81 @@ describe("autoupdate enable (systemd) — installs the timer + writes settings",
     });
     setDockerRunner(runner);
 
-    const r = await runCli(["server", "autoupdate", "enable"], { platform: "linux" });
-    expect(r.exitCode).toBe(0);
+    await withTempHome(async (home) => {
+      const dir = seedDeployState(home);
+      const r = await runCli(["server", "autoupdate", "enable"], { home, platform: "linux" });
+      expect(r.exitCode).toBe(0);
 
-    // Both unit files landed at the system paths with the right content (no secret).
-    expect(copied.get(SERVICE_PATH)).toContain("server autoupdate --run");
-    expect(copied.get(TIMER_PATH)).toContain("OnCalendar=hourly");
-    for (const content of copied.values()) expect(content).not.toMatch(/token|secret|key/i);
+      // Both unit files landed at the system paths with the right content (no secret).
+      // Spec 074 SC1: the service carries the enabling user + the resolved deploy
+      // dir, so the timer fires in the context that owns the deploy — not root's.
+      expect(copied.get(SERVICE_PATH)).toContain(`server autoupdate --run --dir ${dir}`);
+      expect(copied.get(SERVICE_PATH)).toContain(`User=${os.userInfo().username}`);
+      expect(copied.get(TIMER_PATH)).toContain("OnCalendar=hourly");
+      for (const content of copied.values()) expect(content).not.toMatch(/token|secret/i);
 
-    // daemon-reload, then enable --now the TIMER (not the oneshot service).
-    expect(ranSudo(runner, "systemctl", "daemon-reload")).toBe(true);
-    expect(ranSudo(runner, "systemctl", "enable", "--now", AUTOUPDATE_TIMER_NAME)).toBe(true);
-    // The oneshot service is NOT separately enabled (the timer fires it).
-    expect(ranSudo(runner, "systemctl", "enable", "--now", AUTOUPDATE_SERVICE_NAME)).toBe(false);
+      // daemon-reload, then enable --now the TIMER (not the oneshot service).
+      expect(ranSudo(runner, "systemctl", "daemon-reload")).toBe(true);
+      expect(ranSudo(runner, "systemctl", "enable", "--now", AUTOUPDATE_TIMER_NAME)).toBe(true);
+      // The oneshot service is NOT separately enabled (the timer fires it).
+      expect(ranSudo(runner, "systemctl", "enable", "--now", AUTOUPDATE_SERVICE_NAME)).toBe(false);
 
-    // It wrote enabled+cadence into the running server (the bridge `set`).
-    expect(bridgeOps).toContain("set");
-    expect(r.stdout).toMatch(/cadence: daily/i);
+      // It wrote enabled+cadence into the running server (the bridge `set`).
+      expect(bridgeOps).toContain("set");
+      expect(r.stdout).toMatch(/cadence: daily/i);
+    });
+  });
+
+  it("refuses to install when no deploy-state exists at the resolved dir (spec 074 SC3)", async () => {
+    // THE 074 TRAP, caught at enable time: `enable` run in a context whose
+    // `~/.librarian/server` holds no deploy-state (wrong user, wrong machine)
+    // would install a timer that fails silently every hour. Refuse loudly NOW.
+    const runner = systemdReady();
+    setDockerRunner(runner);
+
+    await withTempHome(async (home) => {
+      const r = await runCli(["server", "autoupdate", "enable"], { home, platform: "linux" });
+      expect(r.exitCode).toBe(1);
+      expect(r.stderr).toMatch(/No deploy-state found/i);
+      expect(r.stderr).toMatch(/as the user who ran/i);
+      // NOTHING was installed — no unit copied, no systemctl, no crontab.
+      expect(runner.calls.some((c) => c.cmd === "sudo")).toBe(false);
+      expect(runner.calls.some((c) => c.cmd === "crontab")).toBe(false);
+    });
+  });
+
+  it("the refusal names SUDO_USER as the likely right user when run under sudo (spec 074 D2)", async () => {
+    const runner = systemdReady();
+    setDockerRunner(runner);
+    const prev = process.env.SUDO_USER;
+    process.env.SUDO_USER = "jane";
+    try {
+      await withTempHome(async (home) => {
+        const r = await runCli(["server", "autoupdate", "enable"], { home, platform: "linux" });
+        expect(r.exitCode).toBe(1);
+        expect(r.stderr).toMatch(/sudo/i);
+        expect(r.stderr).toMatch(/jane/);
+      });
+    } finally {
+      if (prev === undefined) delete process.env.SUDO_USER;
+      else process.env.SUDO_USER = prev;
+    }
+  });
+
+  it("rejects a deploy dir unsafe to interpolate unquoted BEFORE touching the host (spec 074 SC4)", async () => {
+    const runner = systemdReady();
+    setDockerRunner(runner);
+
+    await withTempHome(async (home) => {
+      const bad = path.join(home, "has space", "server");
+      const r = await runCli(["server", "autoupdate", "enable", "--dir", bad], {
+        home,
+        platform: "linux",
+      });
+      expect(r.exitCode).toBe(1);
+      expect(r.stderr).toMatch(/not safe to schedule|whitespace|metacharacter/i);
+      expect(runner.calls.some((c) => c.cmd === "sudo")).toBe(false);
+    });
   });
 
   it("--cadence weekly is written through to the server set", async () => {
@@ -210,12 +284,18 @@ describe("autoupdate enable (systemd) — installs the timer + writes settings",
     });
     setDockerRunner(runner);
 
-    const r = await runCli(["server", "autoupdate", "enable", "--cadence", "weekly"], {
-      platform: "linux",
+    await withTempHome(async (home) => {
+      seedDeployState(home);
+      const r = await runCli(["server", "autoupdate", "enable", "--cadence", "weekly"], {
+        home,
+        platform: "linux",
+      });
+      expect(r.exitCode).toBe(0);
+      // The set bridge script carried the weekly cadence in its POST body.
+      expect(setScripts.some((s) => s.includes("autoupdate.set") && s.includes("weekly"))).toBe(
+        true,
+      );
     });
-    expect(r.exitCode).toBe(0);
-    // The set bridge script carried the weekly cadence in its POST body.
-    expect(setScripts.some((s) => s.includes("autoupdate.set") && s.includes("weekly"))).toBe(true);
   });
 
   it("rejects an invalid cadence BEFORE touching the host (no systemctl runs)", async () => {
@@ -255,8 +335,11 @@ describe("autoupdate enable (systemd) — installs the timer + writes settings",
     });
     setDockerRunner(runner);
 
-    await runCli(["server", "autoupdate", "enable"], { platform: "linux" });
-    await runCli(["server", "autoupdate", "enable"], { platform: "linux" });
+    await withTempHome(async (home) => {
+      seedDeployState(home);
+      await runCli(["server", "autoupdate", "enable"], { home, platform: "linux" });
+      await runCli(["server", "autoupdate", "enable"], { home, platform: "linux" });
+    });
 
     const enables = runner.calls.filter(
       (c) => c.cmd === "sudo" && c.args[0] === "systemctl" && c.args.includes("enable"),
@@ -275,10 +358,13 @@ describe("autoupdate enable (systemd) — installs the timer + writes settings",
     withBridge(runner, { getConfig: null, bridgeOps }); // server unreachable
     setDockerRunner(runner);
 
-    const r = await runCli(["server", "autoupdate", "enable"], { platform: "linux" });
-    expect(r.exitCode).toBe(0); // not a failure — the timer is what matters
-    expect(ranSudo(runner, "systemctl", "enable", "--now", AUTOUPDATE_TIMER_NAME)).toBe(true);
-    expect(r.stdout).toMatch(/could not reach the running server/i);
+    await withTempHome(async (home) => {
+      seedDeployState(home);
+      const r = await runCli(["server", "autoupdate", "enable"], { home, platform: "linux" });
+      expect(r.exitCode).toBe(0); // not a failure — the timer is what matters
+      expect(ranSudo(runner, "systemctl", "enable", "--now", AUTOUPDATE_TIMER_NAME)).toBe(true);
+      expect(r.stdout).toMatch(/could not reach the running server/i);
+    });
   });
 });
 
@@ -309,13 +395,17 @@ describe("autoupdate enable (cron fallback) — systemd absent", () => {
     });
     setDockerRunner(runner);
 
-    const r = await runCli(["server", "autoupdate", "enable"], { platform: "linux" });
-    expect(r.exitCode).toBe(0);
-    expect(installedContent).toContain("server autoupdate --run");
-    expect(installedContent).toContain(CRON_MARKER);
-    // No systemd path was taken.
-    expect(runner.calls.some((c) => c.cmd === "sudo")).toBe(false);
-    expect(r.stdout).toMatch(/cron/i);
+    await withTempHome(async (home) => {
+      const dir = seedDeployState(home);
+      const r = await runCli(["server", "autoupdate", "enable"], { home, platform: "linux" });
+      expect(r.exitCode).toBe(0);
+      // Spec 074 SC2: the cron line pins the resolved deploy dir too.
+      expect(installedContent).toContain(`server autoupdate --run --dir ${dir}`);
+      expect(installedContent).toContain(CRON_MARKER);
+      // No systemd path was taken.
+      expect(runner.calls.some((c) => c.cmd === "sudo")).toBe(false);
+      expect(r.stdout).toMatch(/cron/i);
+    });
   });
 
   it("does not duplicate our cron line when one already exists (idempotent)", async () => {
@@ -341,7 +431,10 @@ describe("autoupdate enable (cron fallback) — systemd absent", () => {
     });
     setDockerRunner(runner);
 
-    await runCli(["server", "autoupdate", "enable"], { platform: "linux" });
+    await withTempHome(async (home) => {
+      seedDeployState(home);
+      await runCli(["server", "autoupdate", "enable"], { home, platform: "linux" });
+    });
     // Exactly ONE marker line, and the unrelated job is preserved.
     const markerCount = (installedContent?.match(new RegExp(CRON_MARKER, "g")) ?? []).length;
     expect(markerCount).toBe(1);
@@ -387,7 +480,11 @@ function systemdReadyWithOurUnits(): FakeRunner {
     .onRun("sudo", ["cat", TIMER_PATH], { code: 0, stdout: generateTimerUnit() })
     .onRun("sudo", ["cat", SERVICE_PATH], {
       code: 0,
-      stdout: generateServiceUnit({ librarianPath: "/usr/local/bin/librarian" }),
+      stdout: generateServiceUnit({
+        librarianPath: "/usr/local/bin/librarian",
+        user: "deploy-owner",
+        deployDir: "/home/deploy-owner/.librarian/server",
+      }),
     });
 }
 
@@ -445,7 +542,11 @@ describe("autoupdate uninstall — removes the timer/cron entirely", () => {
       // The service file is genuinely ours (proves we still remove the real one).
       .onRun("sudo", ["cat", SERVICE_PATH], {
         code: 0,
-        stdout: generateServiceUnit({ librarianPath: "/usr/local/bin/librarian" }),
+        stdout: generateServiceUnit({
+          librarianPath: "/usr/local/bin/librarian",
+          user: "deploy-owner",
+          deployDir: "/home/deploy-owner/.librarian/server",
+        }),
       });
     setDockerRunner(runner);
 

--- a/packages/installer-cli/tests/server-autoupdate.test.ts
+++ b/packages/installer-cli/tests/server-autoupdate.test.ts
@@ -17,7 +17,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { RunOptions, RunResult } from "../src/exec.js";
 import { resetRunner } from "../src/exec.js";
 import { runCli } from "../src/runtime.js";
@@ -903,6 +903,54 @@ describe("autoupdate --run — the gated, fail-soft wrapper the timer fires", ()
     const r = await runCli(["server", "autoupdate", "--run"]);
     expect(r.exitCode).toBe(0);
     expect(r.stdout).toMatch(/unreachable.*skipping/i);
+  });
+
+  it("a pre-074 timer's wrong-context failure teaches upgrading + re-running enable (spec 074 SC6)", async () => {
+    await withTempHome(async (home) => {
+      // NO deploy-state seeded — the exact wrong-home failure a root-run pre-074
+      // timer hits every fire (confirmed live on the VPS, 26/07/2026). The line
+      // must carry the migration path, since anyone seeing it has the broken unit.
+      const runner = new FakeRunner()
+        .withWhich("docker")
+        .withWhich("git")
+        .onRun("docker", ["info"], { code: 0 })
+        .withFallback({ code: 0 });
+      const bridgeOps: string[] = [];
+      withBridge(runner, {
+        getConfig: { enabled: true, cadence: "daily", lastRunAt: null },
+        bridgeOps,
+      });
+      setDockerRunner(runner);
+      const logs: string[] = [];
+
+      const result = await runAutoUpdate({ home, log: (l) => logs.push(l) });
+      expect(result.output).toMatch(/update failed/i);
+      expect(result.output).toMatch(/re-run `librarian server autoupdate enable`/);
+      expect(bridgeOps).not.toContain("stampRun");
+      expect(logs).toHaveLength(1);
+    });
+  });
+
+  it("the outcome reaches the journal ONCE: default sink silent, stdout carries the line (spec 074 SC8)", async () => {
+    // Before 074 the wrapper's default sink wrote the line to stderr AND the
+    // runtime printed the returned output to stdout — systemd sends both streams
+    // to the same journal, so every outcome appeared twice.
+    const runner = new FakeRunner().withWhich("docker").withFallback({ code: 0 });
+    withBridge(runner, { getConfig: null, bridgeOps: [] });
+    setDockerRunner(runner);
+    const stderrWrites: string[] = [];
+    const spy = vi.spyOn(process.stderr, "write").mockImplementation(((chunk: unknown): boolean => {
+      stderrWrites.push(String(chunk));
+      return true;
+    }) as unknown as typeof process.stderr.write);
+    try {
+      const r = await runCli(["server", "autoupdate", "--run"]);
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toMatch(/unreachable.*skipping/i);
+      expect(stderrWrites.filter((w) => w.includes("autoupdate:"))).toHaveLength(0);
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it("weekly cadence: 3 days since last run is NOT due (skips)", async () => {

--- a/packages/installer-cli/tests/server-autoupdate.test.ts
+++ b/packages/installer-cli/tests/server-autoupdate.test.ts
@@ -24,7 +24,6 @@ import { runCli } from "../src/runtime.js";
 import {
   AUTOUPDATE_SERVICE_NAME,
   AUTOUPDATE_TIMER_NAME,
-  autoUpdateLockPath,
   CRON_MARKER,
   cronLine,
   generateServiceUnit,
@@ -45,6 +44,7 @@ import {
   setSleep,
   setTokenMinter,
 } from "../src/server/up.js";
+import { updateLockPath } from "../src/server/update-lock.js";
 import { resetLatestFetcher, setLatestFetcher } from "../src/status.js";
 import { FakeRunner, withTempHome } from "./helpers.js";
 
@@ -814,7 +814,7 @@ describe("autoupdate --run — the gated, fail-soft wrapper the timer fires", ()
       seedDeployState(home);
       // Simulate a concurrent update already running: hold the lock by creating
       // the lockfile with a FRESH timestamp (so it isn't reclaimed as stale).
-      const lockPath = autoUpdateLockPath({ home });
+      const lockPath = updateLockPath({ home });
       fs.mkdirSync(path.dirname(lockPath), { recursive: true });
       fs.writeFileSync(lockPath, `99999 ${Date.now()}\n`, { flag: "wx" });
 
@@ -849,7 +849,7 @@ describe("autoupdate --run — the gated, fail-soft wrapper the timer fires", ()
     await withTempHome(async (home) => {
       const dir = seedDeployState(home);
       // A crashed holder left a lockfile ~2h old → stale → reclaimed, update runs.
-      const lockPath = autoUpdateLockPath({ home });
+      const lockPath = updateLockPath({ home });
       fs.mkdirSync(path.dirname(lockPath), { recursive: true });
       const twoHoursAgo = Date.now() - 2 * 60 * 60 * 1000;
       fs.writeFileSync(lockPath, `4242 ${twoHoursAgo}\n`, { flag: "wx" });

--- a/packages/installer-cli/tests/server-update.test.ts
+++ b/packages/installer-cli/tests/server-update.test.ts
@@ -716,6 +716,66 @@ describe("server update — preflight + no-deploy-state teach", () => {
   });
 });
 
+describe("server update — the exclusive update lock (spec 074 SC5)", () => {
+  it("a manual update while another update holds the lock is refused, disturbing nothing", async () => {
+    // Before 074 only the TIMER wrapper took the lock — a manual `server update`
+    // could interleave stop/rm/run with a timer fire, leaving a window with NO
+    // running container. The lock now lives in runUpdate: one acquisition point
+    // covers every caller.
+    await withTempHome(async (home) => {
+      const dir = seedDeployState(home);
+      const lockPath = path.join(dir, ".autoupdate.lock");
+      // A concurrent update (e.g. a timer fire mid-build) holds a FRESH lock.
+      fs.writeFileSync(lockPath, `4242 ${Date.now()}\n`, { flag: "wx" });
+
+      const runner = upgradeRunner().withFallback({ code: 0 });
+      setDockerRunner(runner);
+      stubSeams();
+
+      const r = await runCli(["server", "update"], { home });
+      expect(r.exitCode).toBe(1);
+      expect(r.stderr).toMatch(/another update is already in progress/i);
+      // The in-flight update was not disturbed: no build, no stop/rm/run.
+      expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "build")).toBe(false);
+      expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "rm")).toBe(false);
+      // The holder's lock is left intact — only the acquirer ever releases.
+      expect(fs.existsSync(lockPath)).toBe(true);
+    });
+  });
+
+  it("the lock is released after a SUCCESSFUL update (the next update isn't blocked)", async () => {
+    await withTempHome(async (home) => {
+      const dir = seedDeployState(home);
+      const runner = upgradeRunner().withFallback({ code: 0 });
+      setDockerRunner(runner);
+      stubSeams();
+
+      const r = await runCli(["server", "update"], { home });
+      expect(r.exitCode).toBe(0);
+      expect(fs.existsSync(path.join(dir, ".autoupdate.lock"))).toBe(false);
+    });
+  });
+
+  it("the lock is released after a FAILED update too (a failure never wedges the next fire)", async () => {
+    await withTempHome(async (home) => {
+      const dir = seedDeployState(home);
+      const runner = upgradeRunner()
+        .onRun(
+          "docker",
+          ["build", "-f", "docker/all-in-one.Dockerfile", "-t", `the-librarian:${LATEST_TAG}`, "."],
+          { code: 1, stderr: "build blew up" },
+        )
+        .withFallback({ code: 0 });
+      setDockerRunner(runner);
+      stubSeams();
+
+      const r = await runCli(["server", "update"], { home });
+      expect(r.exitCode).toBe(1);
+      expect(fs.existsSync(path.join(dir, ".autoupdate.lock"))).toBe(false);
+    });
+  });
+});
+
 // --- helpers -------------------------------------------------------------
 
 /** Recursively collect files under `dir` whose contents contain `needle`. */


### PR DESCRIPTION
## What

Server auto-update has **never worked** on any host set up the documented way. The systemd unit installed by `librarian server autoupdate enable` runs as **root** (system unit, no `User=`, no `--dir`), so the hourly `--run` wrapper resolved `~/.librarian/server` against **root's home**, found no deploy-state, and failed — silently, every hour, by fail-soft design. Confirmed live on the production VPS: failing since 30 Jun, visible only in the root-readable system journal, while `autoupdate status` reported everything healthy.

## The fix (spec 074)

- **T1 — the unit runs in the right context.** `generateServiceUnit` bakes `User=<enabling user>` and pins `ExecStart … --run --dir <resolved deploy dir>`; the cron fallback pins the dir too. Running as the enabling user fixes all three facets at once: home resolution, git's dubious-ownership check on the user-owned clone, and docker access via that user's group. `enable` now **hard-refuses** when no deploy-state exists at the resolved dir (naming `SUDO_USER` when relevant) — the silent 3 a.m. failure becomes a loud enable-time error. The deploy dir and username pass the same unquoted-interpolation safety check as the binary path (a newline in either could otherwise smuggle a unit directive).
- **T2 — the update lock actually covers what its comment claimed.** Only the timer wrapper took the exclusive lock; a manual `server update` could interleave stop/rm/run with a fire, leaving a window with no running container. The lock now lives inside `runUpdate` (new shared `update-lock.ts`, no import cycle): one acquisition point, every caller; a held lock is a typed `UpdateInProgressError` — teaching message for the manual CLI, the existing "another update in progress — skipping" (without stamping) for the wrapper. Released on success and failure alike.
- **T3 — one journal line per outcome.** The wrapper's default stderr sink duplicated every line the runtime already printed to stdout (systemd journals both streams). Default sink is now silent; the no-deploy-state failure line teaches the migration (upgrade + re-run `enable`).
- **T4 — docs stop teaching the trap.** Settings claimed the dashboard toggle alone keeps the server updated and offered a nonexistent "monthly" cadence. Corrected; the self-host guide gains an **Automatic updates** walkthrough incl. the `sudo journalctl` diagnostic (the exact stumble from the live debugging session).

## Migration for existing installs

Upgrade the CLI, then re-run `librarian server autoupdate enable` **as the user who ran `server up`** — `enable` idempotently rewrites both unit files in place. The CHANGELOG, the enable refusal, and the wrapper's failure line all say so.

## Verification

- installer-cli: **346/346** (10 new tests: unit/cron generators, enable refusals + SUDO_USER hint, unsafe-dir rejection, lock held/released ×3, migration hint, journal-dedupe stderr spy)
- Full monorepo gate: build clean; **3,436 tests** — one unrelated flake in `apps/dashboard` (`ActivityFeed › keeps the restore button disarmed…`, a 5 s testTimeout exceeded at 6.2 s under full-suite parallel load; passes 576/576 in isolation; file untouched by this branch)
- Docs build: 37 pages, links validated
- `RELEASE_BASE_VERSION=1.17.0 pnpm run check:release` → OK (1.17.1, dated, linked)

Spec: `Work/The Librarian/specs/074-autoupdate-host-context.md` (vault)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tNsUuUqDxcKkd1dmrRYVr