### PR TITLE
chore: move the canonical repo to the code-ministry-ltd org

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 
 You're an AI agent working on this repo. It's part of
-[The Librarian](https://github.com/JimJafar/the-librarian) — a portable
+[The Librarian](https://github.com/code-ministry-ltd/the-librarian) — a portable
 memory + handoff layer for AI agents, open source, designed for
 production use by people we'll never meet. Read this before your first
 commit. Follow it on every change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.17.2] — 2026-07-30
+
+### Changed
+
+- **The canonical repository moved to the `code-ministry-ltd` GitHub org.** Every
+  reference to `github.com/JimJafar/the-librarian` now points at
+  `github.com/code-ministry-ltd/the-librarian`: the published packages' metadata
+  (`@the-librarian/pi-extension`'s `homepage`/`repository`, and a new
+  `homepage`/`repository` on `@the-librarian/cli`, which previously had none), the
+  runtime GitHub endpoints the CLI and server hit (release-version checks, the
+  Hermes/Codex/OpenCode adapter tarball downloads, the Claude Code marketplace
+  slug), the ingest fetcher's user-agent, the docs, and the READMEs. The npm
+  package names are unchanged — they keep the `@the-librarian/*` scope. The old
+  GitHub URLs continue to work via GitHub's automatic redirect after the repo
+  transfer; this change stops relying on that redirect. The archived standalone
+  plugin repos (`the-librarian-claude-plugin` and friends) are a separate concern
+  and are intentionally left as-is.
+
 ## [1.17.1] — 2026-07-26
 
 ### Fixed
@@ -2245,7 +2263,7 @@ dashboard is untouched and still wears its legacy chrome (queued for Phase 2).
   `whitespace-pre` per-line, so a prose-heavy diff (the vault is overwhelmingly notes,
   not code) forced per-line horizontal scrolling on a 13" screen. Swapped to
   `whitespace-pre-wrap` — indentation preserved, lines wrap on word boundaries,
-  `overflow-x-auto` stays as defensive backstop. Closes [#372](https://github.com/JimJafar/the-librarian/issues/372).
+  `overflow-x-auto` stays as defensive backstop. Closes [#372](https://github.com/code-ministry-ltd/the-librarian/issues/372).
 
 ### Added
 
@@ -4246,105 +4264,106 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
-[1.17.1]: https://github.com/JimJafar/the-librarian/compare/v1.17.0...v1.17.1
-[1.17.0]: https://github.com/JimJafar/the-librarian/compare/v1.16.1...v1.17.0
-[1.16.1]: https://github.com/JimJafar/the-librarian/compare/v1.16.0...v1.16.1
-[1.16.0]: https://github.com/JimJafar/the-librarian/compare/v1.15.0...v1.16.0
-[1.15.0]: https://github.com/JimJafar/the-librarian/compare/v1.14.0...v1.15.0
-[1.14.0]: https://github.com/JimJafar/the-librarian/compare/v1.13.0...v1.14.0
-[1.13.0]: https://github.com/JimJafar/the-librarian/compare/v1.12.0...v1.13.0
-[1.12.0]: https://github.com/JimJafar/the-librarian/compare/v1.11.0...v1.12.0
-[1.11.0]: https://github.com/JimJafar/the-librarian/compare/v1.10.0...v1.11.0
-[1.10.2]: https://github.com/JimJafar/the-librarian/compare/v1.10.1...v1.10.2
-[1.10.1]: https://github.com/JimJafar/the-librarian/compare/v1.10.0...v1.10.1
-[1.10.0]: https://github.com/JimJafar/the-librarian/compare/v1.9.0...v1.10.0
-[1.9.0]: https://github.com/JimJafar/the-librarian/compare/v1.8.0...v1.9.0
-[1.8.0]: https://github.com/JimJafar/the-librarian/compare/v1.7.0...v1.8.0
-[1.7.0]: https://github.com/JimJafar/the-librarian/compare/v1.6.0...v1.7.0
-[1.6.0]: https://github.com/JimJafar/the-librarian/compare/v1.5.0...v1.6.0
-[1.5.0]: https://github.com/JimJafar/the-librarian/compare/v1.4.2...v1.5.0
-[1.4.2]: https://github.com/JimJafar/the-librarian/compare/v1.4.1...v1.4.2
-[1.4.1]: https://github.com/JimJafar/the-librarian/compare/v1.4.0...v1.4.1
-[1.4.0]: https://github.com/JimJafar/the-librarian/compare/v1.3.1...v1.4.0
-[1.3.1]: https://github.com/JimJafar/the-librarian/compare/v1.3.0...v1.3.1
-[1.3.0]: https://github.com/JimJafar/the-librarian/compare/v1.2.3...v1.3.0
-[1.2.3]: https://github.com/JimJafar/the-librarian/compare/v1.2.2...v1.2.3
-[1.2.2]: https://github.com/JimJafar/the-librarian/compare/v1.2.1...v1.2.2
-[1.2.1]: https://github.com/JimJafar/the-librarian/compare/v1.2.0...v1.2.1
-[1.2.0]: https://github.com/JimJafar/the-librarian/compare/v1.1.4...v1.2.0
-[1.1.4]: https://github.com/JimJafar/the-librarian/compare/v1.1.3...v1.1.4
-[1.1.3]: https://github.com/JimJafar/the-librarian/compare/v1.1.2...v1.1.3
-[1.1.2]: https://github.com/JimJafar/the-librarian/compare/v1.1.1...v1.1.2
-[1.1.1]: https://github.com/JimJafar/the-librarian/compare/v1.1.0...v1.1.1
-[1.1.0]: https://github.com/JimJafar/the-librarian/compare/v1.0.1...v1.1.0
-[1.0.1]: https://github.com/JimJafar/the-librarian/compare/v1.0.0...v1.0.1
-[1.0.0]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.52...v1.0.0
-[1.0.0-rc.52]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.51...v1.0.0-rc.52
-[1.0.0-rc.51]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.50...v1.0.0-rc.51
-[1.0.0-rc.50]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.49...v1.0.0-rc.50
-[1.0.0-rc.49]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.48...v1.0.0-rc.49
-[1.0.0-rc.48]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.47...v1.0.0-rc.48
-[1.0.0-rc.47]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.46...v1.0.0-rc.47
-[1.0.0-rc.46]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.45...v1.0.0-rc.46
-[1.0.0-rc.45]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.44...v1.0.0-rc.45
-[1.0.0-rc.44]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.43...v1.0.0-rc.44
-[1.0.0-rc.43]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.42...v1.0.0-rc.43
-[1.0.0-rc.42]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.41...v1.0.0-rc.42
-[1.0.0-rc.41]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.40...v1.0.0-rc.41
-[1.0.0-rc.40]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.39...v1.0.0-rc.40
-[1.0.0-rc.39]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.38...v1.0.0-rc.39
-[1.0.0-rc.38]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.37...v1.0.0-rc.38
-[1.0.0-rc.37]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.36...v1.0.0-rc.37
-[1.0.0-rc.36]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.35...v1.0.0-rc.36
-[1.0.0-rc.35]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.34...v1.0.0-rc.35
-[1.0.0-rc.34]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.33...v1.0.0-rc.34
-[1.0.0-rc.33]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.32...v1.0.0-rc.33
-[1.0.0-rc.32]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.31...v1.0.0-rc.32
-[1.0.0-rc.31]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.30...v1.0.0-rc.31
-[1.0.0-rc.30]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.29...v1.0.0-rc.30
-[1.0.0-rc.29]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.28...v1.0.0-rc.29
-[1.0.0-rc.28]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.27...v1.0.0-rc.28
-[1.0.0-rc.27]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.26...v1.0.0-rc.27
-[1.0.0-rc.26]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.25...v1.0.0-rc.26
-[1.0.0-rc.25]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.24...v1.0.0-rc.25
-[1.0.0-rc.24]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.23...v1.0.0-rc.24
-[1.0.0-rc.23]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.22...v1.0.0-rc.23
-[1.0.0-rc.22]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.21...v1.0.0-rc.22
-[1.0.0-rc.21]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.20...v1.0.0-rc.21
-[1.0.0-rc.20]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.19...v1.0.0-rc.20
-[1.0.0-rc.19]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.18...v1.0.0-rc.19
-[1.0.0-rc.18]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.17...v1.0.0-rc.18
-[1.0.0-rc.17]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.16...v1.0.0-rc.17
-[1.0.0-rc.16]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.15...v1.0.0-rc.16
-[1.0.0-rc.15]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.14...v1.0.0-rc.15
-[1.0.0-rc.14]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.13...v1.0.0-rc.14
-[1.0.0-rc.13]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.12...v1.0.0-rc.13
-[1.0.0-rc.12]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.11...v1.0.0-rc.12
-[1.0.0-rc.11]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.10...v1.0.0-rc.11
-[1.0.0-rc.10]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.9...v1.0.0-rc.10
-[1.0.0-rc.9]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.8...v1.0.0-rc.9
-[1.0.0-rc.8]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.7...v1.0.0-rc.8
-[1.0.0-rc.7]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.6...v1.0.0-rc.7
-[1.0.0-rc.6]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.5...v1.0.0-rc.6
-[1.0.0-rc.5]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.4...v1.0.0-rc.5
-[1.0.0-rc.4]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.3...v1.0.0-rc.4
-[1.0.0-rc.3]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.2...v1.0.0-rc.3
-[1.0.0-rc.2]: https://github.com/JimJafar/the-librarian/compare/v1.0.0-rc.1...v1.0.0-rc.2
-[1.0.0-rc.1]: https://github.com/JimJafar/the-librarian/compare/v0.11.0...v1.0.0-rc.1
-[0.11.0]: https://github.com/JimJafar/the-librarian/compare/v0.10.0...v0.11.0
-[0.10.0]: https://github.com/JimJafar/the-librarian/compare/v0.9.0...v0.10.0
-[0.9.0]: https://github.com/JimJafar/the-librarian/compare/v0.8.0...v0.9.0
-[0.8.0]: https://github.com/JimJafar/the-librarian/compare/v0.7.4...v0.8.0
-[0.7.4]: https://github.com/JimJafar/the-librarian/compare/v0.7.3...v0.7.4
-[0.7.3]: https://github.com/JimJafar/the-librarian/compare/v0.7.2...v0.7.3
-[0.7.2]: https://github.com/JimJafar/the-librarian/compare/v0.7.1...v0.7.2
-[0.7.1]: https://github.com/JimJafar/the-librarian/compare/v0.7.0...v0.7.1
-[0.7.0]: https://github.com/JimJafar/the-librarian/compare/v0.6.2...v0.7.0
-[0.6.2]: https://github.com/JimJafar/the-librarian/compare/v0.6.1...v0.6.2
-[0.6.1]: https://github.com/JimJafar/the-librarian/compare/v0.6.0...v0.6.1
-[0.6.0]: https://github.com/JimJafar/the-librarian/compare/v0.5.0...v0.6.0
-[0.5.0]: https://github.com/JimJafar/the-librarian/compare/v0.4.0...v0.5.0
-[0.4.0]: https://github.com/JimJafar/the-librarian/compare/v0.3.0...v0.4.0
-[0.3.0]: https://github.com/JimJafar/the-librarian/compare/v0.2.0...v0.3.0
-[0.2.0]: https://github.com/JimJafar/the-librarian/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/JimJafar/the-librarian/releases/tag/v0.1.0
+[1.17.2]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.17.1...v1.17.2
+[1.17.1]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.17.0...v1.17.1
+[1.17.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.16.1...v1.17.0
+[1.16.1]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.16.0...v1.16.1
+[1.16.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.15.0...v1.16.0
+[1.15.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.14.0...v1.15.0
+[1.14.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.13.0...v1.14.0
+[1.13.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.12.0...v1.13.0
+[1.12.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.11.0...v1.12.0
+[1.11.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.10.0...v1.11.0
+[1.10.2]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.10.1...v1.10.2
+[1.10.1]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.10.0...v1.10.1
+[1.10.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.9.0...v1.10.0
+[1.9.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.8.0...v1.9.0
+[1.8.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.7.0...v1.8.0
+[1.7.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.6.0...v1.7.0
+[1.6.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.5.0...v1.6.0
+[1.5.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.4.2...v1.5.0
+[1.4.2]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.4.1...v1.4.2
+[1.4.1]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.4.0...v1.4.1
+[1.4.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.3.1...v1.4.0
+[1.3.1]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.3.0...v1.3.1
+[1.3.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.2.3...v1.3.0
+[1.2.3]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.2.2...v1.2.3
+[1.2.2]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.2.1...v1.2.2
+[1.2.1]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.2.0...v1.2.1
+[1.2.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.1.4...v1.2.0
+[1.1.4]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.1.3...v1.1.4
+[1.1.3]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.1.2...v1.1.3
+[1.1.2]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.1.1...v1.1.2
+[1.1.1]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.1.0...v1.1.1
+[1.1.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.1...v1.1.0
+[1.0.1]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.52...v1.0.0
+[1.0.0-rc.52]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.51...v1.0.0-rc.52
+[1.0.0-rc.51]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.50...v1.0.0-rc.51
+[1.0.0-rc.50]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.49...v1.0.0-rc.50
+[1.0.0-rc.49]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.48...v1.0.0-rc.49
+[1.0.0-rc.48]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.47...v1.0.0-rc.48
+[1.0.0-rc.47]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.46...v1.0.0-rc.47
+[1.0.0-rc.46]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.45...v1.0.0-rc.46
+[1.0.0-rc.45]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.44...v1.0.0-rc.45
+[1.0.0-rc.44]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.43...v1.0.0-rc.44
+[1.0.0-rc.43]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.42...v1.0.0-rc.43
+[1.0.0-rc.42]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.41...v1.0.0-rc.42
+[1.0.0-rc.41]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.40...v1.0.0-rc.41
+[1.0.0-rc.40]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.39...v1.0.0-rc.40
+[1.0.0-rc.39]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.38...v1.0.0-rc.39
+[1.0.0-rc.38]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.37...v1.0.0-rc.38
+[1.0.0-rc.37]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.36...v1.0.0-rc.37
+[1.0.0-rc.36]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.35...v1.0.0-rc.36
+[1.0.0-rc.35]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.34...v1.0.0-rc.35
+[1.0.0-rc.34]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.33...v1.0.0-rc.34
+[1.0.0-rc.33]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.32...v1.0.0-rc.33
+[1.0.0-rc.32]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.31...v1.0.0-rc.32
+[1.0.0-rc.31]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.30...v1.0.0-rc.31
+[1.0.0-rc.30]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.29...v1.0.0-rc.30
+[1.0.0-rc.29]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.28...v1.0.0-rc.29
+[1.0.0-rc.28]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.27...v1.0.0-rc.28
+[1.0.0-rc.27]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.26...v1.0.0-rc.27
+[1.0.0-rc.26]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.25...v1.0.0-rc.26
+[1.0.0-rc.25]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.24...v1.0.0-rc.25
+[1.0.0-rc.24]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.23...v1.0.0-rc.24
+[1.0.0-rc.23]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.22...v1.0.0-rc.23
+[1.0.0-rc.22]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.21...v1.0.0-rc.22
+[1.0.0-rc.21]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.20...v1.0.0-rc.21
+[1.0.0-rc.20]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.19...v1.0.0-rc.20
+[1.0.0-rc.19]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.18...v1.0.0-rc.19
+[1.0.0-rc.18]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.17...v1.0.0-rc.18
+[1.0.0-rc.17]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.16...v1.0.0-rc.17
+[1.0.0-rc.16]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.15...v1.0.0-rc.16
+[1.0.0-rc.15]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.14...v1.0.0-rc.15
+[1.0.0-rc.14]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.13...v1.0.0-rc.14
+[1.0.0-rc.13]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.12...v1.0.0-rc.13
+[1.0.0-rc.12]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.11...v1.0.0-rc.12
+[1.0.0-rc.11]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.10...v1.0.0-rc.11
+[1.0.0-rc.10]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.9...v1.0.0-rc.10
+[1.0.0-rc.9]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.8...v1.0.0-rc.9
+[1.0.0-rc.8]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.7...v1.0.0-rc.8
+[1.0.0-rc.7]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.6...v1.0.0-rc.7
+[1.0.0-rc.6]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.5...v1.0.0-rc.6
+[1.0.0-rc.5]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.4...v1.0.0-rc.5
+[1.0.0-rc.4]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.3...v1.0.0-rc.4
+[1.0.0-rc.3]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.2...v1.0.0-rc.3
+[1.0.0-rc.2]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.0.0-rc.1...v1.0.0-rc.2
+[1.0.0-rc.1]: https://github.com/code-ministry-ltd/the-librarian/compare/v0.11.0...v1.0.0-rc.1
+[0.11.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v0.10.0...v0.11.0
+[0.10.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v0.9.0...v0.10.0
+[0.9.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v0.7.4...v0.8.0
+[0.7.4]: https://github.com/code-ministry-ltd/the-librarian/compare/v0.7.3...v0.7.4
+[0.7.3]: https://github.com/code-ministry-ltd/the-librarian/compare/v0.7.2...v0.7.3
+[0.7.2]: https://github.com/code-ministry-ltd/the-librarian/compare/v0.7.1...v0.7.2
+[0.7.1]: https://github.com/code-ministry-ltd/the-librarian/compare/v0.7.0...v0.7.1
+[0.7.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v0.6.2...v0.7.0
+[0.6.2]: https://github.com/code-ministry-ltd/the-librarian/compare/v0.6.1...v0.6.2
+[0.6.1]: https://github.com/code-ministry-ltd/the-librarian/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/code-ministry-ltd/the-librarian/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Thanks for picking this up. The codebase is small enough that you should be prod
 ## Clone + install (under 5 minutes)
 
 ```sh
-git clone git@github.com:JimJafar/the-librarian.git
+git clone git@github.com:code-ministry-ltd/the-librarian.git
 cd the-librarian
 corepack enable && corepack prepare pnpm@9.15.0 --activate
 pnpm install

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![The Librarian](./assets/The%20Librarian.png)
 
-[![CI](https://github.com/JimJafar/the-librarian/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/JimJafar/the-librarian/actions/workflows/ci.yml)
+[![CI](https://github.com/code-ministry-ltd/the-librarian/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/code-ministry-ltd/the-librarian/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/@the-librarian/cli?color=3f9c8e&label=npm)](https://www.npmjs.com/package/@the-librarian/cli)
 [![npm downloads](https://img.shields.io/npm/dw/@the-librarian/cli?color=3f9c8e)](https://www.npmjs.com/package/@the-librarian/cli)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)

--- a/apps/dashboard/components/version-badge.tsx
+++ b/apps/dashboard/components/version-badge.tsx
@@ -18,7 +18,7 @@ const DOT_CLASS: Record<Status, string> = {
   unknown: "border border-foreground/30 bg-transparent",
 };
 
-const RELEASES_URL = "https://github.com/JimJafar/the-librarian/releases";
+const RELEASES_URL = "https://github.com/code-ministry-ltd/the-librarian/releases";
 
 export function VersionBadge() {
   const info = trpc.health.info.useQuery(undefined, {

--- a/apps/dashboard/tests/components/curator/autoupdate.test.tsx
+++ b/apps/dashboard/tests/components/curator/autoupdate.test.tsx
@@ -22,7 +22,7 @@ function latestOk(tag: string) {
     kind: "ok" as const,
     release: {
       tag,
-      htmlUrl: `https://github.com/JimJafar/the-librarian/releases/tag/${tag}`,
+      htmlUrl: `https://github.com/code-ministry-ltd/the-librarian/releases/tag/${tag}`,
       publishedAt: "2026-06-01T00:00:00Z",
       bodyExcerpt: null,
     },

--- a/apps/dashboard/tests/components/version-badge.test.tsx
+++ b/apps/dashboard/tests/components/version-badge.test.tsx
@@ -32,7 +32,7 @@ describe("VersionBadge", () => {
         kind: "ok",
         release: {
           tag: "v0.2.0",
-          htmlUrl: "https://github.com/JimJafar/the-librarian/releases/tag/v0.2.0",
+          htmlUrl: "https://github.com/code-ministry-ltd/the-librarian/releases/tag/v0.2.0",
           publishedAt: "2026-06-01T00:00:00Z",
           bodyExcerpt: null,
         },
@@ -44,7 +44,7 @@ describe("VersionBadge", () => {
     expect(badge.textContent).toContain("v0.2.0");
     expect(badge).toHaveAttribute(
       "href",
-      "https://github.com/JimJafar/the-librarian/releases/tag/v0.2.0",
+      "https://github.com/code-ministry-ltd/the-librarian/releases/tag/v0.2.0",
     );
   });
 

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -46,7 +46,7 @@ export default defineConfig({
         {
           icon: "github",
           label: "GitHub",
-          href: "https://github.com/JimJafar/the-librarian",
+          href: "https://github.com/code-ministry-ltd/the-librarian",
         },
       ],
       sidebar: [

--- a/apps/docs/src/content/docs/connect/claude-code.md
+++ b/apps/docs/src/content/docs/connect/claude-code.md
@@ -90,4 +90,4 @@ environment values are set in the shell that launched Claude Code.
 
 For the complete option-by-option setup, the capture hook details, and
 troubleshooting, see the
-[Claude Code integration README](https://github.com/JimJafar/the-librarian/tree/main/integrations/claude).
+[Claude Code integration README](https://github.com/code-ministry-ltd/the-librarian/tree/main/integrations/claude).

--- a/apps/docs/src/content/docs/connect/codex.md
+++ b/apps/docs/src/content/docs/connect/codex.md
@@ -88,4 +88,4 @@ launched Codex.
 ## Full technical reference
 
 For the complete configuration reference and capture details, see the
-[Codex integration README](https://github.com/JimJafar/the-librarian/tree/main/integrations/codex).
+[Codex integration README](https://github.com/code-ministry-ltd/the-librarian/tree/main/integrations/codex).

--- a/apps/docs/src/content/docs/connect/hermes.md
+++ b/apps/docs/src/content/docs/connect/hermes.md
@@ -60,4 +60,4 @@ confirmed to feed the provider on every completed turn.
 ## Full technical reference
 
 For the configuration fields, security posture, and development notes, see the
-[Hermes integration README](https://github.com/JimJafar/the-librarian/tree/main/integrations/hermes).
+[Hermes integration README](https://github.com/code-ministry-ltd/the-librarian/tree/main/integrations/hermes).

--- a/apps/docs/src/content/docs/connect/opencode.md
+++ b/apps/docs/src/content/docs/connect/opencode.md
@@ -78,4 +78,4 @@ one address needs no token).
 ## Full technical reference
 
 For the exact config schema, sources, and capture details, see the
-[OpenCode integration README](https://github.com/JimJafar/the-librarian/tree/main/integrations/opencode).
+[OpenCode integration README](https://github.com/code-ministry-ltd/the-librarian/tree/main/integrations/opencode).

--- a/apps/docs/src/content/docs/connect/pi.md
+++ b/apps/docs/src/content/docs/connect/pi.md
@@ -36,7 +36,7 @@ Install the extension from a local clone of the repository (the package lives in
 subdirectory, so install from a path):
 
 ```sh
-git clone https://github.com/JimJafar/the-librarian
+git clone https://github.com/code-ministry-ltd/the-librarian
 pi install /path/to/the-librarian/integrations/pi
 ```
 
@@ -72,4 +72,4 @@ anything is unexpected.
 ## Full technical reference
 
 For configuration, the security posture, and publishing notes, see the
-[Pi integration README](https://github.com/JimJafar/the-librarian/tree/main/integrations/pi).
+[Pi integration README](https://github.com/code-ministry-ltd/the-librarian/tree/main/integrations/pi).

--- a/apps/docs/src/content/docs/extend/extension-api.md
+++ b/apps/docs/src/content/docs/extend/extension-api.md
@@ -5,10 +5,10 @@ description: Add MCP tools, tRPC routers, and HTTP routes to your own Librarian 
 
 :::note[Stable surface]
 The extension API is **stable** as of the spec 062 release. It now carries the
-[ADR 0011](https://github.com/JimJafar/the-librarian/blob/main/docs/adr/0011-extension-seams.md)
+[ADR 0011](https://github.com/code-ministry-ltd/the-librarian/blob/main/docs/adr/0011-extension-seams.md)
 semver promise: a breaking change to any type or value published on
 `@librarian/mcp-server/extension` is a **major version bump documented in the
-[CHANGELOG](https://github.com/JimJafar/the-librarian/blob/main/CHANGELOG.md)**. Build
+[CHANGELOG](https://github.com/code-ministry-ltd/the-librarian/blob/main/CHANGELOG.md)**. Build
 against it and pin your major. Everything **not** exported through this entrypoint stays
 private and may change at any time — that small stable surface is the point.
 :::
@@ -23,7 +23,7 @@ touching upstream internals**.
 
 A plugin is a plain **imported object** you pass to the factory. There is no dynamic
 loading, no plugin directory, and no runtime discovery
-([ADR 0011](https://github.com/JimJafar/the-librarian/blob/main/docs/adr/0011-extension-seams.md),
+([ADR 0011](https://github.com/code-ministry-ltd/the-librarian/blob/main/docs/adr/0011-extension-seams.md),
 Decision 2): composition is a deliberate code change in whoever owns the entrypoint.
 That keeps the security model trivial — a plugin is code you deliberately linked — and
 the API surface small.
@@ -519,7 +519,7 @@ can back up is restorable.
 
 The dashboard reaches the server over the **trusted internal tRPC listener** — admin with
 no bearer, because that listener is reachable only over loopback / the internal Docker
-network ([ADR 0008](https://github.com/JimJafar/the-librarian/blob/main/docs/adr/0008-auth-secrets-model.md) P3).
+network ([ADR 0008](https://github.com/code-ministry-ltd/the-librarian/blob/main/docs/adr/0008-auth-secrets-model.md) P3).
 From spec 065 the dashboard also **asserts, on every server call, who the call is on
 behalf of** — a signed-in user, or explicitly *nobody* — in one request header. The header
 is a **scoping assertion, not a credential**: the dashboard process is already trusted, so

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -13,7 +13,7 @@ hero:
       icon: right-arrow
       variant: primary
     - text: View on GitHub
-      link: https://github.com/JimJafar/the-librarian
+      link: https://github.com/code-ministry-ltd/the-librarian
       icon: external
       variant: minimal
 ---

--- a/docs/release.md
+++ b/docs/release.md
@@ -24,7 +24,7 @@ in [`docs/release-runbook.md`](./release-runbook.md).
    and add the compare-link at the bottom:
 
    ```md
-   [X.Y.Z]: https://github.com/JimJafar/the-librarian/compare/v<prev>...vX.Y.Z
+   [X.Y.Z]: https://github.com/code-ministry-ltd/the-librarian/compare/v<prev>...vX.Y.Z
    ```
 
 3. **Merge to `main`.** `.github/workflows/release.yml` reads the version, and
@@ -71,7 +71,7 @@ Don't fight the conflict; let it make you choose a fresh version.
 
 The Docker image rebuilds via CI, and deployment is automatic on merge. The
 dashboard version badge reads the running `package.json` and compares it to the
-latest GitHub release of `JimJafar/the-librarian`, refreshing on its 1-hour
+latest GitHub release of `code-ministry-ltd/the-librarian`, refreshing on its 1-hour
 cache (restart the server for an immediate update).
 
 ## Coordinating with the plugin repos

--- a/integrations/claude/.claude-plugin/plugin.json
+++ b/integrations/claude/.claude-plugin/plugin.json
@@ -5,8 +5,8 @@
     "name": "Jim Sangwine",
     "email": "jim@sangwine.net"
   },
-  "homepage": "https://github.com/JimJafar/the-librarian/tree/main/integrations/claude",
-  "repository": "https://github.com/JimJafar/the-librarian",
+  "homepage": "https://github.com/code-ministry-ltd/the-librarian/tree/main/integrations/claude",
+  "repository": "https://github.com/code-ministry-ltd/the-librarian",
   "license": "Apache-2.0",
   "keywords": ["memory", "handoff", "mcp", "librarian", "recall", "cross-harness"]
 }

--- a/integrations/claude/README.md
+++ b/integrations/claude/README.md
@@ -1,6 +1,6 @@
 # The Librarian — Claude Code integration
 
-[The Librarian](https://github.com/JimJafar/the-librarian) gives Claude Code
+[The Librarian](https://github.com/code-ministry-ltd/the-librarian) gives Claude Code
 durable, shared memory and cross-harness handoffs over plain MCP: 7 tools
 (`recall`, `remember`, `flag_memory`, `store_handoff`, `list_handoffs`,
 `claim_handoff`, `search_references`) plus a ≤2KB primer that Claude Code
@@ -78,7 +78,7 @@ start; the 7 tools appear under the `librarian` server.
 In Claude Code:
 
 ```
-/plugin marketplace add JimJafar/the-librarian
+/plugin marketplace add code-ministry-ltd/the-librarian
 /plugin install the-librarian@the-librarian
 ```
 

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -1,6 +1,6 @@
 # The Librarian — Codex integration
 
-[The Librarian](https://github.com/JimJafar/the-librarian) gives
+[The Librarian](https://github.com/code-ministry-ltd/the-librarian) gives
 [Codex](https://developers.openai.com/codex) durable, shared memory and
 cross-harness handoffs over plain MCP. **No plugin, no code — one config
 block.** Modern Codex speaks streamable HTTP MCP natively and renders the

--- a/integrations/opencode/README.md
+++ b/integrations/opencode/README.md
@@ -1,6 +1,6 @@
 # The Librarian — OpenCode integration
 
-[The Librarian](https://github.com/JimJafar/the-librarian) gives
+[The Librarian](https://github.com/code-ministry-ltd/the-librarian) gives
 [opencode](https://opencode.ai) durable, shared memory and cross-harness
 handoffs over plain MCP. The **tools + primer** need only two config entries
 in `opencode.json` — one MCP server block for the 7 tools, one `instructions`

--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -2,7 +2,7 @@
 
 A [Pi](https://pi.dev) package that gives the Pi coding agent durable memory and
 cross-harness handoffs, backed by a remote
-[Librarian](https://github.com/JimJafar/the-librarian) MCP server.
+[Librarian](https://github.com/code-ministry-ltd/the-librarian) MCP server.
 
 Pi's core has **no MCP support**, so this extension does the wiring itself: it
 registers the Librarian's 7 agent verbs as native Pi tools (each one a thin,
@@ -62,7 +62,7 @@ pi install npm:@the-librarian/pi-extension
 From source (works today):
 
 ```sh
-git clone https://github.com/JimJafar/the-librarian
+git clone https://github.com/code-ministry-ltd/the-librarian
 pi install /path/to/the-librarian/integrations/pi
 ```
 

--- a/integrations/pi/package.json
+++ b/integrations/pi/package.json
@@ -12,10 +12,10 @@
     "name": "Jim Sangwine",
     "email": "jim@sangwine.net"
   },
-  "homepage": "https://github.com/JimJafar/the-librarian/tree/main/integrations/pi",
+  "homepage": "https://github.com/code-ministry-ltd/the-librarian/tree/main/integrations/pi",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/JimJafar/the-librarian.git",
+    "url": "git+https://github.com/code-ministry-ltd/the-librarian.git",
     "directory": "integrations/pi"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.17.1",
+  "version": "1.17.2",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/core/src/ingest/fetch-html.ts
+++ b/packages/core/src/ingest/fetch-html.ts
@@ -158,7 +158,8 @@ function requestOnce(
           // Deliberately NO Authorization: never forward our capture credential
           // to an arbitrary third-party origin.
           accept: "text/html,application/xhtml+xml",
-          "user-agent": "Librarian-Ingest/1.0 (+https://github.com/JimJafar/the-librarian)",
+          "user-agent":
+            "Librarian-Ingest/1.0 (+https://github.com/code-ministry-ltd/the-librarian)",
           // identity encoding so the body-size cap measures real bytes and a
           // compressed bomb can't expand past it.
           "accept-encoding": "identity",

--- a/packages/installer-cli/README.md
+++ b/packages/installer-cli/README.md
@@ -1,7 +1,7 @@
 # `@the-librarian/cli` — the `librarian` installer
 
 A small CLI that does two jobs for
-[The Librarian](https://github.com/JimJafar/the-librarian): it **wires it into
+[The Librarian](https://github.com/code-ministry-ltd/the-librarian): it **wires it into
 your AI agents** (installs/updates the integration for each harness, across all
 your machines) and **self-hosts the server** they talk to (`server up` /
 `update`). Think of it as the package manager for your Librarian setup: one tool
@@ -102,7 +102,7 @@ Other server commands: `server update` (upgrade to the latest release, preservin
 your data), `server down` / `status` / `logs`, and `server enable-boot` (Linux
 systemd) to start it on boot. Run it on a private network / behind a VPN, or
 expose it with auth — see the
-[deployment guide](https://github.com/JimJafar/the-librarian/blob/main/DEPLOYMENT.md).
+[deployment guide](https://github.com/code-ministry-ltd/the-librarian/blob/main/DEPLOYMENT.md).
 
 ## What it writes to your environment
 

--- a/packages/installer-cli/package.json
+++ b/packages/installer-cli/package.json
@@ -7,6 +7,12 @@
   },
   "type": "module",
   "description": "The Librarian CLI: self-host the server and install it into your AI coding agents (Claude Code, Codex, OpenCode, Hermes, Pi).",
+  "homepage": "https://github.com/code-ministry-ltd/the-librarian/tree/main/packages/installer-cli",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/code-ministry-ltd/the-librarian.git",
+    "directory": "packages/installer-cli"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {

--- a/packages/installer-cli/src/harnesses/claude.ts
+++ b/packages/installer-cli/src/harnesses/claude.ts
@@ -1,11 +1,11 @@
 // Claude Code harness.
 //
 // Drives the `claude` CLI's native plugin/marketplace commands — we never
-// hand-edit Claude config. The marketplace is `JimJafar/the-librarian`;
+// hand-edit Claude config. The marketplace is `code-ministry-ltd/the-librarian`;
 // the plugin is `the-librarian@the-librarian` (name@marketplace).
 //
 //   detect    `claude` on PATH AND `claude plugin list` shows our plugin
-//   install   `claude plugin marketplace add JimJafar/the-librarian`
+//   install   `claude plugin marketplace add code-ministry-ltd/the-librarian`
 //             then `claude plugin install the-librarian@the-librarian`
 //   uninstall `claude plugin remove the-librarian@the-librarian`
 //             then `claude plugin marketplace remove the-librarian`
@@ -18,7 +18,7 @@ import { run, which } from "../exec.js";
 import type { HarnessConfig, HarnessModule } from "./types.js";
 
 const CLI = "claude";
-const MARKETPLACE = "JimJafar/the-librarian";
+const MARKETPLACE = "code-ministry-ltd/the-librarian";
 const MARKETPLACE_ID = "the-librarian";
 const PLUGIN = "the-librarian@the-librarian";
 const PLUGIN_NAME = "the-librarian";

--- a/packages/installer-cli/src/harnesses/codex.ts
+++ b/packages/installer-cli/src/harnesses/codex.ts
@@ -162,7 +162,7 @@ export type CaptureFetcher = (ref: string) => Promise<string>;
 
 /** The default fetcher: codeload tarball → `tar` extract → integration dir. */
 const defaultCaptureFetcher: CaptureFetcher = async (ref) => {
-  const url = `https://codeload.github.com/JimJafar/the-librarian/tar.gz/refs/tags/${ref}`;
+  const url = `https://codeload.github.com/code-ministry-ltd/the-librarian/tar.gz/refs/tags/${ref}`;
   const work = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-codex-fetch-"));
   const tarball = path.join(work, "src.tar.gz");
   const res = await fetch(url, { redirect: "error" });

--- a/packages/installer-cli/src/harnesses/hermes.ts
+++ b/packages/installer-cli/src/harnesses/hermes.ts
@@ -14,7 +14,7 @@
 // ARTIFACT SOURCING. On a user's machine the adapter does NOT live in the
 // repo — the CLI must fetch it from a pinned release. We download a tarball
 // of the pinned ref from GitHub's codeload endpoint
-//   https://codeload.github.com/JimJafar/the-librarian/tar.gz/refs/tags/<ref>
+//   https://codeload.github.com/code-ministry-ltd/the-librarian/tar.gz/refs/tags/<ref>
 // and extract `integrations/hermes/librarian/**` out of it with `tar`. The
 // FETCH is injectable (`setAdapterFetcher`): tests inject a fetcher that
 // returns a local fixture dir, so nothing touches the network. The pinned
@@ -47,7 +47,7 @@ export type AdapterFetcher = (ref: string) => Promise<string>;
 
 /** The default fetcher: codeload tarball → `tar` extract → adapter dir. */
 const defaultFetcher: AdapterFetcher = async (ref) => {
-  const url = `https://codeload.github.com/JimJafar/the-librarian/tar.gz/refs/tags/${ref}`;
+  const url = `https://codeload.github.com/code-ministry-ltd/the-librarian/tar.gz/refs/tags/${ref}`;
   const work = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-hermes-fetch-"));
   const tarball = path.join(work, "src.tar.gz");
   const res = await fetch(url, { redirect: "error" });

--- a/packages/installer-cli/src/harnesses/opencode.ts
+++ b/packages/installer-cli/src/harnesses/opencode.ts
@@ -142,7 +142,7 @@ export type CaptureFetcher = (ref: string) => Promise<string>;
 
 /** The default fetcher: codeload tarball → `tar` extract → integration dir. */
 const defaultCaptureFetcher: CaptureFetcher = async (ref) => {
-  const url = `https://codeload.github.com/JimJafar/the-librarian/tar.gz/refs/tags/${ref}`;
+  const url = `https://codeload.github.com/code-ministry-ltd/the-librarian/tar.gz/refs/tags/${ref}`;
   const work = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-opencode-fetch-"));
   const tarball = path.join(work, "src.tar.gz");
   const res = await fetch(url, { redirect: "error" });

--- a/packages/installer-cli/src/server/up.ts
+++ b/packages/installer-cli/src/server/up.ts
@@ -63,7 +63,7 @@ import { redactSecrets } from "./redact.js";
 export { redactSecrets } from "./redact.js";
 
 /** The repository the deploy dir clones (same repo the latest-tag fetch targets). */
-export const REPO_URL = "https://github.com/JimJafar/the-librarian";
+export const REPO_URL = "https://github.com/code-ministry-ltd/the-librarian";
 
 /** The container name every `server` command operates on (single instance per host). */
 export const CONTAINER_NAME = "the-librarian";

--- a/packages/installer-cli/src/status.ts
+++ b/packages/installer-cli/src/status.ts
@@ -19,7 +19,8 @@ import { allHarnesses, type DetectResult, type HarnessModule } from "./harnesses
 import { isBehind } from "./semver.js";
 
 /** GitHub releases API for the monorepo (latest published release). */
-const LATEST_RELEASE_URL = "https://api.github.com/repos/JimJafar/the-librarian/releases/latest";
+const LATEST_RELEASE_URL =
+  "https://api.github.com/repos/code-ministry-ltd/the-librarian/releases/latest";
 /** A short timeout so an unreachable network never hangs `status`. */
 const FETCH_TIMEOUT_MS = 3000;
 

--- a/packages/installer-cli/tests/claude.test.ts
+++ b/packages/installer-cli/tests/claude.test.ts
@@ -48,7 +48,9 @@ describe("claude harness", () => {
     const r = new FakeRunner().withWhich("claude");
     setRunner(r);
     await claude.install(CFG);
-    expect(r.ran("claude", ["plugin", "marketplace", "add", "JimJafar/the-librarian"])).toBe(true);
+    expect(
+      r.ran("claude", ["plugin", "marketplace", "add", "code-ministry-ltd/the-librarian"]),
+    ).toBe(true);
     expect(r.ran("claude", ["plugin", "install", "the-librarian@the-librarian"])).toBe(true);
   });
 

--- a/packages/installer-cli/tests/server-up.test.ts
+++ b/packages/installer-cli/tests/server-up.test.ts
@@ -124,7 +124,11 @@ describe("server up — fresh localhost happy path (exact argv)", () => {
       // NOT) — and check out that SHA (S-1). The checkout itself running is
       // proven by the docker build/run below (it follows the checkout in code).
       expect(
-        runner.ran("git", ["clone", "https://github.com/JimJafar/the-librarian", deployDir]),
+        runner.ran("git", [
+          "clone",
+          "https://github.com/code-ministry-ltd/the-librarian",
+          deployDir,
+        ]),
       ).toBe(true);
       expect(
         runner.ran("git", [
@@ -211,7 +215,11 @@ describe("server up — flags reflected in argv", () => {
 
       // Clone + checkout at the pinned ref, into the custom dir.
       expect(
-        runner.ran("git", ["clone", "https://github.com/JimJafar/the-librarian", customDir]),
+        runner.ran("git", [
+          "clone",
+          "https://github.com/code-ministry-ltd/the-librarian",
+          customDir,
+        ]),
       ).toBe(true);
       expect(
         runner.ran("git", [
@@ -556,7 +564,7 @@ describe("server up — foreign deploy dir stops and asks (never clobbers)", () 
       const runner = healthyRunner().onRun(
         "git",
         ["-C", deployDir, "remote", "get-url", "origin"],
-        { stdout: "git@github.com:JimJafar/the-librarian.git\n", code: 0 },
+        { stdout: "git@github.com:code-ministry-ltd/the-librarian.git\n", code: 0 },
       );
       setDockerRunner(runner);
       stubSeams();
@@ -1267,7 +1275,7 @@ describe("server up — master key reuse (P2)", () => {
       const runner = healthyRunner().onRun(
         "git",
         ["-C", deployDir, "remote", "get-url", "origin"],
-        { stdout: "git@github.com:JimJafar/the-librarian.git\n", code: 0 },
+        { stdout: "git@github.com:code-ministry-ltd/the-librarian.git\n", code: 0 },
       );
       setDockerRunner(runner);
       stubSeams(); // MASTER_KEY is what the minter WOULD return — it must NOT be used
@@ -1300,7 +1308,7 @@ describe("server up — master key reuse (P2)", () => {
       const runner = healthyRunner().onRun(
         "git",
         ["-C", deployDir, "remote", "get-url", "origin"],
-        { stdout: "git@github.com:JimJafar/the-librarian.git\n", code: 0 },
+        { stdout: "git@github.com:code-ministry-ltd/the-librarian.git\n", code: 0 },
       );
       setDockerRunner(runner);
       stubSeams();

--- a/packages/mcp-server/src/github-release.ts
+++ b/packages/mcp-server/src/github-release.ts
@@ -6,7 +6,7 @@
 // repo is pre-tag, the operator's instance is offline, the operator
 // disabled the check via `LIBRARIAN_DISABLE_VERSION_CHECK=true`, etc.).
 
-const DEFAULT_REPO = "JimJafar/the-librarian";
+const DEFAULT_REPO = "code-ministry-ltd/the-librarian";
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 const REQUEST_TIMEOUT_MS = 4_000;
 

--- a/packages/mcp-server/tests/github-release.test.ts
+++ b/packages/mcp-server/tests/github-release.test.ts
@@ -45,7 +45,7 @@ describe("getLatestRelease", () => {
     mockFetchOnce(async () =>
       jsonResponse({
         tag_name: "v0.2.0",
-        html_url: "https://github.com/JimJafar/the-librarian/releases/tag/v0.2.0",
+        html_url: "https://github.com/code-ministry-ltd/the-librarian/releases/tag/v0.2.0",
         published_at: "2026-06-01T00:00:00Z",
         body: "## What's new\n\n- handoffs",
       }),

--- a/pull-and-restart.sh
+++ b/pull-and-restart.sh
@@ -159,7 +159,7 @@ if [ -n "$DISCORD_WEBHOOK" ] && [ "$OLD_HEAD" != "$NEW_HEAD" ]; then
     -H "Content-Type: application/json" \
     -d "$(jq -n \
       --rawfile desc "$DESC_FILE" \
-      --arg url "https://github.com/JimJafar/the-librarian/compare/${SHORT_OLD}...${SHORT_NEW}" \
+      --arg url "https://github.com/code-ministry-ltd/the-librarian/compare/${SHORT_OLD}...${SHORT_NEW}" \
       '{
         embeds: [{
           title: "📦 The Librarian deployed",


### PR DESCRIPTION
The Librarian's canonical home is moving from `JimJafar/the-librarian` to `code-ministry-ltd/the-librarian`. GitHub's transfer sets up permanent redirects, so nothing breaks the moment it flips — but leaning on a redirect forever is fragile, and the published packages' metadata should name the real home. This repoints every reference to the monorepo itself.

The npm package names are deliberately unchanged: `@the-librarian/cli` and `@the-librarian/pi-extension` keep their scope, which is independent of the GitHub org. Nothing here renames or republishes a package.

What moved:
  - published metadata — `@the-librarian/pi-extension`'s homepage/repository, plus a homepage/repository on `@the-librarian/cli`, which had none, so its npm page linked nowhere;
  - the runtime GitHub endpoints — release-version checks (CLI `status`, server `github-release`), the Hermes/Codex/OpenCode adapter tarball downloads, the Claude Code marketplace slug, `server up`'s clone URL;
  - the ingest fetcher's user-agent, the docs, the READMEs, and the CHANGELOG's compare-links.

Left alone on purpose: the archived standalone plugin repos (`the-librarian-claude-plugin` and friends) are a separate concern and keep their old URLs. Generated output (`dist/`, `.next/`) is gitignored and rebuilt by CI.

NOTE: the GitHub org transfer must land BEFORE this merges — until `code-ministry-ltd/the-librarian` exists, the repointed runtime fetches 404.

<!--
The Librarian PR template (introduced in T1.4 of the maintainability overhaul).
Keep the sections; trim or expand the contents as the change requires.
-->

## Spec / phase reference

<!-- e.g. "Implements T1.4 — CI workflow + enforcement guards + PR template (Phase 1 of specs/done/002-maintainability-overhaul.md)" -->

## Summary

<!-- 1–3 bullets on what changed and why. Lead with the why. -->

-
-

## Test plan

<!-- Bulleted checklist proving the PR works. Reference the exact commands you ran. -->

- [ ] `pnpm install --frozen-lockfile`
- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm test:vitest`
- [ ] `pnpm build`
- [ ] `pnpm run smoke`
- [ ] `pnpm run healthcheck`
- [ ] Any task-specific verification commands from the spec

## Quality gates

- [ ] **No production source file over 400 LOC introduced** (or each exception noted with rationale below — applies to `packages/*/src/` and `apps/*/src/`, not tests)
- [ ] **No new `any` or `@ts-ignore` introduced** (or each exception noted with rationale below)
- [ ] **User-facing changes are documented in this PR** (CLI / MCP verbs / dashboard / install / harness setup / slash commands — or N/A for internal-only changes)

<!--
If you ticked an exception above, list each here:
  - path/to/file.ts (LOC: 612) — splitting deferred to T#.# because …
  - path/to/file.ts:42 — `any` retained because the third-party type is `unknown` and `…`
-->

## Notes for the reviewer

<!-- Anything reviewer-only: known follow-ups, deliberately-deferred work, screenshots, etc. -->
