### PR TITLE
fix(scripts): make the test-count guard say which tests failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.17.3] — 2026-07-31
+
+### Fixed
+
+- **The test-count guard now names the tests that failed.** The guard re-runs the
+  whole suite with `--reporter=json` and, on a non-zero exit, threw the captured
+  report away — so a failing CI job printed
+  `pnpm -r exec vitest run --reporter=json exited with code 1; aborting guard`
+  and nothing else: no test, no file, no message. A gate that fails without
+  saying why can't be acted on — a flaky timeout and a real regression look
+  identical, so the only move left is to re-run and hope. The failing tests were
+  in the captured JSON the whole time; the guard now parses it and lists each
+  failure with its file and the first line of its message, and says so plainly
+  when a run failed without any test failing (a config error or a crashed
+  worker) rather than implying it knows more than it does.
+- **`scripts/check-test-count.mjs` is importable.** Its guard logic ran at module
+  scope, so any `import` of the file re-ran the entire suite — which is why it
+  had no unit tests. The run is now behind the same entry-point check
+  `scripts/stamp-version.mjs` uses, and the parsing helpers are exported and
+  tested directly.
+
 ## [1.17.2] — 2026-07-30
 
 ### Changed
@@ -4264,6 +4285,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.17.3]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.17.2...v1.17.3
 [1.17.2]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.17.1...v1.17.2
 [1.17.1]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.17.0...v1.17.1
 [1.17.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.16.1...v1.17.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.17.2",
+  "version": "1.17.3",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/scripts/check-test-count.mjs
+++ b/scripts/check-test-count.mjs
@@ -24,34 +24,44 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "..");
 const baselinePath = path.join(repoRoot, "test", "baseline.json");
 
-const baseline = JSON.parse(fs.readFileSync(baselinePath, "utf8"));
-const floor = Number(baseline.count);
-if (!Number.isFinite(floor) || floor < 0) {
-  console.error(`[check-test-count] invalid baseline.count in ${baselinePath}`);
-  process.exit(2);
-}
-
-const nodeTestFiles = collectNodeTestFiles(repoRoot);
-
-try {
-  const nodeCount = nodeTestFiles.length ? await countNodeTests(nodeTestFiles) : 0;
-  const vitestCount = await countVitestTests();
-  const total = nodeCount + vitestCount;
-
-  if (total < floor) {
-    console.error(
-      `[check-test-count] FAIL: ${total} tests reported (node:test=${nodeCount}, vitest=${vitestCount}), floor is ${floor}. ` +
-        "Update test/baseline.json in this PR and explain the reduction in the description.",
-    );
-    process.exit(1);
+async function main() {
+  const baseline = JSON.parse(fs.readFileSync(baselinePath, "utf8"));
+  const floor = Number(baseline.count);
+  if (!Number.isFinite(floor) || floor < 0) {
+    console.error(`[check-test-count] invalid baseline.count in ${baselinePath}`);
+    process.exit(2);
   }
 
-  console.log(
-    `[check-test-count] OK: ${total} tests (node:test=${nodeCount}, vitest=${vitestCount}) >= floor ${floor}`,
-  );
-} catch (err) {
-  console.error(`[check-test-count] ${err.message}`);
-  process.exit(2);
+  const nodeTestFiles = collectNodeTestFiles(repoRoot);
+
+  try {
+    const nodeCount = nodeTestFiles.length ? await countNodeTests(nodeTestFiles) : 0;
+    const vitestCount = await countVitestTests();
+    const total = nodeCount + vitestCount;
+
+    if (total < floor) {
+      console.error(
+        `[check-test-count] FAIL: ${total} tests reported (node:test=${nodeCount}, vitest=${vitestCount}), floor is ${floor}. ` +
+          "Update test/baseline.json in this PR and explain the reduction in the description.",
+      );
+      process.exit(1);
+    }
+
+    console.log(
+      `[check-test-count] OK: ${total} tests (node:test=${nodeCount}, vitest=${vitestCount}) >= floor ${floor}`,
+    );
+  } catch (err) {
+    console.error(`[check-test-count] ${err.message}`);
+    process.exit(2);
+  }
+}
+
+// Only run the guard when invoked as the entry point. Without this the whole
+// suite re-ran on mere `import` — which made the module untestable, since a test
+// importing the helpers below would recursively spawn the very run it counts.
+// Same convention as scripts/stamp-version.mjs.
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  await main();
 }
 
 function collectNodeTestFiles(root) {
@@ -123,6 +133,102 @@ function countRootVitestTests() {
   return runJsonReporter(["pnpm", "exec", "vitest", "run", "--reporter=json"]);
 }
 
+/**
+ * Pull every complete top-level JSON document out of a captured stdout stream.
+ *
+ * `pnpm -r exec` runs vitest once per workspace, so stdout carries several whole
+ * JSON reports back to back, interleaved with pnpm's own prefixes and anything
+ * the tests printed. `JSON.parse(stdout)` therefore throws, and parsing only the
+ * first document loses every later workspace. Brace-matching (string- and
+ * escape-aware, so a `{` inside a failure message can't unbalance it) is what
+ * survives that stream. Exported for tests.
+ */
+export function extractJsonDocuments(text) {
+  const docs = [];
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+    } else if (ch === "{") {
+      if (depth === 0) start = i;
+      depth++;
+    } else if (ch === "}") {
+      if (depth === 0) continue; // stray brace in log noise
+      depth--;
+      if (depth === 0 && start !== -1) {
+        docs.push(text.slice(start, i + 1));
+        start = -1;
+      }
+    }
+  }
+  return docs;
+}
+
+/**
+ * The failing tests named in a `--reporter=json` stdout stream.
+ *
+ * Never throws: unparseable fragments are skipped. This runs only on a path that
+ * is ALREADY failing, so a helper that could throw would just replace one
+ * uninformative failure with another. Exported for tests.
+ */
+export function collectFailedTests(stdout) {
+  const failures = [];
+  for (const doc of extractJsonDocuments(stdout)) {
+    let parsed;
+    try {
+      parsed = JSON.parse(doc);
+    } catch {
+      continue; // log noise that happened to look like a JSON object
+    }
+    if (!Array.isArray(parsed?.testResults)) continue;
+    for (const file of parsed.testResults) {
+      for (const assertion of file?.assertionResults ?? []) {
+        if (assertion?.status !== "failed") continue;
+        // First line only: a full stack per failure buries the list in CI.
+        const message = String(assertion.failureMessages?.[0] ?? "")
+          .split("\n")[0]
+          .trim();
+        failures.push({
+          file: file?.name ?? "(unknown file)",
+          name: assertion.fullName || assertion.title || "(unnamed test)",
+          message,
+        });
+      }
+    }
+  }
+  return failures;
+}
+
+/**
+ * The guard's message for a non-zero runner exit — naming the failing tests when
+ * the report identified any, and saying plainly that it could not when it did
+ * not (a config error or a crashed worker fails the run without failing a test).
+ * Exported for tests.
+ */
+export function formatRunFailure(args, code, failures) {
+  const header = `${args.join(" ")} exited with code ${code}; aborting guard`;
+  if (!failures.length) {
+    return `${header}\n  The run reported no failing test — likely a config error or a crashed worker. Re-run this command locally to see the runner's own output.`;
+  }
+  const noun = failures.length === 1 ? "1 failing test" : `${failures.length} failing tests`;
+  const lines = failures.map((f) => {
+    const where = path.relative(repoRoot, f.file) || f.file;
+    return `  ✗ ${f.name}\n      ${where}${f.message ? `\n      ${f.message}` : ""}`;
+  });
+  return `${header}\n  ${noun}:\n${lines.join("\n")}`;
+}
+
 function runJsonReporter(args) {
   return new Promise((resolve, reject) => {
     const [bin, ...rest] = args;
@@ -142,8 +248,13 @@ function runJsonReporter(args) {
       // tests; any non-zero exit (config error, runtime crash, failing
       // test) must surface as a guard failure so a silently-zeroed
       // numTotalTests can't slip past the floor check.
+      //
+      // The report is on the stdout we just captured, so name the failing
+      // tests instead of throwing them away: this used to reject with the
+      // exit code alone, which left CI saying only "exited with code 1" and
+      // made a flaky timeout indistinguishable from a real regression.
       if (code !== 0) {
-        reject(new Error(`${args.join(" ")} exited with code ${code}; aborting guard`));
+        reject(new Error(formatRunFailure(args, code, collectFailedTests(stdout))));
         return;
       }
       let total = 0;

--- a/test/check-test-count-failures.test.ts
+++ b/test/check-test-count-failures.test.ts
@@ -1,0 +1,134 @@
+// Guards the test-count guard's own diagnostics.
+//
+// The bug this prevents: `check-test-count.mjs` runs the whole suite a second
+// time with `--reporter=json`, capturing the report on stdout. When vitest
+// exited non-zero it discarded that stdout and reported only the exit code, so
+// CI printed `pnpm -r exec vitest run --reporter=json exited with code 1;
+// aborting guard` and nothing else — no test name, no file, no message. A gate
+// that can fail without saying why is unusable: you cannot tell a flaky timeout
+// from a real regression, so the only move left is to re-run and hope. The
+// failing tests were sitting in the captured JSON the whole time.
+//
+// See scripts/check-test-count.mjs.
+
+import { describe, expect, it } from "vitest";
+import { collectFailedTests, formatRunFailure } from "../scripts/check-test-count.mjs";
+
+/** One workspace's `--reporter=json` document, as vitest emits it. */
+function report(
+  testFile: string,
+  assertions: Array<{ name: string; status: string; message?: string }>,
+): string {
+  return JSON.stringify({
+    numTotalTests: assertions.length,
+    numFailedTests: assertions.filter((a) => a.status === "failed").length,
+    testResults: [
+      {
+        name: testFile,
+        status: assertions.some((a) => a.status === "failed") ? "failed" : "passed",
+        assertionResults: assertions.map((a) => ({
+          ancestorTitles: [],
+          title: a.name,
+          fullName: a.name,
+          status: a.status,
+          failureMessages: a.message ? [a.message] : [],
+        })),
+      },
+    ],
+  });
+}
+
+describe("collectFailedTests", () => {
+  it("names the failing test, its file, and the first line of its message", () => {
+    const stdout = report("/repo/packages/mcp-server/tests/trpc/vault.test.ts", [
+      {
+        name: "tRPC vault > edits land as git commits",
+        status: "failed",
+        message: "Error: Timed out waiting for http://0.0.0.0:37463/healthz\n    at waitForHttp",
+      },
+    ]);
+
+    const failures = collectFailedTests(stdout);
+
+    expect(failures).toHaveLength(1);
+    expect(failures[0].name).toBe("tRPC vault > edits land as git commits");
+    expect(failures[0].file).toBe("/repo/packages/mcp-server/tests/trpc/vault.test.ts");
+    // The first line only — a full stack per failure buries the list in CI.
+    expect(failures[0].message).toBe("Error: Timed out waiting for http://0.0.0.0:37463/healthz");
+  });
+
+  it("collects failures across every workspace's report, not just the first", () => {
+    // `pnpm -r exec` runs vitest per workspace, so stdout carries several
+    // complete JSON documents back to back. Parsing only the first (or calling
+    // JSON.parse on the whole stream) loses every later workspace's failures.
+    const stdout = [
+      report("/repo/packages/core/tests/a.test.ts", [{ name: "a passes", status: "passed" }]),
+      report("/repo/packages/mcp-server/tests/b.test.ts", [
+        { name: "b fails", status: "failed", message: "AssertionError: expected 1 to be 2" },
+      ]),
+      report("/repo/apps/dashboard/tests/c.test.tsx", [
+        { name: "c fails", status: "failed", message: "Error: boom" },
+      ]),
+    ].join("\n");
+
+    const failures = collectFailedTests(stdout);
+
+    expect(failures.map((f) => f.name)).toEqual(["b fails", "c fails"]);
+  });
+
+  it("ignores the pnpm prefixes and log noise interleaved with the reports", () => {
+    // Real stdout is not pure JSON: pnpm prefixes lines, and tests themselves
+    // print. Anything unparseable must be skipped rather than crash the guard —
+    // a diagnostics helper that throws would replace one silent failure with another.
+    const stdout = [
+      "packages/core test:vitest: Building 4 posts…",
+      report("/repo/packages/core/tests/a.test.ts", [
+        { name: "a fails", status: "failed", message: "Error: nope" },
+      ]),
+      "{ not valid json at all",
+      "Done.",
+    ].join("\n");
+
+    expect(collectFailedTests(stdout).map((f) => f.name)).toEqual(["a fails"]);
+  });
+
+  it("returns nothing when the run failed with no failing test (a crash or config error)", () => {
+    // vitest can exit non-zero without any assertion failing — a config error or
+    // a worker crash. The guard must still report *something* rather than
+    // claiming a test failed, so an empty list here is the correct answer and
+    // formatRunFailure below is what covers the message.
+    const stdout = report("/repo/packages/core/tests/a.test.ts", [
+      { name: "a passes", status: "passed" },
+    ]);
+
+    expect(collectFailedTests(stdout)).toEqual([]);
+    expect(collectFailedTests("")).toEqual([]);
+  });
+});
+
+describe("formatRunFailure", () => {
+  it("lists every failing test under the command and exit code", () => {
+    const message = formatRunFailure(["pnpm", "-r", "exec", "vitest", "run"], 1, [
+      {
+        file: "/repo/packages/mcp-server/tests/trpc/vault.test.ts",
+        name: "tRPC vault > edits land as git commits",
+        message: "Error: Timed out waiting for /healthz",
+      },
+    ]);
+
+    expect(message).toContain("exited with code 1");
+    expect(message).toContain("1 failing test");
+    expect(message).toContain("tRPC vault > edits land as git commits");
+    expect(message).toContain("packages/mcp-server/tests/trpc/vault.test.ts");
+    expect(message).toContain("Error: Timed out waiting for /healthz");
+  });
+
+  it("says so explicitly when the runner failed without naming a test", () => {
+    // The old behaviour for EVERY failure. Keeping an honest message for the
+    // genuinely-unattributable case is the point: never imply we know more than we do.
+    const message = formatRunFailure(["pnpm", "exec", "vitest", "run"], 2, []);
+
+    expect(message).toContain("exited with code 2");
+    expect(message).toMatch(/no failing test|could not/i);
+  });
+});


### PR DESCRIPTION
## Why

[CI run 30620169074](https://github.com/code-ministry-ltd/the-librarian/actions/runs/30620169074) (on #448) failed with exactly one line of diagnosis:

```
pnpm -r exec vitest run --reporter=json exited with code 1; aborting guard
```

No test name, no file, no message. The guard re-runs the whole suite with `--reporter=json` and captures the report on stdout — then, on a non-zero exit, **threw that stdout away** and rejected with the exit code alone. The failing tests were in the captured JSON the whole time.

That matters because the two things this gate catches look identical from outside: a flaky timeout and a genuine regression both surface as `code 1`. With nothing to tell them apart, the only move left is to re-run and hope — which is how a real failure gets retried until it goes green.

## What changed

- **The guard names the failures.** Each one is listed with its file and the first line of its message. When a run fails with *no* failing test (a config error, a crashed worker) it says so plainly rather than implying it knows more than it does.
- **`check-test-count.mjs` is importable.** Its logic ran at module scope, so any `import` re-ran the entire suite — which is why it had no unit tests. The run now sits behind the same entry-point check `scripts/stamp-version.mjs` uses.

Two details worth knowing:

- `pnpm -r exec` emits **one complete JSON document per workspace**, so stdout is several concatenated reports mixed with pnpm prefixes and test output. `JSON.parse` throws on it, and parsing the first document silently drops every later workspace — so extraction is brace-matched (string- and escape-aware, so a brace inside a failure message can't unbalance it) and skips what it can't parse. It runs only on an already-failing path, so a helper that could throw would just replace one uninformative failure with another.
- The parsing helpers are exported and unit-tested directly (6 tests, ~20ms) rather than tested through a full suite run.

## Verification

- 6/6 new tests pass. Confirmed they could not have passed before: neither export nor the entry-point guard existed in `HEAD`.
- **Confirmed the entry-point check still fires** — invoking the script runs the suite rather than exiting 0 doing nothing. A silently disabled guard would be worse than the bug being fixed.
- `check:release`, prettier, eslint all clean.

## Note on stacking

Based on `chore/move-to-code-ministry-org` (#448), which is unmerged, so this targets `1.17.3` and avoids a version/CHANGELOG collision. GitHub will retarget this to `main` when #448 merges.

**This does not fix the underlying flakiness** — it makes it diagnosable. The hard-coded 3s `tools/list` deadline in `scripts/healthcheck.js` is the likely culprit and is worth its own PR; on a loaded machine I measured it failing 4/4 at 3083–3357ms against that 3000ms limit, on an unmodified checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)