### PR TITLE
fix(dashboard): reset vault move dialog state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.17.3] — 2026-08-02
+
+### Fixed
+
+- **Moving multiple Vault files no longer requires a page refresh.** Opening the
+  Move dialog after selecting a different file now resets its folder and filename
+  to the current selection instead of retaining the previously moved file.
+
 ## [1.17.2] — 2026-07-30
 
 ### Changed
@@ -4264,6 +4272,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.17.3]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.17.2...v1.17.3
 [1.17.2]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.17.1...v1.17.2
 [1.17.1]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.17.0...v1.17.1
 [1.17.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.16.1...v1.17.0

--- a/apps/dashboard/components/vault/file-view.tsx
+++ b/apps/dashboard/components/vault/file-view.tsx
@@ -214,6 +214,17 @@ function MoveDialog({
 
   const to = composePath(folder, filename);
 
+  const changeOpen = (next: boolean) => {
+    setOpen(next);
+    // Reset the picker to the currently selected file each time it opens.
+    if (next) {
+      const current = splitPath(path);
+      setFolder(current.folder);
+      setFilename(current.filename);
+      setError(null);
+    }
+  };
+
   const submit = (event: React.FormEvent) => {
     event.preventDefault();
     startTransition(async () => {
@@ -222,27 +233,14 @@ function MoveDialog({
         setError(result.error);
         return;
       }
-      setOpen(false);
-      setError(null);
+      changeOpen(false);
       router.push(`/?path=${encodeURIComponent(result.path)}`);
     });
   };
 
   return (
-    <Dialog
-      open={open}
-      onOpenChange={(next) => {
-        setOpen(next);
-        // Reset the picker to the file's current location each time it opens.
-        if (next) {
-          const current = splitPath(path);
-          setFolder(current.folder);
-          setFilename(current.filename);
-          setError(null);
-        }
-      }}
-    >
-      <Button variant="outline" onClick={() => setOpen(true)}>
+    <Dialog open={open} onOpenChange={changeOpen}>
+      <Button variant="outline" onClick={() => changeOpen(true)}>
         Move
       </Button>
       <DialogContent>
@@ -278,7 +276,7 @@ function MoveDialog({
           </p>
           {error ? <p className="text-sm text-destructive">{error}</p> : null}
           <DialogFooter>
-            <Button type="button" variant="ghost" onClick={() => setOpen(false)}>
+            <Button type="button" variant="ghost" onClick={() => changeOpen(false)}>
               Cancel
             </Button>
             <Button

--- a/apps/dashboard/tests/components/vault/file-view.test.tsx
+++ b/apps/dashboard/tests/components/vault/file-view.test.tsx
@@ -127,6 +127,28 @@ describe("FileView", () => {
       }),
     );
   });
+
+  it("resets the move dialog to a newly selected file after completing a move", async () => {
+    const acts = actions();
+    const { rerender } = render(<FileView file={memoryFile} actions={acts} directories={DIRS} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Move" }));
+    const folder = await screen.findByRole("combobox", { name: "Folder" });
+    await userEvent.clear(folder);
+    await userEvent.type(folder, "references");
+    await userEvent.click(screen.getByRole("button", { name: "Move file" }));
+    await vi.waitFor(() => expect(acts.rename).toHaveBeenCalledOnce());
+
+    const nextFile = {
+      ...memoryFile,
+      path: "references/schedule.md",
+      hash: "hash-2",
+    };
+    rerender(<FileView file={nextFile} actions={acts} directories={DIRS} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Move" }));
+    expect(await screen.findByRole("textbox", { name: "File name" })).toHaveValue("schedule.md");
+  });
 });
 
 describe("VaultEditor", () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.17.2",
+  "version": "1.17.3",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Summary

- reset the Vault Move dialog from the currently selected file every time it opens
- route all controlled dialog open and close transitions through one state handler
- add a regression test covering a completed move followed by selecting and moving another file
- bump the patch release to 1.17.3 and add the required changelog entry

## Root cause

The Move button called setOpen(true) directly, while the folder and filename reset lived only in Dialog.onOpenChange. Because the controlled open bypassed that callback, the mounted FileView retained the previous file state across client-side selections.

## User impact

References and other Vault files can now be moved one after another without refreshing the page. The second dialog opens with the newly selected file and its current folder.

## Validation

- Regression test observed failing before the fix and passing after it
- pnpm --filter @librarian/dashboard test — 87 files, 577 tests passed
- pnpm --filter @librarian/dashboard build — passed
- pnpm run lint — passed
- pnpm run typecheck — passed after rebuilding pulled workspace artifacts
- pnpm run check:release — passed
- pnpm exec vitest run — 17 files, 230 root tests passed

## Known unrelated test failure

The full recursive Vitest run reaches a pre-existing failure in packages/cli/tests/restore-commands.test.ts: the .git-only vault fixture runs git commit in a throwaway repository without disabling signing. On a machine with global commit.gpgSign=true, that fixture commit exits non-zero. It reproduces in isolation and is unchanged by this PR; all dashboard tests pass independently.

No user documentation was changed because this restores the existing documented Move behavior rather than changing its contract.