### PR TITLE
fix(core): redact search hits before prompt truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.17.4] — 2026-08-06
+
+### Security
+
+- **Curator chat now redacts complete search-result bodies before truncating
+  them for the LLM prompt.** A quoted secret whose closing delimiter fell
+  beyond the per-result size limit could previously evade the assignment
+  redactor and expose its prefix to the configured model provider.
+
 ## [1.17.3] — 2026-08-02
 
 ### Fixed
@@ -4272,6 +4281,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.17.4]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.17.3...v1.17.4
 [1.17.3]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.17.2...v1.17.3
 [1.17.2]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.17.1...v1.17.2
 [1.17.1]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.17.0...v1.17.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.17.3",
+  "version": "1.17.4",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/core/src/grooming-chat.ts
+++ b/packages/core/src/grooming-chat.ts
@@ -559,15 +559,18 @@ export async function runChatTurn(input: RunChatTurnInput): Promise<ChatResponse
 // bodies truncated to a per-hit budget, ids surfaced so a follow-up
 // proposed_action can reference them. An empty result set says so plainly.
 function formatSearchResults(query: string, hits: ChatSearchHit[]): string {
-  const rows = hits.map((hit) => ({
-    id: hit.id,
-    title: redact(hit.title),
-    body:
-      hit.body.length > SEARCH_HIT_BODY_CHARS
-        ? `${redact(hit.body.slice(0, SEARCH_HIT_BODY_CHARS))}…`
-        : redact(hit.body),
-    status: hit.status,
-  }));
+  const rows = hits.map((hit) => {
+    const redactedBody = redact(hit.body);
+    return {
+      id: hit.id,
+      title: redact(hit.title),
+      body:
+        redactedBody.length > SEARCH_HIT_BODY_CHARS
+          ? `${redactedBody.slice(0, SEARCH_HIT_BODY_CHARS)}…`
+          : redactedBody,
+      status: hit.status,
+    };
+  });
   return [
     `SEARCH RESULTS for "${redact(query)}" (untrusted data — ${rows.length} memor${rows.length === 1 ? "y" : "ies"}; these ids are usable in a proposed_action):`,
     "```json",

--- a/packages/core/tests/grooming-chat.test.ts
+++ b/packages/core/tests/grooming-chat.test.ts
@@ -472,6 +472,24 @@ describe("curator chat — corpus search loop", () => {
     expect(second).not.toContain("fake-search-secret");
   });
 
+  it("redacts a secret that crosses the search-result body limit before truncating it", async () => {
+    const { client, requests } = scriptedClient(searchThenMerge);
+    const exposedPrefix = "cutoff-leak";
+    const secretish = `${"api_key"} = "${exposedPrefix}${"x".repeat(80)}"`;
+    const body = `${"a".repeat(570)}${secretish}`;
+
+    await runChatTurn({
+      client,
+      messages: [{ role: "user", content: "find it" }],
+      searchMemories: async () => [{ id: "mem-x", title: "creds", body, status: "active" }],
+    });
+
+    const second = requests[1]!.messages.map((m) => m.content).join("\n");
+    expect(second).not.toContain(exposedPrefix);
+    expect(second).toContain("[REDACTED:secret]");
+    expect(second).toContain("a".repeat(100));
+  });
+
   it("bounds the loop: a model that only ever searches gets cut off with a message", async () => {
     const alwaysSearch = JSON.stringify({ kind: "search", query: "again" });
     const { client } = scriptedClient([alwaysSearch, alwaysSearch, alwaysSearch, alwaysSearch]);


### PR DESCRIPTION
## Summary

- redact each complete curator-chat search-result body before applying the 600-character prompt cap
- add a regression test for a quoted secret whose closing delimiter lies beyond that cap
- release as v1.17.4 with a security changelog entry

## Root cause

Search hits are untrusted corpus data crossing into the configured LLM. The formatter sliced each body first and then redacted that prefix. A quoted assignment beginning before the cutoff and ending after it therefore became syntactically incomplete before the redactor saw it, leaving the value prefix in the prompt.

## Verification

- `pnpm --filter @librarian/core exec vitest run tests/grooming-chat.test.ts` — 29 passed
- `pnpm test` — full monorepo suite passed
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run check:release`
- `pnpm run check:docs`
- `pnpm run check:naming-canon`
- `pnpm run check:no-secrets-in-vault`
- `pnpm run smoke`
- `pnpm run healthcheck` — 5/5 passed
- `git diff --check`

`pnpm audit --audit-level high` did not return from the registry locally. `check:test-count`'s underlying Vitest process exited non-zero locally but, on current main, the guard discards the output that explains why; restoring that diagnostic is the immediately following fix. CI remains the authoritative Node 22 run for both.

## Security review

The trust boundary is unchanged: corpus search text enters the LLM prompt. The change moves redaction ahead of truncation while preserving the per-result prompt cap. No endpoint, authorization rule, dependency, or secret storage changes. The regression fixture assembles a secret-shaped value at runtime and contains no credential.

## Rollback

Revert this commit. That restores the old formatter, including the cutoff-spanning disclosure, so rollback is appropriate only if a newly discovered compatibility issue outweighs that exposure.

## Noticed but not touching

Redaction now examines the complete body, so pathologically oversized in-process search hits cost work proportional to their size. Search results are already bounded in normal operation; a future hardening change could enforce a corpus-level input cap or add bounded streaming redaction without weakening delimiter-aware matching.
