### PR TITLE
fix(scripts): make test-count failures actionable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.17.5] — 2026-08-06
+
+### Fixed
+
+- **The test-count guard now names the tests that failed.** On a non-zero
+  Vitest exit it previously discarded the captured JSON report, leaving CI with
+  only an exit code. The guard now lists each failed test with its file and the
+  first line of its message, and explicitly reports when a runner failed without
+  naming a test, such as a configuration error or worker crash.
+- **The test-count guard is now importable and directly tested.** Its entry-point
+  work no longer runs at module import time, and its fail-soft multi-workspace
+  report parsing has focused coverage.
+
 ## [1.17.4] — 2026-08-06
 
 ### Security
@@ -4281,6 +4294,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.17.5]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.17.4...v1.17.5
 [1.17.4]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.17.3...v1.17.4
 [1.17.3]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.17.2...v1.17.3
 [1.17.2]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.17.1...v1.17.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.17.4",
+  "version": "1.17.5",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/scripts/check-test-count.mjs
+++ b/scripts/check-test-count.mjs
@@ -24,34 +24,44 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "..");
 const baselinePath = path.join(repoRoot, "test", "baseline.json");
 
-const baseline = JSON.parse(fs.readFileSync(baselinePath, "utf8"));
-const floor = Number(baseline.count);
-if (!Number.isFinite(floor) || floor < 0) {
-  console.error(`[check-test-count] invalid baseline.count in ${baselinePath}`);
-  process.exit(2);
-}
-
-const nodeTestFiles = collectNodeTestFiles(repoRoot);
-
-try {
-  const nodeCount = nodeTestFiles.length ? await countNodeTests(nodeTestFiles) : 0;
-  const vitestCount = await countVitestTests();
-  const total = nodeCount + vitestCount;
-
-  if (total < floor) {
-    console.error(
-      `[check-test-count] FAIL: ${total} tests reported (node:test=${nodeCount}, vitest=${vitestCount}), floor is ${floor}. ` +
-        "Update test/baseline.json in this PR and explain the reduction in the description.",
-    );
-    process.exit(1);
+async function main() {
+  const baseline = JSON.parse(fs.readFileSync(baselinePath, "utf8"));
+  const floor = Number(baseline.count);
+  if (!Number.isFinite(floor) || floor < 0) {
+    console.error(`[check-test-count] invalid baseline.count in ${baselinePath}`);
+    process.exit(2);
   }
 
-  console.log(
-    `[check-test-count] OK: ${total} tests (node:test=${nodeCount}, vitest=${vitestCount}) >= floor ${floor}`,
-  );
-} catch (err) {
-  console.error(`[check-test-count] ${err.message}`);
-  process.exit(2);
+  const nodeTestFiles = collectNodeTestFiles(repoRoot);
+
+  try {
+    const nodeCount = nodeTestFiles.length ? await countNodeTests(nodeTestFiles) : 0;
+    const vitestCount = await countVitestTests();
+    const total = nodeCount + vitestCount;
+
+    if (total < floor) {
+      console.error(
+        `[check-test-count] FAIL: ${total} tests reported (node:test=${nodeCount}, vitest=${vitestCount}), floor is ${floor}. ` +
+          "Update test/baseline.json in this PR and explain the reduction in the description.",
+      );
+      process.exit(1);
+    }
+
+    console.log(
+      `[check-test-count] OK: ${total} tests (node:test=${nodeCount}, vitest=${vitestCount}) >= floor ${floor}`,
+    );
+  } catch (err) {
+    console.error(`[check-test-count] ${err.message}`);
+    process.exit(2);
+  }
+}
+
+// Only run the guard when invoked as the entry point. Without this the whole
+// suite re-ran on mere `import` — which made the module untestable, since a test
+// importing the helpers below would recursively spawn the very run it counts.
+// Same convention as scripts/stamp-version.mjs.
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  await main();
 }
 
 function collectNodeTestFiles(root) {
@@ -123,6 +133,115 @@ function countRootVitestTests() {
   return runJsonReporter(["pnpm", "exec", "vitest", "run", "--reporter=json"]);
 }
 
+/**
+ * Pull every complete top-level JSON document out of a captured stdout stream.
+ *
+ * `pnpm -r exec` runs vitest once per workspace, so stdout carries several whole
+ * JSON reports back to back, interleaved with pnpm's own prefixes and anything
+ * the tests printed. `JSON.parse(stdout)` therefore throws, and parsing only the
+ * first document loses every later workspace. Brace-matching (string- and
+ * escape-aware, so a `{` inside a failure message can't unbalance it) is what
+ * survives that stream. Each opening brace is an independent candidate so an
+ * unmatched brace or quote in earlier log noise cannot poison later reports.
+ * Exported for tests.
+ */
+export function extractJsonDocuments(text) {
+  const docs = [];
+  for (let start = 0; start < text.length; start++) {
+    if (text[start] !== "{") continue;
+    const end = findJsonDocumentEnd(text, start);
+    if (end === -1) continue;
+    const candidate = text.slice(start, end + 1);
+    try {
+      JSON.parse(candidate);
+    } catch {
+      continue;
+    }
+    docs.push(candidate);
+    start = end;
+  }
+  return docs;
+}
+
+function findJsonDocumentEnd(text, start) {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+    } else if (ch === "{") {
+      depth++;
+    } else if (ch === "}") {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+/**
+ * The failing tests named in a `--reporter=json` stdout stream.
+ *
+ * Never throws: unparseable fragments are skipped. This runs only on a path that
+ * is ALREADY failing, so a helper that could throw would just replace one
+ * uninformative failure with another. Exported for tests.
+ */
+export function collectFailedTests(stdout) {
+  const failures = [];
+  for (const doc of extractJsonDocuments(stdout)) {
+    let parsed;
+    try {
+      parsed = JSON.parse(doc);
+    } catch {
+      continue; // log noise that happened to look like a JSON object
+    }
+    if (!Array.isArray(parsed?.testResults)) continue;
+    for (const file of parsed.testResults) {
+      for (const assertion of file?.assertionResults ?? []) {
+        if (assertion?.status !== "failed") continue;
+        // First line only: a full stack per failure buries the list in CI.
+        const message = String(assertion.failureMessages?.[0] ?? "")
+          .split("\n")[0]
+          .trim();
+        failures.push({
+          file: file?.name ?? "(unknown file)",
+          name: assertion.fullName || assertion.title || "(unnamed test)",
+          message,
+        });
+      }
+    }
+  }
+  return failures;
+}
+
+/**
+ * The guard's message for a non-zero runner exit — naming the failing tests when
+ * the report identified any, and saying plainly that it could not when it did
+ * not (a config error or a crashed worker fails the run without failing a test).
+ * Exported for tests.
+ */
+export function formatRunFailure(args, code, failures) {
+  const header = `${args.join(" ")} exited with code ${code}; aborting guard`;
+  if (!failures.length) {
+    return `${header}\n  The run reported no failing test — likely a config error or a crashed worker. Re-run this command locally to see the runner's own output.`;
+  }
+  const noun = failures.length === 1 ? "1 failing test" : `${failures.length} failing tests`;
+  const lines = failures.map((f) => {
+    const where = path.relative(repoRoot, f.file) || f.file;
+    return `  ✗ ${f.name}\n      ${where}${f.message ? `\n      ${f.message}` : ""}`;
+  });
+  return `${header}\n  ${noun}:\n${lines.join("\n")}`;
+}
+
 function runJsonReporter(args) {
   return new Promise((resolve, reject) => {
     const [bin, ...rest] = args;
@@ -142,8 +261,13 @@ function runJsonReporter(args) {
       // tests; any non-zero exit (config error, runtime crash, failing
       // test) must surface as a guard failure so a silently-zeroed
       // numTotalTests can't slip past the floor check.
+      //
+      // The report is on the stdout we just captured, so name the failing
+      // tests instead of throwing them away: this used to reject with the
+      // exit code alone, which left CI saying only "exited with code 1" and
+      // made a flaky timeout indistinguishable from a real regression.
       if (code !== 0) {
-        reject(new Error(`${args.join(" ")} exited with code ${code}; aborting guard`));
+        reject(new Error(formatRunFailure(args, code, collectFailedTests(stdout))));
         return;
       }
       let total = 0;

--- a/test/check-test-count-failures.test.ts
+++ b/test/check-test-count-failures.test.ts
@@ -1,0 +1,150 @@
+// Guards the test-count guard's own diagnostics.
+//
+// The bug this prevents: \`check-test-count.mjs\` runs the whole suite a second
+// time with \`--reporter=json\`, capturing the report on stdout. When vitest
+// exited non-zero it discarded that stdout and reported only the exit code, so
+// CI printed \`pnpm -r exec vitest run --reporter=json exited with code 1;
+// aborting guard\` and nothing else — no test name, no file, no message. A gate
+// that can fail without saying why is unusable: you cannot tell a flaky timeout
+// from a real regression, so the only move left is to re-run and hope. The
+// failing tests were sitting in the captured JSON the whole time.
+//
+// See scripts/check-test-count.mjs.
+
+import { describe, expect, it } from "vitest";
+import { collectFailedTests, formatRunFailure } from "../scripts/check-test-count.mjs";
+
+/** One workspace's \`--reporter=json\` document, as vitest emits it. */
+function report(
+  testFile: string,
+  assertions: Array<{ name: string; status: string; message?: string }>,
+): string {
+  return JSON.stringify({
+    numTotalTests: assertions.length,
+    numFailedTests: assertions.filter((a) => a.status === "failed").length,
+    testResults: [
+      {
+        name: testFile,
+        status: assertions.some((a) => a.status === "failed") ? "failed" : "passed",
+        assertionResults: assertions.map((a) => ({
+          ancestorTitles: [],
+          title: a.name,
+          fullName: a.name,
+          status: a.status,
+          failureMessages: a.message ? [a.message] : [],
+        })),
+      },
+    ],
+  });
+}
+
+describe("collectFailedTests", () => {
+  it("names the failing test, its file, and the first line of its message", () => {
+    const stdout = report("/repo/packages/mcp-server/tests/trpc/vault.test.ts", [
+      {
+        name: "tRPC vault > edits land as git commits",
+        status: "failed",
+        message: "Error: Timed out waiting for http://0.0.0.0:37463/healthz\n    at waitForHttp",
+      },
+    ]);
+
+    const failures = collectFailedTests(stdout);
+
+    expect(failures).toHaveLength(1);
+    expect(failures[0].name).toBe("tRPC vault > edits land as git commits");
+    expect(failures[0].file).toBe("/repo/packages/mcp-server/tests/trpc/vault.test.ts");
+    // The first line only — a full stack per failure buries the list in CI.
+    expect(failures[0].message).toBe("Error: Timed out waiting for http://0.0.0.0:37463/healthz");
+  });
+
+  it("collects failures across every workspace's report, not just the first", () => {
+    // \`pnpm -r exec\` runs vitest per workspace, so stdout carries several
+    // complete JSON documents back to back. Parsing only the first (or calling
+    // JSON.parse on the whole stream) loses every later workspace's failures.
+    const stdout = [
+      report("/repo/packages/core/tests/a.test.ts", [{ name: "a passes", status: "passed" }]),
+      report("/repo/packages/mcp-server/tests/b.test.ts", [
+        { name: "b fails", status: "failed", message: "AssertionError: expected 1 to be 2" },
+      ]),
+      report("/repo/apps/dashboard/tests/c.test.tsx", [
+        { name: "c fails", status: "failed", message: "Error: boom" },
+      ]),
+    ].join("\n");
+
+    const failures = collectFailedTests(stdout);
+
+    expect(failures.map((f) => f.name)).toEqual(["b fails", "c fails"]);
+  });
+
+  it("ignores the pnpm prefixes and log noise interleaved with the reports", () => {
+    // Real stdout is not pure JSON: pnpm prefixes lines, and tests themselves
+    // print. Anything unparseable must be skipped rather than crash the guard —
+    // a diagnostics helper that throws would replace one silent failure with another.
+    const stdout = [
+      "packages/core test:vitest: Building 4 posts…",
+      report("/repo/packages/core/tests/a.test.ts", [
+        { name: "a fails", status: "failed", message: "Error: nope" },
+      ]),
+      "{ not valid json at all",
+      "Done.",
+    ].join("\n");
+
+    expect(collectFailedTests(stdout).map((f) => f.name)).toEqual(["a fails"]);
+  });
+
+  it("resynchronizes when malformed log noise precedes a valid report", () => {
+    const valid = report("/repo/packages/core/tests/a.test.ts", [
+      { name: "a fails", status: "failed", message: "Error: nope" },
+    ]);
+
+    expect(collectFailedTests(`log { not closed\n${valid}`).map((f) => f.name)).toEqual([
+      "a fails",
+    ]);
+    expect(
+      collectFailedTests(`log with an unmatched quote: "\n${valid}`).map((f) => f.name),
+    ).toEqual(["a fails"]);
+    expect(collectFailedTests(`log { not closed\n${valid}\nlog }`).map((f) => f.name)).toEqual([
+      "a fails",
+    ]);
+  });
+
+  it("returns nothing when the run failed with no failing test (a crash or config error)", () => {
+    // vitest can exit non-zero without any assertion failing — a config error or
+    // a worker crash. The guard must still report *something* rather than
+    // claiming a test failed, so an empty list here is the correct answer and
+    // formatRunFailure below is what covers the message.
+    const stdout = report("/repo/packages/core/tests/a.test.ts", [
+      { name: "a passes", status: "passed" },
+    ]);
+
+    expect(collectFailedTests(stdout)).toEqual([]);
+    expect(collectFailedTests("")).toEqual([]);
+  });
+});
+
+describe("formatRunFailure", () => {
+  it("lists every failing test under the command and exit code", () => {
+    const message = formatRunFailure(["pnpm", "-r", "exec", "vitest", "run"], 1, [
+      {
+        file: "/repo/packages/mcp-server/tests/trpc/vault.test.ts",
+        name: "tRPC vault > edits land as git commits",
+        message: "Error: Timed out waiting for /healthz",
+      },
+    ]);
+
+    expect(message).toContain("exited with code 1");
+    expect(message).toContain("1 failing test");
+    expect(message).toContain("tRPC vault > edits land as git commits");
+    expect(message).toContain("packages/mcp-server/tests/trpc/vault.test.ts");
+    expect(message).toContain("Error: Timed out waiting for /healthz");
+  });
+
+  it("says so explicitly when the runner failed without naming a test", () => {
+    // The old behaviour for EVERY failure. Keeping an honest message for the
+    // genuinely-unattributable case is the point: never imply we know more than we do.
+    const message = formatRunFailure(["pnpm", "exec", "vitest", "run"], 2, []);
+
+    expect(message).toContain("exited with code 2");
+    expect(message).toMatch(/no failing test|could not/i);
+  });
+});


### PR DESCRIPTION
## Summary

- recover the diagnostic fix from #449, whose base branch was merged but whose commit never reached `main`
- make the test-count guard import-safe and unit-test its captured-report parsing
- name failed tests, files, and first-line messages on non-zero Vitest exits
- resynchronize after malformed brace/quote log noise, including a balanced wrapper around a later valid report
- release as v1.17.5

## Root cause

The guard captures Vitest's JSON reporter stdout so it can count tests. On a non-zero runner exit it discarded that captured report and surfaced only the exit code. The original #449 fixed that on the repository-transfer branch, but the transfer branch had already merged into `main`, so GitHub marked #449 merged without placing its commit on `main`.

This re-port also closes a fresh-review edge case in the original parser: unmatched or malformed prefix noise could poison the global brace/string state and hide a later valid report.

## Verification

- red proof: importing the old module launched the whole guard recursively
- `pnpm exec vitest run test/check-test-count-failures.test.ts` — 7 passed
- `pnpm exec vitest run` — 18 files, 236 tests passed when run serially
- induced resource contention: the real guard named all 9 timed-out tests, their files, and first-line messages instead of returning the old one-line exit code
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run check:release`
- `git diff --check`

The deliberately contended `check:test-count` run exited 2 because the tests it was reporting really did time out. The same root suite passed immediately when rerun without competing load; CI is the authoritative clean Node 22 guard run.

## Review

A fresh-context adversarial review found the malformed-prefix resynchronization gap. Two red-first revisions covered unmatched prefix noise and a balanced malformed wrapper; the reviewer confirmed the required finding is resolved and reported no remaining Critical or required issues.

## Rollback

Revert this commit. The test-count floor remains enforced, but CI failures return to the unactionable exit-code-only diagnostic and the script becomes unsafe to import.

## Noticed but not touching

The local 5-second live-server tests are sensitive to running duplicate suites concurrently. That is unrelated to this diagnostic-only fix; serial execution passed, and changing those timeouts belongs in a separate evidence-led reliability change if clean CI shows a problem.
