### PR TITLE
feat: add tag visibility and browsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.19.0] — 2026-08-06
+
+### Added
+
+- **Memory tags are visible wherever operators review knowledge.** Browse,
+  Recall, Proposals, Flagged, and Archive show the first three stored tags in
+  order, with a bounded `+N more` summary for the remainder.
+- **Browse has an exact-tag filter with active-memory counts.** The searchable
+  picker covers the caller's complete authorised recall corpus, composes with
+  existing filters, and can also be activated from a tag on a Browse card.
+
+### Security
+
+- Tag counts are computed only after the caller's recall shelves are authorised,
+  with duplicate memory ids resolved before counting so neither hidden shelves
+  nor lower-precedence copies can affect the catalogue.
+
 ## [1.18.0] — 2026-08-06
 
 ### Added
@@ -4325,6 +4342,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.19.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.18.0...v1.19.0
 [1.18.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.17.5...v1.18.0
 [1.17.5]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.17.4...v1.17.5
 [1.17.4]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.17.3...v1.17.4

--- a/apps/dashboard/components/memories/archive-view.tsx
+++ b/apps/dashboard/components/memories/archive-view.tsx
@@ -123,6 +123,7 @@ export function ArchiveView() {
               className="min-w-0 flex-1"
               title={memory.title}
               body={memory.body}
+              tags={memory.tags}
               bodyMode="clamp"
               meta={[
                 memory.agent_id ? <span>{memory.agent_id}</span> : null,

--- a/apps/dashboard/components/memories/filter-chips.tsx
+++ b/apps/dashboard/components/memories/filter-chips.tsx
@@ -85,6 +85,24 @@ export function FilterChips({
   onClearAll,
   maxVisible,
 }: FilterChipsProps) {
+  const [pendingFocusKey, setPendingFocusKey] = useState<string | null>(null);
+  const activeRemoveButtons = useRef(new Map<string, HTMLButtonElement>());
+  const overflowTriggerButton = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!pendingFocusKey) return;
+    const button =
+      activeRemoveButtons.current.get(pendingFocusKey) ?? overflowTriggerButton.current;
+    if (!button) return;
+    button.focus();
+    setPendingFocusKey(null);
+  }, [active, pendingFocusKey]);
+
+  const setFilterAndRestoreFocus = (key: string, value: FilterValue, display: string) => {
+    setPendingFocusKey(key);
+    onSet(key, value, display);
+  };
+
   // Render order: active chips first (in their natural order), then
   // outlined add-chip triggers for the inactive dimensions. The
   // overflow collapse applies to the COMBINED list so the chip row
@@ -111,12 +129,16 @@ export function FilterChips({
             label={defLabel(defs, chip.data.key)}
             value={chip.data.display}
             onRemove={() => onRemove(chip.data.key)}
+            removeButtonRef={(button) => {
+              if (button) activeRemoveButtons.current.set(chip.data.key, button);
+              else activeRemoveButtons.current.delete(chip.data.key);
+            }}
           />
         ) : (
           <AddChipTrigger
             key={chip.data.key}
             def={chip.data}
-            onPick={(value, display) => onSet(chip.data.key, value, display)}
+            onPick={(value, display) => setFilterAndRestoreFocus(chip.data.key, value, display)}
           />
         ),
       )}
@@ -125,8 +147,11 @@ export function FilterChips({
           count={overflow.length}
           chips={overflow}
           defs={defs}
-          onSet={onSet}
+          onSet={setFilterAndRestoreFocus}
           onRemove={onRemove}
+          triggerButtonRef={(button) => {
+            overflowTriggerButton.current = button;
+          }}
         />
       ) : null}
       {active.length > 0 && onClearAll ? (
@@ -152,10 +177,12 @@ function ActiveChip({
   label,
   value,
   onRemove,
+  removeButtonRef,
 }: {
   label: string;
   value: string;
   onRemove: () => void;
+  removeButtonRef?: (button: HTMLButtonElement | null) => void;
 }) {
   return (
     <span className="inline-flex max-w-full min-w-0 items-center gap-2 border border-ink-accent/40 bg-ink-accent/[0.06] px-2 py-1 text-xs pointer-coarse:px-3 pointer-coarse:py-2 pointer-coarse:text-sm">
@@ -166,6 +193,7 @@ function ActiveChip({
         {value}
       </span>
       <button
+        ref={removeButtonRef}
         type="button"
         aria-label={`Remove ${label} filter`}
         onClick={onRemove}
@@ -186,9 +214,15 @@ function AddChipTrigger({
 }) {
   const [open, setOpen] = useState(false);
   const wrapperRef = useClickOutside<HTMLSpanElement>(() => setOpen(false));
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const closeAndRestoreFocus = () => {
+    triggerRef.current?.focus();
+    setOpen(false);
+  };
   return (
     <span ref={wrapperRef} className="relative inline-flex">
       <button
+        ref={triggerRef}
         type="button"
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}
@@ -207,7 +241,7 @@ function AddChipTrigger({
             onPick(value, display);
             setOpen(false);
           }}
-          onClose={() => setOpen(false)}
+          onClose={closeAndRestoreFocus}
         />
       ) : null}
     </span>
@@ -220,18 +254,21 @@ function OverflowChip({
   defs,
   onSet,
   onRemove,
+  triggerButtonRef,
 }: {
   count: number;
   chips: Array<{ kind: "active"; data: ActiveFilter } | { kind: "add"; data: FilterDef }>;
   defs: FilterDef[];
   onSet: (key: string, value: FilterValue, display: string) => void;
   onRemove: (key: string) => void;
+  triggerButtonRef?: (button: HTMLButtonElement | null) => void;
 }) {
   const [open, setOpen] = useState(false);
   const wrapperRef = useClickOutside<HTMLSpanElement>(() => setOpen(false));
   return (
     <span ref={wrapperRef} className="relative inline-flex">
       <button
+        ref={triggerButtonRef}
         type="button"
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}

--- a/apps/dashboard/components/memories/filter-chips.tsx
+++ b/apps/dashboard/components/memories/filter-chips.tsx
@@ -158,14 +158,18 @@ function ActiveChip({
   onRemove: () => void;
 }) {
   return (
-    <span className="inline-flex items-center gap-2 border border-ink-accent/40 bg-ink-accent/[0.06] px-2 py-1 text-xs pointer-coarse:px-3 pointer-coarse:py-2 pointer-coarse:text-sm">
-      <span className="font-mono uppercase tracking-wider text-foreground/55">{label}</span>
-      <span className="font-mono text-foreground">{value}</span>
+    <span className="inline-flex max-w-full min-w-0 items-center gap-2 border border-ink-accent/40 bg-ink-accent/[0.06] px-2 py-1 text-xs pointer-coarse:px-3 pointer-coarse:py-2 pointer-coarse:text-sm">
+      <span className="shrink-0 font-mono uppercase tracking-wider text-foreground/55">
+        {label}
+      </span>
+      <span className="min-w-0 max-w-48 truncate font-mono text-foreground" title={value}>
+        {value}
+      </span>
       <button
         type="button"
         aria-label={`Remove ${label} filter`}
         onClick={onRemove}
-        className="-mr-1 ml-0.5 px-1 text-foreground/55 transition-colors hover:text-ink-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ink-accent pointer-coarse:px-2 pointer-coarse:text-base"
+        className="-mr-1 ml-0.5 shrink-0 px-1 text-foreground/55 transition-colors hover:text-ink-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ink-accent pointer-coarse:px-2 pointer-coarse:text-base"
       >
         ×
       </button>
@@ -188,7 +192,7 @@ function AddChipTrigger({
         type="button"
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}
-        aria-haspopup="listbox"
+        aria-haspopup="dialog"
         className="inline-flex items-center gap-1.5 border border-foreground/20 bg-transparent px-2 py-1 text-xs text-foreground/70 transition-colors hover:border-foreground/30 hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ink-accent pointer-coarse:min-h-11 pointer-coarse:px-3 pointer-coarse:py-2 pointer-coarse:text-sm"
       >
         <span className="font-mono uppercase tracking-wider">{def.label}</span>
@@ -302,7 +306,7 @@ function SelectPicker({
   return (
     <div
       className="absolute left-0 top-[calc(100%+4px)] z-30 w-[260px] border border-ink-hairline bg-ink-surface shadow-[0_8px_24px_-12px_rgba(0,0,0,0.25)]"
-      role="listbox"
+      role="dialog"
       aria-label={`${def.label} options`}
     >
       <div className="border-b border-ink-hairline p-2">

--- a/apps/dashboard/components/memories/filter-chips.tsx
+++ b/apps/dashboard/components/memories/filter-chips.tsx
@@ -29,7 +29,12 @@ export type FilterValue = string;
 
 export interface SelectGroup {
   label?: string;
-  options: Array<{ value: FilterValue; label: string; title?: string }>;
+  options: Array<{
+    value: FilterValue;
+    label: string;
+    activeDisplay?: string;
+    title?: string;
+  }>;
 }
 
 export type FilterDef =
@@ -329,7 +334,7 @@ function SelectPicker({
                   <li key={opt.value}>
                     <button
                       type="button"
-                      onClick={() => onPick(opt.value, opt.label)}
+                      onClick={() => onPick(opt.value, opt.activeDisplay ?? opt.label)}
                       title={opt.title}
                       className="block w-full truncate px-3 py-1.5 text-left font-mono text-xs text-foreground transition-colors hover:bg-foreground/[0.04] focus:bg-foreground/[0.06] focus:outline-none"
                     >

--- a/apps/dashboard/components/memories/flagged-view.tsx
+++ b/apps/dashboard/components/memories/flagged-view.tsx
@@ -61,6 +61,7 @@ export function FlaggedView() {
             <MemoryCard
               title={memory.title}
               body={memory.body}
+              tags={memory.tags}
               bodyMode="prose"
               meta={[
                 memory.agent_id ? <span>{memory.agent_id}</span> : null,

--- a/apps/dashboard/components/memories/list.tsx
+++ b/apps/dashboard/components/memories/list.tsx
@@ -13,6 +13,7 @@ interface Props {
   error?: string | undefined;
   selectedId: string | null;
   onSelect: (id: string) => void;
+  onTagSelect?: (tag: string) => void;
   offset: number;
   pageSize: number;
   hasMore: boolean;
@@ -39,6 +40,7 @@ export function MemoriesList({
   error,
   selectedId,
   onSelect,
+  onTagSelect,
   offset,
   pageSize,
   hasMore,
@@ -113,6 +115,8 @@ export function MemoriesList({
             <MemoryCard
               title={memory.title}
               body={memory.body}
+              tags={memory.tags}
+              {...(onTagSelect ? { onTagSelect } : {})}
               bodyMode="clamp"
               selected={selectedId === memory.id}
               ariaPressed={selectedId === memory.id}

--- a/apps/dashboard/components/memories/memory-card.tsx
+++ b/apps/dashboard/components/memories/memory-card.tsx
@@ -148,10 +148,12 @@ export function MemoryCard({
   // Interactive cards keep their controls as siblings: the main trigger,
   // tag controls, and any actions are never nested inside one another.
   return (
-    <div className={`${base} ${interactiveClasses} ${selectedClasses} ${className}`.trim()}>
+    <div
+      className={`${base} ${interactiveClasses} ${selectedClasses} ${className}`.trim()}
+      onClick={onClick}
+    >
       <button
         type="button"
-        onClick={onClick}
         aria-pressed={ariaPressed}
         aria-label={ariaLabel}
         className="flex w-full flex-col gap-1 text-left focus:outline-none"

--- a/apps/dashboard/components/memories/memory-card.tsx
+++ b/apps/dashboard/components/memories/memory-card.tsx
@@ -30,11 +30,14 @@
 // component renders the dot dividers between them so callers don't
 // have to interleave `<span>·</span>` manually.
 
-import type { ElementType, MouseEventHandler, ReactNode } from "react";
+import type { MouseEventHandler, ReactNode } from "react";
+import { MemoryTags } from "./memory-tags";
 
 interface MemoryCardProps {
   title: string;
   body: string;
+  tags?: readonly string[];
+  onTagSelect?: (tag: string) => void;
   /** Full prose vs 2-line clamp. Default `clamp` keeps a dense list
    *  scannable; `prose` is for queues where the whole content matters
    *  (Proposals review, Flagged review). */
@@ -63,6 +66,8 @@ interface MemoryCardProps {
 export function MemoryCard({
   title,
   body,
+  tags = [],
+  onTagSelect,
   bodyMode = "clamp",
   meta,
   children,
@@ -73,8 +78,7 @@ export function MemoryCard({
   ariaPressed,
   ariaLabel,
 }: MemoryCardProps) {
-  const Tag = (onClick ? "button" : "div") as ElementType;
-  const interactive = Tag === "button";
+  const interactive = onClick !== undefined;
 
   // Editorial chrome: hairline border, sharp corners, paper-surface fill,
   // hover wash + focus-visible bloom that match the vault tree row.
@@ -82,7 +86,7 @@ export function MemoryCard({
   // on the left edge (matches the vault tree active row).
   const base = "relative border border-ink-hairline bg-ink-surface px-4 py-3";
   const interactiveClasses = interactive
-    ? "flex w-full flex-col gap-1 text-left transition-[background-color,box-shadow] hover:bg-foreground/[0.03] focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ink-accent focus-visible:[box-shadow:var(--glow-accent-subtle)]"
+    ? "transition-[background-color,box-shadow] hover:bg-foreground/[0.03] focus-within:ring-2 focus-within:ring-inset focus-within:ring-ink-accent focus-within:[box-shadow:var(--glow-accent-subtle)]"
     : "";
   const selectedClasses = selected
     ? "bg-ink-accent/[0.08] pl-[14px] before:absolute before:inset-y-0 before:left-0 before:w-[2px] before:bg-ink-copper before:content-['']"
@@ -103,6 +107,11 @@ export function MemoryCard({
         {body}
       </p>
       {children}
+      <MemoryTags
+        tags={tags}
+        {...(onTagSelect ? { onSelect: onTagSelect } : {})}
+        className="mt-1"
+      />
       {/* In the interactive flow the parent <button> already gap-1's
           its children — passing `tight` drops the meta strip's own
           mt-1 so we don't double the spacing. The two static flows
@@ -136,24 +145,43 @@ export function MemoryCard({
     );
   }
 
-  // Interactive (button): flex-col gap-1 internally — the Memories
-  // list row. Actions on an interactive row aren't expected by any
-  // current caller, but if added they'd nest below the body.
+  // Interactive cards keep their controls as siblings: the main trigger,
+  // tag controls, and any actions are never nested inside one another.
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      aria-pressed={ariaPressed}
-      aria-label={ariaLabel}
-      className={`${base} ${interactiveClasses} ${selectedClasses} ${className}`.trim()}
-    >
-      {inner}
+    <div className={`${base} ${interactiveClasses} ${selectedClasses} ${className}`.trim()}>
+      <button
+        type="button"
+        onClick={onClick}
+        aria-pressed={ariaPressed}
+        aria-label={ariaLabel}
+        className="flex w-full flex-col gap-1 text-left focus:outline-none"
+      >
+        <h3 className="truncate text-sm font-medium text-foreground">
+          {title || <span className="italic text-foreground/55">(untitled)</span>}
+        </h3>
+        <p
+          className={
+            bodyMode === "prose"
+              ? "whitespace-pre-wrap break-words text-sm leading-relaxed text-foreground/70"
+              : "line-clamp-2 text-sm leading-relaxed text-foreground/70"
+          }
+        >
+          {body}
+        </p>
+        {children}
+      </button>
+      <MemoryTags
+        tags={tags}
+        {...(onTagSelect ? { onSelect: onTagSelect } : {})}
+        className="mt-1"
+      />
+      {meta ? <MetaStrip tokens={meta} /> : null}
       {actions ? (
         <div className="mt-1 flex gap-2" onClick={(e) => e.stopPropagation()}>
           {actions}
         </div>
       ) : null}
-    </button>
+    </div>
   );
 }
 

--- a/apps/dashboard/components/memories/memory-tags.tsx
+++ b/apps/dashboard/components/memories/memory-tags.tsx
@@ -27,8 +27,11 @@ export function MemoryTags({ tags, onSelect, className = "" }: MemoryTagsProps) 
             data-testid="memory-tag"
             title={tag}
             aria-label={`Filter by tag ${tag}`}
-            onClick={() => onSelect(tag)}
-            className={`${pillClass} transition-colors hover:border-ink-accent/50 hover:text-ink-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ink-accent`}
+            onClick={(event) => {
+              event.stopPropagation();
+              onSelect(tag);
+            }}
+            className={`${pillClass} transition-colors hover:border-ink-accent/50 hover:text-ink-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ink-accent pointer-coarse:min-h-11 pointer-coarse:px-3 pointer-coarse:py-2`}
           >
             {tag}
           </button>

--- a/apps/dashboard/components/memories/memory-tags.tsx
+++ b/apps/dashboard/components/memories/memory-tags.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+const VISIBLE_TAG_LIMIT = 3;
+
+interface MemoryTagsProps {
+  tags: readonly string[];
+  onSelect?: (tag: string) => void;
+  className?: string;
+}
+
+export function MemoryTags({ tags, onSelect, className = "" }: MemoryTagsProps) {
+  const validTags = tags.filter((tag) => typeof tag === "string" && tag.length > 0);
+  if (validTags.length === 0) return null;
+
+  const visibleTags = validTags.slice(0, VISIBLE_TAG_LIMIT);
+  const hiddenCount = validTags.length - visibleTags.length;
+  const pillClass =
+    "inline-block max-w-48 truncate border border-foreground/15 bg-foreground/[0.035] px-1.5 py-0.5 font-mono text-[10px] leading-4 text-foreground/65";
+
+  return (
+    <div className={`flex min-w-0 flex-wrap items-center gap-1 ${className}`.trim()}>
+      {visibleTags.map((tag, index) =>
+        onSelect ? (
+          <button
+            key={`${tag}-${index}`}
+            type="button"
+            data-testid="memory-tag"
+            title={tag}
+            aria-label={`Filter by tag ${tag}`}
+            onClick={() => onSelect(tag)}
+            className={`${pillClass} transition-colors hover:border-ink-accent/50 hover:text-ink-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ink-accent`}
+          >
+            {tag}
+          </button>
+        ) : (
+          <span key={`${tag}-${index}`} data-testid="memory-tag" title={tag} className={pillClass}>
+            {tag}
+          </span>
+        ),
+      )}
+      {hiddenCount > 0 ? (
+        <span
+          aria-label={`${hiddenCount} more tags`}
+          className="font-mono text-[10px] leading-4 text-foreground/55"
+        >
+          +{hiddenCount} more
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/dashboard/components/memories/proposal-card.tsx
+++ b/apps/dashboard/components/memories/proposal-card.tsx
@@ -27,6 +27,7 @@ import {
   rejectProposalAction,
 } from "@/app/(memories)/actions";
 import { DiscussProposalButton } from "@/components/curator/discuss-proposal-button";
+import { MemoryTags } from "@/components/memories/memory-tags";
 import { approveConsequenceLabel, proposalBadge } from "@/components/memories/proposal-action";
 import { TeachExampleDialog } from "@/components/memories/teach-example-dialog";
 import type { ProposalReviewRow } from "@/components/memories/types";
@@ -193,6 +194,8 @@ export function ProposalCard({
           ) : null}
         </div>
       ) : null}
+
+      <MemoryTags tags={proposal.tags} />
 
       {/* Per-action body. Order matters: split first (1 target, no diff, but
           NOT an intake submission), then single-target diff, then merge, then

--- a/apps/dashboard/components/memories/view.tsx
+++ b/apps/dashboard/components/memories/view.tsx
@@ -78,6 +78,7 @@ export function MemoriesView() {
     limit: PAGE_SIZE,
     offset,
     ...(filtersByKey.agent_id ? { agent_id: filtersByKey.agent_id } : {}),
+    ...(filtersByKey.tags ? { tags: [filtersByKey.tags] } : {}),
     ...(filtersByKey.shelf ? { shelf: filtersByKey.shelf } : {}),
     ...(filtersByKey.from ? { from: filtersByKey.from } : {}),
     ...(filtersByKey.to ? { to: filtersByKey.to } : {}),
@@ -96,14 +97,24 @@ export function MemoriesView() {
   // Filter defs — agent pulls its option list from the distinct-values
   // projection so the operator never types from memory.
   const agentValues = trpc.memories.distinctValues.useQuery({ field: "agent_id" });
+  const tagCountsQuery = trpc.memories.tagCounts.useQuery();
   const shelvesQuery = trpc.vault.shelves.useQuery();
   const filterDefs: FilterDef[] = useMemo(
     () =>
       buildFilterDefs(
         agentValues.data,
         shelvesQuery.isLoading || shelvesQuery.isError ? undefined : shelvesQuery.data,
+        tagCountsQuery.isLoading || tagCountsQuery.isError ? undefined : tagCountsQuery.data,
       ),
-    [agentValues.data, shelvesQuery.data, shelvesQuery.isError, shelvesQuery.isLoading],
+    [
+      agentValues.data,
+      shelvesQuery.data,
+      shelvesQuery.isError,
+      shelvesQuery.isLoading,
+      tagCountsQuery.data,
+      tagCountsQuery.isError,
+      tagCountsQuery.isLoading,
+    ],
   );
 
   const handleRecall = (query: string) => {
@@ -321,6 +332,7 @@ export function MemoriesView() {
                   error={listQuery.error?.message}
                   selectedId={selectedId}
                   onSelect={setSelectedId}
+                  onTagSelect={(tag) => setFilter("tags", tag, tag)}
                   offset={offset}
                   pageSize={PAGE_SIZE}
                   hasMore={offset + listMemories.length < total}
@@ -646,6 +658,7 @@ function filterClientSide(memories: MemoryRow[], term: string): MemoryRow[] {
 function buildFilterDefs(
   agentValues: readonly string[] | undefined,
   shelves: RouterOutputs["vault"]["shelves"] | undefined,
+  tagCounts: RouterOutputs["memories"]["tagCounts"] | undefined,
 ): FilterDef[] {
   const agents: string[] = [];
   const systemActors: string[] = [];
@@ -692,6 +705,25 @@ function buildFilterDefs(
                   value: shelf.id,
                   label: shelf.label ?? shelf.id,
                   title: shelf.id,
+                })),
+              },
+            ],
+          },
+        ]
+      : []),
+    ...(tagCounts
+      ? [
+          {
+            key: "tags",
+            label: "Tag",
+            type: "select" as const,
+            groups: [
+              {
+                options: tagCounts.map(({ tag, count }) => ({
+                  value: tag,
+                  label: `${tag} · ${count}`,
+                  activeDisplay: tag,
+                  title: tag,
                 })),
               },
             ],

--- a/apps/dashboard/components/memories/view.tsx
+++ b/apps/dashboard/components/memories/view.tsx
@@ -99,6 +99,10 @@ export function MemoriesView() {
   const agentValues = trpc.memories.distinctValues.useQuery({ field: "agent_id" });
   const tagCountsQuery = trpc.memories.tagCounts.useQuery();
   const shelvesQuery = trpc.vault.shelves.useQuery();
+  const refreshMemoryReads = () => {
+    void listQuery.refetch();
+    void tagCountsQuery.refetch();
+  };
   const filterDefs: FilterDef[] = useMemo(
     () =>
       buildFilterDefs(
@@ -272,7 +276,7 @@ export function MemoriesView() {
             <NewMemoryForm
               onSaved={() => {
                 setShowNewForm(false);
-                listQuery.refetch();
+                refreshMemoryReads();
               }}
             />
           ) : null}
@@ -571,7 +575,7 @@ export function MemoriesView() {
           memory={selected}
           onClose={() => setSelectedId(null)}
           onMutated={() => {
-            listQuery.refetch();
+            refreshMemoryReads();
             if (recallResults) setRecallResults(null);
           }}
         />
@@ -589,7 +593,7 @@ export function MemoriesView() {
           if (!next) setSelectedId(null);
         }}
         onMutated={() => {
-          listQuery.refetch();
+          refreshMemoryReads();
           if (recallResults) setRecallResults(null);
         }}
       />

--- a/apps/dashboard/e2e/fixtures.ts
+++ b/apps/dashboard/e2e/fixtures.ts
@@ -39,7 +39,7 @@ interface CreatedMemory {
 export async function createTestMemory(
   title: string,
   body: string,
-  overrides: { agent_id?: string } = {},
+  overrides: { agent_id?: string; tags?: string[] } = {},
 ): Promise<{ id: string }> {
   const ctx = await adminContext();
   try {
@@ -47,6 +47,7 @@ export async function createTestMemory(
       title,
       body,
       ...(overrides.agent_id ? { agent_id: overrides.agent_id } : {}),
+      ...(overrides.tags ? { tags: overrides.tags } : {}),
     });
     if (!result?.memory?.id) {
       throw new Error(`createMemory returned no id: ${JSON.stringify(result)}`);

--- a/apps/dashboard/e2e/memories.spec.ts
+++ b/apps/dashboard/e2e/memories.spec.ts
@@ -3,13 +3,29 @@ import { createTestMemory } from "./fixtures";
 
 test.describe("memories list + detail", () => {
   let memoryTitle: string;
+  let matchingTitle: string;
+  let excludedTitle: string;
+  let sharedTag: string;
+  let longTag: string;
 
   test.beforeAll(async () => {
-    memoryTitle = `e2e-memory-${Date.now()}`;
+    const stamp = Date.now();
+    memoryTitle = `e2e-memory-${stamp}`;
+    matchingTitle = `e2e-matching-${stamp}`;
+    excludedTitle = `e2e-excluded-${stamp}`;
+    sharedTag = `e2e-tag-${stamp}`;
+    longTag = `e2e-tag-${"long-unbroken-".repeat(20)}${stamp}`;
     await createTestMemory(
       memoryTitle,
       "Body for the e2e test memory. The list should render this and clicking should open the detail panel.",
+      { tags: [sharedTag, longTag] },
     );
+    await createTestMemory(matchingTitle, "Another memory with the shared tag.", {
+      tags: [sharedTag],
+    });
+    await createTestMemory(excludedTitle, "A memory outside the shared tag filter.", {
+      tags: [`e2e-other-${stamp}`],
+    });
   });
 
   test("renders the memory and opens the detail panel on click", async ({ page }) => {
@@ -44,5 +60,40 @@ test.describe("memories list + detail", () => {
       () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
     );
     expect(overflow).toBeLessThanOrEqual(1); // no horizontal page overflow
+  });
+
+  test("filters by counted picker and card tags without opening the inspector", async ({
+    page,
+  }) => {
+    await page.goto("/memories");
+
+    await page.getByRole("button", { name: "Tag", exact: true }).click();
+    const picker = page.getByRole("listbox", { name: "Tag options" });
+    await expect(picker.getByRole("button", { name: `${sharedTag} · 2` })).toBeVisible();
+    await picker.getByRole("button", { name: `${sharedTag} · 2` }).click();
+
+    await expect(page.getByRole("button", { name: new RegExp(memoryTitle) })).toBeVisible();
+    await expect(page.getByRole("button", { name: new RegExp(matchingTitle) })).toBeVisible();
+    await expect(page.getByRole("button", { name: new RegExp(excludedTitle) })).toHaveCount(0);
+
+    await page.getByRole("button", { name: "Clear all" }).click();
+    await expect(page.getByRole("button", { name: new RegExp(excludedTitle) })).toBeVisible();
+
+    const card = page.getByRole("button", { name: new RegExp(memoryTitle) }).locator("..");
+    await card.getByRole("button", { name: `Filter by tag ${sharedTag}` }).click();
+    await expect(page.getByRole("button", { name: new RegExp(excludedTitle) })).toHaveCount(0);
+    await expect(page.getByRole("heading", { name: memoryTitle, level: 2 })).toHaveCount(0);
+
+    await page.setViewportSize({ width: 320, height: 720 });
+    const longTagPill = card.getByRole("button", { name: `Filter by tag ${longTag}` });
+    await expect(longTagPill).toBeVisible();
+    expect(await longTagPill.getAttribute("title")).toBe(longTag);
+    expect(
+      await longTagPill.evaluate((element) => element.getBoundingClientRect().width),
+    ).toBeLessThanOrEqual(192);
+    const cardOverflow = await card.evaluate(
+      (element) => element.scrollWidth - element.clientWidth,
+    );
+    expect(cardOverflow).toBeLessThanOrEqual(1);
   });
 });

--- a/apps/dashboard/e2e/memories.spec.ts
+++ b/apps/dashboard/e2e/memories.spec.ts
@@ -68,7 +68,7 @@ test.describe("memories list + detail", () => {
     await page.goto("/memories");
 
     await page.getByRole("button", { name: "Tag", exact: true }).click();
-    const picker = page.getByRole("listbox", { name: "Tag options" });
+    const picker = page.getByRole("dialog", { name: "Tag options" });
     await expect(picker.getByRole("button", { name: `${sharedTag} · 2` })).toBeVisible();
     await picker.getByRole("button", { name: `${sharedTag} · 2` }).click();
 
@@ -95,5 +95,15 @@ test.describe("memories list + detail", () => {
       (element) => element.scrollWidth - element.clientWidth,
     );
     expect(cardOverflow).toBeLessThanOrEqual(1);
+
+    await longTagPill.click();
+    const activeTag = page.getByRole("button", { name: "Remove Tag filter" }).locator("..");
+    await expect(activeTag.getByTitle(longTag)).toBeVisible();
+    expect(
+      await activeTag.evaluate((element) => element.getBoundingClientRect().width),
+    ).toBeLessThanOrEqual(272);
+    expect(
+      await activeTag.evaluate((element) => element.scrollWidth - element.clientWidth),
+    ).toBeLessThanOrEqual(1);
   });
 });

--- a/apps/dashboard/tests/components/archive-view.test.tsx
+++ b/apps/dashboard/tests/components/archive-view.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const archivedMemory = {
+  id: "mem_archived",
+  title: "Old deployment note",
+  body: "Use the retired script.",
+  status: "archived",
+  agent_id: "bede",
+  tags: ["deployment", "legacy"],
+  applies_to: [],
+  supersedes: [],
+  conflicts_with: [],
+  flags: [],
+  confidence: "high",
+  created_at: "2026-07-01T00:00:00.000Z",
+  updated_at: "2026-07-02T00:00:00.000Z",
+  is_global: false,
+  requires_approval: false,
+};
+
+vi.mock("@/lib/trpc-client", () => ({
+  trpc: {
+    memories: {
+      list: {
+        useQuery: () => ({
+          data: { memories: [archivedMemory], total: 1 },
+          isLoading: false,
+          isError: false,
+          error: null,
+          refetch: vi.fn(),
+        }),
+      },
+    },
+  },
+}));
+
+vi.mock("@/components/memories/archive-delete-modal", () => ({
+  ArchiveDeleteModal: () => null,
+}));
+
+const { ArchiveView } = await import("@/components/memories/archive-view");
+
+describe("ArchiveView", () => {
+  it("shows archived tags as informational pills", () => {
+    render(<ArchiveView />);
+
+    expect(screen.getByText("deployment").tagName).toBe("SPAN");
+    expect(screen.getByText("legacy")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Filter by tag deployment" })).toBeNull();
+  });
+});

--- a/apps/dashboard/tests/components/flagged-view.test.tsx
+++ b/apps/dashboard/tests/components/flagged-view.test.tsx
@@ -36,6 +36,7 @@ function flaggedRow() {
     title: "Outdated deploy note",
     body: "Deploy with the old script.",
     agent_id: "bede",
+    tags: ["deployment", "outdated"],
     updated_at: "2026-06-01T00:00:00.000Z",
     flags: [
       {
@@ -60,6 +61,8 @@ describe("FlaggedView", () => {
     expect(screen.getByText("Deploy with the old script.")).toBeInTheDocument();
     expect(screen.getByText(/the deploy script was replaced/)).toBeInTheDocument();
     expect(screen.getByText(/scribe/)).toBeInTheDocument();
+    expect(screen.getByText("deployment").tagName).toBe("SPAN");
+    expect(screen.queryByRole("button", { name: "Filter by tag deployment" })).toBeNull();
   });
 
   it("shows the empty state when nothing is flagged", () => {

--- a/apps/dashboard/tests/components/keyboard-host.test.tsx
+++ b/apps/dashboard/tests/components/keyboard-host.test.tsx
@@ -18,7 +18,10 @@ vi.mock("next/navigation", () => ({
 
 vi.mock("@/lib/trpc-client", () => ({
   trpc: {
-    memories: { list: { useQuery: () => ({ data: { memories: [] } }) } },
+    memories: {
+      list: { useQuery: () => ({ data: { memories: [] } }) },
+      tagCounts: { useQuery: () => ({ data: [], isLoading: false, isError: false }) },
+    },
     sessions: { list: { useQuery: () => ({ data: { sessions: [] } }) } },
   },
 }));

--- a/apps/dashboard/tests/components/memories-list-selection.test.tsx
+++ b/apps/dashboard/tests/components/memories-list-selection.test.tsx
@@ -114,4 +114,25 @@ describe("MemoriesList select-all", () => {
     expect(onTagSelect).toHaveBeenCalledWith("decision");
     expect(onSelect).not.toHaveBeenCalled();
   });
+
+  it("keeps metadata inside the card's pointer selection target", async () => {
+    const onSelect = vi.fn();
+    render(
+      <MemoriesList
+        memories={[{ ...row("a"), shelfId: "personal", shelfLabel: "My shelf" }]}
+        isLoading={false}
+        isError={false}
+        selectedId={null}
+        onSelect={onSelect}
+        offset={0}
+        pageSize={25}
+        hasMore={false}
+        onOffsetChange={() => {}}
+      />,
+    );
+
+    await userEvent.click(screen.getByText("My shelf"));
+
+    expect(onSelect).toHaveBeenCalledWith("a");
+  });
 });

--- a/apps/dashboard/tests/components/memories-list-selection.test.tsx
+++ b/apps/dashboard/tests/components/memories-list-selection.test.tsx
@@ -9,8 +9,9 @@ function row(id: string): MemoryRow {
     id,
     title: `Title ${id}`,
     body: "body",
+    tags: [],
     updated_at: "2026-06-01T00:00:00.000Z",
-  } as MemoryRow;
+  } as unknown as MemoryRow;
 }
 
 function renderList(selectedIds: Set<string>) {
@@ -88,5 +89,29 @@ describe("MemoriesList select-all", () => {
     renderList(new Set());
 
     expect(screen.queryByText(/shelf/i)).not.toBeInTheDocument();
+  });
+
+  it("selects a Browse tag without also activating its memory card", async () => {
+    const onSelect = vi.fn();
+    const onTagSelect = vi.fn();
+    render(
+      <MemoriesList
+        memories={[{ ...row("a"), tags: ["decision"] }]}
+        isLoading={false}
+        isError={false}
+        selectedId={null}
+        onSelect={onSelect}
+        onTagSelect={onTagSelect}
+        offset={0}
+        pageSize={25}
+        hasMore={false}
+        onOffsetChange={() => {}}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Filter by tag decision" }));
+
+    expect(onTagSelect).toHaveBeenCalledWith("decision");
+    expect(onSelect).not.toHaveBeenCalled();
   });
 });

--- a/apps/dashboard/tests/components/memories/filter-chips.test.tsx
+++ b/apps/dashboard/tests/components/memories/filter-chips.test.tsx
@@ -65,11 +65,11 @@ describe("FilterChips", () => {
   it("opens the select popover with grouped options when the agent trigger is clicked", async () => {
     render(<FilterChips defs={DEFS} active={[]} onSet={vi.fn()} onRemove={vi.fn()} />);
     await userEvent.click(screen.getByRole("button", { name: /Agent/i }));
-    const listbox = await screen.findByRole("listbox", { name: /Agent options/i });
-    expect(within(listbox).getByText("System actors")).toBeInTheDocument();
-    expect(within(listbox).getByRole("button", { name: "claude-code" })).toBeInTheDocument();
+    const picker = await screen.findByRole("dialog", { name: /Agent options/i });
+    expect(within(picker).getByText("System actors")).toBeInTheDocument();
+    expect(within(picker).getByRole("button", { name: "claude-code" })).toBeInTheDocument();
     expect(
-      within(listbox).getByRole("button", { name: "system-memory-curator" }),
+      within(picker).getByRole("button", { name: "system-memory-curator" }),
     ).toBeInTheDocument();
   });
 
@@ -131,6 +131,21 @@ describe("FilterChips", () => {
     const clear = screen.getByRole("button", { name: "Clear all" });
     await userEvent.click(clear);
     expect(onClearAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds a long active value while preserving its full text", () => {
+    const longTag = `tag-${"unbroken".repeat(40)}`;
+    render(
+      <FilterChips
+        defs={DEFS}
+        active={[{ key: "tags", value: longTag, display: longTag }]}
+        onSet={vi.fn()}
+        onRemove={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(longTag)).toHaveClass("max-w-48", "truncate");
+    expect(screen.getByText(longTag)).toHaveAttribute("title", longTag);
   });
 
   it("keeps an active filter rendered and clearable after its definition disappears", async () => {

--- a/apps/dashboard/tests/components/memories/filter-chips.test.tsx
+++ b/apps/dashboard/tests/components/memories/filter-chips.test.tsx
@@ -81,6 +81,32 @@ describe("FilterChips", () => {
     expect(onSet).toHaveBeenCalledWith("agent_id", "claude-code", "claude-code");
   });
 
+  it("can keep counted option text out of the active filter display", async () => {
+    const onSet = vi.fn();
+    const tagDef: FilterDef = {
+      key: "tags",
+      label: "Tag",
+      type: "select",
+      groups: [
+        {
+          options: [
+            {
+              value: "the-librarian",
+              label: "the-librarian · 165",
+              activeDisplay: "the-librarian",
+            },
+          ],
+        },
+      ],
+    };
+    render(<FilterChips defs={[tagDef]} active={[]} onSet={onSet} onRemove={vi.fn()} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /tag/i }));
+    await userEvent.click(screen.getByRole("button", { name: "the-librarian · 165" }));
+
+    expect(onSet).toHaveBeenCalledWith("tags", "the-librarian", "the-librarian");
+  });
+
   it("collapses chips past maxVisible into an overflow +N more trigger", () => {
     // Force overflow: 4 inactive defs, maxVisible 2 → 2 visible + "+2 more"
     render(

--- a/apps/dashboard/tests/components/memories/filter-chips.test.tsx
+++ b/apps/dashboard/tests/components/memories/filter-chips.test.tsx
@@ -6,10 +6,12 @@
 
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 
 const { FilterChips } = await import("@/components/memories/filter-chips");
 type FilterDef = import("@/components/memories/filter-chips").FilterDef;
+type ActiveFilter = import("@/components/memories/filter-chips").ActiveFilter;
 
 const AGENT_DEF: FilterDef = {
   key: "agent_id",
@@ -34,6 +36,12 @@ const STATUS_DEF: FilterDef = {
   label: "Status",
   type: "select",
   groups: [{ options: [{ value: "active", label: "active" }] }],
+};
+const TAG_DEF: FilterDef = {
+  key: "tags",
+  label: "Tag",
+  type: "select",
+  groups: [{ options: [{ value: "architecture", label: "architecture" }] }],
 };
 const FROM_DEF: FilterDef = { key: "from", label: "From", type: "date" };
 const TO_DEF: FilterDef = { key: "to", label: "To", type: "date" };
@@ -71,6 +79,70 @@ describe("FilterChips", () => {
     expect(
       within(picker).getByRole("button", { name: "system-memory-curator" }),
     ).toBeInTheDocument();
+  });
+
+  it("returns focus to the trigger when Escape closes a select picker", async () => {
+    const user = userEvent.setup();
+    render(<FilterChips defs={DEFS} active={[]} onSet={vi.fn()} onRemove={vi.fn()} />);
+    const trigger = screen.getByRole("button", { name: /Agent/i });
+
+    await user.click(trigger);
+    expect(screen.getByPlaceholderText("Filter agent…")).toHaveFocus();
+    await user.keyboard("{Escape}");
+
+    expect(screen.queryByRole("dialog", { name: /Agent options/i })).toBeNull();
+    expect(trigger).toHaveFocus();
+  });
+
+  it("moves focus to the active chip when a selection replaces its trigger", async () => {
+    const user = userEvent.setup();
+
+    function ControlledChips() {
+      const [active, setActive] = useState<ActiveFilter[]>([]);
+      return (
+        <FilterChips
+          defs={[AGENT_DEF]}
+          active={active}
+          onSet={(key, value, display) => setActive([{ key, value, display }])}
+          onRemove={vi.fn()}
+        />
+      );
+    }
+
+    render(<ControlledChips />);
+    await user.click(screen.getByRole("button", { name: /Agent/i }));
+    await user.click(screen.getByRole("button", { name: "claude-code" }));
+
+    expect(screen.getByRole("button", { name: "Remove Agent filter" })).toHaveFocus();
+  });
+
+  it("returns focus to the overflow trigger when the selected filter remains collapsed", async () => {
+    const user = userEvent.setup();
+
+    function ControlledOverflowChips() {
+      const [active, setActive] = useState<ActiveFilter[]>([
+        { key: "agent_id", value: "claude-code", display: "claude-code" },
+        { key: "status", value: "active", display: "active" },
+      ]);
+      return (
+        <FilterChips
+          defs={[AGENT_DEF, STATUS_DEF, TAG_DEF]}
+          active={active}
+          onSet={(key, value, display) =>
+            setActive((current) => [...current, { key, value, display }])
+          }
+          onRemove={vi.fn()}
+          maxVisible={2}
+        />
+      );
+    }
+
+    render(<ControlledOverflowChips />);
+    await user.click(screen.getByRole("button", { name: /\+1 more/i }));
+    await user.click(screen.getByRole("button", { name: /Tag/i }));
+    await user.click(screen.getByRole("button", { name: "architecture" }));
+
+    expect(screen.getByRole("button", { name: /\+1 more/i })).toHaveFocus();
   });
 
   it("emits onSet with key + value + display when a select option is chosen", async () => {

--- a/apps/dashboard/tests/components/memories/memory-tags.test.tsx
+++ b/apps/dashboard/tests/components/memories/memory-tags.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { MemoryTags } from "@/components/memories/memory-tags";
+
+describe("MemoryTags", () => {
+  it("renders no chrome when there are no stored tags", () => {
+    const { container } = render(<MemoryTags tags={[]} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows up to three tags in stored order and names the hidden remainder", () => {
+    render(<MemoryTags tags={["first", "second", "third", "fourth", "fifth"]} />);
+
+    expect(screen.getAllByTestId("memory-tag").map((tag) => tag.textContent)).toEqual([
+      "first",
+      "second",
+      "third",
+    ]);
+    expect(screen.queryByText("fourth")).not.toBeInTheDocument();
+    expect(screen.getByText("+2 more")).toHaveAccessibleName("2 more tags");
+  });
+
+  it("renders long markup-shaped values as bounded text with the full value available", () => {
+    const hostile = '<img src=x onerror="alert(1)">-a-very-long-tag-value';
+    const { container } = render(<MemoryTags tags={[hostile]} />);
+
+    const tag = screen.getByText(hostile);
+    expect(tag).toHaveAttribute("title", hostile);
+    expect(tag).toHaveClass("truncate");
+    expect(container.querySelector("img")).toBeNull();
+  });
+
+  it("uses informational spans unless selection is explicitly enabled", () => {
+    render(<MemoryTags tags={["decision"]} />);
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.getByText("decision").tagName).toBe("SPAN");
+  });
+
+  it("exposes selectable tags as named keyboard buttons", async () => {
+    const onSelect = vi.fn();
+    const user = userEvent.setup();
+    render(<MemoryTags tags={["decision"]} onSelect={onSelect} />);
+
+    const tag = screen.getByRole("button", { name: "Filter by tag decision" });
+    await user.tab();
+    expect(tag).toHaveFocus();
+    await user.keyboard("{Enter}");
+    expect(onSelect).toHaveBeenCalledWith("decision");
+  });
+});

--- a/apps/dashboard/tests/components/memories/memory-tags.test.tsx
+++ b/apps/dashboard/tests/components/memories/memory-tags.test.tsx
@@ -45,6 +45,7 @@ describe("MemoryTags", () => {
     render(<MemoryTags tags={["decision"]} onSelect={onSelect} />);
 
     const tag = screen.getByRole("button", { name: "Filter by tag decision" });
+    expect(tag).toHaveClass("pointer-coarse:min-h-11");
     await user.tab();
     expect(tag).toHaveFocus();
     await user.keyboard("{Enter}");

--- a/apps/dashboard/tests/components/memories/view-shelf-filter.test.tsx
+++ b/apps/dashboard/tests/components/memories/view-shelf-filter.test.tsx
@@ -29,6 +29,9 @@ vi.mock("@/lib/trpc-client", () => ({
       distinctValues: {
         useQuery: () => ({ data: [] }),
       },
+      tagCounts: {
+        useQuery: () => ({ data: [], isLoading: false, isError: false }),
+      },
     },
     vault: {
       shelves: {

--- a/apps/dashboard/tests/components/memories/view-tag-filter.test.tsx
+++ b/apps/dashboard/tests/components/memories/view-tag-filter.test.tsx
@@ -13,6 +13,7 @@ const state = vi.hoisted(() => ({
   },
   listInputs: [] as unknown[],
   selectedIds: [] as string[],
+  tagRefetch: vi.fn(),
 }));
 
 const memory = {
@@ -49,7 +50,7 @@ vi.mock("@/lib/trpc-client", () => ({
         },
       },
       distinctValues: { useQuery: () => ({ data: ["human"] }) },
-      tagCounts: { useQuery: () => state.tagCounts },
+      tagCounts: { useQuery: () => ({ ...state.tagCounts, refetch: state.tagRefetch }) },
     },
     vault: {
       shelves: {
@@ -70,9 +71,15 @@ vi.mock("@/app/(memories)/actions", () => ({
 vi.mock("@/hooks/use-media-query", () => ({ useMediaQuery: () => false }));
 vi.mock("@/hooks/use-surface-shortcuts", () => ({ useSurfaceShortcuts: () => {} }));
 vi.mock("@/components/memories/memory-inspector", () => ({
-  MemoryInspector: ({ memory }: { memory: { id: string } | null }) => {
+  MemoryInspector: ({
+    memory,
+    onMutated,
+  }: {
+    memory: { id: string } | null;
+    onMutated: () => void;
+  }) => {
     if (memory) state.selectedIds.push(memory.id);
-    return null;
+    return memory ? <button onClick={onMutated}>Simulate memory mutation</button> : null;
   },
 }));
 vi.mock("@/components/memories/memory-bottom-sheet", () => ({ MemoryBottomSheet: () => null }));
@@ -90,6 +97,7 @@ beforeEach(() => {
   };
   state.listInputs = [];
   state.selectedIds = [];
+  state.tagRefetch.mockClear();
 });
 
 describe("MemoriesView tag filter", () => {
@@ -97,7 +105,7 @@ describe("MemoriesView tag filter", () => {
     render(<MemoriesView />);
 
     await userEvent.click(screen.getByRole("button", { name: /^tag$/i }));
-    const picker = screen.getByRole("listbox", { name: "Tag options" });
+    const picker = screen.getByRole("dialog", { name: "Tag options" });
     await userEvent.type(within(picker).getByPlaceholderText("Filter tag…"), "DECIS");
     expect(within(picker).getByRole("button", { name: "Decision · 2" })).toBeInTheDocument();
     expect(within(picker).queryByText("the-librarian · 1")).not.toBeInTheDocument();
@@ -152,5 +160,13 @@ describe("MemoriesView tag filter", () => {
     expect(screen.getByText("Tagged memory")).toBeInTheDocument();
     await userEvent.click(removeTag);
     expect(state.listInputs.at(-1)).not.toHaveProperty("tags");
+  });
+
+  it("refreshes the tag catalogue after a memory mutation", async () => {
+    render(<MemoriesView />);
+    await userEvent.click(screen.getByRole("button", { name: /Tagged memory body/ }));
+    await userEvent.click(screen.getByRole("button", { name: "Simulate memory mutation" }));
+
+    expect(state.tagRefetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/dashboard/tests/components/memories/view-tag-filter.test.tsx
+++ b/apps/dashboard/tests/components/memories/view-tag-filter.test.tsx
@@ -1,0 +1,156 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  tagCounts: {
+    data: [
+      { tag: "Decision", count: 2 },
+      { tag: "the-librarian", count: 1 },
+    ] as Array<{ tag: string; count: number }> | undefined,
+    isLoading: false,
+    isError: false,
+  },
+  listInputs: [] as unknown[],
+  selectedIds: [] as string[],
+}));
+
+const memory = {
+  id: "mem_tagged",
+  title: "Tagged memory",
+  body: "body",
+  status: "active",
+  agent_id: "human",
+  tags: ["Decision"],
+  applies_to: [],
+  supersedes: [],
+  conflicts_with: [],
+  flags: [],
+  confidence: "high",
+  created_at: "2026-08-01T00:00:00.000Z",
+  updated_at: "2026-08-01T00:00:00.000Z",
+  is_global: false,
+  requires_approval: false,
+};
+
+vi.mock("@/lib/trpc-client", () => ({
+  trpc: {
+    memories: {
+      list: {
+        useQuery: (input: unknown) => {
+          state.listInputs.push(input);
+          return {
+            data: { memories: [memory], total: 30 },
+            isLoading: false,
+            isError: false,
+            error: null,
+            refetch: vi.fn(),
+          };
+        },
+      },
+      distinctValues: { useQuery: () => ({ data: ["human"] }) },
+      tagCounts: { useQuery: () => state.tagCounts },
+    },
+    vault: {
+      shelves: {
+        useQuery: () => ({
+          data: [{ id: "main", writable: true }],
+          isLoading: false,
+          isError: false,
+        }),
+      },
+    },
+  },
+}));
+
+vi.mock("@/app/(memories)/actions", () => ({
+  recallAction: vi.fn(),
+  searchReferencesAction: vi.fn(),
+}));
+vi.mock("@/hooks/use-media-query", () => ({ useMediaQuery: () => false }));
+vi.mock("@/hooks/use-surface-shortcuts", () => ({ useSurfaceShortcuts: () => {} }));
+vi.mock("@/components/memories/memory-inspector", () => ({
+  MemoryInspector: ({ memory }: { memory: { id: string } | null }) => {
+    if (memory) state.selectedIds.push(memory.id);
+    return null;
+  },
+}));
+vi.mock("@/components/memories/memory-bottom-sheet", () => ({ MemoryBottomSheet: () => null }));
+
+const { MemoriesView } = await import("@/components/memories/view");
+
+beforeEach(() => {
+  state.tagCounts = {
+    data: [
+      { tag: "Decision", count: 2 },
+      { tag: "the-librarian", count: 1 },
+    ],
+    isLoading: false,
+    isError: false,
+  };
+  state.listInputs = [];
+  state.selectedIds = [];
+});
+
+describe("MemoriesView tag filter", () => {
+  it("searches counted options case-insensitively and keeps counts out of the active chip", async () => {
+    render(<MemoriesView />);
+
+    await userEvent.click(screen.getByRole("button", { name: /^tag$/i }));
+    const picker = screen.getByRole("listbox", { name: "Tag options" });
+    await userEvent.type(within(picker).getByPlaceholderText("Filter tag…"), "DECIS");
+    expect(within(picker).getByRole("button", { name: "Decision · 2" })).toBeInTheDocument();
+    expect(within(picker).queryByText("the-librarian · 1")).not.toBeInTheDocument();
+
+    await userEvent.click(within(picker).getByRole("button", { name: "Decision · 2" }));
+
+    const removeTag = screen.getByRole("button", { name: "Remove Tag filter" });
+    expect(removeTag.parentElement).toHaveTextContent("Decision");
+    expect(removeTag.parentElement).not.toHaveTextContent("Decision · 2");
+    expect(state.listInputs.at(-1)).toEqual(expect.objectContaining({ tags: ["Decision"] }));
+  });
+
+  it("composes with an agent filter, resets pagination, and clears cleanly", async () => {
+    render(<MemoriesView />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(state.listInputs.at(-1)).toEqual(expect.objectContaining({ offset: 25 }));
+    await userEvent.click(screen.getByRole("button", { name: /agent/i }));
+    await userEvent.click(screen.getByRole("button", { name: "human" }));
+    await userEvent.click(screen.getByRole("button", { name: /^tag$/i }));
+    await userEvent.click(screen.getByRole("button", { name: "Decision · 2" }));
+
+    expect(state.listInputs.at(-1)).toEqual(
+      expect.objectContaining({ agent_id: "human", tags: ["Decision"], offset: 0 }),
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /remove tag filter/i }));
+    expect(state.listInputs.at(-1)).toEqual(expect.objectContaining({ agent_id: "human" }));
+    expect(state.listInputs.at(-1)).not.toHaveProperty("tags");
+  });
+
+  it("applies a card tag without opening the inspector", async () => {
+    render(<MemoriesView />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Filter by tag Decision" }));
+
+    expect(state.listInputs.at(-1)).toEqual(expect.objectContaining({ tags: ["Decision"] }));
+    expect(state.selectedIds).toEqual([]);
+  });
+
+  it("fails soft when the catalogue query is unavailable and keeps an active tag clearable", async () => {
+    const { rerender } = render(<MemoriesView />);
+    await userEvent.click(screen.getByRole("button", { name: /^tag$/i }));
+    await userEvent.click(screen.getByRole("button", { name: "Decision · 2" }));
+
+    state.tagCounts = { data: undefined, isLoading: false, isError: true };
+    rerender(<MemoriesView />);
+
+    expect(screen.queryByRole("button", { name: /^tag$/i })).not.toBeInTheDocument();
+    const removeTag = screen.getByRole("button", { name: /remove tags filter/i });
+    expect(removeTag.parentElement).toHaveTextContent("Decision");
+    expect(screen.getByText("Tagged memory")).toBeInTheDocument();
+    await userEvent.click(removeTag);
+    expect(state.listInputs.at(-1)).not.toHaveProperty("tags");
+  });
+});

--- a/apps/dashboard/tests/components/proposal-card.test.tsx
+++ b/apps/dashboard/tests/components/proposal-card.test.tsx
@@ -137,6 +137,18 @@ describe("ProposalCard — grooming update (single target)", () => {
     expect(screen.getByText("Espresso, no sugar.")).toBeInTheDocument();
   });
 
+  it("shows the proposed outcome's tags once as informational pills", () => {
+    const tagged = updateRow();
+    tagged.proposal.tags = ["preference", "coffee"];
+    tagged.targets[0]!.tags = ["target-only"];
+    render(<ProposalCard row={tagged} />);
+
+    expect(screen.getAllByText("preference")).toHaveLength(1);
+    expect(screen.getByText("preference").tagName).toBe("SPAN");
+    expect(screen.queryByText("target-only")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Filter by tag preference" })).toBeNull();
+  });
+
   it("renders a DiffView between old and new", () => {
     render(<ProposalCard row={updateRow()} />);
     expect(screen.getByLabelText("Unified diff")).toBeInTheDocument();

--- a/apps/docs/src/content/docs/dashboard/index.md
+++ b/apps/docs/src/content/docs/dashboard/index.md
@@ -49,3 +49,16 @@ memory, reading a handoff, editing the briefing, or checking a backup ran.
 
 Start with [Reviewing & accepting proposals](/guides/reviewing-proposals/) for the
 core task, then dip into any area below.
+
+## Seeing and browsing tags
+
+Memory cards show up to three tags in their stored order, followed by **+N more**
+when a memory has additional tags. The same compact tag row appears in Browse,
+Recall, Proposals, Flagged, and Archive so you can see how a memory is classified
+without opening it.
+
+In **Memories → Browse**, choose **Tag** to search the tag catalogue. Each option
+shows the number of active memories with that exact tag across the shelves you
+can recall. Picking an option—or selecting a tag directly on a Browse card—adds
+an exact-tag filter. Use the tag's **×** or **Clear all** to remove it. Tags on
+Recall and the review queues are informational and do not change those views.

--- a/integrations/pi/package.json
+++ b/integrations/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-librarian/pi-extension",
-  "version": "1.17.0",
+  "version": "1.19.0",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -349,6 +349,12 @@ export interface LibrarianStore
     filters?: Record<string, unknown>,
   ): { memories: RecalledMemory[]; total: number; limit: number; offset: number };
   /**
+   * Count exact stored tags across the principal's active, visible memories. The principal's
+   * validated `"recall"` shelf set defines visibility; duplicate memory ids resolve by router
+   * precedence before counting, and a repeated tag contributes at most once per memory.
+   */
+  tagCountsForPrincipal(principal: Principal): { tag: string; count: number }[];
+  /**
    * The principal's validated, materialised `"recall"` shelf set in router order (spec 066 SC 3).
    * This is the shelf-enumeration source for member-aware browse surfaces. Zero shelves returns
    * `[]`; validation happens at the same first-use boundary as every other principal surface.
@@ -1212,6 +1218,33 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Libra
     return { memories, total: rows.length, limit, offset };
   };
 
+  const tagCountsForPrincipal = (principal: Principal): { tag: string; count: number }[] => {
+    const shelves = vaultRouter.shelves(principal, "recall");
+    validateShelfSet(shelves);
+    const seenIds = new Set<string>();
+    const counts = new Map<string, number>();
+
+    for (const shelf of shelves) {
+      const { memories } = coreForShelf(shelf).rawMemory.listMemoriesUncapped({
+        status: "active",
+      });
+      for (const memory of memories) {
+        if (seenIds.has(memory.id)) continue;
+        seenIds.add(memory.id);
+        const storedTags: unknown = memory.tags;
+        if (!Array.isArray(storedTags)) continue;
+        const uniqueTags = new Set(
+          storedTags.filter((tag): tag is string => typeof tag === "string" && tag.length > 0),
+        );
+        for (const tag of uniqueTags) counts.set(tag, (counts.get(tag) ?? 0) + 1);
+      }
+    }
+
+    return [...counts.entries()]
+      .map(([tag, count]) => ({ tag, count }))
+      .sort((left, right) => right.count - left.count || cmpStr(left.tag, right.tag));
+  };
+
   const shelvesForPrincipal = (principal: Principal): readonly Shelf[] => {
     const shelves = vaultRouter.shelves(principal, "recall");
     validateShelfSet(shelves);
@@ -1537,6 +1570,7 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Libra
     recallForPrincipal,
     searchReferencesForPrincipal,
     listMemoriesForPrincipal,
+    tagCountsForPrincipal,
     shelvesForPrincipal,
     getMemoryForPrincipal,
     approveProposalForPrincipal,

--- a/packages/core/src/store/markdown/memory-doc.ts
+++ b/packages/core/src/store/markdown/memory-doc.ts
@@ -24,7 +24,14 @@ const MemoryFrontmatterSchema = z.object({
   agent_id: z.string(),
   status: z.string(),
   confidence: z.string(),
-  tags: z.array(z.string()),
+  // Tags pre-date the strict markdown schema and hand-edited vaults can contain scalar or
+  // mixed-array values. Treat only stored strings as tags without rewriting the document; this
+  // keeps one malformed legacy value from making the otherwise-valid memory unreadable.
+  tags: z.preprocess(
+    (value) =>
+      Array.isArray(value) ? value.filter((tag): tag is string => typeof tag === "string") : [],
+    z.array(z.string()),
+  ),
   applies_to: z.array(z.string()),
   supersedes: z.array(z.string()),
   conflicts_with: z.array(z.string()),

--- a/packages/core/tests/store/scoped-list.test.ts
+++ b/packages/core/tests/store/scoped-list.test.ts
@@ -379,6 +379,53 @@ describe("distinctValuesForPrincipal — union over the shelf set (spec 065 SC 7
   });
 });
 
+describe("tagCountsForPrincipal — active tags inside the recall boundary", () => {
+  it("deduplicates memories and their tags before returning deterministic aggregate counts", () => {
+    const { store, dataDir } = freshStore(twoShelfRouter);
+    writeMemoryFile(dataDir, A, mem("mem_shared", { tags: ["winner", "shared", "shared", ""] }));
+    writeMemoryFile(dataDir, A, mem("mem_personal", { tags: ["popular", "zeta"] }));
+    writeMemoryFile(
+      dataDir,
+      A,
+      mem("mem_archived", { status: "archived", tags: ["archived-only"] }),
+    );
+    writeMemoryFile(dataDir, B, mem("mem_shared", { tags: ["loser"] }));
+    writeMemoryFile(dataDir, B, mem("mem_team", { tags: ["popular", "alpha"] }));
+    writeMemoryFile(dataDir, C, mem("mem_off_shelf", { tags: ["secret"] }));
+
+    expect(store.tagCountsForPrincipal(PRINCIPAL)).toEqual([
+      { tag: "popular", count: 2 },
+      { tag: "alpha", count: 1 },
+      { tag: "shared", count: 1 },
+      { tag: "winner", count: 1 },
+      { tag: "zeta", count: 1 },
+    ]);
+  });
+
+  it("counts the principal's single shelf without exposing inactive memories", () => {
+    const singleShelfRouter: VaultRouter = { shelves: () => [A], writeTarget: () => A };
+    const { store, dataDir } = freshStore(singleShelfRouter);
+    writeMemoryFile(dataDir, A, mem("mem_one", { tags: ["Beta", "alpha"] }));
+    writeMemoryFile(dataDir, A, mem("mem_two", { tags: ["alpha"] }));
+    writeMemoryFile(
+      dataDir,
+      A,
+      mem("mem_proposed", { status: "proposed", tags: ["proposal-only"] }),
+    );
+
+    expect(store.tagCountsForPrincipal(PRINCIPAL)).toEqual([
+      { tag: "alpha", count: 2 },
+      { tag: "Beta", count: 1 },
+    ]);
+  });
+
+  it("returns an empty catalogue for a principal with no recall shelves", () => {
+    const { store } = freshStore(zeroShelfRouter);
+
+    expect(store.tagCountsForPrincipal(PRINCIPAL)).toEqual([]);
+  });
+});
+
 describe("countReferencesForPrincipal — the scoped searched denominator (spec 065 T4)", () => {
   function writeReference(dataDir: string, shelf: Shelf, name: string): void {
     const dir = path.join(

--- a/packages/core/tests/store/scoped-list.test.ts
+++ b/packages/core/tests/store/scoped-list.test.ts
@@ -93,6 +93,12 @@ function writeMemoryFile(dataDir: string, shelf: Shelf, memory: Memory): void {
   fs.writeFileSync(path.join(dir, `${memory.id}.md`), serializeMemoryDocument(memory));
 }
 
+function writeRawMemoryFile(dataDir: string, shelf: Shelf, id: string, raw: string): void {
+  const dir = path.join(dataDir, "vault", ...shelf.prefix.split("/").filter(Boolean), "memories");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, `${id}.md`), raw);
+}
+
 describe("listMemoriesForPrincipal — merge rule + attribution (spec 065 SC 7)", () => {
   it("merges two shelves by the requested sort key, attributes rows, and counts unique ids", () => {
     const { store, dataDir } = freshStore(twoShelfRouter);
@@ -416,6 +422,26 @@ describe("tagCountsForPrincipal — active tags inside the recall boundary", () 
     expect(store.tagCountsForPrincipal(PRINCIPAL)).toEqual([
       { tag: "alpha", count: 2 },
       { tag: "Beta", count: 1 },
+    ]);
+  });
+
+  it("ignores malformed legacy tag values without dropping the rest of the corpus", () => {
+    const { store, dataDir } = freshStore(twoShelfRouter);
+    const mixed = serializeMemoryDocument(mem("mem_mixed", { tags: ["valid"] })).replace(
+      "tags:\n  - valid",
+      "tags:\n  - valid\n  - 17\n  - ''",
+    );
+    const scalar = serializeMemoryDocument(mem("mem_scalar", { tags: ["placeholder"] })).replace(
+      "tags:\n  - placeholder",
+      "tags: legacy-scalar",
+    );
+    writeRawMemoryFile(dataDir, A, "mem_mixed", mixed);
+    writeRawMemoryFile(dataDir, A, "mem_scalar", scalar);
+    writeMemoryFile(dataDir, B, mem("mem_normal", { tags: ["normal"] }));
+
+    expect(store.tagCountsForPrincipal(PRINCIPAL)).toEqual([
+      { tag: "normal", count: 1 },
+      { tag: "valid", count: 1 },
     ]);
   });
 

--- a/packages/installer-cli/package.json
+++ b/packages/installer-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-librarian/cli",
-  "version": "1.17.0",
+  "version": "1.19.0",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/mcp-server/src/trpc/memories.ts
+++ b/packages/mcp-server/src/trpc/memories.ts
@@ -2,10 +2,10 @@
 //
 // Typed read/write surface for the dashboard: list/get/recall/aggregates,
 // create/update/delete memories, proposal approve/reject, and
-// related-memory similarity. All procedures are admin-gated EXCEPT the three
+// related-memory similarity. All procedures are admin-gated EXCEPT the four
 // browse-slice reads spec 065 SC 7 deliberately moved to `memberProcedure`
 // WITH principal-scoped store surfaces in the same change (`list`,
-// `distinctValues`, `recall` — the fourth slice procedure is
+// `distinctValues`, `tagCounts`, `recall` — the fifth slice procedure is
 // `vault.searchReferences`); post-ADR-0008-P3 the gate is the network
 // boundary — this surface is served only on the trusted internal tRPC
 // listener, which the default provider resolves to the admin role.
@@ -88,6 +88,7 @@ const SortOrderSchema = z.enum(["asc", "desc"]);
 const ListMemoriesInputSchema = z.object({
   status: MemoryStatusSchema.optional(),
   agent_id: z.string().optional(),
+  tags: z.array(z.string()).optional(),
   shelf: z.string().min(1).optional(),
   from: z.string().optional(),
   to: z.string().optional(),
@@ -458,6 +459,11 @@ export const memoriesRouter = router({
         total: number;
       },
   ),
+
+  // Active tag catalogue for Browse. The store applies the principal's validated recall-shelf
+  // boundary and router-order duplicate resolution before counting, so this read cannot reveal
+  // tag names or corpus sizes from an unreadable shelf.
+  tagCounts: memberProcedure.query(({ ctx }) => ctx.store.tagCountsForPrincipal(ctx.principal)),
 
   // Flagged-memory review queue (spec 048 PR-2): every memory with ≥1 open
   // flag, each row carrying its `flags` so the dashboard can show the reason +

--- a/packages/mcp-server/tests/trpc/memories.test.ts
+++ b/packages/mcp-server/tests/trpc/memories.test.ts
@@ -147,6 +147,7 @@ function seedMemory(
     title: string;
     body: string;
     agent_id: string;
+    tags: string[];
     requires_approval: boolean;
   }> = {},
 ): MemoryRow {
@@ -159,6 +160,7 @@ function seedMemory(
         agent_id: overrides.agent_id || "bede",
         title: overrides.title || "Seeded memory",
         body: overrides.body || "Body text",
+        tags: overrides.tags ?? [],
       },
       opts,
     );
@@ -609,6 +611,48 @@ describe("tRPC memories surface", () => {
         headers: { authorization: `Bearer ${server.token}` },
       });
       expect(response.status).toBe(400);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("memories.list accepts exact any-match tag filters", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      seedMemory(dataDir, { title: "Alpha", tags: ["alpha", "shared"] });
+      seedMemory(dataDir, { title: "Beta", tags: ["beta"] });
+      seedMemory(dataDir, { title: "Other", tags: ["other"] });
+
+      const page = await trpcGet<ListMemoriesResult>(server, "memories.list", {
+        tags: ["alpha", "beta"],
+        sort: "title",
+        order: "asc",
+      });
+
+      expect(page.memories.map((memory) => memory.title)).toEqual(["Alpha", "Beta"]);
+      expect(page.total).toBe(2);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("memories.tagCounts returns active memory counts in deterministic order", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir });
+    try {
+      seedMemory(dataDir, { title: "One", tags: ["shared", "alpha"] });
+      seedMemory(dataDir, { title: "Two", tags: ["shared", "beta"] });
+
+      await expect(
+        trpcGet<{ tag: string; count: number }[]>(server, "memories.tagCounts"),
+      ).resolves.toEqual([
+        { tag: "shared", count: 2 },
+        { tag: "alpha", count: 1 },
+        { tag: "beta", count: 1 },
+      ]);
     } finally {
       await server.stop();
       cleanupTempDir(dataDir);

--- a/packages/mcp-server/tests/trpc/scoped-slice.test.ts
+++ b/packages/mcp-server/tests/trpc/scoped-slice.test.ts
@@ -1,8 +1,8 @@
 // spec 065 T4 — the scoped slice at the PROCEDURE level (SC 7, SC 8).
 //
-// Five procedures use `memberProcedure` WITH principal-scoped store surfaces:
-// `memories.list`, `memories.distinctValues`, `memories.recall`, `vault.searchReferences`,
-// `vault.shelves`.
+// Six procedures use `memberProcedure` WITH principal-scoped store surfaces:
+// `memories.list`, `memories.distinctValues`, `memories.tagCounts`, `memories.recall`,
+// `vault.searchReferences`, `vault.shelves`.
 // Driven through the real appRouter via createCallerFactory (precedent:
 // tests/trpc/principal.test.ts) against a store built with a two-shelf fixture router:
 //   - a member sees ONLY their shelf contents, shelf-attributed per 062's rule;
@@ -135,6 +135,27 @@ describe("spec 065 SC 7 — the four slice procedures, member + fixture router",
     expect(values).toEqual(["agent-a", "agent-t"]);
   });
 
+  it("memories.tagCounts: counts alice's active corpus without leaking bob's tags", async () => {
+    const { store } = freshStore(fixtureRouter);
+    store
+      .forShelf(ALICE_SHELF)
+      .createMemory({ title: "n1", body: "a", agent_id: "agent-a", tags: ["shared", "alice"] }, {});
+    store
+      .groomingStoreForShelf(TEAM_SHELF)
+      .createMemory({ title: "n2", body: "t", agent_id: "agent-t", tags: ["shared", "team"] }, {});
+    store
+      .forShelf(BOB_SHELF)
+      .createMemory({ title: "n3", body: "b", agent_id: "agent-bob", tags: ["bob-secret"] }, {});
+
+    const caller = createCaller(contextFor(alice, store));
+
+    await expect(caller.memories.tagCounts()).resolves.toEqual([
+      { tag: "shared", count: 2 },
+      { tag: "alice", count: 1 },
+      { tag: "team", count: 1 },
+    ]);
+  });
+
   it("memories.recall: merged hits carry 062's provenance labels; bob's memory never surfaces", async () => {
     const { store } = freshStore(fixtureRouter);
     store
@@ -214,6 +235,7 @@ describe("spec 065 SC 7 — the four slice procedures, member + fixture router",
     await expect(caller.memories.distinctValues({ field: "agent_id" })).rejects.toMatchObject({
       code: "UNAUTHORIZED",
     });
+    await expect(caller.memories.tagCounts()).rejects.toMatchObject({ code: "UNAUTHORIZED" });
     await expect(caller.memories.recall({ query: "x" })).rejects.toMatchObject({
       code: "UNAUTHORIZED",
     });


### PR DESCRIPTION
## Depends on

- #453 (Chronicle / v1.18.0). This branch is based on `feat/chronicle`; its release is v1.19.0.

## Summary

- Add principal-scoped, live tag counts for active memories with deterministic ordering and per-memory deduplication.
- Add exact tag filtering to Browse, with searchable counted options, bounded card pills, mutation refreshes, and fail-soft catalogue loading.
- Show informational tags consistently in Flagged, Archive, and Proposal review queues without expanding the MCP tool surface.
- Document the dashboard behaviour and release the change as v1.19.0 across all public manifests.

## Contracts and safety

- Tag counts use the caller's recall shelves, so member queries cannot reveal off-scope tag names or counts.
- Malformed legacy tag values are ignored without dropping the rest of the corpus.
- User-controlled tag text is rendered as React text; no HTML injection or new executable surface is introduced.
- No schema/data migration, dependency change, lockfile change, or new MCP verb.

## Verification

- `pnpm test` — all production builds and workspace suites passed (including 1,654 core, 589 MCP, 600 dashboard, and 242 root tests; one intentional core skip). After the final focus-only review fixes, the complete dashboard suite was rerun: 603/603 passed.
- `pnpm lint`
- `pnpm typecheck`
- `pnpm exec prettier --check .`
- `pnpm check:docs`
- `pnpm check:release`
- `pnpm check:naming-canon`
- `pnpm check:no-secrets-in-vault`
- `pnpm check:test-count` — 3,761 discovered tests >= floor 1,400.
- `LIBRARIAN_TRPC_PORT=44460 pnpm smoke`
- `LIBRARIAN_TRPC_PORT=44461 pnpm healthcheck` — 5/5 checks passed.
- `playwright test e2e/memories.spec.ts --project=chromium` — 3/3 passed, including 320px long-tag containment.

## Existing repository issues noticed, not changed here

- `pnpm audit --audit-level high` reports 73 advisories (6 critical, 29 high, 32 moderate, 6 low). This branch changes no dependency or lockfile entries.
- At a 320px viewport, the pre-existing Memories header action group still creates about 52px of page overflow. The cards and new active tag chip remain contained and are covered by the regression test.
- Existing Proposal chat tests emit a Radix dialog-description warning; those dialogs are outside this change.

## Rollback

Revert this PR and redeploy. There are no migrations or stored-data rewrites to undo.
