### PR TITLE
feat: add project briefing storage foundation (paused)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.20.1] — 2026-08-06
+
+### Added
+
+- **Project Briefings now have their shelf-scoped storage foundation.** Projects,
+  append-only project updates and reviewable section suggestions are first-class,
+  deterministic Markdown records in the Git-backed vault. Their lifecycle and
+  path-safe identifiers are strictly validated, every mutation is attributed,
+  and both public and system access remain confined to one explicit shelf. This
+  is the internal domain layer for the forthcoming briefing compiler and UI; it
+  does not yet add a new agent verb or generate briefings.
+- **Memories can carry optional project associations.** `project_keys` is
+  relevance metadata, never an access-control signal. The field survives intake,
+  curator updates, proposals, splits, stable merge unions and cross-shelf moves;
+  exact list filtering is available, and old scalar `project_key` frontmatter is
+  read compatibly and rewritten as plural on the next intentional memory write.
+  `remember` accepts associations only when each key names an active project on
+  its resolved write shelf. A move remains non-blocking when the destination
+  lacks a matching active project: the bytes and associations are preserved and
+  the admin receives a warning.
+
 ## [1.17.5] — 2026-08-06
 
 ### Fixed
@@ -4294,6 +4315,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.20.1]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.20.0...v1.20.1
 [1.17.5]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.17.4...v1.17.5
 [1.17.4]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.17.3...v1.17.4
 [1.17.3]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.17.2...v1.17.3

--- a/apps/dashboard/app/(memories)/actions.ts
+++ b/apps/dashboard/app/(memories)/actions.ts
@@ -7,7 +7,7 @@ import { serverTRPC } from "@/lib/trpc-server";
 type CreateInput = NonNullable<RouterInputs["memories"]["create"]>;
 type UpdatePatch = RouterInputs["memories"]["update"]["patch"];
 
-type ActionResult = { ok: true } | { ok: false; error: string };
+type ActionResult = { ok: true; warning?: string } | { ok: false; error: string };
 
 function fail(message: string): ActionResult {
   return { ok: false, error: message };
@@ -161,9 +161,10 @@ export async function archiveMemoryAction(id: string): Promise<ActionResult> {
 
 export async function moveMemoryAction(id: string, shelf: string): Promise<ActionResult> {
   try {
-    await serverTRPC.memories.move.mutate({ id, shelf });
+    const moved = await serverTRPC.memories.move.mutate({ id, shelf });
     revalidatePath("/");
-    return { ok: true };
+    const warning = moved.move_warnings?.map((item) => item.message).join(" ");
+    return warning ? { ok: true, warning } : { ok: true };
   } catch (err) {
     return fail(err instanceof Error ? err.message : String(err));
   }

--- a/apps/dashboard/components/memories/move-memory-dialog.tsx
+++ b/apps/dashboard/components/memories/move-memory-dialog.tsx
@@ -29,6 +29,7 @@ export function MoveMemoryDialog({ memory, shelves, canDirectMove, onSuccess }: 
   const [shelfId, setShelfId] = useState("");
   const [rationale, setRationale] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [warning, setWarning] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
 
   const destinations = useMemo(
@@ -49,6 +50,7 @@ export function MoveMemoryDialog({ memory, shelves, canDirectMove, onSuccess }: 
       setShelfId("");
       setRationale("");
       setError(null);
+      setWarning(null);
     }
   };
 
@@ -58,12 +60,18 @@ export function MoveMemoryDialog({ memory, shelves, canDirectMove, onSuccess }: 
       return;
     }
     setError(null);
+    setWarning(null);
     startTransition(async () => {
       const result = direct
         ? await moveMemoryAction(memory.id, selected.id)
         : await proposeMoveAction(memory.id, selected.id, rationale);
       if (!result.ok) {
         setError(result.error);
+        return;
+      }
+      if (result.warning) {
+        setWarning(result.warning);
+        onSuccess();
         return;
       }
       changeOpen(false);
@@ -80,8 +88,9 @@ export function MoveMemoryDialog({ memory, shelves, canDirectMove, onSuccess }: 
         <DialogHeader>
           <DialogTitle>{direct ? "Move memory" : "Propose a shelf move"}</DialogTitle>
           <DialogDescription>
-            Choose where “{memory.title || memory.id}” belongs. A proposal leaves the memory active
-            until an admin applies it.
+            {warning
+              ? `“${memory.title || memory.id}” was moved successfully.`
+              : `Choose where “${memory.title || memory.id}” belongs. A proposal leaves the memory active until an admin applies it.`}
           </DialogDescription>
         </DialogHeader>
 
@@ -94,6 +103,7 @@ export function MoveMemoryDialog({ memory, shelves, canDirectMove, onSuccess }: 
               onChange={(event) => {
                 setShelfId(event.target.value);
                 setError(null);
+                setWarning(null);
               }}
             >
               <option value="">Choose a shelf…</option>
@@ -132,19 +142,37 @@ export function MoveMemoryDialog({ memory, shelves, canDirectMove, onSuccess }: 
           </p>
         ) : null}
 
+        {warning ? (
+          <p
+            role="status"
+            aria-live="polite"
+            className="border border-ink-accent/40 bg-ink-accent/[0.06] p-3 text-sm text-foreground"
+          >
+            {warning}
+          </p>
+        ) : null}
+
         <DialogFooter>
-          <Button variant="ghost" onClick={() => changeOpen(false)} disabled={pending}>
-            Cancel
-          </Button>
-          <Button variant="primary" onClick={submit} disabled={pending || !selected}>
-            {pending
-              ? direct
-                ? "Moving…"
-                : "Proposing…"
-              : direct
-                ? "Move memory"
-                : "Propose move"}
-          </Button>
+          {warning ? (
+            <Button variant="primary" onClick={() => changeOpen(false)}>
+              Close
+            </Button>
+          ) : (
+            <>
+              <Button variant="ghost" onClick={() => changeOpen(false)} disabled={pending}>
+                Cancel
+              </Button>
+              <Button variant="primary" onClick={submit} disabled={pending || !selected}>
+                {pending
+                  ? direct
+                    ? "Moving…"
+                    : "Proposing…"
+                  : direct
+                    ? "Move memory"
+                    : "Propose move"}
+              </Button>
+            </>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/apps/dashboard/tests/components/move-memory-dialog.test.tsx
+++ b/apps/dashboard/tests/components/move-memory-dialog.test.tsx
@@ -95,6 +95,24 @@ describe("MoveMemoryDialog", () => {
     expect(onSuccess).toHaveBeenCalled();
   });
 
+  it("keeps a successful move warning visible without treating it as a failure", async () => {
+    moveMemoryAction.mockResolvedValueOnce({
+      ok: true,
+      warning: "Moved, but source-only has no active project on Team knowledge.",
+    });
+    const onSuccess = vi.fn();
+    render(
+      <MoveMemoryDialog memory={memory()} shelves={shelves} canDirectMove onSuccess={onSuccess} />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Move…" }));
+    await userEvent.selectOptions(screen.getByLabelText("Destination shelf"), "team");
+    await userEvent.click(screen.getByRole("button", { name: "Move memory" }));
+
+    expect(await screen.findByRole("status")).toHaveTextContent("source-only");
+    expect(onSuccess).toHaveBeenCalled();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
   it("proposes a move with rationale for a member or read-only destination", async () => {
     render(
       <MoveMemoryDialog

--- a/apps/dashboard/tests/memories-actions.test.ts
+++ b/apps/dashboard/tests/memories-actions.test.ts
@@ -88,6 +88,22 @@ describe("memories actions", () => {
     expect(revalidateMock).toHaveBeenCalledWith("/");
   });
 
+  it("moveMemoryAction returns the server's non-blocking project warning", async () => {
+    moveMock.mockResolvedValueOnce({
+      move_warnings: [
+        {
+          code: "missing-active-projects",
+          project_keys: ["source-only"],
+          message: "The move succeeded; associations were preserved.",
+        },
+      ],
+    });
+    await expect(actions.moveMemoryAction("mem_1", "team")).resolves.toEqual({
+      ok: true,
+      warning: "The move succeeded; associations were preserved.",
+    });
+  });
+
   it("proposeMoveAction queues the optional rationale and refreshes proposals", async () => {
     proposeMoveMock.mockResolvedValueOnce({});
     await expect(

--- a/apps/docs/src/content/docs/reference/mcp-verbs.md
+++ b/apps/docs/src/content/docs/reference/mcp-verbs.md
@@ -32,6 +32,7 @@ Save a durable fact, preference, or decision the moment you learn it — not tra
 | `title` | `string` | required | Short, self-describing headline for the memory — what you'd scan for to find it later. |
 | `body` | `string` | required | The full fact, preference, or decision, written to stand alone — it must make sense with none of the surrounding conversation for context. |
 | `applies_to` | `string[]` | optional | Optional scope hints — the projects, paths, or contexts this memory is relevant to. |
+| `project_keys` | `string[]` | optional | Optional relevance links to active projects on the destination shelf. These aid retrieval and never grant access. |
 | `confidence` | `string` | optional | Optional confidence note (e.g. 'high', 'tentative'), passed to the curator when it files the memory. |
 | `tags` | `string[]` | optional | Tags to file the memory under, so it surfaces in the right context later. |
 

--- a/docs/adr/0012-project-briefings.md
+++ b/docs/adr/0012-project-briefings.md
@@ -1,0 +1,177 @@
+# ADR 0012 — Shelf-scoped, materialised project briefings
+
+- **Status:** Accepted
+- **Date:** 2026-08-06
+- **Related:** ADR 0006, ADR 0011
+
+## Context
+
+An agent arriving in a project, returning after compaction, or switching from
+another project needs a coherent orientation before narrower memory recall is
+useful. Free-text recall cannot reliably reconstruct what the project is, how it
+is built, where it stands, what changed recently, what is planned next, and what
+remains uncertain. Those facts are spread across memories, handoffs, curator
+runs, and vault history, and the most relevant transient work state is
+deliberately excluded from ordinary durable memories.
+
+The solution must preserve existing product invariants:
+
+- the agent-facing MCP surface remains exactly seven verbs;
+- reading context never waits for an LLM or external provider;
+- Markdown and Git remain the durable, inspectable source of truth;
+- shelf routing, not project metadata, remains the authorisation boundary;
+- private mode produces no capture-derived project evidence;
+- an automatic refresh cannot overwrite an administrator's manual correction;
+- one shelf's identity or source material cannot leak through another shelf.
+
+## Decision
+
+### Projects are first-class, shelf-scoped Markdown records
+
+Each shelf may contain three canonical document types:
+
+- `projects/<project-id>.md` holds identity, lifecycle, section ownership,
+  freshness metadata, and the last valid materialised brief;
+- `project-updates/<update-id>.md` holds append-only, source-grounded evidence;
+- `project-suggestions/<suggestion-id>.md` holds a reviewable replacement for a
+  pinned section.
+
+The immutable id is the filename. A human-facing key is unique within one shelf
+and stable after approval. Proposed, active, archived, and rejected history stays
+at one path rather than moving between directories. Project reads and writes are
+confined to the shelf selected through the existing validated vault router.
+
+### `project_keys` is relevance metadata, never authority
+
+Memories gain an optional `project_keys: string[]`. The field links evidence to
+approved projects in the same shelf; it does not change who can read or mutate a
+memory. Existing memories without the field retain their existing document
+shape. A legacy scalar `project_key` is accepted on read and emitted only in the
+plural form after an intentional write.
+
+Project associations may be changed only through attributed, path-scoped store
+mutations. Moving a memory to another authorised shelf preserves its keys and may
+warn about missing destination projects, but the metadata never blocks the move
+or grants access to the destination.
+
+### Briefs are compiled asynchronously and materialised
+
+The curator compiles an active project's same-shelf evidence into six fixed
+sections and stores the validated result in the Project document. Reads return
+that document in constant local time and make no provider call. A dirty or failed
+refresh leaves the last valid brief intact, labels it stale, and schedules work
+without delaying the caller.
+
+Automatic sections may be replaced after strict grounding validation. A manual
+edit pins its section. Refresh copies pinned text byte-for-byte; materially
+different evidence becomes a ProjectSuggestion instead of an overwrite.
+
+### The existing `recall` verb serves briefings
+
+`recall` will gain additive `briefing` and `project` inputs. Ordinary recall is
+unchanged when briefing mode is absent or false. No eighth verb, automatic
+first-turn call, cwd inference, post-compaction hook, delivery cursor, or dynamic
+harness injection is added. Static, versioned guidance teaches an agent to ask
+for a briefing once it knows the project.
+
+### V1 never synthesises across shelves
+
+A compiler reads one shelf only. Principal-facing resolution considers only the
+caller's validated recall shelves: one visible active match is served, none is
+reported as not found, and multiple visible matches are reported as ambiguous
+using only those visible identities. V1 never merges records or evidence across
+shelves.
+
+## Alternatives considered
+
+### Rank ordinary memories differently at briefing time
+
+This would reuse the existing index and avoid a new domain model. It would still
+return fragments, would miss intentionally transient project state, and would
+make orientation depend on query wording.
+
+**Rejected:** a briefing is a maintained overview, not a differently ranked
+memory search.
+
+### Add a dedicated `brief_me` MCP verb
+
+A separate verb could expose a narrow schema and make discovery obvious. It would
+widen the sacred cross-harness contract, duplicate `recall`'s context-retrieval
+role, and require every integration to teach an eighth operation.
+
+**Rejected:** additive briefing mode on `recall` keeps one retrieval contract and
+the same seven verb names.
+
+### Generate a briefing during each read
+
+Query-time synthesis would always use the newest evidence and avoid storing a
+compiled document. It would add provider latency and failure to the user's turn,
+make outputs harder to audit, and prevent useful reads when no model is
+configured.
+
+**Rejected:** asynchronous materialisation makes reads local, deterministic, and
+available during provider failure.
+
+### Infer the project from cwd or inject it automatically
+
+Automatic context could reduce the need for agents to remember the briefing
+call. A working directory is not a reliable project identity, especially across
+devices, repositories, monorepos, and non-coding work. Dynamic injection would
+also add hidden per-turn behaviour and another cross-harness coordination path.
+
+**Rejected:** the agent requests a briefing after the project is known, guided by
+static versioned instructions.
+
+### Treat project membership as an access-control boundary
+
+Using project keys as permissions could appear to offer more granular access.
+Keys are model- and admin-associated relevance labels, can be stale, and may be
+preserved across moves. Elevating them to authority would make classification
+errors security errors and conflict with the existing shelf policy.
+
+**Rejected:** shelf routing remains the sole authorisation boundary.
+
+### Compile one brief from multiple shelves
+
+Cross-shelf synthesis could produce a single view when similarly named projects
+exist in personal and team material. It would require explicit merge precedence,
+provenance, write ownership, and disclosure rules that V1 does not have.
+
+**Rejected:** ambiguity is safer and reversible; cross-shelf merge requires a
+separate approved design.
+
+## Consequences
+
+### Positive
+
+- Agents can receive one coherent, source-grounded project orientation without a
+  provider call in their turn.
+- Markdown, Git history, backups, restore, and manual editing remain the complete
+  durability story.
+- The seven-verb cross-harness surface stays stable.
+- Shelf isolation is enforceable and testable independently of project matching.
+- Manual corrections survive automation and conflicts become explicit review
+  items.
+
+### Costs and risks accepted
+
+- The product gains three document types, lifecycle/storage APIs, background
+  queues, reconciliation, and an admin surface.
+- ProjectUpdate evidence is retained indefinitely in V1; compiler reads must be
+  bounded until retention has its own reviewed design.
+- Briefs can be stale. The response and dashboard must expose freshness and
+  failure honestly rather than imply that last-good means current.
+- The same key may exist in different authorised shelves, so callers and the UI
+  must handle visible ambiguity instead of choosing the first match.
+- `project_keys` needs explicit compatibility and preservation through every
+  memory mutation; defaulting an absent field to an empty array would create
+  unnecessary vault rewrites.
+- New Git subjects initially remain the audit export's existing `other` action.
+  Widening its permanent action union is a separate breaking API decision.
+
+## Related material
+
+- Approved Project Briefings spec and implementation plan under
+  `Work/The Librarian/monetising the librarian/fable-big-ideas/1-morning-briefing/tasks/`.
+- ADR 0006 — the agent-facing MCP surface.
+- ADR 0011 — extension seams, Principal identity, and shelf routing.

--- a/integrations/pi/extensions/librarian/tools.ts
+++ b/integrations/pi/extensions/librarian/tools.ts
@@ -81,6 +81,16 @@ export function librarianToolSpecs(): LibrarianToolSpec[] {
         title: Type.String(),
         body: Type.String(),
         applies_to: Type.Optional(Type.Array(Type.String())),
+        project_keys: Type.Optional(
+          Type.Array(
+            Type.String({
+              minLength: 1,
+              maxLength: 64,
+              pattern: "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+            }),
+            { maxItems: 20, uniqueItems: true },
+          ),
+        ),
         confidence: Type.Optional(Type.String()),
         tags: Type.Optional(Type.Array(Type.String())),
       }),

--- a/integrations/pi/package.json
+++ b/integrations/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-librarian/pi-extension",
-  "version": "1.17.0",
+  "version": "1.20.1",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.17.5",
+  "version": "1.20.1",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/cli/tests/migrate-data-dir.test.ts
+++ b/packages/cli/tests/migrate-data-dir.test.ts
@@ -111,9 +111,9 @@ describe("the-librarian migrate-data-dir", () => {
       );
       expect(doc).not.toContain("domain:");
       expect(doc).not.toContain("category:");
-      // Retired once memories went project-less / dropped recall counters /
-      // dropped the priority field.
-      expect(doc).not.toContain("project_key:");
+      // The legacy scalar remains untouched until an intentional memory write;
+      // readers normalise a string value to plural project_keys in memory.
+      expect(doc).toContain("project_key: null");
       expect(doc).not.toContain("recall_count:");
       expect(doc).not.toContain("usefulness_score:");
       expect(doc).not.toContain("priority:");

--- a/packages/core/src/backup/restore-staging.ts
+++ b/packages/core/src/backup/restore-staging.ts
@@ -15,6 +15,7 @@ import path from "node:path";
 import { resolveVaultPath } from "../store/corpus/index.js";
 import { cloneVaultBackup } from "../store/git/index.js";
 import type { LibrarianStore } from "../store/librarian-store.js";
+import { parseProjectDocument } from "../store/markdown/project-doc.js";
 import { MAX_SHELF_PREFIX_SEGMENTS, isLegalShelfSegment } from "../vault-router.js";
 import { resolveBackupRemote } from "./config.js";
 
@@ -74,17 +75,17 @@ function restorePaths(dataDir: string): RestorePaths {
 // repo with ONE canonical-named dir up to two levels deep, so a foreign repo that merely contained a
 // nested `references/` folder passed):
 //
-//   ROOT (OSS single-shelf): a canonical entry (`memories`/`inbox`/`references`/`handoffs`) directly
-//     at the vault root. This restores the PRE-062 semantics EXACTLY — `existsSync` (file OR dir), any
-//     one of the four — so the default-path behaviour is unchanged (062 had silently flipped it to
-//     `isDir`; a degenerate root FILE named `memories` is accepted as pre-062).
+//   ROOT (OSS single-shelf): one legacy canonical entry
+//     (`memories`/`inbox`/`references`/`handoffs`) directly at the vault root, preserving the
+//     PRE-062 `existsSync` semantics exactly; or a `projects/` directory containing at least one
+//     valid, filename-matched Project document.
 //
 //   NESTED (Teams shelf-prefixed, spec 062 / ADR 0011 Decision 5): the canonical CLUSTER beneath a
 //     shelf prefix of up to MAX_SHELF_PREFIX_SEGMENTS segments (`team/`, `members/x/`). A "cluster"
-//     is a `memories/` dir (the primary Librarian dir — a minimally-used shelf has ONLY this, so its
-//     presence beneath a legal prefix is signal enough), OR at least TWO of the four canonical DIRS,
-//     OR one canonical dir plus a `.curator/` or `primer.md` sibling — enough co-located Librarian
-//     structure that a foreign repo (e.g. a `src/references/` folder) won't trip it. Every
+//     is a `memories/` dir, a valid `projects/<id>.md`, at least TWO recognised data dirs, or one
+//     recognised data dir plus a `.curator/` or `primer.md` sibling — enough co-located Librarian
+//     structure that a foreign repo (e.g. a `src/references/` or `src/projects/` folder) won't trip
+//     it. Every
 //     intermediate prefix segment must be shelf-legal (reusing {@link isLegalShelfSegment}, so the
 //     scan matches the router's prefix rules), and the descent is bounded to the SAME depth the
 //     validator caps prefixes at — so a backed-up shelf tree is always restorable, by construction.
@@ -98,7 +99,8 @@ function restorePaths(dataDir: string): RestorePaths {
 // This is a "does this look like a vault AT ALL?" guard, not a full structural validation, so it
 // short-circuits on the first hit and never walks the whole tree. `.git` is never a shelf prefix, so
 // it is skipped on descent.
-const VAULT_DIRS = ["memories", "inbox", "references", "handoffs"];
+const LEGACY_VAULT_DIRS = ["memories", "inbox", "references", "handoffs"];
+const PROJECT_AUXILIARY_DIRS = ["project-updates", "project-suggestions"];
 
 function isDir(p: string): boolean {
   try {
@@ -108,13 +110,36 @@ function isDir(p: string): boolean {
   }
 }
 
-// A shelf-prefix directory carries the canonical CLUSTER: a `memories/` dir (the primary Librarian
-// dir — sufficient on its own), OR ≥2 of the four canonical dirs, OR 1 canonical dir plus a
-// `.curator/` or `primer.md` sibling. (Dirs only — a shelf prefix's canonical entries are
-// directories; the file-named degenerate case is a root-only, pre-062 concession.)
+function hasValidProjectDocument(dir: string): boolean {
+  const projectsDir = path.join(dir, "projects");
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(projectsDir, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+  return entries.some((entry) => {
+    if (!entry.isFile() || !entry.name.endsWith(".md")) return false;
+    try {
+      const project = parseProjectDocument(
+        fs.readFileSync(path.join(projectsDir, entry.name), "utf8"),
+      );
+      return entry.name === `${project.id}.md`;
+    } catch {
+      return false;
+    }
+  });
+}
+
+// A shelf-prefix directory carries the canonical CLUSTER: a `memories/` dir, a valid Project
+// document, ≥2 recognised data dirs, or one recognised data dir plus a `.curator/` or `primer.md`
+// sibling. The file-named degenerate case remains a root-only, pre-062 concession.
 function hasCanonicalCluster(dir: string): boolean {
   if (isDir(path.join(dir, "memories"))) return true;
-  const canonical = VAULT_DIRS.filter((name) => isDir(path.join(dir, name))).length;
+  if (hasValidProjectDocument(dir)) return true;
+  const canonical = [...LEGACY_VAULT_DIRS, ...PROJECT_AUXILIARY_DIRS].filter((name) =>
+    isDir(path.join(dir, name)),
+  ).length;
   if (canonical >= 2) return true;
   return (
     canonical >= 1 &&
@@ -145,7 +170,8 @@ function hasNestedShelfCluster(baseDir: string, depthFromRoot: number): boolean 
 function isLibrarianVault(dir: string): boolean {
   if (!fs.existsSync(path.join(dir, ".git"))) return false;
   // Root arm: PRE-062 semantics exactly — existsSync (file OR dir), any of the four.
-  if (VAULT_DIRS.some((name) => fs.existsSync(path.join(dir, name)))) return true;
+  if (LEGACY_VAULT_DIRS.some((name) => fs.existsSync(path.join(dir, name)))) return true;
+  if (hasValidProjectDocument(dir)) return true;
   // Nested arm: a shelf-prefixed layout — the canonical cluster beneath a legal shelf prefix.
   return hasNestedShelfCluster(dir, 0);
 }
@@ -174,7 +200,7 @@ export function stageRestore(store: LibrarianStore): StageRestoreResult {
     fs.rmSync(stagedVault, { recursive: true, force: true });
     throw new Error(
       "restore: the cloned repo does not look like a Librarian vault " +
-        "(no memories/inbox/references/handoffs) — check the configured backup repo",
+        "(no memories/inbox/references/handoffs/projects) — check the configured backup repo",
     );
   }
 

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -13,6 +13,7 @@
 // conv_state.)
 
 import { Confidence, MemoryStatus } from "./schemas/common.js";
+import { ProjectKeysSchema } from "./schemas/project.js";
 
 export const DEFAULT_AGENT_ID = "unknown-agent";
 
@@ -49,6 +50,7 @@ export interface NormalizedMemoryInput {
   body: string;
   agent_id: string;
   applies_to: string[];
+  project_keys?: string[];
   confidence: Confidence;
   tags: string[];
   status: MemoryStatus;
@@ -59,11 +61,16 @@ export interface NormalizedMemoryInput {
 }
 
 export function normalizeMemoryInput(input: Record<string, unknown> = {}): NormalizedMemoryInput {
+  const projectKeys =
+    input.project_keys === undefined
+      ? undefined
+      : ProjectKeysSchema.parse(asArray(input.project_keys));
   return {
     title: normalizeString(input.title || input.content || "Untitled memory"),
     body: normalizeString(input.body || input.content || ""),
     agent_id: normalizeString(input.agent_id, DEFAULT_AGENT_ID),
     applies_to: asArray(input.applies_to),
+    ...(projectKeys !== undefined ? { project_keys: projectKeys } : {}),
     confidence: normalizeEnum(input.confidence, Object.values(Confidence), Confidence.Working),
     tags: asArray(input.tags),
     status: normalizeEnum(input.status, Object.values(MemoryStatus), MemoryStatus.Active),

--- a/packages/core/src/grooming-apply.ts
+++ b/packages/core/src/grooming-apply.ts
@@ -9,9 +9,8 @@
 //     stay authoritative).
 //   - `curator_note` provenance is set only via createMemory's trusted `options`
 //     channel, never via patch (which can't carry it anyway).
-//   - Ownership: every write is owned by the curator actor (slices are
-//     project-key-only post-D8). The agent_id is passed explicitly, never taken
-//     from the model.
+//   - Ownership: every write is owned by the curator actor. The agent_id is
+//     passed explicitly, never taken from the model.
 //   - Auto-applied merges archive their superseded sources in the same
 //     operation. Proposed ops NEVER mutate live sources here — they land as a
 //     new proposal carrying curator_note.supersedes (or, for archive, a flag).
@@ -40,6 +39,7 @@ interface StoredMemory {
   confidence: string;
   tags: string[];
   applies_to: string[];
+  project_keys?: string[];
 }
 
 // The store surface the apply layer needs (all mutation flows through these).
@@ -99,7 +99,7 @@ export function applyOperations(
     store: deps.store,
     runId: deps.runId,
     actorId: deps.actorId,
-    // Slices are project-key-only (rethink D8): the curator actor owns every write.
+    // The curator actor owns every write.
     owner: deps.actorId,
   };
 
@@ -423,6 +423,7 @@ function correctedMemory(
     applies_to: patch.applies_to ?? existing.applies_to,
     confidence: patch.confidence ?? existing.confidence,
     tags: patch.tags ?? existing.tags,
+    ...(existing.project_keys !== undefined ? { project_keys: existing.project_keys } : {}),
   };
 }
 

--- a/packages/core/src/grooming-evidence.ts
+++ b/packages/core/src/grooming-evidence.ts
@@ -21,9 +21,8 @@
 import { curationContentFingerprint, curationNormalizedTitle } from "./grooming-fingerprint.js";
 import { redactSecrets } from "./grooming-redaction.js";
 
-// Memories no longer carry a project_key, so grooming collapses to a single
-// global slice (the per-project `common_project` variant was retired with the
-// memory project_key field). The discriminant is kept for run/hash provenance.
+// Optional plural project associations do not partition grooming: the curator
+// retains one global slice. The discriminant remains for run/hash provenance.
 export type SliceKind = "common_global";
 
 export interface EvidenceSlice {
@@ -42,6 +41,7 @@ export interface GroomingMemoryRecord {
   agentId: string | null;
   requiresApproval: boolean;
   isGlobal: boolean;
+  projectKeys?: string[];
   createdAt: string;
   updatedAt: string;
   /**
@@ -70,8 +70,8 @@ export interface GroomingTombstoneRecord {
 /**
  * The memory reads the curator's evidence gathering needs, abstracted over the
  * storage backend (plan 036 Phase 4). Implementations return records
- * newest-first (by `updatedAt`) and already capped at `limit`. Since memories
- * are project-less, there is a single global slice and no slice filtering.
+ * newest-first (by `updatedAt`) and already capped at `limit`. Project keys are
+ * evidence metadata, so there is a single global slice and no slice filtering.
  */
 export interface GroomingMemorySource {
   /** Slices with curatable (active|proposed) content; the scheduler due-gates them. */
@@ -106,6 +106,7 @@ export interface MemoryEvidenceItem {
   // a protected memory; legacy category strings are gone.
   requiresApproval: boolean;
   isGlobal: boolean;
+  projectKeys?: string[];
   // Present (and true) ONLY when a curator archive proposal is already open on
   // this memory (review F2) — the prompt tells the model to noop instead of
   // re-proposing. Omitted when false, to keep the evidence JSON lean.
@@ -200,6 +201,7 @@ function toItem(
     updatedAt: rec.updatedAt,
     requiresApproval: rec.requiresApproval,
     isGlobal: rec.isGlobal,
+    ...(rec.projectKeys !== undefined ? { projectKeys: rec.projectKeys } : {}),
     ...(rec.hasOpenCuratorFlag === true ? { has_open_curator_flag: true as const } : {}),
   };
 }

--- a/packages/core/src/grooming-source-vault.ts
+++ b/packages/core/src/grooming-source-vault.ts
@@ -1,9 +1,9 @@
 // Markdown-vault-backed GroomingMemorySource (plan 036 Phase 4).
 //
 // Reads memory docs from the git vault (via the markdown memory store's
-// `listAll`). Memories no longer carry a project_key, so grooming operates over
-// a SINGLE `common_global` slice (the per-project `common_project` slice was
-// retired with the memory project_key field).
+// `listAll`). Optional plural project associations are evidence metadata only:
+// grooming still operates over a SINGLE `common_global` slice (the retired
+// `common_project` slice is not revived).
 // Active/proposed feed slice enumeration + evidence; archived feed tombstones.
 //
 // The event ledger is retired on markdown, so a tombstone's `archiveReason` is
@@ -46,6 +46,7 @@ function toRecord(memory: Memory): GroomingMemoryRecord {
     agentId: memory.agent_id ?? null,
     requiresApproval: memory.requires_approval === true,
     isGlobal: memory.is_global === true,
+    ...(memory.project_keys !== undefined ? { projectKeys: memory.project_keys } : {}),
     createdAt: String(memory.created_at ?? memory.updated_at),
     updatedAt: String(memory.updated_at),
     // An OPEN flag from the canonical curator actor means an archive proposal
@@ -72,8 +73,8 @@ export function createVaultGroomingMemorySource(
   reader: GroomingVaultMemoryReader,
 ): GroomingMemorySource {
   function listSlices(): EvidenceSlice[] {
-    // Memories are project-less: a single global slice exists iff any live
-    // (active|proposed) memory exists. Nothing live → no slice to groom.
+    // Project associations do not partition grooming: a single global slice
+    // exists iff any live (active|proposed) memory exists.
     const hasLive = reader.listAll({}).some((m) => m.status !== MemoryStatus.Archived);
     return hasLive ? [{ kind: "common_global" }] : [];
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -583,6 +583,7 @@ export {
   type IntakeInboxOptions,
   type LibrarianStore,
   type LibrarianStoreOptions,
+  type ProjectSystemStores,
   type RollbackAddendumResult,
   type ShelfScopedStore,
   type VaultActivityEntry,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -497,12 +497,24 @@ export {
 export {
   type MarkdownHandoffStoreDeps,
   type MarkdownMemoryStoreDeps,
+  type MarkdownProjectStoreDeps,
+  type MarkdownProjectSuggestionStoreDeps,
+  type MarkdownProjectUpdateStoreDeps,
   createMarkdownHandoffStore,
   createMarkdownMemoryStore,
+  createMarkdownProjectStore,
+  createMarkdownProjectSuggestionStore,
+  createMarkdownProjectUpdateStore,
   parseHandoffDocument,
   parseMemoryDocument,
+  parseProjectDocument,
+  parseProjectSuggestionDocument,
+  parseProjectUpdateDocument,
   serializeHandoffDocument,
   serializeMemoryDocument,
+  serializeProjectDocument,
+  serializeProjectSuggestionDocument,
+  serializeProjectUpdateDocument,
 } from "./store/markdown/index.js";
 export {
   type JsonIntakeStoreDeps,
@@ -832,6 +844,9 @@ export {
 export * from "./schemas/project.js";
 export * from "./schemas/project-update.js";
 export * from "./schemas/project-suggestion.js";
+export * from "./store/project-store.js";
+export * from "./store/project-update-store.js";
+export * from "./store/project-suggestion-store.js";
 export {
   type ClaimedBy,
   type HandoffDetail,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -829,6 +829,9 @@ export {
   StoreHandoffInputSchema,
   StoreHandoffOutputSchema,
 } from "./schemas/handoff.js";
+export * from "./schemas/project.js";
+export * from "./schemas/project-update.js";
+export * from "./schemas/project-suggestion.js";
 export {
   type ClaimedBy,
   type HandoffDetail,

--- a/packages/core/src/intake/apply.ts
+++ b/packages/core/src/intake/apply.ts
@@ -34,6 +34,7 @@ export interface IntakeStoredMemory {
    * idempotent: one open curator flag per target, never a stack (review F3).
    */
   flags?: { agent_id: string }[];
+  project_keys?: string[];
 }
 
 /** The store surface the apply layer needs — all mutation flows through these. */
@@ -130,6 +131,7 @@ export function applyIntakeJudgment(
     // applies_to is a caller-asserted targeting signal the judge can't re-derive
     // from text, so carry it onto the new memory (the judge never sets it).
     if (hints?.appliesTo !== undefined) out.applies_to = hints.appliesTo;
+    if (hints?.projectKeys !== undefined) out.project_keys = hints.projectKeys;
     return out;
   };
   // The model's rationale is untrusted (could carry a hallucinated secret) and is

--- a/packages/core/src/migrate-data-dir.ts
+++ b/packages/core/src/migrate-data-dir.ts
@@ -44,16 +44,15 @@ import {
  * Top-level memory frontmatter fields no current schema reads or writes
  * (spec §10 / D7-D8-D13 long tail): `domain` (D7), the classifier/SQLite-era
  * `category`/`visibility`/`scope`/`actor_kind`/`last_recalled_at` columns, the
- * dead `recall_count`/`usefulness_score`/`project_key` fields dropped once
- * memories went project-less (grooming collapsed to a single global slice), and
+ * dead `recall_count`/`usefulness_score` fields, and
  * `priority` (the memory priority field was retired — recall ranks by keyword
  * relevance + flag penalty only). Confirmed retired against
  * `MemoryFrontmatterSchema` (memory-doc.ts), which tolerates them on read (Zod
  * strips unknowns) and never writes them.
  *
- * NOTE: this sweep runs ONLY over `memories/` docs (scanRetiredFrontmatter /
- * stripRetiredFields), so stripping `project_key` here NEVER touches handoff
- * docs (`handoffs/`), where `project_key` is a LIVE frontmatter field.
+ * `project_key` is intentionally NOT retired: memory reads accept it as legacy
+ * compatibility input and normalise it to plural `project_keys` on the next
+ * intentional write. Handoffs continue to use their distinct scalar field.
  */
 export const RETIRED_FRONTMATTER_FIELDS = [
   "domain",
@@ -64,7 +63,6 @@ export const RETIRED_FRONTMATTER_FIELDS = [
   "last_recalled_at",
   "recall_count",
   "usefulness_score",
-  "project_key",
   "priority",
 ] as const;
 

--- a/packages/core/src/schemas/index.ts
+++ b/packages/core/src/schemas/index.ts
@@ -1,3 +1,6 @@
 export * from "./common.js";
 export * from "./memory.js";
 export * from "./handoff.js";
+export * from "./project.js";
+export * from "./project-update.js";
+export * from "./project-suggestion.js";

--- a/packages/core/src/schemas/memory.ts
+++ b/packages/core/src/schemas/memory.ts
@@ -3,6 +3,7 @@
 
 import { z } from "zod";
 import { ConfidenceSchema, IdSchema, IsoTimestampSchema, MemoryStatusSchema } from "./common.js";
+import { ProjectKeysSchema } from "./project.js";
 
 // Curator provenance attached to a memory (memory-curator spec §8). All fields
 // optional so partial provenance (e.g. just run/operation ids on an auto-applied
@@ -66,6 +67,9 @@ export const MemorySchema = z.object({
   confidence: ConfidenceSchema,
   tags: z.array(z.string()),
   applies_to: z.array(z.string()),
+  // Shelf-local relevance metadata only. Shelf policy remains the sole
+  // authorisation boundary.
+  project_keys: ProjectKeysSchema.optional(),
   supersedes: z.array(z.string()),
   conflicts_with: z.array(z.string()),
   created_at: IsoTimestampSchema,
@@ -99,6 +103,7 @@ export const MemoryInputSchema = z.object({
   body: z.string().optional(),
   content: z.string().optional(),
   applies_to: z.array(z.string()).optional(),
+  project_keys: ProjectKeysSchema.optional(),
   confidence: ConfidenceSchema.optional(),
   tags: z.array(z.string()).optional(),
   status: MemoryStatusSchema.optional(),

--- a/packages/core/src/schemas/project-suggestion.ts
+++ b/packages/core/src/schemas/project-suggestion.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+import { IsoTimestampSchema } from "./common.js";
+import {
+  ProjectDocumentIdSchema,
+  ProjectHashSchema,
+  ProjectSectionKeySchema,
+  ProjectSourceIdSchema,
+} from "./project.js";
+
+export const ProjectSuggestionStatusSchema = z.enum([
+  "pending",
+  "accepted",
+  "rejected",
+  "dismissed",
+]);
+export type ProjectSuggestionStatus = z.infer<typeof ProjectSuggestionStatusSchema>;
+
+export const ProjectSuggestionSchema = z
+  .strictObject({
+    id: ProjectDocumentIdSchema,
+    project_id: ProjectDocumentIdSchema,
+    section: ProjectSectionKeySchema,
+    proposed_content: z.string().min(1).max(12_000),
+    rationale: z.string().min(1).max(2_000),
+    source_ids: z
+      .array(ProjectSourceIdSchema)
+      .min(1)
+      .max(50)
+      .refine((values) => new Set(values).size === values.length, "source ids must be unique"),
+    content_hash: ProjectHashSchema,
+    status: ProjectSuggestionStatusSchema,
+    created_at: IsoTimestampSchema,
+    resolved_at: IsoTimestampSchema.nullable(),
+  })
+  .superRefine((suggestion, context) => {
+    if (suggestion.status === "pending" && suggestion.resolved_at !== null) {
+      context.addIssue({
+        code: "custom",
+        path: ["resolved_at"],
+        message: "a pending suggestion cannot be resolved",
+      });
+    }
+    if (suggestion.status !== "pending" && suggestion.resolved_at === null) {
+      context.addIssue({
+        code: "custom",
+        path: ["resolved_at"],
+        message: "a resolved suggestion requires resolved_at",
+      });
+    }
+  });
+export type ProjectSuggestion = z.infer<typeof ProjectSuggestionSchema>;

--- a/packages/core/src/schemas/project-update.ts
+++ b/packages/core/src/schemas/project-update.ts
@@ -1,0 +1,108 @@
+import { z } from "zod";
+import { IsoTimestampSchema } from "./common.js";
+import {
+  ProjectDocumentIdSchema,
+  ProjectHashSchema,
+  ProjectKeySchema,
+  ProjectSourceIdSchema,
+} from "./project.js";
+
+export const ProjectUpdateSourceKindSchema = z.enum(["intake", "capture", "handoff", "admin"]);
+export type ProjectUpdateSourceKind = z.infer<typeof ProjectUpdateSourceKindSchema>;
+
+const EvidenceItemSchema = z.string().min(1).max(1_000);
+const EvidenceListSchema = z.array(EvidenceItemSchema).max(25);
+const SuggestedNameSchema = z.string().trim().min(1).max(120);
+const SuggestedAliasSchema = z.string().trim().min(1).max(120);
+const SuggestedRepositorySchema = z.string().trim().min(1).max(240);
+const ShelfIdSchema = z
+  .string()
+  .min(1)
+  .max(240)
+  .refine((value) => !value.includes("]") && !/\p{Cc}/u.test(value), {
+    message: "must be a printable shelf id without ']'",
+  });
+
+export const ProjectUpdateEvidenceSchema = z.strictObject({
+  overview: EvidenceListSchema,
+  technology_and_architecture: EvidenceListSchema,
+  completed: EvidenceListSchema,
+  current: EvidenceListSchema,
+  planned: EvidenceListSchema,
+  blockers: EvidenceListSchema,
+});
+export type ProjectUpdateEvidence = z.infer<typeof ProjectUpdateEvidenceSchema>;
+
+export const ProjectUpdateSchema = z
+  .strictObject({
+    id: ProjectDocumentIdSchema,
+    project_id: ProjectDocumentIdSchema.nullable(),
+    candidate_fingerprint: ProjectHashSchema.nullable(),
+    suggested_key: ProjectKeySchema.nullable(),
+    suggested_name: SuggestedNameSchema.nullable(),
+    suggested_aliases: z.array(SuggestedAliasSchema).max(20),
+    suggested_repository_identifiers: z.array(SuggestedRepositorySchema).max(20),
+    confidence: z.number().min(0).max(1),
+    rationale: z.string().min(1).max(2_000),
+    explicitly_new_project: z.boolean(),
+    evidence: ProjectUpdateEvidenceSchema,
+    source_kind: ProjectUpdateSourceKindSchema,
+    source_ref: ProjectSourceIdSchema,
+    observed_at: IsoTimestampSchema,
+    captured_at: IsoTimestampSchema,
+    shelf_id: ShelfIdSchema,
+    fingerprint: ProjectHashSchema,
+  })
+  .superRefine((update, context) => {
+    if (Date.parse(update.captured_at) < Date.parse(update.observed_at)) {
+      context.addIssue({
+        code: "custom",
+        path: ["captured_at"],
+        message: "captured_at cannot precede observed_at",
+      });
+    }
+
+    const matched = update.project_id !== null;
+    const candidate = update.candidate_fingerprint !== null;
+    if (matched === candidate) {
+      context.addIssue({
+        code: "custom",
+        path: ["project_id"],
+        message: "exactly one matched project or candidate fingerprint is required",
+      });
+    }
+
+    if (candidate && (update.suggested_key === null || update.suggested_name === null)) {
+      context.addIssue({
+        code: "custom",
+        path: [update.suggested_key === null ? "suggested_key" : "suggested_name"],
+        message: "a candidate requires a suggested key and name",
+      });
+    }
+    if (
+      matched &&
+      (update.suggested_key !== null ||
+        update.suggested_name !== null ||
+        update.suggested_aliases.length > 0 ||
+        update.suggested_repository_identifiers.length > 0)
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["suggested_key"],
+        message: "matched updates must not carry candidate identity",
+      });
+    }
+
+    const evidenceCount = Object.values(update.evidence).reduce(
+      (total, items) => total + items.length,
+      0,
+    );
+    if (evidenceCount === 0) {
+      context.addIssue({
+        code: "custom",
+        path: ["evidence"],
+        message: "a project update requires at least one evidence item",
+      });
+    }
+  });
+export type ProjectUpdate = z.infer<typeof ProjectUpdateSchema>;

--- a/packages/core/src/schemas/project.ts
+++ b/packages/core/src/schemas/project.ts
@@ -1,0 +1,211 @@
+import { z } from "zod";
+import { IsoTimestampSchema } from "./common.js";
+
+export const PROJECT_SECTION_KEYS = [
+  "what_this_project_is",
+  "technology_and_architecture",
+  "current_state",
+  "last_meaningful_work",
+  "planned_next",
+  "blockers_and_uncertainties",
+] as const;
+
+export const ProjectSectionKeySchema = z.enum(PROJECT_SECTION_KEYS);
+export type ProjectSectionKey = z.infer<typeof ProjectSectionKeySchema>;
+
+export const ProjectSectionOwnershipSchema = z.enum(["automatic", "pinned"]);
+export type ProjectSectionOwnership = z.infer<typeof ProjectSectionOwnershipSchema>;
+
+export const ProjectStatusSchema = z.enum(["proposed", "active", "archived"]);
+export type ProjectStatus = z.infer<typeof ProjectStatusSchema>;
+
+export const ProjectResolutionSchema = z.enum(["rejected", "belongs_to_existing"]);
+export type ProjectResolution = z.infer<typeof ProjectResolutionSchema>;
+
+export const ProjectRefreshStatusSchema = z.enum([
+  "not_built",
+  "dirty",
+  "queued",
+  "compiling",
+  "succeeded",
+  "failed",
+]);
+export type ProjectRefreshStatus = z.infer<typeof ProjectRefreshStatusSchema>;
+
+/** Immutable ids are also Markdown filenames, so only one safe path segment is legal. */
+export const ProjectDocumentIdSchema = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(/^[A-Za-z0-9][A-Za-z0-9_-]*$/, "must be a path-safe document id");
+
+export const ProjectKeySchema = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, "must be a lower-case slug");
+
+export const ProjectSourceIdSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(512)
+  .refine((value) => !/\p{Cc}/u.test(value), "must not contain control characters");
+
+export const ProjectHashSchema = z.string().regex(/^[a-f0-9]{64}$/, "must be a SHA-256 hash");
+
+const DisplayTextSchema = z.string().trim().min(1).max(120);
+const RepositoryIdentifierSchema = z.string().trim().min(1).max(240);
+const FailureClassSchema = z
+  .string()
+  .min(1)
+  .max(100)
+  .regex(/^[a-z0-9][a-z0-9._-]*$/, "must be a content-free failure class");
+
+function hasNoDuplicates(values: readonly string[]): boolean {
+  return new Set(values).size === values.length;
+}
+
+export const ProjectSectionSchema = z.strictObject({
+  content: z.string().max(12_000),
+  ownership: ProjectSectionOwnershipSchema,
+  source_ids: z
+    .array(ProjectSourceIdSchema)
+    .max(50)
+    .refine(hasNoDuplicates, "source ids must be unique"),
+});
+export type ProjectSection = z.infer<typeof ProjectSectionSchema>;
+
+export const ProjectSectionsSchema = z.strictObject({
+  what_this_project_is: ProjectSectionSchema,
+  technology_and_architecture: ProjectSectionSchema,
+  current_state: ProjectSectionSchema,
+  last_meaningful_work: ProjectSectionSchema,
+  planned_next: ProjectSectionSchema,
+  blockers_and_uncertainties: ProjectSectionSchema,
+});
+export type ProjectSections = z.infer<typeof ProjectSectionsSchema>;
+
+export const ProjectSchema = z
+  .strictObject({
+    id: ProjectDocumentIdSchema,
+    key: ProjectKeySchema,
+    display_name: DisplayTextSchema,
+    aliases: z.array(DisplayTextSchema).max(20).refine(hasNoDuplicates, "aliases must be unique"),
+    repository_identifiers: z
+      .array(RepositoryIdentifierSchema)
+      .max(20)
+      .refine(hasNoDuplicates, "repository identifiers must be unique"),
+    status: ProjectStatusSchema,
+    resolution: ProjectResolutionSchema.nullable(),
+    resolved_project_id: ProjectDocumentIdSchema.nullable(),
+    proposal_rationale: z.string().min(1).max(2_000).nullable(),
+    proposal_evidence_ids: z
+      .array(ProjectSourceIdSchema)
+      .max(50)
+      .refine(hasNoDuplicates, "proposal evidence ids must be unique"),
+    suppression_fingerprint: ProjectHashSchema.nullable(),
+    possible_match_ids: z
+      .array(ProjectDocumentIdSchema)
+      .max(20)
+      .refine(hasNoDuplicates, "possible match ids must be unique"),
+    sections: ProjectSectionsSchema,
+    compiled_at: IsoTimestampSchema.nullable(),
+    compiler_version: z
+      .string()
+      .min(1)
+      .max(64)
+      .regex(/^[A-Za-z0-9][A-Za-z0-9._-]*$/, "must be a safe compiler version")
+      .nullable(),
+    source_watermark: ProjectHashSchema.nullable(),
+    source_ids: z
+      .array(ProjectSourceIdSchema)
+      .max(200)
+      .refine(hasNoDuplicates, "source ids must be unique"),
+    content_hash: ProjectHashSchema.nullable(),
+    refresh_status: ProjectRefreshStatusSchema,
+    refresh_failure_class: FailureClassSchema.nullable(),
+    pending_source_count: z.number().int().min(0).max(1_000_000),
+    unresolved_conflict_count: z.number().int().min(0).max(1_000_000),
+    last_activity_at: IsoTimestampSchema.nullable(),
+    created_at: IsoTimestampSchema,
+    updated_at: IsoTimestampSchema,
+  })
+  .superRefine((project, context) => {
+    if (Date.parse(project.updated_at) < Date.parse(project.created_at)) {
+      context.addIssue({
+        code: "custom",
+        path: ["updated_at"],
+        message: "updated_at cannot precede created_at",
+      });
+    }
+
+    if (project.status === "proposed") {
+      if (project.proposal_rationale === null) {
+        context.addIssue({
+          code: "custom",
+          path: ["proposal_rationale"],
+          message: "a proposed project requires a rationale",
+        });
+      }
+      if (project.proposal_evidence_ids.length === 0) {
+        context.addIssue({
+          code: "custom",
+          path: ["proposal_evidence_ids"],
+          message: "a proposed project requires source evidence",
+        });
+      }
+    }
+
+    if (project.status !== "archived" && project.resolution !== null) {
+      context.addIssue({
+        code: "custom",
+        path: ["resolution"],
+        message: "only an archived project may have a resolution",
+      });
+    }
+    if (project.resolution === "rejected" && project.suppression_fingerprint === null) {
+      context.addIssue({
+        code: "custom",
+        path: ["suppression_fingerprint"],
+        message: "a rejected project requires a suppression fingerprint",
+      });
+    }
+    if (project.resolution === "belongs_to_existing" && project.resolved_project_id === null) {
+      context.addIssue({
+        code: "custom",
+        path: ["resolved_project_id"],
+        message: "a mapped proposal requires the existing project id",
+      });
+    }
+    if (project.resolution !== "belongs_to_existing" && project.resolved_project_id !== null) {
+      context.addIssue({
+        code: "custom",
+        path: ["resolved_project_id"],
+        message: "resolved_project_id is only valid for belongs_to_existing",
+      });
+    }
+    if (project.resolution !== "rejected" && project.suppression_fingerprint !== null) {
+      context.addIssue({
+        code: "custom",
+        path: ["suppression_fingerprint"],
+        message: "suppression_fingerprint is only valid for a rejected project",
+      });
+    }
+
+    if (project.refresh_status === "failed" && project.refresh_failure_class === null) {
+      context.addIssue({
+        code: "custom",
+        path: ["refresh_failure_class"],
+        message: "a failed refresh requires a failure class",
+      });
+    }
+    if (project.refresh_status !== "failed" && project.refresh_failure_class !== null) {
+      context.addIssue({
+        code: "custom",
+        path: ["refresh_failure_class"],
+        message: "a failure class is only valid for a failed refresh",
+      });
+    }
+  });
+export type Project = z.infer<typeof ProjectSchema>;

--- a/packages/core/src/schemas/project.ts
+++ b/packages/core/src/schemas/project.ts
@@ -45,6 +45,11 @@ export const ProjectKeySchema = z
   .max(64)
   .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, "must be a lower-case slug");
 
+export const ProjectKeysSchema = z
+  .array(ProjectKeySchema)
+  .max(20)
+  .refine((values) => new Set(values).size === values.length, "project keys must be unique");
+
 export const ProjectSourceIdSchema = z
   .string()
   .trim()

--- a/packages/core/src/store/commit-message.ts
+++ b/packages/core/src/store/commit-message.ts
@@ -68,6 +68,13 @@ export const commitSubject = {
   handoffClaim: (id: string): string => `handoff: claim ${oneLine(id)}`,
   handoffPurge: (id: string): string => `handoff: purge ${oneLine(id)}`,
 
+  // ── project briefings (project Markdown stores) ──────────────────────────────
+  projectCreate: (id: string): string => `project: create ${oneLine(id)}`,
+  projectUpdate: (id: string): string => `project: update ${oneLine(id)}`,
+  projectUpdateAppend: (id: string): string => `project-update: append ${oneLine(id)}`,
+  projectSuggestionCreate: (id: string): string => `project-suggestion: create ${oneLine(id)}`,
+  projectSuggestionUpdate: (id: string): string => `project-suggestion: update ${oneLine(id)}`,
+
   // ── inbox (librarian-store.ts) ───────────────────────────────────────────────
   inboxSubmit: (id: string): string => `inbox: submit ${oneLine(id)}`,
   inboxConsolidateSweep: (): string => "inbox: consolidate sweep",

--- a/packages/core/src/store/corpus/inbox.ts
+++ b/packages/core/src/store/corpus/inbox.ts
@@ -47,6 +47,8 @@ export interface InboxSubmissionHints {
    * carried through and applied to a NEW consolidated memory.
    */
   appliesTo?: string[];
+  /** Validated shelf-local project relevance keys from the submission. */
+  projectKeys?: string[];
   /**
    * A routing DIRECTIVE (not a filing hint): when true, the intake must
    * terminate this submission as a PROPOSAL, never an auto-apply — even at high
@@ -101,7 +103,7 @@ function quote(value: string): string {
 /** Serialize an inbox submission to its on-disk markdown (frontmatter + text). */
 export function serializeInboxItem(item: InboxItem): string {
   const lines = [`id: ${quote(item.id)}`, `created: ${quote(item.created)}`];
-  const { agentId, tags, appliesTo, forceProposal } = item.hints;
+  const { agentId, tags, appliesTo, projectKeys, forceProposal } = item.hints;
   // Hints are written only when present, so an inbox item with none stays minimal.
   if (agentId !== undefined) lines.push(`agent_id: ${quote(agentId)}`);
   if (tags !== undefined) {
@@ -114,6 +116,13 @@ export function serializeInboxItem(item: InboxItem): string {
       appliesTo.length
         ? `applies_to:\n${appliesTo.map((a) => `  - ${quote(a)}`).join("\n")}`
         : "applies_to: []",
+    );
+  }
+  if (projectKeys !== undefined) {
+    lines.push(
+      projectKeys.length
+        ? `project_keys:\n${projectKeys.map((key) => `  - ${quote(key)}`).join("\n")}`
+        : "project_keys: []",
     );
   }
   // A directive, not a filing hint: only the `true` case is meaningful, so absent
@@ -135,6 +144,9 @@ export function parseInboxItem(raw: string): InboxItem {
   if (Array.isArray(d.tags)) hints.tags = d.tags.filter((t): t is string => typeof t === "string");
   if (Array.isArray(d.applies_to)) {
     hints.appliesTo = d.applies_to.filter((a): a is string => typeof a === "string");
+  }
+  if (Array.isArray(d.project_keys)) {
+    hints.projectKeys = d.project_keys.filter((key): key is string => typeof key === "string");
   }
   if (d.force_proposal === true) hints.forceProposal = true;
   return { id: String(d.id ?? ""), created, text: content.trim(), hints };

--- a/packages/core/src/store/index.ts
+++ b/packages/core/src/store/index.ts
@@ -4,5 +4,8 @@ export * from "./intake-store.js";
 export * from "./split-memory.js";
 export * from "./settings-store.js";
 export * from "./handoff-store.js";
+export * from "./project-store.js";
+export * from "./project-update-store.js";
+export * from "./project-suggestion-store.js";
 export * from "./vault-files.js";
 export * from "./sidecar/refusal-log.js";

--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -253,6 +253,14 @@ export class MemoryMoveUnsafePathError extends Error {
   }
 }
 
+export interface MemoryMoveWarning {
+  code: "missing-active-projects";
+  project_keys: string[];
+  message: string;
+}
+
+export type MovedMemory = Memory & { move_warnings?: MemoryMoveWarning[] };
+
 export interface LibrarianStore
   extends MemoryStore, CurationStore, IntakeStore, SettingsStore, PrimerStore {
   handoffs: HandoffStore;
@@ -411,7 +419,7 @@ export interface LibrarianStore
    * visibility are confined to the principal's `"recall"` set. The destination id resolves to its
    * unique writable bearer; both shelf indexes are invalidated after the path-scoped rename commit.
    */
-  moveMemoryForPrincipal(principal: Principal, id: string, destinationShelfId: string): Memory;
+  moveMemoryForPrincipal(principal: Principal, id: string, destinationShelfId: string): MovedMemory;
   /**
    * Principal-scoped distinct field values (spec 065 SC 7, T4): the UNION of `distinctValues`
    * over the `"recall"` shelf set, in the store's own ordering (case-insensitive, locale-stable).
@@ -1335,7 +1343,7 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Libra
     principal: Principal,
     id: string,
     destinationShelfId: string,
-  ): Memory => {
+  ): MovedMemory => {
     const shelves = vaultRouter.shelves(principal, "recall");
     validateShelfSet(shelves);
 
@@ -1454,6 +1462,30 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Libra
     }
     sourceCore.invalidateIndex();
     destinationCore.invalidateIndex();
+    // Warning lookup is intentionally post-move and fail-soft: the authorised
+    // move has committed, so a malformed destination project document must not
+    // turn success into a false failure. A key we cannot confirm as active is
+    // reported for admin attention; it never blocks or rewrites the memory.
+    const missingActiveProjectKeys = (memory.project_keys ?? []).filter((key) => {
+      try {
+        return destinationCore.rawProjects.getByKey(key)?.status !== "active";
+      } catch {
+        return true;
+      }
+    });
+    if (missingActiveProjectKeys.length > 0) {
+      const destinationName = destinationShelf.label ?? destinationShelf.id;
+      return {
+        ...memory,
+        move_warnings: [
+          {
+            code: "missing-active-projects",
+            project_keys: missingActiveProjectKeys,
+            message: `The move succeeded, but ${destinationName} has no active project for: ${missingActiveProjectKeys.join(", ")}. The associations were preserved.`,
+          },
+        ],
+      };
+    }
     return memory;
   };
 

--- a/packages/core/src/store/librarian-store.ts
+++ b/packages/core/src/store/librarian-store.ts
@@ -64,9 +64,15 @@ import type { IntakeStore } from "./intake-store.js";
 import {
   createMarkdownHandoffStore,
   createMarkdownMemoryStore,
+  createMarkdownProjectStore,
+  createMarkdownProjectSuggestionStore,
+  createMarkdownProjectUpdateStore,
   parseMemoryDocument,
 } from "./markdown/index.js";
 import type { Memory, MemoryStore } from "./memory-store.js";
+import type { ProjectStore } from "./project-store.js";
+import type { ProjectSuggestionStore } from "./project-suggestion-store.js";
+import type { ProjectUpdateStore } from "./project-update-store.js";
 import type { SettingsStore } from "./settings-store.js";
 import {
   type ReadRefusalsOptions,
@@ -183,6 +189,12 @@ export interface ShelfScopedStore extends MemoryStore {
   readonly shelf: Shelf;
   /** Handoff read/write confined to `<prefix>handoffs/`. */
   handoffs: HandoffStore;
+  /** Project identity/lifecycle records confined to `<prefix>projects/`. */
+  projects: ProjectStore;
+  /** Append-only project evidence confined to `<prefix>project-updates/`. */
+  projectUpdates: ProjectUpdateStore;
+  /** Pinned-section suggestions confined to `<prefix>project-suggestions/`. */
+  projectSuggestions: ProjectSuggestionStore;
   /** Vault-file read/write confined to the shelf (path discipline + kinds are shelf-relative). */
   vaultFiles: VaultFileStore;
   /** Index-backed recall over THIS shelf's memories only (merged multi-shelf recall is T5). */
@@ -193,6 +205,14 @@ export interface ShelfScopedStore extends MemoryStore {
   countReferences(): number;
   /** Submit raw text to THIS shelf's `<prefix>inbox/` (fire-and-forget, committed instantly). */
   submitToInbox(text: string, hints?: InboxSubmissionHints): InboxItemRef;
+}
+
+/** Raw project stores for one explicitly supplied shelf, used only by trusted system pipelines. */
+export interface ProjectSystemStores {
+  readonly shelf: Shelf;
+  projects: ProjectStore;
+  projectUpdates: ProjectUpdateStore;
+  projectSuggestions: ProjectSuggestionStore;
 }
 
 /** A scoped move could not see the target memory or named destination shelf. */
@@ -236,6 +256,12 @@ export class MemoryMoveUnsafePathError extends Error {
 export interface LibrarianStore
   extends MemoryStore, CurationStore, IntakeStore, SettingsStore, PrimerStore {
   handoffs: HandoffStore;
+  /** Default-shelf project identity/lifecycle records. */
+  projects: ProjectStore;
+  /** Default-shelf append-only project evidence. */
+  projectUpdates: ProjectUpdateStore;
+  /** Default-shelf pinned-section suggestions. */
+  projectSuggestions: ProjectSuggestionStore;
   /**
    * The dashboard's Obsidian-lite vault explorer/editor surface (rethink
    * T18/T19): tree + raw read + backlinks, and validated, compare-and-swap
@@ -412,6 +438,12 @@ export interface LibrarianStore
    * 062 §4). Internal (grooming-tick consumes it); not on the extension entrypoint.
    */
   groomingStoreForShelf(shelf: Shelf): GroomingStore;
+  /**
+   * Trusted system-pipeline project stores confined to exactly `shelf`. Unlike the public
+   * {@link forShelf} handle, this accessor is intentionally not gated by `shelf.writable` because
+   * system curation authority is shelf-scoped rather than principal-attributed.
+   */
+  systemProjectStoresForShelf(shelf: Shelf): ProjectSystemStores;
   /**
    * SYSTEM-PIPELINE inbox submit for `shelf` (spec 062 §4 / review A1 + F) — the inbox analogue of
    * {@link groomingStoreForShelf}'s raw memory surface, and the ONLY seam through which a system
@@ -740,6 +772,12 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Libra
     readonly rawMemory: MemoryStore;
     /** The un-gated handoff store. */
     readonly rawHandoffs: HandoffStore;
+    /** The un-gated Project store. */
+    readonly rawProjects: ProjectStore;
+    /** The un-gated append-only ProjectUpdate store. */
+    readonly rawProjectUpdates: ProjectUpdateStore;
+    /** The un-gated ProjectSuggestion store. */
+    readonly rawProjectSuggestions: ProjectSuggestionStore;
     /** The un-gated vault-file store (speaks FULL vault-relative paths to git). */
     readonly rawFiles: VaultFileStore;
     /** The un-gated inbox submitter. */
@@ -816,6 +854,15 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Libra
       commit: commitScoped,
       ...deterministicDeps,
     });
+    const rawProjects = createMarkdownProjectStore({ vault: scopedVault, commit: commitScoped });
+    const rawProjectUpdates = createMarkdownProjectUpdateStore({
+      vault: scopedVault,
+      commit: commitScoped,
+    });
+    const rawProjectSuggestions = createMarkdownProjectSuggestionStore({
+      vault: scopedVault,
+      commit: commitScoped,
+    });
     // The vault-file store takes the TRUE vault (full paths to git) + the shelf prefix (T2's
     // shelf-relative path discipline / kinds). Its onWrite invalidates this shelf's index and
     // runs the core's extra side effect (the main core's primer-cache drop).
@@ -866,6 +913,9 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Libra
       scopedVault,
       rawMemory,
       rawHandoffs,
+      rawProjects,
+      rawProjectUpdates,
+      rawProjectSuggestions,
       rawFiles,
       rawSubmitToInbox,
       recall,
@@ -920,6 +970,26 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Libra
           claim: () => refuseWrite(),
           purge: () => refuseWrite(),
         };
+    const projects: ProjectStore = shelf.writable
+      ? core.rawProjects
+      : {
+          ...core.rawProjects,
+          create: () => refuseWrite(),
+          update: () => refuseWrite(),
+        };
+    const projectUpdates: ProjectUpdateStore = shelf.writable
+      ? core.rawProjectUpdates
+      : {
+          ...core.rawProjectUpdates,
+          append: () => refuseWrite(),
+        };
+    const projectSuggestions: ProjectSuggestionStore = shelf.writable
+      ? core.rawProjectSuggestions
+      : {
+          ...core.rawProjectSuggestions,
+          create: () => refuseWrite(),
+          update: () => refuseWrite(),
+        };
     const vaultFiles: VaultFileStore = shelf.writable
       ? core.rawFiles
       : {
@@ -935,6 +1005,9 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Libra
       ...memory,
       shelf,
       handoffs,
+      projects,
+      projectUpdates,
+      projectSuggestions,
       vaultFiles,
       recall: core.recall,
       searchReferences: core.searchReferences,
@@ -1472,12 +1545,25 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Libra
     hints?: InboxSubmissionHints,
   ): InboxItemRef => coreForShelf(shelf).rawSubmitToInbox(text, hints);
 
+  const systemProjectStoresForShelf = (shelf: Shelf): ProjectSystemStores => {
+    const core = coreForShelf(shelf);
+    return {
+      shelf,
+      projects: core.rawProjects,
+      projectUpdates: core.rawProjectUpdates,
+      projectSuggestions: core.rawProjectSuggestions,
+    };
+  };
+
   return {
     ...mainHandle.memory,
     ...markdownCuration,
     ...markdownIntake,
     ...jsonSettings,
     handoffs: mainHandle.handoffs,
+    projects: mainHandle.projects,
+    projectUpdates: mainHandle.projectUpdates,
+    projectSuggestions: mainHandle.projectSuggestions,
     vaultFiles: mainHandle.vaultFiles,
     vaultRouter,
     forShelf,
@@ -1498,6 +1584,7 @@ export function createLibrarianStore(options: LibrarianStoreOptions = {}): Libra
     distinctValuesForPrincipal,
     countReferencesForPrincipal,
     groomingStoreForShelf,
+    systemProjectStoresForShelf,
     systemSubmitToInbox,
     submitToInbox: mainHandle.submitToInbox,
     recordRefusal: refusalLog.record,

--- a/packages/core/src/store/markdown/index.ts
+++ b/packages/core/src/store/markdown/index.ts
@@ -4,6 +4,15 @@
 
 export { parseMemoryDocument, serializeMemoryDocument } from "./memory-doc.js";
 export { parseHandoffDocument, serializeHandoffDocument } from "./handoff-doc.js";
+export { parseProjectDocument, serializeProjectDocument } from "./project-doc.js";
+export {
+  parseProjectUpdateDocument,
+  serializeProjectUpdateDocument,
+} from "./project-update-doc.js";
+export {
+  parseProjectSuggestionDocument,
+  serializeProjectSuggestionDocument,
+} from "./project-suggestion-doc.js";
 export {
   type MarkdownHandoffStoreDeps,
   createMarkdownHandoffStore,
@@ -12,3 +21,15 @@ export {
   type MarkdownMemoryStoreDeps,
   createMarkdownMemoryStore,
 } from "./markdown-memory-store.js";
+export {
+  type MarkdownProjectStoreDeps,
+  createMarkdownProjectStore,
+} from "./markdown-project-store.js";
+export {
+  type MarkdownProjectUpdateStoreDeps,
+  createMarkdownProjectUpdateStore,
+} from "./markdown-project-update-store.js";
+export {
+  type MarkdownProjectSuggestionStoreDeps,
+  createMarkdownProjectSuggestionStore,
+} from "./markdown-project-suggestion-store.js";

--- a/packages/core/src/store/markdown/markdown-memory-store.ts
+++ b/packages/core/src/store/markdown/markdown-memory-store.ts
@@ -148,6 +148,7 @@ export function createMarkdownMemoryStore(deps: MarkdownMemoryStoreDeps): Memory
       confidence: normalized.confidence,
       tags: normalized.tags,
       applies_to: normalized.applies_to,
+      ...(normalized.project_keys !== undefined ? { project_keys: normalized.project_keys } : {}),
       supersedes: [],
       conflicts_with: [],
       flags: [],
@@ -447,6 +448,10 @@ export function createMarkdownMemoryStore(deps: MarkdownMemoryStoreDeps): Memory
     let out = readAllMemories();
     if (filters.status) out = out.filter((m) => m.status === filters.status);
     if (filters.agent_id) out = out.filter((m) => m.agent_id === filters.agent_id);
+    if (Array.isArray(filters.project_keys) && filters.project_keys.length > 0) {
+      const wanted = filters.project_keys as string[];
+      out = out.filter((m) => wanted.some((key) => m.project_keys?.includes(key)));
+    }
     return out.sort((a, b) => cmpStr(b.updated_at, a.updated_at));
   }
 
@@ -472,6 +477,10 @@ export function createMarkdownMemoryStore(deps: MarkdownMemoryStoreDeps): Memory
     if (Array.isArray(filters.tags) && filters.tags.length > 0) {
       const wanted = filters.tags as string[];
       out = out.filter((m) => wanted.some((tag) => m.tags.includes(tag)));
+    }
+    if (Array.isArray(filters.project_keys) && filters.project_keys.length > 0) {
+      const wanted = filters.project_keys as string[];
+      out = out.filter((m) => wanted.some((key) => m.project_keys?.includes(key)));
     }
     if (filters.from) out = out.filter((m) => String(m.created_at) >= String(filters.from));
     if (filters.to) {

--- a/packages/core/src/store/markdown/markdown-project-store.ts
+++ b/packages/core/src/store/markdown/markdown-project-store.ts
@@ -1,0 +1,115 @@
+import {
+  ProjectDocumentIdSchema,
+  ProjectKeySchema,
+  ProjectSchema,
+  type Project,
+} from "../../schemas/project.js";
+import { commitSubject } from "../commit-message.js";
+import type { Vault } from "../corpus/vault.js";
+import {
+  DuplicateProjectKeyError,
+  type ListProjectsInput,
+  type ProjectStore,
+  ProjectRecordExistsError,
+  ProjectRecordNotFoundError,
+} from "../project-store.js";
+import { parseProjectDocument, serializeProjectDocument } from "./project-doc.js";
+import { assertSafeProjectStorePath } from "./project-store-path.js";
+
+export interface MarkdownProjectStoreDeps {
+  vault: Vault;
+  commit?: (paths: string[], message: string, actorId?: string) => void;
+}
+
+function assertId(id: string): string {
+  const result = ProjectDocumentIdSchema.safeParse(id);
+  if (!result.success) {
+    throw new Error(`Invalid project id '${id}': ${result.error.issues[0]?.message ?? "invalid"}`);
+  }
+  return result.data;
+}
+
+function projectPath(id: string): string {
+  return `projects/${assertId(id)}.md`;
+}
+
+function compareProjects(a: Project, b: Project): number {
+  return b.updated_at.localeCompare(a.updated_at) || a.id.localeCompare(b.id);
+}
+
+export function createMarkdownProjectStore(deps: MarkdownProjectStoreDeps): ProjectStore {
+  const commit = deps.commit ?? (() => {});
+
+  function readPath(rel: string, expectedId?: string): Project {
+    assertSafeProjectStorePath(deps.vault, rel);
+    const project = parseProjectDocument(deps.vault.readText(rel));
+    if (expectedId !== undefined && project.id !== expectedId) {
+      throw new Error(
+        `Invalid project document: filename id ${expectedId} disagrees with frontmatter id ${project.id}`,
+      );
+    }
+    return project;
+  }
+
+  function getById(id: string): Project | null {
+    const safeId = assertId(id);
+    const rel = projectPath(safeId);
+    assertSafeProjectStorePath(deps.vault, rel);
+    const raw = deps.vault.tryReadText(rel);
+    if (raw === null) return null;
+    const project = parseProjectDocument(raw);
+    if (project.id !== safeId) {
+      throw new Error(
+        `Invalid project document: filename id ${safeId} disagrees with frontmatter id ${project.id}`,
+      );
+    }
+    return project;
+  }
+
+  function list(input: ListProjectsInput = {}): Project[] {
+    const projects = deps.vault
+      .listMarkdown("projects")
+      .map((rel) => readPath(rel, rel.slice("projects/".length, -".md".length)));
+    return projects
+      .filter((project) => input.status === undefined || project.status === input.status)
+      .sort(compareProjects);
+  }
+
+  function getByKey(key: string): Project | null {
+    const safeKey = ProjectKeySchema.parse(key);
+    return list().find((project) => project.key === safeKey) ?? null;
+  }
+
+  function assertUniqueKey(project: Project): void {
+    const existing = getByKey(project.key);
+    if (existing !== null && existing.id !== project.id) {
+      throw new DuplicateProjectKeyError(project.key);
+    }
+  }
+
+  function create(input: Project, actorId?: string): Project {
+    const project = ProjectSchema.parse(input);
+    const rel = projectPath(project.id);
+    assertSafeProjectStorePath(deps.vault, rel);
+    if (deps.vault.exists(rel)) throw new ProjectRecordExistsError(project.id);
+    assertUniqueKey(project);
+    assertSafeProjectStorePath(deps.vault, rel);
+    deps.vault.writeText(rel, serializeProjectDocument(project));
+    commit([rel], commitSubject.projectCreate(project.id), actorId);
+    return project;
+  }
+
+  function update(input: Project, actorId?: string): Project {
+    const project = ProjectSchema.parse(input);
+    const rel = projectPath(project.id);
+    assertSafeProjectStorePath(deps.vault, rel);
+    if (!deps.vault.exists(rel)) throw new ProjectRecordNotFoundError(project.id);
+    assertUniqueKey(project);
+    assertSafeProjectStorePath(deps.vault, rel);
+    deps.vault.writeText(rel, serializeProjectDocument(project));
+    commit([rel], commitSubject.projectUpdate(project.id), actorId);
+    return project;
+  }
+
+  return { create, update, getById, getByKey, list };
+}

--- a/packages/core/src/store/markdown/markdown-project-store.ts
+++ b/packages/core/src/store/markdown/markdown-project-store.ts
@@ -10,6 +10,7 @@ import {
   DuplicateProjectKeyError,
   type ListProjectsInput,
   type ProjectStore,
+  ProjectKeyImmutableError,
   ProjectRecordExistsError,
   ProjectRecordNotFoundError,
 } from "../project-store.js";
@@ -70,6 +71,11 @@ export function createMarkdownProjectStore(deps: MarkdownProjectStoreDeps): Proj
     const projects = deps.vault
       .listMarkdown("projects")
       .map((rel) => readPath(rel, rel.slice("projects/".length, -".md".length)));
+    const seenKeys = new Set<string>();
+    for (const project of projects) {
+      if (seenKeys.has(project.key)) throw new DuplicateProjectKeyError(project.key);
+      seenKeys.add(project.key);
+    }
     return projects
       .filter((project) => input.status === undefined || project.status === input.status)
       .sort(compareProjects);
@@ -103,8 +109,12 @@ export function createMarkdownProjectStore(deps: MarkdownProjectStoreDeps): Proj
     const project = ProjectSchema.parse(input);
     const rel = projectPath(project.id);
     assertSafeProjectStorePath(deps.vault, rel);
-    if (!deps.vault.exists(rel)) throw new ProjectRecordNotFoundError(project.id);
+    const existing = getById(project.id);
+    if (existing === null) throw new ProjectRecordNotFoundError(project.id);
     assertUniqueKey(project);
+    if (existing.status !== "proposed" && existing.key !== project.key) {
+      throw new ProjectKeyImmutableError(existing.key);
+    }
     assertSafeProjectStorePath(deps.vault, rel);
     deps.vault.writeText(rel, serializeProjectDocument(project));
     commit([rel], commitSubject.projectUpdate(project.id), actorId);

--- a/packages/core/src/store/markdown/markdown-project-suggestion-store.ts
+++ b/packages/core/src/store/markdown/markdown-project-suggestion-store.ts
@@ -1,0 +1,139 @@
+import {
+  ProjectSuggestionSchema,
+  type ProjectSuggestion,
+} from "../../schemas/project-suggestion.js";
+import {
+  ProjectDocumentIdSchema,
+  ProjectHashSchema,
+  ProjectSectionKeySchema,
+  type ProjectSectionKey,
+} from "../../schemas/project.js";
+import { commitSubject } from "../commit-message.js";
+import type { Vault } from "../corpus/vault.js";
+import {
+  type ListProjectSuggestionsInput,
+  type ProjectSuggestionStore,
+  ProjectSuggestionExistsError,
+  ProjectSuggestionNotFoundError,
+} from "../project-suggestion-store.js";
+import { assertSafeProjectStorePath } from "./project-store-path.js";
+import {
+  parseProjectSuggestionDocument,
+  serializeProjectSuggestionDocument,
+} from "./project-suggestion-doc.js";
+
+export interface MarkdownProjectSuggestionStoreDeps {
+  vault: Vault;
+  commit?: (paths: string[], message: string, actorId?: string) => void;
+}
+
+function assertId(id: string): string {
+  const result = ProjectDocumentIdSchema.safeParse(id);
+  if (!result.success) {
+    throw new Error(
+      `Invalid project suggestion id '${id}': ${result.error.issues[0]?.message ?? "invalid"}`,
+    );
+  }
+  return result.data;
+}
+
+function suggestionPath(id: string): string {
+  return `project-suggestions/${assertId(id)}.md`;
+}
+
+function boundedLimit(limit: number | undefined): number {
+  const value = limit ?? 100;
+  if (!Number.isInteger(value) || value < 1 || value > 500) {
+    throw new Error("Project suggestion list limit must be an integer between 1 and 500");
+  }
+  return value;
+}
+
+export function createMarkdownProjectSuggestionStore(
+  deps: MarkdownProjectSuggestionStoreDeps,
+): ProjectSuggestionStore {
+  const commit = deps.commit ?? (() => {});
+
+  function getById(id: string): ProjectSuggestion | null {
+    const safeId = assertId(id);
+    const rel = suggestionPath(safeId);
+    assertSafeProjectStorePath(deps.vault, rel);
+    const raw = deps.vault.tryReadText(rel);
+    if (raw === null) return null;
+    const suggestion = parseProjectSuggestionDocument(raw);
+    if (suggestion.id !== safeId) {
+      throw new Error(
+        `Invalid project suggestion document: filename id ${safeId} disagrees with frontmatter id ${suggestion.id}`,
+      );
+    }
+    return suggestion;
+  }
+
+  function readAll(): ProjectSuggestion[] {
+    return deps.vault.listMarkdown("project-suggestions").map((rel) => {
+      assertSafeProjectStorePath(deps.vault, rel);
+      const expectedId = rel.slice("project-suggestions/".length, -".md".length);
+      const suggestion = parseProjectSuggestionDocument(deps.vault.readText(rel));
+      if (suggestion.id !== expectedId) {
+        throw new Error(
+          `Invalid project suggestion document: filename id ${expectedId} disagrees with frontmatter id ${suggestion.id}`,
+        );
+      }
+      return suggestion;
+    });
+  }
+
+  function list(input: ListProjectSuggestionsInput = {}): ProjectSuggestion[] {
+    return readAll()
+      .filter(
+        (suggestion) =>
+          input.project_id === undefined || suggestion.project_id === input.project_id,
+      )
+      .filter((suggestion) => input.section === undefined || suggestion.section === input.section)
+      .filter((suggestion) => input.status === undefined || suggestion.status === input.status)
+      .sort((a, b) => b.created_at.localeCompare(a.created_at) || a.id.localeCompare(b.id))
+      .slice(0, boundedLimit(input.limit));
+  }
+
+  function findByContentHash(
+    projectId: string,
+    section: ProjectSectionKey,
+    contentHash: string,
+  ): ProjectSuggestion | null {
+    const safeProjectId = assertId(projectId);
+    const safeSection = ProjectSectionKeySchema.parse(section);
+    const safeHash = ProjectHashSchema.parse(contentHash);
+    return (
+      readAll().find(
+        (suggestion) =>
+          suggestion.project_id === safeProjectId &&
+          suggestion.section === safeSection &&
+          suggestion.content_hash === safeHash,
+      ) ?? null
+    );
+  }
+
+  function create(input: ProjectSuggestion, actorId?: string): ProjectSuggestion {
+    const suggestion = ProjectSuggestionSchema.parse(input);
+    const rel = suggestionPath(suggestion.id);
+    assertSafeProjectStorePath(deps.vault, rel);
+    if (deps.vault.exists(rel)) throw new ProjectSuggestionExistsError(suggestion.id);
+    assertSafeProjectStorePath(deps.vault, rel);
+    deps.vault.writeText(rel, serializeProjectSuggestionDocument(suggestion));
+    commit([rel], commitSubject.projectSuggestionCreate(suggestion.id), actorId);
+    return suggestion;
+  }
+
+  function update(input: ProjectSuggestion, actorId?: string): ProjectSuggestion {
+    const suggestion = ProjectSuggestionSchema.parse(input);
+    const rel = suggestionPath(suggestion.id);
+    assertSafeProjectStorePath(deps.vault, rel);
+    if (!deps.vault.exists(rel)) throw new ProjectSuggestionNotFoundError(suggestion.id);
+    assertSafeProjectStorePath(deps.vault, rel);
+    deps.vault.writeText(rel, serializeProjectSuggestionDocument(suggestion));
+    commit([rel], commitSubject.projectSuggestionUpdate(suggestion.id), actorId);
+    return suggestion;
+  }
+
+  return { create, update, getById, findByContentHash, list };
+}

--- a/packages/core/src/store/markdown/markdown-project-update-store.ts
+++ b/packages/core/src/store/markdown/markdown-project-update-store.ts
@@ -1,0 +1,114 @@
+import { ProjectUpdateSchema, type ProjectUpdate } from "../../schemas/project-update.js";
+import { ProjectDocumentIdSchema, ProjectHashSchema } from "../../schemas/project.js";
+import { commitSubject } from "../commit-message.js";
+import type { Vault } from "../corpus/vault.js";
+import {
+  type ListProjectUpdatesInput,
+  type ProjectUpdateStore,
+  ProjectUpdateExistsError,
+} from "../project-update-store.js";
+import { assertSafeProjectStorePath } from "./project-store-path.js";
+import {
+  parseProjectUpdateDocument,
+  serializeProjectUpdateDocument,
+} from "./project-update-doc.js";
+
+export interface MarkdownProjectUpdateStoreDeps {
+  vault: Vault;
+  commit?: (paths: string[], message: string, actorId?: string) => void;
+}
+
+function assertId(id: string): string {
+  const result = ProjectDocumentIdSchema.safeParse(id);
+  if (!result.success) {
+    throw new Error(
+      `Invalid project update id '${id}': ${result.error.issues[0]?.message ?? "invalid"}`,
+    );
+  }
+  return result.data;
+}
+
+function updatePath(id: string): string {
+  return `project-updates/${assertId(id)}.md`;
+}
+
+function compareUpdates(a: ProjectUpdate, b: ProjectUpdate): number {
+  return b.captured_at.localeCompare(a.captured_at) || a.id.localeCompare(b.id);
+}
+
+function boundedLimit(limit: number | undefined): number {
+  const value = limit ?? 100;
+  if (!Number.isInteger(value) || value < 1 || value > 500) {
+    throw new Error("Project update list limit must be an integer between 1 and 500");
+  }
+  return value;
+}
+
+export function createMarkdownProjectUpdateStore(
+  deps: MarkdownProjectUpdateStoreDeps,
+): ProjectUpdateStore {
+  const commit = deps.commit ?? (() => {});
+
+  function getById(id: string): ProjectUpdate | null {
+    const safeId = assertId(id);
+    const rel = updatePath(safeId);
+    assertSafeProjectStorePath(deps.vault, rel);
+    const raw = deps.vault.tryReadText(rel);
+    if (raw === null) return null;
+    const update = parseProjectUpdateDocument(raw);
+    if (update.id !== safeId) {
+      throw new Error(
+        `Invalid project update document: filename id ${safeId} disagrees with frontmatter id ${update.id}`,
+      );
+    }
+    return update;
+  }
+
+  function readAll(): ProjectUpdate[] {
+    return deps.vault.listMarkdown("project-updates").map((rel) => {
+      assertSafeProjectStorePath(deps.vault, rel);
+      const expectedId = rel.slice("project-updates/".length, -".md".length);
+      const update = parseProjectUpdateDocument(deps.vault.readText(rel));
+      if (update.id !== expectedId) {
+        throw new Error(
+          `Invalid project update document: filename id ${expectedId} disagrees with frontmatter id ${update.id}`,
+        );
+      }
+      return update;
+    });
+  }
+
+  function list(input: ListProjectUpdatesInput = {}): ProjectUpdate[] {
+    return readAll()
+      .filter((update) => input.project_id === undefined || update.project_id === input.project_id)
+      .filter(
+        (update) =>
+          input.candidate_fingerprint === undefined ||
+          update.candidate_fingerprint === input.candidate_fingerprint,
+      )
+      .filter(
+        (update) => input.source_kind === undefined || update.source_kind === input.source_kind,
+      )
+      .filter((update) => input.source_ref === undefined || update.source_ref === input.source_ref)
+      .sort(compareUpdates)
+      .slice(0, boundedLimit(input.limit));
+  }
+
+  function getByFingerprint(fingerprint: string): ProjectUpdate | null {
+    const safeFingerprint = ProjectHashSchema.parse(fingerprint);
+    return readAll().find((update) => update.fingerprint === safeFingerprint) ?? null;
+  }
+
+  function append(input: ProjectUpdate, actorId?: string): ProjectUpdate {
+    const update = ProjectUpdateSchema.parse(input);
+    const rel = updatePath(update.id);
+    assertSafeProjectStorePath(deps.vault, rel);
+    if (deps.vault.exists(rel)) throw new ProjectUpdateExistsError(update.id);
+    assertSafeProjectStorePath(deps.vault, rel);
+    deps.vault.writeText(rel, serializeProjectUpdateDocument(update));
+    commit([rel], commitSubject.projectUpdateAppend(update.id), actorId);
+    return update;
+  }
+
+  return { append, getById, getByFingerprint, list };
+}

--- a/packages/core/src/store/markdown/memory-doc.ts
+++ b/packages/core/src/store/markdown/memory-doc.ts
@@ -16,6 +16,7 @@
 import matter from "gray-matter";
 import { z } from "zod";
 import { IsoTimestampSchema } from "../../schemas/common.js";
+import { ProjectKeysSchema } from "../../schemas/project.js";
 import type { Memory } from "../memory-store.js";
 
 const MemoryFrontmatterSchema = z.object({
@@ -26,6 +27,7 @@ const MemoryFrontmatterSchema = z.object({
   confidence: z.string(),
   tags: z.array(z.string()),
   applies_to: z.array(z.string()),
+  project_keys: ProjectKeysSchema.optional(),
   supersedes: z.array(z.string()),
   conflicts_with: z.array(z.string()),
   // Open agent flags routing the memory to review (spec 047 / ADR 0006).
@@ -62,6 +64,7 @@ export function serializeMemoryDocument(memory: Memory): string {
     confidence: memory.confidence,
     tags: memory.tags ?? [],
     applies_to: memory.applies_to ?? [],
+    ...(memory.project_keys !== undefined ? { project_keys: memory.project_keys } : {}),
     supersedes: memory.supersedes ?? [],
     conflicts_with: memory.conflicts_with ?? [],
     flags: memory.flags ?? [],
@@ -81,7 +84,8 @@ export function serializeMemoryDocument(memory: Memory): string {
 /** Parse a markdown document back into a `Memory`; teaching error on a bad shape. */
 export function parseMemoryDocument(raw: string): Memory {
   const { data, content } = matter(raw);
-  const result = MemoryFrontmatterSchema.safeParse(coerceDates(data));
+  const compatible = coerceLegacyProjectKey(coerceDates(data));
+  const result = MemoryFrontmatterSchema.safeParse(compatible);
   if (!result.success) {
     const detail = result.error.issues
       .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
@@ -90,12 +94,18 @@ export function parseMemoryDocument(raw: string): Memory {
   }
   // `updated_by` is optional: under exactOptionalPropertyTypes it must be OMITTED when
   // absent, never set to `undefined` (which zod's `.optional()` yields for a missing key).
-  const { updated_by, ...rest } = result.data;
+  const { updated_by, project_keys, ...rest } = result.data;
   return {
     ...rest,
     body: content.trim(),
     ...(updated_by !== undefined ? { updated_by } : {}),
+    ...(project_keys !== undefined ? { project_keys } : {}),
   };
+}
+
+function coerceLegacyProjectKey(data: Record<string, unknown>): Record<string, unknown> {
+  if (data.project_keys !== undefined || typeof data.project_key !== "string") return data;
+  return { ...data, project_keys: [data.project_key] };
 }
 
 function coerceDates(data: Record<string, unknown>): Record<string, unknown> {

--- a/packages/core/src/store/markdown/project-doc.ts
+++ b/packages/core/src/store/markdown/project-doc.ts
@@ -1,0 +1,209 @@
+import matter from "gray-matter";
+import { z } from "zod";
+import { IsoTimestampSchema } from "../../schemas/common.js";
+import {
+  PROJECT_SECTION_KEYS,
+  ProjectDocumentIdSchema,
+  ProjectHashSchema,
+  ProjectKeySchema,
+  ProjectRefreshStatusSchema,
+  ProjectResolutionSchema,
+  ProjectSchema,
+  ProjectSectionOwnershipSchema,
+  ProjectSourceIdSchema,
+  ProjectStatusSchema,
+  type Project,
+  type ProjectSectionKey,
+  type ProjectSections,
+} from "../../schemas/project.js";
+
+const SECTION_HEADINGS: Record<ProjectSectionKey, string> = {
+  what_this_project_is: "What this project is",
+  technology_and_architecture: "Technology and architecture",
+  current_state: "Current state",
+  last_meaningful_work: "Last meaningful work",
+  planned_next: "Planned next",
+  blockers_and_uncertainties: "Blockers and uncertainties",
+};
+
+const SectionOwnershipFrontmatterSchema = z.strictObject({
+  what_this_project_is: ProjectSectionOwnershipSchema,
+  technology_and_architecture: ProjectSectionOwnershipSchema,
+  current_state: ProjectSectionOwnershipSchema,
+  last_meaningful_work: ProjectSectionOwnershipSchema,
+  planned_next: ProjectSectionOwnershipSchema,
+  blockers_and_uncertainties: ProjectSectionOwnershipSchema,
+});
+
+const SectionSourceIdsFrontmatterSchema = z.strictObject({
+  what_this_project_is: z.array(ProjectSourceIdSchema).max(50),
+  technology_and_architecture: z.array(ProjectSourceIdSchema).max(50),
+  current_state: z.array(ProjectSourceIdSchema).max(50),
+  last_meaningful_work: z.array(ProjectSourceIdSchema).max(50),
+  planned_next: z.array(ProjectSourceIdSchema).max(50),
+  blockers_and_uncertainties: z.array(ProjectSourceIdSchema).max(50),
+});
+
+const ProjectFrontmatterSchema = z.strictObject({
+  id: ProjectDocumentIdSchema,
+  key: ProjectKeySchema,
+  display_name: z.string().trim().min(1).max(120),
+  aliases: z.array(z.string().trim().min(1).max(120)).max(20),
+  repository_identifiers: z.array(z.string().trim().min(1).max(240)).max(20),
+  status: ProjectStatusSchema,
+  resolution: ProjectResolutionSchema.nullable(),
+  resolved_project_id: ProjectDocumentIdSchema.nullable(),
+  proposal_rationale: z.string().min(1).max(2_000).nullable(),
+  proposal_evidence_ids: z.array(ProjectSourceIdSchema).max(50),
+  suppression_fingerprint: ProjectHashSchema.nullable(),
+  possible_match_ids: z.array(ProjectDocumentIdSchema).max(20),
+  section_ownership: SectionOwnershipFrontmatterSchema,
+  section_source_ids: SectionSourceIdsFrontmatterSchema,
+  compiled_at: IsoTimestampSchema.nullable(),
+  compiler_version: z.string().min(1).max(64).nullable(),
+  source_watermark: ProjectHashSchema.nullable(),
+  source_ids: z.array(ProjectSourceIdSchema).max(200),
+  content_hash: ProjectHashSchema.nullable(),
+  refresh_status: ProjectRefreshStatusSchema,
+  refresh_failure_class: z.string().min(1).max(100).nullable(),
+  pending_source_count: z.number().int().min(0).max(1_000_000),
+  unresolved_conflict_count: z.number().int().min(0).max(1_000_000),
+  last_activity_at: IsoTimestampSchema.nullable(),
+  created_at: IsoTimestampSchema,
+  updated_at: IsoTimestampSchema,
+});
+
+function startMarker(key: ProjectSectionKey): string {
+  return `<!-- librarian-section:${key}:start -->`;
+}
+
+function endMarker(key: ProjectSectionKey): string {
+  return `<!-- librarian-section:${key}:end -->`;
+}
+
+function renderSections(sections: ProjectSections): string {
+  return PROJECT_SECTION_KEYS.map((key) => {
+    const content = sections[key].content;
+    if (content.includes(startMarker(key)) || content.includes(endMarker(key))) {
+      throw new Error(`Invalid project section ${key}: content contains a reserved framing marker`);
+    }
+    return [`## ${SECTION_HEADINGS[key]}`, startMarker(key), `${content}\n${endMarker(key)}`].join(
+      "\n",
+    );
+  }).join("\n\n");
+}
+
+function parseSections(rawBody: string): Record<ProjectSectionKey, string> {
+  const body = rawBody.endsWith("\n") ? rawBody.slice(0, -1) : rawBody;
+  const sections = {} as Record<ProjectSectionKey, string>;
+  let cursor = 0;
+
+  for (const [index, key] of PROJECT_SECTION_KEYS.entries()) {
+    const prefix = `## ${SECTION_HEADINGS[key]}\n${startMarker(key)}\n`;
+    if (!body.startsWith(prefix, cursor)) {
+      throw new Error(`Invalid project document body: expected framing for section ${key}`);
+    }
+    const contentStart = cursor + prefix.length;
+    const closing = `\n${endMarker(key)}`;
+    const contentEnd = body.indexOf(closing, contentStart);
+    if (contentEnd < 0) {
+      throw new Error(`Invalid project document body: missing end marker for section ${key}`);
+    }
+    sections[key] = body.slice(contentStart, contentEnd);
+    cursor = contentEnd + closing.length;
+    if (index < PROJECT_SECTION_KEYS.length - 1) {
+      if (!body.startsWith("\n\n", cursor)) {
+        throw new Error(`Invalid project document body: expected separator after section ${key}`);
+      }
+      cursor += 2;
+    }
+  }
+
+  if (cursor !== body.length) {
+    throw new Error("Invalid project document body: content exists outside the six sections");
+  }
+  return sections;
+}
+
+function coerceDates(data: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(data).map(([key, value]) => [
+      key,
+      value instanceof Date ? value.toISOString() : value,
+    ]),
+  );
+}
+
+function validationDetail(error: z.ZodError): string {
+  return error.issues
+    .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+    .join("; ");
+}
+
+export function serializeProjectDocument(input: Project): string {
+  const project = ProjectSchema.parse(input);
+  const section_ownership = Object.fromEntries(
+    PROJECT_SECTION_KEYS.map((key) => [key, project.sections[key].ownership]),
+  ) as z.infer<typeof SectionOwnershipFrontmatterSchema>;
+  const section_source_ids = Object.fromEntries(
+    PROJECT_SECTION_KEYS.map((key) => [key, project.sections[key].source_ids]),
+  ) as z.infer<typeof SectionSourceIdsFrontmatterSchema>;
+  const frontmatter = {
+    id: project.id,
+    key: project.key,
+    display_name: project.display_name,
+    aliases: project.aliases,
+    repository_identifiers: project.repository_identifiers,
+    status: project.status,
+    resolution: project.resolution,
+    resolved_project_id: project.resolved_project_id,
+    proposal_rationale: project.proposal_rationale,
+    proposal_evidence_ids: project.proposal_evidence_ids,
+    suppression_fingerprint: project.suppression_fingerprint,
+    possible_match_ids: project.possible_match_ids,
+    section_ownership,
+    section_source_ids,
+    compiled_at: project.compiled_at,
+    compiler_version: project.compiler_version,
+    source_watermark: project.source_watermark,
+    source_ids: project.source_ids,
+    content_hash: project.content_hash,
+    refresh_status: project.refresh_status,
+    refresh_failure_class: project.refresh_failure_class,
+    pending_source_count: project.pending_source_count,
+    unresolved_conflict_count: project.unresolved_conflict_count,
+    last_activity_at: project.last_activity_at,
+    created_at: project.created_at,
+    updated_at: project.updated_at,
+  };
+  return matter.stringify(renderSections(project.sections), frontmatter);
+}
+
+export function parseProjectDocument(raw: string): Project {
+  const { data, content } = matter(raw);
+  const frontmatter = ProjectFrontmatterSchema.safeParse(coerceDates(data));
+  if (!frontmatter.success) {
+    throw new Error(`Invalid project document frontmatter: ${validationDetail(frontmatter.error)}`);
+  }
+  const sectionContent = parseSections(content);
+  const sections = Object.fromEntries(
+    PROJECT_SECTION_KEYS.map((key) => [
+      key,
+      {
+        content: sectionContent[key],
+        ownership: frontmatter.data.section_ownership[key],
+        source_ids: frontmatter.data.section_source_ids[key],
+      },
+    ]),
+  ) as ProjectSections;
+  const {
+    section_ownership: _ownership,
+    section_source_ids: _sources,
+    ...metadata
+  } = frontmatter.data;
+  const project = ProjectSchema.safeParse({ ...metadata, sections });
+  if (!project.success) {
+    throw new Error(`Invalid project document: ${validationDetail(project.error)}`);
+  }
+  return project.data;
+}

--- a/packages/core/src/store/markdown/project-store-path.ts
+++ b/packages/core/src/store/markdown/project-store-path.ts
@@ -1,0 +1,24 @@
+import fs from "node:fs";
+import path from "node:path";
+import { UnsafeVaultPathError, type Vault } from "../corpus/vault.js";
+
+/** Refuse direct project-store access through any symlink beneath the scoped vault root. */
+export function assertSafeProjectStorePath(vault: Vault, relPath: string): void {
+  const absolute = path.resolve(vault.root, relPath);
+  const relative = path.relative(vault.root, absolute);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new UnsafeVaultPathError(relPath);
+  }
+  let current = vault.root;
+  for (const segment of relative.split(path.sep).filter(Boolean)) {
+    current = path.join(current, segment);
+    let stat: fs.Stats;
+    try {
+      stat = fs.lstatSync(current);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+      throw error;
+    }
+    if (stat.isSymbolicLink()) throw new UnsafeVaultPathError(relPath);
+  }
+}

--- a/packages/core/src/store/markdown/project-suggestion-doc.ts
+++ b/packages/core/src/store/markdown/project-suggestion-doc.ts
@@ -1,0 +1,98 @@
+import matter from "gray-matter";
+import { z } from "zod";
+import { IsoTimestampSchema } from "../../schemas/common.js";
+import {
+  ProjectSuggestionSchema,
+  ProjectSuggestionStatusSchema,
+  type ProjectSuggestion,
+} from "../../schemas/project-suggestion.js";
+import {
+  ProjectDocumentIdSchema,
+  ProjectHashSchema,
+  ProjectSectionKeySchema,
+  ProjectSourceIdSchema,
+} from "../../schemas/project.js";
+
+const START_MARKER = "<!-- librarian-suggestion:start -->";
+const END_MARKER = "<!-- librarian-suggestion:end -->";
+const BODY_PREFIX = `## Proposed replacement\n${START_MARKER}\n`;
+
+const ProjectSuggestionFrontmatterSchema = z.strictObject({
+  id: ProjectDocumentIdSchema,
+  project_id: ProjectDocumentIdSchema,
+  section: ProjectSectionKeySchema,
+  rationale: z.string().min(1).max(2_000),
+  source_ids: z.array(ProjectSourceIdSchema).min(1).max(50),
+  content_hash: ProjectHashSchema,
+  status: ProjectSuggestionStatusSchema,
+  created_at: IsoTimestampSchema,
+  resolved_at: IsoTimestampSchema.nullable(),
+});
+
+function validationDetail(error: z.ZodError): string {
+  return error.issues
+    .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+    .join("; ");
+}
+
+function coerceDates(data: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(data).map(([key, value]) => [
+      key,
+      value instanceof Date ? value.toISOString() : value,
+    ]),
+  );
+}
+
+function renderBody(content: string): string {
+  if (content.includes(START_MARKER) || content.includes(END_MARKER)) {
+    throw new Error("Invalid proposed_content: content contains a reserved framing marker");
+  }
+  return `${BODY_PREFIX}${content}\n${END_MARKER}`;
+}
+
+function parseBody(rawBody: string): string {
+  const body = rawBody.endsWith("\n") ? rawBody.slice(0, -1) : rawBody;
+  if (!body.startsWith(BODY_PREFIX)) {
+    throw new Error("Invalid project suggestion body: missing proposed_content start marker");
+  }
+  const closing = `\n${END_MARKER}`;
+  if (!body.endsWith(closing)) {
+    throw new Error("Invalid project suggestion body: missing proposed_content end marker");
+  }
+  return body.slice(BODY_PREFIX.length, -closing.length);
+}
+
+export function serializeProjectSuggestionDocument(input: ProjectSuggestion): string {
+  const suggestion = ProjectSuggestionSchema.parse(input);
+  const frontmatter = {
+    id: suggestion.id,
+    project_id: suggestion.project_id,
+    section: suggestion.section,
+    rationale: suggestion.rationale,
+    source_ids: suggestion.source_ids,
+    content_hash: suggestion.content_hash,
+    status: suggestion.status,
+    created_at: suggestion.created_at,
+    resolved_at: suggestion.resolved_at,
+  };
+  return matter.stringify(renderBody(suggestion.proposed_content), frontmatter);
+}
+
+export function parseProjectSuggestionDocument(raw: string): ProjectSuggestion {
+  const { data, content } = matter(raw);
+  const frontmatter = ProjectSuggestionFrontmatterSchema.safeParse(coerceDates(data));
+  if (!frontmatter.success) {
+    throw new Error(
+      `Invalid project suggestion document frontmatter: ${validationDetail(frontmatter.error)}`,
+    );
+  }
+  const suggestion = ProjectSuggestionSchema.safeParse({
+    ...frontmatter.data,
+    proposed_content: parseBody(content),
+  });
+  if (!suggestion.success) {
+    throw new Error(`Invalid project suggestion document: ${validationDetail(suggestion.error)}`);
+  }
+  return suggestion.data;
+}

--- a/packages/core/src/store/markdown/project-update-doc.ts
+++ b/packages/core/src/store/markdown/project-update-doc.ts
@@ -1,0 +1,98 @@
+import matter from "gray-matter";
+import { z } from "zod";
+import { IsoTimestampSchema } from "../../schemas/common.js";
+import {
+  ProjectUpdateEvidenceSchema,
+  ProjectUpdateSchema,
+  ProjectUpdateSourceKindSchema,
+  type ProjectUpdate,
+} from "../../schemas/project-update.js";
+import {
+  ProjectDocumentIdSchema,
+  ProjectHashSchema,
+  ProjectKeySchema,
+  ProjectSourceIdSchema,
+} from "../../schemas/project.js";
+
+const ShelfIdSchema = z
+  .string()
+  .min(1)
+  .max(240)
+  .refine((value) => !value.includes("]") && !/\p{Cc}/u.test(value));
+
+const ProjectUpdateFrontmatterSchema = z.strictObject({
+  id: ProjectDocumentIdSchema,
+  project_id: ProjectDocumentIdSchema.nullable(),
+  candidate_fingerprint: ProjectHashSchema.nullable(),
+  suggested_key: ProjectKeySchema.nullable(),
+  suggested_name: z.string().trim().min(1).max(120).nullable(),
+  suggested_aliases: z.array(z.string().trim().min(1).max(120)).max(20),
+  suggested_repository_identifiers: z.array(z.string().trim().min(1).max(240)).max(20),
+  confidence: z.number().min(0).max(1),
+  rationale: z.string().min(1).max(2_000),
+  explicitly_new_project: z.boolean(),
+  evidence: ProjectUpdateEvidenceSchema,
+  source_kind: ProjectUpdateSourceKindSchema,
+  source_ref: ProjectSourceIdSchema,
+  observed_at: IsoTimestampSchema,
+  captured_at: IsoTimestampSchema,
+  shelf_id: ShelfIdSchema,
+  fingerprint: ProjectHashSchema,
+});
+
+function validationDetail(error: z.ZodError): string {
+  return error.issues
+    .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+    .join("; ");
+}
+
+function coerceDates(data: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(data).map(([key, value]) => [
+      key,
+      value instanceof Date ? value.toISOString() : value,
+    ]),
+  );
+}
+
+export function serializeProjectUpdateDocument(input: ProjectUpdate): string {
+  const update = ProjectUpdateSchema.parse(input);
+  const frontmatter = {
+    id: update.id,
+    project_id: update.project_id,
+    candidate_fingerprint: update.candidate_fingerprint,
+    suggested_key: update.suggested_key,
+    suggested_name: update.suggested_name,
+    suggested_aliases: update.suggested_aliases,
+    suggested_repository_identifiers: update.suggested_repository_identifiers,
+    confidence: update.confidence,
+    rationale: update.rationale,
+    explicitly_new_project: update.explicitly_new_project,
+    evidence: update.evidence,
+    source_kind: update.source_kind,
+    source_ref: update.source_ref,
+    observed_at: update.observed_at,
+    captured_at: update.captured_at,
+    shelf_id: update.shelf_id,
+    fingerprint: update.fingerprint,
+  };
+  return matter.stringify("", frontmatter);
+}
+
+export function parseProjectUpdateDocument(raw: string): ProjectUpdate {
+  const { data, content } = matter(raw);
+  if (content.trim() !== "") {
+    throw new Error("Invalid project update document body: evidence belongs in frontmatter");
+  }
+  const frontmatter = ProjectUpdateFrontmatterSchema.safeParse(coerceDates(data));
+  if (!frontmatter.success) {
+    throw new Error(
+      `Invalid project update document frontmatter: ${validationDetail(frontmatter.error)}`,
+    );
+  }
+  const update = ProjectUpdateSchema.safeParse(frontmatter.data);
+  if (!update.success) {
+    throw new Error(`Invalid project update document: ${validationDetail(update.error)}`);
+  }
+  return update.data;
+}

--- a/packages/core/src/store/memory-patch.ts
+++ b/packages/core/src/store/memory-patch.ts
@@ -11,6 +11,7 @@ const ALLOWED_PATCH_FIELDS = [
   "body",
   "agent_id",
   "applies_to",
+  "project_keys",
   "status",
   "confidence",
   "supersedes",

--- a/packages/core/src/store/memory-types.ts
+++ b/packages/core/src/store/memory-types.ts
@@ -34,6 +34,8 @@ export interface Memory {
   status: string;
   tags: string[];
   applies_to: string[];
+  /** Shelf-local project relevance metadata; never an authorisation boundary. */
+  project_keys?: string[];
   supersedes: string[];
   conflicts_with: string[];
   // Open agent flags routing this memory to review (spec 047 / ADR 0006).

--- a/packages/core/src/store/merge-memory.ts
+++ b/packages/core/src/store/merge-memory.ts
@@ -52,10 +52,24 @@ export interface MergeMemoryRequest {
  * identical in how they file it).
  */
 export function mergeMemory(store: MergeMemoryStore, request: MergeMemoryRequest): string {
-  const target = store.createMemory(request.replacement.input, request.replacement.options).memory
-    .id;
+  const hasExplicitKeys = Object.prototype.hasOwnProperty.call(
+    request.replacement.input,
+    "project_keys",
+  );
+  const sourceKeys = hasExplicitKeys
+    ? undefined
+    : stableUnion(...request.sourceIds.map((id) => store.getMemory?.(id)?.project_keys ?? []));
+  const input =
+    sourceKeys && sourceKeys.length > 0
+      ? { ...request.replacement.input, project_keys: sourceKeys }
+      : request.replacement.input;
+  const target = store.createMemory(input, request.replacement.options).memory.id;
   if (request.archiveActorId !== undefined) {
     for (const id of request.sourceIds) store.archiveMemory(id, request.archiveActorId);
   }
   return target;
+}
+
+function stableUnion(...groups: string[][]): string[] {
+  return [...new Set(groups.flat())];
 }

--- a/packages/core/src/store/project-store.ts
+++ b/packages/core/src/store/project-store.ts
@@ -1,0 +1,34 @@
+import type { Project, ProjectStatus } from "../schemas/project.js";
+
+export interface ListProjectsInput {
+  status?: ProjectStatus;
+}
+
+export interface ProjectStore {
+  create(project: Project, actorId?: string): Project;
+  update(project: Project, actorId?: string): Project;
+  getById(id: string): Project | null;
+  getByKey(key: string): Project | null;
+  list(input?: ListProjectsInput): Project[];
+}
+
+export class ProjectRecordExistsError extends Error {
+  constructor(id: string) {
+    super(`Project ${id} already exists`);
+    this.name = "ProjectRecordExistsError";
+  }
+}
+
+export class ProjectRecordNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Project ${id} does not exist`);
+    this.name = "ProjectRecordNotFoundError";
+  }
+}
+
+export class DuplicateProjectKeyError extends Error {
+  constructor(key: string) {
+    super(`Project key '${key}' is already in use in this shelf`);
+    this.name = "DuplicateProjectKeyError";
+  }
+}

--- a/packages/core/src/store/project-store.ts
+++ b/packages/core/src/store/project-store.ts
@@ -32,3 +32,10 @@ export class DuplicateProjectKeyError extends Error {
     this.name = "DuplicateProjectKeyError";
   }
 }
+
+export class ProjectKeyImmutableError extends Error {
+  constructor(key: string) {
+    super(`Project key '${key}' is stable after approval and cannot be changed`);
+    this.name = "ProjectKeyImmutableError";
+  }
+}

--- a/packages/core/src/store/project-suggestion-store.ts
+++ b/packages/core/src/store/project-suggestion-store.ts
@@ -1,0 +1,35 @@
+import type { ProjectSuggestion, ProjectSuggestionStatus } from "../schemas/project-suggestion.js";
+import type { ProjectSectionKey } from "../schemas/project.js";
+
+export interface ListProjectSuggestionsInput {
+  project_id?: string;
+  section?: ProjectSectionKey;
+  status?: ProjectSuggestionStatus;
+  limit?: number;
+}
+
+export interface ProjectSuggestionStore {
+  create(suggestion: ProjectSuggestion, actorId?: string): ProjectSuggestion;
+  update(suggestion: ProjectSuggestion, actorId?: string): ProjectSuggestion;
+  getById(id: string): ProjectSuggestion | null;
+  findByContentHash(
+    projectId: string,
+    section: ProjectSectionKey,
+    contentHash: string,
+  ): ProjectSuggestion | null;
+  list(input?: ListProjectSuggestionsInput): ProjectSuggestion[];
+}
+
+export class ProjectSuggestionExistsError extends Error {
+  constructor(id: string) {
+    super(`Project suggestion ${id} already exists`);
+    this.name = "ProjectSuggestionExistsError";
+  }
+}
+
+export class ProjectSuggestionNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Project suggestion ${id} does not exist`);
+    this.name = "ProjectSuggestionNotFoundError";
+  }
+}

--- a/packages/core/src/store/project-update-store.ts
+++ b/packages/core/src/store/project-update-store.ts
@@ -1,0 +1,23 @@
+import type { ProjectUpdate, ProjectUpdateSourceKind } from "../schemas/project-update.js";
+
+export interface ListProjectUpdatesInput {
+  project_id?: string;
+  candidate_fingerprint?: string;
+  source_kind?: ProjectUpdateSourceKind;
+  source_ref?: string;
+  limit?: number;
+}
+
+export interface ProjectUpdateStore {
+  append(update: ProjectUpdate, actorId?: string): ProjectUpdate;
+  getById(id: string): ProjectUpdate | null;
+  getByFingerprint(fingerprint: string): ProjectUpdate | null;
+  list(input?: ListProjectUpdatesInput): ProjectUpdate[];
+}
+
+export class ProjectUpdateExistsError extends Error {
+  constructor(id: string) {
+    super(`Project update ${id} already exists; project updates are append-only`);
+    this.name = "ProjectUpdateExistsError";
+  }
+}

--- a/packages/core/src/store/split-memory.ts
+++ b/packages/core/src/store/split-memory.ts
@@ -29,6 +29,8 @@ export interface SplitMemoryStore {
     options?: Record<string, unknown>,
   ) => { memory: { id: string } };
   archiveMemory: (id: string, agent_id?: string) => unknown;
+  /** Optional read seam used to preserve project associations on replacements. */
+  getMemory?: (id: string) => { project_keys?: string[] } | null;
 }
 
 /** One replacement to spin out of the source — a ready-to-write createMemory call. */
@@ -58,9 +60,24 @@ export interface SplitMemoryRequest {
  * what they file, identical in how they file it).
  */
 export function splitMemory(store: SplitMemoryStore, request: SplitMemoryRequest): string[] {
-  const targets = request.replacements.map((r) => store.createMemory(r.input, r.options).memory.id);
+  const sourceKeys = store.getMemory?.(request.sourceId)?.project_keys ?? [];
+  const targets = request.replacements.map((replacement) => {
+    const explicit = Array.isArray(replacement.input.project_keys)
+      ? (replacement.input.project_keys as string[])
+      : [];
+    const projectKeys = stableUnion(sourceKeys, explicit);
+    const input =
+      projectKeys.length > 0
+        ? { ...replacement.input, project_keys: projectKeys }
+        : replacement.input;
+    return store.createMemory(input, replacement.options).memory.id;
+  });
   if (request.archiveActorId !== undefined) {
     store.archiveMemory(request.sourceId, request.archiveActorId);
   }
   return targets;
+}
+
+function stableUnion(...groups: string[][]): string[] {
+  return [...new Set(groups.flat())];
 }

--- a/packages/core/src/store/vault-files.ts
+++ b/packages/core/src/store/vault-files.ts
@@ -33,9 +33,21 @@ import { renameWikilinkTarget } from "./corpus/wikilink.js";
 import type { FileCommit, GitHistory } from "./git/git-history.js";
 import { parseHandoffDocument } from "./markdown/handoff-doc.js";
 import { parseMemoryDocument, serializeMemoryDocument } from "./markdown/memory-doc.js";
+import { parseProjectDocument } from "./markdown/project-doc.js";
+import { parseProjectSuggestionDocument } from "./markdown/project-suggestion-doc.js";
+import { parseProjectUpdateDocument } from "./markdown/project-update-doc.js";
 
 /** What a vault path IS, deciding which validation rules a write must pass. */
-export type VaultFileKind = "memory" | "handoff" | "reference" | "primer" | "curator" | "other";
+export type VaultFileKind =
+  | "memory"
+  | "handoff"
+  | "project"
+  | "project-update"
+  | "project-suggestion"
+  | "reference"
+  | "primer"
+  | "curator"
+  | "other";
 
 export interface VaultTreeNode {
   /** Basename (e.g. "primer.md", "memories"). */
@@ -197,9 +209,17 @@ const HIDDEN_TOP_LEVEL = new Set([".git", ".index", "inbox"]);
 // (spec 062, `validateShelfSet`) reject a shelf prefix whose first segment shadows a
 // canonical name, reusing the SAME source-of-truth list instead of duplicating it.
 export const CANONICAL_TOP_LEVEL = new Map(
-  [...HIDDEN_TOP_LEVEL, ".curator", "memories", "handoffs", "references", PRIMER_PATH].map(
-    (name) => [name.toLowerCase(), name] as const,
-  ),
+  [
+    ...HIDDEN_TOP_LEVEL,
+    ".curator",
+    "memories",
+    "handoffs",
+    "projects",
+    "project-updates",
+    "project-suggestions",
+    "references",
+    PRIMER_PATH,
+  ].map((name) => [name.toLowerCase(), name] as const),
 );
 
 /** Is this tree entry part of the visible explorer surface? */
@@ -303,6 +323,9 @@ export function vaultFileKind(relPath: string, prefix: string = ""): VaultFileKi
   if (relative.startsWith(".curator/")) return "curator";
   if (relative.startsWith("memories/")) return "memory";
   if (relative.startsWith("handoffs/")) return "handoff";
+  if (relative.startsWith("projects/")) return "project";
+  if (relative.startsWith("project-updates/")) return "project-update";
+  if (relative.startsWith("project-suggestions/")) return "project-suggestion";
   if (relative.startsWith("references/")) return "reference";
   return "other";
 }
@@ -318,6 +341,21 @@ function missingHandoffHeadings(body: string): string[] {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function projectDocumentPathError(
+  relPath: string,
+  prefix: string,
+  directory: string,
+  id: string,
+): string | null {
+  const relative = prefix === "" ? relPath : relPath.slice(prefix.length);
+  const expected = `${directory}/${id}.md`;
+  if (relative === expected) return null;
+  if (relative.split("/").length !== 2) {
+    return `project documents must live directly under ${directory}/`;
+  }
+  return `project document filename must match immutable id '${id}' (expected '${expected}')`;
 }
 
 /**
@@ -364,6 +402,38 @@ export function validateVaultFile(relPath: string, raw: string, prefix: string =
         errors.push(`document body is missing the required heading '## ${heading}'`);
       }
       return errors;
+    }
+    case "project": {
+      try {
+        const project = parseProjectDocument(raw);
+        const pathError = projectDocumentPathError(relPath, prefix, "projects", project.id);
+        return pathError === null ? [] : [pathError];
+      } catch (error) {
+        return [errorMessage(error)];
+      }
+    }
+    case "project-update": {
+      try {
+        const update = parseProjectUpdateDocument(raw);
+        const pathError = projectDocumentPathError(relPath, prefix, "project-updates", update.id);
+        return pathError === null ? [] : [pathError];
+      } catch (error) {
+        return [errorMessage(error)];
+      }
+    }
+    case "project-suggestion": {
+      try {
+        const suggestion = parseProjectSuggestionDocument(raw);
+        const pathError = projectDocumentPathError(
+          relPath,
+          prefix,
+          "project-suggestions",
+          suggestion.id,
+        );
+        return pathError === null ? [] : [pathError];
+      } catch (error) {
+        return [errorMessage(error)];
+      }
     }
     case "primer":
     case "curator": {

--- a/packages/core/src/vault-router.ts
+++ b/packages/core/src/vault-router.ts
@@ -147,8 +147,8 @@ export const defaultVaultRouter: VaultRouter = {
  * (a non-NFC prefix is REFUSED, never silently rewritten — this validator returns void, so
  * rewriting would desync the prefix the router declared from the one the store uses), and a first
  * segment that does not shadow a canonical top-level name (the real {@link CANONICAL_TOP_LEVEL}
- * list: `memories/`, `handoffs/`, `references/`, `.curator/`, `inbox/`, `primer.md`, `.index`,
- * `.git`). The EMPTY prefix is the vault root and is exempt from the syntax rules.
+ * list, including memories, handoffs, projects, project evidence, references and vault
+ * plumbing). The EMPTY prefix is the vault root and is exempt from the syntax rules.
  *
  * Cross-set rules: prefixes are DISJOINT — no duplicates and no nesting (`team/` vs `team/sub/`,
  * and the empty root prefix nests every other) — and the ids of WRITABLE shelves are unique (so
@@ -224,8 +224,7 @@ function validateShelf(shelf: Shelf): void {
     const canonical = CANONICAL_TOP_LEVEL.get(first.toLowerCase()) ?? first;
     throw new Error(
       `${where}: prefix's first segment "${first}" shadows the canonical top-level name ` +
-        `"${canonical}" (memories/, handoffs/, references/, .curator/, inbox/, primer.md, ` +
-        `.index, .git are reserved)`,
+        `"${canonical}" (canonical document directories and vault plumbing are reserved)`,
     );
   }
 }

--- a/packages/core/tests/backup-restore.test.ts
+++ b/packages/core/tests/backup-restore.test.ts
@@ -8,9 +8,11 @@ import {
   RESTORE_FAILED_MARKER,
   RESTORE_MARKER,
   applyPendingRestore,
+  serializeProjectDocument,
   stageRestore,
 } from "@librarian/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { projectRecord } from "./fixtures/project-records.js";
 
 let dataDir: string;
 
@@ -141,6 +143,45 @@ describe("applyPendingRestore", () => {
     );
     writeMarker();
     expect(applyPendingRestore(dataDir).applied).toBe(true);
+  });
+
+  it("accepts a shelf carrying only a valid project record", () => {
+    makeVault(path.join(dataDir, "vault"), "live\n");
+    makeRepoDir(path.join(dataDir, ".restore-staging"), (d) => {
+      const projects = path.join(d, "members", "x", "projects");
+      fs.mkdirSync(projects, { recursive: true });
+      fs.writeFileSync(
+        path.join(projects, "prj_123.md"),
+        serializeProjectDocument(projectRecord()),
+      );
+    });
+    writeMarker();
+    expect(applyPendingRestore(dataDir).applied).toBe(true);
+  });
+
+  it("accepts a root vault carrying only a valid project record", () => {
+    makeVault(path.join(dataDir, "vault"), "live\n");
+    makeRepoDir(path.join(dataDir, ".restore-staging"), (d) => {
+      const projects = path.join(d, "projects");
+      fs.mkdirSync(projects, { recursive: true });
+      fs.writeFileSync(
+        path.join(projects, "prj_123.md"),
+        serializeProjectDocument(projectRecord()),
+      );
+    });
+    writeMarker();
+    expect(applyPendingRestore(dataDir).applied).toBe(true);
+  });
+
+  it("does not accept a foreign nested projects directory without a valid project record", () => {
+    makeVault(path.join(dataDir, "vault"), "live\n");
+    makeRepoDir(path.join(dataDir, ".restore-staging"), (d) => {
+      const projects = path.join(d, "src", "projects");
+      fs.mkdirSync(projects, { recursive: true });
+      fs.writeFileSync(path.join(projects, "README.md"), "ordinary source projects\n");
+    });
+    writeMarker();
+    expect(applyPendingRestore(dataDir).applied).toBe(false);
   });
 
   it("accepts a real shelf tree — the canonical cluster beneath a 2-segment prefix (members/x/)", () => {

--- a/packages/core/tests/corpus-inbox.test.ts
+++ b/packages/core/tests/corpus-inbox.test.ts
@@ -58,7 +58,7 @@ describe("writeInbox", () => {
     expect(ref.relPath).not.toContain(".processing");
   });
 
-  it("round-trips submission hints (agent_id / tags / applies_to)", () => {
+  it("round-trips submission hints (agent_id / tags / applies_to / project_keys)", () => {
     const ref = writeInbox(vault, "Elaine moved to Berlin", {
       now: () => 1000,
       generateId: () => "inbox_a",
@@ -66,12 +66,14 @@ describe("writeInbox", () => {
         agentId: "agent-a",
         tags: ["person", "move"],
         appliesTo: ["Elaine", "Berlin"],
+        projectKeys: ["the-librarian", "website"],
       },
     });
     expect(parseInboxItem(vault.readText(ref.relPath)).hints).toEqual({
       agentId: "agent-a",
       tags: ["person", "move"],
       appliesTo: ["Elaine", "Berlin"],
+      projectKeys: ["the-librarian", "website"],
     });
   });
 
@@ -110,6 +112,7 @@ describe("writeInbox", () => {
       tags: ['tag: with "quote"', "back\\slash"],
       // applies_to is caller-supplied + untrusted — pin its escaping directly.
       appliesTo: ['Elaine "the boss": x\nid: spoofed', "---\ninjected: pwned"],
+      projectKeys: ["safe-project\nforged: true"],
     };
     const ref = writeInbox(vault, "x", { now: () => 1, generateId: () => "inbox_a", hints });
     // The escaping must not break the frontmatter or inject keys — values survive verbatim.

--- a/packages/core/tests/fixtures/project-records.ts
+++ b/packages/core/tests/fixtures/project-records.ts
@@ -1,0 +1,95 @@
+import type { Project, ProjectSuggestion, ProjectUpdate } from "@librarian/core";
+
+export const PROJECT_NOW = "2026-08-06T12:00:00.000Z";
+
+const automaticSection = {
+  content: "Not established from current sources.",
+  ownership: "automatic" as const,
+  source_ids: [] as string[],
+};
+
+export function projectRecord(overrides: Partial<Project> = {}): Project {
+  return {
+    id: "prj_123",
+    key: "the-librarian",
+    display_name: "The Librarian",
+    aliases: ["Librarian"],
+    repository_identifiers: ["code-ministry-ltd/the-librarian"],
+    status: "active",
+    resolution: null,
+    resolved_project_id: null,
+    proposal_rationale: null,
+    proposal_evidence_ids: [],
+    suppression_fingerprint: null,
+    possible_match_ids: [],
+    sections: {
+      what_this_project_is: { ...automaticSection },
+      technology_and_architecture: { ...automaticSection },
+      current_state: { ...automaticSection },
+      last_meaningful_work: { ...automaticSection },
+      planned_next: { ...automaticSection },
+      blockers_and_uncertainties: { ...automaticSection },
+    },
+    compiled_at: null,
+    compiler_version: null,
+    source_watermark: null,
+    source_ids: [],
+    content_hash: null,
+    refresh_status: "not_built",
+    refresh_failure_class: null,
+    pending_source_count: 0,
+    unresolved_conflict_count: 0,
+    last_activity_at: null,
+    created_at: PROJECT_NOW,
+    updated_at: PROJECT_NOW,
+    ...overrides,
+  };
+}
+
+export function projectUpdateRecord(overrides: Partial<ProjectUpdate> = {}): ProjectUpdate {
+  return {
+    id: "pru_123",
+    project_id: "prj_123",
+    candidate_fingerprint: null,
+    suggested_key: null,
+    suggested_name: null,
+    suggested_aliases: [],
+    suggested_repository_identifiers: [],
+    confidence: 0.93,
+    rationale: "The source describes current implementation work.",
+    explicitly_new_project: false,
+    evidence: {
+      overview: [],
+      technology_and_architecture: ["The codebase is a TypeScript monorepo."],
+      completed: [],
+      current: ["The project briefing storage slice is in progress."],
+      planned: ["Build the asynchronous compiler."],
+      blockers: [],
+    },
+    source_kind: "capture",
+    source_ref: "conversation:conv_123",
+    observed_at: "2026-08-06T11:00:00.000Z",
+    captured_at: PROJECT_NOW,
+    shelf_id: "main",
+    fingerprint: "a".repeat(64),
+    ...overrides,
+  };
+}
+
+export function projectSuggestionRecord(
+  overrides: Partial<ProjectSuggestion> = {},
+): ProjectSuggestion {
+  return {
+    id: "prs_123",
+    project_id: "prj_123",
+    section: "current_state",
+    proposed_content: "The storage slice is complete; compiler work is next.",
+    rationale: "New evidence materially changes the pinned current state.",
+    source_ids: ["update:pru_123"],
+    content_hash: "b".repeat(64),
+    status: "pending",
+    created_at: PROJECT_NOW,
+    resolved_at: null,
+    ...overrides,
+  };
+}

--- a/packages/core/tests/grooming-apply.test.ts
+++ b/packages/core/tests/grooming-apply.test.ts
@@ -133,8 +133,8 @@ describe("applyOperations — auto-apply (confidence at/above the threshold)", (
   // create the merged replacement (superseding the sources, carrying the
   // run_id), then archive every source.
   it("merges: creates the replacement and archives the sources atomically", () => {
-    const a = seed({ title: "A", body: "same" });
-    const b = seed({ title: "B", body: "same" });
+    const a = seed({ title: "A", body: "same", project_keys: ["alpha", "shared"] });
+    const b = seed({ title: "B", body: "same", project_keys: ["shared", "beta"] });
     const summary = applyOperations(
       ops({
         operation: {
@@ -161,6 +161,7 @@ describe("applyOperations — auto-apply (confidence at/above the threshold)", (
     expect(merged.status).toBe("active");
     expect(merged.curator_note?.supersedes).toEqual([a.id, b.id]);
     expect(merged.curator_note?.run_id).toBe(s!.runId); // provenance unchanged by the refactor
+    expect(merged.project_keys).toEqual(["alpha", "shared", "beta"]);
   });
 
   it("applies an at-threshold update in place", () => {
@@ -306,7 +307,11 @@ describe("applyOperations — archive/split ALWAYS propose (D13)", () => {
   // status=proposed and the source stays ACTIVE — the admin archives it after
   // accepting (§11.1).
   it("proposes a split's replacements and leaves the source active, even at confidence 1.0", () => {
-    const src = seed({ title: "Mixed", body: "facts about Elaine and Bob" });
+    const src = seed({
+      title: "Mixed",
+      body: "facts about Elaine and Bob",
+      project_keys: ["the-librarian"],
+    });
     const replacement = (title: string, body: string) => ({
       title,
       body,
@@ -328,9 +333,15 @@ describe("applyOperations — archive/split ALWAYS propose (D13)", () => {
       deps(),
     );
     expect(summary.proposed).toBe(1);
+    const targets = recorded().find(
+      (operation) => operation.status === "proposed",
+    )!.target_memory_ids;
+    expect(targets.map((id) => s!.store.getMemory(id)?.project_keys)).toEqual([
+      ["the-librarian"],
+      ["the-librarian"],
+    ]);
     expect(summary.applied).toBe(0);
     expect(s!.store.getMemory(src.id)?.status).toBe("active"); // source NOT archived
-    const targets = recorded()[0]!.target_memory_ids;
     expect(targets.length).toBe(2);
     for (const id of targets) {
       const t = s!.store.getMemory(id)!;
@@ -393,7 +404,7 @@ describe("applyOperations — protected update reconstruction (data integrity)",
     // Active requires-approval memory with a body longer than the evidence
     // truncation cap, plus tags — both must survive a title-only patch.
     const fullBody = "X".repeat(5000);
-    const m = seed({ body: fullBody, tags: ["keep"] });
+    const m = seed({ body: fullBody, tags: ["keep"], project_keys: ["the-librarian"] });
 
     const summary = applyOperations(
       ops({
@@ -417,6 +428,7 @@ describe("applyOperations — protected update reconstruction (data integrity)",
     expect(proposal.title).toBe("Corrected title");
     expect(proposal.body).toBe(fullBody); // full, untruncated, unredacted
     expect(proposal.tags).toContain("keep"); // preserved, not dropped
+    expect(proposal.project_keys).toEqual(["the-librarian"]);
     expect(proposal.curator_note?.supersedes).toEqual([m.id]);
   });
 });

--- a/packages/core/tests/grooming-evidence.test.ts
+++ b/packages/core/tests/grooming-evidence.test.ts
@@ -1,7 +1,7 @@
 // Slice-scoped memory evidence gathering for the curator (spec §9).
 //
-// Memories are project-less, so grooming runs over a SINGLE common_global
-// slice: every live memory feeds it. The load-bearing guard here is the
+// Project associations are metadata, so grooming still runs over a SINGLE
+// common_global slice and every live memory feeds it. The load-bearing guard is
 // SECURITY guard — redaction-before-return: secret-looking material is scrubbed
 // from evidence BEFORE it can be handed to the prompt builder (§9, §10.4); by
 // output-validation time the value would already have left the building.
@@ -61,7 +61,7 @@ function gather(caps: { maxMemories: number; maxBodyChars?: number }) {
 }
 
 describe("gatherMemoryEvidence — the single global slice", () => {
-  it("the global slice gathers every active memory (memories are project-less)", () => {
+  it("the global slice gathers every active memory regardless of project associations", () => {
     const one = seed({ title: "one" }).memory;
     const two = seed({ title: "two" }).memory;
 
@@ -76,6 +76,12 @@ describe("gatherMemoryEvidence — the single global slice", () => {
     const m = seed({ title: "common-by-agent", agent_id: "agent-z" }).memory;
     const bundle = gather({ maxMemories: 50 });
     expect(bundle.activeMemories.map((x) => x.id)).toContain(m.id);
+  });
+
+  it("carries project associations as evidence without changing the model output contract", () => {
+    const memory = seed({ title: "project fact", project_keys: ["the-librarian"] }).memory;
+    const item = gather({ maxMemories: 50 }).activeMemories.find((row) => row.id === memory.id);
+    expect(item?.projectKeys).toEqual(["the-librarian"]);
   });
 });
 

--- a/packages/core/tests/grooming-source-vault.test.ts
+++ b/packages/core/tests/grooming-source-vault.test.ts
@@ -1,7 +1,6 @@
-// Vault-backed GroomingMemorySource (plan 036 Phase 4). Memories are
-// project-less, so grooming runs over a SINGLE common_global slice: every live
-// memory feeds it. Active/proposed feed slices + evidence, archived feed
-// tombstones (no body, archiveReason null).
+// Vault-backed GroomingMemorySource (plan 036 Phase 4). Optional project
+// associations do not restore project slices: grooming runs over one
+// common_global slice and every live memory feeds it.
 
 import { type Memory, createVaultGroomingMemorySource } from "@librarian/core";
 import { describe, expect, it } from "vitest";
@@ -89,10 +88,18 @@ describe("createVaultGroomingMemorySource — selectMemories (global slice)", ()
   });
 
   it("maps the verdict booleans onto the record", () => {
-    const source = sourceOf([mem({ id: "p", requires_approval: true, is_global: true })]);
+    const source = sourceOf([
+      mem({
+        id: "p",
+        requires_approval: true,
+        is_global: true,
+        project_keys: ["the-librarian"],
+      }),
+    ]);
     const [rec] = source.selectMemories(GLOBAL, "active", 50);
     expect(rec?.requiresApproval).toBe(true);
     expect(rec?.isGlobal).toBe(true);
+    expect(rec?.projectKeys).toEqual(["the-librarian"]);
   });
 
   it("marks hasOpenCuratorFlag only for an open flag from the curator actor (review F2)", () => {

--- a/packages/core/tests/intake-apply.test.ts
+++ b/packages/core/tests/intake-apply.test.ts
@@ -11,6 +11,7 @@ interface SeedDoc {
   body: string;
   requires_approval?: boolean;
   flags?: { agent_id: string }[];
+  project_keys?: string[];
 }
 
 function fakeStore(seed: Record<string, SeedDoc> = {}) {
@@ -26,7 +27,13 @@ function fakeStore(seed: Record<string, SeedDoc> = {}) {
     createMemory: (input, options) => {
       const id = `mem_new_${n++}`;
       calls.create.push({ input, ...(options ? { options } : {}) });
-      docs.set(id, { title: String(input.title ?? ""), body: String(input.body ?? "") });
+      docs.set(id, {
+        title: String(input.title ?? ""),
+        body: String(input.body ?? ""),
+        ...(Array.isArray(input.project_keys)
+          ? { project_keys: input.project_keys as string[] }
+          : {}),
+      });
       return { memory: { id } };
     },
     updateMemory: (id, patch) => {
@@ -165,11 +172,16 @@ describe("applyIntakeJudgment — apply lane (confidence at/above the threshold)
       store,
       submissionText: "x",
       actorId: "system-consolidator",
-      submissionHints: { agentId: "agent-a", tags: ["ignored"] },
+      submissionHints: {
+        agentId: "agent-a",
+        tags: ["ignored"],
+        projectKeys: ["the-librarian"],
+      },
     });
     expect(calls.create[0]?.input).toMatchObject({
       agent_id: "agent-a",
       tags: ["judged"], // the judge curated these; the submission's tags don't override
+      project_keys: ["the-librarian"],
     });
   });
 
@@ -183,10 +195,32 @@ describe("applyIntakeJudgment — apply lane (confidence at/above the threshold)
         store,
         submissionText: "x",
         actorId: "system-consolidator",
-        submissionHints: { agentId: "agent-a" },
+        submissionHints: { agentId: "agent-a", projectKeys: ["other-project"] },
       },
     );
     expect(Object.keys(calls.update[0]?.patch ?? {})).toEqual(["body"]); // no agent_id
+  });
+
+  it("a proposed split inherits the source project keys", () => {
+    const { store, calls } = fakeStore({
+      mem_mixed: { title: "Mixed", body: "Two facts", project_keys: ["the-librarian"] },
+    });
+    const out = applyIntakeJudgment(
+      judgment({
+        action: "split",
+        target_id: "mem_mixed",
+        replacements: [
+          { title: "A", body: "A fact", tags: [] },
+          { title: "B", body: "B fact", tags: [] },
+        ],
+      }),
+      deps(store),
+    );
+    expect(out).toMatchObject({ kind: "proposed" });
+    expect(calls.create.map((call) => call.input.project_keys)).toEqual([
+      ["the-librarian"],
+      ["the-librarian"],
+    ]);
   });
 
   it("a store rejection (e.g. protected target) becomes a rejected outcome, not a throw", () => {

--- a/packages/core/tests/migrate-data-dir.test.ts
+++ b/packages/core/tests/migrate-data-dir.test.ts
@@ -37,7 +37,7 @@ id: mem_legacy1
 title: Legacy memory
 agent_id: cli
 status: active
-project_key: null
+project_key: legacy-project
 domain: work
 category: tools
 visibility: common
@@ -115,9 +115,7 @@ curator_note: null
 Already in the current shape.
 `;
 
-// A handoff doc carrying a LIVE `project_key` frontmatter field. The frontmatter
-// sweep is scoped to memories/ only, so handoff project_key must survive — it is
-// retired ONLY on memories, never on handoffs.
+// A handoff doc carrying its native scalar `project_key` frontmatter field.
 const HANDOFF_DOC = `---
 id: handoff_live1
 title: Live handoff
@@ -321,7 +319,6 @@ describe("migrateDataDir (rethink T26, spec §10)", () => {
       "last_recalled_at",
       "recall_count",
       "usefulness_score",
-      "project_key",
       "priority",
     ]) {
       expect(swept).not.toContain(`${field}:`);
@@ -332,7 +329,9 @@ describe("migrateDataDir (rethink T26, spec §10)", () => {
       id: "mem_legacy1",
       status: "active",
       body: "The user prefers tabs over spaces.",
+      project_keys: ["legacy-project"],
     });
+    expect(matter(swept).data.project_key).toBe("legacy-project");
 
     // The proposal's retired curator_note tags are stripped; the proposal survives.
     const proposal = matter(
@@ -354,7 +353,7 @@ describe("migrateDataDir (rethink T26, spec §10)", () => {
     const handoff = matter(
       fs.readFileSync(path.join(vaultDir(), "handoffs", "live-handoff-live1.md"), "utf8"),
     );
-    // project_key is RETIRED on memories but LIVE on handoffs — it must survive.
+    // The scalar remains live compatibility input for memories and handoffs.
     expect(handoff.data.project_key).toBe("the-librarian");
   });
 

--- a/packages/core/tests/schemas/project-suggestion.test.ts
+++ b/packages/core/tests/schemas/project-suggestion.test.ts
@@ -1,0 +1,92 @@
+import { ProjectSuggestionSchema, type ProjectSuggestion } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+const createdAt = "2026-08-06T12:00:00.000Z";
+
+function suggestion(overrides: Partial<ProjectSuggestion> = {}): ProjectSuggestion {
+  return {
+    id: "prs_123",
+    project_id: "prj_123",
+    section: "current_state",
+    proposed_content: "The storage layer is complete and the compiler is next.",
+    rationale: "New evidence materially changes the pinned current state.",
+    source_ids: ["update:pru_123"],
+    content_hash: "c".repeat(64),
+    status: "pending",
+    created_at: createdAt,
+    resolved_at: null,
+    ...overrides,
+  };
+}
+
+describe("ProjectSuggestionSchema", () => {
+  it("accepts one of the six project sections", () => {
+    for (const section of [
+      "what_this_project_is",
+      "technology_and_architecture",
+      "current_state",
+      "last_meaningful_work",
+      "planned_next",
+      "blockers_and_uncertainties",
+    ] as const) {
+      expect(ProjectSuggestionSchema.safeParse(suggestion({ section })).success).toBe(true);
+    }
+  });
+
+  it("rejects unknown fields", () => {
+    expect(ProjectSuggestionSchema.safeParse({ ...suggestion(), surprise: true }).success).toBe(
+      false,
+    );
+  });
+
+  it("bounds content and requires grounded source ids", () => {
+    expect(
+      ProjectSuggestionSchema.safeParse(suggestion({ proposed_content: "x".repeat(12_001) }))
+        .success,
+    ).toBe(false);
+    expect(ProjectSuggestionSchema.safeParse(suggestion({ source_ids: [] })).success).toBe(false);
+    expect(
+      ProjectSuggestionSchema.safeParse(suggestion({ source_ids: Array(51).fill("update:1") }))
+        .success,
+    ).toBe(false);
+    expect(
+      ProjectSuggestionSchema.safeParse(
+        suggestion({ source_ids: ["update:pru_123", "update:pru_123"] }),
+      ).success,
+    ).toBe(false);
+  });
+
+  it("enforces pending and resolved lifecycle timestamps", () => {
+    expect(
+      ProjectSuggestionSchema.safeParse(
+        suggestion({ status: "accepted", resolved_at: "2026-08-06T13:00:00.000Z" }),
+      ).success,
+    ).toBe(true);
+    expect(ProjectSuggestionSchema.safeParse(suggestion({ status: "accepted" })).success).toBe(
+      false,
+    );
+    expect(
+      ProjectSuggestionSchema.safeParse(
+        suggestion({ status: "pending", resolved_at: "2026-08-06T13:00:00.000Z" }),
+      ).success,
+    ).toBe(false);
+  });
+
+  it("requires safe ids, known sections, hashes and timestamps", () => {
+    expect(ProjectSuggestionSchema.safeParse(suggestion({ id: "../suggestion" })).success).toBe(
+      false,
+    );
+    expect(ProjectSuggestionSchema.safeParse(suggestion({ project_id: "a/b" })).success).toBe(
+      false,
+    );
+    expect(
+      ProjectSuggestionSchema.safeParse(suggestion({ section: "history" as never })).success,
+    ).toBe(false);
+    expect(ProjectSuggestionSchema.safeParse(suggestion({ content_hash: "bad" })).success).toBe(
+      false,
+    );
+    expect(ProjectSuggestionSchema.safeParse(suggestion({ created_at: "today" })).success).toBe(
+      false,
+    );
+  });
+});

--- a/packages/core/tests/schemas/project-update.test.ts
+++ b/packages/core/tests/schemas/project-update.test.ts
@@ -1,0 +1,141 @@
+import { ProjectUpdateSchema, type ProjectUpdate } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+const observedAt = "2026-08-06T11:00:00.000Z";
+const capturedAt = "2026-08-06T12:00:00.000Z";
+
+function update(overrides: Partial<ProjectUpdate> = {}): ProjectUpdate {
+  return {
+    id: "pru_123",
+    project_id: null,
+    candidate_fingerprint: "a".repeat(64),
+    suggested_key: "the-librarian",
+    suggested_name: "The Librarian",
+    suggested_aliases: [],
+    suggested_repository_identifiers: ["code-ministry-ltd/the-librarian"],
+    confidence: 0.96,
+    rationale: "The source explicitly names an ongoing repository.",
+    explicitly_new_project: true,
+    evidence: {
+      overview: ["A durable memory service for agents."],
+      technology_and_architecture: ["A TypeScript monorepo with Markdown storage."],
+      completed: [],
+      current: ["Project briefing storage is being built."],
+      planned: ["Add materialised briefing compilation."],
+      blockers: [],
+    },
+    source_kind: "capture",
+    source_ref: "conversation:conv_123",
+    observed_at: observedAt,
+    captured_at: capturedAt,
+    shelf_id: "personal",
+    fingerprint: "b".repeat(64),
+    ...overrides,
+  };
+}
+
+describe("ProjectUpdateSchema", () => {
+  it("accepts bounded candidate evidence from every supported source kind", () => {
+    for (const source_kind of ["intake", "capture", "handoff", "admin"] as const) {
+      expect(ProjectUpdateSchema.safeParse(update({ source_kind })).success).toBe(true);
+    }
+  });
+
+  it("is strict at the update and evidence boundaries", () => {
+    expect(ProjectUpdateSchema.safeParse({ ...update(), surprise: true }).success).toBe(false);
+    expect(
+      ProjectUpdateSchema.safeParse({
+        ...update(),
+        evidence: { ...update().evidence, surprise: [] },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("requires exactly one matched or candidate identity", () => {
+    expect(
+      ProjectUpdateSchema.safeParse(
+        update({
+          project_id: "prj_existing",
+          candidate_fingerprint: null,
+          suggested_key: null,
+          suggested_name: null,
+          suggested_repository_identifiers: [],
+        }),
+      ).success,
+    ).toBe(true);
+    expect(ProjectUpdateSchema.safeParse(update({ project_id: "prj_existing" })).success).toBe(
+      false,
+    );
+    expect(
+      ProjectUpdateSchema.safeParse(
+        update({ candidate_fingerprint: null, suggested_key: null, suggested_name: null }),
+      ).success,
+    ).toBe(false);
+  });
+
+  it("requires candidate identity details and forbids them on a matched update", () => {
+    expect(ProjectUpdateSchema.safeParse(update({ suggested_name: null })).success).toBe(false);
+    expect(ProjectUpdateSchema.safeParse(update({ suggested_key: null })).success).toBe(false);
+    expect(
+      ProjectUpdateSchema.safeParse(
+        update({
+          project_id: "prj_existing",
+          candidate_fingerprint: null,
+          suggested_key: "wrong",
+          suggested_name: null,
+          suggested_repository_identifiers: [],
+        }),
+      ).success,
+    ).toBe(false);
+  });
+
+  it("bounds evidence, source references and confidence", () => {
+    expect(ProjectUpdateSchema.safeParse(update({ confidence: 1.01 })).success).toBe(false);
+    expect(ProjectUpdateSchema.safeParse(update({ source_ref: "x".repeat(513) })).success).toBe(
+      false,
+    );
+    expect(
+      ProjectUpdateSchema.safeParse(
+        update({ evidence: { ...update().evidence, current: Array(26).fill("state") } }),
+      ).success,
+    ).toBe(false);
+    expect(
+      ProjectUpdateSchema.safeParse(
+        update({ evidence: { ...update().evidence, current: ["x".repeat(1_001)] } }),
+      ).success,
+    ).toBe(false);
+    expect(
+      ProjectUpdateSchema.safeParse(
+        update({
+          evidence: {
+            overview: [],
+            technology_and_architecture: [],
+            completed: [],
+            current: [],
+            planned: [],
+            blockers: [],
+          },
+        }),
+      ).success,
+    ).toBe(false);
+  });
+
+  it("requires path-safe ids, SHA-256 fingerprints and ISO timestamps", () => {
+    expect(ProjectUpdateSchema.safeParse(update({ id: "../update" })).success).toBe(false);
+    expect(ProjectUpdateSchema.safeParse(update({ fingerprint: "not-a-hash" })).success).toBe(
+      false,
+    );
+    expect(ProjectUpdateSchema.safeParse(update({ observed_at: "today" })).success).toBe(false);
+    expect(ProjectUpdateSchema.safeParse(update({ captured_at: "2026-08-06" })).success).toBe(
+      false,
+    );
+    expect(
+      ProjectUpdateSchema.safeParse(
+        update({
+          observed_at: "2026-08-06T13:00:00.000Z",
+          captured_at: "2026-08-06T12:00:00.000Z",
+        }),
+      ).success,
+    ).toBe(false);
+  });
+});

--- a/packages/core/tests/schemas/project.test.ts
+++ b/packages/core/tests/schemas/project.test.ts
@@ -1,0 +1,192 @@
+import { PROJECT_SECTION_KEYS, ProjectSchema, type Project } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+
+const now = "2026-08-06T12:00:00.000Z";
+
+const automaticSection = {
+  content: "Not established from current sources.",
+  ownership: "automatic" as const,
+  source_ids: [],
+};
+
+function project(overrides: Partial<Project> = {}): Project {
+  return {
+    id: "prj_123",
+    key: "the-librarian",
+    display_name: "The Librarian",
+    aliases: ["Librarian"],
+    repository_identifiers: ["code-ministry-ltd/the-librarian"],
+    status: "active",
+    resolution: null,
+    resolved_project_id: null,
+    proposal_rationale: null,
+    proposal_evidence_ids: [],
+    suppression_fingerprint: null,
+    possible_match_ids: [],
+    sections: {
+      what_this_project_is: automaticSection,
+      technology_and_architecture: automaticSection,
+      current_state: automaticSection,
+      last_meaningful_work: automaticSection,
+      planned_next: automaticSection,
+      blockers_and_uncertainties: automaticSection,
+    },
+    compiled_at: null,
+    compiler_version: null,
+    source_watermark: null,
+    source_ids: [],
+    content_hash: null,
+    refresh_status: "not_built",
+    refresh_failure_class: null,
+    pending_source_count: 0,
+    unresolved_conflict_count: 0,
+    last_activity_at: null,
+    created_at: now,
+    updated_at: now,
+    ...overrides,
+  };
+}
+
+describe("ProjectSchema", () => {
+  it("accepts the six fixed sections and both ownership values", () => {
+    const value = project({
+      sections: {
+        ...project().sections,
+        current_state: {
+          content: "The first storage slice is in progress.",
+          ownership: "pinned",
+          source_ids: ["memory:mem_123"],
+        },
+      },
+    });
+
+    expect(ProjectSchema.parse(value)).toEqual(value);
+    expect(PROJECT_SECTION_KEYS).toEqual([
+      "what_this_project_is",
+      "technology_and_architecture",
+      "current_state",
+      "last_meaningful_work",
+      "planned_next",
+      "blockers_and_uncertainties",
+    ]);
+  });
+
+  it("rejects unknown fields at every object boundary", () => {
+    expect(ProjectSchema.safeParse({ ...project(), surprise: true }).success).toBe(false);
+    expect(
+      ProjectSchema.safeParse({
+        ...project(),
+        sections: {
+          ...project().sections,
+          current_state: { ...automaticSection, surprise: true },
+        },
+      }).success,
+    ).toBe(false);
+    expect(
+      ProjectSchema.safeParse({
+        ...project(),
+        sections: { ...project().sections, surprise: automaticSection },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("enforces path-safe ids and stable lower-case project keys", () => {
+    for (const id of ["../other", "/absolute", "nested/path", "nested\\path", ".", "a\nb"]) {
+      expect(ProjectSchema.safeParse(project({ id })).success).toBe(false);
+    }
+    for (const key of ["Uppercase", "two words", "-leading", "trailing-", "a/b", "a".repeat(65)]) {
+      expect(ProjectSchema.safeParse(project({ key })).success).toBe(false);
+    }
+    expect(ProjectSchema.safeParse(project({ key: "briefing-v1" })).success).toBe(true);
+  });
+
+  it("bounds identity, section content and source collections", () => {
+    expect(ProjectSchema.safeParse(project({ display_name: "x".repeat(121) })).success).toBe(false);
+    expect(ProjectSchema.safeParse(project({ aliases: Array(21).fill("alias") })).success).toBe(
+      false,
+    );
+    expect(
+      ProjectSchema.safeParse(
+        project({
+          sections: {
+            ...project().sections,
+            current_state: { ...automaticSection, content: "x".repeat(12_001) },
+          },
+        }),
+      ).success,
+    ).toBe(false);
+    expect(
+      ProjectSchema.safeParse(project({ source_ids: Array(201).fill("memory:mem_1") })).success,
+    ).toBe(false);
+    expect(ProjectSchema.safeParse(project({ source_ids: ["x".repeat(513)] })).success).toBe(false);
+  });
+
+  it("requires valid UTC ISO timestamps", () => {
+    expect(ProjectSchema.safeParse(project({ created_at: "yesterday" })).success).toBe(false);
+    expect(ProjectSchema.safeParse(project({ compiled_at: "2026-08-06" })).success).toBe(false);
+    expect(ProjectSchema.safeParse(project({ last_activity_at: "not-a-time" })).success).toBe(
+      false,
+    );
+    expect(
+      ProjectSchema.safeParse(
+        project({
+          created_at: "2026-08-06T13:00:00.000Z",
+          updated_at: "2026-08-06T12:00:00.000Z",
+        }),
+      ).success,
+    ).toBe(false);
+  });
+
+  it("enforces proposal and resolution lifecycle combinations", () => {
+    expect(
+      ProjectSchema.safeParse(
+        project({
+          status: "proposed",
+          proposal_rationale: "A durable named repository was explicitly described.",
+          proposal_evidence_ids: ["capture:conversation-1"],
+        }),
+      ).success,
+    ).toBe(true);
+    expect(ProjectSchema.safeParse(project({ status: "proposed" })).success).toBe(false);
+    expect(ProjectSchema.safeParse(project({ resolution: "rejected" })).success).toBe(false);
+    expect(
+      ProjectSchema.safeParse(
+        project({ status: "archived", resolution: "rejected", suppression_fingerprint: null }),
+      ).success,
+    ).toBe(false);
+    expect(
+      ProjectSchema.safeParse(
+        project({
+          status: "archived",
+          resolution: "rejected",
+          suppression_fingerprint: "a".repeat(64),
+        }),
+      ).success,
+    ).toBe(true);
+    expect(
+      ProjectSchema.safeParse(
+        project({
+          status: "archived",
+          resolution: "belongs_to_existing",
+          resolved_project_id: "prj_existing",
+        }),
+      ).success,
+    ).toBe(true);
+    expect(
+      ProjectSchema.safeParse(project({ status: "archived", resolution: "belongs_to_existing" }))
+        .success,
+    ).toBe(false);
+  });
+
+  it("requires a content-free failure class only for failed refreshes", () => {
+    expect(
+      ProjectSchema.safeParse(
+        project({ refresh_status: "failed", refresh_failure_class: "provider_timeout" }),
+      ).success,
+    ).toBe(true);
+    expect(ProjectSchema.safeParse(project({ refresh_status: "failed" })).success).toBe(false);
+    expect(
+      ProjectSchema.safeParse(project({ refresh_failure_class: "provider_timeout" })).success,
+    ).toBe(false);
+  });
+});

--- a/packages/core/tests/store/actor-trailers.test.ts
+++ b/packages/core/tests/store/actor-trailers.test.ts
@@ -12,6 +12,11 @@ import os from "node:os";
 import path from "node:path";
 import { type LibrarianStore, type LlmClient, createLibrarianStore } from "@librarian/core";
 import { afterEach, describe, expect, it } from "vitest";
+import {
+  projectRecord,
+  projectSuggestionRecord,
+  projectUpdateRecord,
+} from "../fixtures/project-records.js";
 
 const dataDirs: string[] = [];
 afterEach(() => {
@@ -185,6 +190,37 @@ describe("actor trailers on every verb (spec 064 T4 / SC 4)", () => {
     expect(trailer(vaultRoot)).toBe("");
     expect(updatedByOf(vaultRoot, rel)).toBe("bob");
 
+    store.close();
+  });
+
+  it("project, update and suggestion mutations trailer their acting principals", () => {
+    const { store, vaultRoot } = freshStore();
+    const project = store.projects.create(projectRecord(), "admin-alice");
+    expect(subject(vaultRoot)).toBe("project: create prj_123");
+    expect(trailer(vaultRoot)).toBe("admin-alice");
+
+    store.projects.update({ ...project, updated_at: "2026-08-06T13:00:00.000Z" }, "curator-bob");
+    expect(subject(vaultRoot)).toBe("project: update prj_123");
+    expect(trailer(vaultRoot)).toBe("curator-bob");
+
+    store.projectUpdates.append(projectUpdateRecord(), "curator-carol");
+    expect(subject(vaultRoot)).toBe("project-update: append pru_123");
+    expect(trailer(vaultRoot)).toBe("curator-carol");
+
+    const suggestion = store.projectSuggestions.create(projectSuggestionRecord(), "curator-dave");
+    expect(subject(vaultRoot)).toBe("project-suggestion: create prs_123");
+    expect(trailer(vaultRoot)).toBe("curator-dave");
+
+    store.projectSuggestions.update(
+      {
+        ...suggestion,
+        status: "rejected",
+        resolved_at: "2026-08-06T13:00:00.000Z",
+      },
+      "admin-eve",
+    );
+    expect(subject(vaultRoot)).toBe("project-suggestion: update prs_123");
+    expect(trailer(vaultRoot)).toBe("admin-eve");
     store.close();
   });
 });

--- a/packages/core/tests/store/commit-message.test.ts
+++ b/packages/core/tests/store/commit-message.test.ts
@@ -30,6 +30,12 @@ describe("commit-subject vocabulary (spec 064 T1)", () => {
     expect(commitSubject.handoffClaim("hdo_1")).toBe("handoff: claim hdo_1");
     expect(commitSubject.handoffPurge("hdo_1")).toBe("handoff: purge hdo_1");
 
+    expect(commitSubject.projectCreate("prj_1")).toBe("project: create prj_1");
+    expect(commitSubject.projectUpdate("prj_1")).toBe("project: update prj_1");
+    expect(commitSubject.projectUpdateAppend("pru_1")).toBe("project-update: append pru_1");
+    expect(commitSubject.projectSuggestionCreate("prs_1")).toBe("project-suggestion: create prs_1");
+    expect(commitSubject.projectSuggestionUpdate("prs_1")).toBe("project-suggestion: update prs_1");
+
     expect(commitSubject.inboxSubmit("inbox_1")).toBe("inbox: submit inbox_1");
     expect(commitSubject.inboxConsolidateSweep()).toBe("inbox: consolidate sweep");
 
@@ -80,5 +86,11 @@ describe("commit-subject vocabulary (spec 064 T1)", () => {
     );
     expect(commitSubject.curatorAddendum("intake\r")).toBe("curator: addendum intake");
     expect(commitSubject.inboxSubmit("id\nwith\nnewlines")).toBe("inbox: submit idwithnewlines");
+    expect(commitSubject.projectCreate("prj_1\nLibrarian-Actor: root")).toBe(
+      "project: create prj_1Librarian-Actor: root",
+    );
+    expect(commitSubject.projectUpdateAppend("pru_1\r\nforged")).toBe(
+      "project-update: append pru_1forged",
+    );
   });
 });

--- a/packages/core/tests/store/markdown/markdown-memory-mutations.test.ts
+++ b/packages/core/tests/store/markdown/markdown-memory-mutations.test.ts
@@ -40,6 +40,7 @@ function setup() {
       confidence: "working",
       tags: over.tags ?? [],
       applies_to: [],
+      ...(over.project_keys !== undefined ? { project_keys: over.project_keys } : {}),
       supersedes: [],
       conflicts_with: [],
       status: over.status ?? "active",
@@ -63,6 +64,14 @@ describe("markdown MemoryStore — updateMemory", () => {
     expect(updated!.title).toBe("new");
     expect(updated!.body).toBe("new body");
     expect(updated!.updated_at).toBe(NOW);
+  });
+
+  it("preserves project_keys when omitted and clears them only for an explicit empty array", () => {
+    const { store, seed } = setup();
+    seed({ id: "m", project_keys: ["the-librarian"] });
+
+    expect(store.updateMemory("m", { body: "new" })?.project_keys).toEqual(["the-librarian"]);
+    expect(store.updateMemory("m", { project_keys: [] })?.project_keys).toEqual([]);
   });
 
   it("throws for an unknown id", () => {

--- a/packages/core/tests/store/markdown/markdown-memory-reads.test.ts
+++ b/packages/core/tests/store/markdown/markdown-memory-reads.test.ts
@@ -39,6 +39,7 @@ function setup() {
       confidence: over.confidence ?? "working",
       tags: over.tags ?? [],
       applies_to: over.applies_to ?? [],
+      ...(over.project_keys !== undefined ? { project_keys: over.project_keys } : {}),
       supersedes: [],
       conflicts_with: [],
       status: over.status ?? "active",
@@ -111,6 +112,24 @@ describe("markdown MemoryStore — listMemories", () => {
     expect(store.listMemories({ requires_approval: true }).memories.map((m) => m.id)).toEqual([
       "c",
     ]);
+  });
+
+  it("filters project_keys by exact membership, with any requested key matching", () => {
+    const { store, seed } = setup();
+    seed({ id: "exact", project_keys: ["lib"] });
+    seed({ id: "longer", project_keys: ["the-lib"] });
+    seed({ id: "other", project_keys: ["website"] });
+    seed({ id: "absent" });
+
+    expect(store.listMemories({ project_keys: ["lib"] }).memories.map((m) => m.id)).toEqual([
+      "exact",
+    ]);
+    expect(
+      store
+        .listMemories({ project_keys: ["lib", "website"] })
+        .memories.map((m) => m.id)
+        .sort(),
+    ).toEqual(["exact", "other"]);
   });
 
   it("filters by created_at from/to (to is end-of-day inclusive)", () => {

--- a/packages/core/tests/store/markdown/markdown-memory-store.test.ts
+++ b/packages/core/tests/store/markdown/markdown-memory-store.test.ts
@@ -64,6 +64,24 @@ describe("markdown MemoryStore — createMemory + getMemory", () => {
     expect(store.getMemory(memory.id)).toEqual(memory);
   });
 
+  it("creates a memory with optional project associations and leaves them absent when omitted", () => {
+    const { store } = makeStore();
+    const associated = store.createMemory({
+      agent_id: "codex",
+      title: "Briefing evidence",
+      body: "The compiler is live.",
+      project_keys: ["the-librarian"],
+    }).memory;
+    const unassociated = store.createMemory({
+      agent_id: "codex",
+      title: "General",
+      body: "Fact",
+    }).memory;
+
+    expect(associated.project_keys).toEqual(["the-librarian"]);
+    expect(unassociated).not.toHaveProperty("project_keys");
+  });
+
   it("getMemory returns null for an unknown id", () => {
     const { store } = makeStore();
     expect(store.getMemory("mem_ghost")).toBeNull();

--- a/packages/core/tests/store/markdown/markdown-project-store.test.ts
+++ b/packages/core/tests/store/markdown/markdown-project-store.test.ts
@@ -1,0 +1,134 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  DuplicateProjectKeyError,
+  ProjectRecordExistsError,
+  ProjectRecordNotFoundError,
+  UnsafeVaultPathError,
+  createMarkdownProjectStore,
+  createVault,
+  serializeProjectDocument,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { projectRecord } from "../../fixtures/project-records.js";
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-project-store-"));
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("Markdown ProjectStore", () => {
+  it("creates, reads, lists, filters and updates one immutable-id document", () => {
+    const vault = createVault({ dataDir });
+    const store = createMarkdownProjectStore({ vault });
+    const first = projectRecord();
+    const second = projectRecord({
+      id: "prj_456",
+      key: "other-project",
+      display_name: "Other project",
+      status: "archived",
+      created_at: "2026-08-05T12:00:00.000Z",
+      updated_at: "2026-08-05T12:00:00.000Z",
+    });
+
+    expect(store.create(first)).toEqual(first);
+    store.create(second);
+    expect(store.getById(first.id)).toEqual(first);
+    expect(store.getByKey("the-librarian")).toEqual(first);
+    expect(store.list().map((project) => project.id)).toEqual([first.id, second.id]);
+    expect(store.list({ status: "archived" }).map((project) => project.id)).toEqual([second.id]);
+
+    const changed = {
+      ...first,
+      display_name: "The Librarian memory service",
+      updated_at: "2026-08-06T13:00:00.000Z",
+    };
+    expect(store.update(changed)).toEqual(changed);
+    expect(store.getById(first.id)?.display_name).toBe("The Librarian memory service");
+    expect(vault.listMarkdown("projects")).toEqual(["projects/prj_123.md", "projects/prj_456.md"]);
+  });
+
+  it("rejects duplicate ids and duplicate keys within the shelf", () => {
+    const store = createMarkdownProjectStore({ vault: createVault({ dataDir }) });
+    store.create(projectRecord());
+    expect(() => store.create(projectRecord())).toThrow(ProjectRecordExistsError);
+    expect(() =>
+      store.create(projectRecord({ id: "prj_456", display_name: "Duplicate key" })),
+    ).toThrow(DuplicateProjectKeyError);
+    expect(() => store.update(projectRecord({ id: "prj_missing" }))).toThrow(
+      ProjectRecordNotFoundError,
+    );
+  });
+
+  it("revalidates key uniqueness on update", () => {
+    const store = createMarkdownProjectStore({ vault: createVault({ dataDir }) });
+    store.create(projectRecord());
+    const second = projectRecord({ id: "prj_456", key: "other", display_name: "Other" });
+    store.create(second);
+    expect(() => store.update({ ...second, key: "the-librarian" })).toThrow(
+      DuplicateProjectKeyError,
+    );
+  });
+
+  it("refuses unsafe lookup ids and a document whose filename disagrees with its id", () => {
+    const vault = createVault({ dataDir });
+    const store = createMarkdownProjectStore({ vault });
+    for (const id of ["../other", "/absolute", "nested/path", "nested\\path", "."]) {
+      expect(() => store.getById(id)).toThrow(/path-safe document id/);
+    }
+    vault.writeText(
+      "projects/prj_123.md",
+      serializeProjectDocument(projectRecord({ id: "prj_other" })),
+    );
+    expect(() => store.getById("prj_123")).toThrow(/filename.*prj_123.*prj_other/i);
+  });
+
+  it("commits only the affected path with a sanitised subject and actor", () => {
+    const commits: Array<{ paths: string[]; message: string; actor?: string }> = [];
+    const store = createMarkdownProjectStore({
+      vault: createVault({ dataDir }),
+      commit: (paths, message, actor) => commits.push({ paths, message, actor }),
+    });
+    const created = store.create(projectRecord(), "admin-1");
+    store.update({ ...created, updated_at: "2026-08-06T13:00:00.000Z" }, "curator-1");
+    expect(commits).toEqual([
+      {
+        paths: ["projects/prj_123.md"],
+        message: "project: create prj_123",
+        actor: "admin-1",
+      },
+      {
+        paths: ["projects/prj_123.md"],
+        message: "project: update prj_123",
+        actor: "curator-1",
+      },
+    ]);
+  });
+
+  it("refuses reads and writes through a symlinked project document", () => {
+    const vault = createVault({ dataDir });
+    const outside = path.join(dataDir, "outside-project.md");
+    const original = serializeProjectDocument(projectRecord());
+    fs.writeFileSync(outside, original);
+    fs.mkdirSync(path.join(vault.root, "projects"), { recursive: true });
+    fs.symlinkSync(outside, path.join(vault.root, "projects", "prj_123.md"));
+    const store = createMarkdownProjectStore({ vault });
+
+    expect(() => store.getById("prj_123")).toThrow(UnsafeVaultPathError);
+    expect(() =>
+      store.update(
+        projectRecord({
+          display_name: "Attempted overwrite",
+          updated_at: "2026-08-06T13:00:00.000Z",
+        }),
+      ),
+    ).toThrow(UnsafeVaultPathError);
+    expect(fs.readFileSync(outside, "utf8")).toBe(original);
+  });
+});

--- a/packages/core/tests/store/markdown/markdown-project-store.test.ts
+++ b/packages/core/tests/store/markdown/markdown-project-store.test.ts
@@ -76,6 +76,41 @@ describe("Markdown ProjectStore", () => {
     );
   });
 
+  it("keeps an approved key stable while allowing a proposal key to be corrected", () => {
+    const store = createMarkdownProjectStore({ vault: createVault({ dataDir }) });
+    const proposed = projectRecord({
+      id: "prj_proposed",
+      key: "draft-key",
+      display_name: "Draft project",
+      status: "proposed",
+      proposal_rationale: "The source names a durable body of work.",
+      proposal_evidence_ids: ["memory:mem_123"],
+    });
+    store.create(proposed);
+    expect(store.update({ ...proposed, key: "corrected-key" }).key).toBe("corrected-key");
+
+    const active = projectRecord();
+    store.create(active);
+    expect(() => store.update({ ...active, key: "renamed-after-approval" })).toThrow(
+      /stable after approval/,
+    );
+  });
+
+  it("fails closed when hand-edited documents contain a duplicate key", () => {
+    const vault = createVault({ dataDir });
+    vault.writeText("projects/prj_123.md", serializeProjectDocument(projectRecord()));
+    vault.writeText(
+      "projects/prj_456.md",
+      serializeProjectDocument(
+        projectRecord({ id: "prj_456", display_name: "Ambiguous duplicate" }),
+      ),
+    );
+    const store = createMarkdownProjectStore({ vault });
+
+    expect(() => store.list()).toThrow(DuplicateProjectKeyError);
+    expect(() => store.getByKey("the-librarian")).toThrow(DuplicateProjectKeyError);
+  });
+
   it("refuses unsafe lookup ids and a document whose filename disagrees with its id", () => {
     const vault = createVault({ dataDir });
     const store = createMarkdownProjectStore({ vault });

--- a/packages/core/tests/store/markdown/markdown-project-suggestion-store.test.ts
+++ b/packages/core/tests/store/markdown/markdown-project-suggestion-store.test.ts
@@ -1,0 +1,108 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  ProjectSuggestionExistsError,
+  ProjectSuggestionNotFoundError,
+  createMarkdownProjectSuggestionStore,
+  createVault,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { projectSuggestionRecord } from "../../fixtures/project-records.js";
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-project-suggestion-store-"));
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("Markdown ProjectSuggestionStore", () => {
+  it("creates, reads, filters and resolves a suggestion without moving its path", () => {
+    const vault = createVault({ dataDir });
+    const store = createMarkdownProjectSuggestionStore({ vault });
+    const pending = projectSuggestionRecord();
+    store.create(pending);
+    expect(store.getById(pending.id)).toEqual(pending);
+    expect(store.list({ project_id: "prj_123", status: "pending" })).toEqual([pending]);
+
+    const accepted = {
+      ...pending,
+      status: "accepted" as const,
+      resolved_at: "2026-08-06T13:00:00.000Z",
+    };
+    expect(store.update(accepted)).toEqual(accepted);
+    expect(store.list({ status: "pending" })).toEqual([]);
+    expect(store.list({ status: "accepted" })).toEqual([accepted]);
+    expect(vault.listMarkdown("project-suggestions")).toEqual(["project-suggestions/prs_123.md"]);
+  });
+
+  it("refuses duplicate creates, missing updates and unsafe ids", () => {
+    const store = createMarkdownProjectSuggestionStore({ vault: createVault({ dataDir }) });
+    store.create(projectSuggestionRecord());
+    expect(() => store.create(projectSuggestionRecord())).toThrow(ProjectSuggestionExistsError);
+    expect(() => store.update(projectSuggestionRecord({ id: "prs_missing" }))).toThrow(
+      ProjectSuggestionNotFoundError,
+    );
+    expect(() => store.getById("../suggestion")).toThrow(/path-safe document id/);
+  });
+
+  it("finds an existing project/section/hash suggestion for idempotent conflict handling", () => {
+    const store = createMarkdownProjectSuggestionStore({ vault: createVault({ dataDir }) });
+    const suggestion = projectSuggestionRecord();
+    store.create(suggestion);
+    expect(
+      store.findByContentHash(suggestion.project_id, suggestion.section, suggestion.content_hash),
+    ).toEqual(suggestion);
+    expect(
+      store.findByContentHash(suggestion.project_id, "planned_next", suggestion.content_hash),
+    ).toBeNull();
+  });
+
+  it("commits create and update paths with attribution", () => {
+    const commits: unknown[][] = [];
+    const store = createMarkdownProjectSuggestionStore({
+      vault: createVault({ dataDir }),
+      commit: (...args) => commits.push(args),
+    });
+    const pending = store.create(projectSuggestionRecord(), "curator-1");
+    store.update(
+      {
+        ...pending,
+        status: "rejected",
+        resolved_at: "2026-08-06T13:00:00.000Z",
+      },
+      "admin-1",
+    );
+    expect(commits).toEqual([
+      [["project-suggestions/prs_123.md"], "project-suggestion: create prs_123", "curator-1"],
+      [["project-suggestions/prs_123.md"], "project-suggestion: update prs_123", "admin-1"],
+    ]);
+  });
+
+  it("deduplicates by content hash outside the bounded presentation window", () => {
+    const store = createMarkdownProjectSuggestionStore({ vault: createVault({ dataDir }) });
+    const target = projectSuggestionRecord({
+      id: "prs_target",
+      created_at: "2026-08-05T12:00:00.000Z",
+      content_hash: "f".repeat(64),
+    });
+    store.create(target);
+    for (let index = 0; index < 500; index++) {
+      store.create(
+        projectSuggestionRecord({
+          id: `prs_new_${index}`,
+          created_at: "2026-08-06T12:00:00.000Z",
+          content_hash: index.toString(16).padStart(64, "0"),
+        }),
+      );
+    }
+    expect(store.list()).toHaveLength(100);
+    expect(store.findByContentHash(target.project_id, target.section, target.content_hash)).toEqual(
+      target,
+    );
+  });
+});

--- a/packages/core/tests/store/markdown/markdown-project-update-store.test.ts
+++ b/packages/core/tests/store/markdown/markdown-project-update-store.test.ts
@@ -1,0 +1,101 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  ProjectUpdateExistsError,
+  createMarkdownProjectUpdateStore,
+  createVault,
+  serializeProjectUpdateDocument,
+} from "@librarian/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { projectUpdateRecord } from "../../fixtures/project-records.js";
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-project-update-store-"));
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("Markdown ProjectUpdateStore", () => {
+  it("appends evidence and supports bounded deterministic filters", () => {
+    const store = createMarkdownProjectUpdateStore({ vault: createVault({ dataDir }) });
+    const older = projectUpdateRecord();
+    const newer = projectUpdateRecord({
+      id: "pru_456",
+      source_kind: "handoff",
+      source_ref: "handoff:hdo_456",
+      captured_at: "2026-08-06T13:00:00.000Z",
+      fingerprint: "b".repeat(64),
+    });
+    store.append(older);
+    store.append(newer);
+
+    expect(store.getById(older.id)).toEqual(older);
+    expect(store.getByFingerprint(newer.fingerprint)).toEqual(newer);
+    expect(store.list().map((update) => update.id)).toEqual([newer.id, older.id]);
+    expect(store.list({ project_id: "prj_123", source_kind: "handoff" })).toEqual([newer]);
+    expect(store.list({ source_ref: "conversation:conv_123", limit: 1 })).toEqual([older]);
+  });
+
+  it("is append-only: a duplicate id cannot replace the original bytes", () => {
+    const vault = createVault({ dataDir });
+    const store = createMarkdownProjectUpdateStore({ vault });
+    const original = projectUpdateRecord();
+    store.append(original);
+    const raw = vault.readText("project-updates/pru_123.md");
+    expect(() => store.append({ ...original, rationale: "Attempted replacement" })).toThrow(
+      ProjectUpdateExistsError,
+    );
+    expect(vault.readText("project-updates/pru_123.md")).toBe(raw);
+  });
+
+  it("refuses unsafe ids and filename/frontmatter disagreement", () => {
+    const vault = createVault({ dataDir });
+    const store = createMarkdownProjectUpdateStore({ vault });
+    expect(() => store.getById("../update")).toThrow(/path-safe document id/);
+    vault.writeText(
+      "project-updates/pru_123.md",
+      serializeProjectUpdateDocument(projectUpdateRecord({ id: "pru_other" })),
+    );
+    expect(() => store.getById("pru_123")).toThrow(/filename.*pru_123.*pru_other/i);
+  });
+
+  it("commits the appended path with attribution", () => {
+    const commits: unknown[][] = [];
+    const store = createMarkdownProjectUpdateStore({
+      vault: createVault({ dataDir }),
+      commit: (...args) => commits.push(args),
+    });
+    store.append(projectUpdateRecord(), "curator-1");
+    expect(commits).toEqual([
+      [["project-updates/pru_123.md"], "project-update: append pru_123", "curator-1"],
+    ]);
+  });
+
+  it("finds a fingerprint outside the bounded presentation window", () => {
+    const store = createMarkdownProjectUpdateStore({ vault: createVault({ dataDir }) });
+    const target = projectUpdateRecord({
+      id: "pru_target",
+      observed_at: "2026-08-05T11:00:00.000Z",
+      captured_at: "2026-08-05T12:00:00.000Z",
+      fingerprint: "f".repeat(64),
+    });
+    store.append(target);
+    for (let index = 0; index < 500; index++) {
+      store.append(
+        projectUpdateRecord({
+          id: `pru_new_${index}`,
+          source_ref: `conversation:new-${index}`,
+          captured_at: "2026-08-06T12:00:00.000Z",
+          fingerprint: index.toString(16).padStart(64, "0"),
+        }),
+      );
+    }
+    expect(store.list()).toHaveLength(100);
+    expect(store.getByFingerprint(target.fingerprint)).toEqual(target);
+  });
+});

--- a/packages/core/tests/store/markdown/memory-doc.test.ts
+++ b/packages/core/tests/store/markdown/memory-doc.test.ts
@@ -62,17 +62,47 @@ describe("memory <-> document mapping", () => {
     expect(p.curator_note).toEqual({ source: "curator", run_id: "run_1", confidence: 0.9 });
   });
 
-  it("drops a legacy project_key / recall_count / usefulness_score / priority on read", () => {
-    // These fields were retired (memories went project-less; recall counters
-    // are gone; the priority field was removed). A pre-cutover doc still on
-    // disk carries them; the parser must strip them so the round-trip shape
-    // stays canonical.
+  it("round-trips plural project_keys and writes them in deterministic frontmatter order", () => {
+    const associated: Memory = { ...memory, project_keys: ["the-librarian", "website"] };
+    const raw = serializeMemoryDocument(associated);
+    expect(raw).toContain(
+      "applies_to:\n  - the-librarian\nproject_keys:\n  - the-librarian\n  - website\n",
+    );
+    expect(parseMemoryDocument(raw)).toEqual(associated);
+    expect(serializeMemoryDocument(parseMemoryDocument(raw))).toBe(raw);
+  });
+
+  it("keeps an absent project_keys field byte-compatible", () => {
+    const raw = serializeMemoryDocument(memory);
+    expect(raw).not.toMatch(/^project_keys:/m);
+    expect(serializeMemoryDocument(parseMemoryDocument(raw))).toBe(raw);
+    expect(parseMemoryDocument(raw)).not.toHaveProperty("project_keys");
+  });
+
+  it("normalises a legacy scalar project_key on read and writes only the plural form", () => {
+    const legacy = serializeMemoryDocument(memory).replace(
+      /^title:/m,
+      "project_key: legacy-proj\ntitle:",
+    );
+    const parsed = parseMemoryDocument(legacy);
+    expect(parsed.project_keys).toEqual(["legacy-proj"]);
+    const rewritten = serializeMemoryDocument(parsed);
+    expect(rewritten).toMatch(/^project_keys:\n {2}- legacy-proj$/m);
+    expect(rewritten).not.toMatch(/^project_key:/m);
+  });
+
+  it("prefers plural project_keys when a legacy scalar is also present", () => {
+    const plural = serializeMemoryDocument({ ...memory, project_keys: ["current-project"] });
+    const mixed = plural.replace(/^title:/m, "project_key: legacy-project\ntitle:");
+    expect(parseMemoryDocument(mixed).project_keys).toEqual(["current-project"]);
+  });
+
+  it("drops retired recall_count / usefulness_score / priority fields on read", () => {
     const raw = serializeMemoryDocument(memory).replace(
       /^title:/m,
-      "project_key: legacy-proj\nrecall_count: 7\nusefulness_score: 4\npriority: high\ntitle:",
+      "recall_count: 7\nusefulness_score: 4\npriority: high\ntitle:",
     );
     const p = parseMemoryDocument(raw) as Record<string, unknown>;
-    expect(p.project_key).toBeUndefined();
     expect(p.recall_count).toBeUndefined();
     expect(p.usefulness_score).toBeUndefined();
     expect(p.priority).toBeUndefined();

--- a/packages/core/tests/store/markdown/project-doc.test.ts
+++ b/packages/core/tests/store/markdown/project-doc.test.ts
@@ -1,0 +1,92 @@
+import { parseProjectDocument, serializeProjectDocument } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+import { projectRecord } from "../../fixtures/project-records.js";
+
+const EXPECTED_KEYS = [
+  "id",
+  "key",
+  "display_name",
+  "aliases",
+  "repository_identifiers",
+  "status",
+  "resolution",
+  "resolved_project_id",
+  "proposal_rationale",
+  "proposal_evidence_ids",
+  "suppression_fingerprint",
+  "possible_match_ids",
+  "section_ownership",
+  "section_source_ids",
+  "compiled_at",
+  "compiler_version",
+  "source_watermark",
+  "source_ids",
+  "content_hash",
+  "refresh_status",
+  "refresh_failure_class",
+  "pending_source_count",
+  "unresolved_conflict_count",
+  "last_activity_at",
+  "created_at",
+  "updated_at",
+];
+
+function topLevelFrontmatterKeys(raw: string): string[] {
+  return raw
+    .split("\n")
+    .slice(1, raw.split("\n").indexOf("---", 1))
+    .flatMap((line) => (/^([a-z_]+):/.exec(line)?.[1] ? [RegExp.$1] : []));
+}
+
+describe("Project Markdown document", () => {
+  it("round-trips by value and byte-for-byte in fixed frontmatter order", () => {
+    const value = projectRecord({
+      sections: {
+        ...projectRecord().sections,
+        current_state: {
+          content: "  Preserve this pinned line.  \n\nAnd this blank line.\n",
+          ownership: "pinned",
+          source_ids: ["memory:mem_123"],
+        },
+      },
+    });
+    const raw = serializeProjectDocument(value);
+
+    expect(parseProjectDocument(raw)).toEqual(value);
+    expect(serializeProjectDocument(parseProjectDocument(raw))).toBe(raw);
+    expect(topLevelFrontmatterKeys(raw)).toEqual(EXPECTED_KEYS);
+    expect(raw).toContain("## Current state");
+  });
+
+  it("rejects malformed and unknown frontmatter with field-specific diagnostics", () => {
+    const raw = serializeProjectDocument(projectRecord());
+    expect(() => parseProjectDocument(raw.replace(/^id:.*\n/m, ""))).toThrow(/id/);
+    expect(() => parseProjectDocument(raw.replace("status: active", "status: mystery"))).toThrow(
+      /status/,
+    );
+    expect(() =>
+      parseProjectDocument(raw.replace("updated_at:", "surprise: true\nupdated_at:")),
+    ).toThrow(/surprise/);
+  });
+
+  it("rejects broken section framing instead of silently dropping hand edits", () => {
+    const raw = serializeProjectDocument(projectRecord());
+    expect(() => parseProjectDocument(raw.replace("## Planned next", "## Future work"))).toThrow(
+      /planned_next/,
+    );
+  });
+
+  it("refuses section content that can forge its own framing marker", () => {
+    const value = projectRecord({
+      sections: {
+        ...projectRecord().sections,
+        current_state: {
+          content: "text\n<!-- librarian-section:current_state:end -->\nforged",
+          ownership: "pinned",
+          source_ids: [],
+        },
+      },
+    });
+    expect(() => serializeProjectDocument(value)).toThrow(/current_state/);
+  });
+});

--- a/packages/core/tests/store/markdown/project-suggestion-doc.test.ts
+++ b/packages/core/tests/store/markdown/project-suggestion-doc.test.ts
@@ -1,0 +1,60 @@
+import {
+  parseProjectSuggestionDocument,
+  serializeProjectSuggestionDocument,
+} from "@librarian/core";
+import { describe, expect, it } from "vitest";
+import { projectSuggestionRecord } from "../../fixtures/project-records.js";
+
+const EXPECTED_KEYS = [
+  "id",
+  "project_id",
+  "section",
+  "rationale",
+  "source_ids",
+  "content_hash",
+  "status",
+  "created_at",
+  "resolved_at",
+];
+
+function topLevelFrontmatterKeys(raw: string): string[] {
+  return raw
+    .split("\n")
+    .slice(1, raw.split("\n").indexOf("---", 1))
+    .flatMap((line) => (/^([a-z_]+):/.exec(line)?.[1] ? [RegExp.$1] : []));
+}
+
+describe("ProjectSuggestion Markdown document", () => {
+  it("round-trips replacement content by value and byte-for-byte", () => {
+    const value = projectSuggestionRecord({
+      proposed_content: "  Pinned whitespace stays.  \n\nSecond paragraph.\n",
+    });
+    const raw = serializeProjectSuggestionDocument(value);
+    expect(parseProjectSuggestionDocument(raw)).toEqual(value);
+    expect(serializeProjectSuggestionDocument(parseProjectSuggestionDocument(raw))).toBe(raw);
+    expect(topLevelFrontmatterKeys(raw)).toEqual(EXPECTED_KEYS);
+  });
+
+  it("rejects malformed and unknown frontmatter with precise diagnostics", () => {
+    const raw = serializeProjectSuggestionDocument(projectSuggestionRecord());
+    expect(() => parseProjectSuggestionDocument(raw.replace(/^project_id:.*\n/m, ""))).toThrow(
+      /project_id/,
+    );
+    expect(() =>
+      parseProjectSuggestionDocument(raw.replace("section: current_state", "section: history")),
+    ).toThrow(/section/);
+    expect(() =>
+      parseProjectSuggestionDocument(raw.replace("resolved_at:", "surprise: true\nresolved_at:")),
+    ).toThrow(/surprise/);
+  });
+
+  it("rejects forged content framing markers", () => {
+    expect(() =>
+      serializeProjectSuggestionDocument(
+        projectSuggestionRecord({
+          proposed_content: "text\n<!-- librarian-suggestion:end -->\nforged",
+        }),
+      ),
+    ).toThrow(/proposed_content/);
+  });
+});

--- a/packages/core/tests/store/markdown/project-update-doc.test.ts
+++ b/packages/core/tests/store/markdown/project-update-doc.test.ts
@@ -1,0 +1,58 @@
+import { parseProjectUpdateDocument, serializeProjectUpdateDocument } from "@librarian/core";
+import { describe, expect, it } from "vitest";
+import { projectUpdateRecord } from "../../fixtures/project-records.js";
+
+const EXPECTED_KEYS = [
+  "id",
+  "project_id",
+  "candidate_fingerprint",
+  "suggested_key",
+  "suggested_name",
+  "suggested_aliases",
+  "suggested_repository_identifiers",
+  "confidence",
+  "rationale",
+  "explicitly_new_project",
+  "evidence",
+  "source_kind",
+  "source_ref",
+  "observed_at",
+  "captured_at",
+  "shelf_id",
+  "fingerprint",
+];
+
+function topLevelFrontmatterKeys(raw: string): string[] {
+  return raw
+    .split("\n")
+    .slice(1, raw.split("\n").indexOf("---", 1))
+    .flatMap((line) => (/^([a-z_]+):/.exec(line)?.[1] ? [RegExp.$1] : []));
+}
+
+describe("ProjectUpdate Markdown document", () => {
+  it("round-trips by value and byte-for-byte in fixed frontmatter order", () => {
+    const value = projectUpdateRecord();
+    const raw = serializeProjectUpdateDocument(value);
+    expect(parseProjectUpdateDocument(raw)).toEqual(value);
+    expect(serializeProjectUpdateDocument(parseProjectUpdateDocument(raw))).toBe(raw);
+    expect(topLevelFrontmatterKeys(raw)).toEqual(EXPECTED_KEYS);
+  });
+
+  it("rejects malformed or unknown fields with precise diagnostics", () => {
+    const raw = serializeProjectUpdateDocument(projectUpdateRecord());
+    expect(() => parseProjectUpdateDocument(raw.replace(/^source_ref:.*\n/m, ""))).toThrow(
+      /source_ref/,
+    );
+    expect(() =>
+      parseProjectUpdateDocument(raw.replace("source_kind: capture", "source_kind: guess")),
+    ).toThrow(/source_kind/);
+    expect(() =>
+      parseProjectUpdateDocument(raw.replace(/^fingerprint:/m, "surprise: true\nfingerprint:")),
+    ).toThrow(/surprise/);
+  });
+
+  it("rejects a body because update evidence has one canonical frontmatter representation", () => {
+    const raw = serializeProjectUpdateDocument(projectUpdateRecord());
+    expect(() => parseProjectUpdateDocument(`${raw}unexpected body\n`)).toThrow(/body/i);
+  });
+});

--- a/packages/core/tests/store/merge-memory.test.ts
+++ b/packages/core/tests/store/merge-memory.test.ts
@@ -20,6 +20,8 @@ function fakeStore() {
       calls.push(`archive:${id}:${String(actor)}`);
       return null;
     },
+    getMemory: (id) =>
+      id === "mem_a" ? { project_keys: ["alpha", "shared"] } : { project_keys: ["shared", "beta"] },
   };
   return { store, calls };
 }
@@ -59,11 +61,44 @@ describe("mergeMemory", () => {
         return { memory: { id: "x" } };
       },
       archiveMemory: () => null,
+      getMemory: () => null,
     };
     mergeMemory(store, {
       replacement: { input: { title: "M" }, options: { requires_approval: true } },
       sourceIds: ["s1", "s2"],
     });
     expect(seen).toEqual({ requires_approval: true });
+  });
+
+  it("uses a stable union of source project keys when the replacement omits them", () => {
+    const seen: Record<string, unknown>[] = [];
+    const store: MergeMemoryStore = {
+      createMemory: (input) => {
+        seen.push(input);
+        return { memory: { id: "merged" } };
+      },
+      archiveMemory: () => null,
+      getMemory: (id) =>
+        id === "a" ? { project_keys: ["alpha", "shared"] } : { project_keys: ["shared", "beta"] },
+    };
+    mergeMemory(store, { replacement: { input: { title: "M" } }, sourceIds: ["a", "b"] });
+    expect(seen[0]?.project_keys).toEqual(["alpha", "shared", "beta"]);
+  });
+
+  it("honours an explicit replacement project_keys value, including an empty list", () => {
+    const seen: unknown[] = [];
+    const store: MergeMemoryStore = {
+      createMemory: (input) => {
+        seen.push(input.project_keys);
+        return { memory: { id: "merged" } };
+      },
+      archiveMemory: () => null,
+      getMemory: () => ({ project_keys: ["source-project"] }),
+    };
+    mergeMemory(store, {
+      replacement: { input: { title: "M", project_keys: [] } },
+      sourceIds: ["a", "b"],
+    });
+    expect(seen).toEqual([[]]);
   });
 });

--- a/packages/core/tests/store/move-memory.test.ts
+++ b/packages/core/tests/store/move-memory.test.ts
@@ -20,6 +20,7 @@ import {
 } from "@librarian/core";
 import { CuratorNoteSchema } from "@librarian/core/schemas";
 import { afterEach, describe, expect, it } from "vitest";
+import { projectRecord } from "../fixtures/project-records.js";
 
 const SOURCE: Shelf = { id: "personal", prefix: "members/alice/", writable: true };
 const DESTINATION: Shelf = { id: "team", prefix: "team/", writable: true, label: "Team" };
@@ -108,6 +109,53 @@ describe("moveMemoryForPrincipal", () => {
     expect(fs.readFileSync(afterPath)).toEqual(before);
     expect(moved).toEqual(memory);
     expect(store.forShelf(DESTINATION).getMemory(memory.id)?.id).toBe(memory.id);
+  });
+
+  it("preserves project keys and returns a non-blocking warning for missing active destination projects", () => {
+    const { store, vaultDir } = freshStore();
+    store
+      .systemProjectStoresForShelf(DESTINATION)
+      .projects.create(projectRecord({ id: "prj_shared", key: "shared-project" }));
+    const { memory } = store.forShelf(SOURCE).createMemory(
+      {
+        title: "Project evidence",
+        body: "keep these bytes",
+        agent_id: PRINCIPAL.actorId,
+        project_keys: ["shared-project", "source-only"],
+      },
+      {},
+    );
+    const before = fs.readFileSync(memoryPath(vaultDir, SOURCE, memory.id));
+
+    const moved = store.moveMemoryForPrincipal(PRINCIPAL, memory.id, DESTINATION.id);
+
+    expect(fs.readFileSync(memoryPath(vaultDir, DESTINATION, memory.id))).toEqual(before);
+    expect(moved.project_keys).toEqual(["shared-project", "source-only"]);
+    expect(moved.move_warnings).toEqual([
+      expect.objectContaining({
+        code: "missing-active-projects",
+        project_keys: ["source-only"],
+        message: expect.stringMatching(/associations were preserved/i),
+      }),
+    ]);
+  });
+
+  it("returns the original memory shape when every destination project is active", () => {
+    const { store } = freshStore();
+    store
+      .systemProjectStoresForShelf(DESTINATION)
+      .projects.create(projectRecord({ id: "prj_shared", key: "shared-project" }));
+    const { memory } = store.forShelf(SOURCE).createMemory(
+      {
+        title: "Project evidence",
+        body: "body",
+        agent_id: PRINCIPAL.actorId,
+        project_keys: ["shared-project"],
+      },
+      {},
+    );
+
+    expect(store.moveMemoryForPrincipal(PRINCIPAL, memory.id, DESTINATION.id)).toEqual(memory);
   });
 
   it("invalidates both shelves' corpus indexes", async () => {

--- a/packages/core/tests/store/project-shelf-scoped-store.test.ts
+++ b/packages/core/tests/store/project-shelf-scoped-store.test.ts
@@ -1,0 +1,119 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  DEFAULT_SHELF,
+  ShelfNotWritableError,
+  type LibrarianStore,
+  type Shelf,
+  createLibrarianStore,
+} from "@librarian/core";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  projectRecord,
+  projectSuggestionRecord,
+  projectUpdateRecord,
+} from "../fixtures/project-records.js";
+
+const dataDirs: string[] = [];
+const stores: LibrarianStore[] = [];
+
+afterEach(() => {
+  for (const store of stores.splice(0)) store.close();
+  for (const dir of dataDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function freshStore(): { store: LibrarianStore; vault: string } {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-project-shelf-"));
+  dataDirs.push(dataDir);
+  const store = createLibrarianStore({ dataDir });
+  stores.push(store);
+  return { store, vault: path.join(dataDir, "vault") };
+}
+
+const PERSONAL: Shelf = { id: "personal", prefix: "members/x/", writable: true };
+const TEAM_WRITABLE: Shelf = { id: "team", prefix: "team/", writable: true };
+const TEAM_READ_ONLY: Shelf = { ...TEAM_WRITABLE, writable: false };
+
+describe("project stores on shelf-scoped handles", () => {
+  it("keeps default-shelf aliases on the same raw store instances", () => {
+    const { store, vault } = freshStore();
+    const main = store.forShelf(DEFAULT_SHELF);
+    expect(main.projects).toBe(store.projects);
+    expect(main.projectUpdates).toBe(store.projectUpdates);
+    expect(main.projectSuggestions).toBe(store.projectSuggestions);
+
+    store.projects.create(projectRecord(), "admin-1");
+    store.projectUpdates.append(projectUpdateRecord(), "curator-1");
+    store.projectSuggestions.create(projectSuggestionRecord(), "curator-1");
+    expect(fs.existsSync(path.join(vault, "projects/prj_123.md"))).toBe(true);
+    expect(fs.existsSync(path.join(vault, "project-updates/pru_123.md"))).toBe(true);
+    expect(fs.existsSync(path.join(vault, "project-suggestions/prs_123.md"))).toBe(true);
+  });
+
+  it("allows the same project key in different shelves without sibling visibility", () => {
+    const { store, vault } = freshStore();
+    const personal = store.forShelf(PERSONAL);
+    const team = store.forShelf(TEAM_WRITABLE);
+    personal.projects.create(projectRecord(), "admin-personal");
+    team.projects.create(
+      projectRecord({ id: "prj_team", display_name: "The Librarian team" }),
+      "admin-team",
+    );
+
+    expect(personal.projects.list().map((project) => project.id)).toEqual(["prj_123"]);
+    expect(team.projects.list().map((project) => project.id)).toEqual(["prj_team"]);
+    expect(personal.projects.getById("prj_team")).toBeNull();
+    expect(team.projects.getById("prj_123")).toBeNull();
+    expect(personal.projects.getByKey("the-librarian")?.id).toBe("prj_123");
+    expect(team.projects.getByKey("the-librarian")?.id).toBe("prj_team");
+    expect(fs.existsSync(path.join(vault, "projects"))).toBe(false);
+  });
+
+  it("lets a read-only public handle read but refuses every project mutation", () => {
+    const { store } = freshStore();
+    const system = store.systemProjectStoresForShelf(TEAM_READ_ONLY);
+    const project = system.projects.create(
+      projectRecord({ id: "prj_team", display_name: "Team project" }),
+      "system-curator",
+    );
+    const update = projectUpdateRecord({
+      id: "pru_team",
+      project_id: project.id,
+      shelf_id: TEAM_READ_ONLY.id,
+    });
+    const suggestion = projectSuggestionRecord({
+      id: "prs_team",
+      project_id: project.id,
+      source_ids: ["update:pru_team"],
+    });
+    system.projectUpdates.append(update, "system-curator");
+    system.projectSuggestions.create(suggestion, "system-curator");
+
+    const publicTeam = store.forShelf(TEAM_READ_ONLY);
+    expect(publicTeam.projects.getById(project.id)).toEqual(project);
+    expect(publicTeam.projectUpdates.getById(update.id)).toEqual(update);
+    expect(publicTeam.projectSuggestions.getById(suggestion.id)).toEqual(suggestion);
+    expect(() => publicTeam.projects.create(projectRecord({ id: "prj_no" }))).toThrow(
+      ShelfNotWritableError,
+    );
+    expect(() => publicTeam.projects.update(project)).toThrow(ShelfNotWritableError);
+    expect(() => publicTeam.projectUpdates.append(update)).toThrow(ShelfNotWritableError);
+    expect(() => publicTeam.projectSuggestions.create(suggestion)).toThrow(ShelfNotWritableError);
+    expect(() => publicTeam.projectSuggestions.update(suggestion)).toThrow(ShelfNotWritableError);
+  });
+
+  it("confines the raw system accessor to the explicitly supplied shelf", () => {
+    const { store, vault } = freshStore();
+    const systemTeam = store.systemProjectStoresForShelf(TEAM_READ_ONLY);
+    systemTeam.projects.create(projectRecord());
+    systemTeam.projectUpdates.append(projectUpdateRecord({ shelf_id: TEAM_READ_ONLY.id }));
+    systemTeam.projectSuggestions.create(projectSuggestionRecord());
+
+    expect(fs.existsSync(path.join(vault, "team/projects/prj_123.md"))).toBe(true);
+    expect(fs.existsSync(path.join(vault, "team/project-updates/pru_123.md"))).toBe(true);
+    expect(fs.existsSync(path.join(vault, "team/project-suggestions/prs_123.md"))).toBe(true);
+    expect(fs.existsSync(path.join(vault, "projects"))).toBe(false);
+    expect(store.projects.list()).toEqual([]);
+  });
+});

--- a/packages/core/tests/store/split-memory.test.ts
+++ b/packages/core/tests/store/split-memory.test.ts
@@ -20,6 +20,7 @@ function fakeStore() {
       calls.push(`archive:${id}:${String(actor)}`);
       return null;
     },
+    getMemory: () => ({ project_keys: ["source-project"] }),
   };
   return { store, calls };
 }
@@ -55,6 +56,7 @@ describe("splitMemory", () => {
         return { memory: { id: "x" } };
       },
       archiveMemory: () => null,
+      getMemory: () => ({ project_keys: ["source-project"] }),
     };
     splitMemory(store, {
       sourceId: "s",
@@ -64,5 +66,28 @@ describe("splitMemory", () => {
       ],
     });
     expect(seen).toEqual([{ requires_approval: true }, undefined]);
+  });
+
+  it("inherits the source project keys without dropping explicit additions", () => {
+    const seen: Record<string, unknown>[] = [];
+    const store: SplitMemoryStore = {
+      createMemory: (input) => {
+        seen.push(input);
+        return { memory: { id: "x" } };
+      },
+      archiveMemory: () => null,
+      getMemory: () => ({ project_keys: ["source-project", "shared"] }),
+    };
+    splitMemory(store, {
+      sourceId: "s",
+      replacements: [
+        { input: { title: "A" } },
+        { input: { title: "B", project_keys: ["shared", "explicit-project"] } },
+      ],
+    });
+    expect(seen.map((input) => input.project_keys)).toEqual([
+      ["source-project", "shared"],
+      ["source-project", "shared", "explicit-project"],
+    ]);
   });
 });

--- a/packages/core/tests/store/vault-files-shelf-relative.test.ts
+++ b/packages/core/tests/store/vault-files-shelf-relative.test.ts
@@ -33,6 +33,9 @@ describe("assertVaultFilePath — shelf-relative visibility (spec 062 SC 2)", ()
   const cases: { rel: string; accepts: boolean }[] = [
     { rel: "memories/note.md", accepts: true }, // canonical layout beneath the prefix
     { rel: "handoffs/h.md", accepts: true },
+    { rel: "projects/prj_1.md", accepts: true },
+    { rel: "project-updates/pru_1.md", accepts: true },
+    { rel: "project-suggestions/prs_1.md", accepts: true },
     { rel: "references/web/r.md", accepts: true },
     { rel: ".curator/intake-addendum.md", accepts: true }, // the dot-dir exception, shelf-relative
     { rel: "inbox/item.md", accepts: false }, // inbox hidden at shelf depth 0
@@ -78,6 +81,9 @@ describe("assertVaultFilePath — empty prefix is byte-for-byte today's behaviou
     { rel: "primer.md", expected: "primer.md" },
     { rel: "memories/a.md", expected: "memories/a.md" },
     { rel: "handoffs/h.md", expected: "handoffs/h.md" },
+    { rel: "projects/prj_1.md", expected: "projects/prj_1.md" },
+    { rel: "project-updates/pru_1.md", expected: "project-updates/pru_1.md" },
+    { rel: "project-suggestions/prs_1.md", expected: "project-suggestions/prs_1.md" },
     { rel: "references/web/r.md", expected: "references/web/r.md" },
     { rel: ".curator/grooming-addendum.md", expected: ".curator/grooming-addendum.md" },
     { rel: "inbox/i.md", expected: "refused" }, // depth-0 inbox hidden
@@ -103,6 +109,11 @@ describe("vaultFileKind — shelf-relative classification (spec 062 SC 2)", () =
   it("classifies the per-shelf kinds beneath the prefix", () => {
     expect(vaultFileKind("members/x/memories/a.md", PREFIX)).toBe("memory");
     expect(vaultFileKind("members/x/handoffs/h.md", PREFIX)).toBe("handoff");
+    expect(vaultFileKind("members/x/projects/prj_1.md", PREFIX)).toBe("project");
+    expect(vaultFileKind("members/x/project-updates/pru_1.md", PREFIX)).toBe("project-update");
+    expect(vaultFileKind("members/x/project-suggestions/prs_1.md", PREFIX)).toBe(
+      "project-suggestion",
+    );
     expect(vaultFileKind("members/x/references/web/r.md", PREFIX)).toBe("reference");
     expect(vaultFileKind("members/x/.curator/a.md", PREFIX)).toBe("curator");
     expect(vaultFileKind("members/x/notes/free.md", PREFIX)).toBe("other");
@@ -123,6 +134,9 @@ describe("vaultFileKind — shelf-relative classification (spec 062 SC 2)", () =
       "primer.md",
       "memories/a.md",
       "handoffs/h.md",
+      "projects/prj_1.md",
+      "project-updates/pru_1.md",
+      "project-suggestions/prs_1.md",
       "references/r.md",
       ".curator/a.md",
       "random.md",
@@ -132,6 +146,9 @@ describe("vaultFileKind — shelf-relative classification (spec 062 SC 2)", () =
     }
     expect(vaultFileKind("memories/a.md")).toBe("memory");
     expect(vaultFileKind("handoffs/h.md")).toBe("handoff");
+    expect(vaultFileKind("projects/prj_1.md")).toBe("project");
+    expect(vaultFileKind("project-updates/pru_1.md")).toBe("project-update");
+    expect(vaultFileKind("project-suggestions/prs_1.md")).toBe("project-suggestion");
     expect(vaultFileKind("references/r.md")).toBe("reference");
     expect(vaultFileKind(".curator/a.md")).toBe("curator");
     expect(vaultFileKind("primer.md")).toBe("primer");

--- a/packages/core/tests/store/vault-files.test.ts
+++ b/packages/core/tests/store/vault-files.test.ts
@@ -18,9 +18,17 @@ import {
   VaultWriteConflictError,
   createVault,
   createVaultFileStore,
+  serializeProjectDocument,
+  serializeProjectSuggestionDocument,
+  serializeProjectUpdateDocument,
   validateVaultFile,
 } from "@librarian/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  projectRecord,
+  projectSuggestionRecord,
+  projectUpdateRecord,
+} from "../fixtures/project-records.js";
 
 let dataDir: string;
 let vault: Vault;
@@ -95,6 +103,10 @@ const VALID_HANDOFF = [
   "",
 ].join("\n");
 
+const VALID_PROJECT = serializeProjectDocument(projectRecord());
+const VALID_PROJECT_UPDATE = serializeProjectUpdateDocument(projectUpdateRecord());
+const VALID_PROJECT_SUGGESTION = serializeProjectSuggestionDocument(projectSuggestionRecord());
+
 describe("vault file tree (T18)", () => {
   it("lists the vault recursively — dirs first, with name/path/type/mtime", () => {
     vault.writeText("primer.md", "Primer text.\n");
@@ -115,6 +127,21 @@ describe("vault file tree (T18)", () => {
     expect(file?.name).toBe("elaine-1.md");
     expect(file?.type).toBe("file");
     expect(file?.mtime).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("shows the three canonical project document directories", () => {
+    vault.writeText("projects/prj_123.md", VALID_PROJECT);
+    vault.writeText("project-updates/pru_123.md", VALID_PROJECT_UPDATE);
+    vault.writeText("project-suggestions/prs_123.md", VALID_PROJECT_SUGGESTION);
+
+    expect(store.tree().map((node) => node.path)).toEqual([
+      "project-suggestions",
+      "project-updates",
+      "projects",
+    ]);
+    expect(store.readFile("projects/prj_123.md").kind).toBe("project");
+    expect(store.readFile("project-updates/pru_123.md").kind).toBe("project-update");
+    expect(store.readFile("project-suggestions/prs_123.md").kind).toBe("project-suggestion");
   });
 
   it("excludes vault plumbing: .git, the inbox queue, .index, and stray dotfiles", () => {
@@ -171,6 +198,9 @@ describe("path discipline (T18.3)", () => {
     // skipping its rules (hidden surface, per-kind validation, byte caps).
     "Inbox/raw-item.md",
     "Memories/elaine.md",
+    "Projects/prj_123.md",
+    "Project-Updates/pru_123.md",
+    "Project-Suggestions/prs_123.md",
     "PRIMER.MD",
     "",
   ])("rejects '%s' without touching disk", (badPath) => {
@@ -217,6 +247,24 @@ describe("per-kind validation (T19.1)", () => {
     const missing = VALID_HANDOFF.replace("## Open questions", "## Closing thoughts");
     const errors = validateVaultFile("handoffs/ho_123.md", missing);
     expect(errors).toEqual([expect.stringContaining("'## Open questions'")]);
+  });
+
+  it("project records, updates and suggestions must satisfy their strict codecs", () => {
+    expect(validateVaultFile("projects/prj_123.md", VALID_PROJECT)).toEqual([]);
+    expect(validateVaultFile("project-updates/pru_123.md", VALID_PROJECT_UPDATE)).toEqual([]);
+    expect(validateVaultFile("project-suggestions/prs_123.md", VALID_PROJECT_SUGGESTION)).toEqual(
+      [],
+    );
+
+    expect(validateVaultFile("projects/prj_123.md", "broken")[0]).toMatch(/project/i);
+    expect(validateVaultFile("project-updates/pru_123.md", "broken")[0]).toMatch(/project update/i);
+    expect(validateVaultFile("project-suggestions/prs_123.md", "broken")[0]).toMatch(
+      /project suggestion/i,
+    );
+    expect(validateVaultFile("projects/wrong.md", VALID_PROJECT)[0]).toMatch(/filename.*id/i);
+    expect(validateVaultFile("projects/nested/prj_123.md", VALID_PROJECT)[0]).toMatch(
+      /directly under projects/i,
+    );
   });
 
   it("primer.md and .curator addendums are capped at 2 KB", () => {

--- a/packages/core/tests/vault-router.test.ts
+++ b/packages/core/tests/vault-router.test.ts
@@ -111,6 +111,15 @@ describe("validateShelfSet — per-shelf prefix violations throw naming the shel
     );
   });
 
+  it.each(["projects/", "project-updates/", "project-suggestions/"])(
+    "rejects a project document directory as a shelf prefix (%s)",
+    (prefix) => {
+      expect(() => validateShelfSet([shelf("x", prefix)])).toThrow(
+        /shadows the canonical top-level name/,
+      );
+    },
+  );
+
   it("rejects a hidden canonical name too (.git/)", () => {
     expect(() => validateShelfSet([shelf("x", ".git/")])).toThrow(
       /shadows the canonical top-level name "\.git"/,

--- a/packages/installer-cli/package.json
+++ b/packages/installer-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-librarian/cli",
-  "version": "1.17.0",
+  "version": "1.20.1",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/mcp-server/src/mcp/tools/remember.ts
+++ b/packages/mcp-server/src/mcp/tools/remember.ts
@@ -1,4 +1,5 @@
-import { type InboxSubmissionHints, isIntakeEnabled } from "@librarian/core";
+import { type InboxSubmissionHints, type ShelfScopedStore, isIntakeEnabled } from "@librarian/core";
+import { ProjectKeysSchema } from "@librarian/core/schemas";
 import { textResult } from "../result.js";
 import type { ToolDefinition } from "../tool.js";
 import { scopeAgentArgs } from "../visibility.js";
@@ -14,7 +15,22 @@ function submissionHints(scoped: Record<string, unknown>): InboxSubmissionHints 
   if (Array.isArray(scoped.applies_to)) {
     hints.appliesTo = scoped.applies_to.filter((a): a is string => typeof a === "string");
   }
+  if (Array.isArray(scoped.project_keys)) {
+    hints.projectKeys = scoped.project_keys.filter((key): key is string => typeof key === "string");
+  }
   return hints;
+}
+
+function validateProjectKeys(scoped: Record<string, unknown>, shelf: ShelfScopedStore): void {
+  if (scoped.project_keys === undefined) return;
+  const keys = ProjectKeysSchema.parse(scoped.project_keys);
+  const inactive = keys.filter((key) => shelf.projects.getByKey(key)?.status !== "active");
+  if (inactive.length > 0) {
+    throw new Error(
+      `project_keys must name active projects on the destination shelf: ${inactive.join(", ")}`,
+    );
+  }
+  scoped.project_keys = keys;
 }
 
 const remember: ToolDefinition = {
@@ -39,6 +55,7 @@ const remember: ToolDefinition = {
     // write to that shelf's scoped handle. With the default router this is the main shelf — the
     // handle IS the top-level store's own path, so this is byte-identical.
     const shelf = store.forShelf(store.resolveWriteTarget(context.principal), context.principal);
+    validateProjectKeys(scoped, shelf);
 
     // Inbox cutover: when intake is enabled (the dashboard setting
     // `curator.intake.enabled`, spec 043 D-E), `remember` is a fire-and-forget

--- a/packages/mcp-server/src/mcp/tools/schemas.ts
+++ b/packages/mcp-server/src/mcp/tools/schemas.ts
@@ -38,6 +38,19 @@ export function memoryInputSchema(): Record<string, unknown> {
         description:
           "Optional scope hints — the projects, paths, or contexts this memory is relevant to.",
       },
+      project_keys: {
+        type: "array",
+        maxItems: 20,
+        uniqueItems: true,
+        items: {
+          type: "string",
+          minLength: 1,
+          maxLength: 64,
+          pattern: "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+        },
+        description:
+          "Optional relevance links to active projects on the destination shelf. These aid retrieval and never grant access.",
+      },
       confidence: {
         type: "string",
         description:
@@ -53,9 +66,8 @@ export function memoryInputSchema(): Record<string, unknown> {
       // `conv_id` was retired with conv_state (rethink T2); `visibility`
       // with the private-namespace split (rethink T3, D8);
       // `category` / `scope` with the storage cutover (rethink T5);
-      // `project_key` once memories went project-less (grooming collapsed to a
-      // single global slice) — the handler still tolerates all of them from
-      // un-updated plugins.
+      // The retired scalar `project_key` remains tolerated as unknown legacy
+      // input, but only plural `project_keys` is advertised and persisted.
     },
   };
 }

--- a/packages/mcp-server/src/trpc/memories.ts
+++ b/packages/mcp-server/src/trpc/memories.ts
@@ -38,7 +38,12 @@ import {
   splitMemory,
   unifiedMemoryDiff,
 } from "@librarian/core";
-import { MemoryInputSchema, MemoryPatchSchema, MemoryStatusSchema } from "@librarian/core/schemas";
+import {
+  MemoryInputSchema,
+  MemoryPatchSchema,
+  MemoryStatusSchema,
+  ProjectKeysSchema,
+} from "@librarian/core/schemas";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { resolveActorDisplays } from "./actor-displays.js";
@@ -57,6 +62,7 @@ export interface MemoryShape {
   status: string;
   tags: string[];
   applies_to: string[];
+  project_keys?: string[];
   supersedes: string[];
   conflicts_with: string[];
   // Open agent flags routing this memory to review (spec 047 / ADR 0006).
@@ -72,6 +78,11 @@ export interface MemoryShape {
   requires_approval: boolean;
   shelfId?: string;
   shelfLabel?: string;
+  move_warnings?: {
+    code: "missing-active-projects";
+    project_keys: string[];
+    message: string;
+  }[];
   [key: string]: unknown;
 }
 
@@ -88,6 +99,7 @@ const SortOrderSchema = z.enum(["asc", "desc"]);
 const ListMemoriesInputSchema = z.object({
   status: MemoryStatusSchema.optional(),
   agent_id: z.string().optional(),
+  project_keys: ProjectKeysSchema.optional(),
   shelf: z.string().min(1).optional(),
   from: z.string().optional(),
   to: z.string().optional(),
@@ -920,8 +932,13 @@ export const memoriesRouter = router({
         });
       }
 
+      let moved: MemoryShape;
       try {
-        ctx.store.moveMemoryForPrincipal(ctx.principal, targetId as string, plannedShelf as string);
+        moved = ctx.store.moveMemoryForPrincipal(
+          ctx.principal,
+          targetId as string,
+          plannedShelf as string,
+        ) as unknown as MemoryShape;
       } catch (error) {
         if (
           error instanceof MemoryNotFoundForPrincipalError ||
@@ -943,10 +960,7 @@ export const memoriesRouter = router({
         "Proposal not found",
       );
       return {
-        target: ctx.store.getMemoryForPrincipal(
-          ctx.principal,
-          targetId as string,
-        ) as unknown as MemoryShape,
+        target: moved,
         proposal: resolved as unknown as MemoryShape,
       };
     }

--- a/packages/mcp-server/tests/mcp/remember-cutover.test.ts
+++ b/packages/mcp-server/tests/mcp/remember-cutover.test.ts
@@ -8,7 +8,13 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { INTAKE_ENABLED_KEY, type LibrarianStore, createLibrarianStore } from "@librarian/core";
+import {
+  INTAKE_ENABLED_KEY,
+  type LibrarianStore,
+  type Project,
+  createLibrarianStore,
+  parseInboxItem,
+} from "@librarian/core";
 import { handleMcpPayload } from "@librarian/mcp-server";
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -40,6 +46,44 @@ const remember = (args: Record<string, unknown>): Promise<unknown> =>
   });
 const text = (res: unknown): string => (res as CallResult).result.content[0]!.text;
 
+function project(status: Project["status"] = "active"): Project {
+  const section = { content: "", ownership: "automatic" as const, source_ids: [] };
+  return {
+    id: `prj_${status}`,
+    key: "the-librarian",
+    display_name: "The Librarian",
+    aliases: [],
+    repository_identifiers: [],
+    status,
+    resolution: null,
+    resolved_project_id: null,
+    proposal_rationale: status === "proposed" ? "Possible project" : null,
+    proposal_evidence_ids: status === "proposed" ? ["inbox:1"] : [],
+    suppression_fingerprint: null,
+    possible_match_ids: [],
+    sections: {
+      what_this_project_is: { ...section },
+      technology_and_architecture: { ...section },
+      current_state: { ...section },
+      last_meaningful_work: { ...section },
+      planned_next: { ...section },
+      blockers_and_uncertainties: { ...section },
+    },
+    compiled_at: null,
+    compiler_version: null,
+    source_watermark: null,
+    source_ids: [],
+    content_hash: null,
+    refresh_status: "not_built",
+    refresh_failure_class: null,
+    pending_source_count: 0,
+    unresolved_conflict_count: 0,
+    last_activity_at: null,
+    created_at: "2026-08-06T00:00:00.000Z",
+    updated_at: "2026-08-06T00:00:00.000Z",
+  };
+}
+
 describe("remember verb — inbox cutover routing", () => {
   it("submits to the inbox (not a memory) when intake is enabled + markdown", async () => {
     makeStore();
@@ -64,6 +108,64 @@ describe("remember verb — inbox cutover routing", () => {
 
     expect(text(res)).toMatch(/Memory saved/);
     expect(store!.listMemories({ status: "active" }).total).toBe(1);
+  });
+
+  it("stores project_keys only when every key names an active project on the write shelf", async () => {
+    makeStore();
+    store!.projects.create(project());
+
+    const res = await remember({
+      title: "Briefing compiler",
+      body: "The compiler is live.",
+      agent_id: "agent-a",
+      project_keys: ["the-librarian"],
+    });
+
+    expect(text(res)).toMatch(/Memory saved/);
+    expect(store!.listMemories({}).memories[0]?.project_keys).toEqual(["the-librarian"]);
+  });
+
+  it("rejects missing or inactive project associations without writing a memory", async () => {
+    makeStore();
+    store!.projects.create(project("archived"));
+
+    const archived = await remember({
+      title: "Old",
+      body: "Old project fact",
+      agent_id: "agent-a",
+      project_keys: ["the-librarian"],
+    });
+    const missing = await remember({
+      title: "Unknown",
+      body: "Unknown project fact",
+      agent_id: "agent-a",
+      project_keys: ["missing-project"],
+    });
+
+    expect(archived).toHaveProperty("error.message", expect.stringMatching(/active project/i));
+    expect(missing).toHaveProperty("error.message", expect.stringMatching(/active project/i));
+    expect(store!.listMemories({}).total).toBe(0);
+  });
+
+  it("carries validated project_keys through the inbox when intake is enabled", async () => {
+    makeStore();
+    store!.projects.create(project());
+    store!.setSetting(INTAKE_ENABLED_KEY, "true");
+
+    await remember({
+      title: "Briefing compiler",
+      body: "The compiler is live.",
+      agent_id: "agent-a",
+      project_keys: ["the-librarian"],
+    });
+
+    const inboxFile = fs
+      .readdirSync(path.join(dataDir, "vault", "inbox"))
+      .find((file) => file.endsWith(".md"))!;
+    const item = parseInboxItem(
+      fs.readFileSync(path.join(dataDir, "vault", "inbox", inboxFile), "utf8"),
+    );
+    expect(item.hints.projectKeys).toEqual(["the-librarian"]);
   });
 
   it("respects the setting toggled off even after it was on", async () => {

--- a/packages/mcp-server/tests/trpc/memories.test.ts
+++ b/packages/mcp-server/tests/trpc/memories.test.ts
@@ -92,6 +92,7 @@ interface MemoryRow {
   title: string;
   body: string;
   status: string;
+  project_keys?: string[];
 }
 
 interface ListMemoriesResult {
@@ -148,6 +149,7 @@ function seedMemory(
     body: string;
     agent_id: string;
     requires_approval: boolean;
+    project_keys: string[];
   }> = {},
 ): MemoryRow {
   const store = createLibrarianStore({ dataDir });
@@ -159,6 +161,7 @@ function seedMemory(
         agent_id: overrides.agent_id || "bede",
         title: overrides.title || "Seeded memory",
         body: overrides.body || "Body text",
+        ...(overrides.project_keys !== undefined ? { project_keys: overrides.project_keys } : {}),
       },
       opts,
     );
@@ -236,6 +239,24 @@ describe("tRPC memories surface", () => {
         status: "active",
       });
       expect(data.total).toBe(2);
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
+  it("memories.list returns and exactly filters plural project associations", async () => {
+    const dataDir = makeTempDir();
+    seedMemory(dataDir, { title: "Exact", project_keys: ["lib"] });
+    seedMemory(dataDir, { title: "Longer", project_keys: ["the-lib"] });
+    const server = await startHttpServer({ dataDir });
+    try {
+      const data = await trpcGet<ListMemoriesResult>(server, "memories.list", {
+        project_keys: ["lib"],
+      });
+      expect(data.memories).toEqual([
+        expect.objectContaining({ title: "Exact", project_keys: ["lib"] }),
+      ]);
     } finally {
       await server.stop();
       cleanupTempDir(dataDir);

--- a/packages/mcp-server/tests/trpc/scoped-slice.test.ts
+++ b/packages/mcp-server/tests/trpc/scoped-slice.test.ts
@@ -473,13 +473,27 @@ describe("spec 067 — proposeMove and direct move boundaries", () => {
     const { store } = freshStore(router);
     const adminAlice: Principal = { ...alice, kind: "admin", roles: ["admin"] };
     const caller = createCaller(contextFor(adminAlice, store));
-    const direct = store
-      .forShelf(ALICE_SHELF)
-      .createMemory({ title: "Direct", body: "body", agent_id: "alice" }, {}).memory;
+    const direct = store.forShelf(ALICE_SHELF).createMemory(
+      {
+        title: "Direct",
+        body: "body",
+        agent_id: "alice",
+        project_keys: ["source-only"],
+      },
+      {},
+    ).memory;
 
     await expect(
       caller.memories.move({ id: direct.id, shelf: writableTeam.id }),
-    ).resolves.toMatchObject({ id: direct.id });
+    ).resolves.toMatchObject({
+      id: direct.id,
+      move_warnings: [
+        expect.objectContaining({
+          code: "missing-active-projects",
+          project_keys: ["source-only"],
+        }),
+      ],
+    });
     expect(store.forShelf(writableTeam).getMemory(direct.id)?.id).toBe(direct.id);
     await expect(
       caller.memories.move({ id: direct.id, shelf: writableTeam.id }),

--- a/scripts/check-test-count.mjs
+++ b/scripts/check-test-count.mjs
@@ -113,16 +113,33 @@ function countNodeTests(testFiles) {
   });
 }
 
-function countVitestTests() {
-  return Promise.all([countWorkspaceVitestTests(), countRootVitestTests()]).then(
-    ([workspace, root]) => workspace + root,
-  );
+export async function countVitestTests(
+  countWorkspace = countWorkspaceVitestTests,
+  countRoot = countRootVitestTests,
+) {
+  // Keep these runs sequential. The root suite starts several live HTTP/tRPC
+  // servers with deliberately short startup deadlines; competing with every
+  // workspace suite at once can exhaust a busy development host and turn this
+  // counting guard into a source of false timeout failures.
+  const workspace = await countWorkspace();
+  const root = await countRoot();
+  return workspace + root;
 }
 
-function countWorkspaceVitestTests() {
+export function countWorkspaceVitestTests(run = runJsonReporter) {
   // Run vitest in every workspace package via `pnpm -r exec` so every
-  // package that ships a Vitest config gets counted automatically.
-  return runJsonReporter(["pnpm", "-r", "exec", "vitest", "run", "--reporter=json"]);
+  // package that ships a Vitest config gets counted automatically. Keep pnpm's
+  // workspace concurrency at one: several packages start real servers and the
+  // guard is measuring discovery, not parallel-test throughput.
+  return run([
+    "pnpm",
+    "-r",
+    "--workspace-concurrency=1",
+    "exec",
+    "vitest",
+    "run",
+    "--reporter=json",
+  ]);
 }
 
 function countRootVitestTests() {

--- a/scripts/seed/lib.mjs
+++ b/scripts/seed/lib.mjs
@@ -115,7 +115,8 @@ export function rememberArgsFromMarkdown(relPath, raw, agentId) {
   if (Array.isArray(data.applies_to)) {
     args.applies_to = data.applies_to.filter((a) => typeof a === "string");
   }
-  // `project_key` was retired on memories (they're project-less now) — drop it.
+  const projectKeys = importedProjectKeys(data);
+  if (projectKeys !== undefined) args.project_keys = projectKeys;
   return args;
 }
 
@@ -129,8 +130,19 @@ export function rememberArgsFromExtractRecord(rec, fallbackAgentId) {
   if (Array.isArray(rec.tags)) args.tags = rec.tags.filter((t) => typeof t === "string");
   if (Array.isArray(rec.applies_to))
     args.applies_to = rec.applies_to.filter((a) => typeof a === "string");
-  // `project_key` was retired on memories (they're project-less now) — drop it.
+  const projectKeys = importedProjectKeys(rec);
+  if (projectKeys !== undefined) args.project_keys = projectKeys;
   return args;
+}
+
+function importedProjectKeys(input) {
+  if (Array.isArray(input.project_keys)) {
+    return input.project_keys.filter((key) => typeof key === "string");
+  }
+  if (typeof input.project_key === "string" && input.project_key.length > 0) {
+    return [input.project_key];
+  }
+  return undefined;
 }
 
 /** Read exported `extract/*.json` records from a directory. */

--- a/test/check-test-count-failures.test.ts
+++ b/test/check-test-count-failures.test.ts
@@ -12,7 +12,12 @@
 // See scripts/check-test-count.mjs.
 
 import { describe, expect, it } from "vitest";
-import { collectFailedTests, formatRunFailure } from "../scripts/check-test-count.mjs";
+import {
+  collectFailedTests,
+  countWorkspaceVitestTests,
+  countVitestTests,
+  formatRunFailure,
+} from "../scripts/check-test-count.mjs";
 
 /** One workspace's \`--reporter=json\` document, as vitest emits it. */
 function report(
@@ -146,5 +151,54 @@ describe("formatRunFailure", () => {
 
     expect(message).toContain("exited with code 2");
     expect(message).toMatch(/no failing test|could not/i);
+  });
+});
+
+describe("countVitestTests", () => {
+  it("finishes workspace suites before starting the live-server root suite", async () => {
+    const events: string[] = [];
+    let releaseWorkspace!: () => void;
+    const workspaceDone = new Promise<void>((resolve) => {
+      releaseWorkspace = resolve;
+    });
+
+    const totalPromise = countVitestTests(
+      async () => {
+        events.push("workspace:start");
+        await workspaceDone;
+        events.push("workspace:end");
+        return 12;
+      },
+      async () => {
+        events.push("root:start");
+        return 3;
+      },
+    );
+
+    await Promise.resolve();
+    expect(events).toEqual(["workspace:start"]);
+
+    releaseWorkspace();
+    await expect(totalPromise).resolves.toBe(15);
+    expect(events).toEqual(["workspace:start", "workspace:end", "root:start"]);
+  });
+
+  it("runs workspace suites one package at a time", async () => {
+    let command: string[] = [];
+
+    await countWorkspaceVitestTests(async (args: string[]) => {
+      command = args;
+      return 7;
+    });
+
+    expect(command).toEqual([
+      "pnpm",
+      "-r",
+      "--workspace-concurrency=1",
+      "exec",
+      "vitest",
+      "run",
+      "--reporter=json",
+    ]);
   });
 });

--- a/test/seed-import.test.ts
+++ b/test/seed-import.test.ts
@@ -72,9 +72,16 @@ describe("seed lib — pure helpers", () => {
       title: "Elaine",
       tags: ["identity"],
       applies_to: ["Guybrush"],
+      project_keys: ["proj-x"],
     });
-    // project_key was retired on memories — the seed helper no longer carries it.
+    // Scalar compatibility input is normalised; callers never write it back.
     expect(withFm).not.toHaveProperty("project_key");
+    const plural = lib.rememberArgsFromMarkdown(
+      "plural.md",
+      "---\nproject_keys: [proj-x, proj-y]\nproject_key: ignored\n---\n# Plural\nbody",
+      "agent-a",
+    );
+    expect(plural.project_keys).toEqual(["proj-x", "proj-y"]);
     const noFm = lib.rememberArgsFromMarkdown("b.md", "# Plain\ntext", "agent-a");
     expect(noFm).toEqual({ agent_id: "agent-a", title: "Plain", body: "# Plain\ntext" });
 
@@ -91,6 +98,23 @@ describe("seed lib — pure helpers", () => {
     expect(
       lib.rememberArgsFromExtractRecord({ title: "T", body: "B", tags: ["x"] }, "fallback"),
     ).toEqual({ agent_id: "fallback", title: "T", body: "B", tags: ["x"] });
+    expect(
+      lib.rememberArgsFromExtractRecord(
+        { title: "T", body: "B", project_key: "legacy-project" },
+        "fallback",
+      ),
+    ).toMatchObject({ project_keys: ["legacy-project"] });
+    expect(
+      lib.rememberArgsFromExtractRecord(
+        {
+          title: "T",
+          body: "B",
+          project_key: "ignored",
+          project_keys: ["current-project"],
+        },
+        "fallback",
+      ),
+    ).toMatchObject({ project_keys: ["current-project"] });
   });
 
   it("preflightLlm resolves when the LLM answers, and rethrows when it errors", async () => {


### PR DESCRIPTION
## Status

**Paused design exploration — do not merge.**

This draft preserves the completed P0 implementation while the broader Project Briefings design is reconsidered. The likely next product sequence is:

1. Include content-bearing reference results in ordinary `recall`.
2. Add opt-in external sources, beginning with synchronised Git repositories.
3. Re-evaluate how much additional value a maintained Project Brief provides after unified retrieval is proven.

## What this branch contains

- Shelf-scoped Project, ProjectUpdate and ProjectSuggestion domain schemas.
- Deterministic Markdown storage with Git-attributed mutations and backup/restore support.
- Optional shelf-local `project_keys` on memories across intake, grooming, split, merge, move, MCP, Pi, migration and import paths.
- Validation and isolation tests covering unsafe paths, duplicate keys, read-only shelves and cross-shelf behaviour.
- The intended v1.20.1 release metadata.

## Why it is not ready for review or merge

- The persisted three-document design is likely to be replaced by one Project document containing the curated brief, evidence updates and suggestions.
- The branch began from v1.17.5 and is currently 37 commits behind main. A dry-run merge reports six direct conflicts.
- Its test-count guard work overlaps a newer implementation already on main.
- The final full monorepo verification run was interrupted and deliberately stopped; the final tree has not passed the complete gate.
- A fresh-context adversarial review was not completed.
- This is storage foundation only: it does not compile, refresh or serve Project Briefs and has no Projects dashboard.

## Verification evidence

Completed during the P0 slices:

- Core suite reached 1,682 passing tests with one deliberate skip before the final checkpoint.
- All 136 Pi extension tests passed after schema parity was corrected.
- Targeted CLI migration compatibility coverage passed.
- `RELEASE_BASE_VERSION=1.20.0 pnpm check:release` passes on the saved branch.
- `git diff --check` passes.

The complete final gate remains unverified by design while this work is paused.