### PR TITLE
feat(cli): pull stable server images by digest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.21.0] — 2026-08-09
+
+### Added
+
+- **Stable server installs and updates now consume the published all-in-one
+  image.** With no `--ref`, the CLI resolves the latest stable release; an exact
+  `vX.Y.Z` selects that release directly. It pulls the versioned GHCR image,
+  validates its platform and OCI metadata, matches its source commit to the
+  GitHub tag and its digest to the release receipt, then runs the immutable
+  digest without requiring Git or a source checkout.
+- **Managed deployment state records image provenance.** Status distinguishes
+  `published <version> (<short digest>)`, `source <ref>`, and legacy deployments
+  without making Git a requirement for normal Docker-only lifecycle commands.
+
+### Changed
+
+- **`server update` is now a recoverable transition.** Pulls, source builds,
+  image inspection, credential preparation, and configuration capture finish
+  before the current container is stopped. A failed replacement restores and
+  health-checks the previous immutable image and leaves deploy state unchanged;
+  migration failures explicitly distinguish executable recovery from persistent
+  data rollback.
+- **Development refs retain the source path.** `--ref main` and other non-release
+  refs still clone/fetch and build locally, and therefore require Git. Registry,
+  authentication, network, provenance, and architecture failures never silently
+  fall back to a source build.
+- **Automatic updates use the same exact-image and recovery path as manual
+  updates.** They retain the existing schedule, lock, fail-soft reporting, and
+  last-run behavior while avoiding Git and local builds for stable releases.
+
 ## [1.20.1] — 2026-08-09
 
 ### Added
@@ -4370,6 +4400,7 @@ another.
   Code, Hermes) plus copyable setup packages under `integrations/` for the
   rest. See [Harness integrations](./README.md#harness-integrations).
 
+[1.21.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.20.1...v1.21.0
 [1.20.1]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.20.0...v1.20.1
 [1.20.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.17.5...v1.20.0
 [1.17.5]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.17.4...v1.17.5

--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ It runs as a small self-hosted server, reachable locally or over the network.
 ## Self-host in one command
 
 The `librarian` CLI's `server` command group stands up the server for you — it
-builds and runs the all-in-one container, surfaces the master key once, and hands
-you the MCP URL + agent token to paste into clients. Run it with `npx` — no
-install needed:
+resolves the latest stable release, pulls and verifies that exact published image,
+runs it by immutable image digest, surfaces the master key once, and hands you the
+MCP URL + agent token to paste into clients. Stable installs need Docker, but not
+Git or a source checkout. Run it with `npx` — no install needed:
 
 ```sh
 npx @the-librarian/cli server up
@@ -53,11 +54,14 @@ npx @the-librarian/cli server up --data-dir /srv/librarian
 (`enable-boot`), and host-side admin (`server admin backup|restore|auth|rebuild`)
 are all covered in the
 [self-host guide](apps/docs/src/content/docs/deploy-and-operate/self-host.md) in
-the docs site.
+the docs site. Stable updates pull and validate the replacement before stopping
+the current server; a failed replacement restores the previous executable and
+container configuration. Pass `--ref main` (or another development ref) to keep
+the source checkout/build path; that path additionally requires Git.
 
 > **Use native Docker, not the snap.** `librarian server` is unsupported on
-> snap-packaged Docker (common on Ubuntu / LXC) — its confinement breaks the build
-> and hides container health. Install Docker CE. See the
+> snap-packaged Docker (common on Ubuntu / LXC) — its confinement breaks image and
+> container inspection and hides container health. Install Docker CE. See the
 > [self-host guide](apps/docs/src/content/docs/deploy-and-operate/self-host.md).
 
 Prefer to operate Docker yourself? The same all-in-one server and dashboard is

--- a/apps/docs/src/content/docs/deploy-and-operate/manual-install.md
+++ b/apps/docs/src/content/docs/deploy-and-operate/manual-install.md
@@ -7,6 +7,12 @@ The [one-command self-host](/deploy-and-operate/self-host/) path covers most peo
 This page is for operators who want to drive Docker themselves: the published
 all-in-one image, image-only Compose, the source-build Compose stack, or Fly.io.
 
+The managed CLI path is deliberately stricter than these manual examples: stable
+`server up` and `server update` never use `latest`. They select an exact `vX.Y.Z`,
+match its source commit to the GitHub tag and its digest to the release receipt,
+and run the immutable digest. See [Self-host](/deploy-and-operate/self-host/) for
+its pull, provenance, and update-recovery contract.
+
 ## Single container (manual)
 
 One public image runs both services (the MCP server and the dashboard) under a

--- a/apps/docs/src/content/docs/deploy-and-operate/self-host.md
+++ b/apps/docs/src/content/docs/deploy-and-operate/self-host.md
@@ -5,9 +5,9 @@ description: Run and operate your own Librarian server with the one-command CLI.
 
 The Librarian runs as one small self-hosted server. The lowest-friction way to run
 it is the `librarian server` command group, which drives an all-in-one Docker
-container end to end — it builds the image, manages your data, mints your secrets,
-waits for health, and prints the values you paste into clients. You never hand-write
-a `docker run` for the happy path.
+container end to end — it pulls and verifies the exact stable image, manages your
+data, mints your secrets, waits for health, and prints the values you paste into
+clients. You never hand-write a `docker run` for the happy path.
 
 This page is the operator reference. If you just want to get started, the gentler
 [Install](/start-here/install/) walkthrough is the place to begin. Prefer to drive
@@ -15,7 +15,7 @@ Docker yourself? See [Manual deployment](/deploy-and-operate/manual-install/).
 
 ## Standing it up
 
-On a host with Docker and Git:
+On a host with native Docker (Git is not required for a stable release):
 
 ```sh
 npx @the-librarian/cli server up
@@ -23,9 +23,11 @@ npx @the-librarian/cli server up
 
 `server up` does the following:
 
-1. **Clones and builds.** It fetches the project at the latest release into a deploy
-   directory (`~/.librarian/server` by default; `--dir` overrides) and builds the
-   container image.
+1. **Pulls and verifies.** It resolves the latest stable GitHub release, pulls its
+   exact `ghcr.io/code-ministry-ltd/the-librarian:vX.Y.Z` image, verifies its OCI
+   metadata and `linux/amd64` platform, matches its source commit to the GitHub tag,
+   and matches its digest to the release's `docker-image-digest.txt` receipt. It
+   runs the verified repository digest, never the mutable `latest` tag.
 2. **Runs and health-checks.** It starts the all-in-one container on a named data
    volume (`librarian_data`), waits for **both** the MCP server and the dashboard to
    report healthy, and rolls back if they don't — your data volume is never touched
@@ -42,13 +44,22 @@ npx @the-librarian/cli server up
 5. **Optionally configures this machine.** It offers to write this box's own client
    config, so a single-machine setup is done in one shot.
 
+The managed deploy directory is `~/.librarian/server` by default (`--dir`
+overrides it). `deploy.env` contains the protected runtime credentials and is mode
+`0600`; `deploy-state.json` contains only non-secret configuration and provenance,
+including whether the deployment is `registry` or `source`, its readable image
+reference, and the immutable digest for a published release. A fresh stable install
+does not clone the repository. If an older source-managed deployment already has a
+checkout there, adopting a published release preserves it; the CLI never deletes it
+automatically.
+
 :::caution[Use native Docker, not the snap package]
 `librarian server` requires **native Docker** (Docker CE / `docker.io`). It does
 **not** work on snap-packaged Docker (common on Ubuntu, especially inside LXC),
-whose sandboxing breaks the build and hides container health in ways that surface as
-confusing, unrelated-looking failures. On Ubuntu/LXC, install the official Docker CE
-packages instead (and enable LXC nesting first if you're in an unprivileged
-container). With native Docker, no extra flags are needed.
+whose sandboxing breaks image/container inspection and hides container health in
+ways that surface as confusing, unrelated-looking failures. On Ubuntu/LXC, install
+the official Docker CE packages instead (and enable LXC nesting first if you're in
+an unprivileged container). With native Docker, no extra flags are needed.
 :::
 
 ## Reaching it from other machines (`--host`)
@@ -200,19 +211,45 @@ burn flag refuses claims until the operator removes it.
 
 ## Keeping it running and up to date
 
-- **`server update`** re-pins forward: fetch the latest release, rebuild, recreate
-  the container (your data volume is preserved), apply any pending data migrations,
-  and wait for health. It is idempotent — already current and healthy is a clean
-  no-op — and it reuses the existing agent token, so clients keep working untouched.
+- **`server update`** re-pins forward: resolve the latest stable release, pull and
+  verify its exact image while the current server keeps serving, then recreate the
+  container by immutable digest. Storage, host/ports, credentials, restart policy,
+  bootstrap-claim secret, and legacy dashboard-port choices are preserved. Pending
+  data migrations run only after the replacement is healthy. Once the target
+  release is resolved, an already-current, healthy deployment is a no-op before
+  pulling it again; an exact `--ref vX.Y.Z` also avoids resolving the latest release.
 - **`server down`** stops the container with `docker stop` only. It never removes the
   container or the volume; a later `up`/`update` recalls the same memories.
 - **`server status`** reports whether it's running, its health, the deployed and
-  latest versions, and an up-to-date / update-available badge (degrading gracefully
-  to "unknown" when offline rather than crashing).
+  latest versions, and an up-to-date / update-available badge. Provenance appears as
+  `published vX.Y.Z (<short-digest>)`, `source <ref>`, or `legacy <ref>`; offline or
+  unresolvable values degrade to `unknown` rather than crashing. Normal state-backed
+  status does not need Git.
 - **`server logs [-f] [--service mcp|dashboard|all]`** tails the container logs;
   `-f` follows live and `--service` filters the stream.
-- **`--ref <tag|main>`** pins `up`/`update` to a specific release or to `main`
-  (default: the latest release).
+- **`--ref vX.Y.Z`** selects that exact published release. With no `--ref`, the CLI
+  resolves the latest stable release. **`--ref main` and every other branch, tag, or
+  commit are development targets:** they require Git, use the managed checkout, and
+  build a local source image. A registry, authentication, network, provenance, or
+  unsupported-architecture failure is reported with recovery guidance; it never
+  silently falls back to a source build.
+
+### Update recovery
+
+`server update` finishes the pull or source build and prepares protected credentials
+before it interrupts the old container. It captures the old immutable image and
+complete run configuration, then replaces the container under the update lock. If
+the replacement fails to start or become healthy, the CLI recreates the previous
+executable and configuration, verifies it is healthy, and leaves deploy state
+unchanged.
+
+That recovery restores the executable, **not a historical copy of `/data`**. If a
+failure happens after a migration begins, the message states that persistent data
+changes were not rolled back. If restoring the old executable also fails, the CLI
+does not claim success: it preserves the data, protected credentials and state,
+reports both failures, and prints commands using immutable container/image IDs for
+manual recovery. Follow those commands before retrying; do not delete the named
+volume, bind mount, deploy files, or protected recovery env file.
 
 ### Automatic updates
 
@@ -229,7 +266,9 @@ This installs a systemd timer (or an hourly cron line where systemd is absent)
 that fires hourly and performs a `server update` when the cadence says one is
 due. The timer runs as the enabling user against their deploy dir — which is
 why the user matters: `enable` refuses, with an explanation, if it can't find
-the deploy state where it's looking.
+the deploy state where it's looking. A due update resolves, pulls, and verifies
+the exact stable release and does not invoke Git or a local build; this also lets
+an older source-built deployment adopt the published image in place.
 
 The dashboard's [Settings → Dashboard](/dashboard/settings/#dashboard) page
 holds the enable toggle and the cadence as *settings*; the host timer is what
@@ -242,9 +281,9 @@ acts on them. Flipping the toggle without installing the timer updates nothing
   and the next fire no-ops.
 - **`autoupdate uninstall`** — removes the timer/cron entirely.
 
-A failed auto-update (an unreachable server, a failed health check) leaves the
-previous container running and retries at the next fire — the same rollback
-guarantees as a manual `server update`.
+A failed auto-update is fail-soft and retries at the next fire. A pull or
+verification failure leaves the current container serving; a replacement failure
+uses the same executable-recovery contract as manual `server update`.
 
 :::note[If auto-update seems to do nothing]
 The timer logs one line per hourly fire to the **system** journal, which needs

--- a/apps/docs/src/content/docs/reference/cli.md
+++ b/apps/docs/src/content/docs/reference/cli.md
@@ -41,12 +41,13 @@ Harnesses: claude, codex, opencode, hermes, pi
 ```text
 Usage: librarian server <subcommand> [flags]
 
-Self-host the Librarian server (build + run the all-in-one container),
+Self-host the Librarian server from an exact published release,
+or use --ref <development-ref>; source refs build locally,
 then hand its MCP URL + agent token to `librarian install` on clients.
 
 Subcommands:
-  up            Build + run the server; print the MCP URL + agent token
-  update        Re-pin to a release, rebuild, recreate (data volume kept)
+  up            Pull an exact release (or build a source ref) and start it
+  update        Prepare, verify and replace; recover the old image on failure
   down          Stop the container (the data volume is preserved)
   status        Running? healthy? deployed version vs latest release
   logs          Tail the container logs ([-f] [--service mcp|dashboard|all])

--- a/apps/docs/src/content/docs/start-here/install.md
+++ b/apps/docs/src/content/docs/start-here/install.md
@@ -26,8 +26,9 @@ even your laptop to try it out), run:
 npx @the-librarian/cli server up
 ```
 
-This builds and starts The Librarian in a Docker container, waits until it is
-healthy, and then prints three things:
+This resolves the latest stable release, pulls and verifies its exact published
+image, starts it by immutable digest, waits until it is healthy, and then prints
+three things. You do not need Git or a source checkout for this stable path:
 
 - an **MCP URL** (like `http://your-host:3838/mcp`) — the address your agents
   connect to,

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -103,6 +103,10 @@ is a clean no-op.
   `docker-image-digest.txt`; verify it against both tags. The dashboard version
   badge compares the running `package.json` to the latest GitHub release,
   refreshing on its 1-hour cache (restart the server for an immediate update).
+  Stable `librarian server up` / `update` resolves the exact release tag, verifies
+  the pulled image against that receipt and the tag's source commit, and runs the
+  immutable digest. A release is not operationally ready for the managed CLI until
+  the versioned image is anonymously pullable on `linux/amd64`.
 - **Claude marketplace** — installs pull this repo; the manifest's `source`
   points at `./integrations/claude`. A marketplace-visible change should bump
   `plugins[].version` in `.claude-plugin/marketplace.json` in the same PR.
@@ -126,4 +130,5 @@ is a clean no-op.
 - [ ] CI green → merge. `release.yml` tags, verifies the image, then publishes the GitHub release automatically
 - [ ] Verify the release digest receipt matches `vX.Y.Z` and `latest`
 - [ ] On the first image release, make the GHCR package public if required; verify a logged-out pull
+- [ ] With the published CLI, verify a stable `server up` selects the new exact tag, reports its digest, and needs no Git/source checkout
 - [ ] Verify the GitHub release appeared (and, for a Pi publish, `npm view <pkg> version` reports the new version)

--- a/integrations/pi/package.json
+++ b/integrations/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-librarian/pi-extension",
-  "version": "1.20.1",
+  "version": "1.21.0",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.20.1",
+  "version": "1.21.0",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/installer-cli/README.md
+++ b/packages/installer-cli/README.md
@@ -50,7 +50,7 @@ librarian report                 Push this machine's state to the server
 librarian server up              Self-host the server with Docker; prints the
                                   MCP URL + agent token to paste into `install`
 librarian server update          Upgrade the server to the latest release
-                                  (your data is preserved)
+                                  (pulls before stop; data/config are preserved)
 librarian server down|status|logs  Stop / inspect / tail the running server
 ```
 
@@ -63,8 +63,11 @@ an error.
 ## Self-host the server
 
 The Librarian needs a server to talk to. `server up` stands one up with Docker —
-it builds the all-in-one image, mints your secrets, waits for health, and prints
-the MCP URL + agent token to paste into `librarian install`:
+it resolves the latest stable release, pulls and verifies the exact published
+image, runs its immutable digest, mints your secrets, waits for health, and prints
+the MCP URL + agent token to paste into `librarian install`. Stable installs need
+Docker but not Git; pass `--ref main` (or another development ref) to use the
+Git-backed source checkout and local build path:
 
 ```sh
 npx @the-librarian/cli server up
@@ -98,11 +101,22 @@ writable by — you, not a container user. The directory is created if it doesn'
 exist, and `server update` reuses it automatically. (`--data-dir` and
 `--data-volume` are mutually exclusive.)
 
-Other server commands: `server update` (upgrade to the latest release, preserving
-your data), `server down` / `status` / `logs`, and `server enable-boot` (Linux
-systemd) to start it on boot. Run it on a private network / behind a VPN, or
-expose it with auth — see the
+Other server commands: `server update` pulls and verifies before stopping the old
+container, preserving storage, ports, credentials, restart policy, and deploy
+state. A failed replacement restores and health-checks the previous executable;
+if migration began, persistent data changes are explicitly **not** claimed as
+rolled back. `server status` labels deployments as published (with a short
+digest), source, or legacy. `server down` / `logs` and `server enable-boot`
+(Linux systemd) complete the lifecycle. Run it on a private network / behind a
+VPN, or expose it with auth — see the
 [deployment guide](https://github.com/code-ministry-ltd/the-librarian/blob/main/DEPLOYMENT.md).
+
+The managed server files live in `~/.librarian/server` by default:
+`deploy.env` is protected mode `0600`, while `deploy-state.json` contains only
+non-secret configuration and image provenance. Stable registry/network/auth/
+architecture failures are teaching errors and never trigger a source-build
+fallback. Existing source checkouts are preserved when a deployment adopts a
+published image.
 
 ## What it writes to your environment
 

--- a/packages/installer-cli/package.json
+++ b/packages/installer-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-librarian/cli",
-  "version": "1.20.1",
+  "version": "1.21.0",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/installer-cli/src/runtime.ts
+++ b/packages/installer-cli/src/runtime.ts
@@ -258,8 +258,8 @@ async function runServerCommand(rest: string[], options: RuntimeOptions): Promis
 }
 
 /**
- * `librarian server up [flags]` (S2, localhost path). Parses the flags, builds
- * a prompter (for the loop-closer env offer), and runs the orchestrated flow.
+ * `librarian server up [flags]`. Parses the flags, builds a prompter (for the
+ * loop-closer env offer), and runs the selected published-image or source flow.
  * A failure surfaces as one clean stderr line via the top-level catch — no
  * stack trace, and the master key (carried only on the success stdout) never
  * reaches an error path.
@@ -389,13 +389,11 @@ async function runServerAdminCommand(
 }
 
 /**
- * `librarian server update [--ref <tag|main>] [--yes]` (S5). Re-pins the deploy
- * dir to the resolved ref, rebuilds the image, recreates the container
- * (PRESERVING the data volume), waits for health (rolling back on failure), and
- * applies pending data-dir migrations. Idempotent: already at the ref + healthy
- * → a clean no-op. The agent token is reused from the running container (clients
- * keep working) and never reaches an error path or a file. A failure surfaces as
- * one clean stderr line via the top-level catch (already secret-redacted).
+ * `librarian server update [--ref <tag|main>] [--yes]`. Pulls and verifies an
+ * exact stable release, or prepares/builds an explicit development ref, before
+ * replacing the container while preserving storage and credentials. A failed
+ * replacement recovers the previous executable where possible and reports the
+ * exact recovery outcome. Idempotent: the exact healthy target is a clean no-op.
  */
 async function runServerUpdateCommand(rest: string[], options: RuntimeOptions): Promise<CliResult> {
   const { flags } = parseArgs(rest);

--- a/packages/installer-cli/src/runtime.ts
+++ b/packages/installer-cli/src/runtime.ts
@@ -28,7 +28,7 @@ import {
 } from "./server/autoupdate.js";
 import { disableBoot, enableBoot } from "./server/boot.js";
 import { runDown } from "./server/down.js";
-import { serverUsage } from "./server/index.js";
+import { isServerSubcommand, serverSubcommandUsage, serverUsage } from "./server/index.js";
 import { runLogs } from "./server/logs.js";
 import { serverStatus } from "./server/status.js";
 import { runUp } from "./server/up.js";
@@ -226,6 +226,9 @@ async function runServerCommand(rest: string[], options: RuntimeOptions): Promis
 
   if (!subcommand || subcommand === "--help" || subcommand === "-h") {
     return ok(serverUsage());
+  }
+  if (isServerSubcommand(subcommand) && subRest.some((arg) => arg === "--help" || arg === "-h")) {
+    return ok(serverSubcommandUsage(subcommand));
   }
   if (subcommand === "up") {
     return runServerUpCommand(subRest, options);

--- a/packages/installer-cli/src/server/admin.ts
+++ b/packages/installer-cli/src/server/admin.ts
@@ -25,7 +25,7 @@
 // exact argv without a real daemon or container.
 
 import { run, runInteractive } from "./docker.js";
-import { preflight } from "./preflight.js";
+import { dockerPreflight } from "./preflight.js";
 import { redactSecrets } from "./redact.js";
 import { CONTAINER_NAME } from "./up.js";
 
@@ -117,7 +117,7 @@ export async function runAdmin(
     throw new AdminError(unknownVerbMessage(verb));
   }
 
-  await preflight(options.platform ? { platform: options.platform } : {});
+  await dockerPreflight(options.platform ? { platform: options.platform } : {});
   await assertContainerRunning();
 
   // A prompt is only needed when the run is interactive AND the operator hasn't

--- a/packages/installer-cli/src/server/autoupdate.ts
+++ b/packages/installer-cli/src/server/autoupdate.ts
@@ -3,8 +3,9 @@
 // T3). The server settings + admin tRPC are T1/T2; this is the scheduler that
 // actually performs the update on the host.
 //
-// THE ARCHITECTURAL CONSTRAINT (spec §2). `server update` is host-level: it
-// rebuilds the image and `docker rm`s + recreates the container. A process INSIDE
+// THE ARCHITECTURAL CONSTRAINT (spec §2). `server update` is host-level: it pulls
+// an exact stable image (or builds an explicit source ref), then recreates the
+// container. A process INSIDE
 // the container cannot recreate its own container (no docker-socket access, by
 // design). So the act of updating MUST run on the host. This module installs a
 // host scheduler (a systemd timer; a cron fallback where systemd is absent) that
@@ -27,10 +28,10 @@
 // FAIL-SOFT (AGENTS.md + spec §3 SC4/SC7). The `--run` wrapper NEVER throws out of
 // the timer: any failure (server unreachable, a non-zero update) is logged on one
 // line and the wrapper exits 0. Server unreachable → SKIP (conservative: never
-// auto-update a server in an unknown state). A successful update stamps
-// `last_run_at`; a FAILED update does NOT stamp it (so the next fire retries) and
-// relies on `server update`'s own health-check rollback to leave the prior
-// container running.
+// auto-update a server in an unknown state). A successful due check (replacement
+// or exact-target no-op) stamps `last_run_at`; a FAILED update does NOT stamp it
+// (so the next fire retries) and
+// relies on `server update` to report its exact executable-recovery outcome.
 //
 // Everything privileged routes through the injectable `docker.ts` runner (the
 // same seam boot.ts uses), so tests assert the exact systemctl/crontab/docker
@@ -179,11 +180,13 @@ export function generateServiceUnit(input: ServiceUnitInput): string {
     // deploy-state — every fire failed with "No deploy-state found" while
     // `autoupdate status` looked healthy. The ENABLING user is the one context
     // where everything resolves: their `~/.librarian/server` is the deploy dir,
-    // they own the git clone (root git would refuse the dubious-ownership
-    // check), and they have docker access by construction (they ran `server up`).
+    // they own the deploy state and have docker access by construction (they ran
+    // `server up`). A source-ref deployment additionally uses their managed Git
+    // checkout; a stable published deployment does not require Git.
     `User=${user}`,
     // NoNewPrivileges: forbid this oneshot from gaining ANY new privileges via
-    // setuid/setgid/capabilities on the binaries it execs (docker/git) — an
+    // setuid/setgid/capabilities on the binaries it execs (Docker, and Git only
+    // for an explicit source ref) — an
     // auto-executing unit should grant no more than it needs.
     "NoNewPrivileges=true",
     // The wrapper reads the auto-update settings from the running container and,
@@ -511,8 +514,8 @@ export async function enableAutoUpdate(options: EnableOptions = {}): Promise<Aut
     const sudoUser = process.env.SUDO_USER;
     throw new AutoUpdateError(
       `No deploy-state found at ${deployDir} — the auto-update timer must run as the user ` +
-        "who ran `librarian server up` (it reads that user's deploy dir and git clone, with " +
-        "their docker access).\n" +
+        "who ran `librarian server up` (it reads that user's deploy state and uses their " +
+        "Docker access; explicit source refs also require their managed Git checkout).\n" +
         "Re-run `librarian server autoupdate enable` as that user" +
         (sudoUser
           ? ` — you appear to be under sudo, so likely as \`${sudoUser}\` without the leading sudo ` +
@@ -823,10 +826,10 @@ async function isTimerInstalled(): Promise<boolean> {
  *
  *   - Server UNREACHABLE → SKIP (never auto-update a server in an unknown state).
  *   - NOT (enabled && due) → SKIP (the no-op the disabled/not-due case wants).
- *   - enabled && due → run `server update`. On SUCCESS, stamp `last_run_at`
- *     (so the next due-check advances). On FAILURE (the update's own health-check
- *     rollback left the prior container running), log + do NOT stamp (so the next
- *     fire retries).
+ *   - enabled && due → run `server update`. On successful replacement OR an
+ *     exact-target no-op, stamp `last_run_at` (so the next due-check advances).
+ *     On FAILURE (the update's recovery outcome is carried by the typed update
+ *     error), log + do NOT stamp (so the next fire retries).
  *
  * The due-check is computed HOST-SIDE from the config the server returned (so the
  * single source of truth — the core helper's logic — is mirrored here without a
@@ -873,14 +876,16 @@ export async function runAutoUpdate(options: RunOptions = {}): Promise<AutoUpdat
           ? { healthIntervalMs: options.healthIntervalMs }
           : {}),
       });
-      // Stamp last_run_at ONLY on success. The server was recreated, so write the
-      // stamp through the (now-fresh) container's internal tRPC. A failed stamp is
-      // logged but not fatal — the update itself succeeded.
+      // Stamp last_run_at only after a successful replacement or exact-target
+      // check. Write through the running container's internal tRPC; a failed
+      // stamp is logged but not fatal because the lifecycle check itself passed.
       const stamped = await stampRunInServer();
       const stampNote = stamped
         ? ""
         : " (note: could not stamp last_run_at — will re-check next fire)";
-      const line = `autoupdate: updated successfully${stampNote}.`;
+      const line = result.changed
+        ? `autoupdate: updated successfully${stampNote}.`
+        : `autoupdate: checked; already up to date${stampNote}.`;
       log(line);
       // The inner update's own output (carries an at-most-once fresh token note).
       return { output: `${line}\n${redactSecrets(result.output)}` };
@@ -908,7 +913,7 @@ export async function runAutoUpdate(options: RunOptions = {}): Promise<AutoUpdat
           "upgrade the CLI and re-run `librarian server autoupdate enable` as the user who ran " +
           "`server up`."
         : "";
-      const line = `autoupdate: update failed — deployment state was not advanced and last_run_at was NOT stamped (will retry next fire). Inspect \`librarian server status\`; recovery outcome: ${firstLine(detail)}${migrationHint}`;
+      const line = `autoupdate: update did not complete — last_run_at was NOT stamped (will retry next fire). Inspect \`librarian server status\`; recovery outcome: ${firstLine(detail)}${migrationHint}`;
       log(line);
       return { output: line };
     }

--- a/packages/installer-cli/src/server/autoupdate.ts
+++ b/packages/installer-cli/src/server/autoupdate.ts
@@ -892,8 +892,9 @@ export async function runAutoUpdate(options: RunOptions = {}): Promise<AutoUpdat
         log(line);
         return { output: line };
       }
-      // The update failed — its own health-check rollback left the prior container
-      // running. Do NOT stamp last_run_at (so the next fire retries). Log + exit 0.
+      // The update failed. Its typed detail says whether executable recovery also
+      // succeeded; the fail-soft wrapper must not invent a rollback outcome. Do
+      // NOT stamp last_run_at (so the next fire retries). Log + exit 0.
       const detail =
         error instanceof UpdateError || error instanceof Error
           ? redactSecrets(error.message)
@@ -907,7 +908,7 @@ export async function runAutoUpdate(options: RunOptions = {}): Promise<AutoUpdat
           "upgrade the CLI and re-run `librarian server autoupdate enable` as the user who ran " +
           "`server up`."
         : "";
-      const line = `autoupdate: update failed — left the previous server running, did NOT stamp last_run_at (will retry next fire). ${firstLine(detail)}${migrationHint}`;
+      const line = `autoupdate: update failed — deployment state was not advanced and last_run_at was NOT stamped (will retry next fire). Inspect \`librarian server status\`; recovery outcome: ${firstLine(detail)}${migrationHint}`;
       log(line);
       return { output: line };
     }

--- a/packages/installer-cli/src/server/deploy-state.ts
+++ b/packages/installer-cli/src/server/deploy-state.ts
@@ -8,21 +8,22 @@
 //
 // SECURITY (AGENTS.md / spec §11): this file is NON-SECRET by construction. It
 // carries ONLY non-secret fields — a bind host, a volume name (and an optional
-// host data dir), a ref, an image tag, and the container name. It NEVER carries
-// a bearer token, master
-// key, or admin token. `writeDeployState` whitelists exactly those fields, so a
+// host data dir), a ref, image identity/provenance, and the container name. It
+// NEVER carries a bearer token, master key, or admin token. `writeDeployState`
+// whitelists exactly those fields, so a
 // caller that accidentally passes extra keys (a smuggled secret) cannot leak
 // them into the file. The master key / admin token are surfaced to stdout once
 // by `up` and persisted nowhere host-side — that contract is unchanged.
 
 import fs from "node:fs";
 import path from "node:path";
+import { CANONICAL_IMAGE_NAME, isReleasedVersionRef } from "./deployment-image.js";
 
 /**
  * The deploy-state recorded after a successful `up` (and rewritten by `update`).
  * Every field is NON-SECRET — see the module header. Do NOT add a token/key.
  */
-export interface DeployState {
+interface DeployStateBase {
   /** The container name every `server` command operates on. */
   containerName: string;
   /** The resolved bind host the container publishes on (`127.0.0.1`, a tailnet IP, `0.0.0.0`). */
@@ -38,7 +39,7 @@ export interface DeployState {
   dataDir?: string | undefined;
   /** The deployed ref — a `vX.Y.Z` tag or `main` (what was checked out + built). */
   ref: string;
-  /** The built image tag (`the-librarian:<ref>`). */
+  /** Legacy-compatible image identity: local tag for source, registry tag for registry. */
   imageTag: string;
   /**
    * The host port the dashboard is published on (`-p <host>:<dashboardPort>:3000`).
@@ -50,8 +51,88 @@ export interface DeployState {
   dashboardPort?: number | undefined;
 }
 
-/** The keys we ever persist — the whitelist that keeps secrets out of the file. */
-const STATE_KEYS = ["containerName", "host", "dataVolume", "ref", "imageTag"] as const;
+/** State written before explicit image provenance existed; interpreted as source. */
+export interface LegacyDeployState extends DeployStateBase {
+  imageSource?: undefined;
+  imageRef?: undefined;
+  imageDigest?: undefined;
+}
+
+/** A locally built source image; its explicit ref is the existing local image tag. */
+export interface SourceDeployState extends DeployStateBase {
+  imageSource: "source";
+  imageRef: string;
+  imageDigest?: undefined;
+}
+
+/** A released registry image, retaining both its readable tag and immutable digest. */
+export interface RegistryDeployState extends DeployStateBase {
+  imageSource: "registry";
+  imageRef: string;
+  imageDigest: string;
+}
+
+export type DeployState = LegacyDeployState | SourceDeployState | RegistryDeployState;
+
+interface DeployStateCandidate extends DeployStateBase {
+  imageSource?: "registry" | "source" | undefined;
+  imageRef?: string | undefined;
+  imageDigest?: string | undefined;
+}
+
+/** Required legacy keys; optional fields are individually picked and validated below. */
+const REQUIRED_STATE_KEYS = ["containerName", "host", "dataVolume", "ref", "imageTag"] as const;
+const PERSISTED_STATE_KEYS = new Set<string>([
+  ...REQUIRED_STATE_KEYS,
+  "dataDir",
+  "dashboardPort",
+  "imageSource",
+  "imageRef",
+  "imageDigest",
+]);
+
+const IMAGE_DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/;
+const VERSION_IMAGE_PREFIX = `${CANONICAL_IMAGE_NAME}:`;
+const DIGEST_IMAGE_PREFIX = `${CANONICAL_IMAGE_NAME}@`;
+
+function isCanonicalVersionImageRef(imageRef: string): boolean {
+  return (
+    imageRef.startsWith(VERSION_IMAGE_PREFIX) &&
+    isReleasedVersionRef(imageRef.slice(VERSION_IMAGE_PREFIX.length))
+  );
+}
+
+function isCanonicalDigestImageRef(imageRef: string): boolean {
+  return (
+    imageRef.startsWith(DIGEST_IMAGE_PREFIX) &&
+    IMAGE_DIGEST_PATTERN.test(imageRef.slice(DIGEST_IMAGE_PREFIX.length))
+  );
+}
+
+function validImageMetadata(state: DeployStateCandidate): state is DeployState {
+  if (state.imageSource === undefined) {
+    return state.imageRef === undefined && state.imageDigest === undefined;
+  }
+  if (state.imageSource === "source") {
+    return state.imageRef === state.imageTag && state.imageDigest === undefined;
+  }
+  if (state.imageSource !== "registry") return false;
+  const expectedVersionRef = `${CANONICAL_IMAGE_NAME}:${state.ref}`;
+  return (
+    isReleasedVersionRef(state.ref) &&
+    state.imageRef === expectedVersionRef &&
+    isCanonicalVersionImageRef(state.imageRef) &&
+    state.imageTag === expectedVersionRef &&
+    state.imageDigest !== undefined &&
+    isCanonicalDigestImageRef(state.imageDigest)
+  );
+}
+
+function hasOnlyPersistedStateKeys(state: object): boolean {
+  return Reflect.ownKeys(state).every(
+    (key) => typeof key === "string" && PERSISTED_STATE_KEYS.has(key),
+  );
+}
 
 /** `<dir>/deploy-state.json` — the deploy-state file path within a deploy dir. */
 export function deployStatePath(dir: string): string {
@@ -61,15 +142,24 @@ export function deployStatePath(dir: string): string {
 /**
  * Write the deploy-state to `<dir>/deploy-state.json`, creating `dir` if absent.
  *
- * Only the five declared fields are persisted — a `pick`, not a spread — so no
- * extra key (e.g. a smuggled token) can ride along into the file. The file is
- * non-secret, so it gets ordinary (not 0600) permissions.
+ * Inputs with undeclared own keys are rejected, then declared fields are picked
+ * explicitly. The file is non-secret, so it gets ordinary permissions.
  */
 export function writeDeployState(dir: string, state: DeployState): void {
+  if (!hasOnlyPersistedStateKeys(state)) {
+    throw new TypeError(
+      "Invalid deploy state fields: only whitelisted non-secret deployment metadata is allowed; unexpected own keys are rejected.",
+    );
+  }
+  if (!validImageMetadata(state)) {
+    throw new TypeError(
+      "Invalid deploy image metadata: expected legacy fields only; source with imageRef matching imageTag and no digest; or registry with a matching canonical version tag and full lowercase sha256 digest reference.",
+    );
+  }
   fs.mkdirSync(dir, { recursive: true });
   // Pick ONLY the whitelisted keys — never spread `state`, which could carry
   // extra (secret-shaped) properties a caller smuggled in.
-  const safe: DeployState = {
+  const safe: Record<string, string | number> = {
     containerName: state.containerName,
     host: state.host,
     dataVolume: state.dataVolume,
@@ -82,6 +172,9 @@ export function writeDeployState(dir: string, state: DeployState): void {
   // Persist the published dashboard port when set, so `update` reuses it (a state
   // written before this field stays byte-compatible until the next write).
   if (state.dashboardPort !== undefined) safe.dashboardPort = state.dashboardPort;
+  if (state.imageSource !== undefined) safe.imageSource = state.imageSource;
+  if (state.imageRef !== undefined) safe.imageRef = state.imageRef;
+  if (state.imageDigest !== undefined) safe.imageDigest = state.imageDigest;
   fs.writeFileSync(deployStatePath(dir), `${JSON.stringify(safe, null, 2)}\n`, "utf8");
 }
 
@@ -105,16 +198,29 @@ export function readDeployState(dir: string): DeployState | null {
   }
   if (typeof parsed !== "object" || parsed === null) return null;
   const obj = parsed as Record<string, unknown>;
-  for (const key of STATE_KEYS) {
+  if (!hasOnlyPersistedStateKeys(obj)) return null;
+  for (const key of REQUIRED_STATE_KEYS) {
     if (typeof obj[key] !== "string") return null;
   }
-  const result: DeployState = {
+  const result: DeployStateCandidate = {
     containerName: obj.containerName as string,
     host: obj.host as string,
     dataVolume: obj.dataVolume as string,
     ref: obj.ref as string,
     imageTag: obj.imageTag as string,
   };
+  if (
+    obj.imageSource !== undefined &&
+    obj.imageSource !== "registry" &&
+    obj.imageSource !== "source"
+  ) {
+    return null;
+  }
+  if (obj.imageRef !== undefined && typeof obj.imageRef !== "string") return null;
+  if (obj.imageDigest !== undefined && typeof obj.imageDigest !== "string") return null;
+  if (obj.imageSource !== undefined) result.imageSource = obj.imageSource;
+  if (typeof obj.imageRef === "string") result.imageRef = obj.imageRef;
+  if (typeof obj.imageDigest === "string") result.imageDigest = obj.imageDigest;
   // Optional, back-compatible: present only on `--data-dir` deploys written after
   // this field existed; left undefined otherwise (old states still validate).
   if (typeof obj.dataDir === "string") result.dataDir = obj.dataDir;
@@ -125,5 +231,5 @@ export function readDeployState(dir: string): DeployState | null {
   if (typeof obj.dashboardPort === "number" && Number.isInteger(obj.dashboardPort)) {
     result.dashboardPort = obj.dashboardPort;
   }
-  return result;
+  return validImageMetadata(result) ? result : null;
 }

--- a/packages/installer-cli/src/server/deployment-image.ts
+++ b/packages/installer-cli/src/server/deployment-image.ts
@@ -12,6 +12,12 @@ const REVISION_PATTERN = /^[0-9a-f]{40}$/;
 const REQUIRED_PLATFORM = "linux/amd64";
 const GITHUB_API = "https://api.github.com/repos/code-ministry-ltd/the-librarian";
 
+/** Conventional display form: the first 12 hexadecimal characters of a sha256 digest. */
+export function shortImageDigest(imageDigest: string): string {
+  const match = /@sha256:([0-9a-f]{64})$/.exec(imageDigest);
+  return match?.[1]?.slice(0, 12) ?? imageDigest;
+}
+
 /** A pulled release image whose provenance and immutable identity were verified. */
 export interface PreparedRegistryImage {
   imageSource: "registry";

--- a/packages/installer-cli/src/server/deployment-image.ts
+++ b/packages/installer-cli/src/server/deployment-image.ts
@@ -1,5 +1,103 @@
+import { run, stream, type RunResult } from "./docker.js";
+import { redactSecrets } from "./redact.js";
+
 /** The immutable release image published by the repository release workflow. */
 export const CANONICAL_IMAGE_NAME = "ghcr.io/code-ministry-ltd/the-librarian";
+
+/** Canonical source label stamped by the release workflow. */
+export const CANONICAL_SOURCE_REPOSITORY = "https://github.com/code-ministry-ltd/the-librarian";
+
+const IMAGE_DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/;
+const REVISION_PATTERN = /^[0-9a-f]{40}$/;
+const REQUIRED_PLATFORM = "linux/amd64";
+const GITHUB_API = "https://api.github.com/repos/code-ministry-ltd/the-librarian";
+
+/** A pulled release image whose provenance and immutable identity were verified. */
+export interface PreparedRegistryImage {
+  imageSource: "registry";
+  ref: string;
+  /** Human-readable canonical version tag retained in deploy state. */
+  imageRef: string;
+  /** Immutable canonical repository digest passed to `docker run`. */
+  imageDigest: string;
+  /** Source commit stamped by the release workflow. */
+  revision: string;
+}
+
+/** A fail-closed, human-facing registry preparation failure. */
+export class DeploymentImageError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DeploymentImageError";
+  }
+}
+
+export interface ReleaseProvenance {
+  revision: string;
+  imageDigest: string;
+}
+
+export interface PublicHttpResponse {
+  ok: boolean;
+  status: number;
+  json(): Promise<unknown>;
+  text(): Promise<string>;
+}
+
+export type PublicGithubFetch = (
+  url: string,
+  init: { redirect: "error" | "follow"; headers?: Record<string, string> },
+) => Promise<PublicHttpResponse>;
+
+const realPublicGithubFetch: PublicGithubFetch = (url, init) => fetch(url, init);
+let publicGithubFetch = realPublicGithubFetch;
+
+export function setPublicGithubFetch(next: PublicGithubFetch): void {
+  publicGithubFetch = next;
+}
+
+export function resetPublicGithubFetch(): void {
+  publicGithubFetch = realPublicGithubFetch;
+}
+
+export type ReleaseProvenanceResolver = (ref: string) => Promise<ReleaseProvenance>;
+
+const defaultReleaseProvenanceResolver: ReleaseProvenanceResolver = async (ref) => {
+  const reference = await fetchGithubJson(`${GITHUB_API}/git/ref/tags/${encodeURIComponent(ref)}`);
+  let object = gitObject(reference);
+  for (let depth = 0; object.type === "tag" && depth < 5; depth += 1) {
+    object = gitObject(await fetchGithubJson(`${GITHUB_API}/git/tags/${object.sha}`));
+  }
+  if (object.type !== "commit" || !REVISION_PATTERN.test(object.sha)) {
+    throw new Error(`GitHub tag ${ref} did not peel to a full commit SHA.`);
+  }
+  const release = await fetchGithubJson(`${GITHUB_API}/releases/tags/${encodeURIComponent(ref)}`);
+  const assets = objectRecord(release).assets;
+  const receiptUrl = Array.isArray(assets)
+    ? assets.map(objectRecord).find((asset) => asset.name === "docker-image-digest.txt")
+        ?.browser_download_url
+    : undefined;
+  const expectedReceiptUrl = `${CANONICAL_SOURCE_REPOSITORY}/releases/download/${ref}/docker-image-digest.txt`;
+  if (receiptUrl !== expectedReceiptUrl) {
+    throw new Error(`GitHub release ${ref} has no docker-image-digest.txt receipt.`);
+  }
+  const receipt = (await fetchGithubText(receiptUrl)).trim();
+  const prefix = `${CANONICAL_IMAGE_NAME}@`;
+  if (!receipt.startsWith(prefix) || !IMAGE_DIGEST_PATTERN.test(receipt.slice(prefix.length))) {
+    throw new Error(`GitHub release ${ref} has an invalid Docker digest receipt.`);
+  }
+  return { revision: object.sha, imageDigest: receipt };
+};
+
+let releaseProvenanceResolver = defaultReleaseProvenanceResolver;
+
+export function setReleaseProvenanceResolver(next: ReleaseProvenanceResolver): void {
+  releaseProvenanceResolver = next;
+}
+
+export function resetReleaseProvenanceResolver(): void {
+  releaseProvenanceResolver = defaultReleaseProvenanceResolver;
+}
 
 /** A stable released deployment, resolved to a concrete release in the pull flow. */
 export interface RegistryDeploymentTarget {
@@ -31,4 +129,262 @@ export function selectDeploymentTarget(ref: string | undefined): DeploymentTarge
     return { imageSource: "registry", ref };
   }
   return { imageSource: "source", ref };
+}
+
+interface DockerImageInspect {
+  Os?: unknown;
+  Architecture?: unknown;
+  Config?: { Labels?: Record<string, unknown> | null } | null;
+  RepoTags?: unknown;
+  RepoDigests?: unknown;
+}
+
+interface DockerDaemonInfo {
+  OSType?: unknown;
+  Architecture?: unknown;
+}
+
+function imageFailure(message: string): DeploymentImageError {
+  return new DeploymentImageError(
+    `${message} The release image was not used and source fallback is disabled for stable ` +
+      "releases. Resolve the registry/image problem, then re-run `librarian server up`.",
+  );
+}
+
+function objectRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function gitObject(value: unknown): { type: string; sha: string } {
+  const object = objectRecord(objectRecord(value).object);
+  const type = typeof object.type === "string" ? object.type : "";
+  const sha = typeof object.sha === "string" ? object.sha : "";
+  if ((type !== "tag" && type !== "commit") || !REVISION_PATTERN.test(sha)) {
+    throw new Error("GitHub returned malformed tag provenance.");
+  }
+  return { type, sha };
+}
+
+async function fetchGithubJson(url: string): Promise<unknown> {
+  const response = await publicGithubFetch(url, {
+    redirect: "error",
+    headers: {
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+  if (!response.ok) throw new Error(`GitHub API returned HTTP ${response.status}.`);
+  return response.json();
+}
+
+async function fetchGithubText(url: string): Promise<string> {
+  const response = await publicGithubFetch(url, { redirect: "follow" });
+  if (!response.ok) throw new Error(`GitHub receipt download returned HTTP ${response.status}.`);
+  return response.text();
+}
+
+function normalizedPlatform(os: unknown, architecture: unknown): string {
+  const normalizedOs = typeof os === "string" ? os.trim().toLowerCase() : "";
+  const rawArch = typeof architecture === "string" ? architecture.trim().toLowerCase() : "";
+  const normalizedArch = ["amd64", "x86_64", "x86-64"].includes(rawArch)
+    ? "amd64"
+    : ["arm64", "aarch64"].includes(rawArch)
+      ? "arm64"
+      : rawArch;
+  return normalizedOs && normalizedArch ? `${normalizedOs}/${normalizedArch}` : "";
+}
+
+async function inspectDockerDaemon(): Promise<DockerDaemonInfo> {
+  let result: RunResult;
+  try {
+    result = await run("docker", ["info", "--format", "{{json .}}"]);
+  } catch (error) {
+    const detail = redactSecrets(error instanceof Error ? error.message : String(error));
+    throw imageFailure(`Could not inspect the active Docker server platform: ${detail}`);
+  }
+  if (result.code !== 0) {
+    const detail = redactSecrets(result.stderr.trim() || result.stdout.trim());
+    throw imageFailure(
+      `Could not inspect the active Docker server platform${detail ? `: ${detail}` : "."}`,
+    );
+  }
+  try {
+    const parsed: unknown = JSON.parse(result.stdout.trim());
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) throw new Error();
+    return parsed as DockerDaemonInfo;
+  } catch {
+    throw imageFailure("Docker returned malformed server platform metadata.");
+  }
+}
+
+function redactingStream(onProgress: (chunk: string) => void): {
+  write: (chunk: string) => void;
+  flush: () => void;
+} {
+  let buffered = "";
+  const emitCompleteRecords = (): void => {
+    const boundary = Math.max(buffered.lastIndexOf("\n"), buffered.lastIndexOf("\r"));
+    if (boundary < 0) return;
+    const complete = buffered.slice(0, boundary + 1);
+    buffered = buffered.slice(boundary + 1);
+    onProgress(redactSecrets(complete));
+  };
+  return {
+    write(chunk) {
+      buffered += chunk;
+      emitCompleteRecords();
+    },
+    flush() {
+      if (!buffered) return;
+      onProgress(redactSecrets(buffered));
+      buffered = "";
+    },
+  };
+}
+
+/**
+ * Pull and validate a stable release image, returning the digest-pinned run target.
+ * This is shared preparation for `up` now and the B3 update flow later.
+ */
+export async function prepareRegistryImage(
+  ref: string,
+  onProgress: (chunk: string) => void,
+): Promise<PreparedRegistryImage> {
+  if (!isReleasedVersionRef(ref)) {
+    throw imageFailure(`Expected an exact release ref like v1.20.1, got '${ref}'.`);
+  }
+  const daemon = await inspectDockerDaemon();
+  const daemonPlatform = normalizedPlatform(daemon.OSType, daemon.Architecture);
+  if (daemonPlatform !== REQUIRED_PLATFORM) {
+    throw imageFailure(
+      `The active Docker server reports '${daemonPlatform || "unknown"}', but the supported platform is ${REQUIRED_PLATFORM}. ` +
+        "Switch Docker context to a Linux amd64 server or install on a supported host.",
+    );
+  }
+  const imageRef = `${CANONICAL_IMAGE_NAME}:${ref}`;
+  const stdout = redactingStream(onProgress);
+  const stderr = redactingStream(onProgress);
+  let pullCode: number | null;
+  try {
+    pullCode = await stream("docker", ["pull", imageRef], {
+      onStdout: stdout.write,
+      onStderr: stderr.write,
+    });
+  } catch (error) {
+    stdout.flush();
+    stderr.flush();
+    const detail = redactSecrets(error instanceof Error ? error.message : String(error));
+    throw imageFailure(
+      `\`docker pull ${imageRef}\` could not start${detail ? `: ${detail}` : "."}`,
+    );
+  }
+  stdout.flush();
+  stderr.flush();
+  if (pullCode !== 0) {
+    throw imageFailure(
+      `\`docker pull ${imageRef}\` failed (exit ${pullCode ?? "signal"}). Check registry access, ` +
+        "authentication, network connectivity, and whether this release supports your architecture.",
+    );
+  }
+
+  let inspected: RunResult;
+  try {
+    inspected = await run("docker", ["image", "inspect", "--format", "{{json .}}", imageRef]);
+  } catch (error) {
+    const detail = redactSecrets(error instanceof Error ? error.message : String(error));
+    throw imageFailure(
+      `Docker metadata inspection failed for ${imageRef}${detail ? `: ${detail}` : "."}`,
+    );
+  }
+  if (inspected.code !== 0) {
+    const detail = redactSecrets(inspected.stderr.trim() || inspected.stdout.trim());
+    throw imageFailure(
+      `Docker pulled ${imageRef}, but its local metadata could not be inspected` +
+        (detail ? `: ${detail}` : "."),
+    );
+  }
+
+  let record: DockerImageInspect;
+  try {
+    const parsed: unknown = JSON.parse(inspected.stdout.trim());
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) throw new Error();
+    record = parsed as DockerImageInspect;
+  } catch {
+    throw imageFailure(`Docker returned malformed image metadata for ${imageRef}.`);
+  }
+  const validated = validateRegistryImage(ref, imageRef, record, daemonPlatform);
+  let authoritative: ReleaseProvenance;
+  try {
+    authoritative = await releaseProvenanceResolver(ref);
+  } catch (error) {
+    const detail = redactSecrets(error instanceof Error ? error.message : String(error));
+    throw imageFailure(
+      `Could not verify ${ref} against authoritative GitHub release provenance${detail ? `: ${detail}` : "."}`,
+    );
+  }
+  if (validated.revision !== authoritative.revision) {
+    throw imageFailure(
+      `Image revision ${validated.revision} does not match GitHub tag ${ref} commit ${authoritative.revision}.`,
+    );
+  }
+  if (validated.imageDigest !== authoritative.imageDigest) {
+    throw imageFailure(
+      `Image digest ${validated.imageDigest} does not match the GitHub release receipt ${authoritative.imageDigest}.`,
+    );
+  }
+  return validated;
+}
+
+function validateRegistryImage(
+  ref: string,
+  imageRef: string,
+  record: DockerImageInspect,
+  daemonPlatform: string,
+): PreparedRegistryImage {
+  const labels = record.Config?.Labels ?? {};
+  const version = labels["org.opencontainers.image.version"];
+  const source = labels["org.opencontainers.image.source"];
+  const revision = labels["org.opencontainers.image.revision"];
+  const expectedVersion = ref.slice(1);
+  if (!Array.isArray(record.RepoTags) || !record.RepoTags.includes(imageRef)) {
+    throw imageFailure(`The pulled image does not carry the requested tag ${imageRef}.`);
+  }
+  if (version !== expectedVersion) {
+    throw imageFailure(
+      `Image version metadata mismatch: expected '${expectedVersion}' for ${ref}, got '${redactSecrets(String(version))}'.`,
+    );
+  }
+  if (source !== CANONICAL_SOURCE_REPOSITORY) {
+    throw imageFailure(
+      `Image source metadata mismatch: expected ${CANONICAL_SOURCE_REPOSITORY}, got '${redactSecrets(String(source))}'.`,
+    );
+  }
+  if (typeof revision !== "string" || !REVISION_PATTERN.test(revision)) {
+    throw imageFailure(
+      `Image revision metadata is missing or invalid; expected a full 40-character Git commit for traceability.`,
+    );
+  }
+  const imagePlatform = normalizedPlatform(record.Os, record.Architecture);
+  if (imagePlatform !== REQUIRED_PLATFORM || imagePlatform !== daemonPlatform) {
+    throw imageFailure(
+      `The pulled image platform/architecture metadata is '${imagePlatform || "unknown"}', but the supported platform is ${REQUIRED_PLATFORM} and must match the active Docker server.`,
+    );
+  }
+  const digestPrefix = `${CANONICAL_IMAGE_NAME}@`;
+  const imageDigest = Array.isArray(record.RepoDigests)
+    ? record.RepoDigests.find(
+        (value): value is string =>
+          typeof value === "string" &&
+          value.startsWith(digestPrefix) &&
+          IMAGE_DIGEST_PATTERN.test(value.slice(digestPrefix.length)),
+      )
+    : undefined;
+  if (!imageDigest) {
+    throw imageFailure(
+      `Docker metadata for ${imageRef} has no full canonical repository digest (${CANONICAL_IMAGE_NAME}@sha256:<64 lowercase hex characters>).`,
+    );
+  }
+  return { imageSource: "registry", ref, imageRef, imageDigest, revision };
 }

--- a/packages/installer-cli/src/server/deployment-image.ts
+++ b/packages/installer-cli/src/server/deployment-image.ts
@@ -1,0 +1,34 @@
+/** The immutable release image published by the repository release workflow. */
+export const CANONICAL_IMAGE_NAME = "ghcr.io/code-ministry-ltd/the-librarian";
+
+/** A stable released deployment, resolved to a concrete release in the pull flow. */
+export interface RegistryDeploymentTarget {
+  imageSource: "registry";
+  /** Absent when the caller omitted `--ref`; the latest release is resolved later. */
+  ref?: string | undefined;
+}
+
+/** A branch, tag, commit, or malformed release-like ref that must build from source. */
+export interface SourceDeploymentTarget {
+  imageSource: "source";
+  ref: string;
+}
+
+export type DeploymentTarget = RegistryDeploymentTarget | SourceDeploymentTarget;
+
+/** Exact release refs only: `vMAJOR.MINOR.PATCH`, with strict numeric components. */
+export function isReleasedVersionRef(ref: string): boolean {
+  return /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(ref);
+}
+
+/**
+ * Select the deployment strategy without doing network or Docker work.
+ * Omitted/blank refs stay unresolved for the later latest-release lookup.
+ */
+export function selectDeploymentTarget(ref: string | undefined): DeploymentTarget {
+  if (ref === undefined || ref.trim().length === 0) return { imageSource: "registry" };
+  if (isReleasedVersionRef(ref)) {
+    return { imageSource: "registry", ref };
+  }
+  return { imageSource: "source", ref };
+}

--- a/packages/installer-cli/src/server/docker.ts
+++ b/packages/installer-cli/src/server/docker.ts
@@ -29,6 +29,8 @@
 //     exercises, and neither ever spawns a real `docker`.
 
 import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
 import type { RunOptions, RunResult, Runner } from "../exec.js";
 
 export type { RunOptions, RunResult, Runner } from "../exec.js";
@@ -85,20 +87,41 @@ const realRunner: Runner = {
   },
 
   async which(cmd) {
-    const probe = process.platform === "win32" ? "where" : "which";
-    try {
-      const { stdout, code } = await realRunner.run(probe, [cmd]);
-      if (code !== 0) return null;
-      const first = stdout
-        .split("\n")
-        .map((l) => l.trim())
-        .find((l) => l.length > 0);
-      return first ?? null;
-    } catch {
-      return null;
-    }
+    return resolveExecutable(cmd);
   },
 };
+
+/** Resolve an executable without depending on a host `which`/`where` utility. */
+async function resolveExecutable(cmd: string): Promise<string | null> {
+  const isWindows = process.platform === "win32";
+  const hasSeparator = cmd.includes("/") || (isWindows && cmd.includes("\\"));
+  const directories = hasSeparator ? [""] : (process.env.PATH ?? "").split(path.delimiter);
+  const extensions = isWindows
+    ? commandExtensions(cmd, process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD")
+    : [""];
+
+  for (const directory of directories) {
+    const base = hasSeparator ? cmd : path.resolve(directory || ".", cmd);
+    for (const extension of extensions) {
+      const candidate = `${base}${extension}`;
+      try {
+        await fs.promises.access(candidate, isWindows ? fs.constants.F_OK : fs.constants.X_OK);
+        if ((await fs.promises.stat(candidate)).isFile()) return path.resolve(candidate);
+      } catch {
+        // Not an executable file; continue searching PATH.
+      }
+    }
+  }
+  return null;
+}
+
+function commandExtensions(cmd: string, pathExt: string): string[] {
+  const extensions = pathExt
+    .split(";")
+    .filter(Boolean)
+    .map((extension) => extension.toLowerCase());
+  return extensions.some((extension) => cmd.toLowerCase().endsWith(extension)) ? [""] : extensions;
+}
 
 // --- the real, process-spawning streamer ----------------------------------
 

--- a/packages/installer-cli/src/server/down.ts
+++ b/packages/installer-cli/src/server/down.ts
@@ -16,7 +16,7 @@
 // exact argv without a real daemon.
 
 import { run } from "./docker.js";
-import { preflight } from "./preflight.js";
+import { dockerPreflight } from "./preflight.js";
 import { CONTAINER_NAME } from "./up.js";
 
 export interface DownOptions {
@@ -48,7 +48,7 @@ function isNotRunning(stderr: string): boolean {
  * no-op; any other non-zero exit is a teaching `DownError`.
  */
 export async function runDown(options: DownOptions = {}): Promise<DownResult> {
-  await preflight(options.platform ? { platform: options.platform } : {});
+  await dockerPreflight(options.platform ? { platform: options.platform } : {});
 
   // The single, data-safe command. No `rm`, no `-v`, no `volume`, no `-f`.
   const result = await run("docker", ["stop", CONTAINER_NAME]);

--- a/packages/installer-cli/src/server/index.ts
+++ b/packages/installer-cli/src/server/index.ts
@@ -1,14 +1,7 @@
 // The `librarian server` command group — self-host the Librarian from the CLI.
 //
-// S1 lays the foundation the later slices build on: the command SURFACE (the
-// help table from spec §4), the `docker.ts` seam, and server preflights. The
-// individual subcommands (up / update / down / status / logs / enable-boot /
-// disable-boot / admin) are implemented in their own slices; here they resolve
-// to a clear "arrives in a later slice" notice so the surface is honest about
-// what exists today.
-//
-// `server` with NO subcommand prints the surface; `librarian --help` reveals
-// this group alongside the harness commands (wired in `runtime.ts`).
+// `server` with no subcommand prints the lifecycle surface; `librarian --help`
+// reveals this group alongside the harness commands (wired in `runtime.ts`).
 
 /** The `server` subcommands, in the order they appear in the surface (§4). */
 export const SERVER_SUBCOMMANDS = [
@@ -30,12 +23,13 @@ export function serverUsage(): string {
   return [
     "Usage: librarian server <subcommand> [flags]",
     "",
-    "Self-host the Librarian server (build + run the all-in-one container),",
+    "Self-host the Librarian server from an exact published release,",
+    "or use --ref <development-ref>; source refs build locally,",
     "then hand its MCP URL + agent token to `librarian install` on clients.",
     "",
     "Subcommands:",
-    "  up            Build + run the server; print the MCP URL + agent token",
-    "  update        Re-pin to a release, rebuild, recreate (data volume kept)",
+    "  up            Pull an exact release (or build a source ref) and start it",
+    "  update        Prepare, verify and replace; recover the old image on failure",
     "  down          Stop the container (the data volume is preserved)",
     "  status        Running? healthy? deployed version vs latest release",
     "  logs          Tail the container logs ([-f] [--service mcp|dashboard|all])",

--- a/packages/installer-cli/src/server/index.ts
+++ b/packages/installer-cli/src/server/index.ts
@@ -42,6 +42,29 @@ export function serverUsage(): string {
   ].join("\n");
 }
 
+/** Help for one server subcommand; evaluated before any lifecycle dispatch. */
+export function serverSubcommandUsage(subcommand: ServerSubcommand): string {
+  const usage: Record<ServerSubcommand, readonly string[]> = {
+    up: [
+      "Usage: librarian server up [--ref <release|source-ref>] [--dir <path>]",
+      "       [--host <address>] [--dashboard-port <port>]",
+      "       [--data-volume <name> | --data-dir <path>] [--enable-boot] [--yes]",
+    ],
+    update: ["Usage: librarian server update [--ref <release|source-ref>] [--dir <path>] [--yes]"],
+    down: ["Usage: librarian server down"],
+    status: ["Usage: librarian server status [--dir <path>]"],
+    logs: ["Usage: librarian server logs [-f|--follow] [--service mcp|dashboard|all]"],
+    "enable-boot": ["Usage: librarian server enable-boot"],
+    "disable-boot": ["Usage: librarian server disable-boot"],
+    autoupdate: [
+      "Usage: librarian server autoupdate <enable|disable|uninstall|status> [--dir <path>]",
+      "       [--cadence daily|weekly]",
+    ],
+    admin: ["Usage: librarian server admin <backup|restore|auth|rebuild> [args…]"],
+  };
+  return usage[subcommand].join("\n");
+}
+
 /** True iff `name` is one of the known `server` subcommands. */
 export function isServerSubcommand(name: string): name is ServerSubcommand {
   return (SERVER_SUBCOMMANDS as readonly string[]).includes(name);

--- a/packages/installer-cli/src/server/index.ts
+++ b/packages/installer-cli/src/server/index.ts
@@ -1,7 +1,7 @@
 // The `librarian server` command group — self-host the Librarian from the CLI.
 //
 // S1 lays the foundation the later slices build on: the command SURFACE (the
-// help table from spec §4), the `docker.ts` seam, and `preflight()`. The
+// help table from spec §4), the `docker.ts` seam, and server preflights. The
 // individual subcommands (up / update / down / status / logs / enable-boot /
 // disable-boot / admin) are implemented in their own slices; here they resolve
 // to a clear "arrives in a later slice" notice so the surface is honest about

--- a/packages/installer-cli/src/server/logs.ts
+++ b/packages/installer-cli/src/server/logs.ts
@@ -30,7 +30,7 @@
 //     live-per-line) differs.
 
 import { run, stream } from "./docker.js";
-import { preflight } from "./preflight.js";
+import { dockerPreflight } from "./preflight.js";
 import { CONTAINER_NAME } from "./up.js";
 
 /** The services `--service` can target. `all` (default) is unfiltered. */
@@ -174,7 +174,7 @@ function makeLineFilter(
  */
 export async function runLogs(options: LogsOptions = {}): Promise<LogsResult> {
   const service = resolveService(options.service);
-  await preflight(options.platform ? { platform: options.platform } : {});
+  await dockerPreflight(options.platform ? { platform: options.platform } : {});
 
   if (options.follow) {
     // Live tail: stream line-by-line, never buffer to close.

--- a/packages/installer-cli/src/server/preflight.ts
+++ b/packages/installer-cli/src/server/preflight.ts
@@ -1,8 +1,9 @@
 // Preflight for the `server` command group.
 //
-// Every `server` subcommand that drives a container (up / update / down /
-// status / logs / boot / admin) first confirms the host actually has the tools
-// it needs: `docker` installed AND its daemon reachable, and `git` installed.
+// Every `server` subcommand that directly drives a container (up / update /
+// down / status / logs / admin) first confirms the host actually has the tools
+// it needs: `docker` installed AND its daemon reachable. Source deployments
+// additionally require `git`; registry-backed and Docker-only commands do not.
 // A missing or unreachable tool is a TEACHING error (what to install, or "is
 // the daemon running?") — never a stack trace, never a bare "error".
 //
@@ -51,13 +52,13 @@ function dockerDaemonHint(platform: NodeJS.Platform): string {
 }
 
 /**
- * Confirm `docker` (daemon reachable) and `git` are available, or throw a
- * `PreflightError` with a teaching message. Resolves to nothing on success.
+ * Confirm `docker` is installed with a reachable daemon, or throw a teaching
+ * `PreflightError`. Resolves to nothing on success.
  *
  * Order matters: report a missing binary before probing the daemon, so a host
  * without Docker is told to install it (not told the daemon is down).
  */
-export async function preflight(options: PreflightOptions = {}): Promise<void> {
+export async function dockerPreflight(options: PreflightOptions = {}): Promise<void> {
   const platform = options.platform ?? process.platform;
 
   if ((await which("docker")) === null) {
@@ -70,7 +71,11 @@ export async function preflight(options: PreflightOptions = {}): Promise<void> {
   if (info.code !== 0) {
     throw new PreflightError(dockerDaemonHint(platform));
   }
+}
 
+/** Confirm Docker plus Git for a lifecycle path that operates on source. */
+export async function sourcePreflight(options: PreflightOptions = {}): Promise<void> {
+  await dockerPreflight(options);
   if ((await which("git")) === null) {
     throw new PreflightError(GIT_INSTALL);
   }

--- a/packages/installer-cli/src/server/source-repository.ts
+++ b/packages/installer-cli/src/server/source-repository.ts
@@ -1,0 +1,43 @@
+import { redactSecrets } from "./redact.js";
+
+export const CANONICAL_SOURCE_REPOSITORY = "https://github.com/code-ministry-ltd/the-librarian";
+
+const CANONICAL_PATH = "/code-ministry-ltd/the-librarian";
+
+/** Accept the canonical repository only over authenticated, encrypted transports. */
+export function isCanonicalSourceRemote(remote: string): boolean {
+  const value = remote.trim();
+  const scp = value.match(/^git@github\.com:(\/?[^?#]+)$/iu);
+  if (scp) return normalizePath(scp[1] ?? "") === CANONICAL_PATH;
+
+  try {
+    const parsed = new URL(value);
+    if (parsed.hostname.toLowerCase() !== "github.com" || parsed.search || parsed.hash)
+      return false;
+    if (normalizePath(parsed.pathname) !== CANONICAL_PATH) return false;
+    if (parsed.protocol === "https:") return parsed.port === "" || parsed.port === "443";
+    return (
+      parsed.protocol === "ssh:" &&
+      parsed.username === "git" &&
+      parsed.password === "" &&
+      (parsed.port === "" || parsed.port === "22")
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** Git may echo credential-bearing remote URLs; no Git diagnostic is trusted. */
+export function redactGitDiagnostics(text: string): string {
+  return redactSecrets(text)
+    .replace(/\b[a-z][a-z0-9+.-]*:\/\/[^\s'"`]+/giu, "[redacted-remote]")
+    .replace(/\b[^\s/@:]+@[^\s/'":]+(?::|\/)[^\s'"`]+/gu, "[redacted-remote]");
+}
+
+function normalizePath(value: string): string {
+  const withLeadingSlash = value.startsWith("/") ? value : `/${value}`;
+  return withLeadingSlash
+    .replace(/\/$/u, "")
+    .replace(/\.git$/iu, "")
+    .toLowerCase();
+}

--- a/packages/installer-cli/src/server/status.ts
+++ b/packages/installer-cli/src/server/status.ts
@@ -4,9 +4,8 @@
 // latest-release fetcher (so tests never touch a real daemon/network):
 //   - container running? (`docker inspect --format {{.State.Status}}`)
 //   - health (`docker inspect --format {{.State.Health.Status}}`)
-//   - the DEPLOYED version — the ref recorded in deploy-state.json, falling back
-//     to `git -C <dir> describe --tags` when no state file exists (e.g. a clone
-//     made before deploy-state existed)
+//   - the DEPLOYED provenance — published tag + short digest, source ref, or a
+//     legacy ref from old state / `git describe`
 //   - the LATEST release (`fetchLatestVersion` — the same fetch `librarian
 //     status` uses for the harnesses)
 //   - an `up-to-date | update-available` badge via `isBehind(deployed, latest)`
@@ -21,6 +20,7 @@ import { librarianDir } from "../paths.js";
 import { isBehind } from "../semver.js";
 import { fetchLatestVersion } from "../status.js";
 import { readDeployState } from "./deploy-state.js";
+import { shortImageDigest } from "./deployment-image.js";
 import { run, which } from "./docker.js";
 import { dockerPreflight } from "./preflight.js";
 import { CONTAINER_NAME } from "./up.js";
@@ -39,7 +39,7 @@ export interface ServerStatusResult {
   output: string;
 }
 
-/** The deploy dir `status` reads its recorded ref / git-describe fallback from. */
+/** The deploy dir `status` reads its recorded provenance / git fallback from. */
 function resolveDeployDir(options: ServerStatusOptions): string {
   return options.dir ?? path.join(librarianDir(options.home), "server");
 }
@@ -55,19 +55,40 @@ async function inspectField(format: string): Promise<string | null> {
 }
 
 /**
- * Resolve the deployed version: the deploy-state ref first (authoritative — it's
- * exactly what `up` checked out + built), else `git -C <dir> describe --tags`.
- * Returns `null` (→ "unknown") when neither is available.
+ * Resolve deployed provenance from state without Git. Old state and a no-state
+ * `git describe` fallback remain explicitly labelled legacy because neither
+ * records an immutable published digest nor explicit source strategy.
  */
-async function resolveDeployed(deployDir: string): Promise<string | null> {
+interface DeployedIdentity {
+  /** Raw version/ref used for the update badge. */
+  ref: string;
+  /** Human-readable provenance rendered to the operator. */
+  label: string;
+  /** Whether comparing this identity with the latest stable release is meaningful. */
+  releaseComparable: boolean;
+}
+
+async function resolveDeployed(deployDir: string): Promise<DeployedIdentity | null> {
   const state = readDeployState(deployDir);
-  if (state?.ref) return state.ref;
+  if (state?.imageSource === "registry") {
+    return {
+      ref: state.ref,
+      label: `published ${state.ref} (${shortImageDigest(state.imageDigest)})`,
+      releaseComparable: true,
+    };
+  }
+  if (state?.imageSource === "source") {
+    return { ref: state.ref, label: `source ${state.ref}`, releaseComparable: false };
+  }
+  if (state?.ref) {
+    return { ref: state.ref, label: `legacy ${state.ref}`, releaseComparable: false };
+  }
 
   if ((await which("git")) === null) return null;
   const described = await run("git", ["-C", deployDir, "describe", "--tags"]);
   if (described.code === 0) {
     const tag = described.stdout.trim();
-    if (tag) return tag;
+    if (tag) return { ref: tag, label: `legacy ${tag}`, releaseComparable: false };
   }
   return null;
 }
@@ -98,7 +119,7 @@ interface RenderInput {
   statusField: string | null;
   running: boolean;
   health: string | null;
-  deployed: string | null;
+  deployed: DeployedIdentity | null;
   latest: string | null;
 }
 
@@ -107,9 +128,9 @@ interface RenderInput {
  * unknown — an offline run never lies about an available update (mirrors the
  * harness `status` table's `update?` column).
  */
-function badge(deployed: string | null, latest: string | null): string {
-  if (!deployed || !latest) return "?";
-  return isBehind(deployed, latest) ? "update-available" : "up-to-date";
+function badge(deployed: DeployedIdentity | null, latest: string | null): string {
+  if (!deployed?.releaseComparable || !latest) return "?";
+  return isBehind(deployed.ref, latest) ? "update-available" : "up-to-date";
 }
 
 function render(input: RenderInput): string {
@@ -122,7 +143,7 @@ function render(input: RenderInput): string {
     "",
     `  Running:    ${runningLabel}`,
     `  Health:     ${runningLabel === "not running" ? "—" : healthLabel}`,
-    `  Deployed:   ${deployed ?? "unknown"}`,
+    `  Deployed:   ${deployed?.label ?? "unknown"}`,
     `  Latest:     ${latest ?? "unknown"}`,
     `  Update:     ${badge(deployed, latest)}`,
   ];

--- a/packages/installer-cli/src/server/status.ts
+++ b/packages/installer-cli/src/server/status.ts
@@ -21,8 +21,8 @@ import { librarianDir } from "../paths.js";
 import { isBehind } from "../semver.js";
 import { fetchLatestVersion } from "../status.js";
 import { readDeployState } from "./deploy-state.js";
-import { run } from "./docker.js";
-import { preflight } from "./preflight.js";
+import { run, which } from "./docker.js";
+import { dockerPreflight } from "./preflight.js";
 import { CONTAINER_NAME } from "./up.js";
 
 export interface ServerStatusOptions {
@@ -63,6 +63,7 @@ async function resolveDeployed(deployDir: string): Promise<string | null> {
   const state = readDeployState(deployDir);
   if (state?.ref) return state.ref;
 
+  if ((await which("git")) === null) return null;
   const described = await run("git", ["-C", deployDir, "describe", "--tags"]);
   if (described.code === 0) {
     const tag = described.stdout.trim();
@@ -78,7 +79,7 @@ async function resolveDeployed(deployDir: string): Promise<string | null> {
  * `unknown`/`?`.
  */
 export async function serverStatus(options: ServerStatusOptions = {}): Promise<ServerStatusResult> {
-  await preflight(options.platform ? { platform: options.platform } : {});
+  await dockerPreflight(options.platform ? { platform: options.platform } : {});
   const deployDir = resolveDeployDir(options);
 
   // Probe the container. A null status means `docker inspect` failed → absent.

--- a/packages/installer-cli/src/server/up.ts
+++ b/packages/installer-cli/src/server/up.ts
@@ -1,11 +1,13 @@
-// `librarian server up` — build + run the all-in-one container.
+// `librarian server up` — pull a stable release (or build a source ref) and run
+// the all-in-one container.
 //
-// This is the loop-closer: on a fresh Docker host it clones the monorepo at the
-// resolved release tag, builds `the-librarian:<tag>`, mints the master key +
-// agent token into a 0600 deploy env-file, runs the all-in-one container with
-// `docker run --env-file` (ADR 0008 P4 — secrets off argv), waits for it to
-// report healthy, surfaces the CLI-MINTED master key ONCE, and prints the MCP
-// URL + dashboard URL + the agent token ready to paste into `librarian install`.
+// This is the loop-closer: on a fresh Docker host it resolves and validates the
+// stable release image (or clones/builds an arbitrary `--ref`), mints the master
+// key + agent token into a 0600 deploy env-file, creates and starts the
+// all-in-one container with `docker create --env-file` (ADR 0008 P4 — secrets
+// off argv), waits for it to
+// report healthy, surfaces the CLI-MINTED master key ONCE, and prints the MCP URL
+// + dashboard URL + the agent token ready to paste into `librarian install`.
 //
 // ADR 0008 P3: there is no admin token. The admin tRPC API is served only on the
 // trusted internal listener (off the network), so `server up` neither reads back
@@ -34,7 +36,7 @@
 //
 // Security (AGENTS.md): the agent token, master key, and optional bootstrap
 // claim secret ride ONLY in the 0600 deploy env-file fed to
-// `docker run --env-file` (ADR 0008 P4) — never inline on argv. `--env-file`
+// `docker create --env-file` (ADR 0008 P4) — never inline on argv. `--env-file`
 // keeps them off the process argv (and out of any
 // argv-echoing error); it does NOT hide them from `docker inspect .Config.Env`
 // (docker expands the file client-side into the same env list) — that's an
@@ -53,10 +55,18 @@ import { librarianDir } from "../paths.js";
 import type { Prompter } from "../prompt.js";
 import { fetchLatestVersion } from "../status.js";
 import { enableBoot } from "./boot.js";
-import { writeDeployState } from "./deploy-state.js";
+import { deployStatePath, readDeployState, writeDeployState } from "./deploy-state.js";
+import {
+  CANONICAL_IMAGE_NAME,
+  prepareRegistryImage,
+  isReleasedVersionRef,
+  selectDeploymentTarget,
+  type PreparedRegistryImage,
+} from "./deployment-image.js";
 import { run, stream, which, type RunResult } from "./docker.js";
-import { sourcePreflight } from "./preflight.js";
+import { dockerPreflight, sourcePreflight } from "./preflight.js";
 import { redactSecrets } from "./redact.js";
+import { acquireUpdateLock, updateLockPath } from "./update-lock.js";
 
 // Re-exported from its shared home so existing importers (`update.ts`) keep
 // working; new code should import from `./redact.js` directly.
@@ -138,9 +148,49 @@ export const SAVE_KEY_WARNING = "SAVE THIS KEY — excluded from backups";
  */
 export const DEPLOY_ENV_FILE = "deploy.env";
 
+/** Prefix for invocation-private credentials used while a candidate starts. */
+export const STAGED_DEPLOY_ENV_FILE = "deploy.env.next";
+
 /** `<deployDir>/deploy.env` — the 0600 deploy env-file path within a deploy dir. */
 export function deployEnvFilePath(deployDir: string): string {
   return path.join(deployDir, DEPLOY_ENV_FILE);
+}
+
+/** An invocation-private staged env path, promoted only after health succeeds. */
+export function stagedDeployEnvFilePath(deployDir: string, invocationId: string): string {
+  if (!/^[a-zA-Z0-9_-]+$/.test(invocationId)) {
+    throw new UpError("Could not create a safe invocation ID for the staged deploy env-file.");
+  }
+  return path.join(deployDir, `${STAGED_DEPLOY_ENV_FILE}-${invocationId}`);
+}
+
+export type StagedEnvIdMinter = () => string;
+
+const realStagedEnvIdMinter: StagedEnvIdMinter = () => randomBytes(12).toString("hex");
+let stagedEnvIdMinter = realStagedEnvIdMinter;
+
+/** Inject the non-secret staged-file suffix (tests only). */
+export function setStagedEnvIdMinter(next: StagedEnvIdMinter): void {
+  stagedEnvIdMinter = next;
+}
+
+export function resetStagedEnvIdMinter(): void {
+  stagedEnvIdMinter = realStagedEnvIdMinter;
+}
+
+export type FinalizationRenamer = (source: string, destination: string) => void;
+
+const realFinalizationRenamer: FinalizationRenamer = (source, destination) =>
+  fs.renameSync(source, destination);
+let finalizationRenamer = realFinalizationRenamer;
+
+/** Inject the two final promotion operations (tests force the second to fail). */
+export function setFinalizationRenamer(next: FinalizationRenamer): void {
+  finalizationRenamer = next;
+}
+
+export function resetFinalizationRenamer(): void {
+  finalizationRenamer = realFinalizationRenamer;
 }
 
 // --- injectable health-poll sleep ---------------------------------------
@@ -373,14 +423,10 @@ export function buildRunArgs(input: RunArgsInput): string[] {
   return args;
 }
 
-/**
- * Resolve a user-supplied `--data-dir` to an absolute host path, creating it if
- * absent. Absolute because docker treats a RELATIVE `-v` source as a volume name.
- */
-function resolveHostDataDir(input: string): string {
-  const abs = path.resolve(input);
-  fs.mkdirSync(abs, { recursive: true });
-  return abs;
+/** Build the detached candidate configuration without starting it. */
+export function buildCreateArgs(input: RunArgsInput): string[] {
+  const runArgs = buildRunArgs(input);
+  return ["create", ...runArgs.slice(2)];
 }
 
 /**
@@ -431,7 +477,7 @@ export interface DeployEnvInput {
  * raw value is safe; we reject a value with a newline (it would corrupt the file
  * / smuggle a second var) rather than emit a malformed file.
  */
-export function writeDeployEnvFile(deployDir: string, input: DeployEnvInput): string {
+function writeDeployEnvFileAt(file: string, input: DeployEnvInput): string {
   const secretKey = input.secretKey?.trim() ?? "";
   const bootstrapClaimSecret = input.bootstrapClaimSecret ?? "";
   for (const [name, value] of [
@@ -444,7 +490,7 @@ export function writeDeployEnvFile(deployDir: string, input: DeployEnvInput): st
     }
   }
   validateBootstrapClaimSecret(bootstrapClaimSecret);
-  fs.mkdirSync(deployDir, { recursive: true });
+  fs.mkdirSync(path.dirname(file), { recursive: true });
   const lines = [`LIBRARIAN_AGENT_TOKEN=${input.agentToken}`];
   // Omit the key line entirely when absent (update's read-back-failed path) — the
   // server then resolves it from /data/secret.key, preserving encrypted secrets.
@@ -457,12 +503,19 @@ export function writeDeployEnvFile(deployDir: string, input: DeployEnvInput): st
   if (input.host === LOCALHOST) {
     lines.push("LIBRARIAN_ALLOW_NO_AUTH=true");
   }
-  const file = deployEnvFilePath(deployDir);
   fs.writeFileSync(file, `${lines.join("\n")}\n`, { encoding: "utf8", mode: 0o600 });
   // writeFileSync only applies `mode` on create; chmod unconditionally so a
   // pre-existing looser file is tightened (env.ts discipline).
   fs.chmodSync(file, 0o600);
   return file;
+}
+
+export function writeDeployEnvFile(deployDir: string, input: DeployEnvInput): string {
+  return writeDeployEnvFileAt(deployEnvFilePath(deployDir), input);
+}
+
+function writeStagedDeployEnvFile(deployDir: string, input: DeployEnvInput): string {
+  return writeDeployEnvFileAt(stagedDeployEnvFilePath(deployDir, stagedEnvIdMinter()), input);
 }
 
 /**
@@ -514,8 +567,12 @@ export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult>
   // shows where it is + what remains, instead of a blank line.
   const log = deps.log ?? ((line: string): void => void process.stderr.write(`${line}\n`));
 
-  // 1) Preflight: docker (daemon reachable) + git, or a teaching error.
-  await sourcePreflight(deps.platform ? { platform: deps.platform } : {});
+  // 1) Select before preflight: stable releases need Docker only; arbitrary refs
+  // keep the source path's Docker + Git contract.
+  const target = selectDeploymentTarget(options.ref);
+  const preflightOptions = deps.platform ? { platform: deps.platform } : {};
+  if (target.imageSource === "registry") await dockerPreflight(preflightOptions);
+  else await sourcePreflight(preflightOptions);
 
   // 2) Resolve the bind host (default loopback; Tailscale offer; `0.0.0.0`
   //    ask-first). May throw `UpError` if the user declines a `0.0.0.0` bind —
@@ -545,110 +602,242 @@ export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult>
       "Pass either --data-dir (a host directory) or --data-volume (a Docker volume), not both.",
     );
   }
-  const dataDir = options.dataDir ? resolveHostDataDir(options.dataDir) : undefined;
-  const runAsUser = dataDir ? dirOwner(dataDir) : undefined;
+  // Resolve without creating yet: a registry pull/metadata failure must leave no
+  // new host material. Source behavior still creates it before clone/build.
+  const dataDir = options.dataDir ? path.resolve(options.dataDir) : undefined;
+  if (target.imageSource === "source" && dataDir) fs.mkdirSync(dataDir, { recursive: true });
 
-  // 3) Resolve the ref (default = latest release tag), then the deploy dir.
+  // 3) Resolve the ref, then prepare either the immutable registry image or the
+  // source checkout/build. Stable failures never fall back to source.
   log("[1/5] Resolving the latest release…");
-  const tag = await resolveRef(options.ref);
-  log(`[2/5] Preparing the deploy directory at ${deployDir} (cloning the repository)…`);
-  await prepareDeployDir(deployDir, tag);
-  const existingDeployEnv = readDeployEnvFile(deployDir);
-  const bootstrapClaimSecret =
-    suppliedBootstrapClaimSecret === undefined
-      ? existingDeployEnv.LIBRARIAN_BOOTSTRAP_CLAIM_SECRET
-      : suppliedBootstrapClaimSecret || undefined;
-  validateBootstrapClaimSecret(bootstrapClaimSecret ?? "");
+  const tag =
+    target.imageSource === "registry"
+      ? await resolveRegistryRef(target.ref)
+      : await resolveRef(target.ref);
 
-  // 4) Mint the secrets the CLI owns (the loop-closer). Both are CSPRNG and
-  //    NEVER logged: the agent token, and — ADR 0008 P4 — the master key. The
-  //    CLI minting the master key (env wins in core's `env → file → generate`)
-  //    is what keeps it OFF `/data/secret.key`. They ride only in the 0600
-  //    deploy env-file fed to `--env-file`, never inline on argv.
-  //    The MASTER KEY must NOT be re-minted on a re-run — that orphans every
-  //    secret encrypted under the previous key. If the deploy env-file already
-  //    carries one, REUSE it; only a first deploy (no existing key) mints +
-  //    surfaces a new one. (Mirrors `update`'s preserve-don't-mint rule.)
-  const agentToken = minter();
-  const existingKey = existingDeployEnv.LIBRARIAN_SECRET_KEY?.trim() || undefined;
-  const masterKey = existingKey ?? mintSecretKey();
-  const mintedKey = existingKey === undefined;
-  const envFile = writeDeployEnvFile(deployDir, {
-    agentToken,
-    secretKey: masterKey,
-    bootstrapClaimSecret,
-    host,
-  });
+  // The shared deployment lock lives inside deployDir. An initial source clone
+  // must therefore happen before acquiring it; otherwise the lockfile itself
+  // makes the clone target non-empty. Existing managed clones are prepared
+  // under the lock below, alongside the rest of the deployment transaction.
+  const sourceNeedsInitialPreparation =
+    target.imageSource === "source" && !(await pathExists(path.join(deployDir, ".git")));
+  if (sourceNeedsInitialPreparation) {
+    log(`[2/5] Preparing the deploy directory at ${deployDir} (cloning the repository)…`);
+    await prepareDeployDir(deployDir, tag);
+  }
 
-  // 5) Build the image, then run the container (secrets via `--env-file`).
-  log(
-    `[3/5] Building the image ${CONTAINER_NAME}:${tag} — the slow step: pulling the base ` +
-      `image, installing dependencies, and downloading the embeddings model. Expect several ` +
-      `minutes on a first run; live build output follows.`,
-  );
-  await build(deployDir, tag);
-  log("[4/5] Starting the container…");
-  await dockerRun(
-    buildRunArgs({
+  // `server up` and every update path share one host-level critical section.
+  // From the first container inspect through env/state finalization, no loser
+  // may observe or mutate the winner's deployment files or candidate.
+  const deploymentLockPath = updateLockPath({ home: deps.home, dir: options.dir });
+  const deploymentLock = acquireUpdateLock(deploymentLockPath);
+  if (!deploymentLock) {
+    throw new UpError(
+      `Another server deployment is already in progress (lock: ${deploymentLockPath}). ` +
+        "Wait for it to finish, then re-run `librarian server up`.",
+    );
+  }
+  let lockReleased = false;
+  const releaseDeploymentLock = (): void => {
+    if (lockReleased) return;
+    lockReleased = true;
+    deploymentLock.release();
+  };
+  let completedDeployment:
+    | {
+        agentToken: string;
+        masterKey: string;
+        mintedKey: boolean;
+      }
+    | undefined;
+
+  try {
+    const existingDeployEnv = readDeployEnvFile(deployDir);
+    const bootstrapClaimSecret =
+      suppliedBootstrapClaimSecret === undefined
+        ? existingDeployEnv.LIBRARIAN_BOOTSTRAP_CLAIM_SECRET
+        : suppliedBootstrapClaimSecret || undefined;
+    validateBootstrapClaimSecret(bootstrapClaimSecret ?? "");
+    const existingContainer = await inspectContainerPresence();
+    if (existingContainer.exists) {
+      if (target.imageSource !== "registry") throw existingContainerError([]);
+      const drift = registryDeploymentDrift(deployDir, tag, existingContainer.container, {
+        host,
+        dataVolume,
+        dataDir,
+        dashboardPort,
+        bootstrapClaimSecret,
+      });
+      if (drift.length > 0) throw existingContainerError(drift);
+      log("✓ The requested release is already running and healthy.");
+      releaseDeploymentLock();
+      return alreadyRunningOutput(tag, host, dashboardPort, await enableBootOutput(options, deps));
+    }
+
+    let registryImage: PreparedRegistryImage | undefined;
+    if (target.imageSource === "registry") {
+      log(`[2/5] Pulling and validating ${tag} from the release registry…`);
+      registryImage = await prepareRegistryImage(tag, (chunk) => {
+        if (deps.log) {
+          for (const line of chunk.split("\n")) if (line.length > 0) log(line);
+        } else {
+          process.stderr.write(chunk);
+        }
+      });
+    } else if (!sourceNeedsInitialPreparation) {
+      log(`[2/5] Preparing the deploy directory at ${deployDir} (cloning the repository)…`);
+      await prepareDeployDir(deployDir, tag);
+    }
+
+    if (target.imageSource === "registry" && dataDir) fs.mkdirSync(dataDir, { recursive: true });
+    const runAsUser = dataDir ? dirOwner(dataDir) : undefined;
+
+    // 4) Source targets build locally; registry targets are already verified and
+    // run only by immutable digest. No credential material is staged until this
+    // preparation has succeeded.
+    let runImageRef: string;
+    if (registryImage) {
+      log(`[3/5] Release image verified at ${registryImage.imageDigest}.`);
+      runImageRef = registryImage.imageDigest;
+    } else {
+      log(
+        `[3/5] Building the image ${CONTAINER_NAME}:${tag} — the slow step: pulling the base ` +
+          `image, installing dependencies, and downloading the embeddings model. Expect several ` +
+          `minutes on a first run; live build output follows.`,
+      );
+      await build(deployDir, tag);
+      runImageRef = `${CONTAINER_NAME}:${tag}`;
+    }
+
+    // 5) Mint the secrets the CLI owns (the loop-closer). Both are CSPRNG and
+    //    NEVER logged: the agent token, and — ADR 0008 P4 — the master key. The
+    //    MASTER KEY must NOT be re-minted on a re-run — that orphans every secret
+    //    encrypted under the previous key. A candidate env-file is kept separate
+    //    from the live one until the new container reports healthy.
+    const agentToken = minter();
+    const existingKey = existingDeployEnv.LIBRARIAN_SECRET_KEY?.trim() || undefined;
+    const masterKey = existingKey ?? mintSecretKey();
+    const mintedKey = existingKey === undefined;
+    const envFile = writeStagedDeployEnvFile(deployDir, {
+      agentToken,
+      secretKey: masterKey,
+      bootstrapClaimSecret,
+      host,
+    });
+    const nextDeployState: Parameters<typeof writeDeployState>[1] = registryImage
+      ? {
+          containerName: CONTAINER_NAME,
+          host,
+          dataVolume,
+          dataDir,
+          dashboardPort,
+          ref: tag,
+          imageTag: registryImage.imageRef,
+          imageSource: "registry",
+          imageRef: registryImage.imageRef,
+          imageDigest: registryImage.imageDigest,
+        }
+      : {
+          containerName: CONTAINER_NAME,
+          host,
+          dataVolume,
+          dataDir,
+          dashboardPort,
+          ref: tag,
+          imageTag: `${CONTAINER_NAME}:${tag}`,
+          imageSource: "source",
+          imageRef: `${CONTAINER_NAME}:${tag}`,
+        };
+
+    log("[4/5] Starting the container…");
+    const createArgs = buildCreateArgs({
       host,
       dataVolume,
       dashboardPort,
       dataDir,
       runAsUser,
-      imageRef: `${CONTAINER_NAME}:${tag}`,
+      imageRef: runImageRef,
       envFile,
-    }),
-    deployDir,
-  );
+    });
+    let candidateId: string | null = null;
+    let healthRollbackComplete = false;
+    try {
+      const createResult = await run("docker", createArgs, { cwd: deployDir });
+      failIfNonZero("docker", createArgs, createResult);
+      const returnedId = createResult.stdout.trim();
+      if (!/^[0-9a-f]{64}$/.test(returnedId)) {
+        throw new UpError(
+          "Docker created the candidate container but did not return its full immutable ID. " +
+            `Refusing unsafe cleanup by mutable name; inspect ${CONTAINER_NAME} manually before retrying.`,
+        );
+      }
+      candidateId = returnedId;
+      const startArgs = ["start", candidateId];
+      const startResult = await run("docker", startArgs, { cwd: deployDir });
+      failIfNonZero("docker", startArgs, startResult);
 
-  // 6+7) Wait for health. ANY failure in this post-`docker run` phase — a
-  //      timeout/unhealthy report or an exception from `docker inspect`/`sleep`
-  //      — MUST force-remove the container so no half-up state is left behind
-  //      (spec §11). `waitForHealthy` already rolls back on its own
-  //      timeout/unhealthy path; this guard catches the throwing cases it
-  //      can't (the second `rm -f` is best-effort + idempotent).
-  //
-  //      ADR 0008 P4: the master key is no longer READ BACK from the container
-  //      (`docker exec cat /data/secret.key`) — the CLI minted it and supplied
-  //      it via env, so the server never writes that file. We surface the
-  //      key we minted.
-  log("[5/5] Waiting for the server to become healthy…");
-  try {
-    await waitForHealthy(options);
-    log("✓ The server is healthy.");
-  } catch (error) {
-    await run("docker", ["rm", "-f", CONTAINER_NAME]).catch(() => undefined);
-    throw error;
+      // 6+7) Wait for health. ANY failure in this post-`docker start` phase — a
+      //      timeout/unhealthy report or an exception from `docker inspect`/`sleep`
+      //      — MUST force-remove the container so no half-up state is left behind
+      //      (spec §11). `waitForHealthy` already rolls back on its own
+      //      timeout/unhealthy path; this guard catches the throwing cases it
+      //      can't. Every cleanup targets the immutable candidate ID.
+      //
+      //      ADR 0008 P4: the master key is no longer READ BACK from the container
+      //      (`docker exec cat /data/secret.key`) — the CLI minted it and supplied
+      //      it via env, so the server never writes that file. We surface the
+      //      key we minted.
+      log("[5/5] Waiting for the server to become healthy…");
+      await waitForHealthy({ ...options, containerIdentity: candidateId });
+      log("✓ The server is healthy.");
+
+      // Promote the non-secret deploy state and the secret-bearing env-file as
+      // one recoverable operation. A failed promotion restores both exact prior
+      // files (or their absence) before the candidate is removed.
+      finalizeDeploymentFiles(deployDir, envFile, nextDeployState);
+      candidateId = null;
+    } catch (error) {
+      if (error instanceof HealthRollbackCompleteError) {
+        healthRollbackComplete = true;
+        candidateId = null;
+      }
+      if (candidateId && !healthRollbackComplete) {
+        try {
+          await removeAttemptContainer(candidateId);
+          candidateId = null;
+        } catch (cleanupError) {
+          removeStagedEnv(envFile);
+          throw cleanupError;
+        }
+        if (error instanceof CleanupError) {
+          removeStagedEnv(envFile);
+          throw new UpError(
+            "The candidate container could not start or become healthy. The first cleanup " +
+              "attempt failed, but a retry " +
+              "removed the candidate container; the data volume is untouched. Fix the startup " +
+              "cause, then re-run `librarian server up`.",
+          );
+        }
+      }
+      removeStagedEnv(envFile);
+      throw error;
+    }
+
+    completedDeployment = { agentToken, masterKey, mintedKey };
+  } finally {
+    releaseDeploymentLock();
   }
 
-  // 7b) Persist the NON-SECRET deploy-state so `update` can recreate the
-  //     container with the same config and `status` can report the deployed
-  //     ref reliably. This carries the bind host / data volume / ref / image
-  //     tag / container name — NEVER a token or key (deploy-state.ts whitelists
-  //     the fields). Only after a confirmed-healthy run, so the recorded state
-  //     reflects a container that actually came up.
-  writeDeployState(deployDir, {
-    containerName: CONTAINER_NAME,
-    host,
-    dataVolume,
-    dataDir,
-    dashboardPort,
-    ref: tag,
-    imageTag: `${CONTAINER_NAME}:${tag}`,
-    imageSource: "source",
-    imageRef: `${CONTAINER_NAME}:${tag}`,
-  });
+  // A successful locked body always assigns this before releasing the lock;
+  // every failure throws through the finally above.
+  const { agentToken, masterKey, mintedKey } = completedDeployment!;
 
   // 8) Boot persistence (opt-in, spec §5.8). With `--enable-boot`, install +
   //    enable the systemd unit AFTER a healthy up (so the named container the
   //    unit references actually exists). On macOS this prints the deferred
   //    notice and continues — the `up` still succeeds. The unit references the
   //    EXISTING container by name and carries NO secret (boot.ts).
-  const lines: string[] = [];
-  if (options.enableBoot) {
-    const bootResult = await enableBoot(deps.platform ? { platform: deps.platform } : {});
-    lines.push(bootResult.output, "");
-  }
+  const lines = await enableBootOutput(options, deps);
 
   // 9) Close the loop: surface secrets/URLs + offer the local env write.
   await closeTheLoop(lines, {
@@ -793,6 +982,318 @@ async function resolveRef(ref: string | undefined): Promise<string> {
   return `v${latest}`;
 }
 
+/** Resolve an omitted stable ref and reject any non-release response fail-closed. */
+async function resolveRegistryRef(ref: string | undefined): Promise<string> {
+  if (ref !== undefined) return ref;
+  const latest = await fetchLatestVersion();
+  const candidate = latest ? `v${latest}` : "";
+  if (!candidate || !isReleasedVersionRef(candidate)) {
+    throw new UpError(
+      "Could not resolve a valid latest stable release tag from GitHub. Check your network and " +
+        "GitHub availability, or pin an exact stable tag with `--ref vX.Y.Z`. Stable installs " +
+        "never fall back to a source build.",
+    );
+  }
+  return candidate;
+}
+
+interface DesiredDeploymentConfig {
+  host: string;
+  dataVolume: string;
+  dataDir?: string | undefined;
+  dashboardPort: number;
+  bootstrapClaimSecret?: string | undefined;
+}
+
+interface LiveContainer {
+  State?: { Health?: { Status?: unknown } };
+  Config?: { Image?: unknown; User?: unknown; Env?: unknown };
+  HostConfig?: {
+    RestartPolicy?: { Name?: unknown };
+    PortBindings?: unknown;
+  };
+  Mounts?: unknown;
+}
+
+type ContainerPresence = { exists: false } | { exists: true; container: LiveContainer };
+
+function verifiedNotFound(result: RunResult, identity = CONTAINER_NAME): boolean {
+  const detail = `${result.stdout}\n${result.stderr}`;
+  const escapedIdentity = identity.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return (
+    new RegExp(`no such (?:object|container):?\\s*${escapedIdentity}(?:\\s|$)`, "i").test(detail) ||
+    new RegExp(`no container .*${escapedIdentity}.* found`, "i").test(detail)
+  );
+}
+
+/** Inspect the fixed container name without treating daemon/permission failures as absence. */
+async function inspectContainerPresence(): Promise<ContainerPresence> {
+  const result = await run("docker", [
+    "container",
+    "inspect",
+    "--format",
+    "{{json .}}",
+    CONTAINER_NAME,
+  ]);
+  if (result.code !== 0) {
+    if (verifiedNotFound(result)) return { exists: false };
+    const detail = redactSecrets(result.stderr.trim() || result.stdout.trim());
+    throw new UpError(
+      `Could not inspect the existing ${CONTAINER_NAME} container` +
+        (detail ? `: ${detail}` : ".") +
+        " Fix Docker access, then re-run `librarian server up`.",
+    );
+  }
+  try {
+    const parsed: unknown = JSON.parse(result.stdout);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error();
+    return { exists: true, container: parsed as LiveContainer };
+  } catch {
+    throw new UpError(
+      `Docker returned malformed metadata for the existing ${CONTAINER_NAME} container. ` +
+        "Refusing to replace it; inspect or remove it manually, then re-run `librarian server up`.",
+    );
+  }
+}
+
+function envRecord(value: unknown): Record<string, string> | null {
+  if (!Array.isArray(value) || !value.every((entry) => typeof entry === "string")) return null;
+  const record: Record<string, string> = {};
+  for (const entry of value) {
+    const equals = entry.indexOf("=");
+    if (equals > 0) record[entry.slice(0, equals)] = entry.slice(equals + 1);
+  }
+  return record;
+}
+
+function exactPortBinding(bindings: unknown, key: string, host: string, port: number): boolean {
+  if (!bindings || typeof bindings !== "object" || Array.isArray(bindings)) return false;
+  const value = (bindings as Record<string, unknown>)[key];
+  return (
+    Array.isArray(value) &&
+    value.length === 1 &&
+    value[0] !== null &&
+    typeof value[0] === "object" &&
+    !Array.isArray(value[0]) &&
+    (value[0] as Record<string, unknown>).HostIp === host &&
+    (value[0] as Record<string, unknown>).HostPort === String(port)
+  );
+}
+
+/** Exact live + persisted identity check performed before any registry access. */
+function registryDeploymentDrift(
+  deployDir: string,
+  ref: string,
+  container: LiveContainer,
+  desired: DesiredDeploymentConfig,
+): string[] {
+  const drift: string[] = [];
+  const state = readDeployState(deployDir);
+  if (
+    !state ||
+    state.imageSource !== "registry" ||
+    state.ref !== ref ||
+    state.imageRef !== `${CANONICAL_IMAGE_NAME}:${ref}` ||
+    state.imageTag !== `${CANONICAL_IMAGE_NAME}:${ref}` ||
+    !state.imageDigest ||
+    state.host !== desired.host ||
+    state.dataVolume !== desired.dataVolume ||
+    state.dataDir !== desired.dataDir ||
+    state.dashboardPort !== desired.dashboardPort
+  ) {
+    drift.push("persisted deployment state");
+  }
+
+  const digest = state?.imageSource === "registry" ? state.imageDigest : undefined;
+  if (container.State?.Health?.Status !== "healthy") drift.push("health status");
+  if (!digest || container.Config?.Image !== digest) drift.push("image digest");
+
+  const mounts = Array.isArray(container.Mounts)
+    ? container.Mounts.filter(
+        (mount) =>
+          mount !== null &&
+          typeof mount === "object" &&
+          !Array.isArray(mount) &&
+          (mount as Record<string, unknown>).Destination === "/data",
+      )
+    : [];
+  const mount = mounts.length === 1 ? (mounts[0] as Record<string, unknown>) : undefined;
+  if (
+    !mount ||
+    (desired.dataDir
+      ? mount.Type !== "bind" || mount.Source !== desired.dataDir
+      : mount.Type !== "volume" || mount.Name !== desired.dataVolume)
+  ) {
+    drift.push("/data mount source or type");
+  }
+
+  const bindings = container.HostConfig?.PortBindings;
+  if (
+    !bindings ||
+    typeof bindings !== "object" ||
+    Array.isArray(bindings) ||
+    Object.keys(bindings).sort().join(",") !== `3000/tcp,${MCP_PUBLISHED_PORT}/tcp` ||
+    !exactPortBinding(bindings, "3000/tcp", desired.host, desired.dashboardPort) ||
+    !exactPortBinding(bindings, `${MCP_PUBLISHED_PORT}/tcp`, desired.host, MCP_PUBLISHED_PORT)
+  ) {
+    drift.push("published host or ports");
+  }
+  if (container.HostConfig?.RestartPolicy?.Name !== "unless-stopped") {
+    drift.push("restart policy");
+  }
+
+  let expectedUser = "node";
+  if (desired.dataDir) {
+    try {
+      expectedUser = dirOwner(desired.dataDir);
+    } catch {
+      drift.push("bind-mounted data directory");
+    }
+  }
+  if (container.Config?.User !== expectedUser) drift.push("container user");
+
+  const persistedEnv = readDeployEnvFile(deployDir);
+  const liveEnv = envRecord(container.Config?.Env);
+  const requiredRuntime: Record<string, string> = {
+    LIBRARIAN_DATA_DIR: "/data",
+    LIBRARIAN_HOST: ALL_INTERFACES,
+    LIBRARIAN_PORT: String(MCP_PUBLISHED_PORT),
+    PORT: "3000",
+  };
+  let envMatches = liveEnv !== null;
+  for (const [name, value] of Object.entries(requiredRuntime)) {
+    if (liveEnv?.[name] !== value) envMatches = false;
+  }
+  for (const name of [
+    "LIBRARIAN_AGENT_TOKEN",
+    "LIBRARIAN_SECRET_KEY",
+    "LIBRARIAN_BOOTSTRAP_CLAIM_SECRET",
+  ]) {
+    const expected = persistedEnv[name];
+    if ((liveEnv?.[name] || undefined) !== (expected || undefined)) envMatches = false;
+  }
+  if (!persistedEnv.LIBRARIAN_AGENT_TOKEN || !persistedEnv.LIBRARIAN_SECRET_KEY) {
+    envMatches = false;
+  }
+  if (
+    (persistedEnv.LIBRARIAN_BOOTSTRAP_CLAIM_SECRET || undefined) !==
+    (desired.bootstrapClaimSecret || undefined)
+  ) {
+    envMatches = false;
+  }
+  const expectedNoAuth = desired.host === LOCALHOST ? "true" : undefined;
+  if ((liveEnv?.LIBRARIAN_ALLOW_NO_AUTH || undefined) !== expectedNoAuth) envMatches = false;
+  if (!envMatches) drift.push("authentication or runtime environment");
+
+  return drift;
+}
+
+async function enableBootOutput(options: UpOptions, deps: UpDeps): Promise<string[]> {
+  if (!options.enableBoot) return [];
+  const bootResult = await enableBoot(deps.platform ? { platform: deps.platform } : {});
+  return [bootResult.output, ""];
+}
+
+function existingContainerError(drift: string[]): UpError {
+  const detail = drift.length > 0 ? ` (${drift.join(", ")})` : "";
+  return new UpError(
+    `The existing ${CONTAINER_NAME} container differs from the ` +
+      `requested healthy deployment${detail}. Refusing to pull, rewrite credentials, or replace ` +
+      "it. Run `librarian server down` if you intend to replace it, then retry.",
+  );
+}
+
+function alreadyRunningOutput(
+  tag: string,
+  host: string,
+  dashboardPort: number,
+  bootLines: string[],
+): UpResult {
+  const lines = [...bootLines];
+  lines.push(
+    `The Librarian server is already running and healthy at ${tag}.`,
+    "",
+    `  MCP URL:     http://${host}:${MCP_PUBLISHED_PORT}/mcp`,
+    `  Dashboard:   http://${host}:${dashboardPort}`,
+  );
+  return { output: lines.join("\n") };
+}
+
+function removeStagedEnv(stagedEnvFile: string): void {
+  try {
+    fs.rmSync(stagedEnvFile, { force: true });
+  } catch {
+    // The primary deployment/cleanup error is more useful than a temp-file error.
+  }
+}
+
+interface FileSnapshot {
+  contents: Buffer | null;
+  mode?: number | undefined;
+}
+
+function snapshotFile(file: string): FileSnapshot {
+  try {
+    const stat = fs.statSync(file);
+    return { contents: fs.readFileSync(file), mode: stat.mode & 0o777 };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return { contents: null };
+    throw error;
+  }
+}
+
+function restoreFile(file: string, snapshot: FileSnapshot): void {
+  if (snapshot.contents === null) {
+    fs.rmSync(file, { force: true });
+    return;
+  }
+  fs.writeFileSync(file, snapshot.contents, { mode: snapshot.mode });
+  if (snapshot.mode !== undefined) fs.chmodSync(file, snapshot.mode);
+}
+
+/** Promote env + state as one guarded unit, restoring exact prior bytes on failure. */
+function finalizeDeploymentFiles(
+  deployDir: string,
+  stagedEnvFile: string,
+  state: Parameters<typeof writeDeployState>[1],
+): void {
+  const liveEnvFile = deployEnvFilePath(deployDir);
+  const liveStateFile = deployStatePath(deployDir);
+  const priorEnv = snapshotFile(liveEnvFile);
+  const priorState = snapshotFile(liveStateFile);
+  const stagedStateDir = fs.mkdtempSync(path.join(deployDir, ".deploy-state-next-"));
+  const stagedStateFile = deployStatePath(stagedStateDir);
+  try {
+    writeDeployState(stagedStateDir, state);
+    finalizationRenamer(stagedEnvFile, liveEnvFile);
+    finalizationRenamer(stagedStateFile, liveStateFile);
+  } catch (error) {
+    try {
+      restoreFile(liveEnvFile, priorEnv);
+      restoreFile(liveStateFile, priorState);
+    } catch (rollbackError) {
+      const detail = redactSecrets(
+        rollbackError instanceof Error ? rollbackError.message : String(rollbackError),
+      );
+      throw new UpError(
+        `Deployment persistence failed and prior files could not be restored${detail ? `: ${detail}` : "."} ` +
+          "The candidate container will be removed; restore deploy.env and deploy-state.json from backup before retrying.",
+      );
+    }
+    const detail = redactSecrets(error instanceof Error ? error.message : String(error));
+    throw new UpError(
+      `Could not finalize deployment persistence${detail ? `: ${detail}` : "."} ` +
+        "Prior deploy.env and deploy-state.json content was restored.",
+    );
+  } finally {
+    try {
+      fs.rmSync(stagedStateDir, { recursive: true, force: true });
+    } catch {
+      // Non-secret staging residue must not override persistence/rollback truth.
+    }
+  }
+}
+
 /**
  * Ready the deploy dir at `tag`:
  *   - absent → `git clone <repo> <dir>` then checkout the ref;
@@ -878,9 +1379,21 @@ async function build(deployDir: string, tag: string): Promise<void> {
   }
 }
 
-/** Run the container (the assembled run argv) from the deploy dir. */
-async function dockerRun(args: string[], deployDir: string): Promise<void> {
-  await dockerInDir(args, deployDir);
+class CleanupError extends UpError {}
+
+class HealthRollbackCompleteError extends UpError {}
+
+/** Remove only the container created by this attempt, and verify the outcome. */
+async function removeAttemptContainer(candidateId: string): Promise<void> {
+  const result = await run("docker", ["rm", "-f", candidateId]);
+  if (result.code === 0 || verifiedNotFound(result, candidateId)) return;
+  const detail = redactSecrets(result.stderr.trim() || result.stdout.trim());
+  throw new CleanupError(
+    `Could not remove failed candidate container ${candidateId}` +
+      (detail ? `: ${detail}` : ".") +
+      ` The data volume was not removed. Run \`docker rm -f ${candidateId}\` manually, ` +
+      "then re-run `librarian server up`.",
+  );
 }
 
 /**
@@ -895,6 +1408,8 @@ export interface HealthWaitOptions {
   healthIntervalMs?: number | undefined;
   /** Lines of `docker logs` to surface on a failed health-wait. */
   logTailLines?: number | undefined;
+  /** Immutable container ID for owned-candidate cleanup; update omits this for legacy name use. */
+  containerIdentity?: string | undefined;
 }
 
 /**
@@ -910,6 +1425,7 @@ export async function waitForHealthy(options: HealthWaitOptions): Promise<void> 
   const attempts = options.healthAttempts ?? 60;
   const intervalMs = options.healthIntervalMs ?? 2000;
   const tail = options.logTailLines ?? 50;
+  const identity = options.containerIdentity ?? CONTAINER_NAME;
 
   // Track whether ANY poll yielded a non-empty status. Snap docker's confinement
   // does not emit stdout to a non-TTY pipe, so every `docker inspect` comes back
@@ -923,7 +1439,7 @@ export async function waitForHealthy(options: HealthWaitOptions): Promise<void> 
       "inspect",
       "--format",
       "{{.State.Health.Status}}",
-      CONTAINER_NAME,
+      identity,
     ]);
     if (result.code !== 0) allInspectsOk = false; // a failing inspect is NOT the snap signature
     const state = result.stdout.trim();
@@ -939,8 +1455,8 @@ export async function waitForHealthy(options: HealthWaitOptions): Promise<void> 
   // (defense-in-depth, e.g. an older image) — none of that may reach an error
   // message (spec §5.6 wants logs surfaced, just not secrets). Then roll back so
   // no half-up container survives.
-  const logs = await run("docker", ["logs", "--tail", String(tail), CONTAINER_NAME]);
-  await run("docker", ["rm", "-f", CONTAINER_NAME]);
+  const logs = await run("docker", ["logs", "--tail", String(tail), identity]);
+  await removeAttemptContainer(identity);
 
   // Conservative snap-docker detection: every `docker inspect` SUCCEEDED (exit 0)
   // yet returned empty output — never a single "starting"/"healthy"/"unhealthy".
@@ -948,7 +1464,7 @@ export async function waitForHealthy(options: HealthWaitOptions): Promise<void> 
   // (exit ≠ 0) is a different problem and falls through to the normal error below.
   // The container may well be running fine — we just can't see it through snap.
   if (!sawAnyStatus && allInspectsOk) {
-    throw new UpError(
+    throw new HealthRollbackCompleteError(
       `Could not read the container's health — every \`docker inspect\` returned empty ` +
         `output. That is the signature of snap docker, whose confinement does not emit ` +
         `stdout to a non-TTY pipe, so \`librarian server\` cannot read health or logs (the ` +
@@ -960,7 +1476,7 @@ export async function waitForHealthy(options: HealthWaitOptions): Promise<void> 
   }
 
   const detail = redactSecrets(logs.stdout.trim() || logs.stderr.trim());
-  throw new UpError(
+  throw new HealthRollbackCompleteError(
     `The server did not become healthy in time and was rolled back ` +
       `(container removed; the data volume is untouched). Recent logs:\n` +
       (detail ? detail : "(no log output captured)") +
@@ -1117,12 +1633,6 @@ export async function checkoutRef(dir: string, ref: string): Promise<void> {
   ]);
   failIfNonZero("git", ["-C", dir, "rev-parse", ref], resolved);
   await git(["-C", dir, "checkout", resolved.stdout.trim()]);
-}
-
-/** Run a `docker …` command from the deploy dir; non-zero exit → teaching error. */
-async function dockerInDir(args: string[], cwd: string): Promise<void> {
-  const result = await run("docker", args, { cwd });
-  failIfNonZero("docker", args, result);
 }
 
 function failIfNonZero(cmd: string, args: string[], result: RunResult): void {

--- a/packages/installer-cli/src/server/up.ts
+++ b/packages/installer-cli/src/server/up.ts
@@ -55,7 +55,7 @@ import { fetchLatestVersion } from "../status.js";
 import { enableBoot } from "./boot.js";
 import { writeDeployState } from "./deploy-state.js";
 import { run, stream, which, type RunResult } from "./docker.js";
-import { preflight } from "./preflight.js";
+import { sourcePreflight } from "./preflight.js";
 import { redactSecrets } from "./redact.js";
 
 // Re-exported from its shared home so existing importers (`update.ts`) keep
@@ -316,7 +316,8 @@ export interface RunArgsInput {
   dataDir?: string | undefined;
   /** `uid:gid` to run the container as — set for a bind-mount so files stay host-owned. */
   runAsUser?: string | undefined;
-  tag: string;
+  /** Exact local tag or digest-pinned registry reference passed to `docker run`. */
+  imageRef: string;
   /**
    * Absolute path to the 0600 deploy env-file ({@link writeDeployEnvFile}). The
    * secrets (`LIBRARIAN_AGENT_TOKEN`, `LIBRARIAN_SECRET_KEY`, and optional
@@ -345,7 +346,7 @@ export interface RunArgsInput {
  * {@link writeDeployEnvFile}), not on this argv.
  */
 export function buildRunArgs(input: RunArgsInput): string[] {
-  const { host, dataVolume, dashboardPort, dataDir, runAsUser, tag, envFile } = input;
+  const { host, dataVolume, dashboardPort, dataDir, runAsUser, imageRef, envFile } = input;
   const args = [
     "run",
     "-d",
@@ -368,7 +369,7 @@ export function buildRunArgs(input: RunArgsInput): string[] {
   // For a bind-mount, run as the directory's owner so the vault stays owned by —
   // and writable by — the operator, not the image's default user.
   if (runAsUser) args.push("--user", runAsUser);
-  args.push(`${CONTAINER_NAME}:${tag}`);
+  args.push(imageRef);
   return args;
 }
 
@@ -514,7 +515,7 @@ export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult>
   const log = deps.log ?? ((line: string): void => void process.stderr.write(`${line}\n`));
 
   // 1) Preflight: docker (daemon reachable) + git, or a teaching error.
-  await preflight(deps.platform ? { platform: deps.platform } : {});
+  await sourcePreflight(deps.platform ? { platform: deps.platform } : {});
 
   // 2) Resolve the bind host (default loopback; Tailscale offer; `0.0.0.0`
   //    ask-first). May throw `UpError` if the user declines a `0.0.0.0` bind —
@@ -588,7 +589,15 @@ export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult>
   await build(deployDir, tag);
   log("[4/5] Starting the container…");
   await dockerRun(
-    buildRunArgs({ host, dataVolume, dashboardPort, dataDir, runAsUser, tag, envFile }),
+    buildRunArgs({
+      host,
+      dataVolume,
+      dashboardPort,
+      dataDir,
+      runAsUser,
+      imageRef: `${CONTAINER_NAME}:${tag}`,
+      envFile,
+    }),
     deployDir,
   );
 
@@ -626,6 +635,8 @@ export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult>
     dashboardPort,
     ref: tag,
     imageTag: `${CONTAINER_NAME}:${tag}`,
+    imageSource: "source",
+    imageRef: `${CONTAINER_NAME}:${tag}`,
   });
 
   // 8) Boot persistence (opt-in, spec §5.8). With `--enable-boot`, install +

--- a/packages/installer-cli/src/server/up.ts
+++ b/packages/installer-cli/src/server/up.ts
@@ -72,6 +72,11 @@ import {
 import { run, stream, which, type RunResult } from "./docker.js";
 import { dockerPreflight, sourcePreflight } from "./preflight.js";
 import { redactSecrets } from "./redact.js";
+import {
+  CANONICAL_SOURCE_REPOSITORY,
+  isCanonicalSourceRemote,
+  redactGitDiagnostics,
+} from "./source-repository.js";
 import { acquireUpdateLock, updateLockPath } from "./update-lock.js";
 
 // Re-exported from its shared home so existing importers (`update.ts`) keep
@@ -79,7 +84,7 @@ import { acquireUpdateLock, updateLockPath } from "./update-lock.js";
 export { redactSecrets } from "./redact.js";
 
 /** The repository the deploy dir clones (same repo the latest-tag fetch targets). */
-export const REPO_URL = "https://github.com/code-ministry-ltd/the-librarian";
+export const REPO_URL = CANONICAL_SOURCE_REPOSITORY;
 
 /** The container name every `server` command operates on (single instance per host). */
 export const CONTAINER_NAME = "the-librarian";
@@ -1395,27 +1400,20 @@ async function prepareDeployDir(dir: string, tag: string): Promise<void> {
 
   // It's a git repo — confirm it's OUR clone before touching it.
   const originResult = await run("git", ["-C", dir, "remote", "get-url", "origin"]);
-  const origin = originResult.stdout.trim();
-  if (!sameRepo(origin, REPO_URL)) {
+  failIfNonZero(
+    "git",
+    ["-C", dir, "remote", "get-url", "origin"],
+    originResult,
+    redactGitDiagnostics,
+  );
+  if (!isCanonicalSourceRemote(originResult.stdout)) {
     throw new UpError(
-      `Deploy dir ${dir} is a git repo with a different remote (${origin || "none"}). ` +
+      `Deploy dir ${dir} is a git repo with a different remote. ` +
         "Refusing to touch a clone I didn't create — choose another path with `--dir <path>`.",
     );
   }
   await git(["-C", dir, "fetch", "--tags", "origin"]);
   await checkoutRef(dir, tag);
-}
-
-/** True iff `origin` points at the same repo as `REPO_URL` (scheme/.git tolerant). */
-function sameRepo(origin: string, repo: string): boolean {
-  const norm = (u: string): string =>
-    u
-      .trim()
-      .replace(/\.git$/, "")
-      .replace(/\/$/, "")
-      .replace(/^git@github\.com:/, "https://github.com/")
-      .toLowerCase();
-  return norm(origin) === norm(repo);
 }
 
 /**
@@ -1695,7 +1693,7 @@ function isYes(answer: string): boolean {
 /** Run a `git …` command from anywhere; a non-zero exit is a teaching error. */
 async function git(args: string[]): Promise<void> {
   const result = await run("git", args);
-  failIfNonZero("git", args, result);
+  failIfNonZero("git", args, result, redactGitDiagnostics);
 }
 
 /**
@@ -1716,18 +1714,23 @@ export async function checkoutRef(dir: string, ref: string): Promise<void> {
     "--end-of-options",
     `${ref}^{commit}`,
   ]);
-  failIfNonZero("git", ["-C", dir, "rev-parse", ref], resolved);
+  failIfNonZero("git", ["-C", dir, "rev-parse", ref], resolved, redactGitDiagnostics);
   await git(["-C", dir, "checkout", resolved.stdout.trim()]);
 }
 
-function failIfNonZero(cmd: string, args: string[], result: RunResult): void {
+function failIfNonZero(
+  cmd: string,
+  args: string[],
+  result: RunResult,
+  redact: (text: string) => string = redactSecrets,
+): void {
   if (result.code === 0) return;
   // Redact in case a failed docker/git step echoed a secret-shaped value. Post
   // ADR 0008 P4 the secrets ride in the 0600 deploy env-file (via `--env-file`),
   // NOT inline on argv — so an argv-echoing `build`/`run` failure no longer
   // carries them. We still redact defensively (e.g. a daemon that prints the
   // expanded env, or an older code path) so no 64-hex secret reaches the message.
-  const detail = redactSecrets(result.stderr.trim() || result.stdout.trim());
+  const detail = redact(result.stderr.trim() || result.stdout.trim());
   throw new UpError(
     `\`${cmd} ${args[0]}\` failed (exit ${result.code ?? "signal"})` +
       (detail ? `:\n${detail}` : ".") +

--- a/packages/installer-cli/src/server/up.ts
+++ b/packages/installer-cli/src/server/up.ts
@@ -193,6 +193,18 @@ export function resetFinalizationRenamer(): void {
   finalizationRenamer = realFinalizationRenamer;
 }
 
+export type FinalizationRestorer = (file: string, snapshot: FileSnapshot) => void;
+let finalizationRestorer: FinalizationRestorer = restoreFile;
+
+/** Inject prior-file restoration failures (tests only). */
+export function setFinalizationRestorer(next: FinalizationRestorer): void {
+  finalizationRestorer = next;
+}
+
+export function resetFinalizationRestorer(): void {
+  finalizationRestorer = restoreFile;
+}
+
 // --- injectable health-poll sleep ---------------------------------------
 
 /** A sleep used between health polls. Injectable so tests don't actually wait. */
@@ -355,6 +367,17 @@ export class UpError extends Error {
   }
 }
 
+/** Deployment-file promotion failed; tells update whether exact prior bytes were restored. */
+export class DeploymentFinalizationError extends UpError {
+  constructor(
+    message: string,
+    readonly priorFilesRestored: boolean,
+  ) {
+    super(message);
+    this.name = "DeploymentFinalizationError";
+  }
+}
+
 // --- the docker run argv seam -------------------------------------------
 
 export interface RunArgsInput {
@@ -366,6 +389,8 @@ export interface RunArgsInput {
   dataDir?: string | undefined;
   /** `uid:gid` to run the container as — set for a bind-mount so files stay host-owned. */
   runAsUser?: string | undefined;
+  /** Restart policy to preserve during update recovery. Fresh deployments default to unless-stopped. */
+  restartPolicy?: string | undefined;
   /** Exact local tag or digest-pinned registry reference passed to `docker run`. */
   imageRef: string;
   /**
@@ -396,14 +421,23 @@ export interface RunArgsInput {
  * {@link writeDeployEnvFile}), not on this argv.
  */
 export function buildRunArgs(input: RunArgsInput): string[] {
-  const { host, dataVolume, dashboardPort, dataDir, runAsUser, imageRef, envFile } = input;
+  const {
+    host,
+    dataVolume,
+    dashboardPort,
+    dataDir,
+    runAsUser,
+    restartPolicy = "unless-stopped",
+    imageRef,
+    envFile,
+  } = input;
   const args = [
     "run",
     "-d",
     "--name",
     CONTAINER_NAME,
     "--restart",
-    "unless-stopped",
+    restartPolicy,
     // Publish the dashboard on the chosen HOST port; the container always listens
     // on 3000 internally (image PORT=3000), so only the left side varies.
     "-p",
@@ -514,7 +548,7 @@ export function writeDeployEnvFile(deployDir: string, input: DeployEnvInput): st
   return writeDeployEnvFileAt(deployEnvFilePath(deployDir), input);
 }
 
-function writeStagedDeployEnvFile(deployDir: string, input: DeployEnvInput): string {
+export function writeStagedDeployEnvFile(deployDir: string, input: DeployEnvInput): string {
   return writeDeployEnvFileAt(stagedDeployEnvFilePath(deployDir, stagedEnvIdMinter()), input);
 }
 
@@ -1219,7 +1253,7 @@ function alreadyRunningOutput(
   return { output: lines.join("\n") };
 }
 
-function removeStagedEnv(stagedEnvFile: string): void {
+export function removeStagedEnv(stagedEnvFile: string): void {
   try {
     fs.rmSync(stagedEnvFile, { force: true });
   } catch {
@@ -1252,7 +1286,7 @@ function restoreFile(file: string, snapshot: FileSnapshot): void {
 }
 
 /** Promote env + state as one guarded unit, restoring exact prior bytes on failure. */
-function finalizeDeploymentFiles(
+export function finalizeDeploymentFiles(
   deployDir: string,
   stagedEnvFile: string,
   state: Parameters<typeof writeDeployState>[1],
@@ -1269,21 +1303,23 @@ function finalizeDeploymentFiles(
     finalizationRenamer(stagedStateFile, liveStateFile);
   } catch (error) {
     try {
-      restoreFile(liveEnvFile, priorEnv);
-      restoreFile(liveStateFile, priorState);
+      finalizationRestorer(liveEnvFile, priorEnv);
+      finalizationRestorer(liveStateFile, priorState);
     } catch (rollbackError) {
       const detail = redactSecrets(
         rollbackError instanceof Error ? rollbackError.message : String(rollbackError),
       );
-      throw new UpError(
+      throw new DeploymentFinalizationError(
         `Deployment persistence failed and prior files could not be restored${detail ? `: ${detail}` : "."} ` +
           "The candidate container will be removed; restore deploy.env and deploy-state.json from backup before retrying.",
+        false,
       );
     }
     const detail = redactSecrets(error instanceof Error ? error.message : String(error));
-    throw new UpError(
+    throw new DeploymentFinalizationError(
       `Could not finalize deployment persistence${detail ? `: ${detail}` : "."} ` +
         "Prior deploy.env and deploy-state.json content was restored.",
+      true,
     );
   } finally {
     try {

--- a/packages/installer-cli/src/server/up.ts
+++ b/packages/installer-cli/src/server/up.ts
@@ -55,12 +55,18 @@ import { librarianDir } from "../paths.js";
 import type { Prompter } from "../prompt.js";
 import { fetchLatestVersion } from "../status.js";
 import { enableBoot } from "./boot.js";
-import { deployStatePath, readDeployState, writeDeployState } from "./deploy-state.js";
+import {
+  deployStatePath,
+  readDeployState,
+  writeDeployState,
+  type DeployState,
+} from "./deploy-state.js";
 import {
   CANONICAL_IMAGE_NAME,
   prepareRegistryImage,
   isReleasedVersionRef,
   selectDeploymentTarget,
+  shortImageDigest,
   type PreparedRegistryImage,
 } from "./deployment-image.js";
 import { run, stream, which, type RunResult } from "./docker.js";
@@ -643,7 +649,15 @@ export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult>
 
   // 3) Resolve the ref, then prepare either the immutable registry image or the
   // source checkout/build. Stable failures never fall back to source.
-  log("[1/5] Resolving the latest release…");
+  if (target.imageSource === "registry") {
+    log(
+      target.ref
+        ? `[1/5] Selecting exact published release ${target.ref}…`
+        : "[1/5] Resolving the latest published release…",
+    );
+  } else {
+    log(`[1/5] Selecting source ref ${target.ref}…`);
+  }
   const tag =
     target.imageSource === "registry"
       ? await resolveRegistryRef(target.ref)
@@ -656,7 +670,7 @@ export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult>
   const sourceNeedsInitialPreparation =
     target.imageSource === "source" && !(await pathExists(path.join(deployDir, ".git")));
   if (sourceNeedsInitialPreparation) {
-    log(`[2/5] Preparing the deploy directory at ${deployDir} (cloning the repository)…`);
+    log(`[2/5] Preparing the source checkout at ${deployDir} (cloning the repository)…`);
     await prepareDeployDir(deployDir, tag);
   }
 
@@ -682,6 +696,7 @@ export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult>
         agentToken: string;
         masterKey: string;
         mintedKey: boolean;
+        deploymentIdentity: string;
       }
     | undefined;
 
@@ -695,17 +710,32 @@ export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult>
     const existingContainer = await inspectContainerPresence();
     if (existingContainer.exists) {
       if (target.imageSource !== "registry") throw existingContainerError([]);
-      const drift = registryDeploymentDrift(deployDir, tag, existingContainer.container, {
-        host,
-        dataVolume,
-        dataDir,
-        dashboardPort,
-        bootstrapClaimSecret,
-      });
+      const existingState = readDeployState(deployDir);
+      const drift = registryDeploymentDrift(
+        deployDir,
+        tag,
+        existingState,
+        existingContainer.container,
+        {
+          host,
+          dataVolume,
+          dataDir,
+          dashboardPort,
+          bootstrapClaimSecret,
+        },
+      );
       if (drift.length > 0) throw existingContainerError(drift);
+      if (existingState?.imageSource !== "registry") {
+        throw existingContainerError(["persisted deployment state"]);
+      }
       log("✓ The requested release is already running and healthy.");
       releaseDeploymentLock();
-      return alreadyRunningOutput(tag, host, dashboardPort, await enableBootOutput(options, deps));
+      return alreadyRunningOutput(
+        `published ${tag} (${shortImageDigest(existingState.imageDigest)})`,
+        host,
+        dashboardPort,
+        await enableBootOutput(options, deps),
+      );
     }
 
     let registryImage: PreparedRegistryImage | undefined;
@@ -719,7 +749,7 @@ export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult>
         }
       });
     } else if (!sourceNeedsInitialPreparation) {
-      log(`[2/5] Preparing the deploy directory at ${deployDir} (cloning the repository)…`);
+      log(`[2/5] Preparing the source checkout at ${deployDir} (cloning the repository)…`);
       await prepareDeployDir(deployDir, tag);
     }
 
@@ -735,7 +765,7 @@ export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult>
       runImageRef = registryImage.imageDigest;
     } else {
       log(
-        `[3/5] Building the image ${CONTAINER_NAME}:${tag} — the slow step: pulling the base ` +
+        `[3/5] Building source image ${CONTAINER_NAME}:${tag} — the slow step: pulling the base ` +
           `image, installing dependencies, and downloading the embeddings model. Expect several ` +
           `minutes on a first run; live build output follows.`,
       );
@@ -857,14 +887,21 @@ export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult>
       throw error;
     }
 
-    completedDeployment = { agentToken, masterKey, mintedKey };
+    completedDeployment = {
+      agentToken,
+      masterKey,
+      mintedKey,
+      deploymentIdentity: registryImage
+        ? `published ${tag} (${shortImageDigest(registryImage.imageDigest)})`
+        : `source ${tag}`,
+    };
   } finally {
     releaseDeploymentLock();
   }
 
   // A successful locked body always assigns this before releasing the lock;
   // every failure throws through the finally above.
-  const { agentToken, masterKey, mintedKey } = completedDeployment!;
+  const { agentToken, masterKey, mintedKey, deploymentIdentity } = completedDeployment!;
 
   // 8) Boot persistence (opt-in, spec §5.8). With `--enable-boot`, install +
   //    enable the systemd unit AFTER a healthy up (so the named container the
@@ -880,6 +917,7 @@ export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult>
     agentToken,
     masterKey,
     mintedKey,
+    deploymentIdentity,
     options,
     deps,
   });
@@ -1118,11 +1156,11 @@ function exactPortBinding(bindings: unknown, key: string, host: string, port: nu
 function registryDeploymentDrift(
   deployDir: string,
   ref: string,
+  state: DeployState | null,
   container: LiveContainer,
   desired: DesiredDeploymentConfig,
 ): string[] {
   const drift: string[] = [];
-  const state = readDeployState(deployDir);
   if (
     !state ||
     state.imageSource !== "registry" ||
@@ -1238,14 +1276,14 @@ function existingContainerError(drift: string[]): UpError {
 }
 
 function alreadyRunningOutput(
-  tag: string,
+  deploymentIdentity: string,
   host: string,
   dashboardPort: number,
   bootLines: string[],
 ): UpResult {
   const lines = [...bootLines];
   lines.push(
-    `The Librarian server is already running and healthy at ${tag}.`,
+    `The Librarian server is already running and healthy from ${deploymentIdentity}.`,
     "",
     `  MCP URL:     http://${host}:${MCP_PUBLISHED_PORT}/mcp`,
     `  Dashboard:   http://${host}:${dashboardPort}`,
@@ -1543,16 +1581,27 @@ async function closeTheLoop(
     masterKey: string;
     /** True when this run freshly MINTED the master key (vs reused an existing one). */
     mintedKey: boolean;
+    /** Selected image strategy + human-readable immutable identity. */
+    deploymentIdentity: string;
     options: UpOptions;
     deps: UpDeps;
   },
 ): Promise<void> {
-  const { host, dashboardPort, agentToken, masterKey, mintedKey, options, deps } = ctx;
+  const {
+    host,
+    dashboardPort,
+    agentToken,
+    masterKey,
+    mintedKey,
+    deploymentIdentity,
+    options,
+    deps,
+  } = ctx;
   const mcpUrl = `http://${host}:${MCP_PUBLISHED_PORT}/mcp`;
   const dashboardUrl = `http://${host}:${dashboardPort}`;
 
   lines.push(
-    "The Librarian server is up and healthy.",
+    `The Librarian server is up and healthy from ${deploymentIdentity}.`,
     "",
     `  MCP URL:     ${mcpUrl}`,
     `  Dashboard:   ${dashboardUrl}`,

--- a/packages/installer-cli/src/server/update.ts
+++ b/packages/installer-cli/src/server/update.ts
@@ -16,6 +16,7 @@ import {
 import { run, stream, type RunResult } from "./docker.js";
 import { dockerPreflight, sourcePreflight } from "./preflight.js";
 import { redactSecrets } from "./redact.js";
+import { isCanonicalSourceRemote, redactGitDiagnostics } from "./source-repository.js";
 import {
   buildCreateArgs,
   CONTAINER_NAME,
@@ -563,7 +564,7 @@ async function resolveSourceTarget(deployDir: string, ref: string): Promise<Sour
   } else {
     const remote = await run("git", ["-C", checkout, "remote", "get-url", "origin"]);
     checkedResult("git", ["remote", "get-url", "origin"], remote, redactGitDiagnostics);
-    if (!sameRepository(remote.stdout.trim(), REPO_URL)) {
+    if (!isCanonicalSourceRemote(remote.stdout)) {
       throw new UpdateError(
         `Managed source checkout ${checkout} has an unexpected origin; refusing to modify it. ` +
           "Set origin to the canonical repository or use a different deploy directory.",
@@ -980,13 +981,6 @@ function errorDetail(error: unknown, redact: Redactor = redactSecrets): string {
   return redact(error instanceof Error ? error.message : String(error));
 }
 
-/** Git can echo credential-bearing remotes in stderr; never surface a remote URL. */
-function redactGitDiagnostics(text: string): string {
-  return redactSecrets(text)
-    .replace(/\b(?:https?|ssh|git):\/\/[^\s'"`]+/giu, "[redacted-remote]")
-    .replace(/\b[^\s/@:]+@[^\s/:]+:[^\s'"`]+/gu, "[redacted-remote]");
-}
-
 function envMap(value: unknown): Map<string, string> {
   const result = new Map<string, string>();
   if (!Array.isArray(value)) return result;
@@ -1058,30 +1052,6 @@ function verifiedNotFound(result: RunResult, identity: string): boolean {
   return new RegExp(`no such (?:object|container):?\\s*${escaped}(?:\\s|$)`, "i").test(
     `${result.stdout}\n${result.stderr}`,
   );
-}
-
-function sameRepository(left: string, right: string): boolean {
-  const normalize = (value: string): string => {
-    const trimmed = value.trim();
-    try {
-      const parsed = new URL(trimmed);
-      const repositoryPath = parsed.pathname.replace(/\/$/, "").replace(/\.git$/, "");
-      return `${parsed.hostname}${repositoryPath}`.toLowerCase();
-    } catch {
-      const scp = trimmed.match(/^(?:[^@/]+@)?([^:/]+):(.+)$/u);
-      if (scp) {
-        return `${scp[1]}/${scp[2]}`
-          .replace(/\/$/, "")
-          .replace(/\.git$/, "")
-          .toLowerCase();
-      }
-      return trimmed
-        .replace(/\/$/, "")
-        .replace(/\.git$/, "")
-        .toLowerCase();
-    }
-  };
-  return normalize(left) === normalize(right);
 }
 
 function shellWord(value: string): string {

--- a/packages/installer-cli/src/server/update.ts
+++ b/packages/installer-cli/src/server/update.ts
@@ -9,6 +9,7 @@ import { type DeployState, readDeployState } from "./deploy-state.js";
 import {
   prepareRegistryImage,
   selectDeploymentTarget,
+  shortImageDigest,
   type DeploymentTarget,
   type PreparedRegistryImage,
 } from "./deployment-image.js";
@@ -48,6 +49,8 @@ export class UpdateError extends Error {
 
 export interface UpdateResult {
   output: string;
+  /** True only when a replacement completed; false for an exact healthy no-op. */
+  changed: boolean;
 }
 
 interface LiveContainer {
@@ -165,8 +168,13 @@ async function performUpdate(
     ? await isExactHealthySourceTarget(state, targetRef, current, deployDir, sourceResolution)
     : isExactHealthyRegistryTarget(state, targetRef, current, deployDir);
   if (exactTarget) {
+    const identity =
+      target.imageSource === "registry" && state.imageSource === "registry"
+        ? `published ${targetRef} (${shortImageDigest(state.imageDigest)})`
+        : `source ${targetRef}`;
     return {
-      output: `Already up to date (${targetRef}) — the exact deployment is healthy.\nNothing to do.`,
+      output: `Already up to date (${identity}) — the exact deployment is healthy.\nNothing to do.`,
+      changed: false,
     };
   }
 
@@ -314,6 +322,7 @@ async function performUpdate(
     output: [renderSuccess(prepared, tokenIsFresh ? agentToken : null), successCleanupWarning]
       .filter(Boolean)
       .join("\n"),
+    changed: true,
   };
 }
 
@@ -924,7 +933,7 @@ function recoveryFailure(
 function renderSuccess(prepared: PreparedTarget, freshToken: string | null): string {
   const identity =
     prepared.imageSource === "registry"
-      ? `published ${prepared.ref} (${prepared.imageDigest!.slice(-12)})`
+      ? `published ${prepared.ref} (${shortImageDigest(prepared.imageDigest!)})`
       : `source ${prepared.ref}`;
   const lines = [
     `Updated The Librarian server to ${identity} — the container is healthy.`,

--- a/packages/installer-cli/src/server/update.ts
+++ b/packages/installer-cli/src/server/update.ts
@@ -1,103 +1,44 @@
-// `librarian server update` — re-pin forward, rebuild, recreate, migrate.
-//
-// The tag-pinned, deploy-dir-owning successor to `pull-and-restart.sh` (the
-// stash/branch dance is gone — the CLI owns its deploy dir, so it just fetches
-// tags and checks out the resolved ref). The flow (spec §8, success criterion 5):
-//
-//   1. Resolve the target ref: `--ref <tag|main>` pins it; default = the latest
-//      release tag (`fetchLatestVersion`).
-//   2. IDEMPOTENCY FIRST: read deploy-state (current ref) + the container's
-//      health. Already at the resolved ref AND healthy → a CLEAN no-op (no
-//      build, no run, no recreate). When `--ref` is given, compare against it.
-//   3. Otherwise update, IN THE DEPLOY DIR:
-//        git fetch --tags origin → git checkout <ref>
-//        → docker build -f docker/all-in-one.Dockerfile -t the-librarian:<ref> .
-//        → read back the EXISTING agent token + master key + optional bootstrap
-//          claim secret from the running container's env (so clients keep
-//          working, secrets stay decryptable, and pending claims stay armed)
-//          BEFORE removing it
-//        → docker stop → docker rm <container>   (NEVER `-v`, NEVER `volume rm`)
-//        → write the 0600 deploy env-file (preserved/fresh token + preserved-or-
-//          omitted master key + loopback ALLOW_NO_AUTH) then docker run …
-//          (buildRunArgs with the SAME host + dataVolume from deploy-state, via
-//          `--env-file`)
-//        → waitForHealthy (rolls back with `docker rm -f` on failure — reusing
-//          up's pattern, so a failed recreate leaves no half-up container and
-//          does NOT advance deploy-state)
-//        → docker exec the-librarian the-librarian migrate-data-dir
-//          (server boot only WARNS about pending data-dir migrations; the admin
-//           CLI APPLIES them — see packages/cli/src/commands/migrate-data-dir.ts.
-//           The `the-librarian` runtime binary is bundled into the image in S7;
-//           this slice asserts the argv, the runtime target arrives with S7.)
-//   4. writeDeployState with the new ref/imageTag (host/dataVolume unchanged).
-//
-// SECRETS ON UPDATE (decision): recreating the container needs the agent token,
-// the master key (`LIBRARIAN_SECRET_KEY`), and any optional bootstrap-claim
-// secret. They are persisted host-side only in the 0600 deploy env-file. We read
-// the running values back via `docker inspect` BEFORE removal and use the
-// protected file as the claim-secret fallback when the container is unreadable.
-//
-//   - AGENT TOKEN: prefer the read-back token; only if the old container is
-//     gone/unreadable do we mint a FRESH token and surface it ONCE with a
-//     "clients must update their token" note.
-//   - MASTER KEY: prefer the read-back key. If it can't be read back we DO NOT
-//     mint a fresh one — re-minting would orphan every secret encrypted under
-//     the old key. Instead we OMIT `LIBRARIAN_SECRET_KEY` from the new env-file
-//     so the server resolves it from `/data/secret.key` (env → file → generate),
-//     which preserves a pre-P4 on-disk key (and only generates when the data dir
-//     is genuinely fresh — nothing to orphan).
-//
-// These secrets ride ONLY in the 0600 deploy env-file fed to `docker run
-// --env-file` — never inline on argv, never in any other host file or log (the
-// spec's no-leak boundary; tests scan for them).
-//
-// The DATA VOLUME is sacred: recreate removes the CONTAINER only (`docker rm`),
-// never the named volume (the `-v` flag / `docker volume rm` never appear), so
-// `up`/`update`/`down` all recall the same memories from the untouched volume.
-//
-// Everything goes through the injectable `docker.ts` runner + the injectable
-// latest-release fetcher, so tests assert the exact argv (and its order) WITHOUT
-// a real daemon, network, or git.
+// `librarian server update` — prepare an immutable replacement while the current
+// service keeps serving, then replace it as a recoverable transition.
 
+import fs from "node:fs";
 import path from "node:path";
 import { librarianDir } from "../paths.js";
 import { fetchLatestVersion } from "../status.js";
-import { type DeployState, readDeployState, writeDeployState } from "./deploy-state.js";
-import { run, type RunResult } from "./docker.js";
-import { sourcePreflight } from "./preflight.js";
+import { type DeployState, readDeployState } from "./deploy-state.js";
+import {
+  prepareRegistryImage,
+  selectDeploymentTarget,
+  type DeploymentTarget,
+  type PreparedRegistryImage,
+} from "./deployment-image.js";
+import { run, stream, type RunResult } from "./docker.js";
+import { dockerPreflight, sourcePreflight } from "./preflight.js";
 import { redactSecrets } from "./redact.js";
 import {
-  buildRunArgs,
+  buildCreateArgs,
   CONTAINER_NAME,
-  dirOwner,
+  DeploymentFinalizationError,
+  finalizeDeploymentFiles,
   LEGACY_DASHBOARD_PORT,
   mintAgentToken,
   readDeployEnvFile,
-  waitForHealthy,
-  writeDeployEnvFile,
+  REPO_URL,
+  writeStagedDeployEnvFile,
 } from "./up.js";
 import { acquireUpdateLock, UpdateInProgressError, updateLockPath } from "./update-lock.js";
 
 export interface UpdateOptions {
-  /** Pinned ref (`vX.Y.Z` tag or `main`). Default: the latest release tag. */
   ref?: string | undefined;
-  /** Auto-accept prompts (none today; wired for surface parity with `up`). */
   yes?: boolean | undefined;
-  /** Deploy dir override. Default: `~/.librarian/server`. */
   dir?: string | undefined;
-  /** Override home (tests). */
   home?: string | undefined;
-  /** Platform for preflight's daemon hint. Default `process.platform`. */
   platform?: NodeJS.Platform | undefined;
-  /** Health-wait bound: how many polls before declaring failure (small in tests). */
   healthAttempts?: number | undefined;
-  /** Milliseconds between health polls (0 in tests). */
   healthIntervalMs?: number | undefined;
-  /** Lines of `docker logs` to surface on a failed health-wait. */
   logTailLines?: number | undefined;
 }
 
-/** A teaching error from `update`; the runtime renders `.message` as one stderr line. */
 export class UpdateError extends Error {
   constructor(message: string) {
     super(message);
@@ -106,320 +47,1034 @@ export class UpdateError extends Error {
 }
 
 export interface UpdateResult {
-  /** Human-readable report for stdout (carries a FRESH agent token at most once). */
   output: string;
 }
 
-/**
- * Run `server update`. Throws `UpdateError` (teaching message) on a failure
- * before/around the recreate; a failed health-wait throws the (already
- * secret-redacted) `UpError` from `waitForHealthy` after rolling the new
- * container back. deploy-state is advanced ONLY after a confirmed-healthy
- * recreate, so a failed update never records the new ref.
- */
+interface LiveContainer {
+  Id?: unknown;
+  Image?: unknown;
+  State?: { Status?: unknown; Health?: { Status?: unknown } };
+  Config?: { Image?: unknown; User?: unknown; Env?: unknown };
+  HostConfig?: {
+    RestartPolicy?: { Name?: unknown };
+    PortBindings?: unknown;
+  };
+  Mounts?: unknown;
+}
+
+interface PreservedConfig {
+  immutableContainerId: string;
+  immutableImageId: string;
+  configuredImage: string;
+  host: string;
+  dashboardPort: number;
+  dataVolume: string;
+  dataDir?: string | undefined;
+  runAsUser?: string | undefined;
+  restartPolicy: string;
+  env: Map<string, string>;
+  healthy: boolean;
+}
+
+interface PreparedTarget {
+  ref: string;
+  imageSource: "registry" | "source";
+  runImageRef: string;
+  imageRef: string;
+  imageDigest?: string | undefined;
+  cwd: string;
+}
+
+interface SourceResolution {
+  checkout: string;
+  commit: string;
+  imageTag: string;
+}
+
+const IMAGE_ID = /^sha256:[0-9a-f]{64}$/;
+const CONTAINER_ID = /^[0-9a-f]{64}$/;
+type Redactor = (text: string) => string;
+
+export type UpdateSecretArtifactRemover = (file: string) => void;
+const realUpdateSecretArtifactRemover: UpdateSecretArtifactRemover = (file) =>
+  fs.rmSync(file, { force: true });
+let updateSecretArtifactRemover = realUpdateSecretArtifactRemover;
+
+export function setUpdateSecretArtifactRemover(next: UpdateSecretArtifactRemover): void {
+  updateSecretArtifactRemover = next;
+}
+
+export function resetUpdateSecretArtifactRemover(): void {
+  updateSecretArtifactRemover = realUpdateSecretArtifactRemover;
+}
+
+class RecoveryAttemptError extends Error {
+  constructor(
+    message: string,
+    readonly ownedContainerId: string,
+  ) {
+    super(message);
+    this.name = "RecoveryAttemptError";
+  }
+}
+
 export async function runUpdate(options: UpdateOptions = {}): Promise<UpdateResult> {
-  // 1) Preflight: docker (daemon reachable) + git, or a teaching error.
-  await sourcePreflight(options.platform ? { platform: options.platform } : {});
+  const target = selectDeploymentTarget(options.ref);
+  const preflight = options.platform ? { platform: options.platform } : {};
+  if (target.imageSource === "registry") await dockerPreflight(preflight);
+  else await sourcePreflight(preflight);
 
   const deployDir = options.dir ?? path.join(librarianDir(options.home), "server");
-
-  // The deploy-state is authoritative for the bind host + data volume to reuse.
-  // Without it we cannot recreate the container with the same config — teach.
-  const state = readDeployState(deployDir);
-  if (!state) {
-    throw new UpdateError(
-      `No deploy-state found at ${deployDir} — this host has not run \`librarian server up\` ` +
-        "(or the deploy dir is wrong). Run `librarian server up` first, " +
-        "or pass `--dir <path>` to point at an existing deploy dir.",
-    );
-  }
-
-  // SPEC 074 SC5: ONE exclusive lock serialises EVERY update — manual runs and
-  // auto-update timer fires alike — so two can never interleave stop/rm/run on
-  // the same container (a window with no running container takes the server
-  // down). Before 074 only the timer wrapper locked, so a manual update could
-  // race a fire. Held around everything from ref resolution to deploy-state
-  // write; released on success AND failure (a failure must not wedge the next
-  // fire — the stale-reclaim window is for crashes, not ordinary errors).
   const lockPath = updateLockPath({ home: options.home, dir: options.dir });
   const lock = acquireUpdateLock(lockPath);
   if (!lock) throw new UpdateInProgressError(lockPath);
   try {
-    return await performUpdate(options, deployDir, state);
+    // State is read only after winning the same lifecycle lock used by `up`, so
+    // it cannot go stale behind a concurrent file/container finalization.
+    const state = readDeployState(deployDir);
+    if (!state) {
+      throw new UpdateError(
+        `No deploy-state found at ${deployDir} — this host has not run \`librarian server up\` ` +
+          "(or the deploy dir is wrong). Run `librarian server up` first, or pass `--dir <path>`.",
+      );
+    }
+    return await performUpdate(options, deployDir, state, target);
   } finally {
     lock.release();
   }
 }
 
-/** The locked body of {@link runUpdate} — everything after preflight/state/lock. */
 async function performUpdate(
   options: UpdateOptions,
   deployDir: string,
   state: DeployState,
+  target: DeploymentTarget,
 ): Promise<UpdateResult> {
-  // 2) Resolve the target ref (explicit `--ref` wins; else the latest tag).
-  const targetRef = await resolveRef(options.ref);
+  const targetRef = await resolveTargetRef(target);
+  // A moving source ref must be fetched and resolved before idempotency. The
+  // checkout may move while the current service continues serving; no image is
+  // built and no credential/container state is touched yet.
+  const sourceResolution =
+    target.imageSource === "source" ? await resolveSourceTarget(deployDir, targetRef) : undefined;
+  const current = await inspectCurrentContainer(state);
 
-  // 3) IDEMPOTENCY FIRST: already at the resolved ref AND healthy → clean no-op.
-  if (state.ref === targetRef && (await isHealthy())) {
+  // Registry no-op is before a pull. Source no-op compares the fetched commit's
+  // deterministic tag and its current immutable image ID, so `main` advancing
+  // cannot be mistaken for an already-current deployment.
+  const exactTarget = sourceResolution
+    ? await isExactHealthySourceTarget(state, targetRef, current, deployDir, sourceResolution)
+    : isExactHealthyRegistryTarget(state, targetRef, current, deployDir);
+  if (exactTarget) {
     return {
-      output: [
-        `Already up to date (${targetRef}) — the container is healthy.`,
-        "Nothing to do. Pin a different ref with `--ref <tag|main>` to change it.",
-      ].join("\n"),
+      output: `Already up to date (${targetRef}) — the exact deployment is healthy.\nNothing to do.`,
     };
   }
 
-  // 4) Update, in the deploy dir: fetch tags → checkout the resolved ref.
-  await git(["-C", deployDir, "fetch", "--tags", "origin"]);
-  await checkoutRef(deployDir, targetRef);
+  const prepared = await prepareTarget(target.imageSource, targetRef, deployDir, sourceResolution);
 
-  // 5) Build the new image from the deploy dir.
-  await dockerInDir(
-    ["build", "-f", "docker/all-in-one.Dockerfile", "-t", `${CONTAINER_NAME}:${targetRef}`, "."],
-    deployDir,
-  );
-
-  // 6) Read the EXISTING secrets back from the running container's env BEFORE
-  //    removal (one `docker inspect`; ADR 0008 P4 put them there via
-  //    `--env-file`). PREFER reusing them:
-  //      - agent token: reuse, else mint fresh (clients re-paste).
-  //      - master key: reuse, else OMIT (server resolves /data/secret.key) —
-  //        NEVER mint a fresh key, which would orphan encrypted secrets.
-  //      - bootstrap claim: reuse, falling back to the protected deploy file,
-  //        so a stopped/unreadable container does not silently become unarmed.
-  const existingEnv = await readExistingContainerEnv();
-  const existingToken = existingEnv.get("LIBRARIAN_AGENT_TOKEN") ?? null;
-  const existingKey = existingEnv.get("LIBRARIAN_SECRET_KEY") ?? null;
-  const persistedDeployEnv = readDeployEnvFile(deployDir);
-  const existingBootstrapClaimSecret =
-    existingEnv.get("LIBRARIAN_BOOTSTRAP_CLAIM_SECRET") ??
-    persistedDeployEnv.LIBRARIAN_BOOTSTRAP_CLAIM_SECRET ??
-    null;
-  const agentToken = existingToken ?? mintAgentToken();
-  const tokenIsFresh = existingToken === null;
-
-  // 7) Recreate — CONTAINER ONLY. `docker stop` then `docker rm <name>`:
-  //    NEVER `-v`, NEVER `docker volume rm`. The named data volume persists.
-  await dockerStop();
-  await dockerRm();
-
-  // 8) Write the 0600 deploy env-file, then run the new container with the SAME
-  //    host + data volume from deploy-state, secrets via `--env-file` (ADR 0008
-  //    P4 — never inline on argv). The master key is the preserved one, or
-  //    omitted (then the server resolves it from /data/secret.key).
-  const envFile = writeDeployEnvFile(deployDir, {
+  // Finish all local, fallible preparation before interrupting the old service.
+  const persisted = readDeployEnvFile(deployDir);
+  const agentToken =
+    current.env.get("LIBRARIAN_AGENT_TOKEN") ?? persisted.LIBRARIAN_AGENT_TOKEN ?? mintAgentToken();
+  const secretKey =
+    current.env.get("LIBRARIAN_SECRET_KEY") ?? persisted.LIBRARIAN_SECRET_KEY ?? undefined;
+  const bootstrapClaimSecret =
+    current.env.get("LIBRARIAN_BOOTSTRAP_CLAIM_SECRET") ??
+    persisted.LIBRARIAN_BOOTSTRAP_CLAIM_SECRET ??
+    undefined;
+  const tokenIsFresh =
+    !current.env.has("LIBRARIAN_AGENT_TOKEN") && !persisted.LIBRARIAN_AGENT_TOKEN;
+  const stagedEnv = writeStagedDeployEnvFile(deployDir, {
     agentToken,
-    secretKey: existingKey ?? undefined,
-    bootstrapClaimSecret: existingBootstrapClaimSecret ?? undefined,
-    host: state.host,
+    secretKey,
+    bootstrapClaimSecret,
+    host: current.host,
   });
-  // Reuse the published dashboard port from deploy-state. A state written before
-  // `dashboardPort` existed has none → treat it as the historical 3000, so an
-  // existing server keeps its port across the update (no silent jump to 3042).
-  const dashboardPort = state.dashboardPort ?? LEGACY_DASHBOARD_PORT;
-  await dockerInDir(
-    buildRunArgs({
-      host: state.host,
-      dataVolume: state.dataVolume,
-      dashboardPort,
-      // Reuse the same storage: a bind-mounted host dir (run as its owner) when
-      // the deploy chose one, else the named volume. The data is sacred either way.
-      dataDir: state.dataDir,
-      runAsUser: state.dataDir ? dirOwner(state.dataDir) : undefined,
-      imageRef: `${CONTAINER_NAME}:${targetRef}`,
-      envFile,
-    }),
-    deployDir,
-  );
+  const priorRecoveryEnv = `${stagedEnv}.previous`;
+  try {
+    writePriorRecoveryEnv(priorRecoveryEnv, current.env);
+  } catch (error) {
+    const warning = cleanupSecretArtifact(stagedEnv);
+    throw new UpdateError(`${errorDetail(error)}${warning ? ` ${warning}` : ""}`);
+  }
+  const redact = valueAwareRedactor([
+    agentToken,
+    secretKey,
+    bootstrapClaimSecret,
+    current.env.get("LIBRARIAN_AGENT_TOKEN"),
+    current.env.get("LIBRARIAN_SECRET_KEY"),
+    current.env.get("LIBRARIAN_BOOTSTRAP_CLAIM_SECRET"),
+  ]);
 
-  // 9) Wait for health (rolls back with `docker rm -f` on failure — up's
-  //    pattern). If this throws, deploy-state is NOT advanced below.
-  await waitForHealthy(options);
+  const nextState: Parameters<typeof finalizeDeploymentFiles>[2] =
+    prepared.imageSource === "registry"
+      ? {
+          containerName: state.containerName,
+          host: current.host,
+          dataVolume: current.dataVolume,
+          dataDir: current.dataDir,
+          dashboardPort: current.dashboardPort,
+          ref: prepared.ref,
+          imageTag: prepared.imageRef,
+          imageSource: "registry",
+          imageRef: prepared.imageRef,
+          imageDigest: prepared.imageDigest!,
+        }
+      : {
+          containerName: state.containerName,
+          host: current.host,
+          dataVolume: current.dataVolume,
+          dataDir: current.dataDir,
+          dashboardPort: current.dashboardPort,
+          ref: prepared.ref,
+          imageTag: prepared.imageRef,
+          imageSource: "source",
+          imageRef: prepared.imageRef,
+        };
 
-  // 10) Apply pending data-dir migrations via the bundled admin CLI (S7 bundles
-  //     the `the-librarian` binary into the image; this slice asserts the argv).
-  await dockerExecMigrate();
+  let oldRemoved = false;
+  let candidateId: string | null = null;
+  let migrationStarted = false;
+  let successCleanupWarning: string | null = null;
+  try {
+    await stopCurrent(current.immutableContainerId, redact);
+    await removeCurrent(current.immutableContainerId, redact);
+    oldRemoved = true;
 
-  // 11) Persist the new ref/imageTag — host/dataVolume/containerName unchanged.
-  writeDeployState(deployDir, {
-    containerName: state.containerName,
-    host: state.host,
-    dataVolume: state.dataVolume,
-    dataDir: state.dataDir,
-    // Backfill the port we just recreated with — so a legacy state (no port)
-    // becomes an explicit 3000 and never drifts to the fresh-install default.
-    dashboardPort,
-    ref: targetRef,
-    imageTag: `${CONTAINER_NAME}:${targetRef}`,
-    imageSource: "source",
-    imageRef: `${CONTAINER_NAME}:${targetRef}`,
-  });
+    candidateId = await createContainer(
+      prepared.runImageRef,
+      current,
+      stagedEnv,
+      prepared.cwd,
+      redact,
+    );
+    await startContainer(candidateId, prepared.cwd, redact);
+    await waitForHealth(candidateId, options, redact);
 
-  return { output: renderSuccess(targetRef, tokenIsFresh ? agentToken : null) };
+    migrationStarted = true;
+    await execMigration(candidateId, redact);
+
+    finalizeDeploymentFiles(deployDir, stagedEnv, nextState);
+    candidateId = null;
+    successCleanupWarning = cleanupSecretArtifact(priorRecoveryEnv);
+  } catch (primary) {
+    const primaryMessage = errorDetail(primary, redact);
+    const priorFilesRestored =
+      !(primary instanceof DeploymentFinalizationError) || primary.priorFilesRestored;
+    if (candidateId) {
+      const ownedCandidateId = candidateId;
+      try {
+        await removeOwnedContainer(ownedCandidateId, redact);
+        candidateId = null;
+      } catch (cleanupError) {
+        throw recoveryFailure(
+          primaryMessage,
+          errorDetail(cleanupError, redact),
+          current,
+          priorRecoveryEnv,
+          migrationStarted,
+          true,
+          priorFilesRestored,
+          ownedCandidateId,
+        );
+      }
+    }
+
+    try {
+      if (oldRemoved) {
+        await recreatePrevious(current, priorRecoveryEnv, deployDir, options, redact);
+      } else {
+        await restartPrevious(current.immutableContainerId, options, redact);
+      }
+    } catch (recoveryError) {
+      // Keep the protected staged env-file: the printed recovery command uses it.
+      throw recoveryFailure(
+        primaryMessage,
+        errorDetail(recoveryError, redact),
+        current,
+        priorRecoveryEnv,
+        migrationStarted,
+        oldRemoved,
+        priorFilesRestored,
+        recoveryError instanceof RecoveryAttemptError ? recoveryError.ownedContainerId : undefined,
+      );
+    }
+    const cleanupWarnings = [cleanupSecretArtifact(stagedEnv)];
+    if (priorFilesRestored) cleanupWarnings.push(cleanupSecretArtifact(priorRecoveryEnv));
+    throw recoveredFailure(
+      primaryMessage,
+      migrationStarted,
+      priorFilesRestored,
+      priorRecoveryEnv,
+      cleanupWarnings.filter((warning): warning is string => warning !== null),
+    );
+  }
+
+  return {
+    output: [renderSuccess(prepared, tokenIsFresh ? agentToken : null), successCleanupWarning]
+      .filter(Boolean)
+      .join("\n"),
+  };
 }
 
-// --- ref + health probes -------------------------------------------------
-
-/** Resolve the target ref: an explicit `--ref` wins; else the latest tag. */
-async function resolveRef(ref: string | undefined): Promise<string> {
-  if (ref && ref.trim().length > 0) return ref.trim();
+async function resolveTargetRef(target: DeploymentTarget): Promise<string> {
+  if (target.imageSource === "source") return target.ref;
+  if (target.ref) return target.ref;
   const latest = await fetchLatestVersion();
   if (!latest) {
     throw new UpdateError(
-      "Could not resolve the latest release tag from GitHub. " +
-        "Check your network, or pin a ref with `--ref <tag|main>`.",
+      "Could not resolve the latest stable release from GitHub. Check the network, or pin " +
+        "`--ref vX.Y.Z`. Stable updates never fall back to a source build.",
     );
   }
-  // `fetchLatestVersion` strips the leading `v`; the tag we check out keeps it.
   return `v${latest}`;
 }
 
-/**
- * True iff the container exists AND reports `healthy`. Used by the idempotency
- * check — already at the ref but unhealthy means we still recreate. A failing
- * `docker inspect` (no such container) → not healthy.
- */
-async function isHealthy(): Promise<boolean> {
-  const status = await run("docker", ["inspect", "--format", "{{.State.Status}}", CONTAINER_NAME]);
-  if (status.code !== 0 || status.stdout.trim() !== "running") return false;
-  const health = await run("docker", [
-    "inspect",
-    "--format",
-    "{{.State.Health.Status}}",
-    CONTAINER_NAME,
-  ]);
-  return health.code === 0 && health.stdout.trim() === "healthy";
-}
-
-// --- secret read-back (clients keep working; secrets stay decryptable) ----
-
-/**
- * Read the running container's env (`docker inspect .Config.Env`) into a map,
- * BEFORE the container is removed, so an `update` reuses the existing secrets
- * rather than silently breaking clients or orphaning encrypted settings. Returns
- * an EMPTY map when the container is gone/unreadable (a non-zero inspect) — the
- * caller then mints a fresh agent token and omits the master key. Empty values
- * are dropped (treated as "not present"). The values are returned for reuse on
- * recreate — never logged.
- */
-async function readExistingContainerEnv(): Promise<Map<string, string>> {
-  const env = new Map<string, string>();
-  const result = await run("docker", [
-    "inspect",
-    "--format",
-    "{{range .Config.Env}}{{println .}}{{end}}",
-    CONTAINER_NAME,
-  ]);
-  if (result.code !== 0) return env;
-  for (const line of result.stdout.split("\n")) {
-    const trimmed = line.trim();
-    const eq = trimmed.indexOf("=");
-    if (eq <= 0) continue; // no `=`, or a leading `=` (no name) → skip
-    const name = trimmed.slice(0, eq);
-    const value = trimmed.slice(eq + 1);
-    if (value.length > 0) env.set(name, value);
+async function prepareTarget(
+  imageSource: "registry" | "source",
+  ref: string,
+  deployDir: string,
+  sourceResolution?: SourceResolution | undefined,
+): Promise<PreparedTarget> {
+  if (imageSource === "registry") {
+    let image: PreparedRegistryImage;
+    try {
+      image = await prepareRegistryImage(ref, (chunk) => void process.stderr.write(chunk));
+    } catch (error) {
+      throw new UpdateError(
+        errorDetail(error).replaceAll("librarian server up", "librarian server update"),
+      );
+    }
+    return {
+      ref,
+      imageSource,
+      runImageRef: image.imageDigest,
+      imageRef: image.imageRef,
+      imageDigest: image.imageDigest,
+      cwd: deployDir,
+    };
   }
-  return env;
+
+  if (!sourceResolution) throw new UpdateError("Internal error: source target was not resolved.");
+  await buildSourceImage(sourceResolution.checkout, sourceResolution.imageTag);
+  const immutableImageId = await inspectSourceImageId(sourceResolution.imageTag, true);
+  return {
+    ref,
+    imageSource,
+    runImageRef: immutableImageId!,
+    imageRef: sourceResolution.imageTag,
+    cwd: sourceResolution.checkout,
+  };
 }
 
-// --- thin runner wrappers (teaching errors on a non-zero exit) ----------
-
-/** Run a `git …` command; a non-zero exit is a teaching error. */
-async function git(args: string[]): Promise<void> {
-  const result = await run("git", args);
-  failIfNonZero("git", args, result);
-}
-
-/**
- * Check out `ref` in `dir` without letting a `--…`-shaped ref inject a git
- * option (S-1). `git checkout` does NOT honor `--end-of-options` — it reads the
- * marker itself as a pathspec (verified on git 2.43) — so we resolve the ref to
- * a commit SHA with `git rev-parse` (which DOES honor it, the injection guard
- * that works), then check out that SHA — a hex object id can't be an option.
- */
-async function checkoutRef(dir: string, ref: string): Promise<void> {
-  const resolved = await run("git", [
-    "-C",
-    dir,
-    "rev-parse",
-    "--verify",
-    "--end-of-options",
-    `${ref}^{commit}`,
-  ]);
-  failIfNonZero("git", ["-C", dir, "rev-parse", ref], resolved);
-  await git(["-C", dir, "checkout", resolved.stdout.trim()]);
-}
-
-/** Run a `docker …` command from the deploy dir; non-zero exit → teaching error. */
-async function dockerInDir(args: string[], cwd: string): Promise<void> {
-  const result = await run("docker", args, { cwd });
-  failIfNonZero("docker", args, result);
-}
-
-/** Stop the old container. A not-running/not-found container is fine (we recreate). */
-async function dockerStop(): Promise<void> {
-  const result = await run("docker", ["stop", CONTAINER_NAME]);
-  if (result.code === 0) return;
-  if (isNotFound(result.stderr)) return; // nothing to stop — proceed to rm/run
-  failIfNonZero("docker", ["stop", CONTAINER_NAME], result);
-}
-
-/**
- * Remove the old CONTAINER (NOT the volume). `docker rm <name>` — never `-v`,
- * never `docker volume rm`. A not-found container is fine (we recreate).
- */
-async function dockerRm(): Promise<void> {
-  const result = await run("docker", ["rm", CONTAINER_NAME]);
-  if (result.code === 0) return;
-  if (isNotFound(result.stderr)) return; // already gone — proceed to run
-  failIfNonZero("docker", ["rm", CONTAINER_NAME], result);
-}
-
-/** Apply pending data-dir migrations inside the (now-healthy) container. */
-async function dockerExecMigrate(): Promise<void> {
-  const args = ["exec", CONTAINER_NAME, CONTAINER_NAME, "migrate-data-dir"];
+async function inspectCurrentContainer(state: DeployState): Promise<PreservedConfig> {
+  const args = ["container", "inspect", "--format", "{{json .}}", CONTAINER_NAME];
   const result = await run("docker", args);
-  failIfNonZero("docker", args, result);
+  if (result.code !== 0) {
+    throw new UpdateError(
+      `Could not inspect the current ${CONTAINER_NAME} container before update` +
+        detailSuffix(result) +
+        " The existing deployment and state were left untouched; run `librarian server up` if it is absent.",
+    );
+  }
+  let live: LiveContainer;
+  try {
+    const parsed: unknown = JSON.parse(result.stdout.trim());
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error();
+    live = parsed as LiveContainer;
+  } catch {
+    throw new UpdateError(
+      "Docker returned malformed metadata for the current container. Refusing to interrupt it.",
+    );
+  }
+
+  const immutableImageId = typeof live.Image === "string" ? live.Image : "";
+  const immutableContainerId = typeof live.Id === "string" ? live.Id : "";
+  const configuredImage = typeof live.Config?.Image === "string" ? live.Config.Image : "";
+  if (
+    !CONTAINER_ID.test(immutableContainerId) ||
+    !IMAGE_ID.test(immutableImageId) ||
+    !configuredImage
+  ) {
+    throw new UpdateError(
+      "Docker did not report the current container's full immutable image ID. Refusing an update that could not restore the previous executable.",
+    );
+  }
+  const ports = preservedPorts(live.HostConfig?.PortBindings);
+  const mount = preservedMount(live.Mounts, state.dataVolume);
+  const restartPolicy = live.HostConfig?.RestartPolicy?.Name;
+  if (typeof restartPolicy !== "string" || !restartPolicy) {
+    throw new UpdateError(
+      "Docker did not report the current restart policy. Refusing an update that could drift container configuration.",
+    );
+  }
+  return {
+    immutableContainerId,
+    immutableImageId,
+    configuredImage,
+    host: ports.host,
+    dashboardPort: ports.dashboardPort,
+    dataVolume: mount.dataVolume,
+    dataDir: mount.dataDir,
+    runAsUser:
+      typeof live.Config?.User === "string" && live.Config.User ? live.Config.User : undefined,
+    restartPolicy,
+    env: envMap(live.Config?.Env),
+    healthy: live.State?.Status === "running" && live.State?.Health?.Status === "healthy",
+  };
 }
 
-/** True when a docker error means the container simply isn't there. */
-function isNotFound(stderr: string): boolean {
-  return /no such container|no such object|is not running/i.test(stderr);
+function preservedPorts(value: unknown): { host: string; dashboardPort: number } {
+  const record = objectRecord(value);
+  const dashboard = oneBinding(record["3000/tcp"], "dashboard");
+  const mcp = oneBinding(record["3838/tcp"], "MCP");
+  if (dashboard.host !== mcp.host || mcp.port !== 3838) {
+    throw new UpdateError(
+      "The current dashboard/MCP port bindings are not a supported Librarian configuration. Refusing to replace it or change its exposure.",
+    );
+  }
+  return { host: dashboard.host, dashboardPort: dashboard.port };
 }
 
-function failIfNonZero(cmd: string, args: string[], result: RunResult): void {
-  if (result.code === 0) return;
-  // Redact in case a non-zero docker step echoed a secret-shaped line.
-  const detail = redactSecrets(result.stderr.trim() || result.stdout.trim());
+function oneBinding(value: unknown, label: string): { host: string; port: number } {
+  if (!Array.isArray(value) || value.length !== 1) {
+    throw new UpdateError(`Docker did not report exactly one ${label} host-port binding.`);
+  }
+  const binding = objectRecord(value[0]);
+  const host = typeof binding.HostIp === "string" ? binding.HostIp : "";
+  const rawPort = typeof binding.HostPort === "string" ? binding.HostPort : "";
+  const port = Number(rawPort);
+  if (!host || !/^\d+$/.test(rawPort) || !Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new UpdateError(`Docker returned an invalid ${label} host-port binding.`);
+  }
+  return { host, port };
+}
+
+function preservedMount(
+  value: unknown,
+  fallbackVolume: string,
+): { dataVolume: string; dataDir?: string | undefined } {
+  const mounts = Array.isArray(value)
+    ? value.filter((entry) => objectRecord(entry).Destination === "/data")
+    : [];
+  if (mounts.length !== 1) {
+    throw new UpdateError("Docker did not report exactly one /data mount. Refusing to risk data.");
+  }
+  const mount = objectRecord(mounts[0]);
+  if (mount.Type === "bind" && typeof mount.Source === "string" && mount.Source) {
+    return { dataVolume: fallbackVolume, dataDir: mount.Source };
+  }
+  if (mount.Type === "volume" && typeof mount.Name === "string" && mount.Name) {
+    return { dataVolume: mount.Name };
+  }
   throw new UpdateError(
-    `\`${cmd} ${args[0]}\` failed (exit ${result.code ?? "signal"})` +
-      (detail ? `:\n${detail}` : ".") +
-      "\n\nResolve the error above, then re-run `librarian server update`.",
+    "The current /data mount is neither a named volume nor an absolute bind mount. Refusing to replace it.",
   );
 }
 
-// --- success report ------------------------------------------------------
+function hasExactHealthyConfiguration(
+  state: DeployState,
+  requestedSource: "registry" | "source",
+  ref: string,
+  current: PreservedConfig,
+  deployDir: string,
+): boolean {
+  const stateSource = state.imageSource ?? "source";
+  if (!current.healthy || stateSource !== requestedSource || state.ref !== ref) return false;
+  if (state.host !== current.host) return false;
+  if ((state.dashboardPort ?? LEGACY_DASHBOARD_PORT) !== current.dashboardPort) return false;
+  if ((state.dataDir ?? undefined) !== current.dataDir) return false;
+  if (!current.dataDir && state.dataVolume !== current.dataVolume) return false;
+  // Update preserves the live container's validated user and restart policy,
+  // including operator customisations. Those fields are not in deploy state,
+  // so requiring the `up` defaults here would replace the same target forever.
+  const persisted = readDeployEnvFile(deployDir);
+  const requiredRuntime: Record<string, string> = {
+    LIBRARIAN_DATA_DIR: "/data",
+    LIBRARIAN_HOST: "0.0.0.0",
+    LIBRARIAN_PORT: "3838",
+    PORT: "3000",
+  };
+  for (const [name, value] of Object.entries(requiredRuntime)) {
+    if (current.env.get(name) !== value) return false;
+  }
+  for (const name of [
+    "LIBRARIAN_AGENT_TOKEN",
+    "LIBRARIAN_SECRET_KEY",
+    "LIBRARIAN_BOOTSTRAP_CLAIM_SECRET",
+    "LIBRARIAN_ALLOW_NO_AUTH",
+  ]) {
+    if ((current.env.get(name) || undefined) !== (persisted[name] || undefined)) return false;
+  }
+  return Boolean(persisted.LIBRARIAN_AGENT_TOKEN);
+}
 
-/**
- * The success report. `freshToken` is non-null ONLY when we had to mint a new
- * agent token (the old container's token was unreadable) — then we surface it
- * ONCE with a clients-must-update note. When the existing token was reused,
- * nothing about the token is printed (clients keep working untouched).
- */
-function renderSuccess(ref: string, freshToken: string | null): string {
+function isExactHealthyRegistryTarget(
+  state: DeployState,
+  ref: string,
+  current: PreservedConfig,
+  deployDir: string,
+): boolean {
+  return (
+    hasExactHealthyConfiguration(state, "registry", ref, current, deployDir) &&
+    state.imageSource === "registry" &&
+    Boolean(state.imageDigest) &&
+    current.configuredImage === state.imageDigest
+  );
+}
+
+async function isExactHealthySourceTarget(
+  state: DeployState,
+  ref: string,
+  current: PreservedConfig,
+  deployDir: string,
+  source: SourceResolution,
+): Promise<boolean> {
+  if (!hasExactHealthyConfiguration(state, "source", ref, current, deployDir)) return false;
+  if (state.imageSource !== "source" || state.imageRef !== source.imageTag) return false;
+  const taggedImageId = await inspectSourceImageId(source.imageTag, false);
+  return (
+    taggedImageId !== null &&
+    taggedImageId === current.immutableImageId &&
+    current.configuredImage === current.immutableImageId
+  );
+}
+
+async function resolveSourceTarget(deployDir: string, ref: string): Promise<SourceResolution> {
+  assertLiteralSourceRef(ref);
+  const rootGit = path.join(deployDir, ".git");
+  const checkout = fs.existsSync(rootGit) ? deployDir : path.join(deployDir, "source");
+  if (!fs.existsSync(path.join(checkout, ".git"))) {
+    if (fs.existsSync(checkout) && fs.readdirSync(checkout).length > 0) {
+      throw new UpdateError(
+        `Managed source checkout ${checkout} is non-empty but is not a git clone. Refusing to overwrite it.`,
+      );
+    }
+    await checked("git", ["clone", REPO_URL, checkout], redactGitDiagnostics);
+  } else {
+    const remote = await run("git", ["-C", checkout, "remote", "get-url", "origin"]);
+    checkedResult("git", ["remote", "get-url", "origin"], remote, redactGitDiagnostics);
+    if (!sameRepository(remote.stdout.trim(), REPO_URL)) {
+      throw new UpdateError(
+        `Managed source checkout ${checkout} has an unexpected origin; refusing to modify it. ` +
+          "Set origin to the canonical repository or use a different deploy directory.",
+      );
+    }
+  }
+  const statusArgs = ["-C", checkout, "status", "--porcelain", "--untracked-files=all"];
+  const status = await run("git", statusArgs);
+  checkedResult("git", statusArgs, status, redactGitDiagnostics);
+  if (hasUserCheckoutChanges(status.stdout)) {
+    throw new UpdateError(
+      `Managed source checkout ${checkout} has local tracked or untracked changes. ` +
+        "The current container is still serving; commit, stash, or move those files before retrying.",
+    );
+  }
+  await checked("git", ["-C", checkout, "fetch", "--tags", "origin"], redactGitDiagnostics);
+  const commit = await resolveSourceCommit(checkout, ref);
+  await checked("git", ["-C", checkout, "checkout", commit], redactGitDiagnostics);
+  return {
+    checkout,
+    commit,
+    imageTag: `${CONTAINER_NAME}:source-${commit}`,
+  };
+}
+
+async function resolveSourceCommit(checkout: string, ref: string): Promise<string> {
+  const candidates = [`refs/remotes/origin/${ref}^{commit}`, `refs/tags/${ref}^{commit}`];
+  if (/^[0-9a-f]{40}$/i.test(ref)) candidates.push(`${ref}^{commit}`);
+  let last: RunResult | undefined;
+  for (const candidate of candidates) {
+    const result = await run("git", [
+      "-C",
+      checkout,
+      "rev-parse",
+      "--verify",
+      "--end-of-options",
+      candidate,
+    ]);
+    last = result;
+    const commit = result.stdout.trim();
+    if (result.code === 0 && /^[0-9a-f]{40}$/.test(commit)) return commit;
+  }
+  throw new UpdateError(
+    `Could not resolve source ref '${ref}' to a full commit after fetching origin` +
+      (last ? detailSuffix(last, redactGitDiagnostics) : ".") +
+      " Check the branch, tag, or commit and retry.",
+  );
+}
+
+function assertLiteralSourceRef(ref: string): void {
+  const components = ref.split("/");
+  const forbiddenCharacter = [...ref].some((character) => {
+    const codePoint = character.codePointAt(0)!;
+    return (
+      codePoint <= 0x20 ||
+      codePoint === 0x7f ||
+      ["~", "^", ":", "?", "*", "[", "\\"].includes(character)
+    );
+  });
+  const invalidShape =
+    !ref ||
+    ref === "@" ||
+    ref.startsWith("-") ||
+    ref.startsWith("/") ||
+    ref.endsWith("/") ||
+    ref.endsWith(".") ||
+    ref.includes("..") ||
+    ref.includes("//") ||
+    ref.includes("@{") ||
+    components.some((component) => component.startsWith(".") || component.endsWith(".lock"));
+  if (forbiddenCharacter || invalidShape) {
+    throw new UpdateError(
+      "Source --ref must be a literal branch name, tag name, or full 40-character commit SHA; " +
+        "Git revision expressions such as '~', '^', and '@{' are not accepted.",
+    );
+  }
+}
+
+function hasUserCheckoutChanges(porcelain: string): boolean {
+  // In legacy deployments the managed clone itself is the deploy directory.
+  // These exact untracked files are owned by the CLI and necessarily coexist
+  // with source. The lock exists during this check. Do not ignore staged env,
+  // cidfile, state-staging, or wildcard-shaped residue: those need inspection.
+  const cliOwnedUntracked = new Set([
+    "?? deploy.env",
+    "?? deploy-state.json",
+    "?? .autoupdate.lock",
+  ]);
+  return porcelain
+    .split("\n")
+    .map((line) => (line.endsWith("\r") ? line.slice(0, -1) : line))
+    .some((line) => line !== "" && !cliOwnedUntracked.has(line));
+}
+
+async function buildSourceImage(checkout: string, imageTag: string): Promise<void> {
+  const args = [
+    "build",
+    "--progress=plain",
+    "-f",
+    "docker/all-in-one.Dockerfile",
+    "-t",
+    imageTag,
+    ".",
+  ];
+  let code: number | null;
+  try {
+    code = await stream(
+      "docker",
+      args,
+      {
+        onStdout: (chunk) => void process.stderr.write(chunk),
+        onStderr: (chunk) => void process.stderr.write(chunk),
+      },
+      { cwd: checkout },
+    );
+  } catch (error) {
+    throw new UpdateError(`\`docker build\` could not start: ${errorDetail(error)}`);
+  }
+  if (code !== 0) {
+    throw new UpdateError(
+      `\`docker build\` failed (exit ${code ?? "signal"}). The current container is still serving; fix the build and retry.`,
+    );
+  }
+}
+
+async function inspectSourceImageId(imageTag: string, required: boolean): Promise<string | null> {
+  const args = ["image", "inspect", "--format", "{{.Id}}", imageTag];
+  const result = await run("docker", args);
+  if (result.code !== 0) {
+    if (!required) return null;
+    checkedResult("docker", args, result);
+  }
+  const imageId = result.stdout.trim();
+  if (!IMAGE_ID.test(imageId)) {
+    if (!required) return null;
+    throw new UpdateError(
+      `Docker did not report a full immutable image ID after building ${imageTag}. The current container is still serving.`,
+    );
+  }
+  return imageId;
+}
+
+async function stopCurrent(identity: string, redact: Redactor): Promise<void> {
+  const args = ["stop", identity];
+  const result = await run("docker", args);
+  if (result.code === 0 || /is not running/i.test(result.stderr)) return;
+  checkedResult("docker", args, result, redact);
+}
+
+async function removeCurrent(identity: string, redact: Redactor): Promise<void> {
+  const args = ["rm", identity];
+  const result = await run("docker", args);
+  if (result.code === 0 || verifiedNotFound(result, identity)) return;
+  // A failed `docker rm` does not prove whether the daemon removed the target.
+  // Resolve the exact immutable ID before choosing restart-vs-recreate recovery.
+  const classified = await run("docker", ["container", "inspect", identity]);
+  if (classified.code !== 0 && verifiedNotFound(classified, identity)) return;
+  if (classified.code !== 0) {
+    throw new UpdateError(
+      `\`docker rm\` failed and Docker could not determine whether container ${identity} still exists` +
+        detailSuffix(classified, redact) +
+        " Refusing to act on the mutable container name.",
+    );
+  }
+  checkedResult("docker", args, result, redact);
+}
+
+async function createContainer(
+  imageRef: string,
+  config: PreservedConfig,
+  envFile: string,
+  cwd: string,
+  redact: Redactor,
+): Promise<string> {
+  const cidFile = `${envFile}.cid`;
+  const args = buildCreateArgs({
+    host: config.host,
+    dataVolume: config.dataVolume,
+    dashboardPort: config.dashboardPort,
+    dataDir: config.dataDir,
+    runAsUser: config.runAsUser,
+    restartPolicy: config.restartPolicy,
+    imageRef,
+    envFile,
+  });
+  args.splice(1, 0, "--cidfile", cidFile);
+  fs.rmSync(cidFile, { force: true });
+  try {
+    const created = await run("docker", args, { cwd });
+    checkedResult("docker", args, created, redact);
+    let id = "";
+    try {
+      id = fs.readFileSync(cidFile, "utf8").trim();
+    } catch {
+      // A successful `docker create` without its cidfile leaves ownership
+      // ambiguous. Recovery must inspect, never remove/create by mutable name.
+    }
+    if (!CONTAINER_ID.test(id)) {
+      throw new UpdateError(
+        `Docker created a container but did not write a full immutable ID to ${cidFile}. ` +
+          `Refusing cleanup by mutable name; inspect ${CONTAINER_NAME} manually.`,
+      );
+    }
+    return id;
+  } finally {
+    try {
+      fs.rmSync(cidFile, { force: true });
+    } catch {
+      // The cidfile contains only a container ID. Cleanup failure must not lose
+      // an identity we successfully captured and turn safe cleanup ambiguous.
+    }
+  }
+}
+
+async function startContainer(id: string, cwd: string, redact: Redactor): Promise<void> {
+  const started = await run("docker", ["start", id], { cwd });
+  checkedResult("docker", ["start", id], started, redact);
+}
+
+async function waitForHealth(
+  identity: string,
+  options: UpdateOptions,
+  redact: Redactor,
+): Promise<void> {
+  const attempts = options.healthAttempts ?? 60;
+  const interval = options.healthIntervalMs ?? 2000;
+  let last = "unknown";
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const result = await run("docker", [
+      "inspect",
+      "--format",
+      "{{.State.Health.Status}}",
+      identity,
+    ]);
+    if (result.code === 0 && result.stdout.trim()) last = result.stdout.trim();
+    if (last === "healthy") return;
+    if (last === "unhealthy") break;
+    if (attempt < attempts - 1 && interval > 0) {
+      await new Promise((resolve) => setTimeout(resolve, interval));
+    }
+  }
+  const logs = await run("docker", [
+    "logs",
+    "--tail",
+    String(options.logTailLines ?? 50),
+    identity,
+  ]);
+  const detail = redact(logs.stdout.trim() || logs.stderr.trim());
+  throw new UpdateError(
+    `Container ${identity} did not become healthy (last status: ${last})` +
+      (detail ? `:\n${detail}` : "."),
+  );
+}
+
+async function execMigration(identity: string, redact: Redactor): Promise<void> {
+  const args = ["exec", identity, CONTAINER_NAME, "migrate-data-dir"];
+  const result = await run("docker", args);
+  checkedResult("docker", args, result, redact);
+}
+
+async function restartPrevious(
+  identity: string,
+  options: UpdateOptions,
+  redact: Redactor,
+): Promise<void> {
+  const result = await run("docker", ["start", identity]);
+  if (result.code !== 0 && !/already running/i.test(`${result.stdout}\n${result.stderr}`)) {
+    checkedResult("docker", ["start", identity], result, redact);
+  }
+  await waitForHealth(identity, options, redact);
+}
+
+async function recreatePrevious(
+  previous: PreservedConfig,
+  envFile: string,
+  deployDir: string,
+  options: UpdateOptions,
+  redact: Redactor,
+): Promise<void> {
+  const id = await createContainer(previous.immutableImageId, previous, envFile, deployDir, redact);
+  try {
+    await startContainer(id, deployDir, redact);
+    await waitForHealth(id, options, redact);
+  } catch (error) {
+    throw new RecoveryAttemptError(errorDetail(error, redact), id);
+  }
+}
+
+async function removeOwnedContainer(identity: string, redact: Redactor): Promise<void> {
+  const result = await run("docker", ["rm", "-f", identity]);
+  if (result.code === 0 || verifiedNotFound(result, identity)) return;
+  checkedResult("docker", ["rm", "-f", identity], result, redact);
+}
+
+function recoveredFailure(
+  primary: string,
+  migrationStarted: boolean,
+  priorFilesRestored: boolean,
+  recoveryEnv: string,
+  cleanupWarnings: string[],
+): UpdateError {
+  const dataNote = migrationStarted
+    ? " The previous executable was restored and verified healthy, but persistent data changes made after migration began were NOT rolled back."
+    : " The previous executable and container configuration were restored and verified healthy; persistent data was not deleted or rolled back.";
+  const persistenceNote = priorFilesRestored
+    ? " Deploy state was not advanced."
+    : ` Prior deploy.env/deploy-state restoration FAILED, so their on-disk contents may be inconsistent. ` +
+      `The exact prior runtime credentials remain protected at ${recoveryEnv} (mode 0600). Repair deploy.env and deploy-state.json from backup or the running container before retrying; do not delete that recovery file until repair is complete.`;
+  return new UpdateError(
+    `Update failed: ${primary}.${dataNote}${persistenceNote}` +
+      (cleanupWarnings.length > 0 ? ` ${cleanupWarnings.join(" ")}` : ""),
+  );
+}
+
+function recoveryFailure(
+  primary: string,
+  recovery: string,
+  previous: PreservedConfig,
+  envFile: string,
+  migrationStarted: boolean,
+  oldRemoved: boolean,
+  priorFilesRestored: boolean,
+  ownedContainerId?: string | undefined,
+): UpdateError {
+  const create = buildCreateArgs({
+    host: previous.host,
+    dataVolume: previous.dataVolume,
+    dashboardPort: previous.dashboardPort,
+    dataDir: previous.dataDir,
+    runAsUser: previous.runAsUser,
+    restartPolicy: previous.restartPolicy,
+    imageRef: previous.immutableImageId,
+    envFile,
+  });
+  const manualCidFile = `${envFile}.manual-recovery.cid`;
+  create.splice(1, 0, "--cidfile", manualCidFile);
+  const commands = oldRemoved
+    ? ownedContainerId
+      ? [
+          `docker rm -f ${ownedContainerId}`,
+          `docker ${create.map(shellWord).join(" ")}`,
+          `docker start "$(cat ${shellWord(manualCidFile)})"`,
+          `docker inspect --format '{{.State.Health.Status}}' "$(cat ${shellWord(manualCidFile)})"`,
+        ]
+      : [
+          `docker container inspect --format '{{.Id}} {{.Image}} {{.State.Status}}' ${CONTAINER_NAME}`,
+          `Do not remove, recreate, or start ${CONTAINER_NAME} by name until you have verified its immutable ID and ownership.`,
+        ]
+    : [
+        `docker container inspect ${previous.immutableContainerId}`,
+        `docker start ${previous.immutableContainerId}`,
+        `docker inspect --format '{{.State.Health.Status}}' ${previous.immutableContainerId}`,
+      ];
+  return new UpdateError(
+    `Update failed: ${primary}. Recovery also failed: ${recovery}. ` +
+      (migrationStarted
+        ? "Persistent data changes made after migration began were NOT rolled back. "
+        : "Persistent data, secrets, and deploy state were left in place. ") +
+      (priorFilesRestored
+        ? ""
+        : `Prior deploy.env/deploy-state restoration also FAILED; their contents may be inconsistent. Keep ${envFile} (mode 0600) and repair both files from backup or inspected runtime configuration. `) +
+      `Protected prior runtime credentials remain at ${envFile} (mode 0600); keep that file until recovery is complete. ` +
+      `The server was NOT rolled back. Recover the previous ${oldRemoved ? "image" : "container"} manually:\n${commands.join("\n")}`,
+  );
+}
+
+function renderSuccess(prepared: PreparedTarget, freshToken: string | null): string {
+  const identity =
+    prepared.imageSource === "registry"
+      ? `published ${prepared.ref} (${prepared.imageDigest!.slice(-12)})`
+      : `source ${prepared.ref}`;
   const lines = [
-    `Updated The Librarian server to ${ref} — the container is healthy.`,
-    "The data volume was preserved; pending data-dir migrations were applied.",
+    `Updated The Librarian server to ${identity} — the container is healthy.`,
+    "The existing storage, ports, credentials, and restart policy were preserved; pending data-dir migrations were applied.",
   ];
   if (freshToken) {
     lines.push(
       "",
-      "NOTE: the previous container's agent token could not be read back, so a " +
-        "FRESH agent token was minted. Existing clients must update their token:",
+      "NOTE: no previous agent token was recoverable, so a fresh token was minted. Existing clients must update their token:",
       `  Agent token: ${freshToken}`,
-      "Paste it into `librarian install` / `librarian config --token <token>` on your clients.",
     );
   }
   return lines.join("\n");
+}
+
+async function checked(
+  cmd: string,
+  args: string[],
+  redact: Redactor = redactSecrets,
+): Promise<void> {
+  checkedResult(cmd, args, await run(cmd, args), redact);
+}
+
+function checkedResult(
+  cmd: string,
+  args: string[],
+  result: RunResult,
+  redact: Redactor = redactSecrets,
+): void {
+  if (result.code === 0) return;
+  throw new UpdateError(
+    `\`${cmd} ${args[0]}\` failed (exit ${result.code ?? "signal"})` +
+      detailSuffix(result, redact) +
+      " Resolve the error, then re-run `librarian server update`.",
+  );
+}
+
+function detailSuffix(result: RunResult, redact: Redactor = redactSecrets): string {
+  const detail = redact(result.stderr.trim() || result.stdout.trim());
+  return detail ? `: ${detail}` : ".";
+}
+
+function errorDetail(error: unknown, redact: Redactor = redactSecrets): string {
+  return redact(error instanceof Error ? error.message : String(error));
+}
+
+/** Git can echo credential-bearing remotes in stderr; never surface a remote URL. */
+function redactGitDiagnostics(text: string): string {
+  return redactSecrets(text)
+    .replace(/\b(?:https?|ssh|git):\/\/[^\s'"`]+/giu, "[redacted-remote]")
+    .replace(/\b[^\s/@:]+@[^\s/:]+:[^\s'"`]+/gu, "[redacted-remote]");
+}
+
+function envMap(value: unknown): Map<string, string> {
+  const result = new Map<string, string>();
+  if (!Array.isArray(value)) return result;
+  for (const entry of value) {
+    if (typeof entry !== "string") continue;
+    const equals = entry.indexOf("=");
+    if (equals > 0) result.set(entry.slice(0, equals), entry.slice(equals + 1));
+  }
+  return result;
+}
+
+/** A protected env-file that reproduces the previous container's auth exactly. */
+function writePriorRecoveryEnv(file: string, previousEnv: Map<string, string>): void {
+  const names = [
+    "LIBRARIAN_AGENT_TOKEN",
+    "LIBRARIAN_SECRET_KEY",
+    "LIBRARIAN_BOOTSTRAP_CLAIM_SECRET",
+    "LIBRARIAN_ALLOW_NO_AUTH",
+  ];
+  const lines: string[] = [];
+  for (const name of names) {
+    if (!previousEnv.has(name)) continue;
+    const value = previousEnv.get(name)!;
+    if (/[\r\n]/.test(value)) {
+      throw new UpdateError(`Refusing to stage prior ${name} because it contains a newline.`);
+    }
+    lines.push(`${name}=${value}`);
+  }
+  fs.writeFileSync(file, lines.length > 0 ? `${lines.join("\n")}\n` : "", {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  fs.chmodSync(file, 0o600);
+}
+
+/** Shape-redact first, then scrub the exact runtime credentials we already know. */
+function valueAwareRedactor(values: Array<string | undefined>): Redactor {
+  const secrets = [...new Set(values.filter((value): value is string => Boolean(value)))].sort(
+    (left, right) => right.length - left.length,
+  );
+  return (text): string => {
+    let redacted = redactSecrets(text);
+    for (const secret of secrets) redacted = redacted.split(secret).join("[redacted]");
+    return redacted;
+  };
+}
+
+/** Remove a protected update-only credential file, or return a truthful warning. */
+function cleanupSecretArtifact(file: string): string | null {
+  try {
+    updateSecretArtifactRemover(file);
+    return null;
+  } catch {
+    return (
+      `WARNING: protected credential residue remains at ${file} (mode 0600). ` +
+      `Remove it manually with \`rm -- ${shellWord(file)}\` after recovery is complete.`
+    );
+  }
+}
+
+function objectRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function verifiedNotFound(result: RunResult, identity: string): boolean {
+  const escaped = identity.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`no such (?:object|container):?\\s*${escaped}(?:\\s|$)`, "i").test(
+    `${result.stdout}\n${result.stderr}`,
+  );
+}
+
+function sameRepository(left: string, right: string): boolean {
+  const normalize = (value: string): string => {
+    const trimmed = value.trim();
+    try {
+      const parsed = new URL(trimmed);
+      const repositoryPath = parsed.pathname.replace(/\/$/, "").replace(/\.git$/, "");
+      return `${parsed.hostname}${repositoryPath}`.toLowerCase();
+    } catch {
+      const scp = trimmed.match(/^(?:[^@/]+@)?([^:/]+):(.+)$/u);
+      if (scp) {
+        return `${scp[1]}/${scp[2]}`
+          .replace(/\/$/, "")
+          .replace(/\.git$/, "")
+          .toLowerCase();
+      }
+      return trimmed
+        .replace(/\/$/, "")
+        .replace(/\.git$/, "")
+        .toLowerCase();
+    }
+  };
+  return normalize(left) === normalize(right);
+}
+
+function shellWord(value: string): string {
+  return /^[a-zA-Z0-9_./:@=-]+$/.test(value) ? value : `'${value.replaceAll("'", `'\\''`)}'`;
 }

--- a/packages/installer-cli/src/server/update.ts
+++ b/packages/installer-cli/src/server/update.ts
@@ -64,7 +64,7 @@ import { librarianDir } from "../paths.js";
 import { fetchLatestVersion } from "../status.js";
 import { type DeployState, readDeployState, writeDeployState } from "./deploy-state.js";
 import { run, type RunResult } from "./docker.js";
-import { preflight } from "./preflight.js";
+import { sourcePreflight } from "./preflight.js";
 import { redactSecrets } from "./redact.js";
 import {
   buildRunArgs,
@@ -119,7 +119,7 @@ export interface UpdateResult {
  */
 export async function runUpdate(options: UpdateOptions = {}): Promise<UpdateResult> {
   // 1) Preflight: docker (daemon reachable) + git, or a teaching error.
-  await preflight(options.platform ? { platform: options.platform } : {});
+  await sourcePreflight(options.platform ? { platform: options.platform } : {});
 
   const deployDir = options.dir ?? path.join(librarianDir(options.home), "server");
 
@@ -227,7 +227,7 @@ async function performUpdate(
       // the deploy chose one, else the named volume. The data is sacred either way.
       dataDir: state.dataDir,
       runAsUser: state.dataDir ? dirOwner(state.dataDir) : undefined,
-      tag: targetRef,
+      imageRef: `${CONTAINER_NAME}:${targetRef}`,
       envFile,
     }),
     deployDir,
@@ -252,6 +252,8 @@ async function performUpdate(
     dashboardPort,
     ref: targetRef,
     imageTag: `${CONTAINER_NAME}:${targetRef}`,
+    imageSource: "source",
+    imageRef: `${CONTAINER_NAME}:${targetRef}`,
   });
 
   return { output: renderSuccess(targetRef, tokenIsFresh ? agentToken : null) };

--- a/packages/installer-cli/tests/server-admin.test.ts
+++ b/packages/installer-cli/tests/server-admin.test.ts
@@ -31,7 +31,6 @@ afterEach(() => {
 function adminReady(): FakeRunner {
   return new FakeRunner()
     .withWhich("docker")
-    .withWhich("git")
     .onRun("docker", ["info"], { code: 0 })
     .onRun("docker", ["inspect", "--format", "{{.State.Status}}", "the-librarian"], {
       stdout: "running\n",

--- a/packages/installer-cli/tests/server-autoupdate.test.ts
+++ b/packages/installer-cli/tests/server-autoupdate.test.ts
@@ -595,7 +595,6 @@ describe("autoupdate uninstall — removes the timer/cron entirely", () => {
 describe("autoupdate status — timer-installed + server enabled/cadence/last-run + up-to-date", () => {
   it("reports timer installed + the server's config + reuses `server status`", async () => {
     const runner = systemdReady()
-      .withWhich("git") // `server status`' preflight needs git on PATH
       // The timer-installed probe: list-unit-files lists it.
       .onRun("systemctl", ["list-unit-files", AUTOUPDATE_TIMER_NAME], {
         code: 0,

--- a/packages/installer-cli/tests/server-autoupdate.test.ts
+++ b/packages/installer-cli/tests/server-autoupdate.test.ts
@@ -31,7 +31,7 @@ import {
   runAutoUpdate,
   UNIT_DESCRIPTION_MARKER,
 } from "../src/server/autoupdate.js";
-import { writeDeployState } from "../src/server/deploy-state.js";
+import { readDeployState, writeDeployState } from "../src/server/deploy-state.js";
 import {
   CANONICAL_IMAGE_NAME,
   resetReleaseProvenanceResolver,
@@ -45,14 +45,19 @@ import {
 } from "../src/server/docker.js";
 import {
   buildCreateArgs,
+  resetFinalizationRenamer,
+  resetFinalizationRestorer,
   resetSecretKeyMinter,
   resetSleep,
   resetStagedEnvIdMinter,
   resetTokenMinter,
   setSecretKeyMinter,
+  setFinalizationRenamer,
+  setFinalizationRestorer,
   setSleep,
   setStagedEnvIdMinter,
   setTokenMinter,
+  writeDeployEnvFile,
 } from "../src/server/up.js";
 import { updateLockPath } from "../src/server/update-lock.js";
 import { resetLatestFetcher, setLatestFetcher } from "../src/status.js";
@@ -71,6 +76,8 @@ afterEach(() => {
   resetStreamer();
   resetStagedEnvIdMinter();
   resetReleaseProvenanceResolver();
+  resetFinalizationRenamer();
+  resetFinalizationRestorer();
 });
 
 /** The config JSON a `get` bridge call returns, shaped like autoupdate.get's data. */
@@ -135,9 +142,9 @@ describe("autoupdate unit/cron generators — NO secret, the right schedule", ()
     });
     expect(unit).toContain("Type=oneshot");
     // Spec 074: the unit must NOT run as root — root's home has no deploy-state,
-    // root git fails the dubious-ownership check in a user-owned clone. The
-    // enabling user (who ran `server up`) is the one context where home, git
-    // ownership, and docker-group access all resolve.
+    // The enabling user (who ran `server up`) is the one context where deploy
+    // state and docker-group access resolve. Source refs additionally need that
+    // user's managed checkout; stable published updates do not need Git.
     expect(unit).toContain("User=deploy-owner");
     expect(unit).toContain(
       "ExecStart=/usr/local/bin/librarian server autoupdate --run --dir /home/deploy-owner/.librarian/server",
@@ -648,8 +655,8 @@ describe("autoupdate status — timer-installed + server enabled/cadence/last-ru
       expect(r.stdout).toMatch(/Cadence:\s+weekly/i);
       expect(r.stdout).toMatch(/2026-06-15/);
       // The reused `server status` block (deployed vs latest).
-      expect(r.stdout).toMatch(/Deployed:\s+v1\.4\.0/);
-      expect(r.stdout).toMatch(/update-available/);
+      expect(r.stdout).toMatch(/Deployed:\s+legacy v1\.4\.0/);
+      expect(r.stdout).toMatch(/Update:\s+\?/);
     });
   });
 
@@ -691,6 +698,56 @@ const AUTOUPDATE_IMAGE_ID = `sha256:${"92".repeat(32)}`;
 const AUTOUPDATE_DIGEST = `${CANONICAL_IMAGE_NAME}@sha256:${"93".repeat(32)}`;
 const AUTOUPDATE_REVISION = "94".repeat(20);
 const AUTOUPDATE_STAGED_ID = "autoupdate-test";
+
+function seedExactRegistryDeployment(home: string, ref = "v1.4.2"): string {
+  const dir = path.join(home, ".librarian", "server");
+  writeDeployState(dir, {
+    containerName: "the-librarian",
+    host: "127.0.0.1",
+    dataVolume: "librarian_data",
+    dashboardPort: 3000,
+    ref,
+    imageTag: `${CANONICAL_IMAGE_NAME}:${ref}`,
+    imageSource: "registry",
+    imageRef: `${CANONICAL_IMAGE_NAME}:${ref}`,
+    imageDigest: AUTOUPDATE_DIGEST,
+  });
+  writeDeployEnvFile(dir, {
+    agentToken: "tok",
+    secretKey: "key",
+    host: "127.0.0.1",
+  });
+  return dir;
+}
+
+function exactRegistryLive(): string {
+  return JSON.stringify({
+    Id: "95".repeat(32),
+    Image: AUTOUPDATE_IMAGE_ID,
+    State: { Status: "running", Health: { Status: "healthy" } },
+    Config: {
+      Image: AUTOUPDATE_DIGEST,
+      User: "node",
+      Env: [
+        "LIBRARIAN_AGENT_TOKEN=tok",
+        "LIBRARIAN_SECRET_KEY=key",
+        "LIBRARIAN_ALLOW_NO_AUTH=true",
+        "LIBRARIAN_DATA_DIR=/data",
+        "LIBRARIAN_HOST=0.0.0.0",
+        "LIBRARIAN_PORT=3838",
+        "PORT=3000",
+      ],
+    },
+    HostConfig: {
+      RestartPolicy: { Name: "unless-stopped" },
+      PortBindings: {
+        "3000/tcp": [{ HostIp: "127.0.0.1", HostPort: "3000" }],
+        "3838/tcp": [{ HostIp: "127.0.0.1", HostPort: "3838" }],
+      },
+    },
+    Mounts: [{ Type: "volume", Name: "librarian_data", Destination: "/data" }],
+  });
+}
 
 /** Script the real stable update path while keeping these wrapper tests offline. */
 function configureSuccessfulStableUpdate(home: string, runner: FakeRunner): string[][] {
@@ -859,9 +916,59 @@ describe("autoupdate --run — the gated, fail-soft wrapper the timer fires", ()
       // The stable update pulled the exact published tag; it did not need Git/build.
       expect(streams).toContainEqual(["pull", `${CANONICAL_IMAGE_NAME}:v1.5.0`]);
       expect(runner.calls.some((call) => call.cmd === "git")).toBe(false);
+      expect(runner.calls.some((call) => call.args[0] === "build")).toBe(false);
+      expect(runner.calls).toContainEqual(
+        expect.objectContaining({
+          cmd: "docker",
+          args: ["image", "inspect", "--format", "{{json .}}", `${CANONICAL_IMAGE_NAME}:v1.5.0`],
+        }),
+      );
+      expect(readDeployState(path.join(home, ".librarian", "server"))).toMatchObject({
+        imageSource: "registry",
+        ref: "v1.5.0",
+        imageRef: `${CANONICAL_IMAGE_NAME}:v1.5.0`,
+        imageDigest: AUTOUPDATE_DIGEST,
+      });
       // And the stamp bridge fired AFTER the update succeeded.
       expect(bridgeOps).toContain("stampRun");
       expect(result.output).toMatch(/updated successfully/i);
+    });
+  });
+
+  it("a due exact healthy target is checked and stamped without claiming an update", async () => {
+    await withTempHome(async (home) => {
+      seedExactRegistryDeployment(home);
+      const runner = new FakeRunner()
+        .withWhich("docker")
+        .onRun("docker", ["info"], { code: 0 })
+        .onRun("docker", ["container", "inspect", "--format", "{{json .}}", "the-librarian"], {
+          stdout: exactRegistryLive(),
+        })
+        .withFallback({ code: 0 });
+      const bridgeOps: string[] = [];
+      withBridge(runner, {
+        getConfig: { enabled: true, cadence: "daily", lastRunAt: null },
+        bridgeOps,
+      });
+      const streams: string[][] = [];
+      setStreamer({
+        stream: async (_cmd, args) => {
+          streams.push([...args]);
+          return 0;
+        },
+      });
+      setDockerRunner(runner);
+      setLatestFetcher(async () => "1.4.2");
+
+      const result = await runAutoUpdate({ home, log: () => {}, healthIntervalMs: 0 });
+
+      expect(result.output).toMatch(/checked; already up to date/i);
+      expect(result.output).not.toMatch(/updated successfully/i);
+      expect(bridgeOps).toContain("stampRun");
+      expect(streams).toEqual([]);
+      expect(runner.calls.some((call) => call.cmd === "git" || call.args[0] === "build")).toBe(
+        false,
+      );
     });
   });
 
@@ -890,13 +997,48 @@ describe("autoupdate --run — the gated, fail-soft wrapper the timer fires", ()
       const logs: string[] = [];
 
       const result = await runAutoUpdate({ home, log: (l) => logs.push(l), healthIntervalMs: 0 });
-      expect(result.output).toMatch(/update failed/i);
+      expect(result.output).toMatch(/update did not complete/i);
       expect(result.output).not.toMatch(/previous server running|left the previous/i);
       expect(result.output).toMatch(/inspect.*server status/i);
       // CRUCIAL: a failed update must NOT stamp last_run_at (so it retries).
       expect(bridgeOps).not.toContain("stampRun");
       // It never threw — the wrapper resolved (the timer would exit 0).
-      expect(logs.some((l) => /update failed/i.test(l))).toBe(true);
+      expect(logs.some((l) => /update did not complete/i.test(l))).toBe(true);
+    });
+  });
+
+  it("a finalization/recovery failure never claims deploy-state integrity", async () => {
+    await withTempHome(async (home) => {
+      seedDeployState(home);
+      const runner = new FakeRunner()
+        .withWhich("docker")
+        .onRun("docker", ["info"], { code: 0 })
+        .withFallback({ code: 0 });
+      const bridgeOps: string[] = [];
+      withBridge(runner, {
+        getConfig: { enabled: true, cadence: "daily", lastRunAt: null },
+        bridgeOps,
+      });
+      configureSuccessfulStableUpdate(home, runner);
+      let promotions = 0;
+      setFinalizationRenamer((source, destination) => {
+        promotions += 1;
+        if (promotions === 2) throw new Error("state promotion failed");
+        fs.renameSync(source, destination);
+      });
+      setFinalizationRestorer(() => {
+        throw new Error("prior bytes could not be restored");
+      });
+      setDockerRunner(runner);
+      setLatestFetcher(async () => "1.5.0");
+      setSleep(async () => undefined);
+
+      const result = await runAutoUpdate({ home, log: () => {}, healthIntervalMs: 0 });
+
+      expect(result.output).toMatch(/update (?:failed|did not complete)/i);
+      expect(result.output).toMatch(/restoration.*failed|inconsistent/i);
+      expect(result.output).not.toMatch(/deployment state was not advanced/i);
+      expect(bridgeOps).not.toContain("stampRun");
     });
   });
 
@@ -1002,7 +1144,7 @@ describe("autoupdate --run — the gated, fail-soft wrapper the timer fires", ()
       const logs: string[] = [];
 
       const result = await runAutoUpdate({ home, log: (l) => logs.push(l) });
-      expect(result.output).toMatch(/update failed/i);
+      expect(result.output).toMatch(/update did not complete/i);
       expect(result.output).toMatch(/re-run `librarian server autoupdate enable`/);
       expect(bridgeOps).not.toContain("stampRun");
       expect(logs).toHaveLength(1);

--- a/packages/installer-cli/tests/server-autoupdate.test.ts
+++ b/packages/installer-cli/tests/server-autoupdate.test.ts
@@ -33,15 +33,25 @@ import {
 } from "../src/server/autoupdate.js";
 import { writeDeployState } from "../src/server/deploy-state.js";
 import {
+  CANONICAL_IMAGE_NAME,
+  resetReleaseProvenanceResolver,
+  setReleaseProvenanceResolver,
+} from "../src/server/deployment-image.js";
+import {
   resetRunner as resetDockerRunner,
+  resetStreamer,
   setRunner as setDockerRunner,
+  setStreamer,
 } from "../src/server/docker.js";
 import {
+  buildCreateArgs,
   resetSecretKeyMinter,
   resetSleep,
+  resetStagedEnvIdMinter,
   resetTokenMinter,
   setSecretKeyMinter,
   setSleep,
+  setStagedEnvIdMinter,
   setTokenMinter,
 } from "../src/server/up.js";
 import { updateLockPath } from "../src/server/update-lock.js";
@@ -58,6 +68,9 @@ afterEach(() => {
   resetSleep();
   resetTokenMinter();
   resetSecretKeyMinter();
+  resetStreamer();
+  resetStagedEnvIdMinter();
+  resetReleaseProvenanceResolver();
 });
 
 /** The config JSON a `get` bridge call returns, shaped like autoupdate.get's data. */
@@ -673,6 +686,106 @@ function seedDeployState(home: string, ref = "v1.4.2"): string {
   return dir;
 }
 
+const AUTOUPDATE_CANDIDATE_ID = "91".repeat(32);
+const AUTOUPDATE_IMAGE_ID = `sha256:${"92".repeat(32)}`;
+const AUTOUPDATE_DIGEST = `${CANONICAL_IMAGE_NAME}@sha256:${"93".repeat(32)}`;
+const AUTOUPDATE_REVISION = "94".repeat(20);
+const AUTOUPDATE_STAGED_ID = "autoupdate-test";
+
+/** Script the real stable update path while keeping these wrapper tests offline. */
+function configureSuccessfulStableUpdate(home: string, runner: FakeRunner): string[][] {
+  const streams: string[][] = [];
+  setStreamer({
+    stream: async (_cmd, args) => {
+      streams.push([...args]);
+      return 0;
+    },
+  });
+  setStagedEnvIdMinter(() => AUTOUPDATE_STAGED_ID);
+  setReleaseProvenanceResolver(async () => ({
+    revision: AUTOUPDATE_REVISION,
+    imageDigest: AUTOUPDATE_DIGEST,
+  }));
+  const dir = path.join(home, ".librarian", "server");
+  const stagedEnv = path.join(dir, `deploy.env.next-${AUTOUPDATE_STAGED_ID}`);
+  const createArgs = buildCreateArgs({
+    host: "127.0.0.1",
+    dataVolume: "librarian_data",
+    dashboardPort: 3000,
+    runAsUser: "node",
+    restartPolicy: "unless-stopped",
+    imageRef: AUTOUPDATE_DIGEST,
+    envFile: stagedEnv,
+  });
+  createArgs.splice(1, 0, "--cidfile", `${stagedEnv}.cid`);
+  const live = JSON.stringify({
+    Id: "95".repeat(32),
+    Image: AUTOUPDATE_IMAGE_ID,
+    State: { Status: "running", Health: { Status: "healthy" } },
+    Config: {
+      Image: "the-librarian:v1.4.2",
+      User: "node",
+      Env: [
+        "LIBRARIAN_AGENT_TOKEN=tok",
+        "LIBRARIAN_SECRET_KEY=key",
+        "LIBRARIAN_DATA_DIR=/data",
+        "LIBRARIAN_HOST=0.0.0.0",
+        "LIBRARIAN_PORT=3838",
+        "PORT=3000",
+      ],
+    },
+    HostConfig: {
+      RestartPolicy: { Name: "unless-stopped" },
+      PortBindings: {
+        "3000/tcp": [{ HostIp: "127.0.0.1", HostPort: "3000" }],
+        "3838/tcp": [{ HostIp: "127.0.0.1", HostPort: "3838" }],
+      },
+    },
+    Mounts: [{ Type: "volume", Name: "librarian_data", Destination: "/data" }],
+  });
+  runner
+    .onRun("docker", ["info", "--format", "{{json .}}"], {
+      stdout: JSON.stringify({ OSType: "linux", Architecture: "amd64" }),
+    })
+    .onRun("docker", ["container", "inspect", "--format", "{{json .}}", "the-librarian"], {
+      stdout: live,
+    })
+    .onRun(
+      "docker",
+      ["image", "inspect", "--format", "{{json .}}", `${CANONICAL_IMAGE_NAME}:v1.5.0`],
+      {
+        stdout: JSON.stringify({
+          Os: "linux",
+          Architecture: "amd64",
+          Config: {
+            Labels: {
+              "org.opencontainers.image.source":
+                "https://github.com/code-ministry-ltd/the-librarian",
+              "org.opencontainers.image.version": "1.5.0",
+              "org.opencontainers.image.revision": AUTOUPDATE_REVISION,
+            },
+          },
+          RepoTags: [`${CANONICAL_IMAGE_NAME}:v1.5.0`],
+          RepoDigests: [AUTOUPDATE_DIGEST],
+        }),
+      },
+    )
+    .onRun("docker", createArgs, { stdout: `${AUTOUPDATE_CANDIDATE_ID}\n` })
+    .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", AUTOUPDATE_CANDIDATE_ID], {
+      stdout: "healthy\n",
+    });
+  const realRun = runner.run.bind(runner);
+  runner.run = async (cmd, args, opts) => {
+    const result = await realRun(cmd, args, opts);
+    if (cmd === "docker" && args[0] === "create" && result.code === 0) {
+      const cidfileIndex = args.indexOf("--cidfile");
+      if (cidfileIndex >= 0) fs.writeFileSync(args[cidfileIndex + 1]!, `${result.stdout.trim()}\n`);
+    }
+    return result;
+  };
+  return streams;
+}
+
 describe("autoupdate --run — the gated, fail-soft wrapper the timer fires", () => {
   it("server unreachable → SKIP (never update a server in an unknown state), exit 0", async () => {
     const runner = new FakeRunner().withWhich("docker").withFallback({ code: 0 });
@@ -722,25 +835,10 @@ describe("autoupdate --run — the gated, fail-soft wrapper the timer fires", ()
 
   it("enabled AND due → invokes `server update`, then stamps last_run_at on success", async () => {
     await withTempHome(async (home) => {
-      const dir = seedDeployState(home);
+      seedDeployState(home);
       const runner = new FakeRunner()
         .withWhich("docker")
-        .withWhich("git")
         .onRun("docker", ["info"], { code: 0 })
-        // The OLD container's env read-back (agent token + master key).
-        .onRun(
-          "docker",
-          ["inspect", "--format", "{{range .Config.Env}}{{println .}}{{end}}", "the-librarian"],
-          { code: 0, stdout: "LIBRARIAN_AGENT_TOKEN=tok\nLIBRARIAN_SECRET_KEY=key\n" },
-        )
-        .onRun("docker", ["inspect", "--format", "{{.State.Status}}", "the-librarian"], {
-          code: 0,
-          stdout: "running\n",
-        })
-        .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", "the-librarian"], {
-          code: 0,
-          stdout: "healthy\n",
-        })
         .withFallback({ code: 0 });
       const bridgeOps: string[] = [];
       // Enabled + never run → due. (current ref differs from latest so update runs.)
@@ -748,6 +846,7 @@ describe("autoupdate --run — the gated, fail-soft wrapper the timer fires", ()
         getConfig: { enabled: true, cadence: "daily", lastRunAt: null },
         bridgeOps,
       });
+      const streams = configureSuccessfulStableUpdate(home, runner);
       setDockerRunner(runner);
       setLatestFetcher(async () => "1.5.0"); // newer than v1.4.2 → an actual upgrade
       setTokenMinter(() => "fresh-tok");
@@ -757,18 +856,9 @@ describe("autoupdate --run — the gated, fail-soft wrapper the timer fires", ()
 
       const result = await runAutoUpdate({ home, log: (l) => logs.push(l), healthIntervalMs: 0 });
 
-      // The update flow ran (git fetch + docker build for the new tag).
-      expect(runner.ran("git", ["-C", dir, "fetch", "--tags", "origin"])).toBe(true);
-      expect(
-        runner.ran("docker", [
-          "build",
-          "-f",
-          "docker/all-in-one.Dockerfile",
-          "-t",
-          "the-librarian:v1.5.0",
-          ".",
-        ]),
-      ).toBe(true);
+      // The stable update pulled the exact published tag; it did not need Git/build.
+      expect(streams).toContainEqual(["pull", `${CANONICAL_IMAGE_NAME}:v1.5.0`]);
+      expect(runner.calls.some((call) => call.cmd === "git")).toBe(false);
       // And the stamp bridge fired AFTER the update succeeded.
       expect(bridgeOps).toContain("stampRun");
       expect(result.output).toMatch(/updated successfully/i);
@@ -801,6 +891,8 @@ describe("autoupdate --run — the gated, fail-soft wrapper the timer fires", ()
 
       const result = await runAutoUpdate({ home, log: (l) => logs.push(l), healthIntervalMs: 0 });
       expect(result.output).toMatch(/update failed/i);
+      expect(result.output).not.toMatch(/previous server running|left the previous/i);
+      expect(result.output).toMatch(/inspect.*server status/i);
       // CRUCIAL: a failed update must NOT stamp last_run_at (so it retries).
       expect(bridgeOps).not.toContain("stampRun");
       // It never threw — the wrapper resolved (the timer would exit 0).
@@ -846,7 +938,7 @@ describe("autoupdate --run — the gated, fail-soft wrapper the timer fires", ()
 
   it("a stale lock (older than the reclaim window) is reclaimed so the update proceeds (FIX C1)", async () => {
     await withTempHome(async (home) => {
-      const dir = seedDeployState(home);
+      seedDeployState(home);
       // A crashed holder left a lockfile ~2h old → stale → reclaimed, update runs.
       const lockPath = updateLockPath({ home });
       fs.mkdirSync(path.dirname(lockPath), { recursive: true });
@@ -855,27 +947,14 @@ describe("autoupdate --run — the gated, fail-soft wrapper the timer fires", ()
 
       const runner = new FakeRunner()
         .withWhich("docker")
-        .withWhich("git")
         .onRun("docker", ["info"], { code: 0 })
-        .onRun(
-          "docker",
-          ["inspect", "--format", "{{range .Config.Env}}{{println .}}{{end}}", "the-librarian"],
-          { code: 0, stdout: "LIBRARIAN_AGENT_TOKEN=tok\nLIBRARIAN_SECRET_KEY=key\n" },
-        )
-        .onRun("docker", ["inspect", "--format", "{{.State.Status}}", "the-librarian"], {
-          code: 0,
-          stdout: "running\n",
-        })
-        .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", "the-librarian"], {
-          code: 0,
-          stdout: "healthy\n",
-        })
         .withFallback({ code: 0 });
       const bridgeOps: string[] = [];
       withBridge(runner, {
         getConfig: { enabled: true, cadence: "daily", lastRunAt: null },
         bridgeOps,
       });
+      const streams = configureSuccessfulStableUpdate(home, runner);
       setDockerRunner(runner);
       setLatestFetcher(async () => "1.5.0");
       setTokenMinter(() => "fresh-tok");
@@ -885,7 +964,7 @@ describe("autoupdate --run — the gated, fail-soft wrapper the timer fires", ()
       const result = await runAutoUpdate({ home, log: () => {}, healthIntervalMs: 0 });
 
       // The stale lock did NOT block the update.
-      expect(runner.ran("git", ["-C", dir, "fetch", "--tags", "origin"])).toBe(true);
+      expect(streams).toContainEqual(["pull", `${CANONICAL_IMAGE_NAME}:v1.5.0`]);
       expect(result.output).toMatch(/updated successfully/i);
       expect(bridgeOps).toContain("stampRun");
       // The lock was released after the update (so the next fire isn't blocked).

--- a/packages/installer-cli/tests/server-boot-runtime.test.ts
+++ b/packages/installer-cli/tests/server-boot-runtime.test.ts
@@ -9,13 +9,20 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { resetRunner } from "../src/exec.js";
 import { runCli } from "../src/runtime.js";
+import { writeDeployState } from "../src/server/deploy-state.js";
 import {
   resetRunner as resetDockerRunner,
   resetStreamer,
   setRunner as setDockerRunner,
   setStreamer,
 } from "../src/server/docker.js";
-import { resetSleep, resetTokenMinter, setSleep, setTokenMinter } from "../src/server/up.js";
+import {
+  resetSleep,
+  resetTokenMinter,
+  setSleep,
+  setTokenMinter,
+  writeDeployEnvFile,
+} from "../src/server/up.js";
 import { resetLatestFetcher, setLatestFetcher } from "../src/status.js";
 import { FakeRunner, withTempHome } from "./helpers.js";
 import { FakePrompter } from "./prompter.js";
@@ -25,6 +32,10 @@ const UNIT_NAME = "the-librarian.service";
 const AGENT_TOKEN = "agent-token-deterministic-for-tests";
 const MASTER_KEY = "master-key-read-back-from-the-container-once";
 const LATEST = "1.4.2";
+const IMAGE_NAME = "ghcr.io/code-ministry-ltd/the-librarian";
+const IMAGE_REF = `${IMAGE_NAME}:v${LATEST}`;
+const IMAGE_DIGEST = `${IMAGE_NAME}@sha256:${"ab".repeat(32)}`;
+const CANDIDATE_CONTAINER_ID = "cafebabedeadbeef".repeat(4);
 
 // `up`'s image build now STREAMS (live output) via the streamer seam — stub it to
 // succeed so these boot tests never spawn a real `docker build`.
@@ -49,12 +60,16 @@ function bootReady(): FakeRunner {
     .withWhich("systemctl")
     .withWhich("sudo")
     .onRun("docker", ["info"], { code: 0 })
+    .onRun("docker", ["container", "inspect", "--format", "{{json .}}", "the-librarian"], {
+      stderr: "No such container: the-librarian",
+      code: 1,
+    })
     .withFallback({ code: 0 });
 }
 
 /** A fully-successful localhost `up` runner, plus systemctl/sudo for boot. */
 function upPlusBootReady(): FakeRunner {
-  return bootReady()
+  const runner = bootReady()
     .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", "the-librarian"], {
       stdout: "healthy\n",
       code: 0,
@@ -63,6 +78,26 @@ function upPlusBootReady(): FakeRunner {
       stdout: `${MASTER_KEY}\n`,
       code: 0,
     });
+  const realRun = runner.run.bind(runner);
+  runner.run = async (cmd, args, options) => {
+    if (cmd === "docker" && args[0] === "create") {
+      runner.calls.push({ cmd, args: [...args], opts: options });
+      return { stdout: `${CANDIDATE_CONTAINER_ID}\n`, stderr: "", code: 0 };
+    }
+    if (cmd === "docker" && args[0] === "start") {
+      runner.calls.push({ cmd, args: [...args], opts: options });
+      return { stdout: `${CANDIDATE_CONTAINER_ID}\n`, stderr: "", code: 0 };
+    }
+    if (
+      cmd === "docker" &&
+      args.join(" ") === `inspect --format {{.State.Health.Status}} ${CANDIDATE_CONTAINER_ID}`
+    ) {
+      runner.calls.push({ cmd, args: [...args], opts: options });
+      return { stdout: "healthy\n", stderr: "", code: 0 };
+    }
+    return realRun(cmd, args, options);
+  };
+  return runner;
 }
 
 function stubUpSeams(): void {
@@ -157,14 +192,14 @@ describe("server up --enable-boot (linux) — boot enable runs AFTER a healthy u
       stubUpSeams();
       const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
 
-      const r = await runCli(["server", "up", "--enable-boot"], {
+      const r = await runCli(["server", "up", "--ref", "main", "--enable-boot"], {
         home,
         prompter,
         platform: "linux",
       });
       expect(r.exitCode).toBe(0);
 
-      const idxRun = runner.calls.findIndex((c) => c.cmd === "docker" && c.args[0] === "run");
+      const idxRun = runner.calls.findIndex((c) => c.cmd === "docker" && c.args[0] === "start");
       const idxEnable = runner.calls.findIndex(
         (c) => c.cmd === "sudo" && c.args[0] === "systemctl" && c.args.includes("enable"),
       );
@@ -186,9 +221,86 @@ describe("server up --enable-boot (linux) — boot enable runs AFTER a healthy u
       stubUpSeams();
       const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
 
-      const r = await runCli(["server", "up"], { home, prompter, platform: "linux" });
+      const r = await runCli(["server", "up", "--ref", "main"], {
+        home,
+        prompter,
+        platform: "linux",
+      });
       expect(r.exitCode).toBe(0);
       expect(runner.calls.some((c) => c.cmd === "sudo")).toBe(false);
+    });
+  });
+
+  it("enables boot for an exact healthy registry no-op without pulling", async () => {
+    await withTempHome(async (home) => {
+      const deployDir = `${home}/.librarian/server`;
+      writeDeployEnvFile(deployDir, {
+        agentToken: "existing-agent-token",
+        secretKey: "existing-master-key-long-enough-for-safe-reuse",
+        host: "127.0.0.1",
+      });
+      writeDeployState(deployDir, {
+        containerName: "the-librarian",
+        host: "127.0.0.1",
+        dataVolume: "librarian_data",
+        dashboardPort: 3042,
+        ref: `v${LATEST}`,
+        imageTag: IMAGE_REF,
+        imageSource: "registry",
+        imageRef: IMAGE_REF,
+        imageDigest: IMAGE_DIGEST,
+      });
+      const live = {
+        State: { Health: { Status: "healthy" } },
+        Config: {
+          Image: IMAGE_DIGEST,
+          User: "node",
+          Env: [
+            "LIBRARIAN_AGENT_TOKEN=existing-agent-token",
+            "LIBRARIAN_SECRET_KEY=existing-master-key-long-enough-for-safe-reuse",
+            "LIBRARIAN_ALLOW_NO_AUTH=true",
+            "LIBRARIAN_DATA_DIR=/data",
+            "LIBRARIAN_HOST=0.0.0.0",
+            "LIBRARIAN_PORT=3838",
+            "PORT=3000",
+          ],
+        },
+        HostConfig: {
+          RestartPolicy: { Name: "unless-stopped" },
+          PortBindings: {
+            "3000/tcp": [{ HostIp: "127.0.0.1", HostPort: "3042" }],
+            "3838/tcp": [{ HostIp: "127.0.0.1", HostPort: "3838" }],
+          },
+        },
+        Mounts: [{ Destination: "/data", Type: "volume", Name: "librarian_data" }],
+      };
+      const runner = upPlusBootReady().onRun(
+        "docker",
+        ["container", "inspect", "--format", "{{json .}}", "the-librarian"],
+        { stdout: JSON.stringify(live), code: 0 },
+      );
+      setDockerRunner(runner);
+      stubUpSeams();
+      let pulls = 0;
+      setStreamer({
+        stream: async () => {
+          pulls += 1;
+          throw new Error("registry unavailable");
+        },
+      });
+
+      const result = await runCli(["server", "up", "--enable-boot"], {
+        home,
+        prompter: new FakePrompter({}),
+        platform: "linux",
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch(/already running.*healthy/i);
+      expect(pulls).toBe(0);
+      expect(runner.calls.some((call) => call.cmd === "sudo" && call.args.includes("enable"))).toBe(
+        true,
+      );
     });
   });
 });
@@ -201,7 +313,7 @@ describe("server up --enable-boot (macOS) — notice, up still succeeds", () => 
       stubUpSeams();
       const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
 
-      const r = await runCli(["server", "up", "--enable-boot"], {
+      const r = await runCli(["server", "up", "--ref", "main", "--enable-boot"], {
         home,
         prompter,
         platform: "darwin",

--- a/packages/installer-cli/tests/server-deploy-state.test.ts
+++ b/packages/installer-cli/tests/server-deploy-state.test.ts
@@ -26,6 +26,17 @@ const SAMPLE: DeployState = {
   imageTag: "the-librarian:v1.4.2",
 };
 
+const RAW_DIGEST = `sha256:${"0123456789abcdef".repeat(4)}`;
+const VERSION_IMAGE_REF = "ghcr.io/code-ministry-ltd/the-librarian:v1.4.2";
+const DIGEST_IMAGE_REF = `ghcr.io/code-ministry-ltd/the-librarian@${RAW_DIGEST}`;
+
+function expectReadAndWriteReject(dir: string, state: Record<string, unknown>): void {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(deployStatePath(dir), JSON.stringify(state), "utf8");
+  expect(readDeployState(dir)).toBeNull();
+  expect(() => writeDeployState(dir, state as unknown as DeployState)).toThrow(/invalid deploy/i);
+}
+
 describe("deploy-state — round-trip under a fake home", () => {
   it("writeDeployState then readDeployState returns the same state", async () => {
     await withTempHome(async (home) => {
@@ -74,6 +85,159 @@ describe("deploy-state — round-trip under a fake home", () => {
         unknown
       >;
       expect(parsed.dashboardPort).toBe(3500);
+    });
+  });
+
+  it("round-trips a digest-pinned registry deployment", async () => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".librarian", "server");
+      const registryState: DeployState = {
+        ...SAMPLE,
+        imageTag: VERSION_IMAGE_REF,
+        imageSource: "registry",
+        imageRef: VERSION_IMAGE_REF,
+        imageDigest: DIGEST_IMAGE_REF,
+      };
+      writeDeployState(dir, registryState);
+      expect(readDeployState(dir)).toEqual(registryState);
+    });
+  });
+
+  it("round-trips an explicitly recorded source deployment", async () => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".librarian", "server");
+      const sourceState: DeployState = {
+        ...SAMPLE,
+        imageSource: "source",
+        imageRef: "the-librarian:v1.4.2",
+      };
+      writeDeployState(dir, sourceState);
+      expect(readDeployState(dir)).toEqual(sourceState);
+    });
+  });
+
+  it("an old state with no image provenance still parses as a legacy source deployment", async () => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".librarian", "server");
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(deployStatePath(dir), JSON.stringify(SAMPLE), "utf8");
+      const state = readDeployState(dir);
+      expect(state).toEqual(SAMPLE);
+      expect(state?.imageSource ?? "source").toBe("source");
+    });
+  });
+
+  it.each([
+    DIGEST_IMAGE_REF,
+    "docker.io/code-ministry-ltd/the-librarian:v1.4.2",
+    "ghcr.io/code-ministry-ltd/the-librarian:1.4.2",
+    "ghcr.io/code-ministry-ltd/the-librarian:v01.4.2",
+    "ghcr.io/code-ministry-ltd/the-librarian:v1.4.2-beta.1",
+  ])("rejects a registry state with non-canonical version imageRef %j", async (imageRef) => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".librarian", "server");
+      expectReadAndWriteReject(dir, {
+        ...SAMPLE,
+        imageTag: VERSION_IMAGE_REF,
+        imageSource: "registry",
+        imageRef,
+        imageDigest: DIGEST_IMAGE_REF,
+      });
+    });
+  });
+
+  it.each([
+    RAW_DIGEST,
+    `docker.io/code-ministry-ltd/the-librarian@${RAW_DIGEST}`,
+    `ghcr.io/code-ministry-ltd/the-librarian@SHA256:${"0123456789abcdef".repeat(4)}`,
+    `ghcr.io/code-ministry-ltd/the-librarian@sha256:${"ABCDEF0123456789".repeat(4)}`,
+    "ghcr.io/code-ministry-ltd/the-librarian@sha256:abcd",
+  ])("rejects a registry state with non-canonical imageDigest %j", async (imageDigest) => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".librarian", "server");
+      expectReadAndWriteReject(dir, {
+        ...SAMPLE,
+        imageTag: VERSION_IMAGE_REF,
+        imageSource: "registry",
+        imageRef: VERSION_IMAGE_REF,
+        imageDigest,
+      });
+    });
+  });
+
+  it.each([{ imageRef: VERSION_IMAGE_REF }, { imageDigest: DIGEST_IMAGE_REF }])(
+    "rejects a registry state missing one required image identity field",
+    async (identity) => {
+      await withTempHome(async (home) => {
+        const dir = path.join(home, ".librarian", "server");
+        expectReadAndWriteReject(dir, {
+          ...SAMPLE,
+          imageTag: VERSION_IMAGE_REF,
+          imageSource: "registry",
+          ...identity,
+        });
+      });
+    },
+  );
+
+  it.each([
+    {
+      label: "source discriminator without imageRef",
+      state: { ...SAMPLE, imageSource: "source" },
+    },
+    {
+      label: "imageRef without a discriminator",
+      state: { ...SAMPLE, imageRef: SAMPLE.imageTag },
+    },
+    {
+      label: "imageDigest without a discriminator",
+      state: { ...SAMPLE, imageDigest: DIGEST_IMAGE_REF },
+    },
+    {
+      label: "source deployment carrying a registry digest",
+      state: {
+        ...SAMPLE,
+        imageSource: "source",
+        imageRef: SAMPLE.imageTag,
+        imageDigest: DIGEST_IMAGE_REF,
+      },
+    },
+    {
+      label: "source imageRef differing from the local imageTag",
+      state: { ...SAMPLE, imageSource: "source", imageRef: "the-librarian:main" },
+    },
+    {
+      label: "registry imageTag differing from its configured imageRef",
+      state: {
+        ...SAMPLE,
+        imageSource: "registry",
+        imageRef: VERSION_IMAGE_REF,
+        imageDigest: DIGEST_IMAGE_REF,
+      },
+    },
+    {
+      label: "registry imageRef version differing from ref",
+      state: {
+        ...SAMPLE,
+        imageTag: "ghcr.io/code-ministry-ltd/the-librarian:v1.5.0",
+        imageSource: "registry",
+        imageRef: "ghcr.io/code-ministry-ltd/the-librarian:v1.5.0",
+        imageDigest: DIGEST_IMAGE_REF,
+      },
+    },
+    {
+      label: "unsupported imageSource discriminator",
+      state: {
+        ...SAMPLE,
+        imageTag: VERSION_IMAGE_REF,
+        imageSource: "cache",
+        imageRef: VERSION_IMAGE_REF,
+        imageDigest: DIGEST_IMAGE_REF,
+      },
+    },
+  ])("rejects incoherent provenance: $label", async ({ state }) => {
+    await withTempHome(async (home) => {
+      expectReadAndWriteReject(path.join(home, ".librarian", "server"), state);
     });
   });
 
@@ -143,7 +307,7 @@ describe("deploy-state — round-trip under a fake home", () => {
 });
 
 describe("deploy-state — carries NO secret (the file is non-secret)", () => {
-  it("the serialized state contains exactly the five non-secret fields", async () => {
+  it("the serialized legacy state contains exactly the five non-secret fields", async () => {
     await withTempHome(async (home) => {
       const dir = path.join(home, ".librarian", "server");
       writeDeployState(dir, SAMPLE);
@@ -157,23 +321,65 @@ describe("deploy-state — carries NO secret (the file is non-secret)", () => {
     });
   });
 
-  it("a secret-shaped value smuggled onto the input is NOT persisted", async () => {
+  it("persists only the eight whitelisted non-secret fields for registry state", async () => {
     await withTempHome(async (home) => {
       const dir = path.join(home, ".librarian", "server");
-      // Assemble a secret-shaped literal at runtime (GitGuardian scans commits).
-      const fakeToken = "tok_" + "0123456789abcdef".repeat(4);
-      // Even if a caller passes extra keys, writeDeployState only ever persists
-      // the five declared non-secret fields.
       writeDeployState(dir, {
         ...SAMPLE,
-        // @ts-expect-error — extra keys are not part of DeployState and must be dropped.
-        token: fakeToken,
-        // @ts-expect-error — same for an admin token / master key.
-        adminToken: fakeToken,
+        imageTag: VERSION_IMAGE_REF,
+        imageSource: "registry",
+        imageRef: VERSION_IMAGE_REF,
+        imageDigest: DIGEST_IMAGE_REF,
       });
-      const raw = fs.readFileSync(deployStatePath(dir), "utf8");
-      expect(raw).not.toContain(fakeToken);
-      expect(raw).not.toContain("token");
+      const parsed = JSON.parse(fs.readFileSync(deployStatePath(dir), "utf8")) as Record<
+        string,
+        unknown
+      >;
+      expect(Object.keys(parsed).sort()).toEqual(
+        [
+          "containerName",
+          "dataVolume",
+          "host",
+          "imageDigest",
+          "imageRef",
+          "imageSource",
+          "imageTag",
+          "ref",
+        ].sort(),
+      );
+    });
+  });
+
+  it.each([
+    {
+      variant: "legacy",
+      extraKey: "token",
+      state: SAMPLE,
+    },
+    {
+      variant: "source",
+      extraKey: "secretKey",
+      state: { ...SAMPLE, imageSource: "source", imageRef: SAMPLE.imageTag },
+    },
+    {
+      variant: "registry",
+      extraKey: "futureField",
+      state: {
+        ...SAMPLE,
+        imageTag: VERSION_IMAGE_REF,
+        imageSource: "registry",
+        imageRef: VERSION_IMAGE_REF,
+        imageDigest: DIGEST_IMAGE_REF,
+      },
+    },
+  ])("rejects an unexpected own key on $variant state during read and write", async (input) => {
+    await withTempHome(async (home) => {
+      // Assemble a secret-shaped value at runtime (GitGuardian scans commits).
+      const extraValue = "tok_" + "0123456789abcdef".repeat(4);
+      expectReadAndWriteReject(path.join(home, ".librarian", "server"), {
+        ...input.state,
+        [input.extraKey]: extraValue,
+      });
     });
   });
 });

--- a/packages/installer-cli/tests/server-deployment-image.test.ts
+++ b/packages/installer-cli/tests/server-deployment-image.test.ts
@@ -1,9 +1,79 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   CANONICAL_IMAGE_NAME,
   isReleasedVersionRef,
+  prepareRegistryImage,
+  resetPublicGithubFetch,
+  resetReleaseProvenanceResolver,
   selectDeploymentTarget,
+  setPublicGithubFetch,
+  setReleaseProvenanceResolver,
 } from "../src/server/deployment-image.js";
+import { resetRunner, resetStreamer, setRunner, setStreamer } from "../src/server/docker.js";
+import { FakeRunner } from "./helpers.js";
+
+const VERSION = "v1.20.1";
+const IMAGE_REF = `${CANONICAL_IMAGE_NAME}:${VERSION}`;
+const HASH = "ab".repeat(32);
+const IMAGE_DIGEST = `${CANONICAL_IMAGE_NAME}@sha256:${HASH}`;
+const REVISION = "12".repeat(20);
+
+function inspectRecord(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    Os: "linux",
+    Architecture: "amd64",
+    Config: {
+      Labels: {
+        "org.opencontainers.image.source": "https://github.com/code-ministry-ltd/the-librarian",
+        "org.opencontainers.image.version": "1.20.1",
+        "org.opencontainers.image.revision": REVISION,
+      },
+    },
+    RepoTags: [IMAGE_REF],
+    RepoDigests: [IMAGE_DIGEST],
+    ...overrides,
+  });
+}
+
+let streamed: { cmd: string; args: string[]; output: string[] }[];
+
+beforeEach(() => {
+  streamed = [];
+  setReleaseProvenanceResolver(async () => ({
+    revision: REVISION,
+    imageDigest: IMAGE_DIGEST,
+  }));
+  setStreamer({
+    stream: async (cmd, args, handlers) => {
+      const output: string[] = [];
+      streamed.push({ cmd, args: [...args], output });
+      for (const chunk of ["pulling layer\n", "download complete\n"]) {
+        handlers.onStdout?.(chunk);
+        output.push(chunk);
+      }
+      return 0;
+    },
+  });
+});
+
+afterEach(() => {
+  resetRunner();
+  resetStreamer();
+  resetPublicGithubFetch();
+  resetReleaseProvenanceResolver();
+});
+
+function registryRunner(inspect = inspectRecord()): FakeRunner {
+  return new FakeRunner()
+    .onRun("docker", ["info", "--format", "{{json .}}"], {
+      stdout: JSON.stringify({ OSType: "linux", Architecture: "x86_64" }),
+      code: 0,
+    })
+    .onRun("docker", ["image", "inspect", "--format", "{{json .}}", IMAGE_REF], {
+      stdout: `${inspect}\n`,
+      code: 0,
+    });
+}
 
 describe("server deployment image — canonical registry identity", () => {
   it("uses the one published GHCR image name", () => {
@@ -46,5 +116,321 @@ describe("server deployment image — target selection", () => {
     [" main ", { imageSource: "source", ref: " main " }],
   ])("selects %j as %j", (ref, target) => {
     expect(selectDeploymentTarget(ref)).toEqual(target);
+  });
+});
+
+describe("server deployment image — registry preparation", () => {
+  it("streams the exact release pull and returns the validated canonical digest", async () => {
+    const runner = registryRunner();
+    setRunner(runner);
+    const progress: string[] = [];
+
+    await expect(prepareRegistryImage(VERSION, (chunk) => progress.push(chunk))).resolves.toEqual({
+      imageSource: "registry",
+      ref: VERSION,
+      imageRef: IMAGE_REF,
+      imageDigest: IMAGE_DIGEST,
+      revision: REVISION,
+    });
+    expect(streamed).toEqual([
+      {
+        cmd: "docker",
+        args: ["pull", IMAGE_REF],
+        output: ["pulling layer\n", "download complete\n"],
+      },
+    ]);
+    expect(progress.join("")).toBe("pulling layer\ndownload complete\n");
+  });
+
+  it.each([
+    ["missing readable tag", { RepoTags: [] }, /does not carry the requested tag/i],
+    [
+      "version mismatch",
+      {
+        Config: {
+          Labels: {
+            "org.opencontainers.image.source": "https://github.com/code-ministry-ltd/the-librarian",
+            "org.opencontainers.image.version": "1.20.0",
+            "org.opencontainers.image.revision": REVISION,
+          },
+        },
+      },
+      /version metadata.*1\.20\.1.*1\.20\.0/i,
+    ],
+    [
+      "source mismatch",
+      {
+        Config: {
+          Labels: {
+            "org.opencontainers.image.source": "https://github.com/example/other",
+            "org.opencontainers.image.version": "1.20.1",
+            "org.opencontainers.image.revision": REVISION,
+          },
+        },
+      },
+      /source metadata/i,
+    ],
+    [
+      "revision missing",
+      {
+        Config: {
+          Labels: {
+            "org.opencontainers.image.source": "https://github.com/code-ministry-ltd/the-librarian",
+            "org.opencontainers.image.version": "1.20.1",
+          },
+        },
+      },
+      /revision metadata/i,
+    ],
+    ["architecture missing", { Architecture: "" }, /architecture metadata/i],
+    ["digest missing", { RepoDigests: [] }, /canonical repository digest/i],
+    [
+      "wrong repository digest",
+      { RepoDigests: [`ghcr.io/example/other@sha256:${HASH}`] },
+      /canonical repository digest/i,
+    ],
+    [
+      "short digest",
+      { RepoDigests: [`${CANONICAL_IMAGE_NAME}@sha256:abcd`] },
+      /canonical repository digest/i,
+    ],
+  ])("rejects %s without returning an image", async (_name, overrides, message) => {
+    const runner = registryRunner(inspectRecord(overrides as Record<string, unknown>));
+    setRunner(runner);
+
+    await expect(prepareRegistryImage(VERSION, () => undefined)).rejects.toThrow(message);
+  });
+
+  it("fails closed with a redacted teaching error when the pull fails", async () => {
+    const leaked = "0123456789abcdef".repeat(4);
+    setRunner(registryRunner());
+    setStreamer({
+      stream: async (_cmd, _args, handlers) => {
+        handlers.onStderr?.(`registry denied token ${leaked}\n`);
+        return 1;
+      },
+    });
+    const progress: string[] = [];
+
+    await expect(prepareRegistryImage(VERSION, (chunk) => progress.push(chunk))).rejects.toThrow(
+      /docker pull.*failed.*registry access.*network/i,
+    );
+    expect(progress.join("")).not.toContain(leaked);
+    expect(progress.join("")).toContain("[redacted]");
+  });
+
+  it("redacts a rejected metadata inspection and teaches the operator how to recover", async () => {
+    const leaked = "fedcba9876543210".repeat(4);
+    const runner = registryRunner();
+    const realRun = runner.run.bind(runner);
+    runner.run = async (cmd, args, options) => {
+      if (cmd === "docker" && args[0] === "image") {
+        throw new Error(`daemon rejected credential ${leaked}`);
+      }
+      return realRun(cmd, args, options);
+    };
+    setRunner(runner);
+
+    await expect(prepareRegistryImage(VERSION, () => undefined)).rejects.toSatisfy(
+      (error: unknown) => {
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toMatch(/metadata inspection failed/i);
+        expect((error as Error).message).not.toContain(leaked);
+        expect((error as Error).message).toContain("[redacted]");
+        return true;
+      },
+    );
+  });
+
+  it("redacts secret-shaped invalid metadata values", async () => {
+    const leaked = "0123456789abcdef".repeat(4);
+    const runner = registryRunner(
+      inspectRecord({
+        Config: {
+          Labels: {
+            "org.opencontainers.image.source": leaked,
+            "org.opencontainers.image.version": "1.20.1",
+            "org.opencontainers.image.revision": REVISION,
+          },
+        },
+      }),
+    );
+    setRunner(runner);
+
+    await expect(prepareRegistryImage(VERSION, () => undefined)).rejects.toSatisfy(
+      (error: unknown) => {
+        expect((error as Error).message).not.toContain(leaked);
+        expect((error as Error).message).toContain("[redacted]");
+        return true;
+      },
+    );
+  });
+
+  it.each([
+    ["arm64 daemon", { OSType: "linux", Architecture: "arm64" }],
+    ["unknown daemon architecture", { OSType: "linux", Architecture: "mips64" }],
+    ["blank daemon platform", { OSType: "   ", Architecture: "   " }],
+    ["non-linux daemon", { OSType: "windows", Architecture: "amd64" }],
+  ])("rejects %s before pulling or creating credentials", async (_name, daemon) => {
+    const runner = registryRunner().onRun("docker", ["info", "--format", "{{json .}}"], {
+      stdout: JSON.stringify(daemon),
+      code: 0,
+    });
+    setRunner(runner);
+
+    await expect(prepareRegistryImage(VERSION, () => undefined)).rejects.toThrow(
+      /supported platform.*linux\/amd64/i,
+    );
+    expect(streamed).toEqual([]);
+  });
+
+  it.each([
+    ["wrong image architecture", { Architecture: "arm64" }],
+    ["unknown image architecture", { Architecture: "unknown" }],
+    ["blank image platform", { Os: " ", Architecture: " " }],
+    ["daemon/image mismatch", { Os: "windows", Architecture: "amd64" }],
+  ])("rejects %s after pull validation", async (_name, imagePlatform) => {
+    setRunner(registryRunner(inspectRecord(imagePlatform)));
+
+    await expect(prepareRegistryImage(VERSION, () => undefined)).rejects.toThrow(
+      /image platform.*linux\/amd64/i,
+    );
+  });
+
+  it("rejects a plausible but unauthoritative 40-hex OCI revision", async () => {
+    setRunner(registryRunner());
+    setReleaseProvenanceResolver(async () => ({
+      revision: "34".repeat(20),
+      imageDigest: IMAGE_DIGEST,
+    }));
+
+    await expect(prepareRegistryImage(VERSION, () => undefined)).rejects.toThrow(
+      /revision.*does not match.*GitHub/i,
+    );
+  });
+
+  it("rejects a canonical digest that disagrees with the release receipt", async () => {
+    setRunner(registryRunner());
+    setReleaseProvenanceResolver(async () => ({
+      revision: REVISION,
+      imageDigest: `${CANONICAL_IMAGE_NAME}@sha256:${"cd".repeat(32)}`,
+    }));
+
+    await expect(prepareRegistryImage(VERSION, () => undefined)).rejects.toThrow(
+      /digest.*does not match.*release receipt/i,
+    );
+  });
+
+  it("peels the public GitHub tag and verifies the exact release digest receipt", async () => {
+    const tagObject = "34".repeat(20);
+    const urls: string[] = [];
+    resetReleaseProvenanceResolver();
+    setPublicGithubFetch(async (url) => {
+      urls.push(url);
+      const json = async (): Promise<unknown> => {
+        if (url.includes("/git/ref/tags/")) {
+          return { object: { type: "tag", sha: tagObject } };
+        }
+        if (url.includes(`/git/tags/${tagObject}`)) {
+          return { object: { type: "commit", sha: REVISION } };
+        }
+        return {
+          assets: [
+            {
+              name: "docker-image-digest.txt",
+              browser_download_url:
+                "https://github.com/code-ministry-ltd/the-librarian/releases/download/v1.20.1/docker-image-digest.txt",
+            },
+          ],
+        };
+      };
+      return { ok: true, status: 200, json, text: async () => `${IMAGE_DIGEST}\n` };
+    });
+    const runner = registryRunner();
+    setRunner(runner);
+
+    await expect(prepareRegistryImage(VERSION, () => undefined)).resolves.toMatchObject({
+      revision: REVISION,
+      imageDigest: IMAGE_DIGEST,
+    });
+    expect(urls).toEqual([
+      expect.stringContaining("/git/ref/tags/v1.20.1"),
+      expect.stringContaining(`/git/tags/${tagObject}`),
+      expect.stringContaining("/releases/tags/v1.20.1"),
+      expect.stringContaining("/releases/download/v1.20.1/docker-image-digest.txt"),
+    ]);
+    expect(runner.calls.some((call) => call.cmd === "git")).toBe(false);
+  });
+
+  it("rejects a digest receipt URL outside the canonical repository release", async () => {
+    setPublicGithubFetch(async (url) => {
+      if (url.includes("/git/ref/tags/")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ object: { type: "commit", sha: REVISION } }),
+          text: async () => "",
+        };
+      }
+      if (url.includes("/releases/tags/")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            assets: [
+              {
+                name: "docker-image-digest.txt",
+                browser_download_url:
+                  "https://github.com/another-owner/another-repo/releases/download/v1.20.1/docker-image-digest.txt",
+              },
+            ],
+          }),
+          text: async () => "",
+        };
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    resetReleaseProvenanceResolver();
+    setRunner(registryRunner());
+
+    await expect(prepareRegistryImage(VERSION, () => undefined)).rejects.toThrow(
+      /no docker-image-digest\.txt receipt/i,
+    );
+  });
+
+  it("buffers stdout and stderr independently so split secrets are redacted", async () => {
+    const hex = "0123456789abcdef".repeat(4);
+    const admin = "libadmin_" + "split-secret-value";
+    setRunner(registryRunner());
+    setStreamer({
+      stream: async (_cmd, _args, handlers) => {
+        handlers.onStdout?.(`token ${hex.slice(0, 19)}`);
+        handlers.onStderr?.("Generated a new admin ");
+        handlers.onStdout?.(`${hex.slice(19)}\n`);
+        handlers.onStderr?.(`token: ${admin.slice(0, 11)}`);
+        handlers.onStderr?.(`${admin.slice(11)}\n`);
+        return 0;
+      },
+    });
+    const progress: string[] = [];
+
+    await prepareRegistryImage(VERSION, (chunk) => progress.push(chunk));
+
+    const output = progress.join("");
+    expect(output).not.toContain(hex);
+    expect(output).not.toContain(admin);
+    expect(output).not.toMatch(/Generated a new admin token/i);
+    expect(output).toContain("[redacted]");
+  });
+
+  it("rejects invalid release refs before issuing docker commands", async () => {
+    const runner = new FakeRunner();
+    setRunner(runner);
+
+    await expect(prepareRegistryImage("main", () => undefined)).rejects.toThrow(
+      /exact release ref/i,
+    );
+    expect(runner.calls).toEqual([]);
+    expect(streamed).toEqual([]);
   });
 });

--- a/packages/installer-cli/tests/server-deployment-image.test.ts
+++ b/packages/installer-cli/tests/server-deployment-image.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  CANONICAL_IMAGE_NAME,
+  isReleasedVersionRef,
+  selectDeploymentTarget,
+} from "../src/server/deployment-image.js";
+
+describe("server deployment image — canonical registry identity", () => {
+  it("uses the one published GHCR image name", () => {
+    expect(CANONICAL_IMAGE_NAME).toBe("ghcr.io/code-ministry-ltd/the-librarian");
+  });
+});
+
+describe("server deployment image — strict released-version recognition", () => {
+  it.each([
+    ["v0.0.0", true],
+    ["v1.20.1", true],
+    ["v10.200.3000", true],
+    ["1.20.1", false],
+    ["v1.20", false],
+    ["v1.20.1-beta.1", false],
+    ["v1.20.1+build", false],
+    ["v01.20.1", false],
+    ["v1.020.1", false],
+    ["v1.20.01", false],
+    [" v1.20.1", false],
+    ["v1.20.1 ", false],
+  ])("classifies %j as released=%s", (ref, released) => {
+    expect(isReleasedVersionRef(ref)).toBe(released);
+  });
+});
+
+describe("server deployment image — target selection", () => {
+  it.each([
+    [undefined, { imageSource: "registry" }],
+    ["", { imageSource: "registry" }],
+    ["   ", { imageSource: "registry" }],
+    ["v1.20.1", { imageSource: "registry", ref: "v1.20.1" }],
+    ["main", { imageSource: "source", ref: "main" }],
+    ["feature/pull-images", { imageSource: "source", ref: "feature/pull-images" }],
+    ["release-candidate", { imageSource: "source", ref: "release-candidate" }],
+    ["8f1f0f3", { imageSource: "source", ref: "8f1f0f3" }],
+    ["v1.20", { imageSource: "source", ref: "v1.20" }],
+    ["v1.20.1-beta.1", { imageSource: "source", ref: "v1.20.1-beta.1" }],
+    [" v1.20.1 ", { imageSource: "source", ref: " v1.20.1 " }],
+    [" main ", { imageSource: "source", ref: " main " }],
+  ])("selects %j as %j", (ref, target) => {
+    expect(selectDeploymentTarget(ref)).toEqual(target);
+  });
+});

--- a/packages/installer-cli/tests/server-deployment-image.test.ts
+++ b/packages/installer-cli/tests/server-deployment-image.test.ts
@@ -6,6 +6,7 @@ import {
   resetPublicGithubFetch,
   resetReleaseProvenanceResolver,
   selectDeploymentTarget,
+  shortImageDigest,
   setPublicGithubFetch,
   setReleaseProvenanceResolver,
 } from "../src/server/deployment-image.js";
@@ -78,6 +79,10 @@ function registryRunner(inspect = inspectRecord()): FakeRunner {
 describe("server deployment image — canonical registry identity", () => {
   it("uses the one published GHCR image name", () => {
     expect(CANONICAL_IMAGE_NAME).toBe("ghcr.io/code-ministry-ltd/the-librarian");
+  });
+
+  it("formats the conventional first 12 digest hex characters", () => {
+    expect(shortImageDigest(IMAGE_DIGEST)).toBe("abababababab");
   });
 });
 

--- a/packages/installer-cli/tests/server-down.test.ts
+++ b/packages/installer-cli/tests/server-down.test.ts
@@ -22,10 +22,7 @@ afterEach(() => {
 
 /** A runner with docker present + daemon reachable (preflight passes). */
 function dockerReady(): FakeRunner {
-  return new FakeRunner()
-    .withWhich("docker")
-    .withWhich("git")
-    .onRun("docker", ["info"], { code: 0 });
+  return new FakeRunner().withWhich("docker").onRun("docker", ["info"], { code: 0 });
 }
 
 /** True iff the runner ever issued a destructive docker op (rm / volume / -v). */

--- a/packages/installer-cli/tests/server-logs.test.ts
+++ b/packages/installer-cli/tests/server-logs.test.ts
@@ -37,17 +37,13 @@ const COMBINED = [MCP_LINE_A, DASH_LINE_A, MCP_LINE_B, DASH_LINE_B].join("\n") +
 function dockerReady(logsArgs: string[]): FakeRunner {
   return new FakeRunner()
     .withWhich("docker")
-    .withWhich("git")
     .onRun("docker", ["info"], { code: 0 })
     .onRun("docker", logsArgs, { stdout: COMBINED, code: 0 });
 }
 
 /** docker present + daemon reachable, WITHOUT scripting `docker logs` (follow streams). */
 function dockerReadyForFollow(): FakeRunner {
-  return new FakeRunner()
-    .withWhich("docker")
-    .withWhich("git")
-    .onRun("docker", ["info"], { code: 0 });
+  return new FakeRunner().withWhich("docker").onRun("docker", ["info"], { code: 0 });
 }
 
 /** The argv (after `docker`) of the recorded `logs` call. */

--- a/packages/installer-cli/tests/server-source-repository.test.ts
+++ b/packages/installer-cli/tests/server-source-repository.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { isCanonicalSourceRemote, redactGitDiagnostics } from "../src/server/source-repository.js";
+
+describe("managed source repository identity", () => {
+  const credentials = `${["runtime", "user"].join("-")}:${["runtime", "credential"].join("-")}`;
+
+  it.each([
+    "https://github.com/code-ministry-ltd/the-librarian",
+    "https://github.com/code-ministry-ltd/the-librarian.git",
+    `https://${credentials}@github.com/code-ministry-ltd/the-librarian.git`,
+    "ssh://git@github.com/code-ministry-ltd/the-librarian.git",
+    "git@github.com:code-ministry-ltd/the-librarian.git",
+  ])("accepts the canonical repository through a trusted transport: %s", (remote) => {
+    expect(isCanonicalSourceRemote(remote)).toBe(true);
+  });
+
+  it.each([
+    "http://github.com/code-ministry-ltd/the-librarian.git",
+    "git://github.com/code-ministry-ltd/the-librarian.git",
+    "ftp://github.com/code-ministry-ltd/the-librarian.git",
+    "https://github.com/other-owner/the-librarian.git",
+    "https://github.example.com/code-ministry-ltd/the-librarian.git",
+    "ssh://root@github.com/code-ministry-ltd/the-librarian.git",
+    "git@github.com:other-owner/the-librarian.git",
+  ])("rejects an insecure or non-canonical source remote: %s", (remote) => {
+    expect(isCanonicalSourceRemote(remote)).toBe(false);
+  });
+
+  it("redacts credential-bearing URLs and scp remotes from Git diagnostics", () => {
+    const secret = ["runtime", "diagnostic", "credential"].join("-");
+    const httpsRemote = `https://worker:${secret}@github.com/code-ministry-ltd/the-librarian.git`;
+    const scpRemote = `worker@github.com:code-ministry-ltd/the-librarian.git?token=${secret}`;
+    const diagnostic = `fatal: unable to access ${httpsRemote}; fallback ${scpRemote}`;
+
+    const redacted = redactGitDiagnostics(diagnostic);
+
+    expect(redacted).toContain("[redacted-remote]");
+    expect(redacted).not.toContain(secret);
+    expect(redacted).not.toContain(httpsRemote);
+    expect(redacted).not.toContain(scpRemote);
+  });
+});

--- a/packages/installer-cli/tests/server-status.test.ts
+++ b/packages/installer-cli/tests/server-status.test.ts
@@ -15,6 +15,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { resetRunner } from "../src/exec.js";
 import { runCli } from "../src/runtime.js";
 import { writeDeployState } from "../src/server/deploy-state.js";
+import { CANONICAL_IMAGE_NAME } from "../src/server/deployment-image.js";
 import {
   resetRunner as resetDockerRunner,
   setRunner as setDockerRunner,
@@ -29,15 +30,41 @@ afterEach(() => {
 });
 
 const DEPLOYED = "v1.4.2";
+const DEPLOYED_DIGEST = `${CANONICAL_IMAGE_NAME}@sha256:${"42".repeat(32)}`;
 
 /** Seed a deploy-state recording the deployed ref `v1.4.2`. */
-function seedDeployState(home: string): void {
+function seedDeployState(home: string, ref = DEPLOYED): void {
+  writeDeployState(path.join(home, ".librarian", "server"), {
+    containerName: "the-librarian",
+    host: "127.0.0.1",
+    dataVolume: "librarian_data",
+    ref,
+    imageTag: `the-librarian:${ref}`,
+  });
+}
+
+function seedRegistryDeployState(home: string): void {
   writeDeployState(path.join(home, ".librarian", "server"), {
     containerName: "the-librarian",
     host: "127.0.0.1",
     dataVolume: "librarian_data",
     ref: DEPLOYED,
-    imageTag: `the-librarian:${DEPLOYED}`,
+    imageTag: `${CANONICAL_IMAGE_NAME}:${DEPLOYED}`,
+    imageSource: "registry",
+    imageRef: `${CANONICAL_IMAGE_NAME}:${DEPLOYED}`,
+    imageDigest: DEPLOYED_DIGEST,
+  });
+}
+
+function seedSourceDeployState(home: string): void {
+  writeDeployState(path.join(home, ".librarian", "server"), {
+    containerName: "the-librarian",
+    host: "127.0.0.1",
+    dataVolume: "librarian_data",
+    ref: "main",
+    imageTag: "the-librarian:source-deadbeef",
+    imageSource: "source",
+    imageRef: "the-librarian:source-deadbeef",
   });
 }
 
@@ -60,7 +87,7 @@ function runningHealthy(): FakeRunner {
 describe("server status — running + healthy, deployed vs latest badge", () => {
   it("a NEWER latest → update-available", async () => {
     await withTempHome(async (home) => {
-      seedDeployState(home);
+      seedRegistryDeployState(home);
       setDockerRunner(runningHealthy());
       setLatestFetcher(async () => "1.5.0"); // newer than deployed 1.4.2
 
@@ -77,7 +104,7 @@ describe("server status — running + healthy, deployed vs latest badge", () => 
 
   it("an EQUAL latest → up-to-date", async () => {
     await withTempHome(async (home) => {
-      seedDeployState(home);
+      seedRegistryDeployState(home);
       setDockerRunner(runningHealthy());
       setLatestFetcher(async () => "1.4.2"); // equal to deployed
 
@@ -132,6 +159,36 @@ describe("server status — container absent → not running", () => {
 });
 
 describe("server status — deployed version from deploy-state, else git describe", () => {
+  it("renders registry provenance from state without probing Git", async () => {
+    await withTempHome(async (home) => {
+      seedRegistryDeployState(home);
+      const runner = runningHealthy();
+      setDockerRunner(runner);
+      setLatestFetcher(async () => "1.4.2");
+
+      const r = await runCli(["server", "status"], { home });
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toMatch(/Deployed:\s+published v1\.4\.2 \(424242424242\)/);
+      expect(runner.calls.some((call) => call.cmd === "git")).toBe(false);
+    });
+  });
+
+  it("renders source provenance from state without probing Git", async () => {
+    await withTempHome(async (home) => {
+      seedSourceDeployState(home);
+      const runner = runningHealthy();
+      setDockerRunner(runner);
+      setLatestFetcher(async () => "1.5.0");
+
+      const r = await runCli(["server", "status"], { home });
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toMatch(/Deployed:\s+source main/);
+      expect(r.stdout).toMatch(/Update:\s+\?/);
+      expect(r.stdout).not.toMatch(/up-to-date|update-available/);
+      expect(runner.calls.some((call) => call.cmd === "git")).toBe(false);
+    });
+  });
+
   it("reads the deployed ref from deploy-state.json", async () => {
     await withTempHome(async (home) => {
       seedDeployState(home);
@@ -140,7 +197,24 @@ describe("server status — deployed version from deploy-state, else git describ
 
       const r = await runCli(["server", "status"], { home });
       expect(r.exitCode).toBe(0);
-      expect(r.stdout).toContain(DEPLOYED);
+      expect(r.stdout).toMatch(/Deployed:\s+legacy v1\.4\.2/);
+      expect(r.stdout).toMatch(/Update:\s+\?/);
+      expect(r.stdout).not.toMatch(/up-to-date|update-available/);
+    });
+  });
+
+  it("renders a legacy main state as non-comparable without probing Git", async () => {
+    await withTempHome(async (home) => {
+      seedDeployState(home, "main");
+      const runner = runningHealthy();
+      setDockerRunner(runner);
+      setLatestFetcher(async () => "1.5.0");
+
+      const r = await runCli(["server", "status"], { home });
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toMatch(/Deployed:\s+legacy main/);
+      expect(r.stdout).toMatch(/Update:\s+\?/);
+      expect(runner.calls.some((call) => call.cmd === "git")).toBe(false);
     });
   });
 
@@ -158,7 +232,9 @@ describe("server status — deployed version from deploy-state, else git describ
       const r = await runCli(["server", "status"], { home });
       expect(r.exitCode).toBe(0);
       // The git-describe value is surfaced as the deployed version.
-      expect(r.stdout).toContain("v1.3.9");
+      expect(r.stdout).toMatch(/Deployed:\s+legacy v1\.3\.9/);
+      expect(r.stdout).toMatch(/Update:\s+\?/);
+      expect(r.stdout).not.toMatch(/up-to-date|update-available/);
       expect(runner.ran("git", ["-C", deployDir, "describe", "--tags"])).toBe(true);
     });
   });

--- a/packages/installer-cli/tests/server-status.test.ts
+++ b/packages/installer-cli/tests/server-status.test.ts
@@ -180,6 +180,30 @@ describe("server status — deployed version from deploy-state, else git describ
       expect(r.stdout).not.toMatch(/update-available/i);
     });
   });
+
+  it("deployed unknown without git → unknown without failing or running git", async () => {
+    await withTempHome(async (home) => {
+      const runner = new FakeRunner()
+        .withWhich("docker")
+        .onRun("docker", ["info"], { code: 0 })
+        .onRun("docker", ["inspect", "--format", "{{.State.Status}}", "the-librarian"], {
+          stdout: "running\n",
+          code: 0,
+        })
+        .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", "the-librarian"], {
+          stdout: "healthy\n",
+          code: 0,
+        });
+      setDockerRunner(runner);
+      setLatestFetcher(async () => "1.5.0");
+
+      const r = await runCli(["server", "status"], { home });
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toMatch(/Deployed:\s+unknown/);
+      expect(r.stdout).toContain("?");
+      expect(runner.calls.some((call) => call.cmd === "git")).toBe(false);
+    });
+  });
 });
 
 describe("server status — preflight teaches when docker is missing", () => {

--- a/packages/installer-cli/tests/server-up.test.ts
+++ b/packages/installer-cli/tests/server-up.test.ts
@@ -12,7 +12,12 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { readEnvFile } from "../src/env.js";
 import { resetRunner } from "../src/exec.js";
 import { runCli } from "../src/runtime.js";
-import { deployStatePath, readDeployState } from "../src/server/deploy-state.js";
+import { deployStatePath, readDeployState, writeDeployState } from "../src/server/deploy-state.js";
+import {
+  CANONICAL_IMAGE_NAME,
+  resetReleaseProvenanceResolver,
+  setReleaseProvenanceResolver,
+} from "../src/server/deployment-image.js";
 import {
   resetRunner as resetDockerRunner,
   resetStreamer,
@@ -20,14 +25,20 @@ import {
   setStreamer,
 } from "../src/server/docker.js";
 import {
+  buildCreateArgs,
   buildRunArgs,
   deployEnvFilePath,
+  stagedDeployEnvFilePath,
   resetSecretKeyMinter,
+  resetFinalizationRenamer,
   resetSleep,
+  resetStagedEnvIdMinter,
   resetTokenMinter,
   runUp,
   setSecretKeyMinter,
+  setFinalizationRenamer,
   setSleep,
+  setStagedEnvIdMinter,
   setTokenMinter,
   waitForHealthy,
   writeDeployEnvFile,
@@ -43,6 +54,30 @@ const MASTER_KEY = "master-key-minted-by-the-cli-deterministic";
 const BOOTSTRAP_CLAIM_SECRET = "managed-bootstrap-claim-secret-".repeat(2);
 const LATEST = "1.4.2"; // fetchLatestVersion returns the v-stripped version
 const LATEST_TAG = "v1.4.2";
+const REGISTRY_HASH = "ab".repeat(32);
+const REGISTRY_DIGEST = `${CANONICAL_IMAGE_NAME}@sha256:${REGISTRY_HASH}`;
+const REGISTRY_IMAGE_REF = `${CANONICAL_IMAGE_NAME}:${LATEST_TAG}`;
+const REGISTRY_REVISION = "12".repeat(20);
+const CANDIDATE_CONTAINER_ID = "cafebabedeadbeef".repeat(4);
+const UNRELATED_CONTAINER_ID = "decafbad01234567".repeat(4);
+const STAGED_ENV_INVOCATION_ID = "deterministic-invocation";
+
+function registryInspectJson(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    Os: "linux",
+    Architecture: "amd64",
+    Config: {
+      Labels: {
+        "org.opencontainers.image.source": "https://github.com/code-ministry-ltd/the-librarian",
+        "org.opencontainers.image.version": LATEST,
+        "org.opencontainers.image.revision": REGISTRY_REVISION,
+      },
+    },
+    RepoTags: [REGISTRY_IMAGE_REF],
+    RepoDigests: [REGISTRY_DIGEST],
+    ...overrides,
+  });
+}
 
 // The image build STREAMS its output live (so a multi-minute build isn't a blank
 // line) — it goes through the streamer seam, not the capture runner. Record the
@@ -50,6 +85,11 @@ const LATEST_TAG = "v1.4.2";
 let buildStream: { cmd: string; args: string[]; opts?: { cwd?: string } }[];
 beforeEach(() => {
   buildStream = [];
+  setStagedEnvIdMinter(() => STAGED_ENV_INVOCATION_ID);
+  setReleaseProvenanceResolver(async () => ({
+    revision: REGISTRY_REVISION,
+    imageDigest: REGISTRY_DIGEST,
+  }));
   setStreamer({
     stream: async (cmd, args, _handlers, opts) => {
       buildStream.push({ cmd, args: [...args], opts });
@@ -63,14 +103,21 @@ function streamedBuildArgs(): string[] | undefined {
   return buildStream.find((c) => c.cmd === "docker" && c.args[0] === "build")?.args;
 }
 
+function streamedPullArgs(): string[] | undefined {
+  return buildStream.find((c) => c.cmd === "docker" && c.args[0] === "pull")?.args;
+}
+
 afterEach(() => {
   resetRunner();
   resetDockerRunner();
   resetStreamer();
   resetLatestFetcher();
   resetSleep();
+  resetStagedEnvIdMinter();
   resetTokenMinter();
   resetSecretKeyMinter();
+  resetReleaseProvenanceResolver();
+  resetFinalizationRenamer();
 });
 
 /** A FakeRunner wired for a fully-successful localhost `up`. */
@@ -78,14 +125,79 @@ function healthyRunner(): FakeRunner {
   // ADR 0008 P4: secrets are CLI-minted into a 0600 deploy env-file and delivered
   // via `docker run --env-file`; the master key is NOT read back from the
   // container, so there is no `docker exec cat /data/secret.key` to script.
-  return new FakeRunner()
-    .withWhich("docker")
-    .withWhich("git")
-    .onRun("docker", ["info"], { code: 0 })
-    .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", "the-librarian"], {
-      stdout: "healthy\n",
-      code: 0,
-    });
+  return withCandidateLifecycle(
+    new FakeRunner()
+      .withWhich("docker")
+      .withWhich("git")
+      .onRun("docker", ["info"], { code: 0 })
+      .onRun("docker", ["info", "--format", "{{json .}}"], {
+        stdout: JSON.stringify({ OSType: "linux", Architecture: "amd64" }),
+        code: 0,
+      })
+      .onRun("docker", ["container", "inspect", "--format", "{{json .}}", "the-librarian"], {
+        stderr: "No such container: the-librarian",
+        code: 1,
+      })
+      .onRun("docker", ["image", "inspect", "--format", "{{json .}}", REGISTRY_IMAGE_REF], {
+        stdout: `${registryInspectJson()}\n`,
+        code: 0,
+      })
+      .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", "the-librarian"], {
+        stdout: "healthy\n",
+        code: 0,
+      })
+      .onRun(
+        "docker",
+        ["inspect", "--format", "{{.State.Health.Status}}", CANDIDATE_CONTAINER_ID],
+        { stdout: "healthy\n", code: 0 },
+      ),
+  );
+}
+
+/** A fully-successful registry deployment runner; Git is intentionally absent. */
+function healthyRegistryRunner(): FakeRunner {
+  return withCandidateLifecycle(
+    new FakeRunner()
+      .withWhich("docker")
+      .onRun("docker", ["info"], { code: 0 })
+      .onRun("docker", ["info", "--format", "{{json .}}"], {
+        stdout: JSON.stringify({ OSType: "linux", Architecture: "x86_64" }),
+        code: 0,
+      })
+      .onRun("docker", ["container", "inspect", "--format", "{{json .}}", "the-librarian"], {
+        stderr: "No such container: the-librarian",
+        code: 1,
+      })
+      .onRun("docker", ["image", "inspect", "--format", "{{json .}}", REGISTRY_IMAGE_REF], {
+        stdout: `${registryInspectJson()}\n`,
+        code: 0,
+      })
+      .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", "the-librarian"], {
+        stdout: "healthy\n",
+        code: 0,
+      })
+      .onRun(
+        "docker",
+        ["inspect", "--format", "{{.State.Health.Status}}", CANDIDATE_CONTAINER_ID],
+        { stdout: "healthy\n", code: 0 },
+      ),
+  );
+}
+
+function withCandidateLifecycle(runner: FakeRunner): FakeRunner {
+  const realRun = runner.run.bind(runner);
+  runner.run = async (cmd, args, options) => {
+    if (cmd === "docker" && args[0] === "create") {
+      runner.calls.push({ cmd, args: [...args], opts: options });
+      return { stdout: `${CANDIDATE_CONTAINER_ID}\n`, stderr: "", code: 0 };
+    }
+    if (cmd === "docker" && args[0] === "start" && args[1] === CANDIDATE_CONTAINER_ID) {
+      runner.calls.push({ cmd, args: [...args], opts: options });
+      return { stdout: `${CANDIDATE_CONTAINER_ID}\n`, stderr: "", code: 0 };
+    }
+    return realRun(cmd, args, options);
+  };
+  return runner;
 }
 
 /** Install the deterministic seams shared by the happy-path tests. */
@@ -101,20 +213,72 @@ function deployEnvOf(home: string): string {
   return deployEnvFilePath(path.join(home, ".librarian", "server"));
 }
 
-/** The argv (after `docker`) any `run -d …` call recorded by the runner. */
-function dockerRunArgs(runner: FakeRunner): string[] | undefined {
-  return runner.calls.find((c) => c.cmd === "docker" && c.args[0] === "run")?.args;
+function stagedDeployEnvOf(home: string): string {
+  return stagedDeployEnvFilePath(path.join(home, ".librarian", "server"), STAGED_ENV_INVOCATION_ID);
 }
 
-describe("server up — fresh localhost happy path (exact argv)", () => {
-  it("clones at the latest tag, builds, then runs the localhost container", async () => {
+/** The argv (after `docker`) any `run -d …` call recorded by the runner. */
+function dockerRunArgs(runner: FakeRunner): string[] | undefined {
+  return runner.calls.find((c) => c.cmd === "docker" && c.args[0] === "create")?.args;
+}
+
+function liveRegistryContainer() {
+  return {
+    State: { Health: { Status: "healthy" } },
+    Config: {
+      Image: REGISTRY_DIGEST,
+      User: "node",
+      Env: [
+        "LIBRARIAN_AGENT_TOKEN=existing-agent-token",
+        "LIBRARIAN_SECRET_KEY=existing-master-key-long-enough-for-safe-reuse",
+        "LIBRARIAN_ALLOW_NO_AUTH=true",
+        "LIBRARIAN_DATA_DIR=/data",
+        "LIBRARIAN_HOST=0.0.0.0",
+        "LIBRARIAN_PORT=3838",
+        "PORT=3000",
+      ],
+    },
+    HostConfig: {
+      RestartPolicy: { Name: "unless-stopped" },
+      PortBindings: {
+        "3000/tcp": [{ HostIp: "127.0.0.1", HostPort: "3042" }],
+        "3838/tcp": [{ HostIp: "127.0.0.1", HostPort: "3838" }],
+      },
+    },
+    Mounts: [{ Destination: "/data", Type: "volume", Name: "librarian_data" }],
+  };
+}
+
+function seedRegistryDeployment(home: string): string {
+  const deployDir = path.join(home, ".librarian", "server");
+  writeDeployEnvFile(deployDir, {
+    agentToken: "existing-agent-token",
+    secretKey: "existing-master-key-long-enough-for-safe-reuse",
+    host: "127.0.0.1",
+  });
+  writeDeployState(deployDir, {
+    containerName: "the-librarian",
+    host: "127.0.0.1",
+    dataVolume: "librarian_data",
+    dashboardPort: 3042,
+    ref: LATEST_TAG,
+    imageTag: REGISTRY_IMAGE_REF,
+    imageSource: "registry",
+    imageRef: REGISTRY_IMAGE_REF,
+    imageDigest: REGISTRY_DIGEST,
+  });
+  return deployDir;
+}
+
+describe("server up — source localhost happy path (exact argv)", () => {
+  it("clones at an arbitrary source ref, builds, then runs the localhost container", async () => {
     await withTempHome(async (home) => {
       const runner = healthyRunner();
       setDockerRunner(runner);
       stubSeams();
       const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
 
-      const r = await runCli(["server", "up"], { home, prompter });
+      const r = await runCli(["server", "up", "--ref", "main"], { home, prompter });
       expect(r.exitCode).toBe(0);
 
       const deployDir = path.join(home, ".librarian", "server");
@@ -137,7 +301,7 @@ describe("server up — fresh localhost happy path (exact argv)", () => {
           "rev-parse",
           "--verify",
           "--end-of-options",
-          `${LATEST_TAG}^{commit}`,
+          "main^{commit}",
         ]),
       ).toBe(true);
 
@@ -148,15 +312,14 @@ describe("server up — fresh localhost happy path (exact argv)", () => {
         "-f",
         "docker/all-in-one.Dockerfile",
         "-t",
-        `the-librarian:${LATEST_TAG}`,
+        "the-librarian:main",
         ".",
       ]);
 
       // docker run — the EXACT localhost argv. ADR 0008 P4: secrets ride in the
       // 0600 deploy env-file via `--env-file <path>`, NOT inline `-e`. No --init.
       expect(dockerRunArgs(runner)).toEqual([
-        "run",
-        "-d",
+        "create",
         "--name",
         "the-librarian",
         "--restart",
@@ -168,8 +331,8 @@ describe("server up — fresh localhost happy path (exact argv)", () => {
         "-v",
         "librarian_data:/data",
         "--env-file",
-        deployEnvOf(home),
-        `the-librarian:${LATEST_TAG}`,
+        stagedDeployEnvOf(home),
+        "the-librarian:main",
       ]);
 
       // The secrets must NOT appear on argv (off-argv invariant — ADR 0008 P4).
@@ -187,11 +350,11 @@ describe("server up — fresh localhost happy path (exact argv)", () => {
       stubSeams();
       const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
 
-      await runCli(["server", "up"], { home, prompter });
+      await runCli(["server", "up", "--ref", "main"], { home, prompter });
 
       const deployDir = path.join(home, ".librarian", "server");
       const build = buildStream.find((c) => c.args[0] === "build");
-      const dRun = runner.calls.find((c) => c.cmd === "docker" && c.args[0] === "run");
+      const dRun = runner.calls.find((c) => c.cmd === "docker" && c.args[0] === "create");
       expect(build?.opts?.cwd).toBe(deployDir);
       expect(dRun?.opts?.cwd).toBe(deployDir);
     });
@@ -302,25 +465,46 @@ describe("server up — health-wait failure rolls back (no half-up)", () => {
         .withWhich("docker")
         .withWhich("git")
         .onRun("docker", ["info"], { code: 0 })
+        .onRun("docker", ["info", "--format", "{{json .}}"], {
+          stdout: JSON.stringify({ OSType: "linux", Architecture: "amd64" }),
+          code: 0,
+        })
+        .onRun("docker", ["container", "inspect", "--format", "{{json .}}", "the-librarian"], {
+          stderr: "No such container: the-librarian",
+          code: 1,
+        })
+        .onRun("docker", ["image", "inspect", "--format", "{{json .}}", REGISTRY_IMAGE_REF], {
+          stdout: registryInspectJson(),
+          code: 0,
+        })
         .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", "the-librarian"], {
           stdout: "unhealthy\n",
           code: 0,
         })
+        .onRun(
+          "docker",
+          ["inspect", "--format", "{{.State.Health.Status}}", CANDIDATE_CONTAINER_ID],
+          { stdout: "unhealthy\n", code: 0 },
+        )
         .onRun("docker", ["logs", "--tail", "50", "the-librarian"], {
           stdout: "boom: the server crashed on boot\n",
           code: 0,
+        })
+        .onRun("docker", ["logs", "--tail", "50", CANDIDATE_CONTAINER_ID], {
+          stdout: "boom: the server crashed on boot\n",
+          code: 0,
         });
-      setDockerRunner(runner);
+      setDockerRunner(withCandidateLifecycle(runner));
       stubSeams();
       const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
 
       // The container reports `unhealthy`, so the poll terminates fast (no need
       // to wait out the bound) and the flow rolls back.
-      const r = await runCli(["server", "up"], { home, prompter });
+      const r = await runCli(["server", "up", "--ref", "main"], { home, prompter });
 
       expect(r.exitCode).toBe(1);
       // Rolled back — the container was force-removed.
-      expect(runner.ran("docker", ["rm", "-f", "the-librarian"])).toBe(true);
+      expect(runner.ran("docker", ["rm", "-f", CANDIDATE_CONTAINER_ID])).toBe(true);
       // Logs were surfaced to the operator.
       expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "logs")).toBe(true);
       expect(r.stderr).toMatch(/did not become healthy/i);
@@ -334,6 +518,24 @@ describe("server up — health-wait failure rolls back (no half-up)", () => {
 });
 
 describe("server up — a failed docker step REDACTS secret-bearing output (S-2)", () => {
+  it("removes staged credentials when the source image build fails", async () => {
+    await withTempHome(async (home) => {
+      const runner = healthyRunner();
+      setDockerRunner(runner);
+      stubSeams();
+      setStreamer({ stream: async () => 1 });
+
+      const result = await runCli(["server", "up", "--ref", "main"], {
+        home,
+        prompter: new FakePrompter({}),
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect(fs.existsSync(stagedDeployEnvOf(home))).toBe(false);
+      expect(fs.existsSync(deployEnvOf(home))).toBe(false);
+    });
+  });
+
   it("a docker run failure is surfaced redacted; the secrets never reach argv or the error", async () => {
     await withTempHome(async (home) => {
       // The real minters yield 64-hex values; mirror that shape here (assembled
@@ -355,14 +557,18 @@ describe("server up — a failed docker step REDACTS secret-bearing output (S-2)
         .withWhich("docker")
         .withWhich("git")
         .withFallback({ code: 0 })
-        .onRun("docker", ["info"], { code: 0 });
+        .onRun("docker", ["info"], { code: 0 })
+        .onRun("docker", ["container", "inspect", "--format", "{{json .}}", "the-librarian"], {
+          stderr: "No such container: the-librarian",
+          code: 1,
+        });
       // Script the failing `docker run` by matching its full argv.
-      const runArgs = buildRunArgs({
+      const runArgs = buildCreateArgs({
         host: "127.0.0.1",
         dataVolume: "librarian_data",
         dashboardPort: 3042,
-        imageRef: `the-librarian:${LATEST_TAG}`,
-        envFile: deployEnvOf(home),
+        imageRef: "the-librarian:main",
+        envFile: stagedDeployEnvOf(home),
       });
       runner.onRun("docker", runArgs, {
         stderr:
@@ -373,10 +579,10 @@ describe("server up — a failed docker step REDACTS secret-bearing output (S-2)
       setDockerRunner(runner);
       const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
 
-      const r = await runCli(["server", "up"], { home, prompter });
+      const r = await runCli(["server", "up", "--ref", "main"], { home, prompter });
       expect(r.exitCode).toBe(1);
-      // It failed at the `docker run` step (not earlier).
-      expect(r.stderr).toMatch(/docker run/);
+      // It failed at the `docker create` step (not earlier).
+      expect(r.stderr).toMatch(/docker create/);
       // The secrets are NOT on the docker run argv (off-argv invariant).
       expect(runArgs.some((a) => a.includes(hexAgentToken))).toBe(false);
       expect(runArgs.some((a) => a.includes(hexMasterKey))).toBe(false);
@@ -386,8 +592,8 @@ describe("server up — a failed docker step REDACTS secret-bearing output (S-2)
       // ...but the non-secret remainder of the error IS surfaced.
       expect(r.stderr).toMatch(/Error response from daemon/);
       // ...and neither leaked into any file other than the 0600 deploy env-file.
-      expect(filesContaining(home, hexAgentToken)).toEqual([deployEnvOf(home)]);
-      expect(filesContaining(home, hexMasterKey)).toEqual([deployEnvOf(home)]);
+      expect(filesContaining(home, hexAgentToken)).toEqual([]);
+      expect(filesContaining(home, hexMasterKey)).toEqual([]);
     });
   });
 });
@@ -403,7 +609,7 @@ describe("server up — master key surfaced once, persisted only in the 0600 dep
       // key's ONLY host home is the 0600 deploy env-file (ADR 0008 P4).
       const prompter = new FakePrompter({ answers: { "~/.librarian/env": "y" } });
 
-      const r = await runCli(["server", "up"], { home, prompter });
+      const r = await runCli(["server", "up", "--ref", "main"], { home, prompter });
       expect(r.exitCode).toBe(0);
 
       // Surfaced exactly once, beside the SAVE warning — the CLI-minted key.
@@ -426,7 +632,7 @@ describe("server up — the 0600 deploy env-file (ADR 0008 P4)", () => {
       stubSeams();
       const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
 
-      const r = await runCli(["server", "up"], { home, prompter });
+      const r = await runCli(["server", "up", "--ref", "main"], { home, prompter });
       expect(r.exitCode).toBe(0);
 
       const envFile = deployEnvOf(home);
@@ -446,7 +652,7 @@ describe("server up — the 0600 deploy env-file (ADR 0008 P4)", () => {
       const runArgs = dockerRunArgs(runner) ?? [];
       const envFlagIdx = runArgs.indexOf("--env-file");
       expect(envFlagIdx).toBeGreaterThanOrEqual(0);
-      expect(runArgs[envFlagIdx + 1]).toBe(envFile);
+      expect(runArgs[envFlagIdx + 1]).toBe(stagedDeployEnvOf(home));
       expect(runArgs).not.toContain("-e");
       expect(runArgs.some((a) => a.includes(AGENT_TOKEN))).toBe(false);
       expect(runArgs.some((a) => a.includes(MASTER_KEY))).toBe(false);
@@ -542,7 +748,7 @@ describe("server up — foreign deploy dir stops and asks (never clobbers)", () 
       stubSeams();
       const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
 
-      const r = await runCli(["server", "up"], { home, prompter });
+      const r = await runCli(["server", "up", "--ref", "main"], { home, prompter });
       expect(r.exitCode).toBe(1);
       expect(r.stderr).toMatch(/different remote/i);
 
@@ -570,7 +776,7 @@ describe("server up — foreign deploy dir stops and asks (never clobbers)", () 
       stubSeams();
       const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
 
-      const r = await runCli(["server", "up"], { home, prompter });
+      const r = await runCli(["server", "up", "--ref", "main"], { home, prompter });
       expect(r.exitCode).toBe(0);
 
       // No clone (already ours); fetch tags + resolve the ref on `rev-parse`
@@ -584,7 +790,7 @@ describe("server up — foreign deploy dir stops and asks (never clobbers)", () 
           "rev-parse",
           "--verify",
           "--end-of-options",
-          `${LATEST_TAG}^{commit}`,
+          "main^{commit}",
         ]),
       ).toBe(true);
     });
@@ -662,9 +868,10 @@ describe("server up — writes the NON-SECRET deploy-state (S4/S5 prerequisite)"
         dataVolume: "librarian_data",
         dashboardPort: 3042,
         ref: LATEST_TAG,
-        imageTag: `the-librarian:${LATEST_TAG}`,
-        imageSource: "source",
-        imageRef: `the-librarian:${LATEST_TAG}`,
+        imageTag: REGISTRY_IMAGE_REF,
+        imageSource: "registry",
+        imageRef: REGISTRY_IMAGE_REF,
+        imageDigest: REGISTRY_DIGEST,
       });
 
       // The state file carries NO secret: not the agent token, not the master key.
@@ -909,16 +1116,37 @@ describe("server up — failed health-wait redacts secrets from surfaced logs (C
         .withWhich("docker")
         .withWhich("git")
         .onRun("docker", ["info"], { code: 0 })
+        .onRun("docker", ["info", "--format", "{{json .}}"], {
+          stdout: JSON.stringify({ OSType: "linux", Architecture: "amd64" }),
+          code: 0,
+        })
+        .onRun("docker", ["container", "inspect", "--format", "{{json .}}", "the-librarian"], {
+          stderr: "No such container: the-librarian",
+          code: 1,
+        })
+        .onRun("docker", ["image", "inspect", "--format", "{{json .}}", REGISTRY_IMAGE_REF], {
+          stdout: registryInspectJson(),
+          code: 0,
+        })
         .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", "the-librarian"], {
           stdout: "unhealthy\n",
           code: 0,
         })
+        .onRun(
+          "docker",
+          ["inspect", "--format", "{{.State.Health.Status}}", CANDIDATE_CONTAINER_ID],
+          { stdout: "unhealthy\n", code: 0 },
+        )
         // The boot logs CONTAIN the one-time admin-token generation line.
         .onRun("docker", ["logs", "--tail", "50", "the-librarian"], {
           stdout: `boot: starting up\n${FAKE_ADMIN_LOG_LINE}\nboot: health probe failed\n`,
           code: 0,
+        })
+        .onRun("docker", ["logs", "--tail", "50", CANDIDATE_CONTAINER_ID], {
+          stdout: `boot: starting up\n${FAKE_ADMIN_LOG_LINE}\nboot: health probe failed\n`,
+          code: 0,
         });
-      setDockerRunner(runner);
+      setDockerRunner(withCandidateLifecycle(runner));
       stubSeams();
       const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
 
@@ -934,7 +1162,7 @@ describe("server up — failed health-wait redacts secrets from surfaced logs (C
       expect(r.stderr).toMatch(/did not become healthy/i);
 
       // Rolled back — no half-up container.
-      expect(runner.ran("docker", ["rm", "-f", "the-librarian"])).toBe(true);
+      expect(runner.ran("docker", ["rm", "-f", CANDIDATE_CONTAINER_ID])).toBe(true);
     });
   });
 });
@@ -946,7 +1174,7 @@ describe("server up — any post-run failure rolls back (I2, no half-up)", () =>
       // Make `docker inspect` (the health probe) REJECT instead of returning.
       const realRun = runner.run.bind(runner);
       runner.run = async (cmd, args, opts) => {
-        if (cmd === "docker" && args[0] === "inspect") {
+        if (cmd === "docker" && args[0] === "inspect" && args[2] === "{{.State.Health.Status}}") {
           // still record the call so we can reason about ordering
           runner.calls.push({ cmd, args: [...args], opts });
           throw new Error("docker inspect exploded mid-health-loop");
@@ -962,7 +1190,7 @@ describe("server up — any post-run failure rolls back (I2, no half-up)", () =>
 
       // Even though the failure was an exception (not the timeout/unhealthy return
       // path), the container must be force-removed — no half-up state survives.
-      expect(runner.ran("docker", ["rm", "-f", "the-librarian"])).toBe(true);
+      expect(runner.ran("docker", ["rm", "-f", CANDIDATE_CONTAINER_ID])).toBe(true);
     });
   });
 });
@@ -1365,6 +1593,28 @@ describe("server up — snap-docker health-read detection (P5)", () => {
     );
   });
 
+  it("treats a verified already-absent container as successful health cleanup", async () => {
+    const runner = new FakeRunner()
+      .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", "the-librarian"], {
+        stdout: "unhealthy\n",
+        code: 0,
+      })
+      .onRun("docker", ["logs", "--tail", "50", "the-librarian"], {
+        stdout: "boot failed\n",
+        code: 0,
+      })
+      .onRun("docker", ["rm", "-f", "the-librarian"], {
+        stderr: "Error: No such container: the-librarian",
+        code: 1,
+      });
+    setDockerRunner(runner);
+
+    await expect(waitForHealthy({ healthAttempts: 1 })).rejects.toThrow(
+      /did not become healthy.*rolled back/i,
+    );
+    expect(runner.calls.filter((call) => call.args[0] === "rm")).toHaveLength(1);
+  });
+
   it("a FAILING inspect (exit≠0, empty) is NOT snap — falls through to the normal error", async () => {
     // Empty output but a non-zero exit is a different failure (container gone /
     // daemon hiccup), not snap's exit-0-empty signature.
@@ -1381,6 +1631,656 @@ describe("server up — snap-docker health-read detection (P5)", () => {
     await expect(waitForHealthy({ healthAttempts: 2, healthIntervalMs: 0 })).rejects.toThrow(
       /did not become healthy/i,
     );
+  });
+});
+
+describe("server up — stable registry deployments (B2)", () => {
+  it("pulls the latest release without Git/build and runs its exact canonical digest", async () => {
+    await withTempHome(async (home) => {
+      const runner = healthyRegistryRunner();
+      setDockerRunner(runner);
+      stubSeams();
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
+
+      const result = await runCli(["server", "up"], { home, prompter });
+
+      expect(result.exitCode).toBe(0);
+      expect(streamedPullArgs()).toEqual(["pull", REGISTRY_IMAGE_REF]);
+      expect(streamedBuildArgs()).toBeUndefined();
+      expect(runner.calls.some((call) => call.cmd === "git")).toBe(false);
+      expect(dockerRunArgs(runner)?.at(-1)).toBe(REGISTRY_DIGEST);
+      expect(dockerRunArgs(runner)).toContain(stagedDeployEnvOf(home));
+      expect(fs.existsSync(stagedDeployEnvOf(home))).toBe(false);
+      expect(fs.existsSync(deployEnvOf(home))).toBe(true);
+      expect(readDeployState(path.join(home, ".librarian", "server"))).toEqual({
+        containerName: "the-librarian",
+        host: "127.0.0.1",
+        dataVolume: "librarian_data",
+        dashboardPort: 3042,
+        ref: LATEST_TAG,
+        imageTag: REGISTRY_IMAGE_REF,
+        imageSource: "registry",
+        imageRef: REGISTRY_IMAGE_REF,
+        imageDigest: REGISTRY_DIGEST,
+      });
+    });
+  });
+
+  it("uses an exact release ref directly without consulting latest", async () => {
+    await withTempHome(async (home) => {
+      const runner = healthyRegistryRunner();
+      setDockerRunner(runner);
+      let latestCalls = 0;
+      setLatestFetcher(async () => {
+        latestCalls += 1;
+        return LATEST;
+      });
+      setTokenMinter(() => AGENT_TOKEN);
+      setSecretKeyMinter(() => MASTER_KEY);
+      setSleep(async () => undefined);
+
+      const result = await runCli(["server", "up", "--ref", LATEST_TAG], {
+        home,
+        prompter: new FakePrompter({ answers: { "~/.librarian/env": "n" } }),
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(latestCalls).toBe(0);
+      expect(streamedPullArgs()).toEqual(["pull", REGISTRY_IMAGE_REF]);
+      expect(dockerRunArgs(runner)?.at(-1)).toBe(REGISTRY_DIGEST);
+    });
+  });
+
+  it("preserves named-volume and bind-directory storage argv with a digest run target", async () => {
+    await withTempHome(async (home) => {
+      const runner = healthyRegistryRunner();
+      setDockerRunner(runner);
+      stubSeams();
+      const dataDir = path.join(home, "vault-data");
+
+      const result = await runCli(["server", "up", "--data-dir", dataDir], {
+        home,
+        prompter: new FakePrompter({ answers: { "~/.librarian/env": "n" } }),
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(dockerRunArgs(runner)).toContain(`${dataDir}:/data`);
+      expect(dockerRunArgs(runner)?.at(-1)).toBe(REGISTRY_DIGEST);
+      expect(readDeployState(path.join(home, ".librarian", "server"))?.dataDir).toBe(dataDir);
+    });
+  });
+
+  it("a failed pull leaves no container, deploy state, or newly minted credential material", async () => {
+    await withTempHome(async (home) => {
+      const runner = new FakeRunner()
+        .withWhich("docker")
+        .onRun("docker", ["info"], { code: 0 })
+        .onRun("docker", ["info", "--format", "{{json .}}"], {
+          stdout: JSON.stringify({ OSType: "linux", Architecture: "amd64" }),
+          code: 0,
+        })
+        .onRun("docker", ["container", "inspect", "--format", "{{json .}}", "the-librarian"], {
+          stderr: "No such container: the-librarian",
+          code: 1,
+        });
+      setDockerRunner(runner);
+      setLatestFetcher(async () => LATEST);
+      let minted = 0;
+      setTokenMinter(() => {
+        minted += 1;
+        return AGENT_TOKEN;
+      });
+      setSecretKeyMinter(() => {
+        minted += 1;
+        return MASTER_KEY;
+      });
+      setStreamer({ stream: async () => 1 });
+
+      const result = await runCli(["server", "up"], {
+        home,
+        prompter: new FakePrompter({ answers: { "~/.librarian/env": "n" } }),
+      });
+      const deployDir = path.join(home, ".librarian", "server");
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/docker pull.*failed/i);
+      expect(minted).toBe(0);
+      expect(fs.existsSync(deployEnvFilePath(deployDir))).toBe(false);
+      expect(fs.existsSync(deployStatePath(deployDir))).toBe(false);
+      expect(readEnvFile(home)).toBeNull();
+      expect(runner.calls.some((call) => call.args[0] === "run")).toBe(false);
+      expect(runner.calls.some((call) => call.cmd === "git")).toBe(false);
+    });
+  });
+
+  it("rejects a malformed latest-release response without pulling or falling back", async () => {
+    await withTempHome(async (home) => {
+      const runner = new FakeRunner().withWhich("docker").onRun("docker", ["info"], { code: 0 });
+      setDockerRunner(runner);
+      setLatestFetcher(async () => "1.4.2-beta.1");
+      setTokenMinter(() => {
+        throw new Error("must not mint for an invalid latest release");
+      });
+
+      const result = await runCli(["server", "up"], {
+        home,
+        prompter: new FakePrompter({ answers: { "~/.librarian/env": "n" } }),
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/valid latest stable release tag/i);
+      expect(streamedPullArgs()).toBeUndefined();
+      expect(streamedBuildArgs()).toBeUndefined();
+      expect(runner.calls.some((call) => call.cmd === "git")).toBe(false);
+      expect(fs.existsSync(path.join(home, ".librarian", "server"))).toBe(false);
+    });
+  });
+
+  it("metadata or digest mismatch fails closed without source fallback or credentials", async () => {
+    await withTempHome(async (home) => {
+      const runner = healthyRegistryRunner().onRun(
+        "docker",
+        ["image", "inspect", "--format", "{{json .}}", REGISTRY_IMAGE_REF],
+        { stdout: registryInspectJson({ RepoDigests: [] }), code: 0 },
+      );
+      setDockerRunner(runner);
+      stubSeams();
+
+      const result = await runCli(["server", "up"], {
+        home,
+        prompter: new FakePrompter({ answers: { "~/.librarian/env": "n" } }),
+      });
+      const deployDir = path.join(home, ".librarian", "server");
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/canonical repository digest/i);
+      expect(runner.calls.some((call) => call.cmd === "git")).toBe(false);
+      expect(streamedBuildArgs()).toBeUndefined();
+      expect(fs.existsSync(deployEnvFilePath(deployDir))).toBe(false);
+      expect(fs.existsSync(deployStatePath(deployDir))).toBe(false);
+    });
+  });
+
+  it("a concurrent up refuses before touching the winner's staged credentials or deployment files", async () => {
+    await withTempHome(async (home) => {
+      const deployDir = path.join(home, ".librarian", "server");
+      const runner = healthyRegistryRunner();
+      const realRun = runner.run.bind(runner);
+      let createCalls = 0;
+      let releaseWinnerCreate!: () => void;
+      const winnerCreateHeld = new Promise<void>((resolve) => {
+        releaseWinnerCreate = resolve;
+      });
+      let markWinnerAtCreate!: () => void;
+      const winnerAtCreate = new Promise<void>((resolve) => {
+        markWinnerAtCreate = resolve;
+      });
+      runner.run = async (cmd, args, options) => {
+        if (cmd === "docker" && args[0] === "create") {
+          runner.calls.push({ cmd, args: [...args], opts: options });
+          createCalls += 1;
+          if (createCalls === 1) {
+            markWinnerAtCreate();
+            await winnerCreateHeld;
+            return { stdout: `${CANDIDATE_CONTAINER_ID}\n`, stderr: "", code: 0 };
+          }
+          return {
+            stdout: "",
+            stderr: "Conflict. The container name is already in use.",
+            code: 1,
+          };
+        }
+        return realRun(cmd, args, options);
+      };
+      setDockerRunner(runner);
+      setLatestFetcher(async () => LATEST);
+      const mintedTokens = ["winner-agent-token", "loser-agent-token"];
+      const stagedInvocationIds = ["winner-invocation", "loser-invocation"];
+      setTokenMinter(() => mintedTokens.shift() ?? "unexpected-third-token");
+      setStagedEnvIdMinter(() => stagedInvocationIds.shift() ?? "unexpected-third-invocation");
+      setSecretKeyMinter(() => MASTER_KEY);
+      setSleep(async () => undefined);
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
+
+      const winnerPromise = runCli(["server", "up"], { home, prompter });
+      await winnerAtCreate;
+      const winnerCreate = runner.calls.find(
+        (call) => call.cmd === "docker" && call.args[0] === "create",
+      );
+      const envFlag = winnerCreate?.args.indexOf("--env-file") ?? -1;
+      const winnerStagedEnv = winnerCreate?.args[envFlag + 1];
+      expect(winnerStagedEnv).toBeTruthy();
+      const winnerStagedBytes = fs.readFileSync(winnerStagedEnv!);
+
+      const loser = await runCli(["server", "up"], { home, prompter });
+      const stageFilesWhileWinnerHeld = fs
+        .readdirSync(deployDir)
+        .filter((name) => name.startsWith("deploy.env.next"));
+      const winnerStageStillExists = fs.existsSync(winnerStagedEnv!);
+      const winnerStageAfterLoser = winnerStageStillExists
+        ? fs.readFileSync(winnerStagedEnv!)
+        : Buffer.alloc(0);
+      const liveEnvExistsWhileWinnerHeld = fs.existsSync(deployEnvFilePath(deployDir));
+      const liveStateExistsWhileWinnerHeld = fs.existsSync(deployStatePath(deployDir));
+
+      releaseWinnerCreate();
+      const winner = await winnerPromise;
+
+      expect(loser.exitCode).toBe(1);
+      expect(loser.stderr).toMatch(/another.*(?:deployment|update).*in progress/i);
+      expect(createCalls).toBe(1);
+      expect(path.basename(winnerStagedEnv!)).toBe("deploy.env.next-winner-invocation");
+      expect(stagedInvocationIds).toEqual(["loser-invocation"]);
+      expect(stageFilesWhileWinnerHeld).toEqual([path.basename(winnerStagedEnv!)]);
+      expect(winnerStageStillExists).toBe(true);
+      expect(winnerStageAfterLoser).toEqual(winnerStagedBytes);
+      expect(liveEnvExistsWhileWinnerHeld).toBe(false);
+      expect(liveStateExistsWhileWinnerHeld).toBe(false);
+      expect(winner.exitCode).toBe(0);
+      expect(fs.readFileSync(deployEnvFilePath(deployDir), "utf8")).toContain(
+        "LIBRARIAN_AGENT_TOKEN=winner-agent-token",
+      );
+      expect(fs.readdirSync(deployDir).some((name) => name.startsWith("deploy.env.next"))).toBe(
+        false,
+      );
+      expect(fs.existsSync(path.join(deployDir, ".autoupdate.lock"))).toBe(false);
+    });
+  });
+
+  it("cleans up the immutable candidate after docker start fails and removes staged credentials", async () => {
+    await withTempHome(async (home) => {
+      const runner = healthyRegistryRunner();
+      const realRun = runner.run.bind(runner);
+      runner.run = async (cmd, args, options) => {
+        if (cmd === "docker" && args[0] === "start") {
+          runner.calls.push({ cmd, args: [...args], opts: options });
+          return { stdout: "", stderr: "daemon failed during start", code: 1 };
+        }
+        return realRun(cmd, args, options);
+      };
+      setDockerRunner(runner);
+      stubSeams();
+
+      const result = await runCli(["server", "up"], {
+        home,
+        prompter: new FakePrompter({ answers: { "~/.librarian/env": "n" } }),
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/docker start.*failed/i);
+      expect(runner.ran("docker", ["rm", "-f", CANDIDATE_CONTAINER_ID])).toBe(true);
+      expect(fs.existsSync(stagedDeployEnvOf(home))).toBe(false);
+      expect(fs.existsSync(deployEnvOf(home))).toBe(false);
+      expect(fs.existsSync(deployStatePath(path.join(home, ".librarian", "server")))).toBe(false);
+    });
+  });
+
+  it("never removes a same-name unrelated container that appears after candidate creation fails", async () => {
+    await withTempHome(async (home) => {
+      const runner = healthyRegistryRunner();
+      const realRun = runner.run.bind(runner);
+      let nameInspects = 0;
+      runner.run = async (cmd, args, options) => {
+        if (cmd === "docker" && args[0] === "container" && args.at(-1) === "the-librarian") {
+          runner.calls.push({ cmd, args: [...args], opts: options });
+          nameInspects += 1;
+          return nameInspects === 1
+            ? { stdout: "", stderr: "No such container: the-librarian", code: 1 }
+            : {
+                stdout: JSON.stringify({ Id: UNRELATED_CONTAINER_ID }),
+                stderr: "",
+                code: 0,
+              };
+        }
+        if (cmd === "docker" && (args[0] === "create" || args[0] === "run")) {
+          runner.calls.push({ cmd, args: [...args], opts: options });
+          return { stdout: "", stderr: "candidate creation failed", code: 1 };
+        }
+        return realRun(cmd, args, options);
+      };
+      setDockerRunner(runner);
+      stubSeams();
+
+      const result = await runCli(["server", "up"], {
+        home,
+        prompter: new FakePrompter({}),
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect(runner.calls.filter((call) => call.args[0] === "rm")).toEqual([]);
+      expect(fs.existsSync(stagedDeployEnvOf(home))).toBe(false);
+    });
+  });
+
+  it("health rollback targets only the immutable candidate ID after its name is reused", async () => {
+    await withTempHome(async (home) => {
+      const runner = healthyRegistryRunner();
+      const realRun = runner.run.bind(runner);
+      runner.run = async (cmd, args, options) => {
+        if (cmd === "docker" && args[0] === "create") {
+          runner.calls.push({ cmd, args: [...args], opts: options });
+          return { stdout: `${CANDIDATE_CONTAINER_ID}\n`, stderr: "", code: 0 };
+        }
+        if (cmd === "docker" && args[0] === "start") {
+          runner.calls.push({ cmd, args: [...args], opts: options });
+          return { stdout: `${CANDIDATE_CONTAINER_ID}\n`, stderr: "", code: 0 };
+        }
+        if (cmd === "docker" && args[0] === "run") {
+          runner.calls.push({ cmd, args: [...args], opts: options });
+          return { stdout: "legacy run succeeded", stderr: "", code: 0 };
+        }
+        if (cmd === "docker" && args[0] === "inspect") {
+          runner.calls.push({ cmd, args: [...args], opts: options });
+          return { stdout: "unhealthy\n", stderr: "", code: 0 };
+        }
+        if (cmd === "docker" && args[0] === "logs") {
+          runner.calls.push({ cmd, args: [...args], opts: options });
+          return { stdout: "candidate failed\n", stderr: "", code: 0 };
+        }
+        if (cmd === "docker" && args[0] === "rm") {
+          runner.calls.push({ cmd, args: [...args], opts: options });
+          return args.at(-1) === CANDIDATE_CONTAINER_ID
+            ? {
+                stdout: "",
+                stderr: `No such container: ${CANDIDATE_CONTAINER_ID}`,
+                code: 1,
+              }
+            : { stdout: UNRELATED_CONTAINER_ID, stderr: "", code: 0 };
+        }
+        return realRun(cmd, args, options);
+      };
+      setDockerRunner(runner);
+      stubSeams();
+
+      const result = await runCli(["server", "up"], {
+        home,
+        prompter: new FakePrompter({}),
+      });
+
+      expect(result.exitCode).toBe(1);
+      const removals = runner.calls.filter((call) => call.args[0] === "rm");
+      expect(removals).toHaveLength(1);
+      expect(removals[0]?.args.at(-1)).toBe(CANDIDATE_CONTAINER_ID);
+      expect(removals.some((call) => call.args.at(-1) === "the-librarian")).toBe(false);
+      expect(removals.some((call) => call.args.at(-1) === UNRELATED_CONTAINER_ID)).toBe(false);
+      const healthAndLogs = runner.calls.filter(
+        (call) => call.args[0] === "inspect" || call.args[0] === "logs",
+      );
+      expect(healthAndLogs).not.toHaveLength(0);
+      expect(healthAndLogs.every((call) => call.args.at(-1) === CANDIDATE_CONTAINER_ID)).toBe(true);
+    });
+  });
+
+  it("reports cleanup failure truthfully when both health rollback attempts fail", async () => {
+    await withTempHome(async (home) => {
+      const leaked = "fedcba9876543210".repeat(4);
+      const runner = healthyRegistryRunner()
+        .onRun(
+          "docker",
+          ["inspect", "--format", "{{.State.Health.Status}}", CANDIDATE_CONTAINER_ID],
+          { stdout: "unhealthy\n", code: 0 },
+        )
+        .onRun("docker", ["logs", "--tail", "50", CANDIDATE_CONTAINER_ID], {
+          stdout: "server failed\n",
+          code: 0,
+        })
+        .onRun("docker", ["rm", "-f", CANDIDATE_CONTAINER_ID], {
+          stderr: `permission denied ${leaked}`,
+          code: 1,
+        });
+      setDockerRunner(runner);
+      stubSeams();
+
+      const result = await runCli(["server", "up"], {
+        home,
+        prompter: new FakePrompter({ answers: { "~/.librarian/env": "n" } }),
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/could not remove|cleanup failed/i);
+      expect(result.stderr).toContain(`docker rm -f ${CANDIDATE_CONTAINER_ID}`);
+      expect(result.stderr).not.toContain(leaked);
+      expect(result.stderr).not.toMatch(/container removed|was rolled back/i);
+      expect(runner.calls.filter((call) => call.args[0] === "rm")).toHaveLength(2);
+      expect(fs.existsSync(stagedDeployEnvOf(home))).toBe(false);
+      expect(fs.existsSync(deployEnvOf(home))).toBe(false);
+    });
+  });
+
+  it("restores prior env/state bytes and removes the exact candidate when state promotion fails", async () => {
+    await withTempHome(async (home) => {
+      const deployDir = seedRegistryDeployment(home);
+      const priorEnv = fs.readFileSync(deployEnvFilePath(deployDir));
+      const priorState = fs.readFileSync(deployStatePath(deployDir));
+      const runner = healthyRegistryRunner();
+      setDockerRunner(runner);
+      stubSeams();
+      let promotions = 0;
+      setFinalizationRenamer((source, destination) => {
+        promotions += 1;
+        if (promotions === 2) throw new Error("injected state promotion failure");
+        fs.renameSync(source, destination);
+      });
+
+      const result = await runCli(["server", "up"], {
+        home,
+        prompter: new FakePrompter({}),
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/persist|finaliz|promotion/i);
+      expect(runner.ran("docker", ["rm", "-f", CANDIDATE_CONTAINER_ID])).toBe(true);
+      expect(fs.readFileSync(deployEnvFilePath(deployDir))).toEqual(priorEnv);
+      expect(fs.readFileSync(deployStatePath(deployDir))).toEqual(priorState);
+      expect(fs.existsSync(stagedDeployEnvOf(home))).toBe(false);
+      expect(fs.readdirSync(deployDir).some((name) => name.startsWith(".deploy-state-next-"))).toBe(
+        false,
+      );
+    });
+  });
+
+  it("restores file absence and removes the exact candidate when fresh state promotion fails", async () => {
+    await withTempHome(async (home) => {
+      const deployDir = path.join(home, ".librarian", "server");
+      const runner = healthyRegistryRunner();
+      setDockerRunner(runner);
+      stubSeams();
+      let promotions = 0;
+      setFinalizationRenamer((source, destination) => {
+        promotions += 1;
+        if (promotions === 2) throw new Error("injected fresh state promotion failure");
+        fs.renameSync(source, destination);
+      });
+
+      const result = await runCli(["server", "up"], {
+        home,
+        prompter: new FakePrompter({}),
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/persist|finaliz|promotion/i);
+      expect(runner.ran("docker", ["rm", "-f", CANDIDATE_CONTAINER_ID])).toBe(true);
+      expect(fs.existsSync(deployEnvFilePath(deployDir))).toBe(false);
+      expect(fs.existsSync(deployStatePath(deployDir))).toBe(false);
+      expect(fs.existsSync(stagedDeployEnvOf(home))).toBe(false);
+      expect(fs.readdirSync(deployDir).some((name) => name.startsWith(".deploy-state-next-"))).toBe(
+        false,
+      );
+    });
+  });
+
+  it("a healthy deployment already running the same registry digest is a clean no-op", async () => {
+    await withTempHome(async (home) => {
+      const deployDir = seedRegistryDeployment(home);
+      const beforeEnv = fs.readFileSync(deployEnvFilePath(deployDir), "utf8");
+      const beforeState = fs.readFileSync(deployStatePath(deployDir), "utf8");
+      const runner = healthyRegistryRunner().onRun(
+        "docker",
+        ["container", "inspect", "--format", "{{json .}}", "the-librarian"],
+        { stdout: JSON.stringify(liveRegistryContainer()), code: 0 },
+      );
+      setDockerRunner(runner);
+      let pulls = 0;
+      setStreamer({
+        stream: async () => {
+          pulls += 1;
+          throw new Error("registry unavailable");
+        },
+      });
+      setLatestFetcher(async () => LATEST);
+      setTokenMinter(() => {
+        throw new Error("must not mint on a no-op");
+      });
+      setSecretKeyMinter(() => {
+        throw new Error("must not mint on a no-op");
+      });
+
+      const result = await runCli(["server", "up"], {
+        home,
+        prompter: new FakePrompter({}),
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch(/already running.*healthy/i);
+      expect(pulls).toBe(0);
+      expect(dockerRunArgs(runner)).toBeUndefined();
+      expect(runner.ran("docker", ["rm", "-f", "the-librarian"])).toBe(false);
+      expect(fs.readFileSync(deployEnvFilePath(deployDir), "utf8")).toBe(beforeEnv);
+      expect(fs.readFileSync(deployStatePath(deployDir), "utf8")).toBe(beforeState);
+      expect(readEnvFile(home)).toBeNull();
+    });
+  });
+
+  it("does not mistake an unrelated Docker not-found error for an absent container", async () => {
+    await withTempHome(async (home) => {
+      const runner = healthyRegistryRunner().onRun(
+        "docker",
+        ["container", "inspect", "--format", "{{json .}}", "the-librarian"],
+        { stderr: "Docker context 'remote' not found", code: 1 },
+      );
+      setDockerRunner(runner);
+      stubSeams();
+
+      const result = await runCli(["server", "up"], {
+        home,
+        prompter: new FakePrompter({}),
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/could not inspect.*container/i);
+      expect(streamedPullArgs()).toBeUndefined();
+      expect(dockerRunArgs(runner)).toBeUndefined();
+    });
+  });
+
+  it.each([
+    ["a different value", "replacement-bootstrap-claim-secret-".repeat(2)],
+    ["explicit removal", ""],
+  ])(
+    "refuses a registry no-op when the invocation requests %s for the bootstrap claim secret",
+    async (_description, requestedSecret) => {
+      await withTempHome(async (home) => {
+        const existingSecret = "existing-bootstrap-claim-secret-".repeat(2);
+        const deployDir = seedRegistryDeployment(home);
+        writeDeployEnvFile(deployDir, {
+          agentToken: "existing-agent-token",
+          secretKey: "existing-master-key-long-enough-for-safe-reuse",
+          bootstrapClaimSecret: existingSecret,
+          host: "127.0.0.1",
+        });
+        const live = liveRegistryContainer();
+        live.Config.Env.push(`LIBRARIAN_BOOTSTRAP_CLAIM_SECRET=${existingSecret}`);
+        const beforeEnv = fs.readFileSync(deployEnvFilePath(deployDir));
+        const beforeState = fs.readFileSync(deployStatePath(deployDir));
+        const runner = healthyRegistryRunner().onRun(
+          "docker",
+          ["container", "inspect", "--format", "{{json .}}", "the-librarian"],
+          { stdout: JSON.stringify(live), code: 0 },
+        );
+        setDockerRunner(runner);
+        stubSeams();
+
+        const result = await runCli(["server", "up"], {
+          home,
+          env: { LIBRARIAN_BOOTSTRAP_CLAIM_SECRET: requestedSecret },
+          prompter: new FakePrompter({}),
+        });
+
+        expect(result.exitCode).toBe(1);
+        expect(result.stderr).toMatch(/existing.*container.*differs/i);
+        expect(streamedPullArgs()).toBeUndefined();
+        expect(runner.calls.some((call) => call.args[0] === "rm")).toBe(false);
+        expect(fs.readFileSync(deployEnvFilePath(deployDir))).toEqual(beforeEnv);
+        expect(fs.readFileSync(deployStatePath(deployDir))).toEqual(beforeState);
+      });
+    },
+  );
+
+  it.each([
+    [
+      "image digest",
+      (live: ReturnType<typeof liveRegistryContainer>) => (live.Config.Image += "x"),
+    ],
+    [
+      "mount source",
+      (live: ReturnType<typeof liveRegistryContainer>) => (live.Mounts[0]!.Name = "other"),
+    ],
+    [
+      "mount type",
+      (live: ReturnType<typeof liveRegistryContainer>) => (live.Mounts[0]!.Type = "bind"),
+    ],
+    [
+      "published host",
+      (live: ReturnType<typeof liveRegistryContainer>) =>
+        (live.HostConfig.PortBindings["3000/tcp"][0]!.HostIp = "0.0.0.0"),
+    ],
+    [
+      "published port",
+      (live: ReturnType<typeof liveRegistryContainer>) =>
+        (live.HostConfig.PortBindings["3000/tcp"][0]!.HostPort = "3001"),
+    ],
+    [
+      "restart policy",
+      (live: ReturnType<typeof liveRegistryContainer>) =>
+        (live.HostConfig.RestartPolicy.Name = "always"),
+    ],
+    [
+      "container user",
+      (live: ReturnType<typeof liveRegistryContainer>) => (live.Config.User = "root"),
+    ],
+    [
+      "auth environment",
+      (live: ReturnType<typeof liveRegistryContainer>) =>
+        live.Config.Env.splice(live.Config.Env.indexOf("LIBRARIAN_ALLOW_NO_AUTH=true"), 1),
+    ],
+  ])("refuses a live same-name container with drifted %s before mutation", async (_name, drift) => {
+    await withTempHome(async (home) => {
+      const deployDir = seedRegistryDeployment(home);
+      const beforeEnv = fs.readFileSync(deployEnvFilePath(deployDir), "utf8");
+      const beforeState = fs.readFileSync(deployStatePath(deployDir), "utf8");
+      const live = liveRegistryContainer();
+      drift(live);
+      const runner = healthyRegistryRunner().onRun(
+        "docker",
+        ["container", "inspect", "--format", "{{json .}}", "the-librarian"],
+        { stdout: JSON.stringify(live), code: 0 },
+      );
+      setDockerRunner(runner);
+      stubSeams();
+
+      const result = await runCli(["server", "up"], {
+        home,
+        prompter: new FakePrompter({}),
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/existing.*container.*differs|refusing to replace/i);
+      expect(streamedPullArgs()).toBeUndefined();
+      expect(dockerRunArgs(runner)).toBeUndefined();
+      expect(runner.ran("docker", ["rm", "-f", "the-librarian"])).toBe(false);
+      expect(fs.readFileSync(deployEnvFilePath(deployDir), "utf8")).toBe(beforeEnv);
+      expect(fs.readFileSync(deployStatePath(deployDir), "utf8")).toBe(beforeState);
+    });
   });
 });
 
@@ -1402,11 +2302,10 @@ describe("server up — progress feedback", () => {
       const joined = lines.join("\n");
       expect(joined).toContain("[1/5]");
       expect(joined).toContain("[2/5]");
-      expect(joined).toMatch(/\[3\/5\].*[Bb]uilding/);
+      expect(joined).toMatch(/\[3\/5\].*[Vv]erified/);
       expect(joined).toContain("[4/5]");
       expect(joined).toContain("[5/5]");
-      // The slow step is flagged with a time expectation, so the user knows the wait.
-      expect(joined).toMatch(/several minutes/i);
+      expect(joined).toMatch(/pulling and validating/i);
       expect(joined).toContain("✓ The server is healthy.");
     });
   });

--- a/packages/installer-cli/tests/server-up.test.ts
+++ b/packages/installer-cli/tests/server-up.test.ts
@@ -361,7 +361,7 @@ describe("server up — a failed docker step REDACTS secret-bearing output (S-2)
         host: "127.0.0.1",
         dataVolume: "librarian_data",
         dashboardPort: 3042,
-        tag: LATEST_TAG,
+        imageRef: `the-librarian:${LATEST_TAG}`,
         envFile: deployEnvOf(home),
       });
       runner.onRun("docker", runArgs, {
@@ -663,6 +663,8 @@ describe("server up — writes the NON-SECRET deploy-state (S4/S5 prerequisite)"
         dashboardPort: 3042,
         ref: LATEST_TAG,
         imageTag: `the-librarian:${LATEST_TAG}`,
+        imageSource: "source",
+        imageRef: `the-librarian:${LATEST_TAG}`,
       });
 
       // The state file carries NO secret: not the agent token, not the master key.
@@ -694,6 +696,8 @@ describe("server up — writes the NON-SECRET deploy-state (S4/S5 prerequisite)"
         dashboardPort: 3042,
         ref: "main",
         imageTag: "the-librarian:main",
+        imageSource: "source",
+        imageRef: "the-librarian:main",
       });
     });
   });
@@ -1159,7 +1163,7 @@ describe("buildRunArgs — the S3/P4 seam (secrets via --env-file, off argv)", (
       host: "127.0.0.1",
       dataVolume: "librarian_data",
       dashboardPort: 3042,
-      tag: "v1.0.0",
+      imageRef: "the-librarian:v1.0.0",
       envFile: "/tmp/deploy.env",
     });
     // Secrets + the no-auth flag are NOT on argv (they live in the env-file).
@@ -1177,7 +1181,7 @@ describe("buildRunArgs — the S3/P4 seam (secrets via --env-file, off argv)", (
       host: "100.1.2.3",
       dataVolume: "librarian_data",
       dashboardPort: 3042,
-      tag: "v1.0.0",
+      imageRef: "the-librarian:v1.0.0",
       envFile: "/tmp/deploy.env",
     });
     expect(args).toContain("100.1.2.3:3042:3000");
@@ -1191,7 +1195,7 @@ describe("buildRunArgs — the S3/P4 seam (secrets via --env-file, off argv)", (
       host: "127.0.0.1",
       dataVolume: "librarian_data",
       dashboardPort: 3500,
-      tag: "v1.0.0",
+      imageRef: "the-librarian:v1.0.0",
       envFile: "/tmp/deploy.env",
     });
     // Only the published (host) side moves; the container always listens on 3000.

--- a/packages/installer-cli/tests/server-up.test.ts
+++ b/packages/installer-cli/tests/server-up.test.ts
@@ -280,6 +280,7 @@ describe("server up — source localhost happy path (exact argv)", () => {
 
       const r = await runCli(["server", "up", "--ref", "main"], { home, prompter });
       expect(r.exitCode).toBe(0);
+      expect(r.stdout).toMatch(/up and healthy from source main/i);
 
       const deployDir = path.join(home, ".librarian", "server");
 
@@ -1645,6 +1646,7 @@ describe("server up — stable registry deployments (B2)", () => {
       const result = await runCli(["server", "up"], { home, prompter });
 
       expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch(/up and healthy from published v1\.4\.2 \(abababababab\)/i);
       expect(streamedPullArgs()).toEqual(["pull", REGISTRY_IMAGE_REF]);
       expect(streamedBuildArgs()).toBeUndefined();
       expect(runner.calls.some((call) => call.cmd === "git")).toBe(false);
@@ -2142,6 +2144,7 @@ describe("server up — stable registry deployments (B2)", () => {
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toMatch(/already running.*healthy/i);
+      expect(result.stdout).toMatch(/published v1\.4\.2 \(abababababab\)/i);
       expect(pulls).toBe(0);
       expect(dockerRunArgs(runner)).toBeUndefined();
       expect(runner.ran("docker", ["rm", "-f", "the-librarian"])).toBe(false);
@@ -2307,6 +2310,29 @@ describe("server up — progress feedback", () => {
       expect(joined).toContain("[5/5]");
       expect(joined).toMatch(/pulling and validating/i);
       expect(joined).toContain("✓ The server is healthy.");
+    });
+  });
+
+  it("names source selection, checkout and build phases for a development ref", async () => {
+    await withTempHome(async (home) => {
+      setDockerRunner(healthyRunner());
+      stubSeams();
+      const lines: string[] = [];
+
+      const result = await runUp(
+        { ref: "main" },
+        {
+          home,
+          prompter: new FakePrompter({ answers: { "~/.librarian/env": "n" } }),
+          interactive: false,
+          log: (line) => lines.push(line),
+        },
+      );
+
+      expect(result.output).toMatch(/up and healthy from source main/i);
+      expect(lines.join("\n")).toMatch(/\[1\/5\].*source ref main/i);
+      expect(lines.join("\n")).toMatch(/\[2\/5\].*source checkout/i);
+      expect(lines.join("\n")).toMatch(/\[3\/5\].*building.*source image/i);
     });
   });
 });

--- a/packages/installer-cli/tests/server-up.test.ts
+++ b/packages/installer-cli/tests/server-up.test.ts
@@ -735,6 +735,84 @@ describe("server up — the 0600 deploy env-file (ADR 0008 P4)", () => {
 });
 
 describe("server up — foreign deploy dir stops and asks (never clobbers)", () => {
+  it("accepts the canonical HTTPS origin with configured credentials without echoing them", async () => {
+    await withTempHome(async (home) => {
+      const deployDir = path.join(home, ".librarian", "server");
+      fs.mkdirSync(path.join(deployDir, ".git"), { recursive: true });
+      const username = ["runtime", "user"].join("-");
+      const password = ["runtime", "credential"].join("-");
+      const remote = `https://${username}:${password}@github.com/code-ministry-ltd/the-librarian.git`;
+      const runner = healthyRunner().onRun(
+        "git",
+        ["-C", deployDir, "remote", "get-url", "origin"],
+        { stdout: `${remote}\n`, code: 0 },
+      );
+      setDockerRunner(runner);
+      stubSeams();
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
+
+      const r = await runCli(["server", "up", "--ref", "main"], { home, prompter });
+
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).not.toContain(username);
+      expect(r.stdout).not.toContain(password);
+    });
+  });
+
+  it("rejects an insecure canonical-looking origin without leaking credentials", async () => {
+    await withTempHome(async (home) => {
+      const deployDir = path.join(home, ".librarian", "server");
+      fs.mkdirSync(path.join(deployDir, ".git"), { recursive: true });
+      const username = ["runtime", "user"].join("-");
+      const password = ["runtime", "credential"].join("-");
+      const remote = `http://${username}:${password}@github.com/code-ministry-ltd/the-librarian.git`;
+      const runner = healthyRunner().onRun(
+        "git",
+        ["-C", deployDir, "remote", "get-url", "origin"],
+        { stdout: `${remote}\n`, code: 0 },
+      );
+      setDockerRunner(runner);
+      stubSeams();
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
+
+      const r = await runCli(["server", "up", "--ref", "main"], { home, prompter });
+
+      expect(r.exitCode).toBe(1);
+      expect(r.stderr).toMatch(/different remote/i);
+      expect(r.stderr).not.toContain(username);
+      expect(r.stderr).not.toContain(password);
+      expect(r.stderr).not.toContain(remote);
+    });
+  });
+
+  it("redacts a credential-bearing remote from Git failure diagnostics", async () => {
+    await withTempHome(async (home) => {
+      const deployDir = path.join(home, ".librarian", "server");
+      fs.mkdirSync(path.join(deployDir, ".git"), { recursive: true });
+      const secret = ["runtime", "fetch", "credential"].join("-");
+      const remote = `https://worker:${secret}@github.com/code-ministry-ltd/the-librarian.git`;
+      const runner = healthyRunner()
+        .onRun("git", ["-C", deployDir, "remote", "get-url", "origin"], {
+          stdout: "git@github.com:code-ministry-ltd/the-librarian.git\n",
+          code: 0,
+        })
+        .onRun("git", ["-C", deployDir, "fetch", "--tags", "origin"], {
+          stderr: `fatal: authentication failed for ${remote}`,
+          code: 1,
+        });
+      setDockerRunner(runner);
+      stubSeams();
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
+
+      const r = await runCli(["server", "up", "--ref", "main"], { home, prompter });
+
+      expect(r.exitCode).toBe(1);
+      expect(r.stderr).toContain("[redacted-remote]");
+      expect(r.stderr).not.toContain(secret);
+      expect(r.stderr).not.toContain(remote);
+    });
+  });
+
   it("a git repo with a different remote halts before any clobbering git op", async () => {
     await withTempHome(async (home) => {
       const deployDir = path.join(home, ".librarian", "server");

--- a/packages/installer-cli/tests/server-update.test.ts
+++ b/packages/installer-cli/tests/server-update.test.ts
@@ -1,842 +1,1354 @@
-// S5 — `librarian server update`: re-pin forward, rebuild, recreate, migrate.
-//
-// Every test drives the public `runCli(["server", "update", …])` entry against
-// a fresh temp home, the injected `docker.ts` FakeRunner (so the EXACT git/docker
-// argv + ITS ORDER is asserted), a stubbed latest-release fetcher, a no-op
-// health-poll sleep, and a deterministic agent-token minter. No real daemon,
-// network, or git is ever touched.
-//
-// The load-bearing properties (success criterion 5 + spec §8/§11):
-//   - upgrade sequence: git fetch tags → checkout newest → docker build →
-//     stop → rm (container, NOT volume) → docker run (same host/volume) →
-//     health poll → `docker exec … migrate-data-dir`;
-//   - idempotent no-op: already at the resolved ref + healthy → no build/run/rm;
-//   - VOLUME SACRED: no `docker volume rm`, no `docker rm -v`, ever;
-//   - rollback: a failed health-wait force-removes the new container, errors,
-//     and does NOT advance deploy-state; surfaced logs are redacted;
-//   - agent-token: read back from the OLD container's env before removal and
-//     reused on recreate (clients keep working); never written to a file/log.
-//   - master-key (ADR 0008 P4): read back from the OLD container's env (it now
-//     rides there via `--env-file`) and reused on recreate — re-minting it would
-//     orphan every settings.json secret encrypted under it. When the old env is
-//     unreadable, the key is OMITTED from the new env-file so the server resolves
-//     it from /data/secret.key (env -> file -> generate) — never a destructive
-//     fresh mint. The key + token ride only in the 0600 deploy env-file.
-
 import fs from "node:fs";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { resetRunner } from "../src/exec.js";
 import { runCli } from "../src/runtime.js";
 import { readDeployState, writeDeployState } from "../src/server/deploy-state.js";
 import {
+  CANONICAL_IMAGE_NAME,
+  resetReleaseProvenanceResolver,
+  setReleaseProvenanceResolver,
+} from "../src/server/deployment-image.js";
+import {
   resetRunner as resetDockerRunner,
+  resetStreamer,
   setRunner as setDockerRunner,
+  setStreamer,
 } from "../src/server/docker.js";
 import {
+  buildCreateArgs,
   deployEnvFilePath,
+  resetFinalizationRenamer,
+  resetFinalizationRestorer,
   resetSecretKeyMinter,
-  resetSleep,
+  resetStagedEnvIdMinter,
   resetTokenMinter,
   setSecretKeyMinter,
-  setSleep,
+  setFinalizationRenamer,
+  setFinalizationRestorer,
+  setStagedEnvIdMinter,
   setTokenMinter,
+  stagedDeployEnvFilePath,
   writeDeployEnvFile,
 } from "../src/server/up.js";
+import {
+  resetUpdateSecretArtifactRemover,
+  setUpdateSecretArtifactRemover,
+} from "../src/server/update.js";
 import { resetLatestFetcher, setLatestFetcher } from "../src/status.js";
 import { FakeRunner, withTempHome } from "./helpers.js";
 
-const OLD_REF = "v1.4.2";
-const LATEST = "1.5.0"; // fetchLatestVersion returns the v-stripped version
-const LATEST_TAG = "v1.5.0";
-const EXISTING_AGENT_TOKEN = "agent-token-already-running-in-the-old-container";
-const FRESH_AGENT_TOKEN = "fresh-agent-token-minted-on-update";
-const EXISTING_MASTER_KEY = "master-key-already-running-in-the-old-container";
-const EXISTING_BOOTSTRAP_CLAIM_SECRET = "existing-bootstrap-claim-secret-".repeat(2);
-// If the CLI ever (wrongly) minted a fresh master key on update, this is what it
-// would be — tests assert it NEVER appears (re-minting orphans encrypted secrets).
-const FRESH_MASTER_KEY = "fresh-master-key-that-must-never-be-minted-on-update";
+const OLD_REF = "v1.20.1";
+const NEW_VERSION = "1.21.0";
+const NEW_REF = `v${NEW_VERSION}`;
+const OLD_HASH = "10".repeat(32);
+const NEW_HASH = "20".repeat(32);
+const OLD_DIGEST = `${CANONICAL_IMAGE_NAME}@sha256:${OLD_HASH}`;
+const NEW_DIGEST = `${CANONICAL_IMAGE_NAME}@sha256:${NEW_HASH}`;
+const OLD_IMAGE_ID = `sha256:${"30".repeat(32)}`;
+const REVISION = "40".repeat(20);
+const CANDIDATE_ID = "50".repeat(32);
+const RECOVERY_ID = "60".repeat(32);
+const SOURCE_COMMIT = "80".repeat(20);
+const SOURCE_TAG = `the-librarian:source-${SOURCE_COMMIT}`;
+const SOURCE_IMAGE_ID = `sha256:${"81".repeat(32)}`;
+const OLD_SOURCE_COMMIT = "82".repeat(20);
+const OLD_SOURCE_TAG = `the-librarian:source-${OLD_SOURCE_COMMIT}`;
+const OLD_SOURCE_IMAGE_ID = `sha256:${"83".repeat(32)}`;
+const INVOCATION = "update-test";
+const AGENT_TOKEN = "agent-token-already-running";
+const FRESH_TOKEN = "fresh-agent-token-for-update";
+const MASTER_KEY = "master-key-already-running";
+const BOOTSTRAP = "bootstrap-claim-secret-".repeat(2);
+
+interface LiveOptions {
+  imageId?: string;
+  configuredImage?: string;
+  healthy?: boolean;
+  host?: string;
+  dashboardPort?: number;
+  dataVolume?: string;
+  dataDir?: string;
+  user?: string;
+  restartPolicy?: string;
+  env?: string[];
+}
+
+interface StreamCall {
+  args: string[];
+  cwd?: string;
+}
+
+let streamCalls: StreamCall[];
+let streamExit: number | null;
+
+beforeEach(() => {
+  streamCalls = [];
+  streamExit = 0;
+  setStreamer({
+    stream: async (_cmd, args, _handlers, opts) => {
+      streamCalls.push({ args: [...args], cwd: opts?.cwd });
+      return streamExit;
+    },
+  });
+  setLatestFetcher(async () => NEW_VERSION);
+  setReleaseProvenanceResolver(async () => ({ revision: REVISION, imageDigest: NEW_DIGEST }));
+  setStagedEnvIdMinter(() => INVOCATION);
+  setTokenMinter(() => FRESH_TOKEN);
+  setSecretKeyMinter(() => "must-not-be-minted-by-update");
+});
 
 afterEach(() => {
   resetRunner();
   resetDockerRunner();
+  resetStreamer();
   resetLatestFetcher();
-  resetSleep();
+  resetReleaseProvenanceResolver();
+  resetStagedEnvIdMinter();
   resetTokenMinter();
   resetSecretKeyMinter();
+  resetFinalizationRenamer();
+  resetFinalizationRestorer();
+  resetUpdateSecretArtifactRemover();
 });
 
-/** The deploy env-file path under a temp home's default deploy dir. */
-function deployEnvOf(home: string): string {
-  return deployEnvFilePath(path.join(home, ".librarian", "server"));
-}
-
-/** The deploy dir under a temp home. */
-function deployDirOf(home: string): string {
+function deployDir(home: string): string {
   return path.join(home, ".librarian", "server");
 }
 
-/** Seed a deploy-state recording the (old) deployed ref + a managed clone. */
-function seedDeployState(home: string, ref = OLD_REF): string {
-  const dir = deployDirOf(home);
+function envFile(home: string): string {
+  return deployEnvFilePath(deployDir(home));
+}
+
+function stagedEnv(home: string): string {
+  return stagedDeployEnvFilePath(deployDir(home), INVOCATION);
+}
+
+function seedSource(home: string, ref = OLD_REF): void {
+  const dir = deployDir(home);
   fs.mkdirSync(path.join(dir, ".git"), { recursive: true });
   writeDeployState(dir, {
     containerName: "the-librarian",
     host: "127.0.0.1",
     dataVolume: "librarian_data",
+    dashboardPort: 3000,
     ref,
     imageTag: `the-librarian:${ref}`,
+    imageSource: "source",
+    imageRef: `the-librarian:${ref}`,
   });
-  return dir;
+  writeDeployEnvFile(dir, {
+    agentToken: AGENT_TOKEN,
+    secretKey: MASTER_KEY,
+    bootstrapClaimSecret: BOOTSTRAP,
+    host: "127.0.0.1",
+  });
 }
 
-/** The argv (after `docker`) of the `run -d …` call recorded by the runner. */
-function dockerRunArgs(runner: FakeRunner): string[] | undefined {
-  return runner.calls.find((c) => c.cmd === "docker" && c.args[0] === "run")?.args;
+function seedRegistry(home: string, ref = OLD_REF, digest = OLD_DIGEST): void {
+  const dir = deployDir(home);
+  fs.mkdirSync(dir, { recursive: true });
+  writeDeployState(dir, {
+    containerName: "the-librarian",
+    host: "127.0.0.1",
+    dataVolume: "librarian_data",
+    dashboardPort: 3042,
+    ref,
+    imageTag: `${CANONICAL_IMAGE_NAME}:${ref}`,
+    imageSource: "registry",
+    imageRef: `${CANONICAL_IMAGE_NAME}:${ref}`,
+    imageDigest: digest,
+  });
+  writeDeployEnvFile(dir, {
+    agentToken: AGENT_TOKEN,
+    secretKey: MASTER_KEY,
+    bootstrapClaimSecret: BOOTSTRAP,
+    host: "127.0.0.1",
+  });
 }
 
-/**
- * The ordered list of `<cmd> <verb>` for git/docker calls. For docker the verb
- * is `args[0]`; for git the verb is the first arg that isn't the `-C <dir>`
- * prefix (so `git -C <dir> fetch …` reads as `git fetch`).
- */
-function verbSequence(runner: FakeRunner): string[] {
-  return runner.calls
-    .filter((c) => c.cmd === "docker" || c.cmd === "git")
-    .map((c) => {
-      if (c.cmd === "git" && c.args[0] === "-C") return `git ${c.args[2]}`;
-      return `${c.cmd} ${c.args[0]}`;
+function seedResolvedSource(home: string, ref: string, imageTag: string): void {
+  const dir = deployDir(home);
+  fs.mkdirSync(path.join(dir, ".git"), { recursive: true });
+  writeDeployState(dir, {
+    containerName: "the-librarian",
+    host: "127.0.0.1",
+    dataVolume: "librarian_data",
+    dashboardPort: 3000,
+    ref,
+    imageTag,
+    imageSource: "source",
+    imageRef: imageTag,
+  });
+  writeDeployEnvFile(dir, {
+    agentToken: AGENT_TOKEN,
+    secretKey: MASTER_KEY,
+    bootstrapClaimSecret: BOOTSTRAP,
+    host: "127.0.0.1",
+  });
+}
+
+function liveJson(options: LiveOptions = {}): string {
+  const host = options.host ?? "127.0.0.1";
+  const dashboardPort = options.dashboardPort ?? 3000;
+  const dataDir = options.dataDir;
+  return JSON.stringify({
+    Id: "70".repeat(32),
+    Image: options.imageId ?? OLD_IMAGE_ID,
+    State: {
+      Status: "running",
+      Health: { Status: options.healthy === false ? "unhealthy" : "healthy" },
+    },
+    Config: {
+      Image: options.configuredImage ?? `the-librarian:${OLD_REF}`,
+      User: options.user ?? (dataDir ? "1001:1002" : "node"),
+      Env: options.env ?? [
+        `LIBRARIAN_AGENT_TOKEN=${AGENT_TOKEN}`,
+        `LIBRARIAN_SECRET_KEY=${MASTER_KEY}`,
+        `LIBRARIAN_BOOTSTRAP_CLAIM_SECRET=${BOOTSTRAP}`,
+        "LIBRARIAN_ALLOW_NO_AUTH=true",
+        "LIBRARIAN_DATA_DIR=/data",
+        "LIBRARIAN_HOST=0.0.0.0",
+        "LIBRARIAN_PORT=3838",
+        "PORT=3000",
+      ],
+    },
+    HostConfig: {
+      RestartPolicy: { Name: options.restartPolicy ?? "unless-stopped" },
+      PortBindings: {
+        "3000/tcp": [{ HostIp: host, HostPort: String(dashboardPort) }],
+        "3838/tcp": [{ HostIp: host, HostPort: "3838" }],
+      },
+    },
+    Mounts: dataDir
+      ? [{ Type: "bind", Source: dataDir, Destination: "/data" }]
+      : [
+          {
+            Type: "volume",
+            Name: options.dataVolume ?? "librarian_data",
+            Destination: "/data",
+          },
+        ],
+  });
+}
+
+function registryInspect(): string {
+  return JSON.stringify({
+    Os: "linux",
+    Architecture: "amd64",
+    Config: {
+      Labels: {
+        "org.opencontainers.image.source": "https://github.com/code-ministry-ltd/the-librarian",
+        "org.opencontainers.image.version": NEW_VERSION,
+        "org.opencontainers.image.revision": REVISION,
+      },
+    },
+    RepoTags: [`${CANONICAL_IMAGE_NAME}:${NEW_REF}`],
+    RepoDigests: [NEW_DIGEST],
+  });
+}
+
+function baseRunner(live = liveJson()): FakeRunner {
+  return new FakeRunner()
+    .withWhich("docker")
+    .withWhich("git")
+    .onRun("docker", ["info"], { code: 0 })
+    .onRun("docker", ["info", "--format", "{{json .}}"], {
+      stdout: JSON.stringify({ OSType: "linux", Architecture: "amd64" }),
+    })
+    .onRun("docker", ["container", "inspect", "--format", "{{json .}}", "the-librarian"], {
+      stdout: live,
+    })
+    .onRun(
+      "docker",
+      ["image", "inspect", "--format", "{{json .}}", `${CANONICAL_IMAGE_NAME}:${NEW_REF}`],
+      {
+        stdout: registryInspect(),
+      },
+    );
+}
+
+function replacementArgs(home: string, imageRef: string, options: LiveOptions = {}): string[] {
+  const args = buildCreateArgs({
+    host: options.host ?? "127.0.0.1",
+    dataVolume: options.dataVolume ?? "librarian_data",
+    dashboardPort: options.dashboardPort ?? 3000,
+    dataDir: options.dataDir,
+    runAsUser: options.user ?? (options.dataDir ? "1001:1002" : "node"),
+    restartPolicy: options.restartPolicy ?? "unless-stopped",
+    imageRef,
+    envFile: stagedEnv(home),
+  });
+  args.splice(1, 0, "--cidfile", `${stagedEnv(home)}.cid`);
+  return args;
+}
+
+function recoveryArgs(home: string, options: LiveOptions = {}): string[] {
+  const args = replacementArgs(home, OLD_IMAGE_ID, options);
+  args[args.indexOf("--env-file") + 1] = `${stagedEnv(home)}.previous`;
+  args[args.indexOf("--cidfile") + 1] = `${stagedEnv(home)}.previous.cid`;
+  return args;
+}
+
+const cidfileEnabled = new WeakSet<FakeRunner>();
+
+function enableCidfileWrites(runner: FakeRunner): void {
+  if (cidfileEnabled.has(runner)) return;
+  cidfileEnabled.add(runner);
+  const original = runner.run.bind(runner);
+  runner.run = async (cmd, args, opts) => {
+    const result = await original(cmd, args, opts);
+    const cidfileIndex = args.indexOf("--cidfile");
+    if (cmd !== "docker" || args[0] !== "create" || cidfileIndex < 0 || result.code !== 0) {
+      return result;
+    }
+    const id = result.stdout.trim();
+    if (/^[0-9a-f]{64}$/.test(id)) fs.writeFileSync(args[cidfileIndex + 1]!, `${id}\n`);
+    // Docker stdout is intentionally not an identity contract for the update.
+    return { ...result, stdout: "create acknowledged without an ID\n" };
+  };
+}
+
+function scriptSuccessfulReplacement(
+  runner: FakeRunner,
+  home: string,
+  imageRef: string,
+  options: LiveOptions = {},
+): FakeRunner {
+  enableCidfileWrites(runner);
+  const args = replacementArgs(home, imageRef, options);
+  return runner
+    .onRun("docker", args, { stdout: `${CANDIDATE_ID}\n` })
+    .onRun("docker", ["start", CANDIDATE_ID], { code: 0 })
+    .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", CANDIDATE_ID], {
+      stdout: "healthy\n",
     });
 }
 
-/** True iff the runner ever issued a volume-destroying op (rm -v / volume rm). */
-function ranVolumeDestructive(runner: FakeRunner): boolean {
+function scriptSource(runner: FakeRunner, checkout: string, ref: string): FakeRunner {
+  return runner
+    .onRun("git", ["-C", checkout, "remote", "get-url", "origin"], {
+      stdout: "https://github.com/code-ministry-ltd/the-librarian\n",
+    })
+    .onRun("git", ["-C", checkout, "fetch", "--tags", "origin"], { code: 0 })
+    .onRun(
+      "git",
+      [
+        "-C",
+        checkout,
+        "rev-parse",
+        "--verify",
+        "--end-of-options",
+        `refs/remotes/origin/${ref}^{commit}`,
+      ],
+      { stdout: `${SOURCE_COMMIT}\n` },
+    )
+    .onRun("git", ["-C", checkout, "checkout", SOURCE_COMMIT], { code: 0 })
+    .onRun("docker", ["image", "inspect", "--format", "{{.Id}}", SOURCE_TAG], {
+      stdout: `${SOURCE_IMAGE_ID}\n`,
+    });
+}
+
+function callIndex(runner: FakeRunner, verb: string): number {
+  return runner.calls.findIndex((call) => call.cmd === "docker" && call.args[0] === verb);
+}
+
+function destructiveVolumeCommand(runner: FakeRunner): boolean {
   return runner.calls.some(
-    (c) =>
-      c.cmd === "docker" &&
-      ((c.args[0] === "rm" && c.args.includes("-v")) ||
-        (c.args[0] === "volume" && c.args.includes("rm"))),
+    (call) =>
+      call.cmd === "docker" &&
+      ((call.args[0] === "rm" && call.args.includes("-v")) ||
+        (call.args[0] === "volume" && call.args.includes("rm"))),
   );
 }
 
-/**
- * A FakeRunner wired for a successful UPGRADE: docker + git on PATH, daemon up,
- * the OLD container reports its agent token via `docker inspect` env, and the
- * NEW container becomes healthy.
- */
-function upgradeRunner(): FakeRunner {
-  return (
-    new FakeRunner()
-      .withWhich("docker")
-      .withWhich("git")
-      .onRun("docker", ["info"], { code: 0 })
-      // Read the existing agent token + master key from the running container's
-      // env (ADR 0008 P4 puts the master key there via `--env-file`).
-      .onRun(
-        "docker",
-        ["inspect", "--format", "{{range .Config.Env}}{{println .}}{{end}}", "the-librarian"],
-        {
-          stdout:
-            `PATH=/usr/bin\nLIBRARIAN_AGENT_TOKEN=${EXISTING_AGENT_TOKEN}\n` +
-            `LIBRARIAN_SECRET_KEY=${EXISTING_MASTER_KEY}\nNODE_ENV=production\n`,
-          code: 0,
-        },
-      )
-      // The container is running (idempotency probe) ...
-      .onRun("docker", ["inspect", "--format", "{{.State.Status}}", "the-librarian"], {
-        stdout: "running\n",
-        code: 0,
-      })
-      // ... and (re)created healthy.
-      .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", "the-librarian"], {
-        stdout: "healthy\n",
-        code: 0,
-      })
-  );
-}
-
-/** Install the deterministic seams the update tests share. */
-function stubSeams(): void {
-  setLatestFetcher(async () => LATEST);
-  setTokenMinter(() => FRESH_AGENT_TOKEN);
-  // The master-key minter is wired so a test can PROVE update never calls it
-  // (re-minting orphans encrypted secrets). FRESH_MASTER_KEY must never surface.
-  setSecretKeyMinter(() => FRESH_MASTER_KEY);
-  setSleep(async () => undefined);
-}
-
-describe("server update — upgrade path argv sequence (SC 5)", () => {
-  it("fetch tags → checkout newest → build → stop → rm → run → health → migrate, in order", async () => {
+describe("server update — strategy and preparation", () => {
+  it("moves a source deployment to an exact published digest on a Docker-only host", async () => {
     await withTempHome(async (home) => {
-      const dir = seedDeployState(home);
-      const runner = upgradeRunner();
+      seedSource(home);
+      const runner = scriptSuccessfulReplacement(baseRunner(), home, NEW_DIGEST);
       setDockerRunner(runner);
-      stubSeams();
 
-      const r = await runCli(["server", "update"], { home });
-      expect(r.exitCode).toBe(0);
+      const result = await runCli(["server", "update", "--ref", NEW_REF], { home });
 
-      // Each step, with its exact argv.
-      expect(runner.ran("git", ["-C", dir, "fetch", "--tags", "origin"])).toBe(true);
-      // The ref is resolved on `rev-parse --end-of-options` (the injection guard
-      // `git checkout` does NOT honor, S-1); the resolved SHA is then checked out.
-      expect(
-        runner.ran("git", [
-          "-C",
-          dir,
-          "rev-parse",
-          "--verify",
-          "--end-of-options",
-          `${LATEST_TAG}^{commit}`,
-        ]),
-      ).toBe(true);
-      expect(
-        runner.ran("docker", [
-          "build",
-          "-f",
-          "docker/all-in-one.Dockerfile",
-          "-t",
-          `the-librarian:${LATEST_TAG}`,
-          ".",
-        ]),
-      ).toBe(true);
-      expect(runner.ran("docker", ["stop", "the-librarian"])).toBe(true);
-      // Container removed — NOT the volume (no `-v`).
-      expect(runner.ran("docker", ["rm", "the-librarian"])).toBe(true);
-      // Recreated with the SAME host + volume from deploy-state.
-      const runArgs = dockerRunArgs(runner);
-      expect(runArgs).toContain("127.0.0.1:3838:3838");
-      // Legacy state (no dashboardPort) recreates on the historical :3000.
-      expect(runArgs).toContain("127.0.0.1:3000:3000");
-      expect(runArgs).toContain("librarian_data:/data");
-      expect(runArgs?.[runArgs.length - 1]).toBe(`the-librarian:${LATEST_TAG}`);
-      // Migrations applied AFTER the new container is healthy.
-      expect(
-        runner.ran("docker", ["exec", "the-librarian", "the-librarian", "migrate-data-dir"]),
-      ).toBe(true);
+      expect(result.exitCode).toBe(0);
+      expect(runner.calls.some((call) => call.cmd === "git")).toBe(false);
+      expect(streamCalls[0]?.args).toEqual(["pull", `${CANONICAL_IMAGE_NAME}:${NEW_REF}`]);
+      expect(callIndex(runner, "image")).toBeLessThan(callIndex(runner, "stop"));
+      expect(runner.ran("docker", ["stop", "70".repeat(32)])).toBe(true);
+      expect(runner.ran("docker", ["rm", "70".repeat(32)])).toBe(true);
+      expect(readDeployState(deployDir(home))).toMatchObject({
+        imageSource: "registry",
+        ref: NEW_REF,
+        imageRef: `${CANONICAL_IMAGE_NAME}:${NEW_REF}`,
+        imageDigest: NEW_DIGEST,
+      });
+    });
+  });
 
-      // The relative ORDER of the load-bearing steps.
-      const seq = verbSequence(runner);
-      const idx = (needle: string): number => seq.indexOf(needle);
-      expect(idx("git fetch")).toBeGreaterThanOrEqual(0);
-      expect(idx("git fetch")).toBeLessThan(idx("git checkout"));
-      expect(idx("git checkout")).toBeLessThan(idx("docker build"));
-      expect(idx("docker build")).toBeLessThan(idx("docker stop"));
-      expect(idx("docker stop")).toBeLessThan(idx("docker rm"));
-      expect(idx("docker rm")).toBeLessThan(idx("docker run"));
-      // The migrate exec is the last docker verb of the flow.
-      expect(idx("docker run")).toBeLessThan(idx("docker exec"));
+  it("updates a published deployment to a newer published digest", async () => {
+    await withTempHome(async (home) => {
+      seedRegistry(home);
+      const live = liveJson({ configuredImage: OLD_DIGEST, dashboardPort: 3042 });
+      const runner = scriptSuccessfulReplacement(baseRunner(live), home, NEW_DIGEST, {
+        dashboardPort: 3042,
+      });
+      setDockerRunner(runner);
 
-      // deploy-state advanced to the new ref (host/volume unchanged). The legacy
-      // seed had no dashboardPort, so the update BACKFILLS it to the historical
-      // 3000 — an existing server keeps its port (no silent jump to 3042).
-      expect(readDeployState(dir)).toEqual({
-        containerName: "the-librarian",
-        host: "127.0.0.1",
-        dataVolume: "librarian_data",
-        dashboardPort: 3000,
-        ref: LATEST_TAG,
-        imageTag: `the-librarian:${LATEST_TAG}`,
+      const result = await runCli(["server", "update"], { home });
+      expect(result.exitCode).toBe(0);
+      expect(readDeployState(deployDir(home))?.imageDigest).toBe(NEW_DIGEST);
+    });
+  });
+
+  it("creates a managed checkout when a published deployment switches to main", async () => {
+    await withTempHome(async (home) => {
+      seedRegistry(home);
+      const checkout = path.join(deployDir(home), "source");
+      const live = liveJson({ configuredImage: OLD_DIGEST, dashboardPort: 3042 });
+      let runner = baseRunner(live).onRun(
+        "git",
+        ["clone", "https://github.com/code-ministry-ltd/the-librarian", checkout],
+        { code: 0 },
+      );
+      runner = scriptSource(runner, checkout, "main");
+      runner = scriptSuccessfulReplacement(runner, home, SOURCE_IMAGE_ID, {
+        dashboardPort: 3042,
+      });
+      setDockerRunner(runner);
+
+      const result = await runCli(["server", "update", "--ref", "main"], { home });
+      expect(result.exitCode).toBe(0);
+      expect(streamCalls[0]).toMatchObject({
+        args: expect.arrayContaining(["build"]),
+        cwd: checkout,
+      });
+      expect(readDeployState(deployDir(home))).toMatchObject({
         imageSource: "source",
-        imageRef: `the-librarian:${LATEST_TAG}`,
-      });
-    });
-  });
-
-  it("reuses a persisted custom dashboard port across the update (survives autoupdate)", async () => {
-    await withTempHome(async (home) => {
-      const dir = deployDirOf(home);
-      fs.mkdirSync(path.join(dir, ".git"), { recursive: true });
-      // An operator who ran `up --dashboard-port 3500` — the port is in deploy-state.
-      writeDeployState(dir, {
-        containerName: "the-librarian",
-        host: "127.0.0.1",
-        dataVolume: "librarian_data",
-        dashboardPort: 3500,
-        ref: OLD_REF,
-        imageTag: `the-librarian:${OLD_REF}`,
-      });
-      const runner = upgradeRunner();
-      setDockerRunner(runner);
-      stubSeams();
-
-      const r = await runCli(["server", "update"], { home });
-      expect(r.exitCode).toBe(0);
-
-      // Recreated on the SAME published port — not the fresh-install default.
-      const runArgs = dockerRunArgs(runner) ?? [];
-      expect(runArgs).toContain("127.0.0.1:3500:3000");
-      expect(runArgs).not.toContain("127.0.0.1:3042:3000");
-      // ...and carried forward in deploy-state for the next update.
-      expect(readDeployState(dir)?.dashboardPort).toBe(3500);
-    });
-  });
-
-  it("reuses the existing agent token via the env-file (clients keep working); never on argv", async () => {
-    await withTempHome(async (home) => {
-      seedDeployState(home);
-      const runner = upgradeRunner();
-      setDockerRunner(runner);
-      stubSeams();
-
-      const r = await runCli(["server", "update"], { home });
-      expect(r.exitCode).toBe(0);
-
-      // ADR 0008 P4: the recreate delivers secrets via `--env-file`, NOT inline -e.
-      const runArgs = dockerRunArgs(runner) ?? [];
-      expect(runArgs).toContain("--env-file");
-      expect(runArgs).not.toContain("-e");
-      expect(runArgs.some((a) => a.includes(EXISTING_AGENT_TOKEN))).toBe(false);
-
-      // The env-file carries the EXISTING token (reused), not a freshly minted one.
-      const envBody = fs.readFileSync(deployEnvOf(home), "utf8");
-      expect(envBody).toContain(`LIBRARIAN_AGENT_TOKEN=${EXISTING_AGENT_TOKEN}`);
-      expect(envBody).not.toContain(FRESH_AGENT_TOKEN);
-
-      // The token was inspected from the old container BEFORE it was removed.
-      const inspectIdx = runner.calls.findIndex(
-        (c) =>
-          c.cmd === "docker" &&
-          c.args[0] === "inspect" &&
-          c.args.includes("{{range .Config.Env}}{{println .}}{{end}}"),
-      );
-      const rmIdx = runner.calls.findIndex((c) => c.cmd === "docker" && c.args[0] === "rm");
-      expect(inspectIdx).toBeGreaterThanOrEqual(0);
-      expect(rmIdx).toBeGreaterThan(inspectIdx);
-
-      // The token NEVER appears in the surfaced output, and lands in NO file other
-      // than the 0600 deploy env-file.
-      expect(r.stdout).not.toContain(EXISTING_AGENT_TOKEN);
-      expect(filesContaining(home, EXISTING_AGENT_TOKEN)).toEqual([deployEnvOf(home)]);
-    });
-  });
-
-  it("PRESERVES the existing master key on recreate — never re-mints it (would orphan encrypted secrets)", async () => {
-    await withTempHome(async (home) => {
-      seedDeployState(home);
-      const runner = upgradeRunner();
-      setDockerRunner(runner);
-      stubSeams();
-
-      const r = await runCli(["server", "update"], { home });
-      expect(r.exitCode).toBe(0);
-
-      // The env-file carries the EXISTING master key read back from the old
-      // container's env — NOT a freshly minted one (re-minting orphans every
-      // settings.json secret encrypted under the old key).
-      const envBody = fs.readFileSync(deployEnvOf(home), "utf8");
-      expect(envBody).toContain(`LIBRARIAN_SECRET_KEY=${EXISTING_MASTER_KEY}`);
-      expect(envBody).not.toContain(FRESH_MASTER_KEY);
-
-      // The master key is off argv, off stdout, and in NO file but the env-file.
-      const runArgs = dockerRunArgs(runner) ?? [];
-      expect(runArgs.some((a) => a.includes(EXISTING_MASTER_KEY))).toBe(false);
-      expect(r.stdout).not.toContain(EXISTING_MASTER_KEY);
-      expect(r.stdout).not.toContain(FRESH_MASTER_KEY);
-      expect(filesContaining(home, EXISTING_MASTER_KEY)).toEqual([deployEnvOf(home)]);
-      expect(filesContaining(home, FRESH_MASTER_KEY)).toEqual([]);
-    });
-  });
-
-  it("preserves an armed bootstrap claim secret across container recreation", async () => {
-    await withTempHome(async (home) => {
-      seedDeployState(home);
-      const runner = upgradeRunner().onRun(
-        "docker",
-        ["inspect", "--format", "{{range .Config.Env}}{{println .}}{{end}}", "the-librarian"],
-        {
-          stdout:
-            `LIBRARIAN_AGENT_TOKEN=${EXISTING_AGENT_TOKEN}\n` +
-            `LIBRARIAN_SECRET_KEY=${EXISTING_MASTER_KEY}\n` +
-            `LIBRARIAN_BOOTSTRAP_CLAIM_SECRET=${EXISTING_BOOTSTRAP_CLAIM_SECRET}\n`,
-          code: 0,
-        },
-      );
-      setDockerRunner(runner);
-      stubSeams();
-
-      const r = await runCli(["server", "update"], { home });
-
-      expect(r.exitCode).toBe(0);
-      expect(fs.readFileSync(deployEnvOf(home), "utf8")).toContain(
-        `LIBRARIAN_BOOTSTRAP_CLAIM_SECRET=${EXISTING_BOOTSTRAP_CLAIM_SECRET}`,
-      );
-      expect(
-        dockerRunArgs(runner)?.some((arg) => arg.includes(EXISTING_BOOTSTRAP_CLAIM_SECRET)),
-      ).toBe(false);
-      expect(r.stdout).not.toContain(EXISTING_BOOTSTRAP_CLAIM_SECRET);
-      expect(r.stderr).not.toContain(EXISTING_BOOTSTRAP_CLAIM_SECRET);
-    });
-  });
-
-  it("preserves the protected deploy-file claim secret when the old container is unreadable", async () => {
-    await withTempHome(async (home) => {
-      const deployDir = seedDeployState(home);
-      writeDeployEnvFile(deployDir, {
-        agentToken: EXISTING_AGENT_TOKEN,
-        secretKey: EXISTING_MASTER_KEY,
-        bootstrapClaimSecret: EXISTING_BOOTSTRAP_CLAIM_SECRET,
-        host: "127.0.0.1",
-      });
-      const runner = upgradeRunner().onRun(
-        "docker",
-        ["inspect", "--format", "{{range .Config.Env}}{{println .}}{{end}}", "the-librarian"],
-        { stderr: "No such container", code: 1 },
-      );
-      setDockerRunner(runner);
-      stubSeams();
-
-      const r = await runCli(["server", "update"], { home });
-
-      expect(r.exitCode).toBe(0);
-      expect(fs.readFileSync(deployEnvOf(home), "utf8")).toContain(
-        `LIBRARIAN_BOOTSTRAP_CLAIM_SECRET=${EXISTING_BOOTSTRAP_CLAIM_SECRET}`,
-      );
-    });
-  });
-
-  it("OMITS LIBRARIAN_SECRET_KEY when the old env has no key (let the server resolve /data/secret.key — never re-mint)", async () => {
-    await withTempHome(async (home) => {
-      seedDeployState(home);
-      // A PRE-P4 container: its env carries the agent token but NO master key
-      // (the key lived on /data/secret.key). The update must NOT mint a fresh
-      // key — it must omit LIBRARIAN_SECRET_KEY so the server resolves the key
-      // from the data volume (env -> file -> generate), preserving secrets.
-      const runner = upgradeRunner().onRun(
-        "docker",
-        ["inspect", "--format", "{{range .Config.Env}}{{println .}}{{end}}", "the-librarian"],
-        { stdout: `PATH=/usr/bin\nLIBRARIAN_AGENT_TOKEN=${EXISTING_AGENT_TOKEN}\n`, code: 0 },
-      );
-      setDockerRunner(runner);
-      stubSeams();
-
-      const r = await runCli(["server", "update"], { home });
-      expect(r.exitCode).toBe(0);
-
-      const envBody = fs.readFileSync(deployEnvOf(home), "utf8");
-      // The token is preserved; the key is OMITTED (no env line at all) and a
-      // fresh key is NEVER minted.
-      expect(envBody).toContain(`LIBRARIAN_AGENT_TOKEN=${EXISTING_AGENT_TOKEN}`);
-      expect(envBody).not.toContain("LIBRARIAN_SECRET_KEY=");
-      expect(envBody).not.toContain(FRESH_MASTER_KEY);
-      expect(filesContaining(home, FRESH_MASTER_KEY)).toEqual([]);
-    });
-  });
-});
-
-describe("server update — reuses a bind-mounted data dir (run as its owner)", () => {
-  it("recreates with the host data dir at /data and --user <owner> from deploy-state", async () => {
-    await withTempHome(async (home) => {
-      const dir = deployDirOf(home);
-      fs.mkdirSync(path.join(dir, ".git"), { recursive: true });
-      const dataDir = path.join(home, "vault");
-      fs.mkdirSync(dataDir, { recursive: true });
-      // A deploy that chose a host data dir (rather than the named volume).
-      writeDeployState(dir, {
-        containerName: "the-librarian",
-        host: "127.0.0.1",
-        dataVolume: "librarian_data",
-        dataDir,
-        ref: OLD_REF,
-        imageTag: `the-librarian:${OLD_REF}`,
-      });
-      const runner = upgradeRunner();
-      setDockerRunner(runner);
-      stubSeams();
-
-      const r = await runCli(["server", "update"], { home });
-      expect(r.exitCode).toBe(0);
-
-      const runArgs = dockerRunArgs(runner) ?? [];
-      // Reuse the SAME bind-mount — never silently fall back to the named volume.
-      expect(runArgs).toContain(`${dataDir}:/data`);
-      expect(runArgs).not.toContain("librarian_data:/data");
-      // Recreate runs as the directory's owner so the vault stays operator-writable.
-      const owner = `${process.getuid?.()}:${process.getgid?.()}`;
-      const u = runArgs.indexOf("--user");
-      expect(u).toBeGreaterThan(-1);
-      expect(runArgs[u + 1]).toBe(owner);
-      // The data dir survives in deploy-state across the update.
-      expect(readDeployState(dir)?.dataDir).toBe(dataDir);
-      // The data is sacred either way — no volume-destructive op ran.
-      expect(ranVolumeDestructive(runner)).toBe(false);
-    });
-  });
-});
-
-describe("server update — --ref reflected in checkout + build tag", () => {
-  it("--ref main checks out + builds main", async () => {
-    await withTempHome(async (home) => {
-      const dir = seedDeployState(home);
-      const runner = upgradeRunner();
-      setDockerRunner(runner);
-      stubSeams();
-
-      const r = await runCli(["server", "update", "--ref", "main"], { home });
-      expect(r.exitCode).toBe(0);
-
-      expect(
-        runner.ran("git", [
-          "-C",
-          dir,
-          "rev-parse",
-          "--verify",
-          "--end-of-options",
-          "main^{commit}",
-        ]),
-      ).toBe(true);
-      expect(
-        runner.ran("docker", [
-          "build",
-          "-f",
-          "docker/all-in-one.Dockerfile",
-          "-t",
-          "the-librarian:main",
-          ".",
-        ]),
-      ).toBe(true);
-      const runArgs = dockerRunArgs(runner);
-      expect(runArgs?.[runArgs.length - 1]).toBe("the-librarian:main");
-      expect(readDeployState(dir)).toMatchObject({
         ref: "main",
-        imageTag: "the-librarian:main",
-        imageSource: "source",
-        imageRef: "the-librarian:main",
+        imageRef: SOURCE_TAG,
       });
     });
   });
 
-  it("preserves explicit source provenance while advancing the local image ref", async () => {
+  it("keeps an existing source checkout for source updates", async () => {
     await withTempHome(async (home) => {
-      const dir = seedDeployState(home);
+      seedSource(home);
+      const checkout = deployDir(home);
+      let runner = scriptSource(baseRunner(), checkout, "main");
+      runner = scriptSuccessfulReplacement(runner, home, SOURCE_IMAGE_ID);
+      setDockerRunner(runner);
+
+      expect((await runCli(["server", "update", "--ref", "main"], { home })).exitCode).toBe(0);
+      expect(streamCalls[0]?.cwd).toBe(checkout);
+    });
+  });
+
+  it("fetches main before no-op so an advanced remote commit is deployed", async () => {
+    await withTempHome(async (home) => {
+      seedResolvedSource(home, "main", OLD_SOURCE_TAG);
+      const checkout = deployDir(home);
+      const live = liveJson({
+        imageId: OLD_SOURCE_IMAGE_ID,
+        configuredImage: OLD_SOURCE_IMAGE_ID,
+      });
+      let runner = scriptSource(baseRunner(live), checkout, "main");
+      runner = scriptSuccessfulReplacement(runner, home, SOURCE_IMAGE_ID);
+      setDockerRunner(runner);
+
+      const result = await runCli(["server", "update", "--ref", "main"], { home });
+      expect(result.exitCode).toBe(0);
+      expect(streamCalls[0]?.args).toContain(SOURCE_TAG);
+      expect(readDeployState(checkout)).toMatchObject({ ref: "main", imageRef: SOURCE_TAG });
+    });
+  });
+
+  it("an unchanged resolved source commit and immutable image is a clean no-op", async () => {
+    await withTempHome(async (home) => {
+      seedResolvedSource(home, "main", SOURCE_TAG);
+      const checkout = deployDir(home);
+      const live = liveJson({ imageId: SOURCE_IMAGE_ID, configuredImage: SOURCE_IMAGE_ID });
+      const runner = scriptSource(baseRunner(live), checkout, "main");
+      setDockerRunner(runner);
+
+      const result = await runCli(["server", "update", "--ref", "main"], { home });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch(/already up to date/i);
+      expect(streamCalls).toEqual([]);
+      expect(callIndex(runner, "stop")).toBe(-1);
+    });
+  });
+
+  it("builds a slash branch with a commit-derived tag and runs the inspected image ID", async () => {
+    await withTempHome(async (home) => {
+      seedSource(home);
+      const checkout = deployDir(home);
+      let runner = scriptSource(baseRunner(), checkout, "feature/pull-images");
+      runner = scriptSuccessfulReplacement(runner, home, SOURCE_IMAGE_ID);
+      setDockerRunner(runner);
+
+      const result = await runCli(["server", "update", "--ref", "feature/pull-images"], { home });
+      expect(result.exitCode).toBe(0);
+      expect(streamCalls[0]?.args).toContain(SOURCE_TAG);
+      expect(streamCalls[0]?.args.join(" ")).not.toContain("the-librarian:feature/pull-images");
+      const create = runner.calls.find((call) => call.args[0] === "create")?.args;
+      expect(create?.at(-1)).toBe(SOURCE_IMAGE_ID);
+      expect(create).not.toContain(SOURCE_TAG);
+    });
+  });
+
+  it("accepts literal git ref punctuation without treating it as revision syntax", async () => {
+    await withTempHome(async (home) => {
+      seedSource(home);
+      const ref = "release+candidate";
+      let runner = scriptSource(baseRunner(), deployDir(home), ref);
+      runner = scriptSuccessfulReplacement(runner, home, SOURCE_IMAGE_ID);
+      setDockerRunner(runner);
+
+      const result = await runCli(["server", "update", "--ref", ref], { home });
+
+      expect(result.exitCode).toBe(0);
+      expect(streamCalls[0]?.args).toContain(SOURCE_TAG);
+    });
+  });
+
+  it("runs the inspected source image ID rather than the mutable build tag", async () => {
+    await withTempHome(async (home) => {
+      seedSource(home);
+      let runner = scriptSource(baseRunner(), deployDir(home), "main");
+      runner = scriptSuccessfulReplacement(runner, home, SOURCE_IMAGE_ID);
+      setDockerRunner(runner);
+
+      expect((await runCli(["server", "update", "--ref", "main"], { home })).exitCode).toBe(0);
+      const create = runner.calls.find((call) => call.args[0] === "create")?.args;
+      expect(create?.at(-1)).toBe(SOURCE_IMAGE_ID);
+      expect(create).not.toContain(SOURCE_TAG);
+    });
+  });
+
+  it("a failed pull leaves the serving container, deploy files, and state untouched", async () => {
+    await withTempHome(async (home) => {
+      seedSource(home);
+      const beforeEnv = fs.readFileSync(envFile(home));
+      const beforeState = fs.readFileSync(path.join(deployDir(home), "deploy-state.json"));
+      streamExit = 1;
+      const runner = baseRunner();
+      setDockerRunner(runner);
+
+      const result = await runCli(["server", "update", "--ref", NEW_REF], { home });
+      expect(result.exitCode).toBe(1);
+      expect(callIndex(runner, "stop")).toBe(-1);
+      expect(fs.readFileSync(envFile(home))).toEqual(beforeEnv);
+      expect(fs.readFileSync(path.join(deployDir(home), "deploy-state.json"))).toEqual(beforeState);
+    });
+  });
+
+  it("a provenance mismatch leaves the old service serving without source fallback", async () => {
+    await withTempHome(async (home) => {
+      seedSource(home);
+      setReleaseProvenanceResolver(async () => ({
+        revision: REVISION,
+        imageDigest: `${CANONICAL_IMAGE_NAME}@sha256:${"99".repeat(32)}`,
+      }));
+      const runner = baseRunner();
+      setDockerRunner(runner);
+
+      const result = await runCli(["server", "update", "--ref", NEW_REF], { home });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/receipt|digest/i);
+      expect(callIndex(runner, "stop")).toBe(-1);
+      expect(runner.calls.some((call) => call.cmd === "git")).toBe(false);
+    });
+  });
+
+  it("a failed source build leaves the old service serving", async () => {
+    await withTempHome(async (home) => {
+      seedSource(home);
+      streamExit = 7;
+      const runner = scriptSource(baseRunner(), deployDir(home), "main");
+      setDockerRunner(runner);
+
+      const result = await runCli(["server", "update", "--ref", "main"], { home });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("still serving");
+      expect(callIndex(runner, "stop")).toBe(-1);
+    });
+  });
+
+  it.each([
+    ["tracked", " M packages/core/src/index.ts\n"],
+    ["untracked", "?? local-notes.txt\n"],
+  ])(
+    "refuses a source update with %s checkout changes before build or stop",
+    async (_kind, status) => {
+      await withTempHome(async (home) => {
+        seedSource(home);
+        const checkout = deployDir(home);
+        const beforeEnv = fs.readFileSync(envFile(home));
+        const stateFile = path.join(checkout, "deploy-state.json");
+        const beforeState = fs.readFileSync(stateFile);
+        const runner = scriptSource(baseRunner(), checkout, "main").onRun(
+          "git",
+          ["-C", checkout, "status", "--porcelain", "--untracked-files=all"],
+          { stdout: status },
+        );
+        setDockerRunner(runner);
+
+        const result = await runCli(["server", "update", "--ref", "main"], { home });
+
+        expect(result.exitCode).toBe(1);
+        expect(result.stderr).toMatch(/local tracked or untracked changes/i);
+        expect(streamCalls).toEqual([]);
+        expect(callIndex(runner, "stop")).toBe(-1);
+        expect(fs.readFileSync(envFile(home))).toEqual(beforeEnv);
+        expect(fs.readFileSync(stateFile)).toEqual(beforeState);
+      });
+    },
+  );
+
+  it("ignores only the untracked CLI-owned files in a legacy root checkout", async () => {
+    await withTempHome(async (home) => {
+      seedSource(home);
+      const checkout = deployDir(home);
+      let runner = scriptSource(baseRunner(), checkout, "main").onRun(
+        "git",
+        ["-C", checkout, "status", "--porcelain", "--untracked-files=all"],
+        {
+          stdout: "?? deploy.env\n?? deploy-state.json\n?? .autoupdate.lock\n",
+        },
+      );
+      runner = scriptSuccessfulReplacement(runner, home, SOURCE_IMAGE_ID);
+      setDockerRunner(runner);
+
+      const result = await runCli(["server", "update", "--ref", "main"], { home });
+
+      expect(result.exitCode).toBe(0);
+      expect(streamCalls[0]?.cwd).toBe(checkout);
+      expect(runner.ran("docker", ["stop", "70".repeat(32)])).toBe(true);
+    });
+  });
+
+  it("does not echo a credential-bearing unexpected git remote", async () => {
+    await withTempHome(async (home) => {
+      seedSource(home);
+      const username = ["runtime", "user"].join("-");
+      const password = ["runtime", "credential"].join("-");
+      const remote = `https://${username}:${password}@github.com/other-owner/other-repository.git?access=${password}`;
+      const runner = baseRunner().onRun(
+        "git",
+        ["-C", deployDir(home), "remote", "get-url", "origin"],
+        { stdout: `${remote}\n` },
+      );
+      setDockerRunner(runner);
+
+      const result = await runCli(["server", "update", "--ref", "main"], { home });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/unexpected origin/i);
+      expect(result.stderr).not.toContain(username);
+      expect(result.stderr).not.toContain(password);
+      expect(result.stderr).not.toContain(remote);
+    });
+  });
+
+  it("accepts the canonical git remote when HTTPS credentials are configured", async () => {
+    await withTempHome(async (home) => {
+      seedSource(home);
+      const username = ["runtime", "user"].join("-");
+      const password = ["runtime", "credential"].join("-");
+      const remote = `https://${username}:${password}@github.com/code-ministry-ltd/the-librarian.git`;
+      const checkout = deployDir(home);
+      let runner = scriptSource(baseRunner(), checkout, "main").onRun(
+        "git",
+        ["-C", checkout, "remote", "get-url", "origin"],
+        { stdout: `${remote}\n` },
+      );
+      runner = scriptSuccessfulReplacement(runner, home, SOURCE_IMAGE_ID);
+      setDockerRunner(runner);
+
+      const result = await runCli(["server", "update", "--ref", "main"], { home });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).not.toContain(username);
+      expect(result.stdout).not.toContain(password);
+    });
+  });
+
+  it("sanitizes credential-bearing git diagnostics", async () => {
+    await withTempHome(async (home) => {
+      seedSource(home);
+      const credential = ["runtime", "fetch", "credential"].join("-");
+      const leaked = `https://worker:${credential}@github.com/code-ministry-ltd/the-librarian.git?token=${credential}`;
+      const checkout = deployDir(home);
+      const runner = scriptSource(baseRunner(), checkout, "main").onRun(
+        "git",
+        ["-C", checkout, "fetch", "--tags", "origin"],
+        { code: 1, stderr: `fatal: could not read from ${leaked}` },
+      );
+      setDockerRunner(runner);
+
+      const result = await runCli(["server", "update", "--ref", "main"], { home });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("[redacted-remote]");
+      expect(result.stderr).not.toContain(credential);
+      expect(result.stderr).not.toContain(leaked);
+      expect(callIndex(runner, "stop")).toBe(-1);
+    });
+  });
+
+  it("rejects git revision expressions before checkout, build, or stop", async () => {
+    await withTempHome(async (home) => {
+      seedSource(home);
+      const runner = scriptSource(baseRunner(), deployDir(home), "main~1");
+      setDockerRunner(runner);
+
+      const result = await runCli(["server", "update", "--ref", "main~1"], { home });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/literal branch name.*revision expressions/is);
+      expect(streamCalls).toEqual([]);
+      expect(callIndex(runner, "stop")).toBe(-1);
+      expect(
+        runner.calls.some((call) => call.cmd === "git" && call.args.includes("checkout")),
+      ).toBe(false);
+    });
+  });
+});
+
+describe("server update — exact no-op and preserved configuration", () => {
+  it("an exact healthy published deployment is a no-op before registry access", async () => {
+    await withTempHome(async (home) => {
+      seedRegistry(home);
+      const runner = baseRunner(liveJson({ configuredImage: OLD_DIGEST, dashboardPort: 3042 }));
+      setDockerRunner(runner);
+
+      const result = await runCli(["server", "update", "--ref", OLD_REF], { home });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch(/already up to date/i);
+      expect(streamCalls).toEqual([]);
+      expect(callIndex(runner, "stop")).toBe(-1);
+    });
+  });
+
+  it("a strategy change at the same ref is not treated as a no-op", async () => {
+    await withTempHome(async (home) => {
+      seedSource(home);
+      setLatestFetcher(async () => OLD_REF.slice(1));
+      setReleaseProvenanceResolver(async () => ({ revision: REVISION, imageDigest: NEW_DIGEST }));
+      const runner = scriptSuccessfulReplacement(
+        baseRunner().onRun(
+          "docker",
+          ["image", "inspect", "--format", "{{json .}}", `${CANONICAL_IMAGE_NAME}:${OLD_REF}`],
+          {
+            stdout: registryInspect()
+              .replaceAll(NEW_REF, OLD_REF)
+              .replace(`"${NEW_VERSION}"`, `"${OLD_REF.slice(1)}"`),
+          },
+        ),
+        home,
+        NEW_DIGEST,
+      );
+      setDockerRunner(runner);
+
+      const result = await runCli(["server", "update"], { home });
+      expect(result.exitCode).toBe(0);
+      expect(streamCalls[0]?.args[0]).toBe("pull");
+      expect(callIndex(runner, "stop")).toBeGreaterThan(0);
+    });
+  });
+
+  it.each([
+    [
+      "runtime environment",
+      {
+        env: [
+          `LIBRARIAN_AGENT_TOKEN=${AGENT_TOKEN}`,
+          `LIBRARIAN_SECRET_KEY=${MASTER_KEY}`,
+          `LIBRARIAN_BOOTSTRAP_CLAIM_SECRET=${BOOTSTRAP}`,
+          "LIBRARIAN_ALLOW_NO_AUTH=true",
+          "LIBRARIAN_DATA_DIR=/data",
+          "LIBRARIAN_HOST=0.0.0.0",
+          "LIBRARIAN_PORT=3838",
+        ],
+      },
+    ],
+    ["/data mount", { dataVolume: "drifted_volume" }],
+  ] as const)("rejects %s drift instead of returning the pre-pull no-op", async (_label, drift) => {
+    await withTempHome(async (home) => {
+      seedRegistry(home);
+      const liveOptions: LiveOptions = {
+        configuredImage: OLD_DIGEST,
+        dashboardPort: 3042,
+        ...drift,
+      };
+      const oldInspect = registryInspect()
+        .replaceAll(NEW_REF, OLD_REF)
+        .replace(`"${NEW_VERSION}"`, `"${OLD_REF.slice(1)}"`);
+      let runner = baseRunner(liveJson(liveOptions)).onRun(
+        "docker",
+        ["image", "inspect", "--format", "{{json .}}", `${CANONICAL_IMAGE_NAME}:${OLD_REF}`],
+        { stdout: oldInspect },
+      );
+      runner = scriptSuccessfulReplacement(runner, home, NEW_DIGEST, liveOptions);
+      setDockerRunner(runner);
+      setReleaseProvenanceResolver(async () => ({ revision: REVISION, imageDigest: NEW_DIGEST }));
+
+      const result = await runCli(["server", "update", "--ref", OLD_REF], { home });
+      expect(result.stdout).not.toMatch(/already up to date/i);
+      expect(streamCalls[0]?.args[0]).toBe("pull");
+    });
+  });
+
+  it("preserves bind mount ownership, custom ports, secrets, claim, and restart policy", async () => {
+    await withTempHome(async (home) => {
+      const dataDir = path.join(home, "vault");
+      fs.mkdirSync(dataDir);
+      const dir = deployDir(home);
+      fs.mkdirSync(path.join(dir, ".git"), { recursive: true });
       writeDeployState(dir, {
         containerName: "the-librarian",
-        host: "127.0.0.1",
-        dataVolume: "librarian_data",
+        host: "100.64.0.8",
+        dataVolume: "unused",
+        dataDir,
+        dashboardPort: 3500,
         ref: OLD_REF,
         imageTag: `the-librarian:${OLD_REF}`,
         imageSource: "source",
         imageRef: `the-librarian:${OLD_REF}`,
       });
-      const runner = upgradeRunner();
-      setDockerRunner(runner);
-      stubSeams();
-
-      const r = await runCli(["server", "update"], { home });
-      expect(r.exitCode).toBe(0);
-      expect(readDeployState(dir)).toMatchObject({
-        ref: LATEST_TAG,
-        imageTag: `the-librarian:${LATEST_TAG}`,
-        imageSource: "source",
-        imageRef: `the-librarian:${LATEST_TAG}`,
+      writeDeployEnvFile(dir, {
+        agentToken: AGENT_TOKEN,
+        secretKey: MASTER_KEY,
+        bootstrapClaimSecret: BOOTSTRAP,
+        host: "100.64.0.8",
       });
-    });
-  });
-});
-
-describe("server update — idempotent no-op (SC 5)", () => {
-  it("already at latest + healthy → prints up-to-date, NO build/run/rm", async () => {
-    await withTempHome(async (home) => {
-      // deploy-state ref EQUALS the resolved latest.
-      seedDeployState(home, LATEST_TAG);
-      const runner = upgradeRunner();
-      setDockerRunner(runner);
-      stubSeams();
-
-      const r = await runCli(["server", "update"], { home });
-      expect(r.exitCode).toBe(0);
-      expect(r.stdout).toMatch(/already up to date/i);
-      expect(r.stdout).toContain(LATEST_TAG);
-
-      // The hallmark of a clean no-op: NO build, NO run, NO rm, NO stop, NO checkout.
-      expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "build")).toBe(false);
-      expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "run")).toBe(false);
-      expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "rm")).toBe(false);
-      expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "stop")).toBe(false);
-      expect(runner.calls.some((c) => c.cmd === "git" && c.args.includes("checkout"))).toBe(false);
-    });
-  });
-
-  it("--ref pinned to the current ref + healthy → no-op", async () => {
-    await withTempHome(async (home) => {
-      seedDeployState(home, OLD_REF);
-      const runner = upgradeRunner();
-      setDockerRunner(runner);
-      stubSeams();
-
-      // Pin --ref to exactly what's deployed; even though latest is newer, the
-      // pinned compare wins → no-op.
-      const r = await runCli(["server", "update", "--ref", OLD_REF], { home });
-      expect(r.exitCode).toBe(0);
-      expect(r.stdout).toMatch(/already up to date/i);
-      expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "build")).toBe(false);
-      expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "run")).toBe(false);
-    });
-  });
-
-  it("at the ref but NOT healthy → recreates (not a no-op)", async () => {
-    await withTempHome(async (home) => {
-      seedDeployState(home, LATEST_TAG);
-      // The container is at the ref but reports `exited` (not healthy) → recreate.
-      const runner = upgradeRunner().onRun(
-        "docker",
-        ["inspect", "--format", "{{.State.Status}}", "the-librarian"],
-        { stdout: "exited\n", code: 0 },
+      const liveOptions = {
+        host: "100.64.0.8",
+        dashboardPort: 3500,
+        dataDir,
+        user: "1001:1002",
+      };
+      const runner = scriptSuccessfulReplacement(
+        baseRunner(liveJson(liveOptions)),
+        home,
+        NEW_DIGEST,
+        liveOptions,
       );
       setDockerRunner(runner);
-      stubSeams();
 
-      const r = await runCli(["server", "update"], { home });
-      expect(r.exitCode).toBe(0);
-      // It DID rebuild + recreate because the container wasn't healthy.
-      expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "build")).toBe(true);
-      expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "run")).toBe(true);
+      const result = await runCli(["server", "update", "--ref", NEW_REF], { home });
+      expect(result.exitCode).toBe(0);
+      const create = runner.calls.find((call) => call.args[0] === "create")?.args ?? [];
+      expect(create).toContain("100.64.0.8:3500:3000");
+      expect(create).toContain(`${dataDir}:/data`);
+      expect(create).toContain("1001:1002");
+      expect(create.some((arg) => arg.includes(AGENT_TOKEN) || arg.includes(MASTER_KEY))).toBe(
+        false,
+      );
+      expect(fs.readFileSync(envFile(home), "utf8")).toContain(
+        `LIBRARIAN_BOOTSTRAP_CLAIM_SECRET=${BOOTSTRAP}`,
+      );
     });
   });
-});
 
-describe("server update — VOLUME SACRED across the whole flow (SC 5/6)", () => {
-  it("an upgrade never issues `docker volume rm` nor `docker rm -v`", async () => {
+  it("a preserved custom user and restart policy no-op on an immediate same-target update", async () => {
     await withTempHome(async (home) => {
-      seedDeployState(home);
-      const runner = upgradeRunner();
+      seedSource(home);
+      const custom: LiveOptions = { user: "1002:1003", restartPolicy: "always" };
+      let runner = scriptSuccessfulReplacement(
+        baseRunner(liveJson(custom)),
+        home,
+        NEW_DIGEST,
+        custom,
+      );
       setDockerRunner(runner);
-      stubSeams();
+      expect((await runCli(["server", "update", "--ref", NEW_REF], { home })).exitCode).toBe(0);
 
-      const r = await runCli(["server", "update"], { home });
-      expect(r.exitCode).toBe(0);
-      expect(ranVolumeDestructive(runner)).toBe(false);
-      // The `rm` that DID run is the container only — no `-v`.
-      const rmCall = runner.calls.find((c) => c.cmd === "docker" && c.args[0] === "rm");
-      expect(rmCall?.args).toEqual(["rm", "the-librarian"]);
-    });
-  });
-});
-
-describe("server update — rollback on a failed health-wait (SC 5)", () => {
-  it("new container goes unhealthy → force-removed, errors, deploy-state NOT advanced, logs redacted", async () => {
-    await withTempHome(async (home) => {
-      const dir = seedDeployState(home);
-      // Assembled from sub-threshold parts so no realistic secret literal is committed.
-      const fakeAdminLine =
-        "Generated a new admin token (LIBRARIAN_ADMIN_TOKEN): " + "libadmin_" + "FAKETOKENVALUE";
-      const fakeAdminToken = "libadmin_" + "FAKETOKENVALUE";
-
-      const runner = new FakeRunner()
-        .withWhich("docker")
-        .withWhich("git")
-        .onRun("docker", ["info"], { code: 0 })
-        .onRun(
-          "docker",
-          ["inspect", "--format", "{{range .Config.Env}}{{println .}}{{end}}", "the-librarian"],
-          { stdout: `LIBRARIAN_AGENT_TOKEN=${EXISTING_AGENT_TOKEN}\n`, code: 0 },
-        )
-        // The recreated container never becomes healthy.
-        .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", "the-librarian"], {
-          stdout: "unhealthy\n",
-          code: 0,
-        })
-        // Boot logs carry the one-time admin-token generation line.
-        .onRun("docker", ["logs", "--tail", "50", "the-librarian"], {
-          stdout: `boot: starting up\n${fakeAdminLine}\nboot: health probe failed\n`,
-          code: 0,
-        });
+      streamCalls = [];
+      runner = baseRunner(liveJson({ ...custom, configuredImage: NEW_DIGEST }));
       setDockerRunner(runner);
-      stubSeams();
-
-      const r = await runCli(["server", "update"], { home });
-      expect(r.exitCode).toBe(1);
-      expect(r.stderr).toMatch(/did not become healthy|rolled back/i);
-
-      // Rolled back — the new container was force-removed.
-      expect(runner.ran("docker", ["rm", "-f", "the-librarian"])).toBe(true);
-
-      // The surfaced error must NOT carry the boot-logged token nor the gen line.
-      expect(r.stderr).not.toContain(fakeAdminToken);
-      expect(r.stderr).not.toMatch(/Generated a new admin token/i);
-      // ...but the (redacted) tail is still surfaced for debugging.
-      expect(r.stderr).toMatch(/boot: starting up/);
-
-      // deploy-state was NOT advanced — still the old ref.
-      expect(readDeployState(dir)?.ref).toBe(OLD_REF);
-
-      // The agent token never leaked into the error, and lands in NO file other
-      // than the 0600 deploy env-file (written before the recreate; it persists
-      // through the rollback — the next `update` overwrites it).
-      expect(r.stderr).not.toContain(EXISTING_AGENT_TOKEN);
-      expect(filesContaining(home, EXISTING_AGENT_TOKEN)).toEqual([deployEnvOf(home)]);
-      // The deploy env-file is still 0600 even on the failed path.
-      expect(fs.statSync(deployEnvOf(home)).mode & 0o777).toBe(0o600);
+      const second = await runCli(["server", "update", "--ref", NEW_REF], { home });
+      expect(second.exitCode).toBe(0);
+      expect(second.stdout).toMatch(/already up to date/i);
+      expect(streamCalls).toEqual([]);
+      expect(callIndex(runner, "stop")).toBe(-1);
     });
   });
 });
 
-describe("server update — fresh token when the old container is unreadable", () => {
-  it("old container gone (inspect env fails) → mints a fresh token, surfaces it once with a re-paste note", async () => {
+describe("server update — recoverable replacement", () => {
+  it("uses the cidfile identity when docker create stdout is malformed", async () => {
     await withTempHome(async (home) => {
-      seedDeployState(home);
-      const runner = new FakeRunner()
-        .withWhich("docker")
-        .withWhich("git")
-        .onRun("docker", ["info"], { code: 0 })
-        // Env inspect fails — the old container is gone/unreadable.
-        .onRun(
-          "docker",
-          ["inspect", "--format", "{{range .Config.Env}}{{println .}}{{end}}", "the-librarian"],
-          { stderr: "Error: No such object: the-librarian\n", code: 1 },
-        )
-        .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", "the-librarian"], {
+      seedSource(home);
+      const runner = scriptSuccessfulReplacement(baseRunner(), home, NEW_DIGEST);
+      setDockerRunner(runner);
+
+      const result = await runCli(["server", "update", "--ref", NEW_REF], { home });
+
+      expect(result.exitCode).toBe(0);
+      expect(runner.ran("docker", ["start", CANDIDATE_ID])).toBe(true);
+      expect(runner.calls.find((call) => call.args[0] === "create")?.args).toContain("--cidfile");
+      expect(
+        runner.calls.some((call) => call.args.includes("the-librarian") && call.args[0] === "rm"),
+      ).toBe(false);
+    });
+  });
+
+  it("a missing create cidfile gives inspect-only manual guidance without mutable-name cleanup", async () => {
+    await withTempHome(async (home) => {
+      seedSource(home);
+      const runner = baseRunner().onRun("docker", replacementArgs(home, NEW_DIGEST), {
+        stdout: `${CANDIDATE_ID}\n`,
+      });
+      setDockerRunner(runner);
+
+      const result = await runCli(["server", "update", "--ref", NEW_REF], { home });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("docker container inspect");
+      expect(result.stderr).not.toContain("docker create");
+      expect(result.stderr).not.toContain("docker rm -f the-librarian");
+      expect(result.stderr).not.toContain("docker start the-librarian");
+    });
+  });
+
+  it("a stop-boundary failure restarts and verifies the original named container", async () => {
+    await withTempHome(async (home) => {
+      seedSource(home);
+      const runner = baseRunner()
+        .onRun("docker", ["stop", "70".repeat(32)], { code: 1, stderr: "stop failed" })
+        .onRun("docker", ["start", "70".repeat(32)], { code: 0 })
+        .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", "70".repeat(32)], {
           stdout: "healthy\n",
-          code: 0,
         });
       setDockerRunner(runner);
-      stubSeams();
 
-      const r = await runCli(["server", "update"], { home });
-      expect(r.exitCode).toBe(0);
-
-      // A fresh AGENT token was minted and delivered via the env-file (clients
-      // re-paste). Secrets ride in the env-file, NOT inline -e.
-      const runArgs = dockerRunArgs(runner) ?? [];
-      expect(runArgs).toContain("--env-file");
-      expect(runArgs).not.toContain("-e");
-      const envBody = fs.readFileSync(deployEnvOf(home), "utf8");
-      expect(envBody).toContain(`LIBRARIAN_AGENT_TOKEN=${FRESH_AGENT_TOKEN}`);
-
-      // The MASTER KEY is OMITTED (the old env was unreadable) — NEVER re-minted.
-      // The server resolves it from /data/secret.key, preserving encrypted secrets.
-      expect(envBody).not.toContain("LIBRARIAN_SECRET_KEY=");
-      expect(envBody).not.toContain(FRESH_MASTER_KEY);
-      expect(filesContaining(home, FRESH_MASTER_KEY)).toEqual([]);
-
-      // The fresh agent token is surfaced exactly once, with a clients-must-update
-      // note, and never written to any file but the 0600 deploy env-file.
-      expect(r.stdout).toContain(FRESH_AGENT_TOKEN);
-      expect(r.stdout.split(FRESH_AGENT_TOKEN).length - 1).toBe(1);
-      expect(r.stdout).toMatch(/clients|update.*token|re-?paste/i);
-      expect(filesContaining(home, FRESH_AGENT_TOKEN)).toEqual([deployEnvOf(home)]);
+      const result = await runCli(["server", "update", "--ref", NEW_REF], { home });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/restored and verified healthy/i);
+      expect(runner.ran("docker", ["start", "70".repeat(32)])).toBe(true);
+      expect(readDeployState(deployDir(home))?.ref).toBe(OLD_REF);
     });
   });
-});
 
-describe("server update — preflight + no-deploy-state teach", () => {
-  it("docker absent → teaching error, no git/docker ops", async () => {
+  it("a remove-boundary failure restarts the original immutable container ID", async () => {
     await withTempHome(async (home) => {
-      seedDeployState(home);
-      const runner = new FakeRunner(); // nothing on PATH
+      seedSource(home);
+      const runner = baseRunner()
+        .onRun("docker", ["rm", "70".repeat(32)], { code: 1, stderr: "rm failed" })
+        .onRun("docker", ["container", "inspect", "70".repeat(32)], { stdout: "still here" })
+        .onRun("docker", ["start", "70".repeat(32)], { code: 0 })
+        .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", "70".repeat(32)], {
+          stdout: "healthy\n",
+        });
       setDockerRunner(runner);
-      stubSeams();
 
-      const r = await runCli(["server", "update"], { home });
-      expect(r.exitCode).toBe(1);
-      expect(r.stderr).toMatch(/docker/i);
-      expect(r.stderr).toMatch(/install/i);
+      const result = await runCli(["server", "update", "--ref", NEW_REF], { home });
+      expect(result.exitCode).toBe(1);
+      expect(runner.ran("docker", ["start", "70".repeat(32)])).toBe(true);
+      expect(callIndex(runner, "create")).toBe(-1);
     });
   });
 
-  it("no deploy-state → teaching error pointing at `server up`", async () => {
+  it("classifies a failed rm whose immutable ID is already absent as removed", async () => {
     await withTempHome(async (home) => {
-      // No deploy-state seeded.
-      const runner = upgradeRunner();
+      seedSource(home);
+      let runner = baseRunner()
+        .onRun("docker", ["rm", "70".repeat(32)], { code: 1, stderr: "daemon timeout" })
+        .onRun("docker", ["container", "inspect", "70".repeat(32)], {
+          code: 1,
+          stderr: `No such container: ${"70".repeat(32)}`,
+        });
+      runner = scriptSuccessfulReplacement(runner, home, NEW_DIGEST);
       setDockerRunner(runner);
-      stubSeams();
 
-      const r = await runCli(["server", "update"], { home });
-      expect(r.exitCode).toBe(1);
-      expect(r.stderr).toMatch(/server up|no.*deploy|not.*deployed|deploy-state/i);
-      // It never tried to build/run without knowing the config.
-      expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "build")).toBe(false);
+      const result = await runCli(["server", "update", "--ref", NEW_REF], { home });
+      expect(result.exitCode).toBe(0);
+      expect(runner.ran("docker", replacementArgs(home, NEW_DIGEST))).toBe(true);
     });
   });
-});
 
-describe("server update — the exclusive update lock (spec 074 SC5)", () => {
-  it("a manual update while another update holds the lock is refused, disturbing nothing", async () => {
-    // Before 074 only the TIMER wrapper took the lock — a manual `server update`
-    // could interleave stop/rm/run with a timer fire, leaving a window with NO
-    // running container. The lock now lives in runUpdate: one acquisition point
-    // covers every caller.
+  it("an unhealthy replacement is removed by ID and the previous image is recreated and verified", async () => {
     await withTempHome(async (home) => {
-      const dir = seedDeployState(home);
-      const lockPath = path.join(dir, ".autoupdate.lock");
-      // A concurrent update (e.g. a timer fire mid-build) holds a FRESH lock.
-      fs.writeFileSync(lockPath, `4242 ${Date.now()}\n`, { flag: "wx" });
-
-      const runner = upgradeRunner().withFallback({ code: 0 });
+      seedSource(home);
+      let runner = baseRunner();
+      runner = scriptSuccessfulReplacement(runner, home, NEW_DIGEST)
+        .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", CANDIDATE_ID], {
+          stdout: "unhealthy\n",
+        })
+        .onRun("docker", ["logs", "--tail", "50", CANDIDATE_ID], {
+          stdout: `health failed ${AGENT_TOKEN} ${BOOTSTRAP}`,
+        });
+      const oldArgs = recoveryArgs(home);
+      runner
+        .onRun("docker", ["rm", "-f", CANDIDATE_ID], { code: 0 })
+        .onRun("docker", oldArgs, { stdout: `${RECOVERY_ID}\n` })
+        .onRun("docker", ["start", RECOVERY_ID], { code: 0 })
+        .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", RECOVERY_ID], {
+          stdout: "healthy\n",
+        });
       setDockerRunner(runner);
-      stubSeams();
 
-      const r = await runCli(["server", "update"], { home });
-      expect(r.exitCode).toBe(1);
-      expect(r.stderr).toMatch(/another update is already in progress/i);
-      // The in-flight update was not disturbed: no build, no stop/rm/run.
-      expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "build")).toBe(false);
-      expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "rm")).toBe(false);
-      // The holder's lock is left intact — only the acquirer ever releases.
-      expect(fs.existsSync(lockPath)).toBe(true);
+      const result = await runCli(["server", "update", "--ref", NEW_REF], { home });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/restored and verified healthy/i);
+      expect(result.stderr).not.toContain(AGENT_TOKEN);
+      expect(result.stderr).not.toContain(BOOTSTRAP);
+      expect(runner.ran("docker", ["rm", "-f", CANDIDATE_ID])).toBe(true);
+      expect(runner.ran("docker", oldArgs)).toBe(true);
+      expect(readDeployState(deployDir(home))?.ref).toBe(OLD_REF);
     });
   });
 
-  it("the lock is released after a SUCCESSFUL update (the next update isn't blocked)", async () => {
+  it("a migration failure restores the executable and states that data was not rolled back", async () => {
     await withTempHome(async (home) => {
-      const dir = seedDeployState(home);
-      const runner = upgradeRunner().withFallback({ code: 0 });
+      seedSource(home);
+      let runner = scriptSuccessfulReplacement(baseRunner(), home, NEW_DIGEST).onRun(
+        "docker",
+        ["exec", CANDIDATE_ID, "the-librarian", "migrate-data-dir"],
+        { code: 1, stderr: `migration failed ${AGENT_TOKEN} ${BOOTSTRAP}` },
+      );
+      const oldArgs = recoveryArgs(home);
+      runner = runner
+        .onRun("docker", ["rm", "-f", CANDIDATE_ID], { code: 0 })
+        .onRun("docker", oldArgs, { stdout: `${RECOVERY_ID}\n` })
+        .onRun("docker", ["start", RECOVERY_ID], { code: 0 })
+        .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", RECOVERY_ID], {
+          stdout: "healthy\n",
+        });
       setDockerRunner(runner);
-      stubSeams();
 
-      const r = await runCli(["server", "update"], { home });
-      expect(r.exitCode).toBe(0);
-      expect(fs.existsSync(path.join(dir, ".autoupdate.lock"))).toBe(false);
+      const result = await runCli(["server", "update", "--ref", NEW_REF], { home });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/persistent data changes.*NOT rolled back/i);
+      expect(result.stderr).not.toContain(AGENT_TOKEN);
+      expect(result.stderr).not.toContain(BOOTSTRAP);
+      expect(readDeployState(deployDir(home))?.ref).toBe(OLD_REF);
     });
   });
 
-  it("the lock is released after a FAILED update too (a failure never wedges the next fire)", async () => {
+  it("a second-file promotion failure restores old files and recovers with an extant env-file", async () => {
     await withTempHome(async (home) => {
-      const dir = seedDeployState(home);
-      const runner = upgradeRunner()
-        .onRun(
-          "docker",
-          ["build", "-f", "docker/all-in-one.Dockerfile", "-t", `the-librarian:${LATEST_TAG}`, "."],
-          { code: 1, stderr: "build blew up" },
-        )
-        .withFallback({ code: 0 });
+      seedSource(home);
+      const oldEnv = fs.readFileSync(envFile(home));
+      const oldState = fs.readFileSync(path.join(deployDir(home), "deploy-state.json"));
+      let promotions = 0;
+      setFinalizationRenamer((source, destination) => {
+        promotions += 1;
+        if (promotions === 2) throw new Error("state promotion failed");
+        fs.renameSync(source, destination);
+      });
+      let runner = scriptSuccessfulReplacement(baseRunner(), home, NEW_DIGEST);
+      const oldArgs = recoveryArgs(home);
+      runner = runner
+        .onRun("docker", ["rm", "-f", CANDIDATE_ID], { code: 0 })
+        .onRun("docker", oldArgs, { stdout: `${RECOVERY_ID}\n` })
+        .onRun("docker", ["start", RECOVERY_ID], { code: 0 })
+        .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", RECOVERY_ID], {
+          stdout: "healthy\n",
+        });
       setDockerRunner(runner);
-      stubSeams();
 
-      const r = await runCli(["server", "update"], { home });
-      expect(r.exitCode).toBe(1);
-      expect(fs.existsSync(path.join(dir, ".autoupdate.lock"))).toBe(false);
+      const result = await runCli(["server", "update", "--ref", NEW_REF], { home });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/restored and verified healthy/i);
+      expect(runner.ran("docker", oldArgs)).toBe(true);
+      expect(fs.readFileSync(envFile(home))).toEqual(oldEnv);
+      expect(fs.readFileSync(path.join(deployDir(home), "deploy-state.json"))).toEqual(oldState);
     });
   });
-});
 
-// --- helpers -------------------------------------------------------------
+  it("preserves the prior recovery env and teaches file repair when persistence restoration fails", async () => {
+    await withTempHome(async (home) => {
+      seedSource(home);
+      let promotions = 0;
+      setFinalizationRenamer((source, destination) => {
+        promotions += 1;
+        if (promotions === 2) throw new Error("state promotion failed");
+        fs.renameSync(source, destination);
+      });
+      setFinalizationRestorer(() => {
+        throw new Error("prior bytes could not be restored");
+      });
+      let runner = scriptSuccessfulReplacement(baseRunner(), home, NEW_DIGEST);
+      const oldArgs = recoveryArgs(home);
+      runner = runner
+        .onRun("docker", ["rm", "-f", CANDIDATE_ID], { code: 0 })
+        .onRun("docker", oldArgs, { stdout: `${RECOVERY_ID}\n` })
+        .onRun("docker", ["start", RECOVERY_ID], { code: 0 })
+        .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", RECOVERY_ID], {
+          stdout: "healthy\n",
+        });
+      setDockerRunner(runner);
 
-/** Recursively collect files under `dir` whose contents contain `needle`. */
-function filesContaining(dir: string, needle: string): string[] {
-  const hits: string[] = [];
-  const walk = (d: string): void => {
-    let entries: fs.Dirent[];
-    try {
-      entries = fs.readdirSync(d, { withFileTypes: true });
-    } catch {
-      return;
-    }
-    for (const entry of entries) {
-      const full = path.join(d, entry.name);
-      if (entry.isDirectory()) {
-        walk(full);
-      } else if (entry.isFile()) {
-        let content = "";
-        try {
-          content = fs.readFileSync(full, "utf8");
-        } catch {
-          continue;
+      const result = await runCli(["server", "update", "--ref", NEW_REF], { home });
+      const priorEnv = `${stagedEnv(home)}.previous`;
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/restoration FAILED|may be inconsistent/i);
+      expect(result.stderr).not.toContain("Deploy state was not advanced");
+      expect(result.stderr).toContain(priorEnv);
+      expect(fs.statSync(priorEnv).mode & 0o777).toBe(0o600);
+    });
+  });
+
+  it("reports protected credential residue when successful-update cleanup fails", async () => {
+    await withTempHome(async (home) => {
+      seedSource(home);
+      const runner = scriptSuccessfulReplacement(baseRunner(), home, NEW_DIGEST);
+      setDockerRunner(runner);
+      setUpdateSecretArtifactRemover(() => {
+        throw new Error("cleanup denied");
+      });
+
+      const result = await runCli(["server", "update", "--ref", NEW_REF], { home });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch(/credential residue remains/i);
+      expect(result.stdout).toContain(`${stagedEnv(home)}.previous`);
+      expect(result.stdout).not.toContain(AGENT_TOKEN);
+    });
+  });
+
+  it("appends a residue warning when recovered-failure cleanup cannot remove secret artifacts", async () => {
+    await withTempHome(async (home) => {
+      seedSource(home);
+      let runner = scriptSuccessfulReplacement(baseRunner(), home, NEW_DIGEST).onRun(
+        "docker",
+        ["inspect", "--format", "{{.State.Health.Status}}", CANDIDATE_ID],
+        { stdout: "unhealthy\n" },
+      );
+      const oldArgs = recoveryArgs(home);
+      runner = runner
+        .onRun("docker", ["rm", "-f", CANDIDATE_ID], { code: 0 })
+        .onRun("docker", oldArgs, { stdout: `${RECOVERY_ID}\n` })
+        .onRun("docker", ["start", RECOVERY_ID], { code: 0 })
+        .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", RECOVERY_ID], {
+          stdout: "healthy\n",
+        });
+      setDockerRunner(runner);
+      setUpdateSecretArtifactRemover(() => {
+        throw new Error("cleanup denied");
+      });
+
+      const result = await runCli(["server", "update", "--ref", NEW_REF], { home });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/credential residue remains/i);
+      expect(result.stderr).not.toContain(AGENT_TOKEN);
+    });
+  });
+
+  it("a recovery failure reports both failures and inspect-only guidance when ownership is unknown", async () => {
+    await withTempHome(async (home) => {
+      seedSource(home);
+      const leakedSecret = "de".repeat(32);
+      let runner = scriptSuccessfulReplacement(baseRunner(), home, NEW_DIGEST).onRun(
+        "docker",
+        ["inspect", "--format", "{{.State.Health.Status}}", CANDIDATE_ID],
+        { stdout: "unhealthy\n" },
+      );
+      const oldArgs = recoveryArgs(home);
+      runner = runner
+        .onRun("docker", ["logs", "--tail", "50", CANDIDATE_ID], {
+          stdout: `candidate failed ${leakedSecret}`,
+        })
+        .onRun("docker", ["rm", "-f", CANDIDATE_ID], { code: 0 })
+        .onRun("docker", oldArgs, { code: 1, stderr: `recovery failed ${leakedSecret}` });
+      setDockerRunner(runner);
+
+      const result = await runCli(["server", "update", "--ref", NEW_REF], { home });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/Update failed:.*Recovery also failed:/s);
+      expect(result.stderr).toContain("The server was NOT rolled back");
+      expect(result.stderr).toContain("docker container inspect");
+      expect(result.stderr).not.toMatch(/\ndocker create/);
+      expect(result.stderr).toMatch(/do not remove, recreate, or start/i);
+      expect(result.stderr).not.toContain(leakedSecret);
+      expect(result.stderr).not.toContain("docker rm -f the-librarian");
+      expect(fs.existsSync(stagedEnv(home))).toBe(true);
+    });
+  });
+
+  it("a pre-removal restart failure prints only exact old-ID restart recovery commands", async () => {
+    await withTempHome(async (home) => {
+      seedSource(home);
+      const oldId = "70".repeat(32);
+      const runner = baseRunner()
+        .onRun("docker", ["stop", oldId], { code: 1, stderr: "stop failed" })
+        .onRun("docker", ["start", oldId], { code: 1, stderr: "restart failed" });
+      setDockerRunner(runner);
+
+      const result = await runCli(["server", "update", "--ref", NEW_REF], { home });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain(`docker container inspect ${oldId}`);
+      expect(result.stderr).toContain(`docker start ${oldId}`);
+      expect(result.stderr).not.toContain("docker create");
+      expect(result.stderr).not.toContain("docker rm -f the-librarian");
+    });
+  });
+
+  it("a finalization plus recovery failure prints an env-file path that still exists", async () => {
+    await withTempHome(async (home) => {
+      seedSource(home);
+      let promotions = 0;
+      setFinalizationRenamer((source, destination) => {
+        promotions += 1;
+        if (promotions === 2) throw new Error("state promotion failed");
+        fs.renameSync(source, destination);
+      });
+      let runner = scriptSuccessfulReplacement(baseRunner(), home, NEW_DIGEST);
+      const oldArgs = recoveryArgs(home);
+      runner = runner
+        .onRun("docker", ["rm", "-f", CANDIDATE_ID], { code: 0 })
+        .onRun("docker", oldArgs, { code: 1, stderr: "recovery create failed" });
+      setDockerRunner(runner);
+
+      const result = await runCli(["server", "update", "--ref", NEW_REF], { home });
+      const printedEnv = `${stagedEnv(home)}.previous`;
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain(printedEnv);
+      expect(fs.existsSync(printedEnv!)).toBe(true);
+    });
+  });
+
+  it("restores a non-loopback legacy deployment with no token without adopting the fresh candidate token", async () => {
+    await withTempHome(async (home) => {
+      const dir = deployDir(home);
+      fs.mkdirSync(path.join(dir, ".git"), { recursive: true });
+      writeDeployState(dir, {
+        containerName: "the-librarian",
+        host: "100.64.0.9",
+        dataVolume: "librarian_data",
+        dashboardPort: 3000,
+        ref: OLD_REF,
+        imageTag: `the-librarian:${OLD_REF}`,
+      });
+      fs.writeFileSync(envFile(home), `LIBRARIAN_SECRET_KEY=${MASTER_KEY}\n`, { mode: 0o600 });
+      const live = liveJson({
+        host: "100.64.0.9",
+        env: [
+          `LIBRARIAN_SECRET_KEY=${MASTER_KEY}`,
+          "LIBRARIAN_DATA_DIR=/data",
+          "LIBRARIAN_HOST=0.0.0.0",
+          "LIBRARIAN_PORT=3838",
+          "PORT=3000",
+        ],
+      });
+      let runner = scriptSuccessfulReplacement(baseRunner(live), home, NEW_DIGEST, {
+        host: "100.64.0.9",
+      }).onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", CANDIDATE_ID], {
+        stdout: "unhealthy\n",
+      });
+      const oldArgs = recoveryArgs(home, { host: "100.64.0.9" });
+      runner = runner
+        .onRun("docker", ["rm", "-f", CANDIDATE_ID], { code: 0 })
+        .onRun("docker", oldArgs, { stdout: `${RECOVERY_ID}\n` })
+        .onRun("docker", ["start", RECOVERY_ID], { code: 0 })
+        .onRun("docker", ["inspect", "--format", "{{.State.Health.Status}}", RECOVERY_ID], {
+          stdout: "healthy\n",
+        });
+      let recoveryEnvBody = "";
+      const originalRun = runner.run.bind(runner);
+      runner.run = async (cmd, args, opts) => {
+        if (cmd === "docker" && args[0] === "create" && args.at(-1) === OLD_IMAGE_ID) {
+          const envPath = args[args.indexOf("--env-file") + 1];
+          recoveryEnvBody = fs.readFileSync(envPath!, "utf8");
         }
-        if (content.includes(needle)) hits.push(full);
-      }
-    }
-  };
-  walk(dir);
-  return hits;
-}
+        return originalRun(cmd, args, opts);
+      };
+      setDockerRunner(runner);
+
+      const result = await runCli(["server", "update", "--ref", NEW_REF], { home });
+      expect(result.exitCode).toBe(1);
+      expect(recoveryEnvBody).not.toContain("LIBRARIAN_AGENT_TOKEN");
+      expect(recoveryEnvBody).not.toContain(FRESH_TOKEN);
+    });
+  });
+
+  it("a failed recovery start names only the owned recovery ID in cleanup guidance", async () => {
+    await withTempHome(async (home) => {
+      seedSource(home);
+      let runner = scriptSuccessfulReplacement(baseRunner(), home, NEW_DIGEST).onRun(
+        "docker",
+        ["inspect", "--format", "{{.State.Health.Status}}", CANDIDATE_ID],
+        { stdout: "unhealthy\n" },
+      );
+      const oldArgs = recoveryArgs(home);
+      runner = runner
+        .onRun("docker", ["rm", "-f", CANDIDATE_ID], { code: 0 })
+        .onRun("docker", oldArgs, { stdout: `${RECOVERY_ID}\n` })
+        .onRun("docker", ["start", RECOVERY_ID], { code: 1, stderr: "start failed" });
+      setDockerRunner(runner);
+
+      const result = await runCli(["server", "update", "--ref", NEW_REF], { home });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain(`docker rm -f ${RECOVERY_ID}`);
+      expect(result.stderr).not.toContain("docker rm -f the-librarian");
+    });
+  });
+
+  it("never issues destructive volume commands or leaks preserved secrets", async () => {
+    await withTempHome(async (home) => {
+      seedSource(home);
+      const runner = scriptSuccessfulReplacement(baseRunner(), home, NEW_DIGEST);
+      setDockerRunner(runner);
+
+      const result = await runCli(["server", "update", "--ref", NEW_REF], { home });
+      const argv = runner.calls.flatMap((call) => call.args).join("\n");
+      expect(result.exitCode).toBe(0);
+      expect(destructiveVolumeCommand(runner)).toBe(false);
+      expect(argv).not.toContain(AGENT_TOKEN);
+      expect(argv).not.toContain(MASTER_KEY);
+      expect(result.stdout + result.stderr).not.toContain(MASTER_KEY);
+      expect(JSON.stringify(readDeployState(deployDir(home)))).not.toContain(AGENT_TOKEN);
+    });
+  });
+});
+
+describe("server update — lifecycle guardrails", () => {
+  it("acquires the lifecycle lock before attempting to read deploy state", async () => {
+    await withTempHome(async (home) => {
+      const dir = deployDir(home);
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, ".autoupdate.lock"), `${process.pid} ${Date.now()}\n`);
+      setDockerRunner(new FakeRunner().withWhich("docker").onRun("docker", ["info"], { code: 0 }));
+
+      const result = await runCli(["server", "update", "--ref", NEW_REF], { home });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/another update is already in progress/i);
+      expect(result.stderr).not.toMatch(/no deploy-state/i);
+    });
+  });
+  it("uses Docker-only preflight for a release and Git preflight for source", async () => {
+    await withTempHome(async (home) => {
+      seedSource(home);
+      const registryRunner = baseRunner();
+      setDockerRunner(registryRunner);
+      const registry = await runCli(["server", "update", "--ref", NEW_REF], { home });
+      expect(registry.stderr).not.toMatch(/git is required/i);
+
+      const sourceRunner = new FakeRunner().withWhich("docker").onRun("docker", ["info"], {
+        code: 0,
+      });
+      setDockerRunner(sourceRunner);
+      const source = await runCli(["server", "update", "--ref", "main"], { home });
+      expect(source.exitCode).toBe(1);
+      expect(source.stderr).toMatch(/git is required/i);
+    });
+  });
+
+  it("releases the shared lock after success and failure", async () => {
+    await withTempHome(async (home) => {
+      seedSource(home);
+      let runner = scriptSuccessfulReplacement(baseRunner(), home, NEW_DIGEST);
+      setDockerRunner(runner);
+      expect((await runCli(["server", "update", "--ref", NEW_REF], { home })).exitCode).toBe(0);
+      expect(fs.existsSync(path.join(deployDir(home), ".autoupdate.lock"))).toBe(false);
+
+      streamExit = 1;
+      runner = baseRunner(liveJson({ configuredImage: NEW_DIGEST, dashboardPort: 3000 }));
+      setDockerRunner(runner);
+      expect((await runCli(["server", "update", "--ref", "v1.22.0"], { home })).exitCode).toBe(1);
+      expect(fs.existsSync(path.join(deployDir(home), ".autoupdate.lock"))).toBe(false);
+    });
+  });
+});

--- a/packages/installer-cli/tests/server-update.test.ts
+++ b/packages/installer-cli/tests/server-update.test.ts
@@ -237,6 +237,8 @@ describe("server update — upgrade path argv sequence (SC 5)", () => {
         dashboardPort: 3000,
         ref: LATEST_TAG,
         imageTag: `the-librarian:${LATEST_TAG}`,
+        imageSource: "source",
+        imageRef: `the-librarian:${LATEST_TAG}`,
       });
     });
   });
@@ -495,7 +497,39 @@ describe("server update — --ref reflected in checkout + build tag", () => {
       ).toBe(true);
       const runArgs = dockerRunArgs(runner);
       expect(runArgs?.[runArgs.length - 1]).toBe("the-librarian:main");
-      expect(readDeployState(dir)?.ref).toBe("main");
+      expect(readDeployState(dir)).toMatchObject({
+        ref: "main",
+        imageTag: "the-librarian:main",
+        imageSource: "source",
+        imageRef: "the-librarian:main",
+      });
+    });
+  });
+
+  it("preserves explicit source provenance while advancing the local image ref", async () => {
+    await withTempHome(async (home) => {
+      const dir = seedDeployState(home);
+      writeDeployState(dir, {
+        containerName: "the-librarian",
+        host: "127.0.0.1",
+        dataVolume: "librarian_data",
+        ref: OLD_REF,
+        imageTag: `the-librarian:${OLD_REF}`,
+        imageSource: "source",
+        imageRef: `the-librarian:${OLD_REF}`,
+      });
+      const runner = upgradeRunner();
+      setDockerRunner(runner);
+      stubSeams();
+
+      const r = await runCli(["server", "update"], { home });
+      expect(r.exitCode).toBe(0);
+      expect(readDeployState(dir)).toMatchObject({
+        ref: LATEST_TAG,
+        imageTag: `the-librarian:${LATEST_TAG}`,
+        imageSource: "source",
+        imageRef: `the-librarian:${LATEST_TAG}`,
+      });
     });
   });
 });

--- a/packages/installer-cli/tests/server-update.test.ts
+++ b/packages/installer-cli/tests/server-update.test.ts
@@ -474,6 +474,7 @@ describe("server update — strategy and preparation", () => {
       const result = await runCli(["server", "update", "--ref", "main"], { home });
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toMatch(/already up to date/i);
+      expect(result.stdout).toMatch(/source main/i);
       expect(streamCalls).toEqual([]);
       expect(callIndex(runner, "stop")).toBe(-1);
     });
@@ -726,6 +727,7 @@ describe("server update — exact no-op and preserved configuration", () => {
       const result = await runCli(["server", "update", "--ref", OLD_REF], { home });
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toMatch(/already up to date/i);
+      expect(result.stdout).toMatch(/published v1\.20\.1 \(101010101010\)/i);
       expect(streamCalls).toEqual([]);
       expect(callIndex(runner, "stop")).toBe(-1);
     });

--- a/packages/installer-cli/tests/server.test.ts
+++ b/packages/installer-cli/tests/server.test.ts
@@ -41,6 +41,10 @@ describe("librarian server (no subcommand) — the command surface", () => {
     ]) {
       expect(r.stdout).toContain(sub);
     }
+    expect(r.stdout).toMatch(/pull.*exact release/i);
+    expect(r.stdout).toMatch(/source.*build/i);
+    expect(r.stdout).not.toContain("Self-host the Librarian server (build + run");
+    expect(r.stdout).not.toContain("Re-pin to a release, rebuild");
   });
 
   it("--help on the group also prints the surface", async () => {

--- a/packages/installer-cli/tests/server.test.ts
+++ b/packages/installer-cli/tests/server.test.ts
@@ -5,7 +5,7 @@ import {
   resetRunner as resetDockerRunner,
   setRunner as setDockerRunner,
 } from "../src/server/docker.js";
-import { PreflightError, preflight } from "../src/server/preflight.js";
+import { dockerPreflight, PreflightError, sourcePreflight } from "../src/server/preflight.js";
 import { FakeRunner } from "./helpers.js";
 
 afterEach(() => {
@@ -58,11 +58,11 @@ describe("librarian server (no subcommand) — the command surface", () => {
   });
 });
 
-describe("server preflight — teaching errors via the injected runner", () => {
+describe("server Docker preflight — teaching errors via the injected runner", () => {
   it("docker missing: names docker and how to install it (never a stack trace)", async () => {
     setDockerRunner(new FakeRunner()); // nothing on PATH
-    await expect(preflight()).rejects.toBeInstanceOf(PreflightError);
-    const message = await preflight().catch((e: Error) => e.message);
+    await expect(dockerPreflight()).rejects.toBeInstanceOf(PreflightError);
+    const message = await dockerPreflight().catch((e: Error) => e.message);
     expect(message).toMatch(/docker/i);
     expect(message).toMatch(/install/i);
     // Actionable, not a bare "invalid"/"error".
@@ -77,7 +77,7 @@ describe("server preflight — teaching errors via the injected runner", () => {
         .withWhich("git")
         .onRun("docker", ["info"], { code: 1, stderr: "Cannot connect to the Docker daemon" }),
     );
-    const message = await preflight({ platform: "linux" }).catch((e: Error) => e.message);
+    const message = await dockerPreflight({ platform: "linux" }).catch((e: Error) => e.message);
     expect(message).toMatch(/daemon/i);
     expect(message).toMatch(/running/i);
     // Linux hint does NOT mention Docker Desktop.
@@ -88,34 +88,41 @@ describe("server preflight — teaching errors via the injected runner", () => {
     setDockerRunner(
       new FakeRunner().withWhich("docker").withWhich("git").onRun("docker", ["info"], { code: 1 }),
     );
-    const message = await preflight({ platform: "darwin" }).catch((e: Error) => e.message);
+    const message = await dockerPreflight({ platform: "darwin" }).catch((e: Error) => e.message);
     expect(message).toMatch(/Docker Desktop/);
   });
 
-  it("git missing (docker fine): names git and how to install it", async () => {
+  it("docker present and daemon reachable resolves without requiring git", async () => {
     setDockerRunner(
       new FakeRunner()
         .withWhich("docker") // docker present, daemon ok (info exits 0 by default)
         .onRun("docker", ["info"], { code: 0 }),
       // git deliberately NOT marked present
     );
-    const message = await preflight({ platform: "linux" }).catch((e: Error) => e.message);
+    await expect(dockerPreflight({ platform: "linux" })).resolves.toBeUndefined();
+  });
+
+  it("never invokes a real binary — every probe goes through the injected runner", async () => {
+    const runner = new FakeRunner().withWhich("docker");
+    setDockerRunner(runner);
+    await dockerPreflight({ platform: "linux" });
+    // The only `run` recorded is the daemon probe; `which` is recorded too.
+    expect(runner.calls).toContainEqual(expect.objectContaining({ cmd: "docker", args: ["info"] }));
+  });
+});
+
+describe("server source preflight — Docker plus Git", () => {
+  it("git missing (docker fine): names git and how to install it", async () => {
+    setDockerRunner(new FakeRunner().withWhich("docker").onRun("docker", ["info"], { code: 0 }));
+    const message = await sourcePreflight({ platform: "linux" }).catch((e: Error) => e.message);
     expect(message).toMatch(/git/i);
     expect(message).toMatch(/install/i);
   });
 
-  it("all tools present + daemon reachable: resolves (no throw)", async () => {
+  it("all source tools present + daemon reachable: resolves (no throw)", async () => {
     setDockerRunner(
       new FakeRunner().withWhich("docker").withWhich("git").onRun("docker", ["info"], { code: 0 }),
     );
-    await expect(preflight({ platform: "linux" })).resolves.toBeUndefined();
-  });
-
-  it("never invokes a real binary — every probe goes through the injected runner", async () => {
-    const runner = new FakeRunner().withWhich("docker").withWhich("git");
-    setDockerRunner(runner);
-    await preflight({ platform: "linux" });
-    // The only `run` recorded is the daemon probe; `which` is recorded too.
-    expect(runner.calls).toContainEqual(expect.objectContaining({ cmd: "docker", args: ["info"] }));
+    await expect(sourcePreflight({ platform: "linux" })).resolves.toBeUndefined();
   });
 });

--- a/packages/installer-cli/tests/server.test.ts
+++ b/packages/installer-cli/tests/server.test.ts
@@ -1,10 +1,15 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { resetRunner } from "../src/exec.js";
 import { runCli } from "../src/runtime.js";
 import {
   resetRunner as resetDockerRunner,
   setRunner as setDockerRunner,
+  which as whichServerBinary,
 } from "../src/server/docker.js";
+import { SERVER_SUBCOMMANDS } from "../src/server/index.js";
 import { dockerPreflight, PreflightError, sourcePreflight } from "../src/server/preflight.js";
 import { FakeRunner } from "./helpers.js";
 
@@ -54,6 +59,28 @@ describe("librarian server (no subcommand) — the command surface", () => {
     expect(r.stdout).toContain("admin");
   });
 
+  it.each(SERVER_SUBCOMMANDS)("%s --help prints command help without dispatching", async (sub) => {
+    const runner = new FakeRunner().withFallback({ code: 1, stderr: "must not run" });
+    setDockerRunner(runner);
+
+    const r = await runCli(["server", sub, "--help"]);
+
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain(`Usage: librarian server ${sub}`);
+    expect(runner.calls).toEqual([]);
+  });
+
+  it.each(["up", "down", "update"])("%s -h cannot mutate server state", async (sub) => {
+    const runner = new FakeRunner().withFallback({ code: 1, stderr: "must not run" });
+    setDockerRunner(runner);
+
+    const r = await runCli(["server", sub, "-h"]);
+
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain(`Usage: librarian server ${sub}`);
+    expect(runner.calls).toEqual([]);
+  });
+
   it("an unknown subcommand errors and shows the surface", async () => {
     const r = await runCli(["server", "frobnicate"]);
     expect(r.exitCode).toBe(1);
@@ -63,6 +90,27 @@ describe("librarian server (no subcommand) — the command surface", () => {
 });
 
 describe("server Docker preflight — teaching errors via the injected runner", () => {
+  it.skipIf(process.platform === "win32")(
+    "the real runner finds Docker directly when PATH has no which utility",
+    async () => {
+      const binDir = fs.mkdtempSync(path.join(os.tmpdir(), "librarian-path-test-"));
+      const docker = path.join(binDir, "docker");
+      const previousPath = process.env.PATH;
+      try {
+        fs.writeFileSync(docker, "#!/bin/sh\nexit 0\n", { mode: 0o700 });
+        process.env.PATH = binDir;
+        resetDockerRunner();
+
+        await expect(whichServerBinary("docker")).resolves.toBe(docker);
+        await expect(whichServerBinary("which")).resolves.toBeNull();
+      } finally {
+        if (previousPath === undefined) delete process.env.PATH;
+        else process.env.PATH = previousPath;
+        fs.rmSync(binDir, { recursive: true, force: true });
+      }
+    },
+  );
+
   it("docker missing: names docker and how to install it (never a stack trace)", async () => {
     setDockerRunner(new FakeRunner()); // nothing on PATH
     await expect(dockerPreflight()).rejects.toBeInstanceOf(PreflightError);


### PR DESCRIPTION
## Summary

- pull and verify exact public GHCR releases for stable `server up`, `server update`, and autoupdate; run them by immutable digest without requiring Git
- preserve the source clone/build strategy for `main` and other development refs, with strict secure canonical-remote validation
- evolve deploy state compatibly with image provenance, and show published/source provenance in status and lifecycle output
- prepare updates before interruption and restore the previous exact executable and container configuration when replacement health or migration fails
- document the Docker-only stable lifecycle, source-ref escape hatch, rollback limits, and migration behavior

## Release

- version: `1.21.0` (MINOR)
- PR 1 registry gate verified `ghcr.io/code-ministry-ltd/the-librarian:v1.20.1` as public and anonymously pullable at `sha256:ba14c335ac0647c28aec618d141ab35c4cdf49dff898ee4703b814ad6ae3d269`

## Verification

- `pnpm --filter @the-librarian/cli test` — 532 passed
- `pnpm --filter @librarian/docs build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm smoke`
- `pnpm healthcheck` — 5/5 passed
- `pnpm check:docs`
- `pnpm check:release`
- focused final-review regressions — 160 passed
- real host with Docker but no Git or external `which`: fresh up, status, logs, admin rebuild, update, and down
- real source `main` ↔ published `v1.20.1` transitions preserved the protected env-file hash, volume, loopback ports, credentials, and persisted marker
- deliberately unhealthy replacement restored and health-verified the previous exact image/configuration without advancing state

## Rollback

Revert this PR to restore the source-build lifecycle. Existing deploy state remains backward-compatible and existing source checkouts, data, credentials, and volumes are preserved. If a runtime update fails, the command restores the previous executable/container configuration; persistent data is deliberately not rolled back.

## Noticed but not touching

`pnpm audit --audit-level=high` reports 39 existing lockfile advisories (6 low, 16 moderate, 15 high, 2 critical). This PR changes no dependency or `pnpm-lock.yaml` entry; dependency remediation needs a separate focused change.

## Review

Fresh adversarial review completed. Three findings—native executable lookup, secure/redacted source remotes, and side-effect-free subcommand help—were fixed and re-reviewed with no remaining required findings.

Co-authored with OpenAI Codex.
