### PR TITLE
Fix POST-only MCP transport discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.21.2] — 2026-08-11
+
+### Fixed
+
+- **Claude Code can connect over Streamable HTTP.** Authenticated `GET /mcp`
+  probes now return `405 Method Not Allowed` with `Allow: POST`, rather than a
+  misleading HTTP 200 JSON response, to signal that the optional standalone
+  SSE stream is not offered. POST JSON-RPC and the seven-tool MCP surface are
+  unchanged ([#459](https://github.com/code-ministry-ltd/the-librarian/issues/459)).
+
 ## [1.21.1] — 2026-08-09
 
 ### Changed
@@ -4423,6 +4433,7 @@ another.
 
 [1.21.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.20.1...v1.21.0
 [1.21.1]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.21.0...v1.21.1
+[1.21.2]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.21.1...v1.21.2
 [1.20.1]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.20.0...v1.20.1
 [1.20.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.17.5...v1.20.0
 [1.17.5]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.17.4...v1.17.5

--- a/README.md
+++ b/README.md
@@ -167,8 +167,10 @@ in the docs site.
 
 ## MCP tools — the 7-verb agent surface
 
-Agents talk to the Librarian over `/mcp` with a bearer token. The surface is
-exactly seven tools — contract-tested, with zero internal tools:
+Agents talk to the Librarian over `/mcp` with a bearer token. The endpoint
+accepts JSON-RPC over POST; because it offers no standalone server-push SSE
+stream, authenticated GET probes receive `405 Method Not Allowed`. The surface
+is exactly seven tools — contract-tested, with zero internal tools:
 
 ### Memory
 

--- a/apps/docs/src/content/docs/deploy-and-operate/manual-install.md
+++ b/apps/docs/src/content/docs/deploy-and-operate/manual-install.md
@@ -229,7 +229,8 @@ stop the stack, `chown -R 1000:1000` the volume's data directory, and start agai
 - **Dashboard:** `http://<host>:3042/` (single-container default; the Compose
   stack above publishes it on `:3839` instead)
 - **MCP endpoint (`/mcp`):** `http://<host>:3838/mcp` — agents POST JSON-RPC here with an
-  `Authorization: Bearer <token>` header.
+  `Authorization: Bearer <token>` header. The server offers no standalone server-push SSE
+  stream, so authenticated GET probes receive `405 Method Not Allowed`.
 - **Healthcheck (`/healthz`):** `http://<host>:3838/healthz`
 - **Primer (`/primer.md`):** `http://<host>:3838/primer.md` — the agent briefing, served **without
   authentication** by design so tools like OpenCode can load it from a URL. It is the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.21.1",
+  "version": "1.21.2",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/mcp-server/src/http/routes.ts
+++ b/packages/mcp-server/src/http/routes.ts
@@ -658,14 +658,9 @@ async function handleMcp(ctx: RouteContext): Promise<void> {
   if (refuseMissingProxyBearer(ctx)) return;
   const authed = await ctx.provider.authenticate(req, "public", "agent");
   if (!authed.ok) return sendAuthRefusal(ctx, authed);
-  if (req.method === "GET") {
-    return sendJson(res, {
-      status: "ok",
-      transport: "json-rpc-http",
-      message: "POST JSON-RPC MCP messages to this endpoint.",
-    });
+  if (req.method !== "POST") {
+    return sendJson(res, { error: "Method not allowed" }, 405, { allow: "POST" });
   }
-  if (req.method !== "POST") return sendJson(res, { error: "Method not allowed" }, 405);
   const payload = await readJson(req, maxBodyBytes);
   const response = await handleMcpPayload(
     store,

--- a/packages/mcp-server/tests/http/capture-scope.test.ts
+++ b/packages/mcp-server/tests/http/capture-scope.test.ts
@@ -120,11 +120,16 @@ describe("capture-scope isolation end-to-end", () => {
             : { jsonrpc: "2.0", id: 1, method: "tools/list" },
         ),
       });
+    const getMcp = (token: string) =>
+      fetch(`${server.url}/mcp`, {
+        headers: { accept: "text/event-stream", authorization: `Bearer ${token}` },
+      });
     try {
       // /mcp: agent reaches the 7 verbs; a capture token is FORBIDDEN (403), not
       // merely unauthorized — the wall's first direction.
       expect((await post("/mcp", agentTok.token)).status).toBe(200);
       expect((await post("/mcp", captureTok.token)).status).toBe(403);
+      expect((await getMcp(captureTok.token)).status).toBe(403);
 
       // /ingest: capture token accepted (202 queued — the row is written pending;
       // the real write path is a later task); an agent token is FORBIDDEN (403);

--- a/packages/mcp-server/tests/http/routes.test.ts
+++ b/packages/mcp-server/tests/http/routes.test.ts
@@ -111,6 +111,50 @@ describe("HTTP routes (post-T7.1)", () => {
     }
   });
 
+  it("returns 405 for authenticated standalone stream probes while preserving auth and POST", async () => {
+    const dataDir = makeTempDir();
+    const server = await startHttpServer({ dataDir, agentToken: "agent-token" });
+    const authorization = `Bearer ${server.agentToken}`;
+    try {
+      const unauthenticated = await fetch(`${server.url}/mcp`);
+      expect(unauthenticated.status).toBe(401);
+
+      const hostileOrigin = await fetch(`${server.url}/mcp`, {
+        headers: {
+          accept: "text/event-stream",
+          authorization,
+          origin: "https://evil.example",
+        },
+      });
+      expect(hostileOrigin.status).toBe(403);
+
+      for (const method of ["GET", "HEAD", "DELETE"] as const) {
+        const response = await fetch(`${server.url}/mcp`, {
+          method,
+          headers: { accept: "text/event-stream", authorization },
+        });
+        expect(response.status, `${method} /mcp should reject the unsupported method`).toBe(405);
+        expect(response.headers.get("allow"), `${method} /mcp should advertise POST`).toBe("POST");
+        expect(response.headers.get("cache-control")).toBe("no-store");
+        if (method === "GET") {
+          expect(response.headers.get("content-type")).toBe("application/json; charset=utf-8");
+          expect(await response.json()).toEqual({ error: "Method not allowed" });
+        }
+      }
+
+      const post = await postJson(
+        `${server.url}/mcp`,
+        { jsonrpc: "2.0", id: 1, method: "tools/list" },
+        { authorization },
+      );
+      expect(post.response.status).toBe(200);
+      expect(post.json).toMatchObject({ jsonrpc: "2.0", id: 1 });
+    } finally {
+      await server.stop();
+      cleanupTempDir(dataDir);
+    }
+  });
+
   it("flags a memory over /mcp end-to-end and no longer exposes verify_memory", async () => {
     const dataDir = makeTempDir();
     const server = await startHttpServer({ dataDir, agentToken: "agent-token" });

--- a/packages/mcp-server/tests/provider-seam-live.test.ts
+++ b/packages/mcp-server/tests/provider-seam-live.test.ts
@@ -262,10 +262,13 @@ describe("spec 061 T4 — substitute auth provider is the live identity source (
       expect(protectedCalls).toBe(0);
 
       const credentialed = await fetch(`${publicBase}/mcp`, {
+        method: "POST",
         headers: {
           authorization: "Bearer provider-owned-credential",
+          "content-type": "application/json",
           "x-librarian-require-auth": "single-port",
         },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
       });
       expect(credentialed.status).toBe(200);
       expect(protectedCalls).toBe(1);


### PR DESCRIPTION
Closes #459.

## What changed

- Return `405 Method Not Allowed` with `Allow: POST` for authenticated non-POST requests to `/mcp`.
- Preserve authentication, token-scope, proxy-auth, and Origin checks before method rejection.
- Keep POST JSON-RPC and the seven-tool MCP surface unchanged.
- Document the POST-only transport contract and bump the patch version to 1.21.2.

## Why

The endpoint previously returned a successful JSON status document to `GET /mcp`. Streamable HTTP clients can treat that GET as a standalone SSE probe; a successful non-SSE response is misleading and prevents the client from cleanly falling back to POST-only operation. MCP permits a server without standalone SSE support to answer that probe with 405.

## Validation

- MCP server build and typecheck
- ESLint and Prettier on the changed files
- HTTP route tests: 11/11
- Capture-scope and provider-seam tests: 18/18
- Lint and workspace typecheck
- Smoke test (with an unused internal tRPC port)
- Healthcheck: 5/5
- Test-count guard: 3,351 tests >= 1,400 floor
- Documentation and release guards
- Dependency audit: no known vulnerabilities
- Hermes integration: 126/126
- Independent adversarial review: no material findings

`pnpm test` was also attempted on the shared development host. Its parallel core run hit three 5-second store-test timeouts; a serial retry hit the same host-load sensitivity. All seven affected tests passed together in isolation. The focused MCP suites and every other gate above are green; CI should provide the clean-run full-suite result.

## Not touched

- No SSE transport was added.
- No route matcher, authentication policy, Origin policy, or MCP dispatch behavior changed.
- Existing untracked `docs/research/` and `docs/specs/` content was left untouched.
