### PR TITLE
feat(docker): opt-in operator DNS for tailnet-only provider hostnames

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -148,3 +148,15 @@ LIBRARIAN_DATA_GID=1001
 # https://memory.example.com,chrome-extension://<extension-id>
 # Comma-separated; no trailing slash on HTTPS origins.
 LIBRARIAN_ALLOWED_ORIGINS=
+
+# ----- Optional: operator DNS for the containers -----
+# Nameserver(s) the containers use (replaces Docker's default resolv.conf
+# when set). Leave both unset for the default behaviour. Set this when the
+# curator's LLM provider is only reachable on a tailnet — e.g. a Tailscale
+# Serve hostname. Put the Tailscale resolver FIRST: c-ares never consults a
+# later nameserver after an NXDOMAIN, and IP-based access fails (Tailscale
+# Serve TLS needs the hostname SNI). Tailscale MagicDNS also forwards public
+# lookups, so the single server usually suffices; LIBRARIAN_DNS_FALLBACK is
+# an optional second nameserver (e.g. 8.8.8.8).
+# LIBRARIAN_DNS=100.100.100.100
+# LIBRARIAN_DNS_FALLBACK=8.8.8.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.22.0] — 2026-08-17
+
+### Added
+
+- **Opt-in operator DNS for the Docker deployments** (`LIBRARIAN_DNS` /
+  `LIBRARIAN_DNS_FALLBACK`, in both Compose stacks and the env examples):
+  containers can now resolve tailnet-only hostnames — e.g. a Tailscale-Serve
+  LLM provider for the curator — which previously failed with `ENOTFOUND`
+  because the bridge container only saw public resolvers. Unset, deployments
+  keep Docker's default DNS exactly as before. The manual-deployment docs
+  cover the two gotchas: the container's resolver (c-ares) never consults a
+  later nameserver after an NXDOMAIN, so the Tailscale resolver must come
+  first; and IP-based access fails because Tailscale Serve TLS needs the
+  hostname (SNI).
+
 ## [1.21.2] — 2026-08-11
 
 ### Fixed
@@ -4434,6 +4449,7 @@ another.
 [1.21.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.20.1...v1.21.0
 [1.21.1]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.21.0...v1.21.1
 [1.21.2]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.21.1...v1.21.2
+[1.22.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.21.2...v1.22.0
 [1.20.1]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.20.0...v1.20.1
 [1.20.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.17.5...v1.20.0
 [1.17.5]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.17.4...v1.17.5

--- a/apps/docs/src/content/docs/deploy-and-operate/manual-install.md
+++ b/apps/docs/src/content/docs/deploy-and-operate/manual-install.md
@@ -55,6 +55,12 @@ Key points:
   what the secret key wants — not the base64 value used for tokens.
 - Put the published port behind **TLS** on any host reachable beyond loopback, and do
   not set `LIBRARIAN_ALLOW_NO_AUTH=true` on a publicly reachable host.
+- If the curator's LLM provider is only reachable on a tailnet (for example a
+  Tailscale-Serve hostname), add `--dns 100.100.100.100` to the `docker run`
+  command — Docker's default nameservers cannot resolve tailnet-only names.
+  The [Image-only Compose](#image-only-compose-recommended-manual-path) section
+  below covers the why (first-resolver-wins, and IP-based access failing on
+  Tailscale Serve).
 - The image crash-fasts if either service dies, so your orchestrator restarts the
   pair.
 
@@ -90,6 +96,21 @@ beyond loopback, terminate TLS in front of it and treat network access as admin
 access. The default named volume is `librarian_data`. For a bind mount, set
 `LIBRARIAN_DATA_SOURCE` to an absolute host path and set `LIBRARIAN_DATA_UID` /
 `LIBRARIAN_DATA_GID` to its owner.
+
+If the curator's LLM provider is only reachable on a tailnet (for example a
+Tailscale-Serve hostname), give the container the Tailscale resolver in `.env`:
+
+```sh
+LIBRARIAN_DNS=100.100.100.100
+LIBRARIAN_DNS_FALLBACK=8.8.8.8  # optional second nameserver
+```
+
+Both values are opt-in — leave them unset for Docker's default DNS. Two gotchas
+apply to that order: the container's resolver (c-ares) never consults a later
+nameserver after an NXDOMAIN, so the Tailscale resolver must come **first**; and
+reaching the provider by IP fails, because Tailscale Serve TLS needs the
+hostname (SNI), not the address. Tailscale MagicDNS forwards public lookups, so
+the single resolver is usually enough.
 
 Use exact version tags for controlled upgrades and rollbacks:
 
@@ -210,6 +231,10 @@ published hosts:
 LIBRARIAN_MCP_PUBLISHED_HOST=100.x.y.z
 LIBRARIAN_DASHBOARD_PUBLISHED_HOST=100.x.y.z
 ```
+
+If the curator's LLM provider is also reachable only on the tailnet, set the
+Tailscale resolver in `.env` too (first-resolver-wins — see the Image-only
+Compose section above): `LIBRARIAN_DNS=100.100.100.100`.
 
 Build and start, then verify:
 

--- a/docker/all-in-one.env.example
+++ b/docker/all-in-one.env.example
@@ -30,4 +30,12 @@ LIBRARIAN_DATA_GID=1000
 # LIBRARIAN_ALLOWED_ORIGINS=https://memory.example.com
 # LIBRARIAN_SINGLE_PORT=true
 # LIBRARIAN_PUBLIC_URL=https://memory.example.com
+# Operator DNS for the container (replaces Docker's default resolv.conf when
+# set). Leave unset for the default. Needed when the curator's LLM provider is
+# only reachable on a tailnet: put the Tailscale resolver FIRST (c-ares never
+# consults a later nameserver after an NXDOMAIN; IP-based access fails because
+# Tailscale Serve TLS needs the hostname SNI). MagicDNS forwards public
+# lookups, so the single server usually suffices.
+# LIBRARIAN_DNS=100.100.100.100
+# LIBRARIAN_DNS_FALLBACK=8.8.8.8
 

--- a/docker/docker-compose.image.yml
+++ b/docker/docker-compose.image.yml
@@ -21,6 +21,15 @@ services:
       LIBRARIAN_DATA_DIR: /data
       LIBRARIAN_HOST: 0.0.0.0
       LIBRARIAN_PORT: "3838"
+    # Opt-in operator DNS (both unset = Docker's default resolv.conf, no change).
+    # Set the Tailscale resolver FIRST when the curator's LLM provider is only
+    # reachable on a tailnet: c-ares never consults a later nameserver after an
+    # NXDOMAIN, and IP-based access fails (Tailscale Serve TLS needs the hostname).
+    # Tailscale MagicDNS also forwards public lookups, so the one server usually
+    # suffices; LIBRARIAN_DNS_FALLBACK is an optional second nameserver.
+    dns:
+      - ${LIBRARIAN_DNS:-}
+      - ${LIBRARIAN_DNS_FALLBACK:-}
     ports:
       - "${LIBRARIAN_DASHBOARD_PUBLISHED_HOST:-127.0.0.1}:${LIBRARIAN_DASHBOARD_PORT:-3042}:3000"
       - "${LIBRARIAN_MCP_PUBLISHED_HOST:-127.0.0.1}:${LIBRARIAN_MCP_PORT:-3838}:3838"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -38,6 +38,16 @@ services:
       # host. The boundary is the isolated docker network, not a bearer token.
       LIBRARIAN_TRPC_HOST: "0.0.0.0"
       LIBRARIAN_TRPC_PORT: "3840"
+    # Opt-in operator DNS (both unset = Docker's default resolv.conf, no change).
+    # The mcp-server reaches the curator's LLM provider over this DNS; set the
+    # Tailscale resolver FIRST when that provider is only reachable on a tailnet
+    # — c-ares never consults a later nameserver after an NXDOMAIN, and
+    # IP-based access fails (Tailscale Serve TLS needs the hostname SNI).
+    # Tailscale MagicDNS also forwards public lookups, so the one server usually
+    # suffices; LIBRARIAN_DNS_FALLBACK is an optional second nameserver.
+    dns:
+      - ${LIBRARIAN_DNS:-}
+      - ${LIBRARIAN_DNS_FALLBACK:-}
     ports:
       # Only the public agent port (/mcp + /healthz + /primer.md) is published.
       # The tRPC port (3840) is intentionally NOT here — see LIBRARIAN_TRPC_* above.
@@ -84,6 +94,11 @@ services:
       NODE_ENV: "production"
       PORT: "3000"
       HOSTNAME: "0.0.0.0"
+    # Same opt-in operator DNS as mcp-server (see that service's dns: block);
+    # both are unset by default, leaving Docker's default resolv.conf in place.
+    dns:
+      - ${LIBRARIAN_DNS:-}
+      - ${LIBRARIAN_DNS_FALLBACK:-}
     ports:
       - "${LIBRARIAN_DASHBOARD_PUBLISHED_HOST:-127.0.0.1}:3839:3000"
     networks:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.21.2",
+  "version": "1.22.0",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/installer-cli/tests/docker-compose-image.test.ts
+++ b/packages/installer-cli/tests/docker-compose-image.test.ts
@@ -60,4 +60,19 @@ describe("image-only Docker Compose deployment", () => {
       "docker compose --env-file docker/all-in-one.env.example -f docker/docker-compose.image.yml config --quiet",
     );
   });
+
+  it("exposes opt-in operator DNS with no hard-coded tailnet default", () => {
+    // Unset vars render no `dns:` key at all (Compose drops empty list items),
+    // so a default deployment keeps Docker's resolv.conf untouched. The
+    // Tailscale resolver must never be baked in as a default — it adds latency
+    // and is meaningless off a tailnet host.
+    expect(compose).toContain("- ${LIBRARIAN_DNS:-}");
+    expect(compose).toContain("- ${LIBRARIAN_DNS_FALLBACK:-}");
+    expect(compose).not.toContain("100.100.100.100");
+    // The tailnet guidance ships commented out (opt-in) in the env example,
+    // and puts the Tailscale resolver first (c-ares never falls back after an
+    // NXDOMAIN).
+    expect(envExample).toContain("# LIBRARIAN_DNS=100.100.100.100");
+    expect(envExample).toContain("# LIBRARIAN_DNS_FALLBACK=8.8.8.8");
+  });
 });

--- a/test/docker-compose.test.ts
+++ b/test/docker-compose.test.ts
@@ -36,6 +36,18 @@ describe("docker-compose host publishing", () => {
     ).toBe(true);
   });
 
+  it("exposes opt-in operator DNS on every service, with no tailnet default", () => {
+    // Both services share the host's egress constraints (the mcp-server makes
+    // the curator's LLM calls); unset vars render no `dns:` key, so this is a
+    // no-op unless the operator sets LIBRARIAN_DNS(_FALLBACK). The Tailscale
+    // resolver must never be the default — it adds latency off a tailnet host.
+    const dnsSlots = compose.match(/^\s+- \$\{LIBRARIAN_DNS:-\}$/gm) ?? [];
+    expect(dnsSlots, "every service declares the opt-in LIBRARIAN_DNS slot").toHaveLength(2);
+    const fallbackSlots = compose.match(/^\s+- \$\{LIBRARIAN_DNS_FALLBACK:-\}$/gm) ?? [];
+    expect(fallbackSlots, "every service declares the optional DNS fallback slot").toHaveLength(2);
+    expect(compose).not.toContain("100.100.100.100");
+  });
+
   it("never publishes the admin tRPC port (3840) to the host", () => {
     // 3840 appears only as the internal LIBRARIAN_TRPC_PORT env value, never in a
     // host `ports:` mapping (which would read `:3840:3840`). ADR 0008: the admin


### PR DESCRIPTION
## Why

Bridge containers only see Docker's default resolv.conf (public resolvers), so a curator LLM provider reachable only on a tailnet (e.g. a Tailscale-Serve llama-swap hostname) fails with ENOTFOUND while the exact same URL works from the host. IP-based access is not an alternative: Tailscale Serve TLS needs the hostname SNI. This was a real outage (curator intake + grooming pointing at a tailnet-only provider).

## What

- `LIBRARIAN_DNS` / `LIBRARIAN_DNS_FALLBACK` in both compose stacks (all-in-one image + two-service), verified against compose v2.35: **both unset → no `dns:` key at all** (Compose drops empty list items), so existing deployments keep their default DNS untouched; the Tailscale resolver is never a default because it adds latency on non-tailnet hosts.
- One var per list slot on purpose: compose does NOT split comma-separated values into list items.
- Docs: env examples (commented, opt-in) + manual-deployment page covering the two gotchas — c-ares never consults a later nameserver after an NXDOMAIN (Tailscale resolver must come first), and MagicDNS forwards public lookups so the single resolver usually suffices.
- Regression guards added to both compose test suites (opt-in wiring present; no hard-coded tailnet default).

## Version

1.21.2 → 1.22.0 (MINOR: new opt-in config surface). CHANGELOG entry included.

## Verification

- Full `pnpm test` green (root 246, dashboard 603, all workspaces)
- `pnpm run lint`, `pnpm run typecheck`, `scripts/check-release.mjs` all pass
- Live renders with the standalone compose binary v2.35.1: env example unset (renders, no dns key), single server, server + fallback (correct ordered list)