### PR TITLE
feat(installer-cli): opt-in operator DNS for CLI-managed deploys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.23.0] — 2026-08-20
+
+### Added
+
+- **Opt-in operator DNS for CLI-managed all-in-one deploys** (`librarian server
+  up/update --dns 100.100.100.100 [--dns-fallback 8.8.8.8]`): the Compose stacks
+  already had `LIBRARIAN_DNS` (v1.22.0); the installer CLI had no equivalent, so
+  a tailnet-only curator LLM hostname failed with `ENOTFOUND` inside the
+  container, and a manual `docker --dns` was wiped by `server update`
+  ([#462](https://github.com/code-ministry-ltd/the-librarian/issues/462)). Unset,
+  Docker's default resolv.conf is unchanged. `--dns` on `server update` recreates
+  even when the image is already current; later updates reuse the stored
+  nameserver. `--no-dns` clears it.
+
 ## [1.22.0] — 2026-08-17
 
 ### Added
@@ -4449,6 +4463,7 @@ another.
 [1.21.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.20.1...v1.21.0
 [1.21.1]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.21.0...v1.21.1
 [1.21.2]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.21.1...v1.21.2
+[1.23.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.22.0...v1.23.0
 [1.22.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.21.2...v1.22.0
 [1.20.1]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.20.0...v1.20.1
 [1.20.0]: https://github.com/code-ministry-ltd/the-librarian/compare/v1.17.5...v1.20.0

--- a/apps/docs/src/content/docs/deploy-and-operate/manual-install.md
+++ b/apps/docs/src/content/docs/deploy-and-operate/manual-install.md
@@ -58,7 +58,9 @@ Key points:
 - If the curator's LLM provider is only reachable on a tailnet (for example a
   Tailscale-Serve hostname), add `--dns 100.100.100.100` to the `docker run`
   command — Docker's default nameservers cannot resolve tailnet-only names.
-  The [Image-only Compose](#image-only-compose-recommended-manual-path) section
+  CLI-managed deploys (`librarian server up` / `update`) take `--dns 100.100.100.100`
+  instead; that choice is stored so `server update` does not drop it. The
+  [Image-only Compose](#image-only-compose-recommended-manual-path) section
   below covers the why (first-resolver-wins, and IP-based access failing on
   Tailscale Serve).
 - The image crash-fasts if either service dies, so your orchestrator restarts the
@@ -234,7 +236,8 @@ LIBRARIAN_DASHBOARD_PUBLISHED_HOST=100.x.y.z
 
 If the curator's LLM provider is also reachable only on the tailnet, set the
 Tailscale resolver in `.env` too (first-resolver-wins — see the Image-only
-Compose section above): `LIBRARIAN_DNS=100.100.100.100`.
+Compose section above): `LIBRARIAN_DNS=100.100.100.100`. (CLI-managed
+all-in-one deploys use `librarian server update --dns 100.100.100.100` instead.)
 
 Build and start, then verify:
 

--- a/apps/docs/src/content/docs/deploy-and-operate/self-host.md
+++ b/apps/docs/src/content/docs/deploy-and-operate/self-host.md
@@ -133,6 +133,35 @@ A server first brought up before 3042 became the default keeps publishing on
 from under you. Run `up --dashboard-port 3042` (or any port) to opt into a change.
 :::
 
+## Reaching a tailnet-only LLM (`--dns`)
+
+The container's default resolv.conf is Docker's public resolvers. A curator LLM
+provider that exists only on your Tailscale tailnet (a Tailscale-Serve hostname)
+fails with `ENOTFOUND` from inside the container while the same URL works on the
+host. Pointing the curator at the `100.x` IP is not a workaround: Serve TLS needs
+the hostname (SNI).
+
+Give the container the Tailscale resolver:
+
+```sh
+librarian server up --dns 100.100.100.100
+# existing deploy — works even when you are already on the latest image:
+librarian server update --dns 100.100.100.100
+```
+
+`--dns-fallback 8.8.8.8` is optional. The container's resolver (c-ares) never
+consults a later nameserver after an NXDOMAIN, so the Tailscale resolver must
+come **first**; MagicDNS already forwards public lookups, so the single resolver
+usually suffices. `--no-dns` returns to Docker's default. Unset, nothing
+changes — there is no Tailscale default, because that resolver adds latency on
+hosts that are not on a tailnet.
+
+The choice is recorded in deploy-state, so later `update` / auto-update reuse it.
+A same-version `update` with no DNS flags does **not** no-op past a *new* `--dns`
+the way it no-ops an unchanged image; that is how an already-current server picks
+this up. Compose stacks use `LIBRARIAN_DNS` instead — see
+[Manual deployment](/deploy-and-operate/manual-install/).
+
 ## Scripted first-owner bootstrap
 
 The normal first run is still the dashboard's **Settings → Auth** wizard. For an
@@ -214,10 +243,13 @@ burn flag refuses claims until the operator removes it.
 - **`server update`** re-pins forward: resolve the latest stable release, pull and
   verify its exact image while the current server keeps serving, then recreate the
   container by immutable digest. Storage, host/ports, credentials, restart policy,
-  bootstrap-claim secret, and legacy dashboard-port choices are preserved. Pending
+  bootstrap-claim secret, operator DNS (`--dns`), and legacy dashboard-port choices
+  are preserved. Pending
   data migrations run only after the replacement is healthy. Once the target
   release is resolved, an already-current, healthy deployment is a no-op before
-  pulling it again; an exact `--ref vX.Y.Z` also avoids resolving the latest release.
+  pulling it again, **unless** you pass `--dns` / `--no-dns` that differs from
+  what is stored and running; an exact `--ref vX.Y.Z` also avoids resolving the
+  latest release.
 - **`server down`** stops the container with `docker stop` only. It never removes the
   container or the volume; a later `up`/`update` recalls the same memories.
 - **`server status`** reports whether it's running, its health, the deployed and

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/installer-cli/README.md
+++ b/packages/installer-cli/README.md
@@ -101,9 +101,14 @@ writable by — you, not a container user. The directory is created if it doesn'
 exist, and `server update` reuses it automatically. (`--data-dir` and
 `--data-volume` are mutually exclusive.)
 
+If the curator's LLM is only reachable on a tailnet, pass `--dns 100.100.100.100`
+on `server up` or `server update` (the latter works even when the image is
+already current). The nameserver is recorded in deploy-state so later updates
+keep it. Compose stacks use `LIBRARIAN_DNS` instead.
+
 Other server commands: `server update` pulls and verifies before stopping the old
-container, preserving storage, ports, credentials, restart policy, and deploy
-state. A failed replacement restores and health-checks the previous executable;
+container, preserving storage, ports, credentials, restart policy, operator DNS
+(`--dns`), and deploy state. A failed replacement restores and health-checks the previous executable;
 if migration began, persistent data changes are explicitly **not** claimed as
 rolled back. `server status` labels deployments as published (with a short
 digest), source, or legacy. `server down` / `logs` and `server enable-boot`

--- a/packages/installer-cli/src/runtime.ts
+++ b/packages/installer-cli/src/runtime.ts
@@ -406,6 +406,8 @@ async function runServerUpdateCommand(rest: string[], options: RuntimeOptions): 
     ref: flagString(flags.ref),
     dir: flagString(flags.dir),
     yes: flagBool(flags.yes),
+    dns: flags.dns,
+    dnsFallback: flags["dns-fallback"],
     home: options.home,
   });
   return ok(result.output);

--- a/packages/installer-cli/src/runtime.ts
+++ b/packages/installer-cli/src/runtime.ts
@@ -283,6 +283,8 @@ async function runServerUpCommand(rest: string[], options: RuntimeOptions): Prom
         dataVolume: flagString(flags["data-volume"]),
         dataDir: flagString(flags["data-dir"]),
         dashboardPort: flagString(flags["dashboard-port"]),
+        dns: flags.dns,
+        dnsFallback: flags["dns-fallback"],
         enableBoot: flagBool(flags["enable-boot"]),
         yes: flagBool(flags.yes),
       },

--- a/packages/installer-cli/src/server/deploy-state.ts
+++ b/packages/installer-cli/src/server/deploy-state.ts
@@ -49,6 +49,18 @@ interface DeployStateBase {
    * to `3042`. Like `dataDir`, it is back-compatible (old states still validate).
    */
   dashboardPort?: number | undefined;
+  /**
+   * Primary container nameserver (`docker create --dns`). Optional — absent on
+   * deploys that use Docker's default resolv.conf and on states written before
+   * this field existed. Non-secret (an IP address).
+   */
+  dns?: string | undefined;
+  /**
+   * Optional second nameserver. Only meaningful when `dns` is set; c-ares never
+   * consults it after an NXDOMAIN from the primary, so the Tailscale resolver
+   * must be `dns`, not this field.
+   */
+  dnsFallback?: string | undefined;
 }
 
 /** State written before explicit image provenance existed; interpreted as source. */
@@ -86,6 +98,8 @@ const PERSISTED_STATE_KEYS = new Set<string>([
   ...REQUIRED_STATE_KEYS,
   "dataDir",
   "dashboardPort",
+  "dns",
+  "dnsFallback",
   "imageSource",
   "imageRef",
   "imageDigest",
@@ -172,6 +186,8 @@ export function writeDeployState(dir: string, state: DeployState): void {
   // Persist the published dashboard port when set, so `update` reuses it (a state
   // written before this field stays byte-compatible until the next write).
   if (state.dashboardPort !== undefined) safe.dashboardPort = state.dashboardPort;
+  if (state.dns) safe.dns = state.dns;
+  if (state.dnsFallback) safe.dnsFallback = state.dnsFallback;
   if (state.imageSource !== undefined) safe.imageSource = state.imageSource;
   if (state.imageRef !== undefined) safe.imageRef = state.imageRef;
   if (state.imageDigest !== undefined) safe.imageDigest = state.imageDigest;
@@ -230,6 +246,12 @@ export function readDeployState(dir: string): DeployState | null {
   // recreating on a corrupt port.
   if (typeof obj.dashboardPort === "number" && Number.isInteger(obj.dashboardPort)) {
     result.dashboardPort = obj.dashboardPort;
+  }
+  // Optional, back-compatible: present only when the operator set `--dns`.
+  // Garbage (non-string) is ignored so an old/corrupt file still parses.
+  if (typeof obj.dns === "string" && obj.dns.length > 0) result.dns = obj.dns;
+  if (typeof obj.dnsFallback === "string" && obj.dnsFallback.length > 0) {
+    result.dnsFallback = obj.dnsFallback;
   }
   return validImageMetadata(result) ? result : null;
 }

--- a/packages/installer-cli/src/server/dns.ts
+++ b/packages/installer-cli/src/server/dns.ts
@@ -1,0 +1,128 @@
+// Opt-in operator DNS for `librarian server up` / `update`.
+//
+// Docker DNS is a *runtime* setting (`docker create --dns`), not a container
+// env var — so it cannot live in deploy.env. Nameservers are persisted in
+// non-secret deploy-state and emitted from `buildRunArgs`. Compose already has
+// LIBRARIAN_DNS (PR #461); this module is the CLI equivalent.
+//
+// c-ares never consults a later nameserver after NXDOMAIN, so primary must
+// come first. MagicDNS forwards public lookups, so a single Tailscale resolver
+// (`100.100.100.100`) usually suffices. Unset → Docker's default resolv.conf.
+
+import { isIP } from "node:net";
+import type { FlagValue } from "../parse-args.js";
+
+export class DnsConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DnsConfigError";
+  }
+}
+
+export type DnsOption = { kind: "unset" } | { kind: "set"; value: string } | { kind: "clear" };
+
+export interface DnsConfig {
+  dns?: string | undefined;
+  dnsFallback?: string | undefined;
+}
+
+/** Parse `--dns` / `--dns-fallback` / `--no-dns` / `--no-dns-fallback`. */
+export function parseDnsFlag(
+  value: FlagValue | undefined,
+  flag: "--dns" | "--dns-fallback",
+): DnsOption {
+  if (value === undefined) return { kind: "unset" };
+  if (value === false) return { kind: "clear" };
+  if (value === true) {
+    throw new DnsConfigError(`${flag} requires an IPv4 address (e.g. ${flag} 100.100.100.100).`);
+  }
+  if (Array.isArray(value)) {
+    throw new DnsConfigError(`Pass ${flag} once — repeated values are not a DNS list.`);
+  }
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return { kind: "clear" };
+  return { kind: "set", value: validateNameserver(trimmed, flag) };
+}
+
+export function dnsFlagsSpecified(dns: DnsOption, dnsFallback: DnsOption): boolean {
+  return dns.kind !== "unset" || dnsFallback.kind !== "unset";
+}
+
+/**
+ * Merge flags onto stored deploy-state. `--no-dns` clears both; `--no-dns-fallback`
+ * clears only the fallback. A fallback with no primary is a teaching error.
+ */
+export function resolveDnsConfig(input: {
+  dns: DnsOption;
+  dnsFallback: DnsOption;
+  stored?: DnsConfig | undefined;
+}): DnsConfig {
+  let dns = input.stored?.dns;
+  let dnsFallback = input.stored?.dnsFallback;
+  if (input.dns.kind === "set") dns = input.dns.value;
+  if (input.dns.kind === "clear") {
+    dns = undefined;
+    dnsFallback = undefined;
+  }
+  if (input.dnsFallback.kind === "set") dnsFallback = input.dnsFallback.value;
+  if (input.dnsFallback.kind === "clear") dnsFallback = undefined;
+  if (dnsFallback && !dns) {
+    throw new DnsConfigError(
+      "--dns-fallback requires a primary nameserver. Pass --dns <ipv4> as well, or drop --dns-fallback.",
+    );
+  }
+  if (dns) validateNameserver(dns, "--dns");
+  if (dnsFallback) validateNameserver(dnsFallback, "--dns-fallback");
+  return { dns, dnsFallback };
+}
+
+export function nameserverTuple(config: DnsConfig): string[] {
+  const servers: string[] = [];
+  if (config.dns) servers.push(config.dns);
+  if (config.dnsFallback) servers.push(config.dnsFallback);
+  return servers;
+}
+
+export function dnsConfigFromServers(servers: string[]): DnsConfig {
+  return {
+    ...(servers[0] ? { dns: servers[0] } : {}),
+    ...(servers[1] ? { dnsFallback: servers[1] } : {}),
+  };
+}
+
+export function sameNameservers(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((value, i) => value === b[i]);
+}
+
+/** Docker `HostConfig.Dns` is a string array, null, or absent. */
+export function parseLiveDns(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is string => typeof entry === "string" && entry.length > 0);
+}
+
+/**
+ * Replacement nameservers: flags or stored state win; otherwise keep whatever
+ * the live container already has (so a manual `--dns` stopgap survives a
+ * version-bump recreate and gets adopted into deploy-state).
+ */
+export function dnsServersForReplacement(input: {
+  flagsSpecified: boolean;
+  resolved: DnsConfig;
+  live: string[];
+}): string[] {
+  if (input.flagsSpecified || input.resolved.dns) return nameserverTuple(input.resolved);
+  return input.live;
+}
+
+function validateNameserver(value: string, flag: "--dns" | "--dns-fallback"): string {
+  const kind = isIP(value);
+  if (kind === 4) return value;
+  if (kind === 6) {
+    throw new DnsConfigError(
+      `IPv6 nameservers are not supported yet (got '${value}' for ${flag}). Use an IPv4 address (e.g. 100.100.100.100).`,
+    );
+  }
+  throw new DnsConfigError(
+    `Invalid ${flag} '${value}': expected an IPv4 address (e.g. 100.100.100.100).`,
+  );
+}

--- a/packages/installer-cli/src/server/dns.ts
+++ b/packages/installer-cli/src/server/dns.ts
@@ -114,6 +114,26 @@ export function dnsServersForReplacement(input: {
   return input.live;
 }
 
+/**
+ * Same-version no-op may skip DNS when the operator has neither flags nor stored
+ * DNS (a live hand-patch must not force a recreate). Flags or stored DNS must
+ * match both live and state before we no-op.
+ */
+export function dnsAllowsNoOp(input: {
+  flagsSpecified: boolean;
+  stored: string[];
+  live: string[];
+  desired: string[];
+}): boolean {
+  if (input.flagsSpecified) {
+    return (
+      sameNameservers(input.desired, input.live) && sameNameservers(input.desired, input.stored)
+    );
+  }
+  if (input.stored.length > 0) return sameNameservers(input.stored, input.live);
+  return true;
+}
+
 function validateNameserver(value: string, flag: "--dns" | "--dns-fallback"): string {
   const kind = isIP(value);
   if (kind === 4) return value;

--- a/packages/installer-cli/src/server/index.ts
+++ b/packages/installer-cli/src/server/index.ts
@@ -48,6 +48,7 @@ export function serverSubcommandUsage(subcommand: ServerSubcommand): string {
     up: [
       "Usage: librarian server up [--ref <release|source-ref>] [--dir <path>]",
       "       [--host <address>] [--dashboard-port <port>]",
+      "       [--dns <ipv4>] [--dns-fallback <ipv4>]",
       "       [--data-volume <name> | --data-dir <path>] [--enable-boot] [--yes]",
     ],
     update: ["Usage: librarian server update [--ref <release|source-ref>] [--dir <path>] [--yes]"],

--- a/packages/installer-cli/src/server/index.ts
+++ b/packages/installer-cli/src/server/index.ts
@@ -51,7 +51,10 @@ export function serverSubcommandUsage(subcommand: ServerSubcommand): string {
       "       [--dns <ipv4>] [--dns-fallback <ipv4>]",
       "       [--data-volume <name> | --data-dir <path>] [--enable-boot] [--yes]",
     ],
-    update: ["Usage: librarian server update [--ref <release|source-ref>] [--dir <path>] [--yes]"],
+    update: [
+      "Usage: librarian server update [--ref <release|source-ref>] [--dir <path>] [--yes]",
+      "       [--dns <ipv4>] [--dns-fallback <ipv4>]",
+    ],
     down: ["Usage: librarian server down"],
     status: ["Usage: librarian server status [--dir <path>]"],
     logs: ["Usage: librarian server logs [-f|--follow] [--service mcp|dashboard|all]"],

--- a/packages/installer-cli/src/server/up.ts
+++ b/packages/installer-cli/src/server/up.ts
@@ -50,9 +50,18 @@ import { randomBytes } from "node:crypto";
 import fs from "node:fs";
 import { isIP } from "node:net";
 import path from "node:path";
+import type { FlagValue } from "../parse-args.js";
 import { readEnvFile, writeEnvFile } from "../env.js";
 import { librarianDir } from "../paths.js";
 import type { Prompter } from "../prompt.js";
+import {
+  dnsFlagsSpecified,
+  nameserverTuple,
+  parseDnsFlag,
+  parseLiveDns,
+  resolveDnsConfig,
+  sameNameservers,
+} from "./dns.js";
 import { fetchLatestVersion } from "../status.js";
 import { enableBoot } from "./boot.js";
 import {
@@ -319,6 +328,16 @@ export interface UpOptions {
    */
   dashboardPort?: string | undefined;
   /**
+   * Raw `--dns` / `--no-dns` flag. Opt-in container nameserver (IPv4). Parsed by
+   * {@link parseDnsFlag}. Absent → Docker's default resolv.conf.
+   */
+  dns?: FlagValue | undefined;
+  /**
+   * Raw `--dns-fallback` / `--no-dns-fallback` flag. Optional second nameserver;
+   * requires a primary.
+   */
+  dnsFallback?: FlagValue | undefined;
+  /**
    * Bind-mount a host directory at `/data` instead of a Docker named volume — so
    * the vault lives at a path you choose (back it up, put it on a specific disk,
    * copy it to another host). The container runs as the directory's owner
@@ -412,6 +431,11 @@ export interface RunArgsInput {
    * inline on argv (ADR 0008 P4).
    */
   envFile: string;
+  /**
+   * Container nameservers, primary first (`docker create --dns`, repeated).
+   * Absent/empty → Docker's default resolv.conf (no `--dns` on argv).
+   */
+  dnsServers?: string[] | undefined;
 }
 
 /**
@@ -441,6 +465,7 @@ export function buildRunArgs(input: RunArgsInput): string[] {
     restartPolicy = "unless-stopped",
     imageRef,
     envFile,
+    dnsServers,
   } = input;
   const args = [
     "run",
@@ -461,6 +486,11 @@ export function buildRunArgs(input: RunArgsInput): string[] {
     "--env-file",
     envFile,
   ];
+  // Opt-in operator DNS (primary first). Unset → Docker's default resolv.conf.
+  // c-ares never consults a later nameserver after NXDOMAIN, so order matters.
+  if (dnsServers) {
+    for (const nameserver of dnsServers) args.push("--dns", nameserver);
+  }
   // For a bind-mount, run as the directory's owner so the vault stays owned by —
   // and writable by — the operator, not the image's default user.
   if (runAsUser) args.push("--user", runAsUser);
@@ -628,6 +658,11 @@ export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult>
   // value or an MCP-port collision) — BEFORE any clone/build/run, so a typo'd
   // port fails fast and leaves nothing behind.
   const dashboardPort = resolveDashboardPort(options.dashboardPort);
+  const dnsOption = parseDnsFlag(options.dns, "--dns");
+  const dnsFallbackOption = parseDnsFlag(options.dnsFallback, "--dns-fallback");
+  const dnsConfig = resolveDnsConfig({ dns: dnsOption, dnsFallback: dnsFallbackOption });
+  const dnsServers = nameserverTuple(dnsConfig);
+  const dnsRequested = dnsFlagsSpecified(dnsOption, dnsFallbackOption);
 
   const dataVolume = options.dataVolume ?? DEFAULT_DATA_VOLUME;
   const deployDir = options.dir ?? path.join(librarianDir(deps.home), "server");
@@ -727,6 +762,7 @@ export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult>
           dataDir,
           dashboardPort,
           bootstrapClaimSecret,
+          dnsServers: dnsRequested ? dnsServers : undefined,
         },
       );
       if (drift.length > 0) throw existingContainerError(drift);
@@ -805,6 +841,7 @@ export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult>
           imageSource: "registry",
           imageRef: registryImage.imageRef,
           imageDigest: registryImage.imageDigest,
+          ...dnsConfig,
         }
       : {
           containerName: CONTAINER_NAME,
@@ -816,6 +853,7 @@ export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult>
           imageTag: `${CONTAINER_NAME}:${tag}`,
           imageSource: "source",
           imageRef: `${CONTAINER_NAME}:${tag}`,
+          ...dnsConfig,
         };
 
     log("[4/5] Starting the container…");
@@ -827,6 +865,7 @@ export async function runUp(options: UpOptions, deps: UpDeps): Promise<UpResult>
       runAsUser,
       imageRef: runImageRef,
       envFile,
+      dnsServers,
     });
     let candidateId: string | null = null;
     let healthRollbackComplete = false;
@@ -1080,6 +1119,8 @@ interface DesiredDeploymentConfig {
   dataDir?: string | undefined;
   dashboardPort: number;
   bootstrapClaimSecret?: string | undefined;
+  /** When set (including `[]`), live HostConfig.Dns must match exactly. */
+  dnsServers?: string[] | undefined;
 }
 
 interface LiveContainer {
@@ -1088,6 +1129,7 @@ interface LiveContainer {
   HostConfig?: {
     RestartPolicy?: { Name?: unknown };
     PortBindings?: unknown;
+    Dns?: unknown;
   };
   Mounts?: unknown;
 }
@@ -1179,6 +1221,12 @@ function registryDeploymentDrift(
     state.dashboardPort !== desired.dashboardPort
   ) {
     drift.push("persisted deployment state");
+  }
+  if (
+    desired.dnsServers !== undefined &&
+    !sameNameservers(parseLiveDns(container.HostConfig?.Dns), desired.dnsServers)
+  ) {
+    drift.push("container DNS");
   }
 
   const digest = state?.imageSource === "registry" ? state.imageDigest : undefined;

--- a/packages/installer-cli/src/server/update.ts
+++ b/packages/installer-cli/src/server/update.ts
@@ -3,7 +3,18 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import type { FlagValue } from "../parse-args.js";
 import { librarianDir } from "../paths.js";
+import {
+  dnsAllowsNoOp,
+  dnsConfigFromServers,
+  dnsFlagsSpecified,
+  dnsServersForReplacement,
+  nameserverTuple,
+  parseDnsFlag,
+  parseLiveDns,
+  resolveDnsConfig,
+} from "./dns.js";
 import { fetchLatestVersion } from "../status.js";
 import { type DeployState, readDeployState } from "./deploy-state.js";
 import {
@@ -39,6 +50,10 @@ export interface UpdateOptions {
   healthAttempts?: number | undefined;
   healthIntervalMs?: number | undefined;
   logTailLines?: number | undefined;
+  /** Raw `--dns` / `--no-dns`. Parsed by {@link parseDnsFlag}. */
+  dns?: FlagValue | undefined;
+  /** Raw `--dns-fallback` / `--no-dns-fallback`. */
+  dnsFallback?: FlagValue | undefined;
 }
 
 export class UpdateError extends Error {
@@ -62,6 +77,7 @@ interface LiveContainer {
   HostConfig?: {
     RestartPolicy?: { Name?: unknown };
     PortBindings?: unknown;
+    Dns?: unknown;
   };
   Mounts?: unknown;
 }
@@ -78,6 +94,8 @@ interface PreservedConfig {
   restartPolicy: string;
   env: Map<string, string>;
   healthy: boolean;
+  /** Live `HostConfig.Dns` (empty = Docker default). Used for recovery and adopt-on-recreate. */
+  dnsServers: string[];
 }
 
 interface PreparedTarget {
@@ -161,6 +179,20 @@ async function performUpdate(
   const sourceResolution =
     target.imageSource === "source" ? await resolveSourceTarget(deployDir, targetRef) : undefined;
   const current = await inspectCurrentContainer(state);
+  const dnsOption = parseDnsFlag(options.dns, "--dns");
+  const dnsFallbackOption = parseDnsFlag(options.dnsFallback, "--dns-fallback");
+  const flagsSpecified = dnsFlagsSpecified(dnsOption, dnsFallbackOption);
+  const resolvedDns = resolveDnsConfig({
+    dns: dnsOption,
+    dnsFallback: dnsFallbackOption,
+    stored: { dns: state.dns, dnsFallback: state.dnsFallback },
+  });
+  const replacementDns = dnsServersForReplacement({
+    flagsSpecified,
+    resolved: resolvedDns,
+    live: current.dnsServers,
+  });
+  const storedDns = nameserverTuple({ dns: state.dns, dnsFallback: state.dnsFallback });
 
   // Registry no-op is before a pull. Source no-op compares the fetched commit's
   // deterministic tag and its current immutable image ID, so `main` advancing
@@ -168,7 +200,15 @@ async function performUpdate(
   const exactTarget = sourceResolution
     ? await isExactHealthySourceTarget(state, targetRef, current, deployDir, sourceResolution)
     : isExactHealthyRegistryTarget(state, targetRef, current, deployDir);
-  if (exactTarget) {
+  if (
+    exactTarget &&
+    dnsAllowsNoOp({
+      flagsSpecified,
+      stored: storedDns,
+      live: current.dnsServers,
+      desired: replacementDns,
+    })
+  ) {
     const identity =
       target.imageSource === "registry" && state.imageSource === "registry"
         ? `published ${targetRef} (${shortImageDigest(state.imageDigest)})`
@@ -228,6 +268,7 @@ async function performUpdate(
           imageSource: "registry",
           imageRef: prepared.imageRef,
           imageDigest: prepared.imageDigest!,
+          ...dnsConfigFromServers(replacementDns),
         }
       : {
           containerName: state.containerName,
@@ -239,6 +280,7 @@ async function performUpdate(
           imageTag: prepared.imageRef,
           imageSource: "source",
           imageRef: prepared.imageRef,
+          ...dnsConfigFromServers(replacementDns),
         };
 
   let oldRemoved = false;
@@ -252,7 +294,7 @@ async function performUpdate(
 
     candidateId = await createContainer(
       prepared.runImageRef,
-      current,
+      { ...current, dnsServers: replacementDns },
       stagedEnv,
       prepared.cwd,
       redact,
@@ -431,6 +473,7 @@ async function inspectCurrentContainer(state: DeployState): Promise<PreservedCon
     restartPolicy,
     env: envMap(live.Config?.Env),
     healthy: live.State?.Status === "running" && live.State?.Health?.Status === "healthy",
+    dnsServers: parseLiveDns(live.HostConfig?.Dns),
   };
 }
 
@@ -749,6 +792,7 @@ async function createContainer(
     restartPolicy: config.restartPolicy,
     imageRef,
     envFile,
+    dnsServers: config.dnsServers,
   });
   args.splice(1, 0, "--cidfile", cidFile);
   fs.rmSync(cidFile, { force: true });
@@ -898,6 +942,7 @@ function recoveryFailure(
     restartPolicy: previous.restartPolicy,
     imageRef: previous.immutableImageId,
     envFile,
+    dnsServers: previous.dnsServers,
   });
   const manualCidFile = `${envFile}.manual-recovery.cid`;
   create.splice(1, 0, "--cidfile", manualCidFile);

--- a/packages/installer-cli/tests/server-deploy-state.test.ts
+++ b/packages/installer-cli/tests/server-deploy-state.test.ts
@@ -88,6 +88,27 @@ describe("deploy-state — round-trip under a fake home", () => {
     });
   });
 
+  it("round-trips optional DNS nameservers when present and omits them otherwise", async () => {
+    await withTempHome(async (home) => {
+      const dir = path.join(home, ".librarian", "server");
+      const withDns: DeployState = {
+        ...SAMPLE,
+        dns: "100.100.100.100",
+        dnsFallback: "8.8.8.8",
+      };
+      writeDeployState(dir, withDns);
+      expect(readDeployState(dir)).toEqual(withDns);
+      writeDeployState(dir, SAMPLE);
+      const parsed = JSON.parse(fs.readFileSync(deployStatePath(dir), "utf8")) as Record<
+        string,
+        unknown
+      >;
+      expect("dns" in parsed).toBe(false);
+      expect("dnsFallback" in parsed).toBe(false);
+      expect(readDeployState(dir)?.dns).toBeUndefined();
+    });
+  });
+
   it("round-trips a digest-pinned registry deployment", async () => {
     await withTempHome(async (home) => {
       const dir = path.join(home, ".librarian", "server");

--- a/packages/installer-cli/tests/server-dns.test.ts
+++ b/packages/installer-cli/tests/server-dns.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   DnsConfigError,
+  dnsAllowsNoOp,
   dnsConfigFromServers,
   dnsFlagsSpecified,
   dnsServersForReplacement,
@@ -115,5 +116,27 @@ describe("replacement nameservers", () => {
     expect(parseLiveDns(["100.100.100.100", "8.8.8.8"])).toEqual(["100.100.100.100", "8.8.8.8"]);
     expect(parseLiveDns(null)).toEqual([]);
     expect(parseLiveDns(["", 1, "1.1.1.1"])).toEqual(["1.1.1.1"]);
+  });
+
+  it("same-version no-op ignores a live hand-patch when nothing is stored or flagged", () => {
+    expect(
+      dnsAllowsNoOp({
+        flagsSpecified: false,
+        stored: [],
+        live: ["100.100.100.100"],
+        desired: ["100.100.100.100"],
+      }),
+    ).toBe(true);
+  });
+
+  it("same-version --dns still recreates when state has not recorded the nameserver", () => {
+    expect(
+      dnsAllowsNoOp({
+        flagsSpecified: true,
+        stored: [],
+        live: [],
+        desired: ["100.100.100.100"],
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/installer-cli/tests/server-dns.test.ts
+++ b/packages/installer-cli/tests/server-dns.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import {
+  DnsConfigError,
+  dnsConfigFromServers,
+  dnsFlagsSpecified,
+  dnsServersForReplacement,
+  nameserverTuple,
+  parseDnsFlag,
+  parseLiveDns,
+  resolveDnsConfig,
+  sameNameservers,
+} from "../src/server/dns.js";
+import { parseArgs } from "../src/parse-args.js";
+
+describe("parseDnsFlag — --dns / --no-dns", () => {
+  it("treats an omitted flag as unset", () => {
+    expect(parseDnsFlag(undefined, "--dns")).toEqual({ kind: "unset" });
+  });
+
+  it("reads --dns <ipv4> from parseArgs", () => {
+    const { flags } = parseArgs(["--dns", "100.100.100.100"]);
+    expect(parseDnsFlag(flags.dns, "--dns")).toEqual({
+      kind: "set",
+      value: "100.100.100.100",
+    });
+  });
+
+  it("treats --no-dns as clear", () => {
+    const { flags } = parseArgs(["--no-dns"]);
+    expect(parseDnsFlag(flags.dns, "--dns")).toEqual({ kind: "clear" });
+  });
+
+  it("a bare --dns without an address is a teaching error", () => {
+    const { flags } = parseArgs(["--dns"]);
+    expect(() => parseDnsFlag(flags.dns, "--dns")).toThrow(DnsConfigError);
+    expect(() => parseDnsFlag(flags.dns, "--dns")).toThrow(/requires an IPv4 address/i);
+  });
+
+  it("a hostname is a teaching error that names the input", () => {
+    expect(() => parseDnsFlag("marvin.akita-betelgeuse.ts.net", "--dns")).toThrow(
+      /Invalid --dns 'marvin\.akita-betelgeuse\.ts\.net'/,
+    );
+  });
+
+  it("an IPv6 nameserver is a teaching error", () => {
+    expect(() => parseDnsFlag("::1", "--dns")).toThrow(/IPv6 nameservers are not supported/);
+  });
+});
+
+describe("resolveDnsConfig", () => {
+  it("omitted flags keep stored nameservers", () => {
+    expect(
+      resolveDnsConfig({
+        dns: { kind: "unset" },
+        dnsFallback: { kind: "unset" },
+        stored: { dns: "100.100.100.100", dnsFallback: "8.8.8.8" },
+      }),
+    ).toEqual({ dns: "100.100.100.100", dnsFallback: "8.8.8.8" });
+  });
+
+  it("--no-dns clears primary and fallback", () => {
+    expect(
+      resolveDnsConfig({
+        dns: { kind: "clear" },
+        dnsFallback: { kind: "unset" },
+        stored: { dns: "100.100.100.100", dnsFallback: "8.8.8.8" },
+      }),
+    ).toEqual({ dns: undefined, dnsFallback: undefined });
+  });
+
+  it("--dns-fallback without a primary is a teaching error", () => {
+    expect(() =>
+      resolveDnsConfig({
+        dns: { kind: "unset" },
+        dnsFallback: { kind: "set", value: "8.8.8.8" },
+      }),
+    ).toThrow(/--dns-fallback requires a primary nameserver/);
+  });
+
+  it("flagsSpecified is false when both flags are omitted", () => {
+    expect(dnsFlagsSpecified({ kind: "unset" }, { kind: "unset" })).toBe(false);
+    expect(dnsFlagsSpecified({ kind: "set", value: "1.1.1.1" }, { kind: "unset" })).toBe(true);
+  });
+});
+
+describe("replacement nameservers", () => {
+  it("flags or stored state win over live HostConfig.Dns", () => {
+    expect(
+      dnsServersForReplacement({
+        flagsSpecified: true,
+        resolved: { dns: "100.100.100.100" },
+        live: ["8.8.8.8"],
+      }),
+    ).toEqual(["100.100.100.100"]);
+  });
+
+  it("with no flags and no stored primary, a recreate keeps live DNS", () => {
+    expect(
+      dnsServersForReplacement({
+        flagsSpecified: false,
+        resolved: {},
+        live: ["100.100.100.100"],
+      }),
+    ).toEqual(["100.100.100.100"]);
+  });
+
+  it("round-trips a two-server list through state fields", () => {
+    const servers = ["100.100.100.100", "8.8.8.8"];
+    expect(nameserverTuple(dnsConfigFromServers(servers))).toEqual(servers);
+    expect(sameNameservers(servers, ["100.100.100.100", "8.8.8.8"])).toBe(true);
+    expect(sameNameservers(servers, ["8.8.8.8", "100.100.100.100"])).toBe(false);
+  });
+
+  it("parses Docker HostConfig.Dns arrays and treats null/garbage as unset", () => {
+    expect(parseLiveDns(["100.100.100.100", "8.8.8.8"])).toEqual(["100.100.100.100", "8.8.8.8"]);
+    expect(parseLiveDns(null)).toEqual([]);
+    expect(parseLiveDns(["", 1, "1.1.1.1"])).toEqual(["1.1.1.1"]);
+  });
+});

--- a/packages/installer-cli/tests/server-up.test.ts
+++ b/packages/installer-cli/tests/server-up.test.ts
@@ -1029,6 +1029,43 @@ describe("server up — writes the NON-SECRET deploy-state (S4/S5 prerequisite)"
       });
     }
   });
+
+  it("--dns: records the nameserver, emits --dns on create, and teaches on a hostname", async () => {
+    await withTempHome(async (home) => {
+      const runner = healthyRunner();
+      setDockerRunner(runner);
+      stubSeams();
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
+
+      const r = await runCli(
+        ["server", "up", "--dns", "100.100.100.100", "--dns-fallback", "8.8.8.8"],
+        { home, prompter },
+      );
+      expect(r.exitCode).toBe(0);
+      const args = dockerRunArgs(runner);
+      const first = args?.indexOf("--dns") ?? -1;
+      expect(args?.[first + 1]).toBe("100.100.100.100");
+      expect(args?.[first + 3]).toBe("8.8.8.8");
+      expect(readDeployState(path.join(home, ".librarian", "server"))).toMatchObject({
+        dns: "100.100.100.100",
+        dnsFallback: "8.8.8.8",
+      });
+    });
+
+    await withTempHome(async (home) => {
+      const runner = healthyRunner();
+      setDockerRunner(runner);
+      stubSeams();
+      const prompter = new FakePrompter({ answers: { "~/.librarian/env": "n" } });
+      const r = await runCli(["server", "up", "--dns", "marvin.example.ts.net"], {
+        home,
+        prompter,
+      });
+      expect(r.exitCode).toBe(1);
+      expect(r.stderr).toMatch(/Invalid --dns 'marvin\.example\.ts\.net'/);
+      expect(runner.calls.some((c) => c.cmd === "docker" && c.args[0] === "create")).toBe(false);
+    });
+  });
 });
 
 describe("server up — beyond-localhost binding (S3)", () => {
@@ -1509,6 +1546,33 @@ describe("buildRunArgs — the S3/P4 seam (secrets via --env-file, off argv)", (
     expect(args).toContain("127.0.0.1:3500:3000");
     // The MCP publish is unaffected.
     expect(args).toContain("127.0.0.1:3838:3838");
+  });
+
+  it("emits --dns entries primary-first when nameservers are set, and omits them otherwise", () => {
+    const withDns = buildRunArgs({
+      host: "127.0.0.1",
+      dataVolume: "librarian_data",
+      dashboardPort: 3042,
+      imageRef: "the-librarian:v1.0.0",
+      envFile: "/tmp/deploy.env",
+      dnsServers: ["100.100.100.100", "8.8.8.8"],
+    });
+    const first = withDns.indexOf("--dns");
+    expect(first).toBeGreaterThanOrEqual(0);
+    expect(withDns[first + 1]).toBe("100.100.100.100");
+    expect(withDns[first + 2]).toBe("--dns");
+    expect(withDns[first + 3]).toBe("8.8.8.8");
+    // Nameservers stay off the image position (last) and off the env-file secrets.
+    expect(withDns[withDns.length - 1]).toBe("the-librarian:v1.0.0");
+
+    const without = buildRunArgs({
+      host: "127.0.0.1",
+      dataVolume: "librarian_data",
+      dashboardPort: 3042,
+      imageRef: "the-librarian:v1.0.0",
+      envFile: "/tmp/deploy.env",
+    });
+    expect(without).not.toContain("--dns");
   });
 });
 

--- a/packages/installer-cli/tests/server-update.test.ts
+++ b/packages/installer-cli/tests/server-update.test.ts
@@ -72,6 +72,7 @@ interface LiveOptions {
   user?: string;
   restartPolicy?: string;
   env?: string[];
+  dns?: string[];
 }
 
 interface StreamCall {
@@ -219,6 +220,7 @@ function liveJson(options: LiveOptions = {}): string {
         "3000/tcp": [{ HostIp: host, HostPort: String(dashboardPort) }],
         "3838/tcp": [{ HostIp: host, HostPort: "3838" }],
       },
+      ...(options.dns && options.dns.length > 0 ? { Dns: options.dns } : {}),
     },
     Mounts: dataDir
       ? [{ Type: "bind", Source: dataDir, Destination: "/data" }]
@@ -278,6 +280,7 @@ function replacementArgs(home: string, imageRef: string, options: LiveOptions = 
     restartPolicy: options.restartPolicy ?? "unless-stopped",
     imageRef,
     envFile: stagedEnv(home),
+    dnsServers: options.dns,
   });
   args.splice(1, 0, "--cidfile", `${stagedEnv(home)}.cid`);
   return args;
@@ -875,6 +878,111 @@ describe("server update — exact no-op and preserved configuration", () => {
       expect(second.stdout).toMatch(/already up to date/i);
       expect(streamCalls).toEqual([]);
       expect(callIndex(runner, "stop")).toBe(-1);
+    });
+  });
+});
+
+describe("server update — opt-in operator DNS", () => {
+  it("recreates a healthy latest deploy when --dns is new (does not no-op)", async () => {
+    await withTempHome(async (home) => {
+      seedRegistry(home, NEW_REF, NEW_DIGEST);
+      const live = liveJson({ configuredImage: NEW_DIGEST, dashboardPort: 3042 });
+      const dns = ["100.100.100.100"];
+      const runner = scriptSuccessfulReplacement(baseRunner(live), home, NEW_DIGEST, {
+        dashboardPort: 3042,
+        dns,
+      });
+      setDockerRunner(runner);
+
+      const result = await runCli(["server", "update", "--dns", "100.100.100.100"], { home });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).not.toMatch(/already up to date/i);
+      expect(callIndex(runner, "stop")).toBeGreaterThan(0);
+      expect(readDeployState(deployDir(home))).toMatchObject({ dns: "100.100.100.100" });
+    });
+  });
+
+  it("reuses stored DNS on a later update with no DNS flags", async () => {
+    await withTempHome(async (home) => {
+      seedRegistry(home);
+      const dir = deployDir(home);
+      writeDeployState(dir, { ...readDeployState(dir)!, dns: "100.100.100.100" });
+      const live = liveJson({
+        configuredImage: OLD_DIGEST,
+        dashboardPort: 3042,
+        dns: ["100.100.100.100"],
+      });
+      const runner = scriptSuccessfulReplacement(baseRunner(live), home, NEW_DIGEST, {
+        dashboardPort: 3042,
+        dns: ["100.100.100.100"],
+      });
+      setDockerRunner(runner);
+
+      const result = await runCli(["server", "update"], { home });
+      expect(result.exitCode).toBe(0);
+      expect(readDeployState(dir)).toMatchObject({
+        imageDigest: NEW_DIGEST,
+        dns: "100.100.100.100",
+      });
+    });
+  });
+
+  it("a same-version update without DNS flags leaves a live hand-patch in place", async () => {
+    await withTempHome(async (home) => {
+      seedRegistry(home, NEW_REF, NEW_DIGEST);
+      const runner = baseRunner(
+        liveJson({
+          configuredImage: NEW_DIGEST,
+          dashboardPort: 3042,
+          dns: ["100.100.100.100"],
+        }),
+      );
+      setDockerRunner(runner);
+
+      const result = await runCli(["server", "update"], { home });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch(/already up to date/i);
+      expect(callIndex(runner, "stop")).toBe(-1);
+      expect(readDeployState(deployDir(home))?.dns).toBeUndefined();
+    });
+  });
+
+  it("a version bump with no flags adopts live HostConfig.Dns into deploy-state", async () => {
+    await withTempHome(async (home) => {
+      seedRegistry(home);
+      const dns = ["100.100.100.100"];
+      const live = liveJson({ configuredImage: OLD_DIGEST, dashboardPort: 3042, dns });
+      const runner = scriptSuccessfulReplacement(baseRunner(live), home, NEW_DIGEST, {
+        dashboardPort: 3042,
+        dns,
+      });
+      setDockerRunner(runner);
+
+      const result = await runCli(["server", "update"], { home });
+      expect(result.exitCode).toBe(0);
+      expect(readDeployState(deployDir(home))).toMatchObject({ dns: "100.100.100.100" });
+    });
+  });
+
+  it("--no-dns on an already-current deploy recreates without --dns", async () => {
+    await withTempHome(async (home) => {
+      seedRegistry(home, NEW_REF, NEW_DIGEST);
+      const dir = deployDir(home);
+      writeDeployState(dir, { ...readDeployState(dir)!, dns: "100.100.100.100" });
+      const live = liveJson({
+        configuredImage: NEW_DIGEST,
+        dashboardPort: 3042,
+        dns: ["100.100.100.100"],
+      });
+      const runner = scriptSuccessfulReplacement(baseRunner(live), home, NEW_DIGEST, {
+        dashboardPort: 3042,
+      });
+      setDockerRunner(runner);
+
+      const result = await runCli(["server", "update", "--no-dns"], { home });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).not.toMatch(/already up to date/i);
+      expect(readDeployState(dir)?.dns).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Closes #462: installer-CLI all-in-one deploys had no equivalent of Compose `LIBRARIAN_DNS` (PR #461), so a tailnet-only curator LLM hostname failed with `ENOTFOUND` inside the container, and a manual `docker --dns` was wiped by `librarian server update`.
- `librarian server up/update --dns 100.100.100.100 [--dns-fallback 8.8.8.8]` persists nameservers in non-secret deploy-state and emits Docker `--dns` (primary first). `--no-dns` clears. Unset keeps Docker's default resolv.conf — no Tailscale default.
- `server update --dns` recreates even when the image is already current (the existing exact-healthy no-op ignored HostConfig.Dns). Omitted flags reuse stored DNS; a same-version fire with no flags still no-ops around a live hand-patch; a version-bump recreate adopts live DNS into deploy-state.

## Test plan
- [ ] `pnpm --filter @the-librarian/cli exec vitest run` (installer-cli suite; 557 passed locally)
- [ ] Confirm `librarian server update --help` shows `--dns` / `--dns-fallback`
- [ ] Fresh `server up --dns 100.100.100.100` → `docker inspect` shows that nameserver and `deploy-state.json` records `dns`
- [ ] On an already-current healthy deploy, `server update --dns 100.100.100.100` recreates (not "Already up to date") and persists
- [ ] A later `server update` with no DNS flags keeps the stored nameserver
- [ ] `--dns marvin.example.ts.net` fails before any container mutation with a teaching error that names the input
- [ ] After merge: on ssd-nodes, refresh the CLI, then `librarian server update --dns 100.100.100.100`, then point the curator at the Tailscale **hostname** (not the 100.x IP)


Made with [Cursor](https://cursor.com)