### PR TITLE
fix(curator): raise default LLM request timeout to 5 min (was 60 s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ This changelog starts at v0.1.0 — the first version likely to see public
 adoption. The pre-v0.1.0 development history lives in the git log; only
 changes from this point forward are catalogued here.
 
+## [1.23.1] — 2026-08-22
+
+### Fixed
+
+- **Curator LLM requests no longer abort at 60 s on slow self-hosted models:**
+  with `curator.<consumer>.timeout_ms` unset, the fallback was 60 s, but a small
+  local model serving 27–31K prompt tokens runs 1–4 min per call (~10 s prefill
+  + thousands of output tokens at ~40–60 t/s) — every long call died at exactly
+  the 60 s mark while the same model served multi-minute requests from other
+  clients. The unset default is now 5 min in all three read paths (per-consumer
+  settings, the legacy `curator.llm` keyspace helper, and the client's
+  `complete()` fallback). Explicitly configured timeouts are unchanged
+  (bounds [1 s, 10 min]).
+  ([#464](https://github.com/code-ministry-ltd/the-librarian/pull/464))
+
 ## [1.23.0] — 2026-08-20
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the-librarian",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "description": "A portable, agent-agnostic memory system for AI agents.",
   "private": true,
   "type": "module",

--- a/packages/core/src/curator-consumers.ts
+++ b/packages/core/src/curator-consumers.ts
@@ -58,7 +58,10 @@ export type LlmConsumer = ConfigurableJobConsumer | "chat";
 const CHAT_FALLBACK_CONSUMER: CuratorConsumer = "grooming";
 const CHRONICLE_FALLBACK_CONSUMER: CuratorConsumer = "grooming";
 
-const DEFAULT_TIMEOUT_MS = 60_000;
+// 5 min default (was 60 s): slow self-hosted models (e.g. a 9B with 27–31K
+// prompt tokens: ~10 s prefill + thousands of output tokens at ~40–60 t/s)
+// routinely run 1–4 min, so the old default aborted healthy long calls.
+const DEFAULT_TIMEOUT_MS = 300_000;
 const MIN_TIMEOUT_MS = 1_000;
 const MAX_TIMEOUT_MS = 600_000;
 

--- a/packages/core/src/grooming-llm-client.ts
+++ b/packages/core/src/grooming-llm-client.ts
@@ -20,7 +20,8 @@ export interface LlmClientConfig {
   model: string;
   /**
    * Default request timeout in ms applied when `complete()` is called without
-   * an explicit `timeoutMs`. Falls back to 60s when unset. Operator-configurable
+   * an explicit `timeoutMs`. Falls back to 5 min (300_000) when unset.
+   * Operator-configurable
    * on the curator path so a slow self-hosted model doesn't time out mid-batch.
    */
   timeoutMs?: number;
@@ -41,7 +42,7 @@ export interface LlmCompletionRequest {
   temperature?: number;
   /** Cap on completion tokens; omitted when undefined. */
   maxTokens?: number;
-  /** Overall request timeout in ms. Default 60_000. */
+  /** Overall request timeout in ms. Default 300_000 (5 min). */
   timeoutMs?: number;
 }
 
@@ -84,7 +85,8 @@ export interface LlmClientDeps {
   fetch?: FetchFn;
 }
 
-const DEFAULT_TIMEOUT_MS = 60_000;
+// 5 min default (was 60 s) — slow self-hosted models run 1–4 min per call.
+const DEFAULT_TIMEOUT_MS = 300_000;
 
 export function createGroomingLlmClient(
   config: LlmClientConfig,

--- a/packages/core/src/llm-connection.ts
+++ b/packages/core/src/llm-connection.ts
@@ -11,7 +11,8 @@
 import { z } from "zod";
 import type { SettingMeta } from "./store/settings-store.js";
 
-const DEFAULT_TIMEOUT_MS = 60_000;
+// 5 min default (was 60 s) — slow self-hosted models run 1–4 min per call.
+const DEFAULT_TIMEOUT_MS = 300_000;
 const MIN_TIMEOUT_MS = 1_000;
 const MAX_TIMEOUT_MS = 600_000;
 
@@ -19,7 +20,7 @@ export interface LlmConnection {
   provider: string;
   endpoint: string;
   model: string;
-  /** Per-request timeout in ms. Default 60s; range [1s, 10min]. */
+  /** Per-request timeout in ms. Default 5 min; range [1s, 10min]. */
   timeoutMs: number;
 }
 

--- a/packages/core/tests/curator-consumers.test.ts
+++ b/packages/core/tests/curator-consumers.test.ts
@@ -70,7 +70,7 @@ describe("per-consumer LLM resolution", () => {
           providerExists: false,
           endpoint: "",
           model: "",
-          timeoutMs: 60_000,
+          timeoutMs: 300_000,
           hasToken: false,
           isOperational: false,
         });
@@ -81,11 +81,11 @@ describe("per-consumer LLM resolution", () => {
       const { store } = s!;
       // A hand-edited vault value must never reach a tick as 0/negative/huge.
       store.setSetting("curator.intake.timeout_ms", "0");
-      expect(readConsumerConfig(store, "intake").timeoutMs).toBe(60_000);
+      expect(readConsumerConfig(store, "intake").timeoutMs).toBe(300_000);
       store.setSetting("curator.intake.timeout_ms", "999999999");
-      expect(readConsumerConfig(store, "intake").timeoutMs).toBe(60_000);
+      expect(readConsumerConfig(store, "intake").timeoutMs).toBe(300_000);
       store.setSetting("curator.intake.timeout_ms", "not-a-number");
-      expect(readConsumerConfig(store, "intake").timeoutMs).toBe(60_000);
+      expect(readConsumerConfig(store, "intake").timeoutMs).toBe(300_000);
     });
 
     it("round-trips the unified per-consumer enabled flag (spec 043 D-E)", () => {

--- a/packages/core/tests/grooming-tick.test.ts
+++ b/packages/core/tests/grooming-tick.test.ts
@@ -116,7 +116,7 @@ describe("runGroomingTick — operational", () => {
     expect(buildClient).toHaveBeenCalledTimes(1);
     // The grooming connection + decrypted token flow into the builder.
     expect(buildClient).toHaveBeenCalledWith(
-      { endpoint: "https://api.example.com/v1", model: "gpt-x", timeoutMs: 60_000 },
+      { endpoint: "https://api.example.com/v1", model: "gpt-x", timeoutMs: 300_000 },
       "dummy-decrypted-token",
     );
     if (result.ran) expect(result.summary.ran).toBeGreaterThanOrEqual(1);

--- a/packages/core/tests/llm-connection.test.ts
+++ b/packages/core/tests/llm-connection.test.ts
@@ -75,7 +75,7 @@ describe("llm-connection helper", () => {
       expect(got.provider).toBe("");
       expect(got.endpoint).toBe("");
       expect(got.model).toBe("");
-      expect(got.timeoutMs).toBe(60_000); // default
+      expect(got.timeoutMs).toBe(300_000); // default
       expect(got.hasToken).toBe(false);
       expect(got.isComplete).toBe(false);
     });
@@ -84,7 +84,7 @@ describe("llm-connection helper", () => {
       const { store } = s!;
       const keys = llmConnectionKeys("test.llm");
       store.setSetting(keys.timeoutMs, "not-a-number");
-      expect(readLlmConnection(store, keys).timeoutMs).toBe(60_000);
+      expect(readLlmConnection(store, keys).timeoutMs).toBe(300_000);
     });
 
     it("never returns the token plaintext — only hasToken", () => {


### PR DESCRIPTION
## What & why

Every failing Librarian 9B curator request died at exactly 60 s while the same model served multi-minute requests from other clients fine. Root cause: the curator LLM client's 60 s AbortController default — a slow self-hosted model with 27–31K prompt tokens runs ~10 s prefill + thousands of output tokens at ~40–60 t/s, i.e. 1–4 min per call, so the default aborts healthy long calls.

## Change

Bumps the *unset-value fallback* from 60 s to 5 min (300 000 ms) in all three places it lives:

- `packages/core/src/curator-consumers.ts` — per-consumer `curator.<consumer>.timeout_ms` read path (intake/grooming/chronicle/chat)
- `packages/core/src/llm-connection.ts` — shared `curator.llm` keyspace helper
- `packages/core/src/grooming-llm-client.ts` — client-side `complete()` fallback

Explicitly configured timeouts are untouched (bounds remain [1 s, 10 min]; an operator-set value still wins, and out-of-range hand-edited values still clamp to the new default). Tests updated to pin the new default.

## Verification

- `@librarian/core`: 142 files, 1654 passed / 1 skipped — green.
- `@librarian/mcp-server`: 589 passed / 1 failed — the failure (`routes.test.ts`: GET /mcp 405) is **pre-existing on clean main** (reproduced with this branch's changes stashed and core rebuilt from main); unrelated to timeouts.